### PR TITLE
refactor(commerce): read Product schema directories through owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -223,11 +223,19 @@ These are source-contract defects, not verification-only tasks.
   preserving search/category/sort/attribute filters, pagination validation, channel
   visibility, requested/default locale, service actor/deadline context, response
   projection, and correlation-aware stable public owner errors.
-- [ ] Cut remaining mounted Product REST delete/publish/unpublish lifecycle commands and
-  GraphQL product lifecycle/schema operations over to host-composed Product owner ports.
-  Direct Product entities, `CatalogService`, and `ProductCatalogSchemaService` remain
-  explicit source debt; repeatable lifecycle commands need an explicit caller
-  idempotency contract before cutover.
+- [x] Publish Product-owned `ProductCatalogSchemaReadPort` as an optional secondary
+  capability on `ProductCatalogReadRuntime`, preserving existing catalog-read runtime
+  construction, and cut mounted GraphQL `productAttributes`, `catalogCategories`, and
+  `productAttributeSchemas` to it with current-tenant/permission admission,
+  authenticated actor, trimmed locale, request channel, bounded deadline, and the
+  shared stable Product GraphQL public error mapper.
+- [ ] Cut remaining mounted Product schema reads (`productEffectiveForm`,
+  `productAttributeValues`, and `storefrontCatalogSearchOptions`), schema writes,
+  REST delete/publish/unpublish lifecycle commands, and remaining GraphQL Product
+  lifecycle operations over to host-composed Product owner ports. Direct Product
+  entities, `CatalogService`, and `ProductCatalogSchemaService` remain explicit source
+  debt; repeatable lifecycle commands need an explicit caller idempotency contract
+  before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -629,6 +637,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-product-admin-list-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-graphql-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-storefront-graphql-read.mjs`
+- [ ] `node scripts/verify/verify-product-catalog-schema-read-port.mjs`
 - [ ] `cargo xtask module validate commerce`
 - [ ] `cargo xtask module validate order`
 - [ ] `cargo xtask module validate payment`
@@ -662,8 +671,9 @@ Source inspection is not execution evidence.
   handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
   marketplace-financial topology, Product command-port, Product admin-detail read,
-  Product admin-list read, Product admin-GraphQL read, and Product storefront-GraphQL
-  read static guards against a repository checkout and retain their output.
+  Product admin-list read, Product admin-GraphQL read, Product storefront-GraphQL read,
+  and Product schema-directory read static guards against a repository checkout and
+  retain their output.
 
 ### Compile/tests
 
@@ -851,6 +861,10 @@ Source inspection is not execution evidence.
   storefront GraphQL catalog reads to the host-selected Product runtime/port without
   changing the existing published-list request, filter/pagination/channel semantics, or
   GraphQL projection; Product lifecycle/schema cutover remains open.
+- [x] Publish the optional Product schema-directory read capability on the host-selected
+  Product read runtime and cut `productAttributes`, `catalogCategories`, and
+  `productAttributeSchemas` away from direct `ProductCatalogSchemaService` construction;
+  effective-form/value/search-option schema reads and Product writes remain open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/src/graphql/product_catalog.rs
+++ b/crates/rustok-commerce/src/graphql/product_catalog.rs
@@ -14,7 +14,7 @@ use super::{
     require_storefront_channel_enabled,
 };
 
-fn product_catalog_port_error(
+pub(crate) fn product_catalog_port_error(
     context: &PortContext,
     error: PortError,
     operation: &'static str,

--- a/crates/rustok-commerce/src/graphql/query.rs
+++ b/crates/rustok-commerce/src/graphql/query.rs
@@ -56,6 +56,50 @@ fn first_non_empty(values: impl IntoIterator<Item = String>) -> String {
         .unwrap_or_default()
 }
 
+fn product_schema_read_port_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    actor: rustok_api::PortActor,
+    locale: &str,
+    operation: &'static str,
+) -> rustok_api::PortContext {
+    let context = rustok_api::PortContext::new(
+        tenant_id.to_string(),
+        actor,
+        locale,
+        format!("commerce-graphql-product-schema:{operation}:{tenant_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    ctx.data_opt::<RequestContext>()
+        .and_then(|request| request.channel_slug.as_deref())
+        .map(str::trim)
+        .filter(|channel| !channel.is_empty())
+        .map(|channel| context.clone().with_channel(channel))
+        .unwrap_or(context)
+}
+
+fn product_schema_read_port(
+    db: &DatabaseConnection,
+    event_bus: &TransactionalEventBus,
+    context: &rustok_api::PortContext,
+    operation: &'static str,
+) -> Result<std::sync::Arc<dyn rustok_product::ProductCatalogSchemaReadPort>> {
+    let runtime = crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+        db.clone(),
+        event_bus.clone(),
+    );
+    runtime.schema_read_port().ok_or_else(|| {
+        super::product_catalog::product_catalog_port_error(
+            context,
+            rustok_api::PortError::unavailable(
+                "product.schema_read_unavailable",
+                "product schema directory is unavailable",
+            ),
+            operation,
+        )
+    })
+}
+
 #[Object]
 impl CommerceQuery {
     /// Pricing-authoritative admin product detail.
@@ -1554,7 +1598,7 @@ impl CommerceQuery {
     ) -> Result<GqlProductAttributeList> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_READ],
             "Permission denied: products:read required",
@@ -1562,11 +1606,26 @@ impl CommerceQuery {
 
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        let items = service
-            .list_attributes(tenant_id, locale.trim())
+        let locale = locale.trim();
+        let port_context = product_schema_read_port_context(
+            ctx,
+            tenant_id,
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale,
+            "product_attributes",
+        );
+        let schema_read_port =
+            product_schema_read_port(db, event_bus, &port_context, "product_attributes")?;
+        let items = schema_read_port
+            .list_attributes(port_context.clone())
             .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
+            .map_err(|error| {
+                super::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "product_attributes",
+                )
+            })?
             .into_iter()
             .map(Into::into)
             .collect::<Vec<_>>();
@@ -1585,7 +1644,7 @@ impl CommerceQuery {
     ) -> Result<GqlCatalogCategoryList> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_READ],
             "Permission denied: products:read required",
@@ -1593,11 +1652,26 @@ impl CommerceQuery {
 
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        let items = service
-            .list_categories(tenant_id, locale.trim())
+        let locale = locale.trim();
+        let port_context = product_schema_read_port_context(
+            ctx,
+            tenant_id,
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale,
+            "catalog_categories",
+        );
+        let schema_read_port =
+            product_schema_read_port(db, event_bus, &port_context, "catalog_categories")?;
+        let items = schema_read_port
+            .list_categories(port_context.clone())
             .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
+            .map_err(|error| {
+                super::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "catalog_categories",
+                )
+            })?
             .into_iter()
             .map(Into::into)
             .collect::<Vec<_>>();
@@ -1616,7 +1690,7 @@ impl CommerceQuery {
     ) -> Result<GqlProductAttributeSchemaList> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_READ],
             "Permission denied: products:read required",
@@ -1624,11 +1698,30 @@ impl CommerceQuery {
 
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        let items = service
-            .list_schemas(tenant_id, locale.trim())
+        let locale = locale.trim();
+        let port_context = product_schema_read_port_context(
+            ctx,
+            tenant_id,
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale,
+            "product_attribute_schemas",
+        );
+        let schema_read_port = product_schema_read_port(
+            db,
+            event_bus,
+            &port_context,
+            "product_attribute_schemas",
+        )?;
+        let items = schema_read_port
+            .list_schemas(port_context.clone())
             .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
+            .map_err(|error| {
+                super::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "product_attribute_schemas",
+                )
+            })?
             .into_iter()
             .map(Into::into)
             .collect::<Vec<_>>();

--- a/crates/rustok-product/src/catalog_schema_read_port.rs
+++ b/crates/rustok-product/src/catalog_schema_read_port.rs
@@ -1,0 +1,169 @@
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use uuid::Uuid;
+
+use crate::services::{
+    CatalogCategoryListRecord, ProductAttributeListRecord, ProductAttributeSchemaListRecord,
+    ProductCatalogSchemaService,
+};
+
+const LIST_ATTRIBUTES_OPERATION: &str = "list_catalog_attributes";
+const LIST_CATEGORIES_OPERATION: &str = "list_catalog_categories";
+const LIST_SCHEMAS_OPERATION: &str = "list_attribute_schemas";
+
+/// Optional Product-owned read boundary for catalog schema directory projections.
+#[async_trait]
+pub trait ProductCatalogSchemaReadPort: Send + Sync {
+    async fn list_attributes(
+        &self,
+        context: PortContext,
+    ) -> Result<Vec<ProductAttributeListRecord>, PortError>;
+
+    async fn list_categories(
+        &self,
+        context: PortContext,
+    ) -> Result<Vec<CatalogCategoryListRecord>, PortError>;
+
+    async fn list_schemas(
+        &self,
+        context: PortContext,
+    ) -> Result<Vec<ProductAttributeSchemaListRecord>, PortError>;
+}
+
+#[async_trait]
+impl ProductCatalogSchemaReadPort for ProductCatalogSchemaService {
+    async fn list_attributes(
+        &self,
+        context: PortContext,
+    ) -> Result<Vec<ProductAttributeListRecord>, PortError> {
+        let owner_operation = LIST_ATTRIBUTES_OPERATION;
+        require_schema_read_context(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        ProductCatalogSchemaService::list_attributes(self, tenant_id, context.locale.as_str())
+            .await
+            .map_err(|error| schema_error_to_port_error(&context, owner_operation, error))
+    }
+
+    async fn list_categories(
+        &self,
+        context: PortContext,
+    ) -> Result<Vec<CatalogCategoryListRecord>, PortError> {
+        let owner_operation = LIST_CATEGORIES_OPERATION;
+        require_schema_read_context(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        ProductCatalogSchemaService::list_categories(self, tenant_id, context.locale.as_str())
+            .await
+            .map_err(|error| schema_error_to_port_error(&context, owner_operation, error))
+    }
+
+    async fn list_schemas(
+        &self,
+        context: PortContext,
+    ) -> Result<Vec<ProductAttributeSchemaListRecord>, PortError> {
+        let owner_operation = LIST_SCHEMAS_OPERATION;
+        require_schema_read_context(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        ProductCatalogSchemaService::list_schemas(self, tenant_id, context.locale.as_str())
+            .await
+            .map_err(|error| schema_error_to_port_error(&context, owner_operation, error))
+    }
+}
+
+fn require_schema_read_context(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .map_err(|error| {
+            tracing::warn!(
+                internal_code = %error.code,
+                internal_message = %error.message,
+                kind = ?error.kind,
+                retryable = error.retryable,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                operation = owner_operation,
+                code = "product.schema_context_invalid",
+                "Product catalog schema read context was rejected"
+            );
+            let PortError {
+                kind,
+                code,
+                retryable,
+                ..
+            } = error;
+            match kind {
+                PortErrorKind::Timeout => {
+                    PortError::timeout(code, "product schema request context is invalid")
+                }
+                PortErrorKind::Validation => {
+                    PortError::validation(code, "product schema request context is invalid")
+                }
+                kind => PortError::new(
+                    kind,
+                    "product.schema_context_invalid",
+                    "product schema request context is invalid",
+                    retryable,
+                ),
+            }
+        })
+}
+
+fn parse_tenant_id(context: &PortContext, owner_operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+        tracing::warn!(
+            error = ?error,
+            internal_tenant_id = %context.tenant_id,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation = owner_operation,
+            code = "product.tenant_id_invalid",
+            "Product catalog schema tenant context is invalid"
+        );
+        PortError::validation(
+            "product.tenant_id_invalid",
+            "product schema request context is invalid",
+        )
+    })
+}
+
+fn schema_error_to_port_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    error: crate::CommerceError,
+) -> PortError {
+    use crate::CommerceError;
+
+    let code = match &error {
+        CommerceError::Database(_) => "product.database_unavailable",
+        CommerceError::Validation(_) => "product.validation",
+        CommerceError::ProductNotFound(_) => "product.product_not_found",
+        _ => "product.invariant_violation",
+    };
+    tracing::error!(
+        error = ?error,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation = owner_operation,
+        code,
+        "Product catalog schema owner read failed"
+    );
+
+    match error {
+        CommerceError::Database(_) => PortError::unavailable(
+            "product.database_unavailable",
+            "product storage is temporarily unavailable",
+        ),
+        CommerceError::Validation(_) => {
+            PortError::validation("product.validation", "product request is invalid")
+        }
+        CommerceError::ProductNotFound(_) => {
+            PortError::not_found("product.product_not_found", "product was not found")
+        }
+        _ => PortError::invariant_violation(
+            "product.invariant_violation",
+            "product operation could not be completed safely",
+        ),
+    }
+}

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -15,6 +15,7 @@ use rustok_seo_targets::register_seo_target_provider;
 use sea_orm_migration::MigrationTrait;
 
 mod catalog_command_port;
+mod catalog_schema_read_port;
 pub mod dto;
 pub mod entities;
 pub mod error;
@@ -26,6 +27,7 @@ mod seo_targets;
 pub mod services;
 
 pub use catalog_command_port::ProductCatalogCommandPort;
+pub use catalog_schema_read_port::ProductCatalogSchemaReadPort;
 pub use error::{CommerceError, CommerceResult};
 pub use ports::*;
 pub use public_error::{ProductPublicError, map_product_public_error};

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -59,7 +59,10 @@ impl ProductCatalogReadRuntime {
         Self::new(read_port, ProductCatalogReadProfile::External)
     }
 
-    pub fn with_schema_read_port(mut self, schema_read_port: Arc<dyn ProductCatalogSchemaReadPort>) -> Self {
+    pub fn with_schema_read_port(
+        mut self,
+        schema_read_port: Arc<dyn ProductCatalogSchemaReadPort>,
+    ) -> Self {
         self.schema_read_port = Some(schema_read_port);
         self
     }

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 
-use crate::{CatalogService, ProductCatalogCommandPort, ProductCatalogReadPort};
+use crate::{
+    CatalogService, ProductCatalogCommandPort, ProductCatalogReadPort, ProductCatalogSchemaReadPort,
+    ProductCatalogSchemaService,
+};
 
 /// Host-selected execution profile for the Product catalog read boundary.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -28,6 +31,7 @@ impl ProductCatalogReadProfile {
 #[derive(Clone)]
 pub struct ProductCatalogReadRuntime {
     read_port: Arc<dyn ProductCatalogReadPort>,
+    schema_read_port: Option<Arc<dyn ProductCatalogSchemaReadPort>>,
     profile: ProductCatalogReadProfile,
 }
 
@@ -36,22 +40,36 @@ impl ProductCatalogReadRuntime {
         read_port: Arc<dyn ProductCatalogReadPort>,
         profile: ProductCatalogReadProfile,
     ) -> Self {
-        Self { read_port, profile }
+        Self {
+            read_port,
+            schema_read_port: None,
+            profile,
+        }
     }
 
     pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
         Self::new(
-            Arc::new(CatalogService::new(db, event_bus)),
+            Arc::new(CatalogService::new(db.clone(), event_bus.clone())),
             ProductCatalogReadProfile::EmbeddedNative,
         )
+        .with_schema_read_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))
     }
 
     pub fn external(read_port: Arc<dyn ProductCatalogReadPort>) -> Self {
         Self::new(read_port, ProductCatalogReadProfile::External)
     }
 
+    pub fn with_schema_read_port(mut self, schema_read_port: Arc<dyn ProductCatalogSchemaReadPort>) -> Self {
+        self.schema_read_port = Some(schema_read_port);
+        self
+    }
+
     pub fn read_port(&self) -> Arc<dyn ProductCatalogReadPort> {
         self.read_port.clone()
+    }
+
+    pub fn schema_read_port(&self) -> Option<Arc<dyn ProductCatalogSchemaReadPort>> {
+        self.schema_read_port.clone()
     }
 
     pub const fn profile(&self) -> ProductCatalogReadProfile {

--- a/scripts/verify/verify-product-catalog-schema-read-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-read-port.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`Product catalog schema read-port guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireText(source, text, message) {
+  if (!source.includes(text)) fail(message);
+}
+
+const port = read("crates/rustok-product/src/catalog_schema_read_port.rs");
+for (const required of [
+  "pub trait ProductCatalogSchemaReadPort",
+  "async fn list_attributes(",
+  "async fn list_categories(",
+  "async fn list_schemas(",
+  "require_policy(PortCallPolicy::read())",
+  "ProductCatalogSchemaService::list_attributes(",
+  "ProductCatalogSchemaService::list_categories(",
+  "ProductCatalogSchemaService::list_schemas(",
+  "correlation_id = %context.correlation_id",
+  '"product.database_unavailable"',
+  '"product.validation"',
+]) {
+  requireText(port, required, `schema read port must contain ${required}`);
+}
+
+const runtime = read("crates/rustok-product/src/runtime.rs");
+for (const required of [
+  "schema_read_port: Option<Arc<dyn ProductCatalogSchemaReadPort>>",
+  "schema_read_port: None",
+  ".with_schema_read_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))",
+  "pub fn with_schema_read_port(",
+  "pub fn schema_read_port(&self)",
+]) {
+  requireText(runtime, required, `Product read runtime must contain ${required}`);
+}
+
+const lib = read("crates/rustok-product/src/lib.rs");
+for (const required of [
+  "mod catalog_schema_read_port;",
+  "pub use catalog_schema_read_port::ProductCatalogSchemaReadPort;",
+]) {
+  requireText(lib, required, `Product root must contain ${required}`);
+}
+
+const commerceQuery = read("crates/rustok-commerce/src/graphql/query.rs");
+requireText(
+  commerceQuery,
+  "ProductCatalogSchemaService::new",
+  "Commerce GraphQL schema-directory consumer cutover must remain explicit follow-up debt",
+);
+
+if (!process.exitCode) {
+  console.log("Product catalog schema read-port guard: source contract OK");
+}

