### PR TITLE
test(index): retain Channel identity transition PostgreSQL packet

### DIFF
--- a/crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs
+++ b/crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs
@@ -1,0 +1,717 @@
+#![cfg(feature = "mod-product")]
+
+use std::{env, error::Error};
+
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation, IndexQuery,
+    IndexQueryPort, IndexQueryScope, IndexSourceLoadRequest, IndexValue, LocaleKey, ModuleName,
+    MutationApplyOutcome, MutationDelivery, Pagination, PostgresMutationStore,
+    PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion, SharedIndexQueryRuntime,
+    SharedIndexSchemaRegistry, SharedIndexSourceRegistry, materialize_index_source_registry,
+    materialize_postgres_index_query_runtime, materialize_postgres_index_sources,
+};
+use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistrations, ModuleWorkScheduler};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const TENANT_A: Uuid = Uuid::from_u128(1);
+const TENANT_B: Uuid = Uuid::from_u128(2);
+const PRODUCT_A: Uuid = Uuid::from_u128(101);
+const PRODUCT_B: Uuid = Uuid::from_u128(102);
+const PRODUCT_A_TRANSLATION: Uuid = Uuid::from_u128(111);
+const PRODUCT_B_TRANSLATION: Uuid = Uuid::from_u128(112);
+const ALPHA_CHANNEL: Uuid = Uuid::from_u128(201);
+const BETA_CHANNEL: Uuid = Uuid::from_u128(202);
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    migration: DatabaseConnection,
+    work: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    writer: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Channel identity transition harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_channel_identity_transitions_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_channel_identity_transitions_migration_{suffix}"),
+        )
+        .await?;
+        create_migration_prerequisites(&migration).await?;
+        let manager = SchemaManager::new(&migration);
+        for migration_step in rustok_channel::migrations::migrations() {
+            migration_step.up(&manager).await?;
+        }
+        for migration_step in rustok_product::migrations::migrations() {
+            migration_step.up(&manager).await?;
+        }
+        for migration_step in IndexModule.migrations() {
+            migration_step.up(&manager).await?;
+        }
+        seed_owner_rows(&migration).await?;
+
+        Ok(Some(Self {
+            control,
+            migration,
+            work: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_channel_identity_transitions_work_{suffix}"),
+            )
+            .await?,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_channel_identity_transitions_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_channel_identity_transitions_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_channel_identity_transitions_query_{suffix}"),
+            )
+            .await?,
+            writer: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_channel_identity_transitions_writer_{suffix}"),
+            )
+            .await?,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.migration.close().await?;
+        self.work.close().await?;
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.writer.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct Runtime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+    scheduler: ModuleWorkScheduler,
+}
+
+#[tokio::test]
+async fn channel_identity_transitions_drive_exact_product_convergence() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let result = run_scenarios(&database).await;
+    let cleanup = database.cleanup().await;
+    result?;
+    cleanup
+}
+
+async fn run_scenarios(database: &TestDatabase) -> TestResult<()> {
+    let runtime = build_runtime(database).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 24).await?;
+
+    let baseline_a_generation = channel_generation(&database.writer, TENANT_A).await?;
+    let baseline_b_generation = channel_generation(&database.writer, TENANT_B).await?;
+    assert!(baseline_a_generation > 0);
+    assert_eq!(baseline_b_generation, 0);
+    assert_state_checkpoint(&database.writer, TENANT_A, baseline_a_generation).await?;
+    assert_state_checkpoint(&database.writer, TENANT_B, baseline_b_generation).await?;
+    assert_eq!(
+        latest_membership(&database.writer, TENANT_A, PRODUCT_A).await?.1,
+        vec![ALPHA_CHANNEL]
+    );
+    assert!(latest_membership(&database.writer, TENANT_B, PRODUCT_B).await?.1.is_empty());
+
+    materialize_current(&runtime, TENANT_A, PRODUCT_A).await?;
+    materialize_current(&runtime, TENANT_B, PRODUCT_B).await?;
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, true).await?;
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, true).await?;
+
+    // CREATE: adding beta changes tenant A unrestricted membership, so query freshness invalidates the
+    // old Product row immediately. Convergence must advance relation/projection and a current Product
+    // mutation is required before query authority returns.
+    let a_relation_before_create = latest_membership(&database.writer, TENANT_A, PRODUCT_A).await?.0;
+    let a_projection_before_create = latest_projection(&database.writer, TENANT_A, PRODUCT_A).await?;
+    insert_channel(&database.writer, TENANT_A, BETA_CHANNEL, "beta", "Beta").await?;
+    let generation_after_create = channel_generation(&database.writer, TENANT_A).await?;
+    assert!(generation_after_create > baseline_a_generation);
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, false).await?;
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, true).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 12).await?;
+    let (a_relation_after_create, a_membership_after_create) =
+        latest_membership(&database.writer, TENANT_A, PRODUCT_A).await?;
+    let a_projection_after_create = latest_projection(&database.writer, TENANT_A, PRODUCT_A).await?;
+    assert!(a_relation_after_create > a_relation_before_create);
+    assert!(a_projection_after_create > a_projection_before_create);
+    assert_eq!(a_membership_after_create, vec![ALPHA_CHANNEL, BETA_CHANNEL]);
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, false).await?;
+    materialize_current(&runtime, TENANT_A, PRODUCT_A).await?;
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, true).await?;
+
+    // DELETE: removing beta changes membership back to alpha. Again relation/projection must advance,
+    // and the old materialized row must stay hidden until the current Product projection is applied.
+    let a_relation_before_delete = a_relation_after_create;
+    let a_projection_before_delete = a_projection_after_create;
+    delete_channel(&database.writer, TENANT_A, BETA_CHANNEL).await?;
+    let generation_after_delete = channel_generation(&database.writer, TENANT_A).await?;
+    assert!(generation_after_delete > generation_after_create);
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, false).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 12).await?;
+    let (a_relation_after_delete, a_membership_after_delete) =
+        latest_membership(&database.writer, TENANT_A, PRODUCT_A).await?;
+    let a_projection_after_delete = latest_projection(&database.writer, TENANT_A, PRODUCT_A).await?;
+    assert!(a_relation_after_delete > a_relation_before_delete);
+    assert!(a_projection_after_delete > a_projection_before_delete);
+    assert_eq!(a_membership_after_delete, vec![ALPHA_CHANNEL]);
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, false).await?;
+    materialize_current(&runtime, TENANT_A, PRODUCT_A).await?;
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, true).await?;
+
+    // TENANT MOVE: moving alpha A -> B must advance both tenant generations. Product A loses alpha and
+    // Product B gains the same Channel UUID. Both old rows are fail-closed until convergence and new
+    // Product projections are materialized.
+    let a_relation_before_move = a_relation_after_delete;
+    let a_projection_before_move = a_projection_after_delete;
+    let b_relation_before_move = latest_membership(&database.writer, TENANT_B, PRODUCT_B).await?.0;
+    let b_projection_before_move = latest_projection(&database.writer, TENANT_B, PRODUCT_B).await?;
+    move_channel(&database.writer, ALPHA_CHANNEL, TENANT_A, TENANT_B).await?;
+    let generation_a_after_move = channel_generation(&database.writer, TENANT_A).await?;
+    let generation_b_after_move = channel_generation(&database.writer, TENANT_B).await?;
+    assert!(generation_a_after_move > generation_after_delete);
+    assert!(generation_b_after_move > baseline_b_generation);
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, false).await?;
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, false).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 20).await?;
+
+    let (a_relation_after_move, a_membership_after_move) =
+        latest_membership(&database.writer, TENANT_A, PRODUCT_A).await?;
+    let a_projection_after_move = latest_projection(&database.writer, TENANT_A, PRODUCT_A).await?;
+    let (b_relation_after_move, b_membership_after_move) =
+        latest_membership(&database.writer, TENANT_B, PRODUCT_B).await?;
+    let b_projection_after_move = latest_projection(&database.writer, TENANT_B, PRODUCT_B).await?;
+    assert!(a_relation_after_move > a_relation_before_move);
+    assert!(a_projection_after_move > a_projection_before_move);
+    assert!(a_membership_after_move.is_empty());
+    assert!(b_relation_after_move > b_relation_before_move);
+    assert!(b_projection_after_move > b_projection_before_move);
+    assert_eq!(b_membership_after_move, vec![ALPHA_CHANNEL]);
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, false).await?;
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, false).await?;
+    materialize_current(&runtime, TENANT_A, PRODUCT_A).await?;
+    materialize_current(&runtime, TENANT_B, PRODUCT_B).await?;
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, true).await?;
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, true).await?;
+
+    // DELETE + RECREATE before convergence: current B membership returns to exactly the same alpha UUID.
+    // Channel generation must still advance twice and hide the old Product row until a new freshness
+    // witness is recorded. Because the final UUID set is unchanged, relation/projection must not move
+    // and the exact same materialized Index row becomes admissible again without a Product mutation.
+    let b_relation_before_recreate = b_relation_after_move;
+    let b_projection_before_recreate = b_projection_after_move;
+    let b_materialized_before_recreate =
+        materialized_source_version(&database.mutation, TENANT_B, PRODUCT_B).await?;
+    delete_channel(&database.writer, TENANT_B, ALPHA_CHANNEL).await?;
+    let generation_after_identity_delete = channel_generation(&database.writer, TENANT_B).await?;
+    insert_channel(&database.writer, TENANT_B, ALPHA_CHANNEL, "alpha", "Alpha recreated").await?;
+    let generation_after_recreate = channel_generation(&database.writer, TENANT_B).await?;
+    assert!(generation_after_identity_delete > generation_b_after_move);
+    assert!(generation_after_recreate > generation_after_identity_delete);
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, false).await?;
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, true).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 16).await?;
+
+    let (b_relation_after_recreate, b_membership_after_recreate) =
+        latest_membership(&database.writer, TENANT_B, PRODUCT_B).await?;
+    let b_projection_after_recreate = latest_projection(&database.writer, TENANT_B, PRODUCT_B).await?;
+    assert_eq!(b_relation_after_recreate, b_relation_before_recreate);
+    assert_eq!(b_projection_after_recreate, b_projection_before_recreate);
+    assert_eq!(b_membership_after_recreate, vec![ALPHA_CHANNEL]);
+    assert_freshness_generation(
+        &database.writer,
+        TENANT_B,
+        PRODUCT_B,
+        generation_after_recreate,
+    )
+    .await?;
+    assert_eq!(
+        materialized_source_version(&database.mutation, TENANT_B, PRODUCT_B).await?,
+        b_materialized_before_recreate
+    );
+    assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, true).await?;
+    assert_product_visible(&runtime.query, TENANT_A, PRODUCT_A, true).await?;
+    assert_state_checkpoint(&database.writer, TENANT_A, generation_a_after_move).await?;
+    assert_state_checkpoint(&database.writer, TENANT_B, generation_after_recreate).await?;
+    Ok(())
+}
+
+async fn build_runtime(database: &TestDatabase) -> TestResult<Runtime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Index schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for tenant_id in [TENANT_A, TENANT_B] {
+        for registered in schemas.registry().iter() {
+            schema_store.register(tenant_id, &registered.schema).await?;
+        }
+    }
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Index source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Index query runtime is missing"))?;
+    let registrations = extensions
+        .get::<ModuleWorkRegistrations>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product convergence work is missing"))?;
+    let scheduler = ModuleWorkScheduler::new();
+    registrations
+        .register_all(&HostRuntimeContext::new(database.work.clone()), &scheduler)
+        .await?;
+    Ok(Runtime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+        scheduler,
+    })
+}
+
+async fn run_scheduler_until_idle(
+    scheduler: &ModuleWorkScheduler,
+    maximum_iterations: usize,
+) -> TestResult<usize> {
+    let mut executed = 0;
+    for _ in 0..maximum_iterations {
+        let current = scheduler.run_once().await?;
+        if current == 0 {
+            return Ok(executed);
+        }
+        executed += current;
+    }
+    Err(std::io::Error::other(format!(
+        "ModuleWork scheduler did not become idle after {maximum_iterations} bounded iterations"
+    ))
+    .into())
+}
+
+async fn materialize_current(runtime: &Runtime, tenant_id: Uuid, product_id: Uuid) -> TestResult<()> {
+    let mutation = load_product_mutation(&runtime.sources, tenant_id, product_id).await?;
+    let source_version = mutation.source_version();
+    let delivery = MutationDelivery::from_event(PRODUCT_SOURCE, mutation)?;
+    let outcome = runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?;
+    match outcome {
+        MutationApplyOutcome::Applied {
+            source_version: applied,
+        } if applied == source_version => Ok(()),
+        other => Err(std::io::Error::other(format!(
+            "expected Product mutation {source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn load_product_mutation(
+    sources: &SharedIndexSourceRegistry,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> TestResult<IndexMutation> {
+    let request = IndexSourceLoadRequest::new(vec![product_key(tenant_id, product_id)?])?;
+    let mut mutations = sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected one Product mutation, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    Ok(mutations.remove(0))
+}
+
+async fn assert_product_visible(
+    query: &SharedIndexQueryRuntime,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    expected: bool,
+) -> TestResult<()> {
+    let page = query
+        .execute_query(product_identity_query(tenant_id, product_id)?)
+        .await?;
+    let expected_rows = if expected { 1 } else { 0 };
+    let expected_count = if expected { 1_u64 } else { 0_u64 };
+    assert_eq!(page.items.len(), expected_rows);
+    assert_eq!(page.exact_count, Some(expected_count));
+    if expected {
+        assert_eq!(page.items[0].entity_id, product_id);
+    }
+    Ok(())
+}
+
+fn product_identity_query(tenant_id: Uuid, product_id: Uuid) -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: product_schema_ref()?,
+        fields: vec![FieldPath::new(FieldName::new("title")?)],
+        filter: Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("id")?),
+            IndexValue::Uuid(product_id),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+fn product_key(tenant_id: Uuid, product_id: Uuid) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id,
+        schema: product_schema_ref()?,
+        entity_id: product_id,
+        locale: Some(LocaleKey::new("en")?),
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        version: SchemaVersion::new(3),
+    })
+}
+
+async fn channel_generation(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT COALESCE(
+    (SELECT generation FROM channel_index_identity_generations WHERE tenant_id = $1),
+    0
+)::bigint AS generation
+"#,
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Channel generation query returned no row"))?;
+    let generation: i64 = row.try_get("", "generation")?;
+    Ok(u64::try_from(generation)?)
+}
+
+async fn latest_membership(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> TestResult<(u64, Vec<Uuid>)> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT relation_epoch, channel_ids
+FROM product_sales_channel_index_relation_snapshots
+WHERE tenant_id = $1 AND product_id = $2
+ORDER BY relation_epoch DESC
+LIMIT 1
+"#,
+            vec![tenant_id.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product relation snapshot is missing"))?;
+    let epoch: i64 = row.try_get("", "relation_epoch")?;
+    let channel_ids: JsonValue = row.try_get("", "channel_ids")?;
+    let mut decoded = channel_ids
+        .as_array()
+        .ok_or_else(|| std::io::Error::other("relation channel_ids is not an array"))?
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| std::io::Error::other("relation channel id is not text"))
+                .and_then(|value| Uuid::parse_str(value).map_err(std::io::Error::other))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    decoded.sort_unstable();
+    Ok((u64::try_from(epoch)?, decoded))
+}
+
+async fn latest_projection(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT projection_epoch
+FROM product_index_graph_projection_snapshots
+WHERE tenant_id = $1 AND product_id = $2
+ORDER BY projection_epoch DESC
+LIMIT 1
+"#,
+            vec![tenant_id.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product projection is missing"))?;
+    let epoch: i64 = row.try_get("", "projection_epoch")?;
+    Ok(u64::try_from(epoch)?)
+}
+
+async fn assert_freshness_generation(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    product_id: Uuid,
+    expected_generation: u64,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT channel_identity_generation
+FROM product_sales_channel_index_relation_freshness_snapshots
+WHERE tenant_id = $1 AND product_id = $2
+ORDER BY sequence_no DESC
+LIMIT 1
+"#,
+            vec![tenant_id.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product freshness witness is missing"))?;
+    let generation: i64 = row.try_get("", "channel_identity_generation")?;
+    assert_eq!(u64::try_from(generation)?, expected_generation);
+    Ok(())
+}
+
+async fn materialized_source_version(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(source_version AS TEXT) AS source_version_text
+FROM index_entities
+WHERE tenant_id = $1
+  AND module_name = 'rustok-product'
+  AND entity_name = 'product'
+  AND schema_version = 3
+  AND entity_id = $2
+  AND locale_key = 'en'
+  AND is_deleted = FALSE
+"#,
+            vec![tenant_id.into(), product_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("materialized Product row is missing"))?;
+    let value: String = row.try_get("", "source_version_text")?;
+    Ok(value.parse()?)
+}
+
+async fn assert_state_checkpoint(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    expected_generation: u64,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT channel_identity_generation, sweep_generation, sweep_after_product_id, lease_token
+FROM product_sales_channel_index_relation_convergence_state
+WHERE tenant_id = $1
+"#,
+            vec![tenant_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Product convergence state is missing"))?;
+    let generation: Option<i64> = row.try_get("", "channel_identity_generation")?;
+    let sweep_generation: Option<i64> = row.try_get("", "sweep_generation")?;
+    let sweep_after: Option<Uuid> = row.try_get("", "sweep_after_product_id")?;
+    let lease_token: Option<Uuid> = row.try_get("", "lease_token")?;
+    assert_eq!(generation, Some(i64::try_from(expected_generation)?));
+    assert!(sweep_generation.is_none());
+    assert!(sweep_after.is_none());
+    assert!(lease_token.is_none());
+    Ok(())
+}
+
+async fn insert_channel(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    channel_id: Uuid,
+    slug: &str,
+    name: &str,
+) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO channels (id, tenant_id, slug, name) VALUES ($1, $2, $3, $4)",
+        vec![
+            channel_id.into(),
+            tenant_id.into(),
+            slug.to_owned().into(),
+            name.to_owned().into(),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn delete_channel(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    channel_id: Uuid,
+) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "DELETE FROM channels WHERE tenant_id = $1 AND id = $2",
+        vec![tenant_id.into(), channel_id.into()],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn move_channel(
+    db: &DatabaseConnection,
+    channel_id: Uuid,
+    from_tenant: Uuid,
+    to_tenant: Uuid,
+) -> TestResult<()> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE channels SET tenant_id = $3 WHERE tenant_id = $1 AND id = $2",
+            vec![from_tenant.into(), channel_id.into(), to_tenant.into()],
+        ))
+        .await?;
+    assert_eq!(result.rows_affected(), 1);
+    Ok(())
+}
+
+async fn create_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE oauth_apps (
+    id UUID PRIMARY KEY
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_owner_rows(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_A}'), ('{TENANT_B}');
+
+INSERT INTO channels (id, tenant_id, slug, name) VALUES
+    ('{ALPHA_CHANNEL}', '{TENANT_A}', 'alpha', 'Alpha');
+
+INSERT INTO products (id, tenant_id, metadata) VALUES
+    ('{PRODUCT_A}', '{TENANT_A}', '{{}}'::jsonb),
+    ('{PRODUCT_B}', '{TENANT_B}', '{{}}'::jsonb);
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{PRODUCT_A_TRANSLATION}', '{PRODUCT_A}', '{TENANT_A}', 'en', 'Tenant A Product', 'tenant-a-product'),
+    ('{PRODUCT_B_TRANSLATION}', '{PRODUCT_B}', '{TENANT_B}', 'en', 'Tenant B Product', 'tenant-b-product');
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/m7-product-channel-identity-transitions-postgres-harness.md
+++ b/crates/rustok-index/docs/m7-product-channel-identity-transitions-postgres-harness.md
@@ -1,0 +1,151 @@
+# M7 Product / Channel identity-transition PostgreSQL harness
+
+Status: `source_ready_execution_pending`.
+
+## Purpose
+
+This retained PostgreSQL packet follows the Product materialized-freshness and Product/Channel
+convergence packets. It focuses on Channel identity transitions not covered by slug-only convergence
+scenarios: Channel create, Channel delete, tenant move, and delete + recreate of the same Channel
+identity before convergence.
+
+The packet uses the production Channel/Product/Index migration chains, selected distribution runtime,
+Product-owned convergence state, generic `ModuleWorkScheduler`, real Product replay source, generic
+Index mutation storage, persisted tenant schema readiness, and the canonical Product query-admission
+fence. It is source-ready but has not been executed or admitted by the implementation agent.
+
+## Baseline
+
+Two tenants are created:
+
+- tenant A has unrestricted Product A and Channel `alpha`;
+- tenant B has unrestricted Product B and no Channel identity history.
+
+Initial Product INSERT requests and the baseline Channel-generation sweep run through the real generic
+scheduler. The packet requires:
+
+- tenant A generation to be positive;
+- tenant B generation to be exactly zero;
+- completed convergence checkpoints for both tenants;
+- Product A membership `[alpha UUID]`;
+- Product B membership `[]`.
+
+Both current Product projections are then materialized through the real Product source and
+`PostgresMutationStore` and must be query-visible.
+
+## Channel create
+
+Channel `beta` is inserted into tenant A through the real Channel owner table.
+
+Expected retained evidence:
+
+1. tenant A Channel identity generation advances;
+2. Product A becomes query-inadmissible immediately because its freshness witness is older;
+3. tenant B Product remains query-visible;
+4. the real convergence sweep changes Product A membership from `[alpha]` to `[alpha, beta]`;
+5. Product A `relation_epoch` and `projection_epoch` both advance;
+6. the old materialized Product A row remains query-inadmissible after convergence;
+7. only the current Product projection mutation restores query authority.
+
+This proves Channel create is a true relation-membership mutation for unrestricted Products.
+
+## Channel delete
+
+The newly created `beta` Channel is deleted from tenant A.
+
+Expected retained evidence mirrors create:
+
+- tenant A generation advances;
+- Product A is hidden before convergence;
+- convergence returns membership to `[alpha]`;
+- relation/projection both advance;
+- the old Index row stays hidden;
+- applying the current Product projection restores query authority.
+
+This proves a retained stale Product row cannot survive a Channel delete merely because its old link
+rows remain physically stored.
+
+## Channel tenant move
+
+Channel `alpha` is moved from tenant A to tenant B by updating the Channel owner `tenant_id`.
+
+The Channel owner trigger is required to advance **both tenant generations** under its deterministic
+lock order. Before convergence, Product A and Product B must both be query-inadmissible because each
+tenant now has a newer Channel identity watermark.
+
+After the real scheduler drains both due tenants:
+
+- Product A membership becomes empty;
+- Product B membership becomes `[alpha UUID]`;
+- Product A relation/projection advance;
+- Product B relation/projection advance;
+- both previously materialized Product rows remain hidden until their current Product projection
+  mutations are applied.
+
+This proves tenant movement invalidates both sides of the cross-owner relation and does not collapse two
+owner changes into one tenant-local watermark.
+
+## Channel delete + recreate before convergence
+
+After tenant move, Product B is current and materialized with `[alpha UUID]`. The packet then:
+
+1. deletes Channel `alpha` from tenant B;
+2. records the resulting generation;
+3. recreates the same Channel UUID and canonical slug in tenant B **before** running convergence;
+4. requires a second Channel generation advance;
+5. requires the old Product B row to be query-inadmissible while freshness is stale.
+
+When the scheduler finally converges, current resolved membership is again exactly `[alpha UUID]`.
+Therefore the correct result is freshness-only convergence:
+
+- `relation_epoch` does not advance;
+- `projection_epoch` does not advance;
+- freshness witness advances to the newest Channel generation;
+- the physically existing Product B `index_entities.source_version` remains unchanged;
+- the **same materialized Product row** becomes query-admissible again without a Product mutation.
+
+This is the important delete/recreate proof: Channel identity generations preserve the ordering fence
+even when transient identity loss is repaired before the resolver observes it, while the relation and
+Product mutation clocks remain semantic membership clocks instead of generic invalidation counters.
+
+Tenant A is also required to remain query-visible throughout the tenant-B delete/recreate sequence,
+proving tenant scope is not widened.
+
+## Deliberate scope
+
+Together with the previous retained packets, source now exists for:
+
+- Product scalar/locale source-read -> delayed-apply races;
+- Product visibility changes;
+- Channel slug-generation changes with unchanged and changed membership;
+- multi-host convergence lease expiry/reclaim;
+- rejected Product isolation;
+- Channel create/delete;
+- Channel tenant move;
+- Channel delete + recreate with net-unchanged membership.
+
+This packet does not claim successful runtime execution. It also does not close typed Product event
+admission, ProductVariant/SalesChannel linked-target materialization parity, or Storefront cutover.
+Those remain separate admission gates. No new Product schema, relation copy, or freshness clock is
+introduced.
+
+## Maintainer verification
+
+Suggested commands, intentionally not run by the implementation agent:
+
+```bash
+cargo test -p rustok-distribution --features mod-product --test product_channel_identity_transitions_postgres -- --nocapture
+node scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-relation-convergence.mjs
+node scripts/verify/verify-index-product-channel-relation-freshness.mjs
+node scripts/verify/verify-index-product-materialized-query-freshness.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-channel --all-targets
+cargo check -p rustok-product --all-targets
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-sales-channel-convergence.md
+++ b/crates/rustok-index/docs/m7-product-sales-channel-convergence.md
@@ -97,9 +97,9 @@ in-flight stale-mutation window and for this convergence state machine remains p
 
 ## Retained PostgreSQL convergence packet
 
-`crates/rustok-distribution/tests/product_channel_convergence_postgres.rs` is now a source-ready,
-execution-pending packet for this state machine. It uses two independent generic `ModuleWorkScheduler`
-hosts and the production Product/Channel/Index storage/runtime path.
+`crates/rustok-distribution/tests/product_channel_convergence_postgres.rs` is a source-ready,
+execution-pending packet for the convergence state machine. It uses two independent generic
+`ModuleWorkScheduler` hosts and the production Product/Channel/Index storage/runtime path.
 
 The packet retains assertions for:
 
@@ -118,13 +118,36 @@ Detailed packet contract:
 
 This is retained source only. It has not been executed or admitted.
 
+## Retained Channel identity-transition packet
+
+`crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs` is a separate
+source-ready, execution-pending packet for Channel create/delete/tenant-move/delete-recreate identity
+semantics.
+
+It retains evidence that:
+
+- Channel create and delete advance the tenant Channel generation and, when unrestricted Product UUID
+  membership changes, advance both Product `relation_epoch` and `projection_epoch`;
+- a Channel tenant move advances both old and new tenant generations, removes membership from the old
+  tenant Product, adds the same Channel UUID to the new tenant Product, and requires current Product
+  projection mutations on both sides before query authority returns;
+- delete + recreate of the same Channel UUID/canonical slug before convergence advances Channel
+  generation twice but produces the same final Product membership, so relation/projection do not
+  advance; only the freshness witness advances and the same materialized Product row becomes
+  query-admissible again without a Product mutation;
+- tenant scope remains isolated while the other tenant changes.
+
+Detailed packet contract:
+[M7 Product / Channel identity-transition PostgreSQL harness](./m7-product-channel-identity-transitions-postgres-harness.md).
+
+This is retained source only. It has not been executed or admitted.
+
 ## Remaining M7 admission
 
 - execute/admit the source-ready Product delayed-mutation/locale-deletion PostgreSQL query-freshness
   packet;
 - execute/admit the source-ready Product visibility + Channel-generation convergence packet;
-- retain any still-missing Channel create/delete/tenant-move and delete-recreate evidence not covered by
-  the slug-generation packet;
+- execute/admit the source-ready Channel create/delete/tenant-move/delete-recreate packet;
 - admit canonical Product typed events/routes only after event-contract digest verification;
 - prove complete Product/Variant/Channel query parity, including linked-target availability;
 - move Storefront traffic only after readiness, equivalence, convergence, and materialized-freshness
@@ -135,8 +158,10 @@ This is retained source only. It has not been executed or admitted.
 ```bash
 cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
 cargo test -p rustok-distribution --features mod-product --test product_channel_convergence_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_channel_identity_transitions_postgres -- --nocapture
 node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
 node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-product-channel-relation-freshness.mjs

--- a/scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
+++ b/scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-channel-identity-transitions-postgres-harness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const harnessPath = 'crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs';
+const harness = requireMarkers(harnessPath, [
+  '#![cfg(feature = "mod-product")]',
+  'RUSTOK_INDEX_TEST_DATABASE_URL',
+  'rustok_channel::migrations::migrations()',
+  'rustok_product::migrations::migrations()',
+  'for migration_step in IndexModule.migrations()',
+  "INSERT INTO tenants (id) VALUES ('{TENANT_A}'), ('{TENANT_B}')",
+  '.register(IndexModule)',
+  '.register(rustok_channel::ChannelModule)',
+  '.register(rustok_product::ProductModule)',
+  'rustok_distribution::build_runtime_extensions(&registry)',
+  '.get::<ModuleWorkRegistrations>()',
+  '.register_all(&HostRuntimeContext::new(database.work.clone()), &scheduler)',
+  'run_scheduler_until_idle(&runtime.scheduler, 24)',
+  'baseline_b_generation, 0',
+  'materialize_current(&runtime, TENANT_A, PRODUCT_A)',
+  'materialize_current(&runtime, TENANT_B, PRODUCT_B)',
+  'insert_channel(&database.writer, TENANT_A, BETA_CHANNEL, "beta", "Beta")',
+  'generation_after_create > baseline_a_generation',
+  'a_relation_after_create > a_relation_before_create',
+  'a_projection_after_create > a_projection_before_create',
+  'vec![ALPHA_CHANNEL, BETA_CHANNEL]',
+  'delete_channel(&database.writer, TENANT_A, BETA_CHANNEL)',
+  'generation_after_delete > generation_after_create',
+  'a_relation_after_delete > a_relation_before_delete',
+  'a_projection_after_delete > a_projection_before_delete',
+  'vec![ALPHA_CHANNEL]',
+  'move_channel(&database.writer, ALPHA_CHANNEL, TENANT_A, TENANT_B)',
+  'generation_a_after_move > generation_after_delete',
+  'generation_b_after_move > baseline_b_generation',
+  'a_membership_after_move.is_empty()',
+  'b_relation_after_move > b_relation_before_move',
+  'b_projection_after_move > b_projection_before_move',
+  'vec![ALPHA_CHANNEL]',
+  'delete_channel(&database.writer, TENANT_B, ALPHA_CHANNEL)',
+  'insert_channel(&database.writer, TENANT_B, ALPHA_CHANNEL, "alpha", "Alpha recreated")',
+  'generation_after_identity_delete > generation_b_after_move',
+  'generation_after_recreate > generation_after_identity_delete',
+  'b_relation_after_recreate, b_relation_before_recreate',
+  'b_projection_after_recreate, b_projection_before_recreate',
+  'assert_freshness_generation(',
+  'b_materialized_before_recreate',
+  'materialized_source_version(&database.mutation, TENANT_B, PRODUCT_B)',
+  'assert_product_visible(&runtime.query, TENANT_B, PRODUCT_B, true)',
+  'assert_state_checkpoint(&database.writer, TENANT_A, generation_a_after_move)',
+  'assert_state_checkpoint(&database.writer, TENANT_B, generation_after_recreate)',
+  'channel_index_identity_generations',
+  'product_sales_channel_index_relation_snapshots',
+  'product_sales_channel_index_relation_freshness_snapshots',
+  'product_index_graph_projection_snapshots',
+  'product_sales_channel_index_relation_convergence_state',
+  'index_entities',
+]);
+forbidMarkers(harnessPath, harness, [
+  'FakeIndex',
+  'FakeSource',
+  'MockIndex',
+  'MockSource',
+  'INSERT INTO index_entities',
+  'UPDATE index_entities',
+  'DELETE FROM index_entities',
+  'PostgresIndexQueryPort::new',
+  'PostgresIndexQueryPort::with_admissions',
+  'ProductSalesChannelRelationResolver::new',
+  'ProductSalesChannelRelationConvergenceAdapter',
+  'loop {',
+  'tokio::spawn',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-product-channel-identity-transitions-postgres-harness.md', [
+  'Status: `source_ready_execution_pending`',
+  'Channel create',
+  'Channel delete',
+  'tenant move',
+  'delete + recreate',
+  'both tenant generations',
+  'same materialized Product row',
+  'relation/projection do not advance',
+  'not executed',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-product-channel-identity-transitions-postgres-harness.mjs'",
+]);
+
+console.log('[verify-index-product-channel-identity-transitions-postgres-harness] source packet verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -72,6 +72,7 @@ const scripts = [
   'verify-index-product-materialized-query-freshness.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
+  'verify-index-product-channel-identity-transitions-postgres-harness.mjs',
   'verify-index-product-graph-projection-ledger.mjs',
   'verify-index-product-variant-source.mjs',
   'verify-index-product-tombstone-source.mjs',


### PR DESCRIPTION
## Summary

- add a retained PostgreSQL packet for Channel create/delete/tenant-move/delete-recreate Product convergence semantics;
- use real Channel, Product, and Index migration chains in an isolated PostgreSQL schema;
- compose the selected Index+Channel+Product runtime, real Product replay source, persisted schema readiness, generic mutation storage, canonical Product query admission, and the registered generic `ModuleWorkScheduler` worker;
- retain Channel create/delete evidence where unrestricted Product membership changes and both `relation_epoch` and `projection_epoch` advance;
- retain tenant-move evidence where the Channel owner advances both old/new tenant generations and Product membership/projection changes on both sides;
- retain delete+recreate evidence where the same Channel UUID/canonical slug is restored before convergence, Channel generation advances twice, but final membership is unchanged so relation/projection remain unchanged and only freshness advances;
- prove the same already-materialized Product row becomes query-admissible again after freshness-only convergence without a new Product mutation;
- add a dedicated static verifier, include it in the aggregate Index query contract, and advance the M7 cursor to linked-target ProductVariant/SalesChannel parity.

## Baseline

Two tenants are used. Tenant A has unrestricted Product A plus Channel `alpha`; tenant B has unrestricted Product B and no Channel identity history. The real scheduler drains initial Product visibility requests and baseline Channel-generation sweeps. Tenant A must checkpoint a positive generation, tenant B generation/checkpoint remains zero, Product A resolves `[alpha UUID]`, and Product B resolves `[]`. Both current Product projections are then materialized and query-visible.

## Channel create/delete

Creating `beta` in tenant A advances Channel generation and immediately makes the old Product A row query-inadmissible. Real convergence must change membership to `[alpha,beta]` and advance relation/projection. The old Index row stays hidden until the current Product projection is applied.

Deleting `beta` repeats the inverse transition: generation advances, membership returns to `[alpha]`, relation/projection advance, and query authority returns only after current Product materialization.

## Tenant move

Moving `alpha` from tenant A to tenant B must advance both tenant generations. Both Product A and Product B old rows become query-inadmissible. After the real scheduler drains both tenants, Product A membership is empty and Product B membership is `[alpha UUID]`; both relation/projection clocks advance. Both current Product projection mutations are required before query authority returns.

## Delete + recreate before convergence

After tenant move, Product B is current with `[alpha UUID]`. The packet deletes `alpha` from tenant B and recreates the same Channel UUID/canonical slug before running convergence. Channel generation must advance twice and the old Product B row must be hidden while its witness is stale.

When convergence runs, current membership is again exactly `[alpha UUID]`. Therefore `relation_epoch` and `projection_epoch` must remain unchanged; freshness alone advances to the newest Channel generation. The existing `index_entities.source_version` must remain unchanged and the exact same materialized Product B row becomes query-admissible again without a Product mutation. Tenant A remains query-visible, proving tenant scope is not widened.

## Scope

This PR changes no production source or migration. It adds retained source evidence only and does not claim execution success. Channel target tombstone/recreate materialization and ProductVariant/SalesChannel linked-target query parity remain the next M7 source slice; typed Product events remain separately blocked on event-contract digest admission. No new Product schema, relation copy, or freshness clock is introduced.

## Validation

Per maintainer instruction, this packet is **source-ready, execution-pending**. No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.