### PR TITLE
test(index): retain Product materialized freshness PostgreSQL packet

### DIFF
--- a/crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs
+++ b/crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs
@@ -162,6 +162,12 @@ async fn run_materialized_freshness_scenarios(database: &TestDatabase) -> TestRe
     let delayed = load_product_mutation(&runtime.sources, STALE_PRODUCT_ID, "en").await?;
     let delayed_source_version = delayed.source_version();
     bump_stale_product_owner_revision(&database.writer).await?;
+    assert_owner_projection_advanced(
+        &database.writer,
+        STALE_PRODUCT_ID,
+        delayed_source_version,
+    )
+    .await?;
     apply_product_mutation(&runtime, delayed).await?;
     assert_materialized_source_version(
         &database.mutation,
@@ -222,6 +228,12 @@ async fn run_materialized_freshness_scenarios(database: &TestDatabase) -> TestRe
         load_product_mutation(&runtime.sources, LOCALE_DELETE_PRODUCT_ID, "en").await?;
     let locale_delayed_source_version = locale_delayed.source_version();
     delete_product_locale(&database.writer).await?;
+    assert_owner_projection_advanced(
+        &database.writer,
+        LOCALE_DELETE_PRODUCT_ID,
+        locale_delayed_source_version,
+    )
+    .await?;
     apply_product_mutation(&runtime, locale_delayed).await?;
     assert_materialized_source_version(
         &database.mutation,
@@ -398,6 +410,35 @@ fn projected_string<'a>(
         ))
         .into()),
     }