--- a/scripts/verify/verify-product-catalog-schema-read-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-read-port.mjs
@@ -20,6 +20,20 @@ function requireText(source, text, message) {
   if (!source.includes(text)) fail(message);
 }
 
+function forbidText(source, text, message) {
+  if (source.includes(text)) fail(message);
+}
+
+function resolverSlice(source, name, nextName) {
+  const start = source.indexOf(`async fn ${name}(`);
+  if (start < 0) {
+    fail(`missing resolver ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
 const port = read("crates/rustok-product/src/catalog_schema_read_port.rs");
 for (const required of [
   "pub trait ProductCatalogSchemaReadPort",
@@ -56,11 +70,59 @@ for (const required of [
   requireText(lib, required, `Product root must contain ${required}`);
 }
 
-const commerceQuery = read("crates/rustok-commerce/src/graphql/query.rs");
+const productCatalog = read("crates/rustok-commerce/src/graphql/product_catalog.rs");
 requireText(
+  productCatalog,
+  "pub(crate) fn product_catalog_port_error(",
+  "Product GraphQL port-error mapper must be reusable by schema directory resolvers",
+);
+
+const commerceQuery = read("crates/rustok-commerce/src/graphql/query.rs");
+for (const required of [
+  "fn product_schema_read_port_context(",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "fn product_schema_read_port(",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".schema_read_port()",
+  '"product.schema_read_unavailable"',
+]) {
+  requireText(commerceQuery, required, `Commerce schema read boundary must contain ${required}`);
+}
+
+const resolvers = [
+  ["product_attributes", "catalog_categories", ".list_attributes("],
+  ["catalog_categories", "product_attribute_schemas", ".list_categories("],
+  ["product_attribute_schemas", "product_effective_form", ".list_schemas("],
+];
+for (const [name, nextName, ownerCall] of resolvers) {
+  const resolver = resolverSlice(commerceQuery, name, nextName);
+  for (const required of [
+    "let auth = require_commerce_permission(",
+    "product_query_tenant(ctx, tenant_id)",
+    "rustok_api::PortActor::user(auth.user_id.to_string())",
+    "product_schema_read_port_context(",
+    "product_schema_read_port(",
+    ownerCall,
+    "product_catalog_port_error(",
+  ]) {
+    requireText(resolver, required, `${name} must contain ${required}`);
+  }
+  forbidText(
+    resolver,
+    "ProductCatalogSchemaService::new",
+    `${name} must not construct ProductCatalogSchemaService`,
+  );
+}
+
+const effectiveForm = resolverSlice(
   commerceQuery,
+  "product_effective_form",
+  "product_attribute_values",
+);
+requireText(
+  effectiveForm,
   "ProductCatalogSchemaService::new",
-  "Commerce GraphQL schema-directory consumer cutover must remain explicit follow-up debt",
+  "productEffectiveForm must remain explicit follow-up debt in this bounded slice",
 );
 
 if (!process.exitCode) {


### PR DESCRIPTION
## Summary

- publish Product-owned `ProductCatalogSchemaReadPort` for attribute, category, and attribute-schema directory projections
- attach it as an optional secondary capability on the existing `ProductCatalogReadRuntime`: existing `new` / `external` callers remain source-compatible, embedded runtime composes the owner schema service automatically, and external hosts may opt in with `with_schema_read_port`
- cut mounted GraphQL `productAttributes`, `catalogCategories`, and `productAttributeSchemas` from direct `ProductCatalogSchemaService` construction to the host-selected Product runtime capability
- preserve current-tenant and `PRODUCTS_READ` admission, authenticated actor, trimmed locale, request channel, bounded read deadline, unchanged GraphQL DTO projection, and the shared stable correlation-aware Product public error envelope
- fail closed through the same safe public error boundary when a selected external Product runtime does not provide the schema-directory capability
- keep `productEffectiveForm`, `productAttributeValues`, `storefrontCatalogSearchOptions`, schema writes, Product lifecycle commands, and other direct Product query/source debt as explicit follow-up work
- add an unexecuted source guard and update the canonical ecommerce plan without closing the broad Product/Order/Payment/Fulfillment topology P0 or promoting FBA/FFA status

## Validation

Source-reviewed only. Tests, source verifiers, Cargo checks, formatting commands, workflows/CI, and database/runtime scenarios were not run. Execution evidence remains open in the canonical plan.