### PR TITLE
refactor(commerce): read storefront Product GraphQL catalog through owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -217,11 +217,17 @@ These are source-contract defects, not verification-only tasks.
   admission, typed catalog filters, pagination validation, requested/default locale,
   request channel, authenticated actor, bounded deadline, response projection, and
   correlation-aware stable public owner errors.
-- [ ] Cut remaining mounted Product storefront catalog reads, REST delete/publish/unpublish
-  lifecycle commands, and GraphQL product lifecycle/schema operations over to
-  host-composed Product owner ports. Direct Product entities, `CatalogService`, and
-  `ProductCatalogSchemaService` remain explicit source debt; repeatable lifecycle
-  commands need an explicit caller idempotency contract before cutover.
+- [x] Publish an optional filtered storefront-list capability without changing
+  `PublishedProductsRequest`, and cut mounted storefront GraphQL Product catalog reads
+  to the host-selected `ProductCatalogReadRuntime` / `ProductCatalogReadPort` while
+  preserving search/category/sort/attribute filters, pagination validation, channel
+  visibility, requested/default locale, service actor/deadline context, response
+  projection, and correlation-aware stable public owner errors.
+- [ ] Cut remaining mounted Product REST delete/publish/unpublish lifecycle commands and
+  GraphQL product lifecycle/schema operations over to host-composed Product owner ports.
+  Direct Product entities, `CatalogService`, and `ProductCatalogSchemaService` remain
+  explicit source debt; repeatable lifecycle commands need an explicit caller
+  idempotency contract before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -622,6 +628,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-product-admin-detail-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-list-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-graphql-read.mjs`
+- [ ] `node scripts/verify/verify-commerce-product-storefront-graphql-read.mjs`
 - [ ] `cargo xtask module validate commerce`
 - [ ] `cargo xtask module validate order`
 - [ ] `cargo xtask module validate payment`
@@ -655,8 +662,8 @@ Source inspection is not execution evidence.
   handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
   marketplace-financial topology, Product command-port, Product admin-detail read,
-  Product admin-list read, and Product admin-GraphQL read static guards against a
-  repository checkout and retain their output.
+  Product admin-list read, Product admin-GraphQL read, and Product storefront-GraphQL
+  read static guards against a repository checkout and retain their output.
 
 ### Compile/tests
 
@@ -840,6 +847,10 @@ Source inspection is not execution evidence.
   runtime/port with authenticated actor, request channel/locale context, bounded deadline,
   existing filter/pagination semantics, unchanged response projection, and safe stable
   public owner errors; storefront catalog and lifecycle/schema cutover remain open.
+- [x] Publish the optional filtered storefront Product read capability and cut mounted
+  storefront GraphQL catalog reads to the host-selected Product runtime/port without
+  changing the existing published-list request, filter/pagination/channel semantics, or
+  GraphQL projection; Product lifecycle/schema cutover remains open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/graphql/product_catalog.rs
+++ b/crates/rustok-commerce/src/graphql/product_catalog.rs
@@ -4,7 +4,7 @@ use rustok_api::{
     graphql::require_module_enabled,
 };
 use rustok_outbox::TransactionalEventBus;
-use rustok_product::{AdminProductListQuery, CatalogService, StorefrontProductListQuery};
+use rustok_product::{AdminProductListQuery, StorefrontProductListQuery};
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
@@ -14,9 +14,10 @@ use super::{
     require_storefront_channel_enabled,
 };
 
-fn admin_product_catalog_port_error(
+fn product_catalog_port_error(
     context: &PortContext,
     error: PortError,
+    operation: &'static str,
 ) -> async_graphql::Error {
     let (code, message, retryable, error_kind) = match &error.kind {
         PortErrorKind::Validation => (
@@ -60,14 +61,14 @@ fn admin_product_catalog_port_error(
     tracing::error!(
         correlation_id = %context.correlation_id,
         tenant_id = %context.tenant_id,
-        operation = "admin_product_catalog",
+        operation,
         owner_code = %error.code,
         owner_kind = error_kind,
         owner_retryable = error.retryable,
         public_code = code,
         retryable,
         boundary = "commerce_graphql_product",
-        "commerce GraphQL Product admin catalog owner port failed"
+        "commerce GraphQL Product catalog owner port failed"
     );
 
     async_graphql::Error::new(message).extend_with(|_, extensions| {
@@ -165,16 +166,38 @@ impl ProductCatalogQuery {
         )
         .map_err(|error| map_product_service_error(error, "storefront_product_catalog_input"))?
         .with_pagination(page, per_page);
-        let products = CatalogService::new(db.clone(), event_bus.clone())
-            .list_published_products_with_query(
-                tenant.id,
-                requested_locale.as_str(),
-                Some(tenant.default_locale.as_str()),
-                public_channel_slug.as_deref(),
-                list_query,
+
+        let port_context = PortContext::new(
+            tenant.id.to_string(),
+            PortActor::service("commerce-storefront-graphql"),
+            requested_locale.as_str(),
+            format!("commerce-graphql-product:storefront-catalog:{page}:{per_page}"),
+        )
+        .with_deadline(std::time::Duration::from_secs(2));
+        let port_context = match public_channel_slug.as_deref() {
+            Some(channel) => port_context.with_channel(channel),
+            None => port_context,
+        };
+        let product_read_runtime =
+            crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+                db.clone(),
+                event_bus.clone(),
+            );
+        let products = product_read_runtime
+            .read_port()
+            .list_filtered_published_products(
+                port_context.clone(),
+                rustok_product::FilteredPublishedProductsRequest {
+                    locale: Some(requested_locale),
+                    fallback_locale: Some(tenant.default_locale.clone()),
+                    public_channel_slug,
+                    query: list_query,
+                },
             )
             .await
-            .map_err(|error| map_product_service_error(error, "storefront_product_catalog"))?;
+            .map_err(|error| {
+                product_catalog_port_error(&port_context, error, "storefront_product_catalog")
+            })?;
 
         Ok(GqlProductList {
             total: products.total,
@@ -279,7 +302,9 @@ impl ProductCatalogQuery {
                 },
             )
             .await
-            .map_err(|error| admin_product_catalog_port_error(&port_context, error))?;
+            .map_err(|error| {
+                product_catalog_port_error(&port_context, error, "admin_product_catalog")
+            })?;
 
         Ok(AdminProductCatalogList {
             total: products.total,

--- a/crates/rustok-product/src/ports.rs
+++ b/crates/rustok-product/src/ports.rs
@@ -4,7 +4,9 @@ use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{AdminProductList, AdminProductListQuery, StorefrontProductList};
+use crate::{
+    AdminProductList, AdminProductListQuery, StorefrontProductList, StorefrontProductListQuery,
+};
 use crate::dto::ProductResponse;
 use crate::entities::product_variant;
 
@@ -13,6 +15,7 @@ const MAX_ADMIN_PRODUCTS_PER_PAGE: u64 = 100;
 const READ_PRODUCT_PROJECTION_OPERATION: &str = "read_product_projection";
 const READ_VARIANT_PRODUCT_PROJECTION_OPERATION: &str = "read_variant_product_projection";
 const LIST_PUBLISHED_PRODUCTS_OPERATION: &str = "list_published_products";
+const LIST_FILTERED_PUBLISHED_PRODUCTS_OPERATION: &str = "list_filtered_published_products";
 const LIST_ADMIN_PRODUCTS_OPERATION: &str = "list_admin_products";
 
 /// Transport-neutral owner boundary for product catalog read projections.
@@ -40,6 +43,19 @@ pub trait ProductCatalogReadPort: Send + Sync {
         context: PortContext,
         request: PublishedProductsRequest,
     ) -> Result<StorefrontProductList, PortError>;
+
+    /// Optional filtered storefront-list capability for consumers that need the full owner
+    /// search/category/sort/attribute-filter contract. Existing adapters remain compatible.
+    async fn list_filtered_published_products(
+        &self,
+        _context: PortContext,
+        _request: FilteredPublishedProductsRequest,
+    ) -> Result<StorefrontProductList, PortError> {
+        Err(PortError::unavailable(
+            "product.filtered_published_list_unavailable",
+            "filtered product listing is unavailable",
+        ))
+    }
 
     /// Optional admin-list capability. Existing remote/test adapters remain source-compatible
     /// until they explicitly support this projection; mounted consumers fail closed otherwise.
@@ -76,6 +92,14 @@ pub struct PublishedProductsRequest {
     pub public_channel_slug: Option<String>,
     pub page: u64,
     pub per_page: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilteredPublishedProductsRequest {
+    pub locale: Option<String>,
+    pub fallback_locale: Option<String>,
+    pub public_channel_slug: Option<String>,
+    pub query: StorefrontProductListQuery,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,6 +191,29 @@ impl ProductCatalogReadPort for crate::CatalogService {
             request.public_channel_slug.as_deref(),
             request.page,
             request.per_page,
+        )
+        .await
+        .map_err(|error| product_error_to_port_error(&context, owner_operation, error))
+    }
+
+    async fn list_filtered_published_products(
+        &self,
+        context: PortContext,
+        request: FilteredPublishedProductsRequest,
+    ) -> Result<StorefrontProductList, PortError> {
+        let owner_operation = LIST_FILTERED_PUBLISHED_PRODUCTS_OPERATION;
+        context
+            .require_policy(PortCallPolicy::read())
+            .map_err(|error| product_context_error(&context, owner_operation, error))?;
+        let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
+        let locale = request.locale.as_deref().unwrap_or(context.locale.as_str());
+        crate::CatalogService::list_published_products_with_query(
+            self,
+            tenant_id,
+            locale,
+            request.fallback_locale.as_deref(),
+            request.public_channel_slug.as_deref(),
+            request.query,
         )
         .await
         .map_err(|error| product_error_to_port_error(&context, owner_operation, error))

--- a/scripts/verify/verify-commerce-product-storefront-graphql-read.mjs
+++ b/scripts/verify/verify-commerce-product-storefront-graphql-read.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`commerce Product storefront GraphQL read guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireText(source, text, message) {
+  if (!source.includes(text)) fail(message);
+}
+
+function forbidText(source, text, message) {
+  if (source.includes(text)) fail(message);
+}
+
+function resolverSlice(source, name, nextName) {
+  const start = source.indexOf(`async fn ${name}(`);
+  if (start < 0) {
+    fail(`missing resolver ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const ports = read("crates/rustok-product/src/ports.rs");
+for (const required of [
+  "async fn list_filtered_published_products(",
+  "pub struct FilteredPublishedProductsRequest",
+  "pub query: StorefrontProductListQuery",
+  "product.filtered_published_list_unavailable",
+  "filtered product listing is unavailable",
+  "LIST_FILTERED_PUBLISHED_PRODUCTS_OPERATION",
+  "CatalogService::list_published_products_with_query(",
+]) {
+  requireText(ports, required, `filtered Product read capability must contain ${required}`);
+}
+
+const publishedStart = ports.indexOf("pub struct PublishedProductsRequest");
+const filteredStart = ports.indexOf("pub struct FilteredPublishedProductsRequest", publishedStart);
+const published = ports.slice(publishedStart, filteredStart);
+for (const forbidden of ["search", "category_id", "sort_by", "attribute_filters", "query:"]) {
+  forbidText(
+    published,
+    forbidden,
+    `existing PublishedProductsRequest public shape must not gain filtered field ${forbidden}`,
+  );
+}
+
+const source = read("crates/rustok-commerce/src/graphql/product_catalog.rs");
+const storefront = resolverSlice(source, "storefront_product_catalog", "admin_product_catalog");
+const admin = resolverSlice(source, "admin_product_catalog", null);
+
+for (const required of [
+  "StorefrontProductListQuery::try_new_with_attribute_filters(",
+  ".with_pagination(page, per_page)",
+  "PortActor::service(\"commerce-storefront-graphql\")",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "public_channel_slug.as_deref()",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".read_port()",
+  ".list_filtered_published_products(",
+  "rustok_product::FilteredPublishedProductsRequest",
+  "fallback_locale: Some(tenant.default_locale.clone())",
+  "public_channel_slug,",
+  "query: list_query",
+  "product_catalog_port_error(&port_context, error, \"storefront_product_catalog\")",
+]) {
+  requireText(storefront, required, `storefront Product catalog resolver must contain ${required}`);
+}
+
+for (const forbidden of [
+  "CatalogService::new",
+  ".list_published_products_with_query(",
+  "product::Entity::find",
+  "product_translation::Entity::find",
+]) {
+  forbidText(storefront, forbidden, `storefront Product catalog resolver must not contain ${forbidden}`);
+}
+
+for (const required of [
+  ".list_admin_products(",
+  "product_catalog_port_error(&port_context, error, \"admin_product_catalog\")",
+]) {
+  requireText(admin, required, `admin Product catalog cutover must remain intact: ${required}`);
+}
+forbidText(source, "CatalogService::new", "Product GraphQL catalog module must not construct CatalogService");
+
+for (const required of [
+  '"PRODUCT_VALIDATION"',
+  '"PRODUCT_TEMPORARILY_UNAVAILABLE"',
+  'extensions.set("correlation_id", context.correlation_id.to_string())',
+]) {
+  requireText(source, required, `shared Product GraphQL PortError mapper must contain ${required}`);
+}
+for (const forbidden of ["Error::new(error.message)", 'extensions.set("message", error.message)']) {
+  forbidText(source, forbidden, `Product GraphQL owner errors must not expose ${forbidden}`);
+}
+
+if (!process.exitCode) {
+  console.log("commerce Product storefront GraphQL read guard: source contract OK");
+}


### PR DESCRIPTION
## Summary

- publish an optional fail-closed filtered storefront-list capability on `ProductCatalogReadPort` without changing the existing `PublishedProductsRequest` public shape or requiring existing adapters to implement it
- cut mounted storefront Product GraphQL catalog reads from direct `CatalogService` construction to the host-selected `ProductCatalogReadRuntime` / `ProductCatalogReadPort`
- preserve search/category/sort/attribute filters, owner pagination validation, public-channel visibility, requested/default locale fallback, service actor/channel/deadline context, and unchanged GraphQL projection
- keep the already-merged admin Product GraphQL owner-port cutover intact and share the same stable correlation-aware public owner error boundary
- add an unexecuted source guard and update the canonical ecommerce plan without closing lifecycle/schema or the broad Product/Order/Payment/Fulfillment topology P0

## Validation

Source-reviewed only. Tests, source verifiers, Cargo checks, formatting, workflows/CI, and database/runtime scenarios were not run. Execution evidence remains open in the canonical plan.