+}
+
+async fn assert_owner_projection_advanced(
+    db: &DatabaseConnection,
+    product_id: Uuid,
+    delayed_source_version: u64,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(projection_epoch AS TEXT) AS projection_epoch_text
+FROM product_index_graph_projection_snapshots
+WHERE tenant_id = $1
+  AND product_id = $2
+ORDER BY projection_epoch DESC
+LIMIT 1
+"#,
+            vec![TENANT_ID.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("expected current Product projection"))?;
+    let projection_epoch: String = row.try_get("", "projection_epoch_text")?;
+    let projection_epoch = projection_epoch.parse::<u64>()?;
+    assert!(
+        projection_epoch > delayed_source_version,
+        "owner projection {projection_epoch} must be newer than delayed mutation {delayed_source_version}"
+    );
+    Ok(())
 }
 
 async fn assert_materialized_source_version(

--- a/crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs
+++ b/crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs
@@ -1,0 +1,559 @@
+#![cfg(feature = "mod-product")]
+
+use std::{env, error::Error};
+
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation,
+    IndexQuery, IndexQueryPort, IndexQueryScope, IndexSourceLoadRequest, IndexValue, LocaleKey,
+    ModuleName, MutationApplyOutcome, MutationDelivery, OrderDirection, OrderExpr, Pagination,
+    PostgresMutationStore, PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion,
+    SharedIndexQueryRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+    materialize_index_source_registry, materialize_postgres_index_query_runtime,
+    materialize_postgres_index_sources,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const STALE_PRODUCT_ID: Uuid = Uuid::from_u128(101);
+const CONTROL_PRODUCT_ID: Uuid = Uuid::from_u128(102);
+const LOCALE_DELETE_PRODUCT_ID: Uuid = Uuid::from_u128(103);
+const STALE_TRANSLATION_ID: Uuid = Uuid::from_u128(111);
+const CONTROL_TRANSLATION_ID: Uuid = Uuid::from_u128(112);
+const LOCALE_DELETE_TRANSLATION_ID: Uuid = Uuid::from_u128(113);
+const STALE_TITLE: &str = "A stale candidate";
+const CONTROL_TITLE: &str = "B fresh control";
+const LOCALE_DELETE_TITLE: &str = "C deleted locale";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct ProductMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for ProductMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_product::migrations::migrations()
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    writer: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Product materialized query freshness harness"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_product_query_freshness_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_product_query_freshness_migration_{suffix}"),
+        )
+        .await?;
+        create_product_migration_prerequisites(&migration).await?;
+        ProductMigrator::up(&migration, None).await?;
+        let manager = SchemaManager::new(&migration);
+        for migration_step in IndexModule.migrations() {
+            migration_step.up(&manager).await?;
+        }
+        seed_products(&migration).await?;
+        migration.close().await?;
+
+        Ok(Some(Self {
+            control,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_query_freshness_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_query_freshness_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_query_freshness_query_{suffix}"),
+            )
+            .await?,
+            writer: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_query_freshness_writer_{suffix}"),
+            )
+            .await?,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.writer.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct ProductIndexRuntime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+}
+
+#[tokio::test]
+async fn product_materialized_freshness_fences_delayed_mutations_before_query_semantics(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+
+    let outcome = run_materialized_freshness_scenarios(&database).await;
+    let cleanup = database.cleanup().await;
+    outcome?;
+    cleanup
+}
+
+async fn run_materialized_freshness_scenarios(database: &TestDatabase) -> TestResult<()> {
+    let runtime = product_runtime(database).await?;
+
+    // Keep one genuinely fresh Product materialized as a control row. The stale candidate sorts
+    // before this row, so a missing root-admission fence would change page identity and exact count.
+    let control = load_product_mutation(&runtime.sources, CONTROL_PRODUCT_ID, "en").await?;
+    apply_product_mutation(&runtime, control).await?;
+
+    // Capture a valid Product mutation, then advance owner Product/projection state before applying
+    // that already-produced mutation. The mutation store intentionally knows only Index source
+    // version ordering, so the delayed mutation is physically accepted into index_entities.
+    let delayed = load_product_mutation(&runtime.sources, STALE_PRODUCT_ID, "en").await?;
+    let delayed_source_version = delayed.source_version();
+    bump_stale_product_owner_revision(&database.writer).await?;
+    apply_product_mutation(&runtime, delayed).await?;
+    assert_materialized_source_version(
+        &database.mutation,
+        STALE_PRODUCT_ID,
+        "en",
+        delayed_source_version,
+    )
+    .await?;
+
+    // Admission happens before the user title filter, title ordering, cursor lookahead/limit, and
+    // exact count. The physically stored stale A-row therefore cannot displace fresh B or inflate
+    // count even though A sorts first.
+    let fenced = runtime
+        .query
+        .execute_query(product_title_page(None)?)
+        .await?;
+    assert_eq!(fenced.items.len(), 1);
+    assert_eq!(fenced.items[0].entity_id, CONTROL_PRODUCT_ID);
+    assert_eq!(projected_string(&fenced.items[0], "title")?, CONTROL_TITLE);
+    assert_eq!(fenced.exact_count, Some(1));
+    assert!(!fenced.has_more);
+    assert!(fenced.next_cursor.is_none());
+
+    // Once the corrective current projection is materialized, A becomes query-admissible again.
+    // Cursor pagination must then retain ordinary semantics with the same admission predicate.
+    let current = load_product_mutation(&runtime.sources, STALE_PRODUCT_ID, "en").await?;
+    assert!(current.source_version() > delayed_source_version);
+    apply_product_mutation(&runtime, current).await?;
+
+    let first = runtime
+        .query
+        .execute_query(product_title_page(None)?)
+        .await?;
+    assert_eq!(first.items.len(), 1);
+    assert_eq!(first.items[0].entity_id, STALE_PRODUCT_ID);
+    assert_eq!(projected_string(&first.items[0], "title")?, STALE_TITLE);
+    assert_eq!(first.exact_count, Some(2));
+    assert!(first.has_more);
+    let cursor = first
+        .next_cursor
+        .clone()
+        .ok_or_else(|| std::io::Error::other("two admitted Products must emit a cursor"))?;
+
+    let second = runtime
+        .query
+        .execute_query(product_title_page(Some(cursor))?)
+        .await?;
+    assert_eq!(second.items.len(), 1);
+    assert_eq!(second.items[0].entity_id, CONTROL_PRODUCT_ID);
+    assert_eq!(projected_string(&second.items[0], "title")?, CONTROL_TITLE);
+    assert_eq!(second.exact_count, Some(2));
+    assert!(!second.has_more);
+
+    // Repeat the delayed-apply window for locale deletion. The stale upsert is deliberately written
+    // after the owner translation has disappeared; query admission must still hide the stored row
+    // before the retained Product delete mutation is delivered.
+    let locale_delayed =
+        load_product_mutation(&runtime.sources, LOCALE_DELETE_PRODUCT_ID, "en").await?;
+    let locale_delayed_source_version = locale_delayed.source_version();
+    delete_product_locale(&database.writer).await?;
+    apply_product_mutation(&runtime, locale_delayed).await?;
+    assert_materialized_source_version(
+        &database.mutation,
+        LOCALE_DELETE_PRODUCT_ID,
+        "en",
+        locale_delayed_source_version,
+    )
+    .await?;
+
+    let deleted_locale = runtime
+        .query
+        .execute_query(product_identity_query(LOCALE_DELETE_PRODUCT_ID)?)
+        .await?;
+    assert!(deleted_locale.items.is_empty());
+    assert_eq!(deleted_locale.exact_count, Some(0));
+    assert!(!deleted_locale.has_more);
+
+    Ok(())
+}
+
+async fn product_runtime(database: &TestDatabase) -> TestResult<ProductIndexRuntime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for registered in schemas.registry().iter() {
+        schema_store
+            .register(TENANT_ID, &registered.schema)
+            .await?;
+    }
+
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Product source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Product query runtime is missing"))?;
+
+    Ok(ProductIndexRuntime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+    })
+}
+
+async fn load_product_mutation(
+    sources: &SharedIndexSourceRegistry,
+    product_id: Uuid,
+    locale: &str,
+) -> TestResult<IndexMutation> {
+    let request = IndexSourceLoadRequest::new(vec![product_key(product_id, locale)?])?;
+    let mut mutations = sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected one Product mutation, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    Ok(mutations.remove(0))
+}
+
+async fn apply_product_mutation(
+    runtime: &ProductIndexRuntime,
+    mutation: IndexMutation,
+) -> TestResult<()> {
+    let expected_source_version = mutation.source_version();
+    let delivery = MutationDelivery::from_event(PRODUCT_SOURCE, mutation)?;
+    let outcome = runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?;
+    match outcome {
+        MutationApplyOutcome::Applied { source_version }
+            if source_version == expected_source_version => Ok(()),
+        other => Err(std::io::Error::other(format!(
+            "expected Product mutation version {expected_source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+fn product_title_page(after: Option<String>) -> TestResult<IndexQuery> {
+    let title = field_path("title")?;
+    Ok(IndexQuery {
+        scope: product_scope("en")?,
+        schema: product_schema_ref()?,
+        fields: vec![title.clone()],
+        filter: Some(FilterExpr::In(
+            title.clone(),
+            vec![
+                IndexValue::String(STALE_TITLE.to_owned()),
+                IndexValue::String(CONTROL_TITLE.to_owned()),
+            ],
+        )),
+        order_by: vec![OrderExpr {
+            field: title,
+            direction: OrderDirection::Asc,
+        }],
+        pagination: Pagination::Cursor { first: 1, after },
+        include_exact_count: true,
+    })
+}
+
+fn product_identity_query(product_id: Uuid) -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: product_scope("en")?,
+        schema: product_schema_ref()?,
+        fields: vec![field_path("title")?],
+        filter: Some(FilterExpr::Eq(
+            field_path("id")?,
+            IndexValue::Uuid(product_id),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+fn product_scope(locale: &str) -> TestResult<IndexQueryScope> {
+    Ok(IndexQueryScope {
+        tenant_id: TENANT_ID,
+        locale: Some(LocaleKey::new(locale)?),
+    })
+}
+
+fn product_key(product_id: Uuid, locale: &str) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: product_schema_ref()?,
+        entity_id: product_id,
+        locale: Some(LocaleKey::new(locale)?),
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        // Index core still requires one positive numeric routing/storage key. Distribution registers
+        // only this current Product contract.
+        version: SchemaVersion::new(3),
+    })
+}
+
+fn field_path(name: &str) -> TestResult<FieldPath> {
+    Ok(FieldPath::new(FieldName::new(name)?))
+}
+
+fn projected_string<'a>(
+    item: &'a rustok_index::IndexQueryItem,
+    field: &str,
+) -> TestResult<&'a str> {
+    let path = field_path(field)?;
+    let projected = item
+        .fields
+        .iter()
+        .find(|projected| projected.path == path)
+        .ok_or_else(|| std::io::Error::other(format!("missing projected field {field}")))?;
+    match &projected.value {
+        IndexValue::String(value) => Ok(value.as_str()),
+        other => Err(std::io::Error::other(format!(
+            "projected field {field} is not a string: {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn assert_materialized_source_version(
+    db: &DatabaseConnection,
+    product_id: Uuid,
+    locale: &str,
+    expected_source_version: u64,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(source_version AS TEXT) AS source_version_text
+FROM index_entities
+WHERE tenant_id = $1
+  AND module_name = 'rustok-product'
+  AND entity_name = 'product'
+  AND schema_version = 3
+  AND entity_id = $2
+  AND locale_key = $3
+  AND is_deleted = FALSE
+"#,
+            vec![TENANT_ID.into(), product_id.into(), locale.to_owned().into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("expected stale Product row to be materialized"))?;
+    let source_version: String = row.try_get("", "source_version_text")?;
+    assert_eq!(source_version.parse::<u64>()?, expected_source_version);
+    Ok(())
+}
+
+async fn create_product_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+-- Product query admission reads the Channel-owned tenant identity watermark. This focused packet does
+-- not exercise Channel convergence yet, so an empty owner-shaped table represents generation 0.
+CREATE TABLE channel_index_identity_generations (
+    tenant_id UUID PRIMARY KEY,
+    generation BIGINT NOT NULL CHECK (generation > 0)
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_products(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+
+INSERT INTO products (id, tenant_id) VALUES
+    ('{STALE_PRODUCT_ID}', '{TENANT_ID}'),
+    ('{CONTROL_PRODUCT_ID}', '{TENANT_ID}'),
+    ('{LOCALE_DELETE_PRODUCT_ID}', '{TENANT_ID}');
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{STALE_TRANSLATION_ID}', '{STALE_PRODUCT_ID}', '{TENANT_ID}', 'en', '{STALE_TITLE}', 'a-stale-candidate'),
+    ('{CONTROL_TRANSLATION_ID}', '{CONTROL_PRODUCT_ID}', '{TENANT_ID}', 'en', '{CONTROL_TITLE}', 'b-fresh-control'),
+    ('{LOCALE_DELETE_TRANSLATION_ID}', '{LOCALE_DELETE_PRODUCT_ID}', '{TENANT_ID}', 'en', '{LOCALE_DELETE_TITLE}', 'c-deleted-locale');
+
+-- One resolved empty-membership relation per Product creates the exact current graph projection.
+INSERT INTO product_sales_channel_index_relation_snapshots (
+    tenant_id,
+    product_id,
+    relation_epoch,
+    channel_ids
+) VALUES
+    ('{TENANT_ID}', '{STALE_PRODUCT_ID}', 1, '[]'::jsonb),
+    ('{TENANT_ID}', '{CONTROL_PRODUCT_ID}', 1, '[]'::jsonb),
+    ('{TENANT_ID}', '{LOCALE_DELETE_PRODUCT_ID}', 1, '[]'::jsonb);
+
+-- Generation 0 is exact because this packet intentionally has no Channels. Product visibility is the
+-- default unrestricted `all`; retained INSERT convergence requests are at or before this witness.
+INSERT INTO product_sales_channel_index_relation_freshness_snapshots (
+    tenant_id,
+    product_id,
+    relation_epoch,
+    product_source_version,
+    visibility_key,
+    channel_identity_generation
+)
+SELECT
+    product.tenant_id,
+    product.id,
+    relation.relation_epoch,
+    product.index_revision,
+    'all',
+    0
+FROM products product
+JOIN LATERAL (
+    SELECT relation_epoch
+    FROM product_sales_channel_index_relation_snapshots relation
+    WHERE relation.tenant_id = product.tenant_id
+      AND relation.product_id = product.id
+    ORDER BY relation.relation_epoch DESC
+    LIMIT 1
+) relation ON TRUE
+WHERE product.tenant_id = '{TENANT_ID}';
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn bump_stale_product_owner_revision(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        "UPDATE products SET vendor = 'owner-newer-than-delayed-mutation' WHERE tenant_id = '{TENANT_ID}' AND id = '{STALE_PRODUCT_ID}'"
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn delete_product_locale(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        "DELETE FROM product_translations WHERE tenant_id = '{TENANT_ID}' AND product_id = '{LOCALE_DELETE_PRODUCT_ID}' AND locale = 'en'"
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-07
 
-Status overlay rechecked against `main@14063a98cbdb6d3e0f5cc93b3b46b9ab01a9ca68` and continued on
-`agent/index-product-relation-convergence-20260807`.
+Status overlay rechecked against `main@844067c689aed6f810f23bcb3e908d2e579c0b62` and continued on
+`agent/index-product-materialized-freshness-postgres-evidence-20260807`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
 cursor.
@@ -31,7 +31,12 @@ inspection. Independent M7 source work can continue while that owner-execution g
 - live Product replay/absence source-admission freshness gate;
 - Product-owned visibility convergence requests and tenant lease/checkpoint state;
 - bounded generic ModuleWork Product-SalesChannel automatic convergence;
+- generic schema-scoped PostgreSQL root query admission;
+- canonical Product materialized/query freshness fence for the source-read -> mutation-apply window;
 - persisted tenant schema readiness gate.
+
+The first retained PostgreSQL Product materialized-freshness race packet is now source-ready, but it has
+not been executed or admitted.
 
 ## Canonical Product policy
 
@@ -45,18 +50,20 @@ it is not a Product compatibility matrix. The current Product graph contains Pro
 `variant_ids`/`variants`, and `sales_channel_ids`/`sales_channels`. Product visibility slugs stay
 owner-side resolver input rather than transitional Index fields.
 
-## Membership, ordering, freshness, and convergence are separate
+## Membership, ordering, freshness, convergence, and query admission are separate
 
 1. `relation_epoch` changes only when resolved Product-to-SalesChannel UUID membership changes.
 2. `projection_epoch` advances when complete Product record inputs move and is the only Product Index
    mutation `source_version`.
 3. `product_sales_channel_index_relation_freshness_snapshots` records that one retained relation epoch
-   was verified against current Product visibility and a Channel identity generation.
+   was verified against Product visibility and a Channel identity generation.
 4. `product_sales_channel_index_relation_convergence_requests` plus tenant convergence state ensure
    owner changes are durably driven back through the bounded resolver.
+5. Product root query admission compares materialized `projection_epoch` and existing owner freshness
+   evidence at query time so an already-produced stale mutation cannot become authoritative.
 
 A freshness-only change never fabricates a relation membership change. A convergence checkpoint is not
-an Index mutation clock.
+an Index mutation clock. Query admission adds no Product schema and no duplicate relation watermark.
 
 ## Channel identity generation
 
@@ -83,15 +90,14 @@ The Product owner accepts a freshness witness only for a live Product and the cu
 Direct SQL inserts use the same DDL guard and lock order.
 
 Live Product replay and Product locale absence fail closed unless the latest witness for the exact
-projection relation epoch matches the current canonical visibility key and current tenant Channel
-identity generation. A witness Product watermark may be older than the current Product revision only
-when current visibility still matches; unrelated Product updates therefore do not falsely stale the
-relation. Product hard-delete replay does not require a live freshness witness because it removes the
-graph.
+projection relation epoch matches current visibility and current tenant Channel identity generation. A
+witness Product watermark may be older than current Product revision only when visibility remains
+unchanged; unrelated Product updates therefore do not falsely stale the relation. Product hard-delete
+replay removes the graph and does not require a live freshness witness.
 
 ## Automatic owner-change relation convergence source complete
 
-Product now owns two additional durable surfaces:
+Product owns two additional durable surfaces:
 
 - append-only exact Product requests for INSERT/canonical `channel_visibility` changes;
 - one tenant convergence state with exact request cursor, completed opaque Channel generation,
@@ -113,19 +119,63 @@ Rejected Product owner data is isolated from tenant progress. Invalid visibility
 or too many resolved Channel targets leave that Product individually source-stale without blocking
 later Products in the same tenant. Correcting Product visibility creates a new exact request; a
 Channel-side correction advances Channel generation and schedules another tenant pass. Retryable
-concurrency/storage/relation/freshness failures still preserve the current page for retry.
+concurrency/storage/relation/freshness failures preserve the current page for retry.
 
 The Product DDL state machine prevents direct SQL from skipping visibility requests, changing an
 in-progress sweep generation, resetting a partial Product cursor, forging a completed Channel
 checkpoint, or deleting convergence state. Product still does not read Channel storage or depend on
 `rustok-channel`/`rustok-index`.
 
-This closes the previous manual scheduling gap. It does **not** close the materialized/query freshness
-window: source read and Index mutation application are separate transactions. A Channel identity change
-can commit after a valid Product source page was read but before its already-produced mutation is
-applied. The next source read fails closed and automatic convergence repairs owner relation state, but
-a previously produced/applied Index record still requires a materialized/query freshness fence or
-equivalent retained admission evidence before authoritative cutover.
+## Materialized/query freshness fence source complete
+
+The previous source-read -> mutation-apply window is now fenced at the root query boundary.
+
+`rustok-index` owns a module-neutral `PostgresQueryRootAdmission` and exact-schema admission catalog.
+The canonical query runtime snapshots those rules, rejects rules for schemas absent from the immutable
+schema registry, and applies an admission predicate to the compiler-owned root `index_entities`
+baseline in the same `REPEATABLE READ`, `READ ONLY` transaction as query execution.
+
+Admission is applied before user filter, cursor, order, pagination/limit, and exact count. The same
+predicate is inserted into exact-count SQL. It changes no bind values, selected columns, plan
+fingerprint, or cursor contract and fails closed if the compiler baseline no longer matches the exact
+expected anchor.
+
+The Product rule requires:
+
+- live Product and exact locale translation;
+- materialized `index_entities.source_version` equal to latest Product `projection_epoch`;
+- projection Product component equal current `products.index_revision`;
+- freshness witness for the projection relation epoch;
+- witness Channel generation equal current tenant Channel generation;
+- no visibility convergence request newer than the witness Product revision.
+
+This closes the materialized/query freshness fence at source level without a new Product schema,
+duplicate relation membership, a query-time visibility parser, or a new Index watermark.
+
+## Product materialized freshness PostgreSQL packet 1
+
+`crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs` is source-ready and
+execution-pending. It uses real Product/Index migrations, real Product source loading,
+`PostgresMutationStore`, persisted schema registration, and the canonical shared Index query runtime.
+
+The packet deliberately materializes a stale Product mutation after owner state has advanced, proves
+the stale source version is physically present in `index_entities`, and requires it to be excluded
+before title filter/order/cursor lookahead/limit/exact-count. It then applies the current mutation and
+proves normal two-page cursor behavior. A second scenario applies a delayed locale upsert after the
+owner translation is deleted and requires the physically stored row to remain query-inadmissible with
+exact count zero.
+
+This is retained source, not admitted evidence. No PostgreSQL execution result is claimed.
+
+The next M7 evidence packet should cover Product visibility + Channel identity races together with
+multi-host/restart/rejected-Product convergence behavior:
+
+- visibility change after source read;
+- Channel generation change with unchanged resolved UUID membership;
+- Channel identity change with changed membership/projection epoch;
+- concurrent host lease competition;
+- lease expiry/restart continuation;
+- rejected Product isolation while valid Products continue converging.
 
 ## Event-contract admission status
 
@@ -176,30 +226,38 @@ Required sequence remains:
 - [x] Product visibility convergence request ledger and tenant lease/checkpoint state.
 - [x] Automatic bounded Product visibility / Channel identity relation convergence through generic
       ModuleWork composition, including rejected-Product poison isolation.
+- [x] Implement/admit a materialized/query freshness fence for the source-read -> mutation-apply
+      in-flight window at source level.
+- [x] Add source-ready PostgreSQL packet for delayed Product scalar mutation and locale deletion query
+      admission across filter/order/cursor/limit/exact-count.
 - [x] Remove parallel Product/ProductVariant compatibility implementations.
-- [ ] Execute PostgreSQL evidence for schema readiness, relation/freshness/convergence storage,
-      rejected-Product isolation, multi-host lease expiry/restart, resolver convergence, projection
-      concurrency/delete ordering, and canonical replay.
-- [ ] Implement/admit a materialized/query freshness fence for the source-read -> mutation-apply
-      in-flight window.
+- [ ] Execute/admit the Product materialized freshness PostgreSQL packet.
+- [ ] Add/execute PostgreSQL visibility + Channel-generation convergence packet with multi-host lease
+      expiry/restart and rejected-Product evidence.
+- [ ] Execute PostgreSQL evidence for schema readiness, relation/freshness storage, resolver
+      convergence, projection concurrency/delete ordering, and canonical replay.
 - [ ] Admit canonical Product typed wire events/routes/consumers after digest verification.
 - [ ] Retain Channel create/delete/slug/identity, Product visibility, retry/restart/delete-recreate,
       out-of-order, locale fan-out, in-flight mutation, and freshness evidence.
-- [ ] Prove complete Product/Variant/Channel query parity.
+- [ ] Prove complete Product/Variant/Channel query parity, including linked-target availability.
 - [ ] Move Storefront traffic only after readiness/equivalence/materialized-freshness evidence passes.
 
 ## Next implementation step
 
 Primary owner step remains: execute and admit the locked M6 repair PostgreSQL packet.
 
-Next unblocked M7 source step: design the **materialized/query freshness fence** for the remaining
-source-read -> mutation-apply window. Prefer an explicit persisted watermark/admission comparison at
-query/materialization boundary over adding another Product schema or duplicating relation membership.
-Keep typed Product event work separately blocked until digest admission.
+Next unblocked M7 source step: add the retained Product visibility/Channel identity convergence
+PostgreSQL evidence packet. It should exercise the automatic convergence state machine and Product
+query-admission interaction across unchanged membership, changed membership, multi-host lease
+competition, restart/lease expiry, and rejected Product isolation. Do not add another Product schema or
+freshness clock. Keep typed Product event work separately blocked until digest admission.
 
 ## Maintainer verification for this slice
 
 ```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-resolver.mjs

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness-postgres-harness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness-postgres-harness.md
@@ -1,0 +1,104 @@
+# M7 Product materialized/query freshness PostgreSQL harness
+
+Status: `source_ready_execution_pending`.
+
+## Purpose
+
+This retained PostgreSQL packet exercises the source-read -> owner-change -> delayed-mutation-apply
+window against the real Product replay source, Index mutation store, persisted schema readiness, and
+canonical shared query runtime. It is intentionally separate from the Product-to-SalesChannel
+convergence worker packet so a failure identifies either materialized query admission or convergence,
+not a mixture of both mechanisms.
+
+The packet is source-ready but has not been executed by the implementation agent.
+
+## Production surfaces used
+
+`crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs` creates an isolated
+PostgreSQL schema and uses:
+
+- the real Product migration chain;
+- the real Index migration chain;
+- `rustok_distribution::build_runtime_extensions` with Index, Channel, and Product selected;
+- the immutable source schema registry and `PostgresSchemaRegistrationStore` for tenant readiness;
+- `materialize_postgres_index_sources` plus `SharedIndexSourceRegistry::load`;
+- `PostgresMutationStore` to physically apply the delayed mutation;
+- `materialize_postgres_index_query_runtime` and `SharedIndexQueryRuntime::execute_query`;
+- the Product root query-admission rule introduced by the materialized freshness slice.
+
+No fake Index source, fake query port, direct `index_entities` mutation, background task, or timing
+sleep is used.
+
+## Scenario 1: delayed scalar mutation
+
+Three Product fixtures share tenant and locale scope. `A stale candidate` sorts before
+`B fresh control`; a third Product is reserved for locale deletion.
+
+1. The control Product is loaded from the real Product source and materialized normally.
+2. The stale candidate is loaded from the real Product source, but its mutation is retained in memory.
+3. The owner Product is updated through PostgreSQL (`vendor` change). The real Product revision and
+   graph-projection triggers advance owner state.
+4. The already-produced old mutation is then applied through `PostgresMutationStore`.
+5. Direct read-only evidence confirms that the delayed old source version is physically present in
+   `index_entities`.
+6. A real Product Index query applies a title `IN` filter, title ascending order, cursor page size one,
+   lookahead/limit, and exact count.
+
+Expected retained assertion: only `B fresh control` is query-visible, exact count is one, and no
+continuation cursor is emitted. Therefore the physically materialized stale A row cannot influence
+filter/order/cursor/limit/exact-count semantics.
+
+The packet then loads and applies the corrective current mutation. The same query must return A on
+page one with exact count two and a continuation cursor; page two must return B with exact count two.
+This proves normal cursor behavior is restored after current Product materialization is admitted.
+
+## Scenario 2: locale deletion after source read
+
+1. The locale-deletion Product is loaded from the real Product source while its `en` translation
+   exists.
+2. The owner translation is deleted before the retained upsert mutation is applied. The real Product
+   translation trigger advances Product owner revision/projection state.
+3. The old upsert is applied through `PostgresMutationStore` and is again confirmed physically present
+   in `index_entities`.
+4. A real Product query for that Product/locale must return zero rows and exact count zero.
+
+This proves live locale ownership is part of admission: a stale upsert cannot become query-authoritative
+while the retained Product delete mutation is still in transit.
+
+## Deliberate scope boundary
+
+This first packet proves the materialized stale-mutation mechanism for Product revision/projection
+changes and live locale deletion. Channel-generation and visibility convergence races are deliberately
+not folded into this file.
+
+The next retained packet should cover:
+
+- Product `channel_visibility` change after source read;
+- Channel identity generation change with unchanged UUID membership;
+- Channel identity change that produces new relation membership/projection epoch;
+- multi-host lease competition and restart recovery for the convergence worker;
+- rejected Product isolation while valid Products continue converging.
+
+Keeping those cases together allows the evidence to prove the durable convergence state machine and
+its query-admission interaction without weakening this packet into a broad scenario with ambiguous
+failure ownership.
+
+## Admission state
+
+Source existence is not evidence admission. This packet remains `source_ready_execution_pending` until
+a maintainer runs the PostgreSQL harness and retains the resulting execution evidence under the
+repository's normal evidence/admission process.
+
+Suggested maintainer commands, intentionally not run by the implementation agent:
+
+```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No test, Node verifier, Cargo check, formatting command, PostgreSQL scenario, workflow, or CI job was
+run by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -1,15 +1,15 @@
 # M7 Product materialized/query freshness fence
 
-Status: `source_complete_runtime_evidence_pending`.
+Status: `source_complete_postgres_packet_source_ready_execution_pending`.
 
-## Problem closed by this slice
+## Problem closed by the source fence
 
 Product source admission already rejects stale Product-to-SalesChannel relation state, and automatic
 convergence re-establishes owner freshness after Product visibility or Channel identity changes. Those
 contracts do not by themselves protect an Index mutation that was produced under a valid source
 snapshot and then applied after owner state changed.
 
-The remaining window is:
+The race window is:
 
 1. Product source reads a valid Product projection and freshness witness;
 2. owner Product/Channel state changes;
@@ -21,14 +21,14 @@ ordering, cursor pagination, and exact count before the check sees returned rows
 
 ## Generic root query admission
 
-`rustok-index` now owns a trusted schema-scoped PostgreSQL root-admission contract.
+`rustok-index` owns a trusted schema-scoped PostgreSQL root-admission contract.
 
 `PostgresQueryRootAdmission` accepts a source-code predicate template that:
 
 - must reference the compiler-controlled `{{root}}` alias;
 - cannot contain bind placeholders, SQL statement boundaries, or comments;
 - is bounded to 32 KiB;
-- is applied to the compiler's exact canonical root `index_entities` baseline;
+- is applied to the compiler's exact canonical root `index_entities` baseline, including locale scope;
 - fails closed if page or exact-count SQL no longer contains exactly one expected root anchor.
 
 The admission predicate changes no user binds, selected columns, query fingerprint, or cursor contract.
@@ -36,8 +36,8 @@ It is injected into root `WHERE` before user filter/cursor/order/limit semantics
 injected into exact-count SQL.
 
 `PostgresIndexQueryAdmissionCatalog` owns at most one rule per exact `SchemaRef`. Query runtime
-materialization snapshots that catalog into `PostgresIndexQueryPort`; schemas without a rule retain the
-existing generic behavior.
+materialization snapshots that catalog into `PostgresIndexQueryPort`, rejects admission rules targeting
+an unregistered schema, and preserves the existing generic behavior for schemas without a rule.
 
 ## Product admission evidence
 
@@ -112,27 +112,54 @@ A rejected Product remains individually fail-closed. Its retained visibility req
 its last valid freshness witness, so query admission excludes it without blocking unrelated valid
 Products in the same tenant.
 
+## PostgreSQL evidence packet 1
+
+`crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs` is now a retained,
+environment-gated source packet for the materialized stale-mutation race. Its detailed contract is in
+`m7-product-materialized-query-freshness-postgres-harness.md`.
+
+The packet uses the real Product source, real Product and Index migrations, persisted schema
+registration, `PostgresMutationStore`, and the canonical shared query runtime. It intentionally:
+
+- reads a valid Product mutation;
+- changes owner Product state before apply;
+- applies the delayed old mutation and proves that old source version is physically present in
+  `index_entities`;
+- proves the stale row is excluded before title filter/order/cursor lookahead/limit/exact count;
+- applies the corrective current mutation and proves ordinary two-page cursor behavior returns;
+- repeats the delayed-upsert window across owner locale deletion and proves the physically stored row
+  remains query-inadmissible with exact count zero.
+
+This packet is **source-ready, not executed, and not admitted**. No successful PostgreSQL evidence is
+claimed yet.
+
 ## Scope and remaining admission
 
-This closes the source-read -> mutation-apply **Product root materialized/query freshness** gap at query
-admission source level. It does not claim successful PostgreSQL execution, latency, query parity, or
-Storefront production readiness.
+The Product root source-read -> mutation-apply freshness mechanism is source-complete. The first
+retained PostgreSQL race packet is source-ready, but execution/admission remains pending.
 
 Still required before cutover:
 
-- retained PostgreSQL evidence proving page/filter/order/cursor/exact-count exclusion across the owner
-  race window;
-- automatic-convergence multi-host/restart/rejected-Product evidence;
+- execute and retain the first materialized stale-mutation PostgreSQL packet;
+- retained Product visibility + Channel-generation race evidence, including unchanged-membership and
+  changed-membership transitions;
+- automatic-convergence multi-host lease/restart/rejected-Product evidence;
 - complete Product/Variant/Channel query equivalence, including linked target availability behavior;
 - canonical Product typed event admission after event-contract digest verification;
 - Storefront cutover evidence after schema readiness, equivalence, convergence, and query-freshness
   packets pass.
+
+The next source packet should combine Product visibility/Channel identity races with the convergence
+worker's durable multi-host/restart state machine. It must not introduce another Product schema or
+freshness clock.
 
 ## Maintainer verification
 
 Suggested commands, intentionally not run by the implementation agent:
 
 ```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-query-runtime-composition.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs

--- a/crates/rustok-index/docs/m7-product-sales-channel-convergence.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-convergence.md
@@ -1,18 +1,13 @@
 # M7 Product-to-SalesChannel automatic convergence
 
-Status: `source_complete_runtime_evidence_pending`.
+Status: `source_and_query_fence_complete_runtime_evidence_pending`.
 
 ## Selected boundary
 
-The canonical Product Index relation already has three separate durable facts:
-
-1. membership in Product-owned `relation_epoch` snapshots;
-2. complete Product mutation ordering in Product-owned `projection_epoch` snapshots;
-3. freshness witnesses proving the retained membership was resolved from current Product visibility
-   and tenant Channel identity generation.
-
-This slice adds the missing automatic convergence path without creating another Product schema or event
-family.
+The canonical Product Index relation has separate durable facts for membership, complete Product
+mutation ordering, freshness, automatic owner-change convergence, and materialized query admission.
+This separation prevents a freshness-only observation from fabricating relation membership or a new
+Product schema.
 
 Product owns:
 
@@ -56,9 +51,9 @@ a live relation to publish, and hard-delete replay is already independent of fre
 
 Rejected Product owner data is isolated rather than allowed to poison the ordered queue. Invalid
 visibility, an oversized allowlist, or too many resolved Channel targets complete the exact request
-without a freshness witness. That Product remains fail-closed in canonical source admission. A later
-Product correction appends another exact request; a Channel-side correction advances Channel identity
-generation and starts another tenant sweep.
+without a freshness witness. That Product remains fail-closed in canonical source/query admission. A
+later Product correction appends another exact request; a Channel-side correction advances Channel
+identity generation and starts another tenant sweep.
 
 ## Channel identity changes
 
@@ -67,7 +62,7 @@ missing checkpoint forces a baseline sweep. A newer Channel generation starts a 
 with a fixed generation and Product UUID keyset cursor.
 
 A rejected Product does not head-of-line block later valid Products in the same tenant. The convergence
-page leaves that Product source-stale, continues the remaining exact resolver calls, and checkpoints the
+page leaves that Product stale, continues the remaining exact resolver calls, and checkpoints the
 bounded page. Retryable concurrency/storage/relation/freshness errors still stop the page and preserve
 its durable cursor for retry.
 
@@ -91,27 +86,33 @@ Automatic relation convergence is now source complete. It closes the previous re
 external caller manually invoke Product relation reconciliation after Product visibility or Channel
 identity changes, while isolating rejected Product owner data from valid tenant progress.
 
-It does **not** close the materialized/query freshness window. Source observation and Index mutation
-application are still separate transactions. A Channel identity change can commit after a Product
-source page was read and before that page's mutation reaches `index_entities/index_links`. The next
-source observation fails closed and this worker repairs the owner relation, but authoritative query
-admission still needs a materialized/query freshness fence or equivalent retained evidence.
+The separate materialized/query freshness fence is also source complete. Product root queries compare
+materialized `projection_epoch` with current Product projection/revision, live locale identity, relation
+freshness, current Channel generation, and the visibility-request watermark before user
+filter/order/cursor/limit/exact-count semantics. Therefore an already-produced stale mutation can land
+in Index storage without becoming query-authoritative.
 
-Therefore this slice does not authorize Storefront cutover.
+Source completeness still does not authorize Storefront cutover. PostgreSQL execution evidence for the
+in-flight stale-mutation window and for this convergence state machine remains pending.
 
 ## Remaining M7 admission
 
-- execute PostgreSQL evidence for relation/freshness/convergence storage, rejected-Product isolation,
-  and multi-host lease recovery;
+- execute/admit the source-ready Product delayed-mutation/locale-deletion PostgreSQL query-freshness
+  packet;
+- add and execute PostgreSQL Product visibility + Channel-generation convergence evidence;
+- retain multi-host lease competition, lease expiry/restart, and rejected-Product isolation evidence;
 - retain Channel create/delete/slug/tenant, Product visibility, retry/restart/delete-recreate evidence;
-- close the source-read -> mutation-apply materialized/query freshness window;
 - admit canonical Product typed events/routes only after event-contract digest verification;
-- prove complete Product/Variant/Channel query parity;
-- move Storefront traffic only after readiness, equivalence, and materialized-freshness evidence pass.
+- prove complete Product/Variant/Channel query parity, including linked-target availability;
+- move Storefront traffic only after readiness, equivalence, convergence, and materialized-freshness
+  evidence pass.
 
 ## Maintainer verification
 
 ```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-resolver.mjs

--- a/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md
@@ -1,6 +1,6 @@
 # Product to SalesChannel relation admission
 
-Status: `canonical_source_freshness_and_convergence_complete_runtime_evidence_pending`.
+Status: `canonical_source_freshness_convergence_and_query_fence_complete_runtime_evidence_pending`.
 
 The current Product Index graph contains the Product-to-SalesChannel link. There is one canonical
 Product contract; no compatibility schema is waiting to add relation support.
@@ -96,6 +96,25 @@ the witness. Product locale absence uses the same gate.
 
 Hard-delete replay does not require a live freshness witness because it removes the Product graph.
 
+## Materialized/query freshness admission
+
+The source-read -> mutation-apply window is now fenced at the generic Index root query boundary.
+`rustok-index` applies a trusted schema-scoped admission predicate before user filter, cursor, order,
+pagination/limit, and exact count in the same PostgreSQL repeatable-read query snapshot.
+
+The canonical Product rule requires the materialized Product `source_version` to equal the latest
+Product `projection_epoch`, requires the projection Product component to equal current owner revision,
+requires current relation freshness/Channel generation evidence, rejects a visibility request newer than
+the witness, and requires the live Product plus exact locale translation to still exist.
+
+Therefore a previously valid Product mutation that is applied after owner state changes is physically
+allowed to land in Index storage but remains query-inadmissible until current owner state is
+materialized. This adds no Product schema, duplicate relation watermark, or Product-owned Channel
+read.
+
+Detailed contract:
+[M7 Product materialized/query freshness fence](./m7-product-materialized-query-freshness.md).
+
 ## Production admission status
 
 1. Durable relation membership storage: source complete.
@@ -107,18 +126,23 @@ Hard-delete replay does not require a live freshness witness because it removes 
 7. Durable Product visibility requests and tenant convergence checkpoint/lease: source complete.
 8. Automatic Product visibility / Channel identity relation convergence through generic ModuleWork:
    source complete.
-9. PostgreSQL concurrency/restart/delete-recreate/freshness/convergence evidence: pending.
-10. Materialized/query freshness admission for the source-read -> mutation-apply window: pending.
+9. Materialized/query freshness admission for the source-read -> mutation-apply window: source complete;
+   PostgreSQL execution/admission evidence pending.
+10. PostgreSQL concurrency/restart/delete-recreate/freshness/convergence evidence: pending.
 11. Product typed event route/consumer after event-contract digest admission: pending.
 12. Storefront/production cutover and query equivalence: pending.
 
-Automatic convergence does not authorize cutover by itself. A previously valid source page can still be
-in flight when owner facts change; that already-produced mutation needs a materialized/query freshness
-fence or equivalent retained admission evidence.
+Automatic convergence plus the query fence closes the source-level authority gap, but neither authorizes
+cutover without retained PostgreSQL execution evidence. The first delayed-mutation/locale-deletion
+query-freshness packet is source-ready; Product visibility/Channel-generation and multi-host convergence
+evidence remains the next packet.
 
 ## Maintainer validation
 
 ```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
 node scripts/verify/verify-index-product-source.mjs

--- a/crates/rustok-index/docs/m7-product-sales-channel-resolver.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-resolver.md
@@ -1,6 +1,6 @@
 # M7 Product-to-SalesChannel cross-owner resolver
 
-Status: `automatic_convergence_source_complete_runtime_evidence_pending`.
+Status: `automatic_convergence_and_query_fence_source_complete_runtime_evidence_pending`.
 
 ## Current contract
 
@@ -72,31 +72,39 @@ state, or cross-owner storage writes beyond the existing Product-owned relation/
 Detailed convergence contract:
 [Product-to-SalesChannel automatic convergence](./m7-product-sales-channel-convergence.md).
 
-## Replay boundary
+## Replay and query boundary
 
-The canonical Product Index source already materializes the `sales_channels` link. Live replay is
-fail-closed unless the latest freshness witness for the projection's exact relation epoch matches:
+The canonical Product Index source materializes the `sales_channels` link. Live replay is fail-closed
+unless the latest freshness witness for the projection's exact relation epoch matches current canonical
+Product visibility and current tenant Channel identity generation. Product locale absence uses the same
+freshness gate. Product hard-delete replay remains independent of a live witness because it removes the
+graph.
 
-- current canonical Product visibility; and
-- current tenant Channel identity generation.
+Automatic convergence now re-establishes stale/missing relation freshness without a manual caller.
+The materialized/query freshness fence separately closes the in-flight source-read -> mutation-apply
+authority gap: a Product mutation produced before a later owner change may still be physically applied,
+but the Product root row is query-inadmissible until materialized `projection_epoch`, current Product
+revision, live locale identity, current freshness witness, Channel generation, and visibility-request
+watermark agree.
 
-Product locale absence uses the same freshness gate. Product hard-delete replay remains independent of
-a live witness because it removes the graph.
-
-Automatic convergence now re-establishes stale/missing relation freshness without a manual caller. It
-still does not make source observation atomic with later Index mutation application; the in-flight
-source-read -> mutation-apply materialized/query freshness boundary remains open.
+The first retained PostgreSQL packet for delayed Product scalar mutation and locale deletion is
+source-ready and execution-pending. Visibility/Channel-generation races plus multi-host/restart
+convergence evidence remain the next packet.
 
 ## Still open
 
-- retained PostgreSQL multi-host/restart/delete-recreate/freshness/convergence evidence;
-- a materialized/query freshness fence or equivalent admission evidence for in-flight mutations;
+- execute/admit retained PostgreSQL delayed-mutation query-freshness evidence;
+- Product visibility + Channel-generation convergence evidence for unchanged/changed membership;
+- multi-host lease/restart/delete-recreate/rejected-Product convergence evidence;
 - Product typed event routes after event-contract digest admission;
 - complete Product/Variant/Channel query equivalence and Storefront cutover evidence.
 
 ## Maintainer verification
 
 ```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-resolver.mjs

--- a/crates/rustok-product/docs/index-sales-channel-relation-freshness.md
+++ b/crates/rustok-product/docs/index-sales-channel-relation-freshness.md
@@ -1,6 +1,6 @@
 # Product-SalesChannel relation freshness witness
 
-Status: `source_and_automatic_convergence_complete_materialized_fence_and_runtime_evidence_pending`.
+Status: `source_convergence_and_materialized_fence_complete_runtime_evidence_pending`.
 
 ## Purpose
 
@@ -61,8 +61,8 @@ not require a live witness because the mutation removes the graph rather than pu
 
 ## Automatic convergence
 
-Product visibility changes now append durable exact convergence requests, and tenant Channel identity
-changes are detected by comparing the current Channel generation with Product-owned durable tenant
+Product visibility changes append durable exact convergence requests, and tenant Channel identity
+changes are detected by comparing current Channel generation with Product-owned durable tenant
 checkpoint state. The selected distribution invokes the same bounded resolver through the generic
 ModuleWork scheduler, with tenant leases, restartable request cursors, and restartable 64-Product sweep
 cursors.
@@ -73,25 +73,35 @@ invoke reconciliation. The detailed owner/runtime contract is documented in
 
 ## Materialized freshness boundary
 
-The witness plus automatic resolver convergence still do **not** make source observation and Index
-mutation application one cross-owner atomic transaction. A Channel identity change may commit after a
-Product source page was read but before that already-produced mutation is applied. The next source
-observation will fail closed and automatic convergence will repair owner relation state, but the
-watermark alone is not a production materialized-view freshness guarantee for an already-produced or
-already-applied mutation.
+The witness and convergence worker do not make source observation and Index mutation application one
+cross-owner atomic transaction. Instead, the canonical Index query boundary now supplies the separate
+materialized/query freshness fence.
 
-Therefore authoritative cutover still requires retained evidence for this in-flight window plus an
-explicit materialized/query freshness fence (or an equivalent admission boundary). This distinction is
-deliberate: the witness closes stale source admission, and the convergence worker closes manual owner
-repair scheduling; neither by itself fences a previously produced Index mutation.
+A Product root row is query-admissible only when the materialized Product `projection_epoch` matches the
+latest owner projection, the projection Product component matches current Product revision, the live
+Product and exact locale still exist, the freshness witness matches current Channel generation, and no
+visibility convergence request is newer than the witness Product revision.
+
+This means a mutation produced before a later owner change may still be accepted physically by generic
+Index mutation storage, but it cannot become query-authoritative while its owner evidence is stale. The
+fence is intentionally outside Product ownership: Product still does not depend on `rustok-index` or
+read Channel storage.
+
+The first retained PostgreSQL materialized-freshness packet is source-ready. It delays a real Product
+mutation across an owner revision change, confirms that the stale version is physically present in
+`index_entities`, and requires Product query admission to exclude it before filter/order/cursor/limit
+and exact count. The same packet covers locale deletion after source read. It has not been executed or
+admitted by the implementation agent.
 
 ## Remaining admission
 
 Still required before production cutover:
 
-- materialized/query freshness fencing for the source-read -> mutation-apply window;
-- retained PostgreSQL multi-host/concurrency/restart/delete-recreate/in-flight freshness and
-  convergence evidence;
+- execute/admit the delayed-mutation/locale-deletion PostgreSQL query-freshness packet;
+- retained Product visibility + Channel-generation convergence evidence for unchanged/changed
+  membership;
+- retained PostgreSQL multi-host/concurrency/restart/delete-recreate/rejected-Product convergence
+  evidence;
 - canonical Product typed event admission/routes after event-contract digest admission;
 - complete query equivalence and Storefront cutover evidence.
 
@@ -100,6 +110,9 @@ Still required before production cutover:
 Suggested commands, intentionally not run by the implementation agent:
 
 ```bash
+cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-resolver.mjs

--- a/scripts/verify/verify-index-product-channel-relation-admission.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-admission.mjs
@@ -26,6 +26,7 @@ const forbidMarkers = (relative, source, markers) => {
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'pub(crate) mod relation_admission;',
   'mod channel_relation_convergence;',
+  'mod query_admission;',
 ]);
 
 const admissionPath = 'crates/rustok-distribution/src/product_index/relation_admission.rs';
@@ -80,7 +81,7 @@ forbidMarkers(productPath, product, [
 
 const documentPath = 'crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md';
 const document = requireMarkers(documentPath, [
-  'Status: `canonical_source_freshness_and_convergence_complete_runtime_evidence_pending`',
+  'Status: `canonical_source_freshness_convergence_and_query_fence_complete_runtime_evidence_pending`',
   'current Product Index graph contains the Product-to-SalesChannel link',
   '`product_sales_channel_index_relation_snapshots`',
   '`product_sales_channel_index_relation_freshness_snapshots`',
@@ -90,7 +91,8 @@ const document = requireMarkers(documentPath, [
   '`sales_channels` `IndexLink`',
   'Canonical Product replay/absence freshness gate: source complete',
   'Automatic Product visibility / Channel identity relation convergence through generic ModuleWork',
-  'Materialized/query freshness admission for the source-read -> mutation-apply window: pending',
+  'Materialized/query freshness admission for the source-read -> mutation-apply window: source complete',
+  'PostgreSQL execution/admission evidence pending',
 ]);
 forbidMarkers(documentPath, document, [
   'Product v1',
@@ -104,6 +106,7 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-channel-relation-admission.mjs'",
   "'verify-index-product-channel-relation-freshness.mjs'",
   "'verify-index-product-channel-relation-convergence.mjs'",
+  "'verify-index-product-materialized-query-freshness.mjs'",
 ]);
 
-console.log('[verify-index-product-channel-relation-admission] relation, freshness, and convergence admission verified');
+console.log('[verify-index-product-channel-relation-admission] relation, freshness, convergence, and query fence admission verified');

--- a/scripts/verify/verify-index-product-channel-relation-convergence.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-convergence.mjs
@@ -195,27 +195,30 @@ requireMarkers('crates/rustok-product/docs/index-sales-channel-relation-converge
   'source-read -> mutation-apply',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-convergence.md', [
-  'Status: `source_complete_runtime_evidence_pending`',
+  'Status: `source_and_query_fence_complete_runtime_evidence_pending`',
   'Generic ModuleWork composition',
   'Multi-host and restart behavior',
-  'rejected Product',
   'Automatic relation convergence is now source complete',
-  'materialized/query freshness window',
+  'materialized/query freshness fence is also source complete',
+  'PostgreSQL execution evidence',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-resolver.md', [
-  'Status: `automatic_convergence_source_complete_runtime_evidence_pending`',
-  'Product-to-SalesChannel automatic convergence',
+  'Status: `automatic_convergence_and_query_fence_source_complete_runtime_evidence_pending`',
+  'ProductSalesChannelIndexRelationFreshnessStore::record',
+  'Automatic convergence composition',
   'Automatic convergence now re-establishes stale/missing relation freshness',
+  'materialized/query freshness fence separately closes',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-relation-admission.md', [
   'Automatic Product visibility / Channel identity relation convergence through generic ModuleWork',
-  'Materialized/query freshness admission for the source-read -> mutation-apply window: pending',
+  'Materialized/query freshness admission for the source-read -> mutation-apply window: source complete',
+  'PostgreSQL execution/admission evidence pending',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-07.md', [
   'Product-owned visibility convergence requests and tenant lease/checkpoint state',
   'bounded generic ModuleWork Product-SalesChannel automatic convergence',
   'Automatic owner-change relation convergence source complete',
-  'materialized/query freshness fence',
+  'Materialized/query freshness fence source complete',
 ]);
 
 const aggregate = read('scripts/verify/verify-index-query-contract.mjs');
@@ -223,4 +226,4 @@ if (!aggregate.includes("'verify-index-product-channel-relation-convergence.mjs'
   fail('Index aggregate verifier does not include Product-SalesChannel convergence guard');
 }
 
-console.log('[verify-index-product-channel-relation-convergence] durable convergence contract verified');
+console.log('[verify-index-product-channel-relation-convergence] durable convergence and query-fence contract verified');

--- a/scripts/verify/verify-index-product-channel-relation-freshness.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-freshness.mjs
@@ -178,24 +178,27 @@ const absence = requireMarkers(absencePath, [
 forbidMarkers(absencePath, absence, ['INSERT ', 'UPDATE ', 'DELETE FROM']);
 
 requireMarkers('crates/rustok-product/docs/index-sales-channel-relation-freshness.md', [
-  'Status: `source_and_automatic_convergence_complete_materialized_fence_and_runtime_evidence_pending`',
+  'Status: `source_convergence_and_materialized_fence_complete_runtime_evidence_pending`',
   'freshness-only change does not pretend that the graph membership changed',
   '`channel_index_identity_generations`',
   'fails closed at source observation',
   '## Automatic convergence',
   'generic ModuleWork scheduler',
-  'still do **not** make source observation and Index mutation application one cross-owner atomic',
-  'materialized/query freshness fence',
+  '## Materialized freshness boundary',
+  'canonical Index query boundary now supplies the separate',
+  'cannot become query-authoritative',
+  'first retained PostgreSQL materialized-freshness packet is source-ready',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-resolver.md', [
-  'Status: `automatic_convergence_source_complete_runtime_evidence_pending`',
+  'Status: `automatic_convergence_and_query_fence_source_complete_runtime_evidence_pending`',
   'ProductSalesChannelIndexRelationFreshnessStore::record',
   'Automatic convergence composition',
   'Automatic convergence now re-establishes stale/missing relation freshness',
+  'materialized/query freshness fence separately closes',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-convergence.md', [
   'Automatic relation convergence is now source complete',
-  'materialized/query freshness window',
+  'materialized/query freshness fence is also source complete',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-graph-source.md', [
   'canonical_source_and_freshness_gate_complete_runtime_evidence_pending',
@@ -206,6 +209,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-07.
   'Channel identity generation',
   'Freshness watermark source complete',
   'Automatic owner-change relation convergence source complete',
+  'Materialized/query freshness fence source complete',
   'source-read -> mutation-apply',
 ]);
 
@@ -213,10 +217,11 @@ const aggregate = read('scripts/verify/verify-index-query-contract.mjs');
 for (const expected of [
   "'verify-index-product-channel-relation-freshness.mjs'",
   "'verify-index-product-channel-relation-convergence.mjs'",
+  "'verify-index-product-materialized-query-freshness.mjs'",
 ]) {
   if (!aggregate.includes(expected)) {
     fail(`Index aggregate verifier is missing ${expected}`);
   }
 }
 
-console.log('[verify-index-product-channel-relation-freshness] source admission freshness and convergence boundary verified');
+console.log('[verify-index-product-channel-relation-freshness] source freshness, convergence, and materialized fence boundary verified');

--- a/scripts/verify/verify-index-product-channel-relation-resolver.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-resolver.mjs
@@ -86,10 +86,11 @@ requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'pub(crate) mod channel_relation_resolver;',
   'mod channel_relation_convergence;',
   'mod channel_visibility;',
+  'mod query_admission;',
 ]);
 
 const resolverDoc = requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-resolver.md', [
-  'Status: `automatic_convergence_source_complete_runtime_evidence_pending`',
+  'Status: `automatic_convergence_and_query_fence_source_complete_runtime_evidence_pending`',
   '`REPEATABLE READ`, `READ ONLY`',
   '1024 visibility slugs',
   '64 Products per',
@@ -99,6 +100,8 @@ const resolverDoc = requireMarkers('crates/rustok-index/docs/m7-product-sales-ch
   'Automatic convergence composition',
   'Product-to-SalesChannel automatic convergence',
   'Automatic convergence now re-establishes stale/missing relation freshness',
+  'materialized/query freshness fence separately closes',
+  'first retained PostgreSQL packet',
   'No tests, Node verifiers, Cargo checks',
 ]);
 for (const legacy of ['Product v1', 'Product v2', 'Product v3', 'new Product Index schema version']) {
@@ -110,12 +113,14 @@ requireMarkers('crates/rustok-index/docs/m7-product-sales-channel-relation-admis
   'Product-owned freshness witness',
   'Channel identity generation',
   'Automatic convergence',
+  'Materialized/query freshness admission',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-07.md', [
   'bounded cross-owner Product visibility to SalesChannel UUID resolver',
   'one canonical Product Index source',
   'Freshness watermark source complete',
   'Automatic owner-change relation convergence source complete',
+  'Materialized/query freshness fence source complete',
 ]);
 
 const aggregate = read('scripts/verify/verify-index-query-contract.mjs');
@@ -123,4 +128,4 @@ if (!aggregate.includes("'verify-index-product-channel-relation-resolver.mjs'"))
   fail('Index aggregate verifier does not include the Product-SalesChannel resolver guard');
 }
 
-console.log('[verify-index-product-channel-relation-resolver] resolver, freshness, and convergence composition verified');
+console.log('[verify-index-product-channel-relation-resolver] resolver, freshness, convergence, and query fence composition verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-materialized-query-freshness-postgres-harness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const harnessPath = 'crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs';
+const harness = requireMarkers(harnessPath, [
+  '#![cfg(feature = "mod-product")]',
+  'RUSTOK_INDEX_TEST_DATABASE_URL',
+  'struct ProductMigrator;',
+  'rustok_product::migrations::migrations()',
+  'for migration_step in IndexModule.migrations()',
+  'CREATE SCHEMA',
+  'DROP SCHEMA IF EXISTS',
+  '.register(IndexModule)',
+  '.register(rustok_channel::ChannelModule)',
+  '.register(rustok_product::ProductModule)',
+  'rustok_distribution::build_runtime_extensions(&registry)',
+  'PostgresSchemaRegistrationStore::new',
+  '.register(TENANT_ID, &registered.schema)',
+  'materialize_postgres_index_sources',
+  'materialize_index_source_registry',
+  'materialize_postgres_index_query_runtime',
+  'SharedIndexSourceRegistry',
+  'IndexSourceLoadRequest::new',
+  'sources.load(request).await?',
+  'PostgresMutationStore::new',
+  'MutationDelivery::from_event(PRODUCT_SOURCE, mutation)',
+  '.apply(runtime.schemas.registry(), &delivery)',
+  'let delayed = load_product_mutation',
+  'let delayed_source_version = delayed.source_version()',
+  'bump_stale_product_owner_revision(&database.writer).await?',
+  'apply_product_mutation(&runtime, delayed).await?',
+  'assert_materialized_source_version(',
+  'FROM index_entities',
+  'FilterExpr::In(',
+  'OrderDirection::Asc',
+  'Pagination::Cursor { first: 1, after }',
+  'include_exact_count: true',
+  'assert_eq!(fenced.items[0].entity_id, CONTROL_PRODUCT_ID)',
+  'assert_eq!(fenced.exact_count, Some(1))',
+  'assert!(fenced.next_cursor.is_none())',
+  'assert!(current.source_version() > delayed_source_version)',
+  'assert_eq!(first.items[0].entity_id, STALE_PRODUCT_ID)',
+  'assert_eq!(first.exact_count, Some(2))',
+  'let cursor = first',
+  '.next_cursor',
+  'product_title_page(Some(cursor))',
+  'assert_eq!(second.items[0].entity_id, CONTROL_PRODUCT_ID)',
+  'let locale_delayed =',
+  'delete_product_locale(&database.writer).await?',
+  'apply_product_mutation(&runtime, locale_delayed).await?',
+  'product_identity_query(LOCALE_DELETE_PRODUCT_ID)',
+  'assert!(deleted_locale.items.is_empty())',
+  'assert_eq!(deleted_locale.exact_count, Some(0))',
+  'UPDATE products SET vendor =',
+  'DELETE FROM product_translations',
+  'product_index_graph_projection_snapshots',
+  'product_sales_channel_index_relation_freshness_snapshots',
+  'channel_index_identity_generations',
+]);
+forbidMarkers(harnessPath, harness, [
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'FakeIndex',
+  'FakeSource',
+  'MockIndex',
+  'MockSource',
+  'INSERT INTO index_entities',
+  'UPDATE index_entities',
+  'DELETE FROM index_entities',
+  'PostgresIndexQueryPort::new',
+  'PostgresIndexQueryPort::with_admissions',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness-postgres-harness.md', [
+  'Status: `source_ready_execution_pending`',
+  'delayed scalar mutation',
+  'physically present in `index_entities`',
+  'filter/order/cursor/limit/exact-count',
+  'corrective current mutation',
+  'locale deletion',
+  'not executed',
+  'Channel-generation and visibility convergence races',
+]);
+
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-product-materialized-query-freshness-postgres-harness.mjs'",
+]);
+
+console.log('[verify-index-product-materialized-query-freshness-postgres-harness] source packet verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
@@ -50,6 +50,9 @@ const harness = requireMarkers(harnessPath, [
   'let delayed = load_product_mutation',
   'let delayed_source_version = delayed.source_version()',
   'bump_stale_product_owner_revision(&database.writer).await?',
+  'assert_owner_projection_advanced(',
+  'FROM product_index_graph_projection_snapshots',
+  'projection_epoch > delayed_source_version',
   'apply_product_mutation(&runtime, delayed).await?',
   'assert_materialized_source_version(',
   'FROM index_entities',
@@ -75,7 +78,6 @@ const harness = requireMarkers(harnessPath, [
   'assert_eq!(deleted_locale.exact_count, Some(0))',
   'UPDATE products SET vendor =',
   'DELETE FROM product_translations',
-  'product_index_graph_projection_snapshots',
   'product_sales_channel_index_relation_freshness_snapshots',
   'channel_index_identity_generations',
 ]);

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -80,8 +80,10 @@ requireMarkers(runtimePath, [
   '.get::<PostgresIndexQueryAdmissionCatalog>()',
   '.cloned()',
   '.unwrap_or_default()',
+  'AdmissionSchemaMissing',
   'PostgresIndexQueryPort::with_admissions(',
   'query_admission_catalog_is_snapshotted_into_runtime_composition',
+  'dangling_query_admission_schema_fails_composition',
 ]);
 
 const productAdmissionPath = 'crates/rustok-distribution/src/product_index/query_admission.rs';
@@ -130,7 +132,7 @@ requireMarkers('crates/rustok-index/src/lib.rs', [
   'PostgresIndexQueryAdmissionDescriptor',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
-  'Status: `source_complete_runtime_evidence_pending`',
+  'Status: `source_complete_postgres_packet_source_ready_execution_pending`',
   'source-read -> mutation-apply',
   'A post-result freshness check is insufficient',
   'Generic root query admission',
@@ -140,6 +142,12 @@ requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness
   'same predicate is',
   'exact-count SQL',
   'Rejected Product owner data',
+  'PostgreSQL evidence packet 1',
+  'source-ready, not executed, and not admitted',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness-postgres-harness.md', [
+  'Status: `source_ready_execution_pending`',
+  'physically present in `index_entities`',
 ]);
 
 const compilerPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
@@ -155,4 +163,4 @@ requireMarkers(compilerPath, [
   'AND {root_alias}.locale_key = {locale} AND {root_alias}.is_deleted = FALSE',
 ]);
 
-console.log('[verify-index-product-materialized-query-freshness] Product root query freshness fence verified');
+console.log('[verify-index-product-materialized-query-freshness] Product root query freshness fence and packet cursor verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -70,6 +70,7 @@ const scripts = [
   'verify-index-product-channel-relation-freshness.mjs',
   'verify-index-product-channel-relation-convergence.mjs',
   'verify-index-product-materialized-query-freshness.mjs',
+  'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-graph-projection-ledger.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

- add a retained PostgreSQL integration packet for the Product source-read -> owner-change -> delayed-mutation-apply window;
- use real Product and Index migrations, real `SharedIndexSourceRegistry::load`, persisted schema readiness, `PostgresMutationStore`, and the canonical shared query runtime;
- prove the owner Product `projection_epoch` is already newer before applying the held mutation;
- prove the held stale source version is nevertheless physically materialized in `index_entities` through generic mutation storage;
- prove Product root admission excludes that stale row before title filter/order/cursor lookahead/limit/exact count;
- apply the corrective current mutation and retain normal two-page cursor assertions;
- cover a second delayed-upsert race where the owner locale translation is deleted before apply and require zero query rows/exact count;
- add a static harness verifier and include it in the aggregate Index query contract;
- actualize M7 relation/freshness/resolver/convergence docs and their guards so they no longer describe the already-merged materialized query fence as pending.

## Packet 1 scenarios

### Delayed scalar mutation

1. Materialize one fresh control Product.
2. Load a second Product mutation from the real Product source and retain it in memory.
3. Update owner Product state (`vendor`), letting the real Product revision/projection triggers advance.
4. Assert latest owner `product_index_graph_projection_snapshots.projection_epoch` is greater than the delayed mutation source version.
5. Apply the old mutation through `PostgresMutationStore` and assert that old version exists physically in `index_entities`.
6. Execute a Product query with title `IN` filter, title ASC order, cursor `first=1`, lookahead/limit, and exact count.
7. Require only the fresh control row, exact count 1, no continuation cursor.
8. Load/apply the current Product mutation; require A on page 1, B on page 2, exact count 2, and canonical cursor continuation.

This proves a physically stored stale row cannot affect Product filter/order/cursor/limit/exact-count semantics.

### Locale deletion after source read

1. Load an `en` Product upsert and retain it.
2. Delete the owner translation, advancing real Product owner revision/projection state.
3. Assert owner projection is newer than the retained mutation.
4. Apply the old upsert through `PostgresMutationStore` and confirm it is physically present in `index_entities`.
5. Query the exact Product/locale through the canonical shared runtime and require zero rows/exact count.

This proves live locale identity fences a stale upsert before the retained delete mutation arrives.

## Deliberate scope

This PR changes no production source or migration. It does not claim Channel-generation/convergence evidence. The next packet remains Product visibility + Channel identity generation races together with multi-host lease competition, restart/lease expiry, changed/unchanged membership, and rejected-Product isolation.

## Main recheck

The branch started from #3163 merge `844067c689aed6f810f23bcb3e908d2e579c0b62`. Subsequent `main` changes inspected before PR creation are outside this evidence/doc/verifier file set; no production Index/distribution overlap was found.

## Validation

Per maintainer instruction, this packet is **source-ready, execution-pending**. No tests, Node verifiers, Cargo checks, formatting, PostgreSQL scenarios, workflows, CI, migrations, or `git diff --check` were executed by the implementation agent.