### PR TITLE
test(index): retain Product Channel convergence PostgreSQL packet

### DIFF
--- a/crates/rustok-distribution/tests/product_channel_convergence_postgres.rs
+++ b/crates/rustok-distribution/tests/product_channel_convergence_postgres.rs
@@ -1,0 +1,818 @@
+#![cfg(feature = "mod-product")]
+
+use std::{env, error::Error, time::Duration};
+
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation, IndexQuery,
+    IndexQueryPort, IndexQueryScope, IndexSourceLoadRequest, IndexValue, LocaleKey, ModuleName,
+    MutationApplyOutcome, MutationDelivery, Pagination, PostgresMutationStore,
+    PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion, SharedIndexQueryRuntime,
+    SharedIndexSchemaRegistry, SharedIndexSourceRegistry, materialize_index_source_registry,
+    materialize_postgres_index_query_runtime, materialize_postgres_index_sources,
+};
+use rustok_product::{
+    ProductSalesChannelIndexRelationConvergenceClaimOutcome,
+    ProductSalesChannelIndexRelationConvergenceStore,
+    ProductSalesChannelIndexRelationConvergenceWork,
+};
+use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistrations, ModuleWorkScheduler};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const UNRESTRICTED_PRODUCT_ID: Uuid = Uuid::from_u128(101);
+const MALFORMED_PRODUCT_ID: Uuid = Uuid::from_u128(102);
+const VALID_AFTER_MALFORMED_PRODUCT_ID: Uuid = Uuid::from_u128(103);
+const RESTRICTED_PRODUCT_ID: Uuid = Uuid::from_u128(104);
+const ALPHA_CHANNEL_ID: Uuid = Uuid::from_u128(201);
+const BETA_CHANNEL_ID: Uuid = Uuid::from_u128(202);
+const UNRESTRICTED_TRANSLATION_ID: Uuid = Uuid::from_u128(301);
+const MALFORMED_TRANSLATION_ID: Uuid = Uuid::from_u128(302);
+const VALID_AFTER_MALFORMED_TRANSLATION_ID: Uuid = Uuid::from_u128(303);
+const RESTRICTED_TRANSLATION_ID: Uuid = Uuid::from_u128(304);
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct ProductMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for ProductMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_product::migrations::migrations()
+    }
+}
+
+struct ChannelMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for ChannelMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_channel::migrations::migrations()
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    migration: DatabaseConnection,
+    host_a: DatabaseConnection,
+    host_b: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    writer: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Product/Channel convergence harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_product_channel_convergence_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_product_channel_convergence_migration_{suffix}"),
+        )
+        .await?;
+        create_migration_prerequisites(&migration).await?;
+        ChannelMigrator::up(&migration, None).await?;
+        ProductMigrator::up(&migration, None).await?;
+        let manager = SchemaManager::new(&migration);
+        for migration_step in IndexModule.migrations() {
+            migration_step.up(&manager).await?;
+        }
+        seed_owner_rows(&migration).await?;
+
+        Ok(Some(Self {
+            control,
+            migration,
+            host_a: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_channel_convergence_host_a_{suffix}"),
+            )
+            .await?,
+            host_b: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_channel_convergence_host_b_{suffix}"),
+            )
+            .await?,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_channel_convergence_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_channel_convergence_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_channel_convergence_query_{suffix}"),
+            )
+            .await?,
+            writer: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_channel_convergence_writer_{suffix}"),
+            )
+            .await?,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.migration.close().await?;
+        self.host_a.close().await?;
+        self.host_b.close().await?;
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.writer.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct ProductRuntime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+    scheduler_a: ModuleWorkScheduler,
+    scheduler_b: ModuleWorkScheduler,
+}
+
+#[tokio::test]
+async fn product_channel_convergence_is_restartable_and_query_fenced() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let result = run_scenarios(&database).await;
+    let cleanup = database.cleanup().await;
+    result?;
+    cleanup
+}
+
+async fn run_scenarios(database: &TestDatabase) -> TestResult<()> {
+    let runtime = build_product_runtime(database).await?;
+    let initial_generation = current_channel_generation(&database.writer).await?;
+    assert!(initial_generation > 0);
+
+    // Host A claims through the same Product-owned store used by the registered ModuleWork source,
+    // then disappears before handler execution. Host B must not claim while the lease is live and
+    // must reclaim the exact durable request after expiry without losing tenant progress.
+    let store_a = ProductSalesChannelIndexRelationConvergenceStore::new(database.host_a.clone());
+    let first_claim = match store_a
+        .claim(TENANT_ID, initial_generation, Duration::from_secs(1))
+        .await?
+    {
+        ProductSalesChannelIndexRelationConvergenceClaimOutcome::Claimed(claim) => claim,
+        other => {
+            return Err(std::io::Error::other(format!(
+                "expected initial convergence claim, got {other:?}"
+            ))
+            .into());
+        }
+    };
+    let first_sequence = match first_claim.work() {
+        ProductSalesChannelIndexRelationConvergenceWork::VisibilityRequest { sequence_no, .. } => {
+            *sequence_no
+        }
+        other => {
+            return Err(std::io::Error::other(format!(
+                "expected first Product visibility request, got {other:?}"
+            ))
+            .into());
+        }
+    };
+    assert_eq!(runtime.scheduler_b.run_once().await?, 0);
+    assert_active_lease(&database.writer, first_claim.lease_token(), 1).await?;
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    assert_eq!(runtime.scheduler_b.run_once().await?, 1);
+    assert_reclaimed_progress(&database.writer, first_sequence).await?;
+
+    // Finish all initial Product requests plus the Channel-generation baseline sweep through the
+    // real generic scheduler. The malformed Product sorts before a valid Product in tenant sweep
+    // order; valid convergence must continue even though malformed owner visibility stays fail-closed.
+    run_scheduler_until_idle(&runtime.scheduler_b, 32).await?;
+    let baseline_generation = current_channel_generation(&database.writer).await?;
+    assert_eq!(baseline_generation, initial_generation);
+    assert_state_checkpoint(&database.writer, baseline_generation).await?;
+    assert_no_relation_or_freshness(&database.writer, MALFORMED_PRODUCT_ID).await?;
+    assert_freshness_generation(
+        &database.writer,
+        VALID_AFTER_MALFORMED_PRODUCT_ID,
+        baseline_generation,
+    )
+    .await?;
+
+    assert_eq!(
+        latest_relation_membership(&database.writer, UNRESTRICTED_PRODUCT_ID).await?.1,
+        vec![ALPHA_CHANNEL_ID, BETA_CHANNEL_ID]
+    );
+    assert_eq!(
+        latest_relation_membership(&database.writer, RESTRICTED_PRODUCT_ID).await?.1,
+        vec![ALPHA_CHANNEL_ID]
+    );
+
+    // Materialize only query-valid baseline Products. The malformed Product deliberately has no
+    // Product relation/freshness evidence and is never allowed to become an Index authority.
+    for product_id in [UNRESTRICTED_PRODUCT_ID, VALID_AFTER_MALFORMED_PRODUCT_ID] {
+        let mutation = load_product_mutation(&runtime.sources, product_id).await?;
+        apply_product_mutation(&runtime, mutation).await?;
+        assert_product_visible(&runtime.query, product_id, true).await?;
+    }
+
+    // Visibility race: read a valid restricted Product mutation, then switch alpha -> beta before
+    // applying it. The old mutation is physically accepted but root query admission must hide it.
+    let delayed_visibility = load_product_mutation(&runtime.sources, RESTRICTED_PRODUCT_ID).await?;
+    let delayed_visibility_version = delayed_visibility.source_version();
+    let (before_visibility_relation, _) =
+        latest_relation_membership(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    let before_visibility_projection =
+        latest_projection_epoch(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    update_restricted_visibility(&database.writer, "beta").await?;
+    assert!(
+        latest_projection_epoch(&database.writer, RESTRICTED_PRODUCT_ID).await?
+            > delayed_visibility_version
+    );
+    apply_product_mutation(&runtime, delayed_visibility).await?;
+    assert_materialized_source_version(
+        &database.mutation,
+        RESTRICTED_PRODUCT_ID,
+        delayed_visibility_version,
+    )
+    .await?;
+    assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, false).await?;
+
+    // Host A can resume the same durable queue after Host B performed restart recovery.
+    run_scheduler_until_idle(&runtime.scheduler_a, 16).await?;
+    let (after_visibility_relation, visibility_membership) =
+        latest_relation_membership(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    let after_visibility_projection =
+        latest_projection_epoch(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    assert!(after_visibility_relation > before_visibility_relation);
+    assert!(after_visibility_projection > before_visibility_projection);
+    assert_eq!(visibility_membership, vec![BETA_CHANNEL_ID]);
+    assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, false).await?;
+    let current_restricted = load_product_mutation(&runtime.sources, RESTRICTED_PRODUCT_ID).await?;
+    assert!(current_restricted.source_version() > delayed_visibility_version);
+    apply_product_mutation(&runtime, current_restricted).await?;
+    assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, true).await?;
+
+    // Channel identity generation changes while unrestricted UUID membership stays identical. The
+    // query fence hides the already-materialized Product until convergence refreshes the witness.
+    // Relation/projection clocks must not move, and the same Index mutation becomes admissible again.
+    let unrestricted_relation_before =
+        latest_relation_membership(&database.writer, UNRESTRICTED_PRODUCT_ID).await?.0;
+    let unrestricted_projection_before =
+        latest_projection_epoch(&database.writer, UNRESTRICTED_PRODUCT_ID).await?;
+    rename_channel(&database.writer, ALPHA_CHANNEL_ID, "alpha-renamed").await?;
+    let generation_after_alpha_rename = current_channel_generation(&database.writer).await?;
+    assert!(generation_after_alpha_rename > baseline_generation);
+    assert_product_visible(&runtime.query, UNRESTRICTED_PRODUCT_ID, false).await?;
+    run_scheduler_until_idle(&runtime.scheduler_b, 16).await?;
+    assert_eq!(
+        latest_relation_membership(&database.writer, UNRESTRICTED_PRODUCT_ID).await?.0,
+        unrestricted_relation_before
+    );
+    assert_eq!(
+        latest_projection_epoch(&database.writer, UNRESTRICTED_PRODUCT_ID).await?,
+        unrestricted_projection_before
+    );
+    assert_freshness_generation(
+        &database.writer,
+        UNRESTRICTED_PRODUCT_ID,
+        generation_after_alpha_rename,
+    )
+    .await?;
+    assert_freshness_generation(
+        &database.writer,
+        VALID_AFTER_MALFORMED_PRODUCT_ID,
+        generation_after_alpha_rename,
+    )
+    .await?;
+    assert_no_relation_or_freshness(&database.writer, MALFORMED_PRODUCT_ID).await?;
+    assert_product_visible(&runtime.query, UNRESTRICTED_PRODUCT_ID, true).await?;
+
+    // A second Channel rename removes beta from the restricted visibility result. Convergence must
+    // advance relation/projection for the restricted Product while leaving unrestricted membership
+    // unchanged. The old restricted Index row stays hidden until its new projection is applied.
+    let restricted_relation_before_beta =
+        latest_relation_membership(&database.writer, RESTRICTED_PRODUCT_ID).await?.0;
+    let restricted_projection_before_beta =
+        latest_projection_epoch(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    let unrestricted_relation_before_beta =
+        latest_relation_membership(&database.writer, UNRESTRICTED_PRODUCT_ID).await?.0;
+    let unrestricted_projection_before_beta =
+        latest_projection_epoch(&database.writer, UNRESTRICTED_PRODUCT_ID).await?;
+    rename_channel(&database.writer, BETA_CHANNEL_ID, "beta-renamed").await?;
+    let generation_after_beta_rename = current_channel_generation(&database.writer).await?;
+    assert!(generation_after_beta_rename > generation_after_alpha_rename);
+    assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, false).await?;
+    run_scheduler_until_idle(&runtime.scheduler_a, 16).await?;
+
+    let (restricted_relation_after_beta, restricted_membership_after_beta) =
+        latest_relation_membership(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    let restricted_projection_after_beta =
+        latest_projection_epoch(&database.writer, RESTRICTED_PRODUCT_ID).await?;
+    assert!(restricted_relation_after_beta > restricted_relation_before_beta);
+    assert!(restricted_projection_after_beta > restricted_projection_before_beta);
+    assert!(restricted_membership_after_beta.is_empty());
+    assert_eq!(
+        latest_relation_membership(&database.writer, UNRESTRICTED_PRODUCT_ID).await?.0,
+        unrestricted_relation_before_beta
+    );
+    assert_eq!(
+        latest_projection_epoch(&database.writer, UNRESTRICTED_PRODUCT_ID).await?,
+        unrestricted_projection_before_beta
+    );
+    assert_freshness_generation(
+        &database.writer,
+        UNRESTRICTED_PRODUCT_ID,
+        generation_after_beta_rename,
+    )
+    .await?;
+    assert_product_visible(&runtime.query, UNRESTRICTED_PRODUCT_ID, true).await?;
+    assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, false).await?;
+
+    let current_after_beta = load_product_mutation(&runtime.sources, RESTRICTED_PRODUCT_ID).await?;
+    assert_eq!(
+        current_after_beta.source_version(),
+        restricted_projection_after_beta
+    );
+    apply_product_mutation(&runtime, current_after_beta).await?;
+    assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, true).await?;
+    assert_state_checkpoint(&database.writer, generation_after_beta_rename).await?;
+    Ok(())
+}
+
+async fn build_product_runtime(database: &TestDatabase) -> TestResult<ProductRuntime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Index schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for registered in schemas.registry().iter() {
+        schema_store.register(TENANT_ID, &registered.schema).await?;
+    }
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Index source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Index query runtime is missing"))?;
+    let registrations = extensions
+        .get::<ModuleWorkRegistrations>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product convergence work is not registered"))?;
+    let scheduler_a = ModuleWorkScheduler::new();
+    let scheduler_b = ModuleWorkScheduler::new();
+    registrations
+        .register_all(&HostRuntimeContext::new(database.host_a.clone()), &scheduler_a)
+        .await?;
+    registrations
+        .register_all(&HostRuntimeContext::new(database.host_b.clone()), &scheduler_b)
+        .await?;
+    Ok(ProductRuntime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+        scheduler_a,
+        scheduler_b,
+    })
+}
+
+async fn run_scheduler_until_idle(
+    scheduler: &ModuleWorkScheduler,
+    maximum_iterations: usize,
+) -> TestResult<usize> {
+    let mut executed = 0;
+    for _ in 0..maximum_iterations {
+        let current = scheduler.run_once().await?;
+        if current == 0 {
+            return Ok(executed);
+        }
+        executed += current;
+    }
+    Err(std::io::Error::other(format!(
+        "ModuleWork scheduler did not become idle after {maximum_iterations} bounded iterations"
+    ))
+    .into())
+}
+
+async fn load_product_mutation(
+    sources: &SharedIndexSourceRegistry,
+    product_id: Uuid,
+) -> TestResult<IndexMutation> {
+    let request = IndexSourceLoadRequest::new(vec![product_key(product_id)?])?;
+    let mut mutations = sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected one Product mutation, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    Ok(mutations.remove(0))
+}
+
+async fn apply_product_mutation(runtime: &ProductRuntime, mutation: IndexMutation) -> TestResult<()> {
+    let source_version = mutation.source_version();
+    let delivery = MutationDelivery::from_event(PRODUCT_SOURCE, mutation)?;
+    let outcome = runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?;
+    match outcome {
+        MutationApplyOutcome::Applied {
+            source_version: applied,
+        } if applied == source_version => Ok(()),
+        other => Err(std::io::Error::other(format!(
+            "expected Product mutation {source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn assert_product_visible(
+    query: &SharedIndexQueryRuntime,
+    product_id: Uuid,
+    expected: bool,
+) -> TestResult<()> {
+    let page = query.execute_query(product_identity_query(product_id)?).await?;
+    assert_eq!(page.items.len(), usize::from(expected));
+    assert_eq!(page.exact_count, Some(u64::from(expected)));
+    if expected {
+        assert_eq!(page.items[0].entity_id, product_id);
+    }
+    Ok(())
+}
+
+fn product_identity_query(product_id: Uuid) -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: TENANT_ID,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: product_schema_ref()?,
+        fields: vec![FieldPath::new(FieldName::new("title")?)],
+        filter: Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("id")?),
+            IndexValue::Uuid(product_id),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+fn product_key(product_id: Uuid) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: product_schema_ref()?,
+        entity_id: product_id,
+        locale: Some(LocaleKey::new("en")?),
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        version: SchemaVersion::new(3),
+    })
+}
+
+async fn current_channel_generation(db: &DatabaseConnection) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT generation FROM channel_index_identity_generations WHERE tenant_id = $1",
+            vec![TENANT_ID.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Channel identity generation is missing"))?;
+    let generation: i64 = row.try_get("", "generation")?;
+    Ok(u64::try_from(generation)?)
+}
+
+async fn latest_relation_membership(
+    db: &DatabaseConnection,
+    product_id: Uuid,
+) -> TestResult<(u64, Vec<Uuid>)> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT relation_epoch, channel_ids
+FROM product_sales_channel_index_relation_snapshots
+WHERE tenant_id = $1 AND product_id = $2
+ORDER BY relation_epoch DESC
+LIMIT 1
+"#,
+            vec![TENANT_ID.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product relation snapshot is missing"))?;
+    let epoch: i64 = row.try_get("", "relation_epoch")?;
+    let channel_ids: JsonValue = row.try_get("", "channel_ids")?;
+    let mut decoded = channel_ids
+        .as_array()
+        .ok_or_else(|| std::io::Error::other("relation channel_ids is not an array"))?
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| std::io::Error::other("relation channel id is not text"))
+                .and_then(|value| Uuid::parse_str(value).map_err(std::io::Error::other))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    decoded.sort_unstable();
+    Ok((u64::try_from(epoch)?, decoded))
+}
+
+async fn latest_projection_epoch(db: &DatabaseConnection, product_id: Uuid) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT projection_epoch
+FROM product_index_graph_projection_snapshots
+WHERE tenant_id = $1 AND product_id = $2
+ORDER BY projection_epoch DESC
+LIMIT 1
+"#,
+            vec![TENANT_ID.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product projection is missing"))?;
+    let epoch: i64 = row.try_get("", "projection_epoch")?;
+    Ok(u64::try_from(epoch)?)
+}
+
+async fn assert_freshness_generation(
+    db: &DatabaseConnection,
+    product_id: Uuid,
+    expected_generation: u64,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT channel_identity_generation
+FROM product_sales_channel_index_relation_freshness_snapshots
+WHERE tenant_id = $1 AND product_id = $2
+ORDER BY sequence_no DESC
+LIMIT 1
+"#,
+            vec![TENANT_ID.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product freshness witness is missing"))?;
+    let generation: i64 = row.try_get("", "channel_identity_generation")?;
+    assert_eq!(u64::try_from(generation)?, expected_generation);
+    Ok(())
+}
+
+async fn assert_no_relation_or_freshness(
+    db: &DatabaseConnection,
+    product_id: Uuid,
+) -> TestResult<()> {
+    for table in [
+        "product_sales_channel_index_relation_snapshots",
+        "product_sales_channel_index_relation_freshness_snapshots",
+    ] {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                format!(
+                    "SELECT COUNT(*)::bigint AS row_count FROM {table} WHERE tenant_id = $1 AND product_id = $2"
+                ),
+                vec![TENANT_ID.into(), product_id.into()],
+            ))
+            .await?
+            .ok_or_else(|| std::io::Error::other("count query returned no row"))?;
+        let count: i64 = row.try_get("", "row_count")?;
+        assert_eq!(count, 0, "malformed Product unexpectedly wrote {table}");
+    }
+    Ok(())
+}
+
+async fn assert_active_lease(
+    db: &DatabaseConnection,
+    expected_token: Uuid,
+    expected_attempt_count: i64,
+) -> TestResult<()> {
+    let row = convergence_state(db).await?;
+    let lease_token: Option<Uuid> = row.try_get("", "lease_token")?;
+    let attempt_count: i64 = row.try_get("", "attempt_count")?;
+    assert_eq!(lease_token, Some(expected_token));
+    assert_eq!(attempt_count, expected_attempt_count);
+    Ok(())
+}
+
+async fn assert_reclaimed_progress(db: &DatabaseConnection, first_sequence: i64) -> TestResult<()> {
+    let row = convergence_state(db).await?;
+    let visibility_cursor: i64 = row.try_get("", "visibility_cursor")?;
+    let lease_token: Option<Uuid> = row.try_get("", "lease_token")?;
+    let attempt_count: i64 = row.try_get("", "attempt_count")?;
+    assert_eq!(visibility_cursor, first_sequence);
+    assert!(lease_token.is_none());
+    assert_eq!(attempt_count, 2);
+    Ok(())
+}
+
+async fn assert_state_checkpoint(db: &DatabaseConnection, generation: u64) -> TestResult<()> {
+    let row = convergence_state(db).await?;
+    let channel_generation: Option<i64> = row.try_get("", "channel_identity_generation")?;
+    let sweep_generation: Option<i64> = row.try_get("", "sweep_generation")?;
+    let sweep_after: Option<Uuid> = row.try_get("", "sweep_after_product_id")?;
+    let lease_token: Option<Uuid> = row.try_get("", "lease_token")?;
+    assert_eq!(channel_generation, Some(i64::try_from(generation)?));
+    assert!(sweep_generation.is_none());
+    assert!(sweep_after.is_none());
+    assert!(lease_token.is_none());
+    Ok(())
+}
+
+async fn convergence_state(db: &DatabaseConnection) -> TestResult<sea_orm::QueryResult> {
+    db.query_one(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"
+SELECT visibility_cursor, channel_identity_generation, sweep_generation, sweep_after_product_id,
+       lease_token, lease_expires_at, attempt_count, last_error
+FROM product_sales_channel_index_relation_convergence_state
+WHERE tenant_id = $1
+"#,
+        vec![TENANT_ID.into()],
+    ))
+    .await?
+    .ok_or_else(|| std::io::Error::other("Product convergence state is missing").into())
+}
+
+async fn assert_materialized_source_version(
+    db: &DatabaseConnection,
+    product_id: Uuid,
+    expected_source_version: u64,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(source_version AS TEXT) AS source_version_text
+FROM index_entities
+WHERE tenant_id = $1
+  AND module_name = 'rustok-product'
+  AND entity_name = 'product'
+  AND schema_version = 3
+  AND entity_id = $2
+  AND locale_key = 'en'
+  AND is_deleted = FALSE
+"#,
+            vec![TENANT_ID.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("materialized Product row is missing"))?;
+    let source_version: String = row.try_get("", "source_version_text")?;
+    assert_eq!(source_version.parse::<u64>()?, expected_source_version);
+    Ok(())
+}
+
+async fn update_restricted_visibility(db: &DatabaseConnection, slug: &str) -> TestResult<()> {
+    let metadata = serde_json::json!({
+        "channel_visibility": {"allowed_channel_slugs": [slug]}
+    });
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "UPDATE products SET metadata = $3 WHERE tenant_id = $1 AND id = $2",
+        vec![TENANT_ID.into(), RESTRICTED_PRODUCT_ID.into(), metadata.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn rename_channel(db: &DatabaseConnection, channel_id: Uuid, slug: &str) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "UPDATE channels SET slug = $3 WHERE tenant_id = $1 AND id = $2",
+        vec![TENANT_ID.into(), channel_id.into(), slug.to_owned().into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE oauth_apps (
+    id UUID PRIMARY KEY
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_owner_rows(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+
+INSERT INTO channels (id, tenant_id, slug, name) VALUES
+    ('{ALPHA_CHANNEL_ID}', '{TENANT_ID}', 'alpha', 'Alpha'),
+    ('{BETA_CHANNEL_ID}', '{TENANT_ID}', 'beta', 'Beta');
+
+INSERT INTO products (id, tenant_id, metadata) VALUES
+    ('{UNRESTRICTED_PRODUCT_ID}', '{TENANT_ID}', '{{}}'::jsonb),
+    ('{MALFORMED_PRODUCT_ID}', '{TENANT_ID}',
+        '{{"channel_visibility":{{"allowed_channel_slugs":[" Alpha "]}}}}'::jsonb),
+    ('{VALID_AFTER_MALFORMED_PRODUCT_ID}', '{TENANT_ID}', '{{}}'::jsonb),
+    ('{RESTRICTED_PRODUCT_ID}', '{TENANT_ID}',
+        '{{"channel_visibility":{{"allowed_channel_slugs":["alpha"]}}}}'::jsonb);
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{UNRESTRICTED_TRANSLATION_ID}', '{UNRESTRICTED_PRODUCT_ID}', '{TENANT_ID}', 'en', 'Unrestricted', 'unrestricted'),
+    ('{MALFORMED_TRANSLATION_ID}', '{MALFORMED_PRODUCT_ID}', '{TENANT_ID}', 'en', 'Malformed', 'malformed'),
+    ('{VALID_AFTER_MALFORMED_TRANSLATION_ID}', '{VALID_AFTER_MALFORMED_PRODUCT_ID}', '{TENANT_ID}', 'en', 'Valid after malformed', 'valid-after-malformed'),
+    ('{RESTRICTED_TRANSLATION_ID}', '{RESTRICTED_PRODUCT_ID}', '{TENANT_ID}', 'en', 'Restricted', 'restricted');
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-distribution/tests/product_channel_convergence_postgres.rs
+++ b/crates/rustok-distribution/tests/product_channel_convergence_postgres.rs
@@ -20,7 +20,7 @@ use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistrations, ModuleWorkSche
 use sea_orm::{
     ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
 };
-use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
@@ -39,24 +39,6 @@ const VALID_AFTER_MALFORMED_TRANSLATION_ID: Uuid = Uuid::from_u128(303);
 const RESTRICTED_TRANSLATION_ID: Uuid = Uuid::from_u128(304);
 
 type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
-
-struct ProductMigrator;
-
-#[async_trait::async_trait]
-impl MigratorTrait for ProductMigrator {
-    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        rustok_product::migrations::migrations()
-    }
-}
-
-struct ChannelMigrator;
-
-#[async_trait::async_trait]
-impl MigratorTrait for ChannelMigrator {
-    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        rustok_channel::migrations::migrations()
-    }
-}
 
 struct TestDatabase {
     control: DatabaseConnection,
@@ -91,9 +73,13 @@ impl TestDatabase {
         )
         .await?;
         create_migration_prerequisites(&migration).await?;
-        ChannelMigrator::up(&migration, None).await?;
-        ProductMigrator::up(&migration, None).await?;
         let manager = SchemaManager::new(&migration);
+        for migration_step in rustok_channel::migrations::migrations() {
+            migration_step.up(&manager).await?;
+        }
+        for migration_step in rustok_product::migrations::migrations() {
+            migration_step.up(&manager).await?;
+        }
         for migration_step in IndexModule.migrations() {
             migration_step.up(&manager).await?;
         }
@@ -365,10 +351,7 @@ async fn run_scenarios(database: &TestDatabase) -> TestResult<()> {
     assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, false).await?;
 
     let current_after_beta = load_product_mutation(&runtime.sources, RESTRICTED_PRODUCT_ID).await?;
-    assert_eq!(
-        current_after_beta.source_version(),
-        restricted_projection_after_beta
-    );
+    assert_eq!(current_after_beta.source_version(), restricted_projection_after_beta);
     apply_product_mutation(&runtime, current_after_beta).await?;
     assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, true).await?;
     assert_state_checkpoint(&database.writer, generation_after_beta_rename).await?;
@@ -474,8 +457,10 @@ async fn assert_product_visible(
     expected: bool,
 ) -> TestResult<()> {
     let page = query.execute_query(product_identity_query(product_id)?).await?;
-    assert_eq!(page.items.len(), usize::from(expected));
-    assert_eq!(page.exact_count, Some(u64::from(expected)));
+    let expected_rows = if expected { 1 } else { 0 };
+    let expected_count = if expected { 1_u64 } else { 0_u64 };
+    assert_eq!(page.items.len(), expected_rows);
+    assert_eq!(page.exact_count, Some(expected_count));
     if expected {
         assert_eq!(page.items[0].entity_id, product_id);
     }

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-07
 
-Status overlay rechecked against `main@844067c689aed6f810f23bcb3e908d2e579c0b62` and continued on
-`agent/index-product-materialized-freshness-postgres-evidence-20260807`.
+Status overlay rechecked against `main@0746ffa4aa4eea4383732bd4f4679c3d800cbf1d` and continued on
+`agent/index-product-channel-convergence-postgres-evidence-20260807`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
 cursor.
@@ -35,8 +35,13 @@ inspection. Independent M7 source work can continue while that owner-execution g
 - canonical Product materialized/query freshness fence for the source-read -> mutation-apply window;
 - persisted tenant schema readiness gate.
 
-The first retained PostgreSQL Product materialized-freshness race packet is now source-ready, but it has
-not been executed or admitted.
+Two retained M7 PostgreSQL packets are now source-ready and execution/admission pending:
+
+1. delayed Product scalar mutation + locale deletion materialized/query freshness;
+2. Product visibility + Channel identity convergence with multi-host lease/restart and rejected-Product
+   isolation.
+
+Neither packet has been executed by the implementation agent.
 
 ## Canonical Product policy
 
@@ -167,15 +172,32 @@ exact count zero.
 
 This is retained source, not admitted evidence. No PostgreSQL execution result is claimed.
 
-The next M7 evidence packet should cover Product visibility + Channel identity races together with
-multi-host/restart/rejected-Product convergence behavior:
+## Product visibility / Channel convergence PostgreSQL packet 2
 
-- visibility change after source read;
-- Channel generation change with unchanged resolved UUID membership;
-- Channel identity change with changed membership/projection epoch;
-- concurrent host lease competition;
-- lease expiry/restart continuation;
-- rejected Product isolation while valid Products continue converging.
+`crates/rustok-distribution/tests/product_channel_convergence_postgres.rs` is source-ready and
+execution-pending. It uses real Channel/Product/Index migrations, two independent generic
+`ModuleWorkScheduler` hosts, Product-owned convergence state, the real Product replay source, generic
+Index mutation storage, persisted schema readiness, and the canonical Product query fence.
+
+The retained scenarios cover:
+
+- a one-second Product-owned lease claimed by host A, active-lease exclusion on host B, expiry, and
+  reclaim/completion by host B without resetting visibility progress;
+- malformed Product visibility remaining without relation/freshness while a later valid Product still
+  converges and the tenant Channel-generation sweep completes;
+- Product visibility `alpha -> beta` after source read, physical old Index materialization, query
+  exclusion, relation/projection advancement, and corrective current Product mutation;
+- Channel slug identity change with unchanged unrestricted UUID membership, where query admission fails
+  until freshness reaches the new generation but relation/projection remain unchanged and the same Index
+  row becomes admissible again;
+- a later Channel slug identity change that removes restricted membership, advances relation/projection,
+  leaves the old restricted Index row inadmissible, and requires the current Product mutation before
+  query authority returns.
+
+Detailed contract:
+`m7-product-channel-convergence-postgres-harness.md`.
+
+This packet is retained source only. No PostgreSQL execution result is claimed.
 
 ## Event-contract admission status
 
@@ -230,15 +252,16 @@ Required sequence remains:
       in-flight window at source level.
 - [x] Add source-ready PostgreSQL packet for delayed Product scalar mutation and locale deletion query
       admission across filter/order/cursor/limit/exact-count.
+- [x] Add source-ready PostgreSQL Product visibility + Channel-generation convergence packet with
+      multi-host lease expiry/restart, unchanged/changed membership, and rejected-Product evidence.
 - [x] Remove parallel Product/ProductVariant compatibility implementations.
 - [ ] Execute/admit the Product materialized freshness PostgreSQL packet.
-- [ ] Add/execute PostgreSQL visibility + Channel-generation convergence packet with multi-host lease
-      expiry/restart and rejected-Product evidence.
-- [ ] Execute PostgreSQL evidence for schema readiness, relation/freshness storage, resolver
-      convergence, projection concurrency/delete ordering, and canonical replay.
+- [ ] Execute/admit the Product visibility + Channel-generation convergence PostgreSQL packet.
+- [ ] Retain any remaining Channel create/delete/tenant-move/delete-recreate identity evidence.
+- [ ] Execute PostgreSQL evidence for schema readiness, relation/freshness storage, projection
+      concurrency/delete ordering, and canonical replay not already covered by the two Product packets.
 - [ ] Admit canonical Product typed wire events/routes/consumers after digest verification.
-- [ ] Retain Channel create/delete/slug/identity, Product visibility, retry/restart/delete-recreate,
-      out-of-order, locale fan-out, in-flight mutation, and freshness evidence.
+- [ ] Retain remaining out-of-order, locale fan-out, and linked-target availability evidence.
 - [ ] Prove complete Product/Variant/Channel query parity, including linked-target availability.
 - [ ] Move Storefront traffic only after readiness/equivalence/materialized-freshness evidence passes.
 
@@ -246,17 +269,20 @@ Required sequence remains:
 
 Primary owner step remains: execute and admit the locked M6 repair PostgreSQL packet.
 
-Next unblocked M7 source step: add the retained Product visibility/Channel identity convergence
-PostgreSQL evidence packet. It should exercise the automatic convergence state machine and Product
-query-admission interaction across unchanged membership, changed membership, multi-host lease
-competition, restart/lease expiry, and rejected Product isolation. Do not add another Product schema or
-freshness clock. Keep typed Product event work separately blocked until digest admission.
+The two largest Product freshness/convergence M7 runtime packets are now source-ready. The next
+unblocked M7 source step is to retain the remaining Channel identity transition evidence that is not
+covered by slug changes: Channel create/delete, tenant move, and delete-recreate behavior, including
+Product query admission and relation/projection consequences. After that, continue complete
+Product/Variant/Channel linked-target query parity. Do not add another Product schema or freshness
+clock. Keep typed Product event work separately blocked until digest admission.
 
 ## Maintainer verification for this slice
 
 ```bash
 cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_channel_convergence_postgres -- --nocapture
 node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
@@ -271,5 +297,5 @@ cargo check -p rustok-distribution --features mod-product --all-targets
 git diff --check
 ```
 
-No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, or CI
-were executed by the implementation agent.
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-channel-convergence-postgres-harness.md
+++ b/crates/rustok-index/docs/m7-product-channel-convergence-postgres-harness.md
@@ -1,0 +1,158 @@
+# M7 Product visibility / Channel identity convergence PostgreSQL harness
+
+Status: `source_ready_execution_pending`.
+
+## Purpose
+
+This retained PostgreSQL packet covers the cross-owner convergence state machine that follows the
+materialized Product query-freshness packet. It uses the production Product and Channel migration
+chains, Product-owned convergence storage, the selected distribution worker registered through the
+generic ModuleWork runtime, the real Product replay source, generic Index mutation storage, persisted
+schema readiness, and the canonical shared query runtime.
+
+The packet is source-ready but has not been executed or admitted by the implementation agent.
+
+## Production runtime path
+
+`crates/rustok-distribution/tests/product_channel_convergence_postgres.rs` builds one selected runtime
+with Index, Channel, and Product. It retrieves `ModuleWorkRegistrations` from the same distribution
+composition used by the host and registers them into two independent `ModuleWorkScheduler` hosts with
+separate PostgreSQL connections.
+
+The test does **not** construct the private distribution resolver or convergence adapter. Work executes
+only through `ModuleWorkScheduler::run_once`. The one direct owner call is the public
+`ProductSalesChannelIndexRelationConvergenceStore::claim` used to simulate a host that has durably
+claimed work and then crashed before handler execution; this is the same Product-owned lease operation
+used by the registered ModuleWork source.
+
+Scheduler draining is bounded by an explicit maximum iteration count. There is no worker-local infinite
+loop.
+
+## Scenario 1: multi-host lease exclusion and restart reclaim
+
+Initial Channel inserts advance the real tenant Channel identity generation. Initial Product inserts
+append the real Product-owned visibility convergence requests.
+
+1. Host A claims the first exact Product request with a one-second lease through the public Product
+   convergence store.
+2. Host B's independently registered scheduler runs while that lease is active and must execute zero
+   work.
+3. The packet retains the lease token and attempt count from Product-owned state.
+4. After bounded lease expiry, Host B runs the real registered worker and must reclaim/complete that
+   same durable request.
+5. Product-owned state must advance exactly to the retained request sequence, clear the lease, and show
+   attempt count two.
+6. Host B then drains the remaining initial requests and the baseline Channel-generation sweep through
+   bounded `run_once` calls.
+
+This proves durable work ownership survives loss of one host and another host resumes without resetting
+visibility cursor or tenant Channel checkpoint.
+
+## Scenario 2: rejected Product isolation
+
+Products are ordered so a malformed Product precedes a later valid Product in Channel sweep order. The
+malformed Product uses non-canonical Product visibility (`" Alpha "`) and therefore remains fail-closed.
+
+After the initial exact requests and baseline sweep:
+
+- the malformed Product must have no relation snapshot and no freshness witness;
+- the later valid Product must have a freshness witness at the completed tenant Channel generation;
+- the tenant convergence state must still reach a completed generation checkpoint.
+
+The same assertions are repeated after a later Channel-generation sweep. This proves rejected Product
+owner data does not head-of-line block valid Product convergence.
+
+## Scenario 3: Product visibility alpha -> beta after source read
+
+A restricted Product initially resolves only Channel `alpha`.
+
+1. The real Product source reads a valid mutation and retains it in memory.
+2. Product metadata changes from allowed slug `alpha` to `beta`; real Product revision/projection and
+   visibility-request triggers advance owner state.
+3. The previously produced mutation is applied through `PostgresMutationStore` and is confirmed
+   physically present in `index_entities`.
+4. Canonical Product query admission must return zero rows while owner visibility/projection is newer.
+5. Host A's real scheduler drains the exact visibility request.
+6. Relation membership must change from alpha UUID to beta UUID and both `relation_epoch` and
+   `projection_epoch` must advance.
+7. The old Index row must remain query-inadmissible after convergence because its materialized
+   projection is still old.
+8. Loading/applying the current Product mutation makes the Product query-visible again.
+
+This ties visibility convergence and the materialized query fence together without adding another
+Product clock.
+
+## Scenario 4: Channel generation change with unchanged UUID membership
+
+The unrestricted Product contains both Channel UUIDs. Renaming Channel `alpha` to `alpha-renamed`
+advances the real Channel identity generation but leaves the unrestricted UUID set unchanged.
+
+Before convergence the existing materialized Product must be query-inadmissible because its witness has
+the previous Channel generation. After a real tenant sweep:
+
+- unrestricted `relation_epoch` is unchanged;
+- unrestricted `projection_epoch` is unchanged;
+- freshness witness advances to the new Channel generation;
+- the exact same already-materialized Product row becomes query-admissible again without a new Index
+  mutation.
+
+The later valid Product must also receive the new freshness generation even though the malformed Product
+appears before it in the sweep.
+
+This is the key proof that freshness-only Channel identity changes do not fabricate relation or Product
+mutation epochs.
+
+## Scenario 5: Channel identity change with changed membership
+
+The restricted Product is now allowed only slug `beta` and has been materialized with beta membership.
+Renaming Channel `beta` to `beta-renamed` advances Channel generation and makes the restricted resolved
+membership empty.
+
+After the real sweep:
+
+- restricted `relation_epoch` advances;
+- restricted `projection_epoch` advances;
+- restricted membership is empty;
+- the previously materialized restricted Product remains query-inadmissible;
+- unrestricted Product relation/projection remain unchanged and its existing Index row is admitted once
+  its freshness witness reaches the new generation.
+
+Only after the current restricted Product projection is loaded/applied does that Product become
+query-visible again. Tenant convergence state must finish with the newest Channel generation, no sweep
+cursor, and no lease.
+
+## Deliberate scope boundary
+
+This packet covers automatic convergence, multi-host lease exclusion/reclaim, rejected Product
+isolation, Product visibility change, Channel generation with unchanged membership, Channel generation
+with changed membership, and interaction with Product root query admission.
+
+It does not claim:
+
+- production event-contract digest admission or typed Product Index events;
+- linked ProductVariant/SalesChannel target materialization equivalence;
+- Storefront traffic cutover;
+- successful execution of this retained source packet.
+
+Those remain separate admission gates. No new Product schema, relation copy, or freshness clock is
+introduced by this packet.
+
+## Maintainer verification
+
+Suggested commands, intentionally not run by the implementation agent:
+
+```bash
+cargo test -p rustok-distribution --features mod-product --test product_channel_convergence_postgres -- --nocapture
+node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-relation-convergence.mjs
+node scripts/verify/verify-index-product-channel-relation-freshness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-channel --all-targets
+cargo check -p rustok-product --all-targets
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-sales-channel-convergence.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-convergence.md
@@ -95,13 +95,36 @@ in Index storage without becoming query-authoritative.
 Source completeness still does not authorize Storefront cutover. PostgreSQL execution evidence for the
 in-flight stale-mutation window and for this convergence state machine remains pending.
 
+## Retained PostgreSQL convergence packet
+
+`crates/rustok-distribution/tests/product_channel_convergence_postgres.rs` is now a source-ready,
+execution-pending packet for this state machine. It uses two independent generic `ModuleWorkScheduler`
+hosts and the production Product/Channel/Index storage/runtime path.
+
+The packet retains assertions for:
+
+- live-lease exclusion and reclaim after lease expiry;
+- restart continuation without resetting the Product visibility cursor;
+- malformed Product isolation while later valid Products still receive current freshness;
+- Product visibility `alpha -> beta` after source read, including physical stale Index materialization,
+  relation/projection advancement, query exclusion, and corrective current mutation;
+- Channel generation change with unchanged unrestricted UUID membership, where only freshness advances
+  and the same materialized Product becomes admissible again;
+- Channel generation change with changed restricted membership, where relation/projection advance and
+  the old Index row stays inadmissible until the current Product mutation is applied.
+
+Detailed packet contract:
+[M7 Product visibility / Channel identity convergence PostgreSQL harness](./m7-product-channel-convergence-postgres-harness.md).
+
+This is retained source only. It has not been executed or admitted.
+
 ## Remaining M7 admission
 
 - execute/admit the source-ready Product delayed-mutation/locale-deletion PostgreSQL query-freshness
   packet;
-- add and execute PostgreSQL Product visibility + Channel-generation convergence evidence;
-- retain multi-host lease competition, lease expiry/restart, and rejected-Product isolation evidence;
-- retain Channel create/delete/slug/tenant, Product visibility, retry/restart/delete-recreate evidence;
+- execute/admit the source-ready Product visibility + Channel-generation convergence packet;
+- retain any still-missing Channel create/delete/tenant-move and delete-recreate evidence not covered by
+  the slug-generation packet;
 - admit canonical Product typed events/routes only after event-contract digest verification;
 - prove complete Product/Variant/Channel query parity, including linked-target availability;
 - move Storefront traffic only after readiness, equivalence, convergence, and materialized-freshness
@@ -111,7 +134,9 @@ in-flight stale-mutation window and for this convergence state machine remains p
 
 ```bash
 cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_channel_convergence_postgres -- --nocapture
 node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs
@@ -122,5 +147,5 @@ cargo check -p rustok-distribution --features mod-product --all-targets
 git diff --check
 ```
 
-No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, or CI
-were executed by the implementation agent.
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
+++ b/scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-channel-convergence-postgres-harness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const harnessPath = 'crates/rustok-distribution/tests/product_channel_convergence_postgres.rs';
+const harness = requireMarkers(harnessPath, [
+  '#![cfg(feature = "mod-product")]',
+  'RUSTOK_INDEX_TEST_DATABASE_URL',
+  'rustok_channel::migrations::migrations()',
+  'rustok_product::migrations::migrations()',
+  'for migration_step in IndexModule.migrations()',
+  'CREATE TABLE oauth_apps',
+  'CREATE SCHEMA',
+  'DROP SCHEMA IF EXISTS',
+  '.register(IndexModule)',
+  '.register(rustok_channel::ChannelModule)',
+  '.register(rustok_product::ProductModule)',
+  'rustok_distribution::build_runtime_extensions(&registry)',
+  'PostgresSchemaRegistrationStore::new',
+  'materialize_postgres_index_sources',
+  'materialize_index_source_registry',
+  'materialize_postgres_index_query_runtime',
+  '.get::<ModuleWorkRegistrations>()',
+  'let scheduler_a = ModuleWorkScheduler::new()',
+  'let scheduler_b = ModuleWorkScheduler::new()',
+  '.register_all(&HostRuntimeContext::new(database.host_a.clone()), &scheduler_a)',
+  '.register_all(&HostRuntimeContext::new(database.host_b.clone()), &scheduler_b)',
+  'ProductSalesChannelIndexRelationConvergenceStore::new(database.host_a.clone())',
+  '.claim(TENANT_ID, initial_generation, Duration::from_secs(1))',
+  'ProductSalesChannelIndexRelationConvergenceWork::VisibilityRequest',
+  'assert_eq!(runtime.scheduler_b.run_once().await?, 0)',
+  'assert_active_lease',
+  'tokio::time::sleep(Duration::from_millis(1_100)).await',
+  'assert_eq!(runtime.scheduler_b.run_once().await?, 1)',
+  'assert_reclaimed_progress',
+  'run_scheduler_until_idle(&runtime.scheduler_b, 32)',
+  'for _ in 0..maximum_iterations',
+  'assert_no_relation_or_freshness(&database.writer, MALFORMED_PRODUCT_ID)',
+  'VALID_AFTER_MALFORMED_PRODUCT_ID',
+  'let delayed_visibility = load_product_mutation',
+  'update_restricted_visibility(&database.writer, "beta")',
+  'apply_product_mutation(&runtime, delayed_visibility)',
+  'assert_materialized_source_version',
+  'assert_product_visible(&runtime.query, RESTRICTED_PRODUCT_ID, false)',
+  'run_scheduler_until_idle(&runtime.scheduler_a, 16)',
+  'assert_eq!(visibility_membership, vec![BETA_CHANNEL_ID])',
+  'rename_channel(&database.writer, ALPHA_CHANNEL_ID, "alpha-renamed")',
+  'generation_after_alpha_rename',
+  'unrestricted_relation_before',
+  'unrestricted_projection_before',
+  'assert_freshness_generation(',
+  'rename_channel(&database.writer, BETA_CHANNEL_ID, "beta-renamed")',
+  'generation_after_beta_rename',
+  'restricted_relation_after_beta > restricted_relation_before_beta',
+  'restricted_projection_after_beta > restricted_projection_before_beta',
+  'assert!(restricted_membership_after_beta.is_empty())',
+  'current_after_beta.source_version()',
+  'assert_state_checkpoint(&database.writer, generation_after_beta_rename)',
+  'channel_index_identity_generations',
+  'product_sales_channel_index_relation_convergence_state',
+  'product_sales_channel_index_relation_snapshots',
+  'product_sales_channel_index_relation_freshness_snapshots',
+  'product_index_graph_projection_snapshots',
+  'index_entities',
+]);
+forbidMarkers(harnessPath, harness, [
+  'FakeIndex',
+  'FakeSource',
+  'MockIndex',
+  'MockSource',
+  'INSERT INTO index_entities',
+  'UPDATE index_entities',
+  'DELETE FROM index_entities',
+  'PostgresIndexQueryPort::new',
+  'PostgresIndexQueryPort::with_admissions',
+  'ProductSalesChannelRelationResolver::new',
+  'ProductSalesChannelRelationConvergenceAdapter',
+  'loop {',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-product-channel-convergence-postgres-harness.md', [
+  'Status: `source_ready_execution_pending`',
+  'two independent `ModuleWorkScheduler` hosts',
+  'lease expiry',
+  'rejected Product',
+  'visibility alpha -> beta',
+  'unchanged UUID membership',
+  'changed membership',
+  'query-inadmissible',
+  'not executed',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-product-channel-convergence-postgres-harness.mjs'",
+]);
+
+console.log('[verify-index-product-channel-convergence-postgres-harness] source packet verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -71,6 +71,7 @@ const scripts = [
   'verify-index-product-channel-relation-convergence.mjs',
   'verify-index-product-materialized-query-freshness.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
+  'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-graph-projection-ledger.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

- add a retained PostgreSQL integration packet for Product visibility / Channel identity automatic convergence;
- run real Channel, Product, and Index migration chains in an isolated schema;
- build the selected Index+Channel+Product distribution runtime and register its real `ModuleWorkRegistrations` into two independent generic `ModuleWorkScheduler` hosts;
- use the public Product convergence store only to simulate a host that durably claimed work and crashed before handler execution, then prove another scheduler is excluded until lease expiry and reclaims the same durable request afterward;
- retain rejected-Product isolation while later valid Products continue through the tenant Channel-generation sweep;
- retain Product `channel_visibility` alpha -> beta after source read, including physical stale Index materialization, query exclusion, relation/projection advancement, and corrective current mutation;
- retain Channel generation changes with unchanged unrestricted UUID membership, proving freshness advances while `relation_epoch`/`projection_epoch` stay unchanged and the same materialized Index row becomes admissible again;
- retain Channel generation changes with changed restricted membership, proving relation/projection advance and the old Index row stays inadmissible until the current Product mutation applies;
- add a dedicated static source-packet verifier, include it in the aggregate Index query contract, and actualize the current M7 execution cursor.

## Runtime path

The harness does not instantiate private `rustok-distribution` resolver/convergence implementation types. It retrieves `ModuleWorkRegistrations` from `rustok_distribution::build_runtime_extensions` and drives work only with `ModuleWorkScheduler::run_once` on two independent host connections.

The one direct convergence call is `ProductSalesChannelIndexRelationConvergenceStore::claim` with a one-second lease to model Host A crashing after the exact durable claim but before handler execution. This is the same Product-owned store operation used by the registered ModuleWork source. Host B must execute zero work while the lease is active; after bounded expiry, Host B must reclaim/complete the retained exact request with the visibility cursor preserved and attempt count incremented.

Scheduler draining uses a bounded `for` loop with explicit maximum iterations; no private worker loop/background task is added.

## Scenarios

### Rejected Product isolation

A malformed Product with non-canonical `" Alpha "` visibility sorts before a later valid Product in tenant sweep order. The malformed Product must retain no relation/freshness evidence, while the later valid Product reaches the completed Channel generation and the tenant checkpoint advances. The same isolation is asserted after a later Channel-generation sweep.

### Visibility change after source read

A restricted Product initially resolves `alpha`. The real Product source mutation is retained, owner visibility changes to `beta`, and the old mutation is then physically applied through `PostgresMutationStore`. Product root query admission must hide it. Real scheduler convergence must move membership to beta and advance both relation/projection epochs; the old Index row remains hidden until the current Product mutation is loaded/applied.

### Channel identity / unchanged membership

Renaming Channel `alpha` advances the real tenant Channel generation. An unrestricted Product keeps the exact same UUID set. Before convergence its materialized row is hidden by the freshness-generation fence. After the real sweep, relation/projection epochs must remain unchanged, freshness must advance, and the same Index row must become query-admissible again without a new mutation.

### Channel identity / changed membership

Renaming Channel `beta` makes the restricted `beta` allowlist resolve empty. The real sweep must advance restricted relation/projection, leave unrestricted relation/projection unchanged, and keep the old restricted Index row hidden until its current projection mutation is applied.

## Scope

This PR changes no production source or migration. It adds retained source evidence only. It does not claim execution success, typed Product event admission, linked-target query parity, or Storefront cutover. No new Product schema, relation copy, or freshness clock is introduced.

## Main recheck

The branch started from #3170 merge `0746ffa4aa4eea4383732bd4f4679c3d800cbf1d`. Current `main@63258bbf9f203ba529975996fc6a504838c1bfeb` was compared before PR creation. The intervening Moderation host composition and Commerce Product owner-port changes are disjoint from all files in this evidence slice; the only Product file touched on main is `rustok-product/src/ports.rs`, not convergence storage/runtime/migrations.

## Validation

Per maintainer instruction, this packet is **source-ready, execution-pending**. No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.