### PR TITLE
feat(index): fence stale linked target query rows

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -35,7 +35,7 @@ mod tests {
     };
 
     #[test]
-    fn selected_product_bridge_registers_two_current_schemas_three_factories_and_query_admission() {
+    fn selected_product_bridge_registers_two_current_schemas_three_factories_and_entity_admissions() {
         let mut extensions = ModuleRuntimeExtensions::default();
         extensions.insert(rustok_product::ProductRuntimeSelected);
         extensions.insert(rustok_index::IndexSchemaSourceCatalog::new());
@@ -68,13 +68,13 @@ mod tests {
         }));
         let admissions = extensions
             .get::<rustok_index::PostgresIndexQueryAdmissionCatalog>()
-            .expect("Product selection must publish one query admission rule");
-        assert_eq!(admissions.len(), 1);
+            .expect("Product selection must publish Product and ProductVariant query admissions");
+        assert_eq!(admissions.len(), 2);
         assert!(!extensions.contains::<ModuleWorkRegistrations>());
     }
 
     #[test]
-    fn selected_product_and_channel_bridge_registers_convergence_work() {
+    fn selected_product_and_channel_bridge_registers_channel_admission_and_convergence_work() {
         let mut extensions = ModuleRuntimeExtensions::default();
         extensions.insert(rustok_product::ProductRuntimeSelected);
         extensions.insert(rustok_channel::ChannelRuntimeSelected);
@@ -83,6 +83,10 @@ mod tests {
 
         register(&mut extensions).unwrap();
 
+        let admissions = extensions
+            .get::<rustok_index::PostgresIndexQueryAdmissionCatalog>()
+            .expect("Product+Channel selection must publish graph entity admissions");
+        assert_eq!(admissions.len(), 3);
         let registrations = extensions
             .get::<ModuleWorkRegistrations>()
             .expect("Product+Channel composition must publish convergence work");

--- a/crates/rustok-distribution/src/product_index/query_admission.rs
+++ b/crates/rustok-distribution/src/product_index/query_admission.rs
@@ -1,6 +1,6 @@
 use rustok_core::ModuleRuntimeExtensions;
 use rustok_index::{
-    EntityName, ModuleName, PostgresQueryRootAdmission, SchemaRef, SchemaVersion,
+    EntityName, ModuleName, PostgresQueryEntityAdmission, SchemaRef, SchemaVersion,
     register_postgres_index_query_admission,
 };
 
@@ -14,8 +14,8 @@ EXISTS (
             projection.product_source_version,
             projection.relation_epoch
         FROM product_index_graph_projection_snapshots projection
-        WHERE projection.tenant_id = {{root}}.tenant_id
-          AND projection.product_id = {{root}}.entity_id
+        WHERE projection.tenant_id = {{entity}}.tenant_id
+          AND projection.product_id = {{entity}}.entity_id
         ORDER BY projection.projection_epoch DESC
         LIMIT 1
     ) current_projection ON TRUE
@@ -24,39 +24,59 @@ EXISTS (
             witness.product_source_version,
             witness.channel_identity_generation
         FROM product_sales_channel_index_relation_freshness_snapshots witness
-        WHERE witness.tenant_id = {{root}}.tenant_id
-          AND witness.product_id = {{root}}.entity_id
+        WHERE witness.tenant_id = {{entity}}.tenant_id
+          AND witness.product_id = {{entity}}.entity_id
           AND witness.relation_epoch = current_projection.relation_epoch
         ORDER BY witness.sequence_no DESC
         LIMIT 1
     ) current_freshness ON TRUE
-    WHERE owner_product.tenant_id = {{root}}.tenant_id
-      AND owner_product.id = {{root}}.entity_id
-      AND {{root}}.source_version = current_projection.projection_epoch
+    WHERE owner_product.tenant_id = {{entity}}.tenant_id
+      AND owner_product.id = {{entity}}.entity_id
+      AND {{entity}}.source_version = current_projection.projection_epoch
       AND current_projection.product_source_version = owner_product.index_revision
       AND current_freshness.product_source_version <= owner_product.index_revision
       AND current_freshness.channel_identity_generation = COALESCE(
           (
               SELECT channel_generation.generation
               FROM channel_index_identity_generations channel_generation
-              WHERE channel_generation.tenant_id = {{root}}.tenant_id
+              WHERE channel_generation.tenant_id = {{entity}}.tenant_id
           ),
           0
       )
       AND NOT EXISTS (
           SELECT 1
           FROM product_sales_channel_index_relation_convergence_requests request
-          WHERE request.tenant_id = {{root}}.tenant_id
-            AND request.product_id = {{root}}.entity_id
+          WHERE request.tenant_id = {{entity}}.tenant_id
+            AND request.product_id = {{entity}}.entity_id
             AND request.product_source_version > current_freshness.product_source_version
       )
       AND EXISTS (
           SELECT 1
           FROM product_translations translation
-          WHERE translation.tenant_id = {{root}}.tenant_id
-            AND translation.product_id = {{root}}.entity_id
-            AND translation.locale = {{root}}.locale_key
+          WHERE translation.tenant_id = {{entity}}.tenant_id
+            AND translation.product_id = {{entity}}.entity_id
+            AND translation.locale = {{entity}}.locale_key
       )
+)
+"#;
+
+const PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS: &str = r#"
+EXISTS (
+    SELECT 1
+    FROM product_variants owner_variant
+    WHERE owner_variant.tenant_id = {{entity}}.tenant_id
+      AND owner_variant.id = {{entity}}.entity_id
+      AND owner_variant.index_revision = {{entity}}.source_version
+)
+"#;
+
+const SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS: &str = r#"
+EXISTS (
+    SELECT 1
+    FROM channels owner_channel
+    WHERE owner_channel.tenant_id = {{entity}}.tenant_id
+      AND owner_channel.id = {{entity}}.entity_id
+      AND owner_channel.index_revision = {{entity}}.source_version
 )
 "#;
 
@@ -64,35 +84,91 @@ pub(crate) fn register(extensions: &mut ModuleRuntimeExtensions) -> rustok_core:
     if !extensions.contains::<rustok_product::ProductRuntimeSelected>() {
         return Ok(());
     }
-    let admission = PostgresQueryRootAdmission::new(PRODUCT_QUERY_MATERIALIZED_FRESHNESS).map_err(
-        |error| {
-            rustok_core::Error::Validation(format!(
-                "selected Product Index query admission construction failed: {error}"
-            ))
-        },
-    )?;
-    register_postgres_index_query_admission(
+
+    register_rule(
         extensions,
         "product",
         product_schema_ref()?,
-        admission,
-    )
-    .map_err(|error| {
+        PRODUCT_QUERY_MATERIALIZED_FRESHNESS,
+        "Product",
+    )?;
+    register_rule(
+        extensions,
+        "product",
+        product_variant_schema_ref()?,
+        PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS,
+        "ProductVariant",
+    )?;
+
+    if extensions.contains::<rustok_channel::ChannelRuntimeSelected>() {
+        register_rule(
+            extensions,
+            "channel",
+            sales_channel_schema_ref()?,
+            SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS,
+            "SalesChannel",
+        )?;
+    }
+    Ok(())
+}
+
+fn register_rule(
+    extensions: &mut ModuleRuntimeExtensions,
+    owner_module: &str,
+    schema: SchemaRef,
+    template: &str,
+    label: &str,
+) -> rustok_core::Result<()> {
+    let admission = PostgresQueryEntityAdmission::new(template).map_err(|error| {
         rustok_core::Error::Validation(format!(
-            "selected Product Index query admission registration failed: {error}"
+            "selected {label} Index query admission construction failed: {error}"
         ))
-    })
+    })?;
+    register_postgres_index_query_admission(extensions, owner_module, schema, admission).map_err(
+        |error| {
+            rustok_core::Error::Validation(format!(
+                "selected {label} Index query admission registration failed: {error}"
+            ))
+        },
+    )
 }
 
 fn product_schema_ref() -> rustok_core::Result<SchemaRef> {
+    schema_ref("rustok-product", "product", SchemaVersion::new(3), "Product")
+}
+
+fn product_variant_schema_ref() -> rustok_core::Result<SchemaRef> {
+    schema_ref(
+        "rustok-product",
+        "product_variant",
+        SchemaVersion::new(2),
+        "ProductVariant",
+    )
+}
+
+fn sales_channel_schema_ref() -> rustok_core::Result<SchemaRef> {
+    schema_ref(
+        "rustok-channel",
+        "sales_channel",
+        SchemaVersion::INITIAL,
+        "SalesChannel",
+    )
+}
+
+fn schema_ref(
+    module: &str,
+    entity: &str,
+    version: SchemaVersion,
+    label: &str,
+) -> rustok_core::Result<SchemaRef> {
     Ok(SchemaRef {
-        module: ModuleName::new("rustok-product").map_err(|error| {
-            rustok_core::Error::Validation(format!("Product Index module name is invalid: {error}"))
+        module: ModuleName::new(module).map_err(|error| {
+            rustok_core::Error::Validation(format!("{label} Index module name is invalid: {error}"))
         })?,
-        entity: EntityName::new("product").map_err(|error| {
-            rustok_core::Error::Validation(format!("Product Index entity name is invalid: {error}"))
+        entity: EntityName::new(entity).map_err(|error| {
+            rustok_core::Error::Validation(format!("{label} Index entity name is invalid: {error}"))
         })?,
-        version: SchemaVersion::new(3),
+        version,
     })
 }
 
@@ -101,16 +177,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn materialized_freshness_predicate_fences_owner_and_locale_state() {
+    fn product_materialized_freshness_predicate_fences_owner_and_locale_state() {
         for marker in [
             "product_index_graph_projection_snapshots",
             "product_sales_channel_index_relation_freshness_snapshots",
             "channel_index_identity_generations",
             "product_sales_channel_index_relation_convergence_requests",
-            "{{root}}.source_version = current_projection.projection_epoch",
+            "{{entity}}.source_version = current_projection.projection_epoch",
             "current_projection.product_source_version = owner_product.index_revision",
             "request.product_source_version > current_freshness.product_source_version",
-            "translation.locale = {{root}}.locale_key",
+            "translation.locale = {{entity}}.locale_key",
             "LIMIT 1",
         ] {
             assert!(
@@ -118,11 +194,38 @@ mod tests {
                 "missing {marker}"
             );
         }
-        for forbidden in ["index_links", "index_entities", "$1", "channel_visibility"] {
-            assert!(
-                !PRODUCT_QUERY_MATERIALIZED_FRESHNESS.contains(forbidden),
-                "forbidden {forbidden}"
-            );
+    }
+
+    #[test]
+    fn linked_target_predicates_require_live_owner_revision_identity() {
+        for (template, owner_table) in [
+            (
+                PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS,
+                "product_variants owner_variant",
+            ),
+            (
+                SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS,
+                "channels owner_channel",
+            ),
+        ] {
+            assert!(template.contains(owner_table));
+            assert!(template.contains("owner_"));
+            assert!(template.contains(".tenant_id = {{entity}}.tenant_id"));
+            assert!(template.contains(".id = {{entity}}.entity_id"));
+            assert!(template.contains(".index_revision = {{entity}}.source_version"));
+        }
+    }
+
+    #[test]
+    fn owner_admission_predicates_do_not_read_materialized_index_storage() {
+        for template in [
+            PRODUCT_QUERY_MATERIALIZED_FRESHNESS,
+            PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS,
+            SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS,
+        ] {
+            for forbidden in ["index_links", "index_entities", "$1", "IndexMutation"] {
+                assert!(!template.contains(forbidden), "forbidden {forbidden}");
+            }
         }
     }
 }

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -1,173 +1,150 @@
 # M7 Product materialized/query freshness fence
 
-Status: `source_complete_postgres_packet_source_ready_execution_pending`.
+Status: `source_complete_linked_target_fence_execution_pending`.
 
-## Problem closed by the source fence
+## Problem closed at source level
 
-Product source admission already rejects stale Product-to-SalesChannel relation state, and automatic
-convergence re-establishes owner freshness after Product visibility or Channel identity changes. Those
-contracts do not by themselves protect an Index mutation that was produced under a valid source
-snapshot and then applied after owner state changed.
+Product source admission and automatic Product-to-SalesChannel convergence protect source reads, but an
+already-produced Index mutation can still arrive after owner state changes. A post-result freshness
+check is too late because stale root or linked rows may already have affected filtering, ordering,
+cursor pagination, many projections, aggregate ordering, and exact count.
 
-The race window is:
+The query boundary therefore treats owner freshness as an admission property of every materialized
+`index_entities` relation used by the compiler, not only the root row.
 
-1. Product source reads a valid Product projection and freshness witness;
-2. owner Product/Channel state changes;
-3. the already-produced mutation is applied to `index_entities/index_links`;
-4. an Index query executes before the corrective mutation arrives.
+## Generic entity query admission
 
-A post-result freshness check is insufficient because a stale row can already have changed filtering,
-ordering, cursor pagination, and exact count before the check sees returned rows.
+`rustok-index` owns `PostgresQueryEntityAdmission`, a trusted schema-scoped PostgreSQL entity-admission
+contract.
 
-## Generic root query admission
+A rule:
 
-`rustok-index` owns a trusted schema-scoped PostgreSQL root-admission contract.
-
-`PostgresQueryRootAdmission` accepts a source-code predicate template that:
-
-- must reference the compiler-controlled `{{root}}` alias;
+- must reference the compiler-controlled `{{entity}}` alias;
 - cannot contain bind placeholders, SQL statement boundaries, or comments;
 - is bounded to 32 KiB;
-- is applied to the compiler's exact canonical root `index_entities` baseline, including locale scope;
-- fails closed if page or exact-count SQL no longer contains exactly one expected root anchor.
+- changes no user bind, selected column, plan fingerprint, or cursor contract;
+- is applied to every compiler-owned materialized entity alias in page and exact-count SQL;
+- fails closed when the compiler emits an unknown entity alias family or omits the canonical
+  `is_deleted = FALSE` entity anchor.
 
-The admission predicate changes no user binds, selected columns, query fingerprint, or cursor contract.
-It is injected into root `WHERE` before user filter/cursor/order/limit semantics. The same predicate is
-injected into exact-count SQL.
+Current compiler alias families covered by the admission boundary are:
 
-`PostgresIndexQueryAdmissionCatalog` owns at most one rule per exact `SchemaRef`. Query runtime
-materialization snapshots that catalog into `PostgresIndexQueryPort`, rejects admission rules targeting
-an unregistered schema, and preserves the existing generic behavior for schemas without a rule.
+- `tN` for root and ordinary outer-join entity relations;
+- `mpN_tN` for many-cardinality projections;
+- `mx_tN` for many-cardinality filter `EXISTS` relations;
+- `mo_tN` for many-cardinality aggregate-order relations.
 
-## Product admission evidence
+`PostgresIndexQueryAdmissionCatalog` still owns at most one owner rule per exact `SchemaRef`. At runtime
+those owner rules are compiled into one schema-dispatch predicate. If at least one owner rule exists,
+the immutable runtime adds local pass-through descriptors for otherwise ungoverned registered root
+schemas. Those pass-through descriptors are not published owner rules; they only ensure that a query
+rooted elsewhere still applies governed freshness rules to linked targets.
 
-The selected distribution registers one rule for the canonical Product schema. A materialized Product
-root row is query-admissible only when all of these facts are true in the same PostgreSQL
-`REPEATABLE READ`, `READ ONLY` query snapshot:
+## Product graph owner rules
 
-- the owner Product still exists;
-- the exact Product locale translation still exists;
-- the materialized `index_entities.source_version` equals the latest Product
-  `product_index_graph_projection_snapshots.projection_epoch`;
-- that projection's Product component equals current `products.index_revision`;
-- a freshness witness exists for the projection's exact `relation_epoch`;
-- the witness Product revision is not ahead of current Product revision;
-- witness Channel identity generation equals current tenant `channel_index_identity_generations`
-  (or generation `0` when no Channel generation row exists);
-- there is no retained Product visibility convergence request with
-  `product_source_version > witness.product_source_version`.
+The selected Product distribution registers current entity admission for Product and ProductVariant.
+When Channel is selected it also registers SalesChannel admission. No new Index schema or freshness
+clock is introduced.
 
-The last condition is the current-visibility proof. Product convergence requests are appended only for
-Product INSERT or canonical `channel_visibility` changes. Therefore an unrelated Product scalar update
-does not falsely invalidate relation freshness, while any later visibility change makes an older
-witness query-inadmissible without re-parsing Product visibility JSON in SQL.
+### Product
 
-## Why no extra materialized watermark is needed
+A Product materialized row is admitted only when, in the same PostgreSQL `REPEATABLE READ, READ ONLY`
+query snapshot:
 
-The existing clocks already carry the required evidence:
+- the owner Product and exact locale translation still exist;
+- materialized `source_version` equals current Product `projection_epoch`;
+- the projection Product component equals current `products.index_revision`;
+- an exact relation freshness witness exists;
+- witness Channel generation equals current tenant Channel generation;
+- no visibility convergence request is newer than the witness Product revision.
 
-- `index_entities.source_version` is Product `projection_epoch`;
-- Product projection state identifies current Product and relation components;
-- the freshness witness identifies the observed Product revision and Channel generation;
-- the convergence request ledger identifies visibility-affecting Product revisions;
-- live Product/translation rows prove the materialized identity/locale still exists.
+This is the existing Product root/source-read -> mutation-apply fence, now reusable when Product appears
+as any governed materialized entity relation.
 
-A new Product schema, duplicate relation membership, query-time visibility parser, or new Index storage
-column would add another authority without improving the proof.
+### ProductVariant
 
-## Important transitions
+A ProductVariant row is admitted only when a live owner `product_variants` row exists for the same
+tenant/UUID and:
 
-### Product scalar/Variant change
+`product_variants.index_revision = index_entities.source_version`.
 
-Product `index_revision` and projection advance. An older materialized row fails the projection epoch
-comparison until the new Product mutation is applied.
+Therefore a delayed stale ProductVariant mutation or a stale materialized ProductVariant after owner
+delete cannot participate in Product `variants` projection/filter/order semantics before the corrective
+Index mutation arrives.
 
-### Product visibility change
+### SalesChannel
 
-The Product update advances projection and appends an exact visibility convergence request. An older
-witness cannot satisfy the request-watermark check. The row remains query-inadmissible until resolver
-freshness is current and the new Product projection is materialized.
+A SalesChannel row is admitted only when a live owner `channels` row exists for the same tenant/UUID
+and:
 
-### Channel identity change
+`channels.index_revision = index_entities.source_version`.
 
-Current tenant Channel generation immediately differs from the old witness, so Product rows are
-query-inadmissible even if an old already-produced mutation applies afterward. Automatic convergence
-then refreshes witness/membership.
+Therefore stale/deleted SalesChannel materialization cannot participate in Product `sales_channels`
+projection/filter/order semantics while the Product root itself remains current.
 
-If resolved UUID membership is unchanged, `relation_epoch`/`projection_epoch` need not move; updating
-the freshness witness to the current Channel generation is enough to make the unchanged materialized
-Product row query-admissible again.
+## Query surfaces protected
 
-If membership changes, Product `relation_epoch` and `projection_epoch` advance; the old materialized
-row remains inadmissible until the new Product mutation is applied.
+The same composite admission is applied before or inside every materialized target relation used by:
 
-### Product/locale delete
+- root predicates and exact count;
+- ordinary linked projection/filter/order joins;
+- many-cardinality nested projections;
+- many-cardinality `EXISTS` filters;
+- many-cardinality `MIN`/`MAX` aggregate ordering;
+- exact-count recompilation of the same plan.
 
-A stale materialized Product row fails immediately because the live Product or exact translation no
-longer exists, even before the retained delete mutation reaches Index storage.
+This closes the previous source-level linked-target availability gap without making generic Index code
+understand Product, ProductVariant, or SalesChannel owner storage.
 
-### Rejected Product owner data
+## Retained PostgreSQL packets
 
-A rejected Product remains individually fail-closed. Its retained visibility request stays newer than
-its last valid freshness witness, so query admission excludes it without blocking unrelated valid
-Products in the same tenant.
+The existing retained packets remain execution-pending:
 
-## PostgreSQL evidence packet 1
+1. `product_materialized_query_freshness_postgres.rs` — delayed Product scalar mutation and locale
+   deletion;
+2. `product_channel_convergence_postgres.rs` — Product visibility / Channel identity convergence,
+   lease reclaim, rejected Product isolation, changed and unchanged membership;
+3. `product_channel_identity_transitions_postgres.rs` — Channel create/delete/tenant-move and
+   delete+recreate Product relation/freshness behavior.
 
-`crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs` is now a retained,
-environment-gated source packet for the materialized stale-mutation race. Its detailed contract is in
-`m7-product-materialized-query-freshness-postgres-harness.md`.
+They have not been executed or admitted by the implementation agent.
 
-The packet uses the real Product source, real Product and Index migrations, persisted schema
-registration, `PostgresMutationStore`, and the canonical shared query runtime. It intentionally:
+## Explicit remaining recreate boundary
 
-- reads a valid Product mutation;
-- changes owner Product state before apply;
-- applies the delayed old mutation and proves that old source version is physically present in
-  `index_entities`;
-- proves the stale row is excluded before title filter/order/cursor lookahead/limit/exact count;
-- applies the corrective current mutation and proves ordinary two-page cursor behavior returns;
-- repeats the delayed-upsert window across owner locale deletion and proves the physically stored row
-  remains query-inadmissible with exact count zero.
+ProductVariant and SalesChannel currently use their live owner `index_revision` as source version. A
+hard delete followed by recreation of the same UUID can reset that owner-local revision to an earlier
+numeric value. Equality-based entity admission cannot distinguish a new incarnation when the recreated
+row happens to reuse the same revision as an old materialized row.
 
-This packet is **source-ready, not executed, and not admitted**. No successful PostgreSQL evidence is
-claimed yet.
+Therefore this slice does **not** claim delete+recreate identity safety for ProductVariant or
+SalesChannel target materialization. The next source slice must make those two owner source clocks
+monotonic across retained tombstone/recreate history, while preserving the current ProductVariant and
+SalesChannel SchemaRefs. Do not add another Product schema or compatibility version.
 
-## Scope and remaining admission
+## Remaining M7 admission
 
-The Product root source-read -> mutation-apply freshness mechanism is source-complete. The first
-retained PostgreSQL race packet is source-ready, but execution/admission remains pending.
+Still required before Storefront cutover:
 
-Still required before cutover:
-
-- execute and retain the first materialized stale-mutation PostgreSQL packet;
-- retained Product visibility + Channel-generation race evidence, including unchanged-membership and
-  changed-membership transitions;
-- automatic-convergence multi-host lease/restart/rejected-Product evidence;
-- complete Product/Variant/Channel query equivalence, including linked target availability behavior;
-- canonical Product typed event admission after event-contract digest verification;
-- Storefront cutover evidence after schema readiness, equivalence, convergence, and query-freshness
-  packets pass.
-
-The next source packet should combine Product visibility/Channel identity races with the convergence
-worker's durable multi-host/restart state machine. It must not introduce another Product schema or
-freshness clock.
+- implement recreate-safe monotonic ProductVariant and SalesChannel source clocks;
+- retain PostgreSQL linked-target stale/delete/recreate query evidence after that clock change;
+- execute/admit the retained Product freshness/convergence/identity packets;
+- complete Product/ProductVariant/SalesChannel query equivalence and linked-target availability proof;
+- admit canonical Product typed events only after event-contract digest verification;
+- pass schema readiness, equivalence, convergence, freshness, and restart evidence.
 
 ## Maintainer verification
 
 Suggested commands, intentionally not run by the implementation agent:
 
 ```bash
-cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
-node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
+node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-query-runtime-composition.mjs
-node scripts/verify/verify-index-product-channel-relation-convergence.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
 cargo check -p rustok-distribution --features mod-product --all-targets
 git diff --check
 ```
 
-No tests, Node verifiers, Cargo checks, formatting, PostgreSQL scenarios, workflows, or CI were executed
-by the implementation agent.
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -58,8 +58,8 @@ query snapshot:
 - witness Channel generation equals current tenant Channel generation;
 - no visibility convergence request is newer than the witness Product revision.
 
-This is the existing Product root/source-read -> mutation-apply fence, now reusable when Product appears
-as any governed materialized entity relation.
+This is the existing Product source-read -> mutation-apply fence, now reusable when Product appears as
+any governed materialized entity relation.
 
 ### ProductVariant
 
@@ -68,9 +68,9 @@ tenant/UUID and:
 
 `product_variants.index_revision = index_entities.source_version`.
 
-Therefore a delayed stale ProductVariant mutation or a stale materialized ProductVariant after owner
-delete cannot participate in Product `variants` projection/filter/order semantics before the corrective
-Index mutation arrives.
+A delayed stale ProductVariant row therefore cannot contribute its old payload to Product `variants`
+projection/filter/order semantics after the owner revision has advanced or the owner row has been
+deleted.
 
 ### SalesChannel
 
@@ -79,10 +79,10 @@ and:
 
 `channels.index_revision = index_entities.source_version`.
 
-Therefore stale/deleted SalesChannel materialization cannot participate in Product `sales_channels`
-projection/filter/order semantics while the Product root itself remains current.
+A stale/deleted SalesChannel row therefore cannot contribute its old payload to Product
+`sales_channels` projection/filter/order semantics while the Product root itself remains current.
 
-## Query surfaces protected
+## Query surfaces fenced against stale target payloads
 
 The same composite admission is applied before or inside every materialized target relation used by:
 
@@ -93,8 +93,14 @@ The same composite admission is applied before or inside every materialized targ
 - many-cardinality `MIN`/`MAX` aggregate ordering;
 - exact-count recompilation of the same plan.
 
-This closes the previous source-level linked-target availability gap without making generic Index code
+This closes the stale-materialized-target participation path without making generic Index code
 understand Product, ProductVariant, or SalesChannel owner storage.
+
+It does **not** yet prove complete linked-target availability semantics. In particular, a source link
+may exist while its target has not yet been materialized, and existing left-join / many-subquery
+semantics can represent an unavailable target as a missing/null relation. Complete Product graph parity
+still requires retained evidence and an explicit fail-closed policy for that availability window so a
+missing target cannot be mistaken for authoritative owner null/absence semantics.
 
 ## Retained PostgreSQL packets
 
@@ -126,7 +132,9 @@ SalesChannel SchemaRefs. Do not add another Product schema or compatibility vers
 Still required before Storefront cutover:
 
 - implement recreate-safe monotonic ProductVariant and SalesChannel source clocks;
-- retain PostgreSQL linked-target stale/delete/recreate query evidence after that clock change;
+- define and retain fail-closed linked-target availability semantics for link-present / target-missing
+  windows;
+- retain PostgreSQL linked-target stale/delete/recreate/query evidence after those source changes;
 - execute/admit the retained Product freshness/convergence/identity packets;
 - complete Product/ProductVariant/SalesChannel query equivalence and linked-target availability proof;
 - admit canonical Product typed events only after event-contract digest verification;

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -119,8 +119,8 @@ pub use postgres_compiler::{
     CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError, PostgresQueryCompileError,
 };
 pub use postgres_query_admission::{
-    PostgresQueryRootAdmission, PostgresQueryRootAdmissionApplyError,
-    PostgresQueryRootAdmissionError,
+    PostgresQueryEntityAdmission, PostgresQueryEntityAdmissionApplyError,
+    PostgresQueryEntityAdmissionError,
 };
 pub use postgres_query_result::{
     CompiledPostgresCell, CompiledPostgresPageQuery, CompiledPostgresRow,

--- a/crates/rustok-index/src/application/postgres_query_admission.rs
+++ b/crates/rustok-index/src/application/postgres_query_admission.rs
@@ -1,23 +1,27 @@
+use std::collections::BTreeSet;
+
 use thiserror::Error;
 
-use super::{CompiledPostgresQuery, CompiledQueryColumn, postgres_compiler::quote_identifier};
+use super::{CompiledPostgresQuery, postgres_compiler::quote_identifier};
 
-const ROOT_ALIAS_TOKEN: &str = "{{root}}";
-const MAX_ROOT_ADMISSION_BYTES: usize = 32 * 1024;
+const ENTITY_ALIAS_TOKEN: &str = "{{entity}}";
+const MAX_ENTITY_ADMISSION_BYTES: usize = 32 * 1024;
+const INDEX_ENTITY_ALIAS_MARKER: &str = "index_entities AS \"";
 
-/// Trusted PostgreSQL predicate applied to the root `index_entities` row before filtering,
-/// ordering, pagination, and exact-count evaluation.
+/// Trusted PostgreSQL predicate applied to every compiler-owned `index_entities` relation before
+/// filtering, ordering, pagination, nested projection, and exact-count evaluation.
 ///
 /// Module-owned admission rules are source code, not user input. They intentionally accept no bind
-/// placeholders: all tenant/entity/locale correlation must flow through the controlled root alias.
-/// This keeps query bind numbering and cursor fingerprints independent of runtime admission state.
+/// placeholders: tenant/entity/locale correlation must flow through the controlled entity alias.
+/// This keeps query bind numbering, plan fingerprints, and cursor contracts independent of runtime
+/// admission state.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PostgresQueryRootAdmission {
+pub struct PostgresQueryEntityAdmission {
     template: String,
 }
 
-impl PostgresQueryRootAdmission {
-    pub fn new(template: impl Into<String>) -> Result<Self, PostgresQueryRootAdmissionError> {
+impl PostgresQueryEntityAdmission {
+    pub fn new(template: impl Into<String>) -> Result<Self, PostgresQueryEntityAdmissionError> {
         let template = template.into();
         validate_template(&template)?;
         Ok(Self { template })
@@ -27,123 +31,153 @@ impl PostgresQueryRootAdmission {
         &self.template
     }
 
-    /// Applies the trusted predicate to a validated compiler product without changing bind values,
-    /// selected columns, query-plan fingerprint, or cursor semantics.
+    /// Applies the trusted predicate to every materialized entity relation in the page query and
+    /// optional exact-count query without changing binds, selected columns, plan fingerprint, or
+    /// cursor semantics.
     ///
-    /// The compiler-owned root baseline is intentionally treated as a fail-closed anchor. If page or
-    /// exact-count SQL no longer contains exactly one canonical anchor, the query is rejected rather
-    /// than silently running without admission.
+    /// Relation aliases are discovered only from compiler-owned `index_entities AS "..."` clauses
+    /// and must match one of the canonical compiler alias families. Every discovered alias must have
+    /// at least one canonical `is_deleted = FALSE` anchor. Compiler drift therefore fails closed
+    /// instead of silently bypassing owner admission on one query path.
     pub fn apply(
         &self,
         compiled: &mut CompiledPostgresQuery,
-    ) -> Result<(), PostgresQueryRootAdmissionApplyError> {
-        let root_alias = compiled
-            .columns
-            .iter()
-            .find_map(|column| match column {
-                CompiledQueryColumn::EntityId { relation_alias, .. } => Some(relation_alias.as_str()),
-                _ => None,
-            })
-            .ok_or(PostgresQueryRootAdmissionApplyError::MissingRootIdentity)?;
-        validate_relation_alias(root_alias)?;
-        let rendered = self.render(root_alias);
-        apply_to_sql(&mut compiled.sql, root_alias, &rendered)?;
+    ) -> Result<(), PostgresQueryEntityAdmissionApplyError> {
+        apply_to_sql(&mut compiled.sql, &self.template)?;
         if let Some(exact_count) = compiled.exact_count.as_mut() {
-            apply_to_sql(&mut exact_count.sql, root_alias, &rendered)?;
+            apply_to_sql(&mut exact_count.sql, &self.template)?;
         }
         Ok(())
     }
 
-    fn render(&self, root_alias: &str) -> String {
+    fn render(&self, entity_alias: &str) -> String {
         self.template
-            .replace(ROOT_ALIAS_TOKEN, &quote_identifier(root_alias))
+            .replace(ENTITY_ALIAS_TOKEN, &quote_identifier(entity_alias))
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
-pub enum PostgresQueryRootAdmissionError {
-    #[error("PostgreSQL root query admission predicate is empty")]
+pub enum PostgresQueryEntityAdmissionError {
+    #[error("PostgreSQL entity query admission predicate is empty")]
     Empty,
-    #[error("PostgreSQL root query admission predicate is too large")]
+    #[error("PostgreSQL entity query admission predicate is too large")]
     TooLarge,
-    #[error("PostgreSQL root query admission predicate must reference the controlled root alias")]
-    MissingRootAlias,
-    #[error("PostgreSQL root query admission predicate contains a forbidden SQL boundary")]
+    #[error("PostgreSQL entity query admission predicate must reference the controlled entity alias")]
+    MissingEntityAlias,
+    #[error("PostgreSQL entity query admission predicate contains a forbidden SQL boundary")]
     ForbiddenSqlBoundary,
-    #[error("PostgreSQL root query admission predicate contains a bind placeholder")]
+    #[error("PostgreSQL entity query admission predicate contains a bind placeholder")]
     BindPlaceholderForbidden,
-    #[error("PostgreSQL root query admission predicate contains a control character")]
+    #[error("PostgreSQL entity query admission predicate contains a control character")]
     ControlCharacter,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
-pub enum PostgresQueryRootAdmissionApplyError {
-    #[error("compiled PostgreSQL query has no root entity identity column")]
-    MissingRootIdentity,
-    #[error("compiled PostgreSQL query root alias is invalid")]
-    InvalidRootAlias,
-    #[error("compiled PostgreSQL query does not contain exactly one canonical root admission anchor")]
-    RootAnchorMismatch,
+pub enum PostgresQueryEntityAdmissionApplyError {
+    #[error("compiled PostgreSQL query contains no materialized entity relation")]
+    MissingEntityRelation,
+    #[error("compiled PostgreSQL query contains an invalid materialized entity alias: {0}")]
+    InvalidEntityAlias(String),
+    #[error("compiled PostgreSQL query has no canonical admission anchor for entity alias {0}")]
+    EntityAnchorMissing(String),
 }
 
-fn validate_template(template: &str) -> Result<(), PostgresQueryRootAdmissionError> {
+fn validate_template(template: &str) -> Result<(), PostgresQueryEntityAdmissionError> {
     if template.trim().is_empty() {
-        return Err(PostgresQueryRootAdmissionError::Empty);
+        return Err(PostgresQueryEntityAdmissionError::Empty);
     }
-    if template.len() > MAX_ROOT_ADMISSION_BYTES {
-        return Err(PostgresQueryRootAdmissionError::TooLarge);
+    if template.len() > MAX_ENTITY_ADMISSION_BYTES {
+        return Err(PostgresQueryEntityAdmissionError::TooLarge);
     }
-    if !template.contains(ROOT_ALIAS_TOKEN) {
-        return Err(PostgresQueryRootAdmissionError::MissingRootAlias);
+    if !template.contains(ENTITY_ALIAS_TOKEN) {
+        return Err(PostgresQueryEntityAdmissionError::MissingEntityAlias);
     }
     if template.contains(';')
         || template.contains("--")
         || template.contains("/*")
         || template.contains("*/")
     {
-        return Err(PostgresQueryRootAdmissionError::ForbiddenSqlBoundary);
+        return Err(PostgresQueryEntityAdmissionError::ForbiddenSqlBoundary);
     }
     if template.contains('$') {
-        return Err(PostgresQueryRootAdmissionError::BindPlaceholderForbidden);
+        return Err(PostgresQueryEntityAdmissionError::BindPlaceholderForbidden);
     }
     if template
         .chars()
         .any(|character| character.is_control() && !matches!(character, '\n' | '\r' | '\t'))
     {
-        return Err(PostgresQueryRootAdmissionError::ControlCharacter);
+        return Err(PostgresQueryEntityAdmissionError::ControlCharacter);
     }
     Ok(())
 }
 
-fn validate_relation_alias(alias: &str) -> Result<(), PostgresQueryRootAdmissionApplyError> {
-    let valid = alias.strip_prefix('t').is_some_and(|suffix| {
-        !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+fn entity_aliases(sql: &str) -> Result<BTreeSet<String>, PostgresQueryEntityAdmissionApplyError> {
+    let mut aliases = BTreeSet::new();
+    let mut remainder = sql;
+    while let Some(offset) = remainder.find(INDEX_ENTITY_ALIAS_MARKER) {
+        let after_marker = &remainder[offset + INDEX_ENTITY_ALIAS_MARKER.len()..];
+        let Some(end) = after_marker.find('"') else {
+            return Err(PostgresQueryEntityAdmissionApplyError::InvalidEntityAlias(
+                after_marker.to_owned(),
+            ));
+        };
+        let alias = &after_marker[..end];
+        validate_relation_alias(alias)?;
+        aliases.insert(alias.to_owned());
+        remainder = &after_marker[end + 1..];
+    }
+    if aliases.is_empty() {
+        return Err(PostgresQueryEntityAdmissionApplyError::MissingEntityRelation);
+    }
+    Ok(aliases)
+}
+
+fn validate_relation_alias(alias: &str) -> Result<(), PostgresQueryEntityAdmissionApplyError> {
+    let plain = numeric_suffix(alias, "t");
+    let many_projection = alias.strip_prefix("mp").is_some_and(|remainder| {
+        let Some((projection, target)) = remainder.split_once("_t") else {
+            return false;
+        };
+        numeric_component(projection) && numeric_component(target)
     });
-    if valid {
+    let many_filter = alias
+        .strip_prefix("mx_t")
+        .is_some_and(numeric_component);
+    let many_order = alias
+        .strip_prefix("mo_t")
+        .is_some_and(numeric_component);
+    if plain || many_projection || many_filter || many_order {
         Ok(())
     } else {
-        Err(PostgresQueryRootAdmissionApplyError::InvalidRootAlias)
+        Err(PostgresQueryEntityAdmissionApplyError::InvalidEntityAlias(
+            alias.to_owned(),
+        ))
     }
 }
 
-fn root_baseline(root_alias: &str) -> String {
-    let root = quote_identifier(root_alias);
-    format!(
-        "{root}.tenant_id = $1 AND {root}.module_name = $2 AND {root}.entity_name = $3 AND {root}.schema_version = $4 AND {root}.locale_key = $5 AND {root}.is_deleted = FALSE"
-    )
+fn numeric_suffix(value: &str, prefix: &str) -> bool {
+    value.strip_prefix(prefix).is_some_and(numeric_component)
+}
+
+fn numeric_component(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn apply_to_sql(
     sql: &mut String,
-    root_alias: &str,
-    rendered: &str,
-) -> Result<(), PostgresQueryRootAdmissionApplyError> {
-    let anchor = root_baseline(root_alias);
-    if sql.match_indices(&anchor).count() != 1 {
-        return Err(PostgresQueryRootAdmissionApplyError::RootAnchorMismatch);
+    template: &str,
+) -> Result<(), PostgresQueryEntityAdmissionApplyError> {
+    let aliases = entity_aliases(sql)?;
+    for alias in aliases {
+        let alias_q = quote_identifier(&alias);
+        let anchor = format!("{alias_q}.is_deleted = FALSE");
+        if !sql.contains(&anchor) {
+            return Err(PostgresQueryEntityAdmissionApplyError::EntityAnchorMissing(alias));
+        }
+        let rendered = template.replace(ENTITY_ALIAS_TOKEN, &alias_q);
+        let replacement = format!("{anchor} AND ({rendered})");
+        *sql = sql.replace(&anchor, &replacement);
     }
-    let replacement = format!("{anchor} AND ({rendered})");
-    *sql = sql.replacen(&anchor, &replacement, 1);
     Ok(())
 }
 
@@ -153,41 +187,63 @@ mod tests {
 
     #[test]
     fn admission_requires_controlled_alias_without_sql_boundaries_or_binds() {
-        assert!(PostgresQueryRootAdmission::new("{{root}}.source_version > 0").is_ok());
+        assert!(PostgresQueryEntityAdmission::new("{{entity}}.source_version > 0").is_ok());
         for invalid in [
             "",
             "TRUE",
-            "{{root}}.source_version = $1",
-            "{{root}}.source_version > 0; SELECT 1",
-            "{{root}}.source_version > 0 -- bypass",
+            "{{entity}}.source_version = $1",
+            "{{entity}}.source_version > 0; SELECT 1",
+            "{{entity}}.source_version > 0 -- bypass",
         ] {
-            assert!(PostgresQueryRootAdmission::new(invalid).is_err(), "{invalid}");
+            assert!(PostgresQueryEntityAdmission::new(invalid).is_err(), "{invalid}");
         }
     }
 
     #[test]
-    fn admission_renders_only_the_compiler_owned_root_alias() {
-        let admission = PostgresQueryRootAdmission::new(
-            "EXISTS (SELECT 1 WHERE {{root}}.source_version > 0 AND {{root}}.is_deleted = FALSE)",
+    fn admission_renders_only_the_compiler_owned_entity_alias() {
+        let admission = PostgresQueryEntityAdmission::new(
+            "EXISTS (SELECT 1 WHERE {{entity}}.source_version > 0 AND {{entity}}.is_deleted = FALSE)",
         )
         .unwrap();
-        let rendered = admission.render("t0");
-        assert!(rendered.contains("\"t0\".source_version"));
-        assert!(!rendered.contains(ROOT_ALIAS_TOKEN));
+        let rendered = admission.render("mx_t1");
+        assert!(rendered.contains("\"mx_t1\".source_version"));
+        assert!(!rendered.contains(ENTITY_ALIAS_TOKEN));
     }
 
     #[test]
-    fn admission_anchor_matches_locale_scoped_compiler_baseline_and_fails_closed() {
-        let baseline = root_baseline("t0");
-        assert!(baseline.contains("\"t0\".locale_key = $5"));
-        let mut sql = format!(
-            "SELECT 1 FROM index_entities AS \"t0\" WHERE {baseline}"
-        );
-        apply_to_sql(&mut sql, "t0", "\"t0\".source_version > 0").unwrap();
-        assert!(sql.contains("AND (\"t0\".source_version > 0)"));
+    fn admission_covers_root_outer_many_projection_filter_and_aggregate_aliases() {
+        let mut sql = concat!(
+            "SELECT 1 FROM index_entities AS \"t0\" ",
+            "LEFT JOIN index_entities AS \"t1\" ON \"t1\".is_deleted = FALSE ",
+            "WHERE \"t0\".is_deleted = FALSE ",
+            "AND EXISTS (SELECT 1 FROM index_entities AS \"mp0_t1\" WHERE \"mp0_t1\".is_deleted = FALSE) ",
+            "AND EXISTS (SELECT 1 FROM index_entities AS \"mx_t1\" WHERE \"mx_t1\".is_deleted = FALSE) ",
+            "AND EXISTS (SELECT 1 FROM index_entities AS \"mo_t1\" WHERE \"mo_t1\".is_deleted = FALSE)"
+        )
+        .to_owned();
+        apply_to_sql(&mut sql, "{{entity}}.source_version > 0").unwrap();
+        for alias in ["t0", "t1", "mp0_t1", "mx_t1", "mo_t1"] {
+            let marker = format!(
+                "\"{alias}\".is_deleted = FALSE AND (\"{alias}\".source_version > 0)"
+            );
+            assert!(sql.contains(&marker), "missing {marker}");
+        }
+    }
+
+    #[test]
+    fn compiler_alias_or_anchor_drift_fails_closed() {
         assert_eq!(
-            apply_to_sql(&mut "SELECT 1".to_owned(), "t0", "TRUE"),
-            Err(PostgresQueryRootAdmissionApplyError::RootAnchorMismatch)
+            entity_aliases("SELECT 1 FROM index_entities AS \"future_alias\""),
+            Err(PostgresQueryEntityAdmissionApplyError::InvalidEntityAlias(
+                "future_alias".to_owned()
+            ))
+        );
+        let mut sql = "SELECT 1 FROM index_entities AS \"t0\"".to_owned();
+        assert_eq!(
+            apply_to_sql(&mut sql, "{{entity}}.source_version > 0"),
+            Err(PostgresQueryEntityAdmissionApplyError::EntityAnchorMissing(
+                "t0".to_owned()
+            ))
         );
     }
 }

--- a/crates/rustok-index/src/infrastructure/postgres/query_admission.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_admission.rs
@@ -3,13 +3,18 @@ use std::collections::BTreeMap;
 use rustok_core::ModuleRuntimeExtensions;
 use thiserror::Error;
 
-use crate::{PostgresQueryRootAdmission, PostgresQueryRootAdmissionError, SchemaRef};
+use crate::{PostgresQueryEntityAdmission, PostgresQueryEntityAdmissionError, SchemaRef};
+
+const ENTITY_ALIAS_TOKEN: &str = "{{entity}}";
+const RUNTIME_PASSTHROUGH_OWNER: &str = "index";
+const RUNTIME_PASSTHROUGH_RULE: &str = "{{entity}}.entity_id IS NOT NULL";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PostgresIndexQueryAdmissionDescriptor {
     owner_module: String,
     schema: SchemaRef,
-    admission: PostgresQueryRootAdmission,
+    rule: Option<PostgresQueryEntityAdmission>,
+    admission: PostgresQueryEntityAdmission,
 }
 
 impl PostgresIndexQueryAdmissionDescriptor {
@@ -21,8 +26,12 @@ impl PostgresIndexQueryAdmissionDescriptor {
         &self.schema
     }
 
-    pub fn admission(&self) -> &PostgresQueryRootAdmission {
+    pub fn admission(&self) -> &PostgresQueryEntityAdmission {
         &self.admission
+    }
+
+    pub fn is_governed(&self) -> bool {
+        self.rule.is_some()
     }
 }
 
@@ -56,7 +65,7 @@ impl PostgresIndexQueryAdmissionCatalog {
         &mut self,
         owner_module: impl Into<String>,
         schema: SchemaRef,
-        admission: PostgresQueryRootAdmission,
+        admission: PostgresQueryEntityAdmission,
     ) -> Result<(), PostgresIndexQueryAdmissionError> {
         let owner_module = owner_module.into();
         validate_owner_module(&owner_module)?;
@@ -72,9 +81,68 @@ impl PostgresIndexQueryAdmissionCatalog {
             PostgresIndexQueryAdmissionDescriptor {
                 owner_module,
                 schema,
+                rule: Some(admission.clone()),
                 admission,
             },
         );
+        self.rebuild_composite()
+    }
+
+    /// Adds a runtime-local pass-through root descriptor for an otherwise ungoverned registered
+    /// schema. Pass-through descriptors are never published as owner rules; they exist only in the
+    /// immutable query runtime so a query rooted at any registered schema still applies the same
+    /// composite owner admission to governed linked targets.
+    pub(crate) fn ensure_runtime_schema(
+        &mut self,
+        schema: SchemaRef,
+    ) -> Result<(), PostgresIndexQueryAdmissionError> {
+        if self.entries.contains_key(&schema) {
+            return Ok(());
+        }
+        let admission = PostgresQueryEntityAdmission::new(RUNTIME_PASSTHROUGH_RULE)?;
+        self.entries.insert(
+            schema.clone(),
+            PostgresIndexQueryAdmissionDescriptor {
+                owner_module: RUNTIME_PASSTHROUGH_OWNER.to_owned(),
+                schema,
+                rule: None,
+                admission,
+            },
+        );
+        self.rebuild_composite()
+    }
+
+    fn rebuild_composite(&mut self) -> Result<(), PostgresIndexQueryAdmissionError> {
+        let governed = self
+            .entries
+            .values()
+            .filter_map(|descriptor| {
+                descriptor
+                    .rule
+                    .as_ref()
+                    .map(|rule| (descriptor.schema.clone(), rule.template().to_owned()))
+            })
+            .collect::<Vec<_>>();
+        if governed.is_empty() {
+            return Ok(());
+        }
+
+        let guards = governed
+            .iter()
+            .map(|(schema, _)| schema_guard(schema))
+            .collect::<Vec<_>>();
+        let allowed = governed
+            .iter()
+            .map(|(schema, rule)| format!("({} AND ({rule}))", schema_guard(schema)))
+            .collect::<Vec<_>>();
+        let composite = PostgresQueryEntityAdmission::new(format!(
+            "(NOT ({}) OR {})",
+            guards.join(" OR "),
+            allowed.join(" OR ")
+        ))?;
+        for descriptor in self.entries.values_mut() {
+            descriptor.admission = composite.clone();
+        }
         Ok(())
     }
 }
@@ -92,20 +160,33 @@ pub enum PostgresIndexQueryAdmissionError {
         incoming_owner: String,
     },
     #[error(transparent)]
-    InvalidAdmission(#[from] PostgresQueryRootAdmissionError),
+    InvalidAdmission(#[from] PostgresQueryEntityAdmissionError),
 }
 
 pub fn register_postgres_index_query_admission(
     extensions: &mut ModuleRuntimeExtensions,
     owner_module: impl Into<String>,
     schema: SchemaRef,
-    admission: PostgresQueryRootAdmission,
+    admission: PostgresQueryEntityAdmission,
 ) -> Result<(), PostgresIndexQueryAdmissionError> {
     extensions
         .get_or_insert_with::<PostgresIndexQueryAdmissionCatalog, _>(
             PostgresIndexQueryAdmissionCatalog::new,
         )
         .register(owner_module, schema, admission)
+}
+
+fn schema_guard(schema: &SchemaRef) -> String {
+    format!(
+        "({ENTITY_ALIAS_TOKEN}.module_name = '{}' AND {ENTITY_ALIAS_TOKEN}.entity_name = '{}' AND {ENTITY_ALIAS_TOKEN}.schema_version = {})",
+        sql_literal(schema.module.as_str()),
+        sql_literal(schema.entity.as_str()),
+        schema.version.get(),
+    )
+}
+
+fn sql_literal(value: &str) -> String {
+    value.replace('\'', "''")
 }
 
 fn validate_owner_module(value: &str) -> Result<(), PostgresIndexQueryAdmissionError> {
@@ -130,26 +211,66 @@ mod tests {
     use super::*;
     use crate::{EntityName, ModuleName, SchemaVersion};
 
-    fn schema() -> SchemaRef {
+    fn schema(entity: &str) -> SchemaRef {
         SchemaRef {
             module: ModuleName::new("rustok-product").unwrap(),
-            entity: EntityName::new("product").unwrap(),
-            version: SchemaVersion::new(3),
+            entity: EntityName::new(entity).unwrap(),
+            version: SchemaVersion::INITIAL,
         }
     }
 
     #[test]
     fn exact_schema_has_one_query_admission_owner() {
-        let admission = PostgresQueryRootAdmission::new("{{root}}.source_version > 0").unwrap();
+        let admission = PostgresQueryEntityAdmission::new("{{entity}}.source_version > 0").unwrap();
         let mut catalog = PostgresIndexQueryAdmissionCatalog::new();
         catalog
-            .register("product", schema(), admission.clone())
+            .register("product", schema("product"), admission.clone())
             .unwrap();
         assert_eq!(catalog.len(), 1);
-        assert_eq!(catalog.get(&schema()).unwrap().owner_module(), "product");
+        assert_eq!(
+            catalog.get(&schema("product")).unwrap().owner_module(),
+            "product"
+        );
         assert!(matches!(
-            catalog.register("other", schema(), admission),
+            catalog.register("other", schema("product"), admission),
             Err(PostgresIndexQueryAdmissionError::DuplicateSchema { .. })
         ));
+    }
+
+    #[test]
+    fn every_runtime_root_receives_the_same_governed_entity_dispatch() {
+        let mut catalog = PostgresIndexQueryAdmissionCatalog::new();
+        catalog
+            .register(
+                "product",
+                schema("product"),
+                PostgresQueryEntityAdmission::new("{{entity}}.source_version > 10").unwrap(),
+            )
+            .unwrap();
+        catalog
+            .register(
+                "product",
+                schema("product_variant"),
+                PostgresQueryEntityAdmission::new("{{entity}}.source_version > 20").unwrap(),
+            )
+            .unwrap();
+        let unrelated = SchemaRef {
+            module: ModuleName::new("other").unwrap(),
+            entity: EntityName::new("item").unwrap(),
+            version: SchemaVersion::INITIAL,
+        };
+        catalog.ensure_runtime_schema(unrelated.clone()).unwrap();
+
+        let product = catalog.get(&schema("product")).unwrap();
+        let passthrough = catalog.get(&unrelated).unwrap();
+        assert!(product.is_governed());
+        assert!(!passthrough.is_governed());
+        assert_eq!(product.admission(), passthrough.admission());
+        let template = product.admission().template();
+        assert!(template.contains("entity_name = 'product'"));
+        assert!(template.contains("entity_name = 'product_variant'"));
+        assert!(template.contains("source_version > 10"));
+        assert!(template.contains("source_version > 20"));
+        assert!(!template.contains("entity_name = 'item'"));
     }
 }

--- a/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_runtime.rs
@@ -7,7 +7,9 @@ use thiserror::Error;
 use crate::application::{SharedIndexQueryRuntime, SharedIndexSchemaRegistry};
 use crate::domain::SchemaRef;
 
-use super::{PostgresIndexQueryAdmissionCatalog, PostgresIndexQueryPort};
+use super::{
+    PostgresIndexQueryAdmissionCatalog, PostgresIndexQueryAdmissionError, PostgresIndexQueryPort,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum IndexQueryRuntimeCompositionError {
@@ -18,14 +20,20 @@ pub enum IndexQueryRuntimeCompositionError {
         owner_module: String,
         schema: SchemaRef,
     },
+    #[error(transparent)]
+    AdmissionCatalog(#[from] PostgresIndexQueryAdmissionError),
 }
 
 /// Materializes the canonical PostgreSQL-backed query runtime from the complete source registry.
 ///
 /// Absence of a source registry is represented as `Ok(None)` and never produces an empty or
-/// partially useful runtime. Trusted schema-scoped root admission rules are snapshotted into the
-/// immutable runtime at materialization time. Every rule must target a schema present in the same
-/// complete immutable registry; dangling rules fail composition rather than silently never applying.
+/// partially useful runtime. Trusted schema-scoped entity admission rules are snapshotted into the
+/// immutable runtime at materialization time. Every owner rule must target a schema present in the
+/// same complete immutable registry; dangling rules fail composition rather than silently never
+/// applying. When at least one owner rule exists, runtime-local pass-through descriptors are added
+/// for every otherwise ungoverned registered root schema so the same composite admission still
+/// fences governed linked targets reached from those roots.
+///
 /// The function performs no database I/O and makes no tenant schema-readiness or owner-freshness
 /// claim; those checks remain inside the query port when a request executes.
 pub fn materialize_postgres_index_query_runtime(
@@ -39,7 +47,7 @@ pub fn materialize_postgres_index_query_runtime(
     let Some(registry) = extensions.get::<SharedIndexSchemaRegistry>().cloned() else {
         return Ok(None);
     };
-    let admissions = extensions
+    let mut admissions = extensions
         .get::<PostgresIndexQueryAdmissionCatalog>()
         .cloned()
         .unwrap_or_default();
@@ -49,6 +57,11 @@ pub fn materialize_postgres_index_query_runtime(
                 owner_module: descriptor.owner_module().to_owned(),
                 schema: descriptor.schema().clone(),
             });
+        }
+    }
+    if !admissions.is_empty() {
+        for registered in registry.registry().iter() {
+            admissions.ensure_runtime_schema(registered.schema.reference.clone())?;
         }
     }
 
@@ -68,7 +81,7 @@ mod tests {
 
     use crate::{
         EntityName, FieldCardinality, FieldName, IndexField, IndexSchema, IndexValueType,
-        LocaleMode, ModuleName, PostgresIndexQueryAdmissionCatalog, PostgresQueryRootAdmission,
+        LocaleMode, ModuleName, PostgresIndexQueryAdmissionCatalog, PostgresQueryEntityAdmission,
         SchemaRef, SchemaVersion, SharedIndexQueryRuntime, materialize_index_schema_registry,
         register_index_schema_source, register_postgres_index_query_admission,
     };
@@ -147,7 +160,7 @@ mod tests {
             &mut extensions,
             "runtime_owner",
             selected.reference.clone(),
-            PostgresQueryRootAdmission::new("{{root}}.source_version > 0").unwrap(),
+            PostgresQueryEntityAdmission::new("{{entity}}.source_version > 0").unwrap(),
         )
         .unwrap();
         let registry = materialize_index_schema_registry(&extensions)
@@ -182,7 +195,7 @@ mod tests {
             &mut extensions,
             "runtime_owner",
             missing.clone(),
-            PostgresQueryRootAdmission::new("{{root}}.source_version > 0").unwrap(),
+            PostgresQueryEntityAdmission::new("{{entity}}.source_version > 0").unwrap(),
         )
         .unwrap();
         let registry = materialize_index_schema_registry(&extensions)

--- a/scripts/verify/verify-index-linked-target-query-freshness.mjs
+++ b/scripts/verify/verify-index-linked-target-query-freshness.mjs
@@ -114,13 +114,15 @@ for (const [relative, source] of [
 }
 
 requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
-  'Query surfaces protected',
+  'Query surfaces fenced against stale target payloads',
   'many-cardinality nested projections',
   'many-cardinality `EXISTS` filters',
   'many-cardinality `MIN`/`MAX` aggregate ordering',
+  'does **not** yet prove complete linked-target availability semantics',
+  'link exists while its target has not yet been materialized',
   'Explicit remaining recreate boundary',
   'hard delete followed by recreation of the same UUID can reset',
   'next source slice must make those two owner source clocks monotonic',
 ]);
 
-console.log('[verify-index-linked-target-query-freshness] linked target freshness source contract verified');
+console.log('[verify-index-linked-target-query-freshness] linked target stale-payload fence and remaining availability gate verified');

--- a/scripts/verify/verify-index-linked-target-query-freshness.mjs
+++ b/scripts/verify/verify-index-linked-target-query-freshness.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-linked-target-query-freshness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const entityAdmissionPath = 'crates/rustok-index/src/application/postgres_query_admission.rs';
+const entityAdmission = requireMarkers(entityAdmissionPath, [
+  'index_entities AS \\"',
+  'BTreeSet<String>',
+  'numeric_suffix(alias, "t")',
+  'remainder.split_once("_t")',
+  '.strip_prefix("mx_t")',
+  '.strip_prefix("mo_t")',
+  'is_deleted = FALSE',
+  'sql.replace(&anchor, &replacement)',
+  'compiled.exact_count.as_mut()',
+]);
+forbidMarkers(entityAdmissionPath, entityAdmission, [
+  'rustok-product',
+  'product_variants',
+  'channels owner_channel',
+  'channel_index_identity_generations',
+]);
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
+const compiler = requireMarkers(compilerPath, [
+  'FROM index_entities AS {root_alias}',
+  'LEFT JOIN index_entities AS {target_alias}',
+  'let target_alias_name = format!("mp{projection_index}_t{}", index + 1)',
+  'let target_alias_name = format!("mx_t{}", index + 1)',
+  'let target_alias_name = format!("mo_t{}", index + 1)',
+  'JOIN index_entities AS {target_alias} ON {target_predicate}',
+  'compile_many_exists(plan, field, bindings',
+  'compile_many_order_aggregate(plan, &order.field, aggregate, bindings)',
+  '.then(|| compile_exact_count(plan))',
+]);
+forbidMarkers(compilerPath, compiler, [
+  'product_variants owner_variant',
+  'channels owner_channel',
+  'PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS',
+  'SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS',
+]);
+
+const catalogPath = 'crates/rustok-index/src/infrastructure/postgres/query_admission.rs';
+requireMarkers(catalogPath, [
+  'rule: Option<PostgresQueryEntityAdmission>',
+  'pub(crate) fn ensure_runtime_schema(',
+  'rule: None',
+  'fn rebuild_composite(',
+  'filter_map(|descriptor|',
+  'schema_guard(schema)',
+  'PostgresQueryEntityAdmission::new(format!(',
+]);
+
+const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/query_runtime.rs';
+requireMarkers(runtimePath, [
+  'if !admissions.is_empty()',
+  'for registered in registry.registry().iter()',
+  'admissions.ensure_runtime_schema(registered.schema.reference.clone())?',
+  'PostgresIndexQueryPort::with_admissions(',
+]);
+
+const ownerPath = 'crates/rustok-distribution/src/product_index/query_admission.rs';
+const owner = requireMarkers(ownerPath, [
+  'PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS',
+  'FROM product_variants owner_variant',
+  'owner_variant.tenant_id = {{entity}}.tenant_id',
+  'owner_variant.id = {{entity}}.entity_id',
+  'owner_variant.index_revision = {{entity}}.source_version',
+  'SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS',
+  'FROM channels owner_channel',
+  'owner_channel.tenant_id = {{entity}}.tenant_id',
+  'owner_channel.id = {{entity}}.entity_id',
+  'owner_channel.index_revision = {{entity}}.source_version',
+  'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
+]);
+forbidMarkers(ownerPath, owner, ['index_entities', 'index_links', '$1']);
+
+const variantSource = requireMarkers('crates/rustok-distribution/src/product_variant_index.rs', [
+  'v.index_revision',
+  'tombstone.source_version AS index_revision',
+  'PRODUCT_VARIANT_SCHEMA_VERSION: u32 = 2',
+]);
+const channelSource = requireMarkers('crates/rustok-distribution/src/channel_index.rs', [
+  'c.index_revision',
+  'tombstone.source_version AS index_revision',
+  'SchemaVersion::INITIAL',
+]);
+for (const [relative, source] of [
+  ['crates/rustok-distribution/src/product_variant_index.rs', variantSource],
+  ['crates/rustok-distribution/src/channel_index.rs', channelSource],
+]) {
+  if (!source.includes('index_revision')) fail(`${relative} lost current owner source revision`);
+}
+
+requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
+  'Query surfaces protected',
+  'many-cardinality nested projections',
+  'many-cardinality `EXISTS` filters',
+  'many-cardinality `MIN`/`MAX` aggregate ordering',
+  'Explicit remaining recreate boundary',
+  'hard delete followed by recreation of the same UUID can reset',
+  'next source slice must make those two owner source clocks monotonic',
+]);
+
+console.log('[verify-index-linked-target-query-freshness] linked target freshness source contract verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -25,22 +25,25 @@ const forbidMarkers = (relative, source, markers) => {
 
 const admissionPath = 'crates/rustok-index/src/application/postgres_query_admission.rs';
 const admission = requireMarkers(admissionPath, [
-  'ROOT_ALIAS_TOKEN: &str = "{{root}}"',
-  'MAX_ROOT_ADMISSION_BYTES: usize = 32 * 1024',
+  'ENTITY_ALIAS_TOKEN: &str = "{{entity}}"',
+  'MAX_ENTITY_ADMISSION_BYTES: usize = 32 * 1024',
+  'INDEX_ENTITY_ALIAS_MARKER: &str = "index_entities AS \\""',
+  'pub struct PostgresQueryEntityAdmission',
   'BindPlaceholderForbidden',
-  'RootAnchorMismatch',
-  'pub fn apply(',
-  '.columns',
-  '.iter()',
-  '.find_map(',
-  'CompiledQueryColumn::EntityId',
+  'MissingEntityRelation',
+  'InvalidEntityAlias',
+  'EntityAnchorMissing',
   'compiled.exact_count.as_mut()',
-  'root_baseline(root_alias)',
-  '.locale_key = $5',
-  'sql.match_indices(&anchor).count() != 1',
-  '*sql = sql.replacen(&anchor, &replacement, 1)',
+  'entity_aliases(sql)?',
+  'alias.strip_prefix("mp")',
+  '.strip_prefix("mx_t")',
+  '.strip_prefix("mo_t")',
+  'let anchor = format!("{alias_q}.is_deleted = FALSE")',
+  '*sql = sql.replace(&anchor, &replacement)',
 ]);
 forbidMarkers(admissionPath, admission, [
+  'PostgresQueryRootAdmission',
+  '{{root}}',
   'DatabaseConnection',
   'Statement::',
   'IndexMutation',
@@ -51,12 +54,22 @@ forbidMarkers(admissionPath, admission, [
 const catalogPath = 'crates/rustok-index/src/infrastructure/postgres/query_admission.rs';
 const catalog = requireMarkers(catalogPath, [
   'pub struct PostgresIndexQueryAdmissionCatalog',
-  'BTreeMap<SchemaRef, PostgresIndexQueryAdmissionDescriptor>',
+  'rule: Option<PostgresQueryEntityAdmission>',
   'pub fn register_postgres_index_query_admission(',
-  'DuplicateSchema',
-  '.get_or_insert_with::<PostgresIndexQueryAdmissionCatalog',
+  'pub(crate) fn ensure_runtime_schema(',
+  'rule: None',
+  'fn rebuild_composite(',
+  'schema_guard(schema)',
+  'guards.join(" OR ")',
+  'allowed.join(" OR ")',
 ]);
-forbidMarkers(catalogPath, catalog, ['DatabaseConnection', 'Statement::', 'tokio::spawn']);
+forbidMarkers(catalogPath, catalog, [
+  'PostgresQueryRootAdmission',
+  '{{root}}',
+  'DatabaseConnection',
+  'Statement::',
+  'tokio::spawn',
+]);
 
 const portPath = 'crates/rustok-index/src/infrastructure/postgres/query_port.rs';
 const port = requireMarkers(portPath, [
@@ -70,97 +83,75 @@ const port = requireMarkers(portPath, [
   'verify_persisted_schemas(transaction, query, required_schemas).await?',
   'compiled_statement(compiled)',
   'compiled.exact_count.as_ref()',
-  'self.registry.decode_postgres_query_page(query, page_query, page_rows, exact_count_row)',
 ]);
 forbidMarkers(portPath, port, ['tokio::spawn', 'IndexMutation::']);
 
 const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/query_runtime.rs';
 requireMarkers(runtimePath, [
-  'PostgresIndexQueryAdmissionCatalog',
+  'let mut admissions = extensions',
   '.get::<PostgresIndexQueryAdmissionCatalog>()',
-  '.cloned()',
-  '.unwrap_or_default()',
   'AdmissionSchemaMissing',
+  'if !admissions.is_empty()',
+  'for registered in registry.registry().iter()',
+  'admissions.ensure_runtime_schema(registered.schema.reference.clone())?',
   'PostgresIndexQueryPort::with_admissions(',
-  'query_admission_catalog_is_snapshotted_into_runtime_composition',
-  'dangling_query_admission_schema_fails_composition',
+  'registry.shared()',
+  'admissions,',
 ]);
 
 const productAdmissionPath = 'crates/rustok-distribution/src/product_index/query_admission.rs';
 const productAdmission = requireMarkers(productAdmissionPath, [
   'PRODUCT_QUERY_MATERIALIZED_FRESHNESS',
+  'PRODUCT_VARIANT_QUERY_MATERIALIZED_FRESHNESS',
+  'SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS',
   'FROM products owner_product',
   'product_index_graph_projection_snapshots',
-  'ORDER BY projection.projection_epoch DESC',
   'product_sales_channel_index_relation_freshness_snapshots',
-  'witness.relation_epoch = current_projection.relation_epoch',
-  'ORDER BY witness.sequence_no DESC',
-  '{{root}}.source_version = current_projection.projection_epoch',
-  'current_projection.product_source_version = owner_product.index_revision',
-  'current_freshness.product_source_version <= owner_product.index_revision',
-  'channel_index_identity_generations',
-  'current_freshness.channel_identity_generation = COALESCE(',
-  'product_sales_channel_index_relation_convergence_requests',
-  'request.product_source_version > current_freshness.product_source_version',
-  'FROM product_translations translation',
-  'translation.locale = {{root}}.locale_key',
-  'register_postgres_index_query_admission(',
+  '{{entity}}.source_version = current_projection.projection_epoch',
+  'translation.locale = {{entity}}.locale_key',
+  'FROM product_variants owner_variant',
+  'owner_variant.index_revision = {{entity}}.source_version',
+  'FROM channels owner_channel',
+  'owner_channel.index_revision = {{entity}}.source_version',
+  'PostgresQueryEntityAdmission::new(template)',
+  'product_variant_schema_ref()',
+  'sales_channel_schema_ref()',
+  'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
   'SchemaVersion::new(3)',
+  'SchemaVersion::new(2)',
+  'SchemaVersion::INITIAL',
 ]);
 forbidMarkers(productAdmissionPath, productAdmission, [
+  'PostgresQueryRootAdmission',
+  '{{root}}',
   'index_entities',
   'index_links',
   '$1',
-  'channel_visibility',
   'IndexMutation',
-  'INSERT ',
-  'UPDATE ',
-  'DELETE FROM',
   'tokio::spawn',
   'loop {',
 ]);
 
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
-  'mod query_admission;',
   'query_admission::register(extensions)?;',
-  'selected_product_bridge_registers_two_current_schemas_three_factories_and_query_admission',
-  'PostgresIndexQueryAdmissionCatalog',
+  'assert_eq!(admissions.len(), 2)',
+  'assert_eq!(admissions.len(), 3)',
 ]);
-requireMarkers('crates/rustok-index/src/lib.rs', [
-  'register_postgres_index_query_admission',
-  'PostgresIndexQueryAdmissionCatalog',
-  'PostgresIndexQueryAdmissionDescriptor',
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'PostgresQueryEntityAdmission',
+  'PostgresQueryEntityAdmissionApplyError',
+  'PostgresQueryEntityAdmissionError',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
-  'Status: `source_complete_postgres_packet_source_ready_execution_pending`',
-  'source-read -> mutation-apply',
-  'A post-result freshness check is insufficient',
-  'Generic root query admission',
-  'Product admission evidence',
-  '`index_entities.source_version` is Product `projection_epoch`',
-  'there is no retained Product visibility convergence request',
-  'same predicate is',
-  'exact-count SQL',
-  'Rejected Product owner data',
-  'PostgreSQL evidence packet 1',
-  'source-ready, not executed, and not admitted',
-]);
-requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness-postgres-harness.md', [
-  'Status: `source_ready_execution_pending`',
-  'physically present in `index_entities`',
+  'Status: `source_complete_linked_target_fence_execution_pending`',
+  '`PostgresQueryEntityAdmission`',
+  '`mpN_tN`',
+  '`mx_tN`',
+  '`mo_tN`',
+  'ProductVariant',
+  'SalesChannel',
+  'Explicit remaining recreate boundary',
+  'does **not** claim delete+recreate identity safety',
 ]);
 
-const compilerPath = 'crates/rustok-index/src/application/postgres_query_sql.rs';
-requireMarkers(compilerPath, [
-  'push_identity_column(',
-  '&plan.root_alias,',
-  'let mut predicates = base.predicates;',
-  'predicates.push(compile_filter(plan, filter, &mut bindings)?);',
-  'predicates.push(compile_keyset(plan, cursor, &mut bindings)?);',
-  'let pagination = compile_pagination(&plan.pagination, &mut bindings)?;',
-  'let exact_count = plan',
-  '.then(|| compile_exact_count(plan))',
-  'AND {root_alias}.locale_key = {locale} AND {root_alias}.is_deleted = FALSE',
-]);
-
-console.log('[verify-index-product-materialized-query-freshness] Product root query freshness fence and packet cursor verified');
+console.log('[verify-index-product-materialized-query-freshness] Product graph entity freshness fence verified');

--- a/scripts/verify/verify-index-product-source.mjs
+++ b/scripts/verify/verify-index-product-source.mjs
@@ -34,8 +34,12 @@ const moduleSource = requireMarkers(modulePath, [
   'mod variant;',
   'product::register(extensions)?;',
   'variant::register(extensions)?;',
-  'absence::register(extensions)',
-  'selected_product_bridge_registers_two_current_schemas_and_three_factories',
+  'absence::register(extensions)?;',
+  'query_admission::register(extensions)?;',
+  'selected_product_bridge_registers_two_current_schemas_three_factories_and_entity_admissions',
+  'selected_product_and_channel_bridge_registers_channel_admission_and_convergence_work',
+  'assert_eq!(admissions.len(), 2)',
+  'assert_eq!(admissions.len(), 3)',
 ]);
 forbidMarkers(modulePath, moduleSource, ['mod graph;', 'graph::', 'four_schemas']);
 
@@ -160,6 +164,7 @@ forbidMarkers(
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-source.mjs'",
   "'verify-index-product-channel-relation-freshness.mjs'",
+  "'verify-index-linked-target-query-freshness.mjs'",
 ]);
 
-console.log('[verify-index-product-source] canonical Product source and freshness gate verified');
+console.log('[verify-index-product-source] canonical Product source and graph entity admission verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -70,6 +70,7 @@ const scripts = [
   'verify-index-product-channel-relation-freshness.mjs',
   'verify-index-product-channel-relation-convergence.mjs',
   'verify-index-product-materialized-query-freshness.mjs',
+  'verify-index-linked-target-query-freshness.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- replace root-only PostgreSQL query admission with one generic compiler-owned entity admission applied to every materialized `index_entities` relation in page and exact-count SQL;
- cover root/ordinary joins plus current many-projection (`mpN_tN`), many-filter (`mx_tN`), and many-aggregate-order (`mo_tN`) aliases without changing binds, selected columns, plan fingerprints, or cursor contracts;
- keep one exact owner rule per SchemaRef and compile them into one schema-dispatch predicate;
- add runtime-local pass-through root descriptors so a query rooted at an ungoverned registered schema still applies governed rules to linked targets;
- register current ProductVariant freshness (`product_variants.index_revision == index_entities.source_version`) and, when Channel is selected, SalesChannel freshness (`channels.index_revision == index_entities.source_version`) alongside the existing Product projection/freshness rule;
- keep generic Index code owner-neutral and keep Product/Channel owner predicates free of Index table reads;
- update Product graph source/freshness guards and add a focused linked-target freshness guard to the aggregate Index contract.

## Source boundary

This slice prevents a stale/deleted ProductVariant or SalesChannel materialized row from contributing its old payload through ordinary joins, nested many projections, many `EXISTS` filters, aggregate ordering, or exact-count recompilation after owner state changes.

It deliberately does **not** claim complete linked-target availability parity. A Product link may exist while a target has not yet been materialized; current left-join/many-subquery semantics can represent that target as missing/null, so the link-present/target-missing window still needs an explicit fail-closed parity policy and retained PostgreSQL evidence.

It also does **not** claim ProductVariant/SalesChannel delete-recreate identity safety. Both current sources still use live owner `index_revision`; recreating the same UUID can reset that revision and collide with an older materialized row. The next source slice is recreate-safe monotonic owner clocks for those two targets, preserving the current SchemaRefs and adding no Product compatibility version.

## Main recheck

The branch started from `main@9cffa70608b63c74e9a0ddd16e955acb4dc8c0ce` (#3176). Current `main@192dfa4b6458d79a2d701c7e017ba5f9d534284e` advanced only through Pages #3178; compare shows no overlap with this Index/distribution/doc/verifier file set.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.