### PR TITLE
test(index): retain linked target recreate PostgreSQL packet

### DIFF
--- a/crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs
@@ -234,8 +234,14 @@ async fn run_scenarios(database: &TestDatabase) -> TestResult<()> {
 
     assert_product_root_visible(&runtime.query, false).await?;
     run_scheduler_until_idle(&runtime.scheduler, 20).await?;
-    assert_eq!(latest_relation_epoch(&database.writer).await?, relation_before_channel_recreate);
-    assert_eq!(latest_projection_epoch(&database.writer).await?, projection_before_channel_recreate);
+    assert_eq!(
+        latest_relation_epoch(&database.writer).await?,
+        relation_before_channel_recreate
+    );
+    assert_eq!(
+        latest_projection_epoch(&database.writer).await?,
+        projection_before_channel_recreate
+    );
     assert_eq!(
         materialized_product_version(&database.mutation).await?,
         product_materialized_before_channel_recreate
@@ -441,8 +447,8 @@ async fn assert_product_root_visible(
     expected: bool,
 ) -> TestResult<()> {
     let page = query.execute_query(product_graph_query()?).await?;
-    let expected_rows = usize::from(expected);
-    let expected_count = u64::from(expected);
+    let expected_rows = if expected { 1 } else { 0 };
+    let expected_count = if expected { 1 } else { 0 };
     assert_eq!(page.items.len(), expected_rows);
     assert_eq!(page.exact_count, Some(expected_count));
     Ok(())
@@ -459,8 +465,16 @@ async fn assert_graph_payloads(
     let item = &page.items[0];
     let variant_values = nested_strings(item, "variants", "sku")?;
     let channel_values = nested_strings(item, "sales_channels", "name")?;
-    assert_eq!(variant_values, expected_variant_skus);
-    assert_eq!(channel_values, expected_channel_names);
+    let expected_variant_values = expected_variant_skus
+        .iter()
+        .map(|value| (*value).to_owned())
+        .collect::<Vec<_>>();
+    let expected_channel_values = expected_channel_names
+        .iter()
+        .map(|value| (*value).to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(variant_values, expected_variant_values);
+    assert_eq!(channel_values, expected_channel_values);
     Ok(())
 }
 
@@ -476,7 +490,7 @@ fn nested_strings(
         .iter()
         .find(|projection| projection.path == vec![link_name.clone()])
         .ok_or_else(|| std::io::Error::other(format!("missing nested projection {link}")))?;
-    projection
+    let values = projection
         .items
         .iter()
         .map(|nested| {
@@ -484,7 +498,9 @@ fn nested_strings(
                 .fields
                 .iter()
                 .find(|projected| projected.path == field_path)
-                .ok_or_else(|| std::io::Error::other(format!("missing nested field {link}.{field}")))?;
+                .ok_or_else(|| {
+                    std::io::Error::other(format!("missing nested field {link}.{field}"))
+                })?;
             match &projected.value {
                 IndexValue::String(value) => Ok(value.clone()),
                 other => Err(std::io::Error::other(format!(
@@ -492,8 +508,8 @@ fn nested_strings(
                 ))),
             }
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(Into::into)
+        .collect::<Result<Vec<_>, std::io::Error>>()?;
+    Ok(values)
 }
 
 async fn delete_variant(db: &DatabaseConnection) -> TestResult<()> {
@@ -550,9 +566,10 @@ async fn recreate_channel(db: &DatabaseConnection) -> TestResult<()> {
 }
 
 async fn live_variant_revision(db: &DatabaseConnection) -> TestResult<u64> {
-    scalar_revision(
+    required_revision(
         db,
         "SELECT index_revision FROM product_variants WHERE tenant_id = $1 AND id = $2",
+        "index_revision",
         VARIANT_ID,
         "live ProductVariant revision",
     )
@@ -560,9 +577,10 @@ async fn live_variant_revision(db: &DatabaseConnection) -> TestResult<u64> {
 }
 
 async fn live_channel_revision(db: &DatabaseConnection) -> TestResult<u64> {
-    scalar_revision(
+    required_revision(
         db,
         "SELECT index_revision FROM channels WHERE tenant_id = $1 AND id = $2",
+        "index_revision",
         CHANNEL_ID,
         "live SalesChannel revision",
     )
@@ -570,37 +588,41 @@ async fn live_channel_revision(db: &DatabaseConnection) -> TestResult<u64> {
 }
 
 async fn variant_tombstone_version(db: &DatabaseConnection) -> TestResult<Option<u64>> {
-    optional_scalar_revision(
+    optional_revision(
         db,
         "SELECT source_version FROM product_variant_index_tombstones WHERE tenant_id = $1 AND variant_id = $2",
+        "source_version",
         VARIANT_ID,
     )
     .await
 }
 
 async fn channel_tombstone_version(db: &DatabaseConnection) -> TestResult<Option<u64>> {
-    optional_scalar_revision(
+    optional_revision(
         db,
         "SELECT source_version FROM channel_index_tombstones WHERE tenant_id = $1 AND channel_id = $2",
+        "source_version",
         CHANNEL_ID,
     )
     .await
 }
 
-async fn scalar_revision(
+async fn required_revision(
     db: &DatabaseConnection,
     sql: &str,
+    column: &str,
     entity_id: Uuid,
     label: &str,
 ) -> TestResult<u64> {
-    optional_scalar_revision(db, sql, entity_id)
+    optional_revision(db, sql, column, entity_id)
         .await?
         .ok_or_else(|| std::io::Error::other(format!("{label} is missing")).into())
 }
 
-async fn optional_scalar_revision(
+async fn optional_revision(
     db: &DatabaseConnection,
     sql: &str,
+    column: &str,
     entity_id: Uuid,
 ) -> TestResult<Option<u64>> {
     let row = db
@@ -610,11 +632,11 @@ async fn optional_scalar_revision(
             vec![TENANT_ID.into(), entity_id.into()],
         ))
         .await?;
-    row.map(|row| {
-        let value: i64 = row.try_get("", if sql.contains("source_version") { "source_version" } else { "index_revision" })?;
-        Ok(u64::try_from(value)?)
-    })
-    .transpose()
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let value: i64 = row.try_get("", column)?;
+    Ok(Some(u64::try_from(value)?))
 }
 
 async fn channel_generation(db: &DatabaseConnection) -> TestResult<u64> {
@@ -631,7 +653,7 @@ async fn channel_generation(db: &DatabaseConnection) -> TestResult<u64> {
 }
 
 async fn latest_relation_epoch(db: &DatabaseConnection) -> TestResult<u64> {
-    scalar_product_epoch(
+    product_epoch(
         db,
         "SELECT relation_epoch FROM product_sales_channel_index_relation_snapshots WHERE tenant_id = $1 AND product_id = $2 ORDER BY relation_epoch DESC LIMIT 1",
         "relation_epoch",
@@ -640,7 +662,7 @@ async fn latest_relation_epoch(db: &DatabaseConnection) -> TestResult<u64> {
 }
 
 async fn latest_projection_epoch(db: &DatabaseConnection) -> TestResult<u64> {
-    scalar_product_epoch(
+    product_epoch(
         db,
         "SELECT projection_epoch FROM product_index_graph_projection_snapshots WHERE tenant_id = $1 AND product_id = $2 ORDER BY projection_epoch DESC LIMIT 1",
         "projection_epoch",
@@ -649,7 +671,7 @@ async fn latest_projection_epoch(db: &DatabaseConnection) -> TestResult<u64> {
 }
 
 async fn latest_freshness_generation(db: &DatabaseConnection) -> TestResult<u64> {
-    scalar_product_epoch(
+    product_epoch(
         db,
         "SELECT channel_identity_generation FROM product_sales_channel_index_relation_freshness_snapshots WHERE tenant_id = $1 AND product_id = $2 ORDER BY sequence_no DESC LIMIT 1",
         "channel_identity_generation",
@@ -657,11 +679,7 @@ async fn latest_freshness_generation(db: &DatabaseConnection) -> TestResult<u64>
     .await
 }
 
-async fn scalar_product_epoch(
-    db: &DatabaseConnection,
-    sql: &str,
-    column: &str,
-) -> TestResult<u64> {
+async fn product_epoch(db: &DatabaseConnection, sql: &str, column: &str) -> TestResult<u64> {
     let row = db
         .query_one(Statement::from_sql_and_values(
             DbBackend::Postgres,
@@ -682,7 +700,7 @@ async fn assert_materialized_target_version(
     db: &DatabaseConnection,
     module_name: &str,
     entity_name: &str,
-    schema_version: i32,
+    schema_version: i64,
     entity_id: Uuid,
     expected_source_version: u64,
 ) -> TestResult<()> {
@@ -697,7 +715,7 @@ async fn materialized_target_version(
     db: &DatabaseConnection,
     module_name: &str,
     entity_name: &str,
-    schema_version: i32,
+    schema_version: i64,
     entity_id: Uuid,
 ) -> TestResult<u64> {
     let row = db
@@ -722,7 +740,11 @@ WHERE tenant_id = $1
             ],
         ))
         .await?
-        .ok_or_else(|| std::io::Error::other(format!("materialized {module_name}/{entity_name} row is missing")))?;
+        .ok_or_else(|| {
+            std::io::Error::other(format!(
+                "materialized {module_name}/{entity_name} row is missing"
+            ))
+        })?;
     let value: String = row.try_get("", "source_version_text")?;
     Ok(value.parse()?)
 }

--- a/crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs
@@ -1,0 +1,801 @@
+#![cfg(feature = "mod-product")]
+
+use std::{env, error::Error};
+
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation, IndexQuery,
+    IndexQueryPort, IndexQueryScope, IndexSourceLoadRequest, IndexValue, LinkName, LocaleKey,
+    ModuleName, MutationApplyOutcome, MutationDelivery, Pagination, PostgresMutationStore,
+    PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion, SharedIndexQueryRuntime,
+    SharedIndexSchemaRegistry, SharedIndexSourceRegistry, materialize_index_source_registry,
+    materialize_postgres_index_query_runtime, materialize_postgres_index_sources,
+};
+use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistrations, ModuleWorkScheduler};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const PRODUCT_VARIANT_SOURCE: &str = "product-variant-postgres-primary";
+const SALES_CHANNEL_SOURCE: &str = "sales-channel-postgres-primary";
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const PRODUCT_ID: Uuid = Uuid::from_u128(101);
+const PRODUCT_TRANSLATION_ID: Uuid = Uuid::from_u128(111);
+const VARIANT_ID: Uuid = Uuid::from_u128(201);
+const CHANNEL_ID: Uuid = Uuid::from_u128(301);
+const OLD_VARIANT_SKU: &str = "variant-before-recreate";
+const NEW_VARIANT_SKU: &str = "variant-after-recreate";
+const OLD_CHANNEL_NAME: &str = "Channel before recreate";
+const NEW_CHANNEL_NAME: &str = "Channel after recreate";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    migration: DatabaseConnection,
+    work: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    writer: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping linked-target recreate harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_linked_target_recreate_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_linked_target_recreate_migration_{suffix}"),
+        )
+        .await?;
+        create_migration_prerequisites(&migration).await?;
+        let manager = SchemaManager::new(&migration);
+        for step in rustok_channel::migrations::migrations() {
+            step.up(&manager).await?;
+        }
+        for step in rustok_product::migrations::migrations() {
+            step.up(&manager).await?;
+        }
+        for step in IndexModule.migrations() {
+            step.up(&manager).await?;
+        }
+        seed_owner_rows(&migration).await?;
+
+        Ok(Some(Self {
+            control,
+            migration,
+            work: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_linked_target_recreate_work_{suffix}"),
+            )
+            .await?,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_linked_target_recreate_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_linked_target_recreate_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_linked_target_recreate_query_{suffix}"),
+            )
+            .await?,
+            writer: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_linked_target_recreate_writer_{suffix}"),
+            )
+            .await?,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.migration.close().await?;
+        self.work.close().await?;
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.writer.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct Runtime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+    scheduler: ModuleWorkScheduler,
+}
+
+#[tokio::test]
+async fn linked_targets_remain_revision_monotonic_and_stale_payloads_are_fenced_across_recreate(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let result = run_scenarios(&database).await;
+    let cleanup = database.cleanup().await;
+    result?;
+    cleanup
+}
+
+async fn run_scenarios(database: &TestDatabase) -> TestResult<()> {
+    let runtime = build_runtime(database).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 24).await?;
+
+    materialize_current(&runtime, PRODUCT_SOURCE, product_key()?).await?;
+    let old_variant_version =
+        materialize_current(&runtime, PRODUCT_VARIANT_SOURCE, variant_key()?).await?;
+    let old_channel_version =
+        materialize_current(&runtime, SALES_CHANNEL_SOURCE, channel_key()?).await?;
+    assert_graph_payloads(
+        &runtime.query,
+        &[OLD_VARIANT_SKU],
+        &[OLD_CHANNEL_NAME],
+    )
+    .await?;
+
+    // ProductVariant delete -> recreate keeps the same UUID but must not reuse an old source version.
+    // Deliberately do not deliver either target delete or recreated upsert to Index: the old target row
+    // remains physically materialized while owner state moves through retained tombstone history.
+    delete_variant(&database.writer).await?;
+    let variant_tombstone = variant_tombstone_version(&database.writer)
+        .await?
+        .ok_or_else(|| std::io::Error::other("ProductVariant tombstone was not retained"))?;
+    assert!(variant_tombstone > old_variant_version);
+    recreate_variant(&database.writer).await?;
+    let recreated_variant_version = live_variant_revision(&database.writer).await?;
+    assert!(recreated_variant_version > variant_tombstone);
+    assert!(recreated_variant_version > old_variant_version);
+    assert!(variant_tombstone_version(&database.writer).await?.is_none());
+
+    // Variant membership delete/insert advances the Product owner/projection. Refresh only Product;
+    // keep the old Variant Index target row in place. The Product root is current but stale Variant
+    // payload must be filtered out by entity admission.
+    materialize_current(&runtime, PRODUCT_SOURCE, product_key()?).await?;
+    assert_materialized_target_version(
+        &database.mutation,
+        "rustok-product",
+        "product_variant",
+        2,
+        VARIANT_ID,
+        old_variant_version,
+    )
+    .await?;
+    assert_graph_payloads(&runtime.query, &[], &[OLD_CHANNEL_NAME]).await?;
+
+    let applied_variant_version =
+        materialize_current(&runtime, PRODUCT_VARIANT_SOURCE, variant_key()?).await?;
+    assert_eq!(applied_variant_version, recreated_variant_version);
+    assert_graph_payloads(
+        &runtime.query,
+        &[NEW_VARIANT_SKU],
+        &[OLD_CHANNEL_NAME],
+    )
+    .await?;
+
+    // SalesChannel delete -> recreate likewise seeds live index_revision above the retained delete
+    // tombstone. Product membership returns to the same Channel UUID before convergence. Product root
+    // authority is temporarily fenced by Channel generation, then freshness-only convergence restores
+    // that exact already-materialized Product row while the old Channel target remains stale.
+    let relation_before_channel_recreate = latest_relation_epoch(&database.writer).await?;
+    let projection_before_channel_recreate = latest_projection_epoch(&database.writer).await?;
+    let product_materialized_before_channel_recreate =
+        materialized_product_version(&database.mutation).await?;
+    let generation_before_channel_recreate = channel_generation(&database.writer).await?;
+
+    delete_channel(&database.writer).await?;
+    let channel_tombstone = channel_tombstone_version(&database.writer)
+        .await?
+        .ok_or_else(|| std::io::Error::other("SalesChannel tombstone was not retained"))?;
+    assert!(channel_tombstone > old_channel_version);
+    let generation_after_channel_delete = channel_generation(&database.writer).await?;
+    assert!(generation_after_channel_delete > generation_before_channel_recreate);
+
+    recreate_channel(&database.writer).await?;
+    let recreated_channel_version = live_channel_revision(&database.writer).await?;
+    assert!(recreated_channel_version > channel_tombstone);
+    assert!(recreated_channel_version > old_channel_version);
+    assert!(channel_tombstone_version(&database.writer).await?.is_none());
+    let generation_after_channel_recreate = channel_generation(&database.writer).await?;
+    assert!(generation_after_channel_recreate > generation_after_channel_delete);
+
+    assert_product_root_visible(&runtime.query, false).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 20).await?;
+    assert_eq!(latest_relation_epoch(&database.writer).await?, relation_before_channel_recreate);
+    assert_eq!(latest_projection_epoch(&database.writer).await?, projection_before_channel_recreate);
+    assert_eq!(
+        materialized_product_version(&database.mutation).await?,
+        product_materialized_before_channel_recreate
+    );
+    assert_eq!(
+        latest_freshness_generation(&database.writer).await?,
+        generation_after_channel_recreate
+    );
+    assert_materialized_target_version(
+        &database.mutation,
+        "rustok-channel",
+        "sales_channel",
+        1,
+        CHANNEL_ID,
+        old_channel_version,
+    )
+    .await?;
+    assert_product_root_visible(&runtime.query, true).await?;
+    assert_graph_payloads(&runtime.query, &[NEW_VARIANT_SKU], &[]).await?;
+
+    let applied_channel_version =
+        materialize_current(&runtime, SALES_CHANNEL_SOURCE, channel_key()?).await?;
+    assert_eq!(applied_channel_version, recreated_channel_version);
+    assert_graph_payloads(
+        &runtime.query,
+        &[NEW_VARIANT_SKU],
+        &[NEW_CHANNEL_NAME],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn build_runtime(database: &TestDatabase) -> TestResult<Runtime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Index schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for registered in schemas.registry().iter() {
+        schema_store.register(TENANT_ID, &registered.schema).await?;
+    }
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Index source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Index query runtime is missing"))?;
+    let registrations = extensions
+        .get::<ModuleWorkRegistrations>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product convergence work is missing"))?;
+    let scheduler = ModuleWorkScheduler::new();
+    registrations
+        .register_all(&HostRuntimeContext::new(database.work.clone()), &scheduler)
+        .await?;
+    Ok(Runtime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+        scheduler,
+    })
+}
+
+async fn run_scheduler_until_idle(
+    scheduler: &ModuleWorkScheduler,
+    maximum_iterations: usize,
+) -> TestResult<usize> {
+    let mut executed = 0;
+    for _ in 0..maximum_iterations {
+        let current = scheduler.run_once().await?;
+        if current == 0 {
+            return Ok(executed);
+        }
+        executed += current;
+    }
+    Err(std::io::Error::other(format!(
+        "ModuleWork scheduler did not become idle after {maximum_iterations} bounded iterations"
+    ))
+    .into())
+}
+
+async fn materialize_current(
+    runtime: &Runtime,
+    source_name: &str,
+    key: EntityKey,
+) -> TestResult<u64> {
+    let request = IndexSourceLoadRequest::new(vec![key])?;
+    let mut mutations = runtime.sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected one mutation from {source_name}, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    let mutation: IndexMutation = mutations.remove(0);
+    let source_version = mutation.source_version();
+    let delivery = MutationDelivery::from_event(source_name, mutation)?;
+    let outcome = runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?;
+    match outcome {
+        MutationApplyOutcome::Applied {
+            source_version: applied,
+        } if applied == source_version => Ok(source_version),
+        other => Err(std::io::Error::other(format!(
+            "expected {source_name} mutation {source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+fn product_key() -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: product_schema_ref()?,
+        entity_id: PRODUCT_ID,
+        locale: Some(LocaleKey::new("en")?),
+    })
+}
+
+fn variant_key() -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: variant_schema_ref()?,
+        entity_id: VARIANT_ID,
+        locale: None,
+    })
+}
+
+fn channel_key() -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: channel_schema_ref()?,
+        entity_id: CHANNEL_ID,
+        locale: None,
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        version: SchemaVersion::new(3),
+    })
+}
+
+fn variant_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product_variant")?,
+        version: SchemaVersion::new(2),
+    })
+}
+
+fn channel_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-channel")?,
+        entity: EntityName::new("sales_channel")?,
+        version: SchemaVersion::INITIAL,
+    })
+}
+
+fn product_graph_query() -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: TENANT_ID,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: product_schema_ref()?,
+        fields: vec![
+            FieldPath::new(FieldName::new("title")?),
+            FieldPath::linked(
+                [LinkName::new("variants")?],
+                FieldName::new("sku")?,
+            ),
+            FieldPath::linked(
+                [LinkName::new("sales_channels")?],
+                FieldName::new("name")?,
+            ),
+        ],
+        filter: Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("id")?),
+            IndexValue::Uuid(PRODUCT_ID),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+async fn assert_product_root_visible(
+    query: &SharedIndexQueryRuntime,
+    expected: bool,
+) -> TestResult<()> {
+    let page = query.execute_query(product_graph_query()?).await?;
+    let expected_rows = usize::from(expected);
+    let expected_count = u64::from(expected);
+    assert_eq!(page.items.len(), expected_rows);
+    assert_eq!(page.exact_count, Some(expected_count));
+    Ok(())
+}
+
+async fn assert_graph_payloads(
+    query: &SharedIndexQueryRuntime,
+    expected_variant_skus: &[&str],
+    expected_channel_names: &[&str],
+) -> TestResult<()> {
+    let page = query.execute_query(product_graph_query()?).await?;
+    assert_eq!(page.items.len(), 1, "Product root must remain query-admissible");
+    assert_eq!(page.exact_count, Some(1));
+    let item = &page.items[0];
+    let variant_values = nested_strings(item, "variants", "sku")?;
+    let channel_values = nested_strings(item, "sales_channels", "name")?;
+    assert_eq!(variant_values, expected_variant_skus);
+    assert_eq!(channel_values, expected_channel_names);
+    Ok(())
+}
+
+fn nested_strings(
+    item: &rustok_index::IndexQueryItem,
+    link: &str,
+    field: &str,
+) -> TestResult<Vec<String>> {
+    let link_name = LinkName::new(link)?;
+    let field_path = FieldPath::linked([link_name.clone()], FieldName::new(field)?);
+    let projection = item
+        .nested_relations
+        .iter()
+        .find(|projection| projection.path == vec![link_name.clone()])
+        .ok_or_else(|| std::io::Error::other(format!("missing nested projection {link}")))?;
+    projection
+        .items
+        .iter()
+        .map(|nested| {
+            let projected = nested
+                .fields
+                .iter()
+                .find(|projected| projected.path == field_path)
+                .ok_or_else(|| std::io::Error::other(format!("missing nested field {link}.{field}")))?;
+            match &projected.value {
+                IndexValue::String(value) => Ok(value.clone()),
+                other => Err(std::io::Error::other(format!(
+                    "nested field {link}.{field} is not a string: {other:?}"
+                ))),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+async fn delete_variant(db: &DatabaseConnection) -> TestResult<()> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "DELETE FROM product_variants WHERE tenant_id = $1 AND id = $2",
+            vec![TENANT_ID.into(), VARIANT_ID.into()],
+        ))
+        .await?;
+    assert_eq!(result.rows_affected(), 1);
+    Ok(())
+}
+
+async fn recreate_variant(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO product_variants (id, product_id, tenant_id, sku) VALUES ($1, $2, $3, $4)",
+        vec![
+            VARIANT_ID.into(),
+            PRODUCT_ID.into(),
+            TENANT_ID.into(),
+            NEW_VARIANT_SKU.to_owned().into(),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn delete_channel(db: &DatabaseConnection) -> TestResult<()> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "DELETE FROM channels WHERE tenant_id = $1 AND id = $2",
+            vec![TENANT_ID.into(), CHANNEL_ID.into()],
+        ))
+        .await?;
+    assert_eq!(result.rows_affected(), 1);
+    Ok(())
+}
+
+async fn recreate_channel(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "INSERT INTO channels (id, tenant_id, slug, name) VALUES ($1, $2, 'alpha', $3)",
+        vec![
+            CHANNEL_ID.into(),
+            TENANT_ID.into(),
+            NEW_CHANNEL_NAME.to_owned().into(),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn live_variant_revision(db: &DatabaseConnection) -> TestResult<u64> {
+    scalar_revision(
+        db,
+        "SELECT index_revision FROM product_variants WHERE tenant_id = $1 AND id = $2",
+        VARIANT_ID,
+        "live ProductVariant revision",
+    )
+    .await
+}
+
+async fn live_channel_revision(db: &DatabaseConnection) -> TestResult<u64> {
+    scalar_revision(
+        db,
+        "SELECT index_revision FROM channels WHERE tenant_id = $1 AND id = $2",
+        CHANNEL_ID,
+        "live SalesChannel revision",
+    )
+    .await
+}
+
+async fn variant_tombstone_version(db: &DatabaseConnection) -> TestResult<Option<u64>> {
+    optional_scalar_revision(
+        db,
+        "SELECT source_version FROM product_variant_index_tombstones WHERE tenant_id = $1 AND variant_id = $2",
+        VARIANT_ID,
+    )
+    .await
+}
+
+async fn channel_tombstone_version(db: &DatabaseConnection) -> TestResult<Option<u64>> {
+    optional_scalar_revision(
+        db,
+        "SELECT source_version FROM channel_index_tombstones WHERE tenant_id = $1 AND channel_id = $2",
+        CHANNEL_ID,
+    )
+    .await
+}
+
+async fn scalar_revision(
+    db: &DatabaseConnection,
+    sql: &str,
+    entity_id: Uuid,
+    label: &str,
+) -> TestResult<u64> {
+    optional_scalar_revision(db, sql, entity_id)
+        .await?
+        .ok_or_else(|| std::io::Error::other(format!("{label} is missing")).into())
+}
+
+async fn optional_scalar_revision(
+    db: &DatabaseConnection,
+    sql: &str,
+    entity_id: Uuid,
+) -> TestResult<Option<u64>> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            vec![TENANT_ID.into(), entity_id.into()],
+        ))
+        .await?;
+    row.map(|row| {
+        let value: i64 = row.try_get("", if sql.contains("source_version") { "source_version" } else { "index_revision" })?;
+        Ok(u64::try_from(value)?)
+    })
+    .transpose()
+}
+
+async fn channel_generation(db: &DatabaseConnection) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT generation FROM channel_index_identity_generations WHERE tenant_id = $1",
+            vec![TENANT_ID.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Channel identity generation is missing"))?;
+    let generation: i64 = row.try_get("", "generation")?;
+    Ok(u64::try_from(generation)?)
+}
+
+async fn latest_relation_epoch(db: &DatabaseConnection) -> TestResult<u64> {
+    scalar_product_epoch(
+        db,
+        "SELECT relation_epoch FROM product_sales_channel_index_relation_snapshots WHERE tenant_id = $1 AND product_id = $2 ORDER BY relation_epoch DESC LIMIT 1",
+        "relation_epoch",
+    )
+    .await
+}
+
+async fn latest_projection_epoch(db: &DatabaseConnection) -> TestResult<u64> {
+    scalar_product_epoch(
+        db,
+        "SELECT projection_epoch FROM product_index_graph_projection_snapshots WHERE tenant_id = $1 AND product_id = $2 ORDER BY projection_epoch DESC LIMIT 1",
+        "projection_epoch",
+    )
+    .await
+}
+
+async fn latest_freshness_generation(db: &DatabaseConnection) -> TestResult<u64> {
+    scalar_product_epoch(
+        db,
+        "SELECT channel_identity_generation FROM product_sales_channel_index_relation_freshness_snapshots WHERE tenant_id = $1 AND product_id = $2 ORDER BY sequence_no DESC LIMIT 1",
+        "channel_identity_generation",
+    )
+    .await
+}
+
+async fn scalar_product_epoch(
+    db: &DatabaseConnection,
+    sql: &str,
+    column: &str,
+) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            vec![TENANT_ID.into(), PRODUCT_ID.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other(format!("{column} is missing")))?;
+    let value: i64 = row.try_get("", column)?;
+    Ok(u64::try_from(value)?)
+}
+
+async fn materialized_product_version(db: &DatabaseConnection) -> TestResult<u64> {
+    materialized_target_version(db, "rustok-product", "product", 3, PRODUCT_ID).await
+}
+
+async fn assert_materialized_target_version(
+    db: &DatabaseConnection,
+    module_name: &str,
+    entity_name: &str,
+    schema_version: i32,
+    entity_id: Uuid,
+    expected_source_version: u64,
+) -> TestResult<()> {
+    assert_eq!(
+        materialized_target_version(db, module_name, entity_name, schema_version, entity_id).await?,
+        expected_source_version
+    );
+    Ok(())
+}
+
+async fn materialized_target_version(
+    db: &DatabaseConnection,
+    module_name: &str,
+    entity_name: &str,
+    schema_version: i32,
+    entity_id: Uuid,
+) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(source_version AS TEXT) AS source_version_text
+FROM index_entities
+WHERE tenant_id = $1
+  AND module_name = $2
+  AND entity_name = $3
+  AND schema_version = $4
+  AND entity_id = $5
+  AND is_deleted = FALSE
+"#,
+            vec![
+                TENANT_ID.into(),
+                module_name.to_owned().into(),
+                entity_name.to_owned().into(),
+                schema_version.into(),
+                entity_id.into(),
+            ],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other(format!("materialized {module_name}/{entity_name} row is missing")))?;
+    let value: String = row.try_get("", "source_version_text")?;
+    Ok(value.parse()?)
+}
+
+async fn create_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE oauth_apps (
+    id UUID PRIMARY KEY
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_owner_rows(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+
+INSERT INTO channels (id, tenant_id, slug, name) VALUES
+    ('{CHANNEL_ID}', '{TENANT_ID}', 'alpha', '{OLD_CHANNEL_NAME}');
+
+INSERT INTO products (id, tenant_id, metadata) VALUES
+    ('{PRODUCT_ID}', '{TENANT_ID}', '{{}}'::jsonb);
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{PRODUCT_TRANSLATION_ID}', '{PRODUCT_ID}', '{TENANT_ID}', 'en', 'Linked target Product', 'linked-target-product');
+
+INSERT INTO product_variants (id, product_id, tenant_id, sku) VALUES
+    ('{VARIANT_ID}', '{PRODUCT_ID}', '{TENANT_ID}', '{OLD_VARIANT_SKU}');
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-07
 
-Status overlay rechecked against `main@0746ffa4aa4eea4383732bd4f4679c3d800cbf1d` and continued on
-`agent/index-product-channel-convergence-postgres-evidence-20260807`.
+Status overlay rechecked against `main@68d8c86b1371929bc096576f204f730a7a7b9bb9` and continued on
+`agent/index-linked-target-recreate-postgres-evidence-20260807`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
 cursor.
@@ -12,205 +12,142 @@ cursor.
 
 The repair implementation, recovery policy, PostgreSQL harness, and retained-evidence admission source
 are complete. Maintainer execution of the locked packet remains required and is not claimed by source
-inspection. Independent M7 source work can continue while that owner-execution gate is pending.
+inspection. Independent M7 source work continues while that owner-execution gate is pending.
 
 ## Current source-complete foundation
 
 - mutation-source registry and commit-before-ack worker contract;
 - bounded replay/reconciliation/retry/dead-letter/drift/repair foundations;
+- persisted tenant schema readiness;
 - Product locale and ProductVariant refresh ledgers plus durable relay cursor;
-- Product/ProductVariant retained hard-delete identities;
-- one canonical Product Index source and one canonical ProductVariant source;
-- Product `variants` and `sales_channels` graph links;
+- one canonical Product, ProductVariant, and SalesChannel source contract;
+- Product/ProductVariant/SalesChannel retained hard-delete identities;
+- Product `variants` and `sales_channels` links;
 - Product-owned Product-to-SalesChannel relation snapshots with independent `relation_epoch`;
-- bounded cross-owner Product visibility to SalesChannel UUID resolver;
-- Product-owned graph `projection_epoch` as the one complete Product mutation clock;
+- bounded cross-owner Product visibility -> SalesChannel UUID resolver;
+- Product-owned graph `projection_epoch` as the complete Product mutation clock;
 - projection-aware Product locale absence;
-- Product-SalesChannel freshness witness ledger;
-- tenant-scoped Channel identity generation;
-- live Product replay/absence source-admission freshness gate;
-- Product-owned visibility convergence requests and tenant lease/checkpoint state;
-- bounded generic ModuleWork Product-SalesChannel automatic convergence;
-- generic schema-scoped PostgreSQL root query admission;
-- canonical Product materialized/query freshness fence for the source-read -> mutation-apply window;
-- persisted tenant schema readiness gate.
+- Product-to-SalesChannel freshness witness and tenant Channel identity generation;
+- Product visibility convergence requests plus tenant lease/checkpoint state;
+- bounded generic ModuleWork Product/Channel convergence with restart/reclaim and rejected-Product
+  isolation;
+- generic schema-scoped PostgreSQL **entity** query admission covering root and linked materialized
+  entity aliases;
+- Product, ProductVariant, and SalesChannel owner freshness admission rules;
+- recreate-safe ProductVariant and SalesChannel `index_revision` through retained tombstone seed/clear
+  protocols.
 
-Two retained M7 PostgreSQL packets are now source-ready and execution/admission pending:
+No parallel Product/ProductVariant compatibility source is selected. Generic numeric `SchemaVersion`
+values remain Index storage/routing keys only; do not introduce a new Product schema/version to solve
+freshness or ordering.
 
-1. delayed Product scalar mutation + locale deletion materialized/query freshness;
-2. Product visibility + Channel identity convergence with multi-host lease/restart and rejected-Product
-   isolation.
+## Clock and ownership boundaries
 
-Neither packet has been executed by the implementation agent.
+The current Product graph intentionally keeps distinct facts:
 
-## Canonical Product policy
+1. `relation_epoch` — Product-to-SalesChannel UUID membership changes only;
+2. `projection_epoch` — complete Product record mutation ordering;
+3. Product relation freshness witness — verifies one relation epoch against current Product visibility
+   and Channel identity generation;
+4. Channel identity generation — tenant-scoped resolver invalidation/freshness, not SalesChannel entity
+   source version;
+5. ProductVariant `index_revision` — ProductVariant entity mutation version;
+6. SalesChannel `index_revision` — SalesChannel entity mutation version;
+7. Product/Variant/Channel entity query admission — prevents physically materialized stale rows from
+   becoming query-authoritative.
 
-Product Index has no parallel Product compatibility implementations. The selected distribution
-registers one current Product schema through `product-postgres-primary`, one current ProductVariant
-schema through `product-variant-postgres-primary`, and the current SalesChannel schema through
-`sales-channel-postgres-primary`.
+A freshness-only Channel transition must not fabricate `relation_epoch` or `projection_epoch`. A target
+entity update/recreate must not advance Product membership clocks merely to make the target payload
+current.
 
-The generic numeric `SchemaVersion` inside `SchemaRef` remains an Index storage/routing primitive only;
-it is not a Product compatibility matrix. The current Product graph contains Product scalars,
-`variant_ids`/`variants`, and `sales_channel_ids`/`sales_channels`. Product visibility slugs stay
-owner-side resolver input rather than transitional Index fields.
+## Product/Channel convergence source complete
 
-## Membership, ordering, freshness, convergence, and query admission are separate
+Product owns append-only visibility requests and one tenant convergence state with request cursor,
+completed Channel generation, in-progress sweep generation/Product cursor, lease, retry availability,
+attempt count, and bounded error state.
 
-1. `relation_epoch` changes only when resolved Product-to-SalesChannel UUID membership changes.
-2. `projection_epoch` advances when complete Product record inputs move and is the only Product Index
-   mutation `source_version`.
-3. `product_sales_channel_index_relation_freshness_snapshots` records that one retained relation epoch
-   was verified against Product visibility and a Channel identity generation.
-4. `product_sales_channel_index_relation_convergence_requests` plus tenant convergence state ensure
-   owner changes are durably driven back through the bounded resolver.
-5. Product root query admission compares materialized `projection_epoch` and existing owner freshness
-   evidence at query time so an already-produced stale mutation cannot become authoritative.
+The selected distribution registers `product_sales_channel_relation_convergence` through generic
+`ModuleWorkScheduler` composition only when Product and Channel are both selected. Work is bounded to
+one exact request or one bounded Product page. Product-owned `FOR UPDATE` claim state makes duplicate
+discovery across hosts harmless; lease expiry preserves progress across restart.
 
-A freshness-only change never fabricates a relation membership change. A convergence checkpoint is not
-an Index mutation clock. Query admission adds no Product schema and no duplicate relation watermark.
+Rejected Product owner data is isolated. Invalid visibility/oversized allowlists/too many targets leave
+that Product individually stale without blocking later valid Products. Product correction enqueues a
+new exact request; Channel identity correction advances generation and schedules another tenant pass.
 
-## Channel identity generation
+## Materialized entity query freshness source complete
 
-`rustok-channel` owns `channel_index_identity_generations`, one durable generation per tenant.
-Transactionally observed identity changes advance it for Channel insert/delete/id/tenant/canonical-slug
-changes. `is_active` and unrelated Channel configuration do not invalidate Product relation identity.
+`rustok-index` owns module-neutral `PostgresQueryEntityAdmission` plus an exact-schema admission catalog.
+The query runtime rejects owner rules for schemas absent from the immutable registry and builds one
+schema-dispatch predicate. Runtime-local pass-through roots ensure governed target rules still apply
+when a query root itself has no owner rule.
 
-Generation `0` represents a tenant with no historical Channel identity row. After the first identity
-mutation, the positive generation is retained even if the tenant later has zero Channels.
+The admission predicate is inserted into every compiler-owned materialized entity relation used by page
+SQL and exact count, including:
 
-## Freshness watermark source complete
+- `tN` root/ordinary joins;
+- `mpN_tN` many projections;
+- `mx_tN` many-filter `EXISTS` paths;
+- `mo_tN` many aggregate-order paths.
 
-For an exact Product, the distribution resolver:
+It changes no user binds, selected columns, plan fingerprint, or cursor contract and fails closed for
+unknown alias families or missing canonical `is_deleted = FALSE` anchors.
 
-1. observes Product visibility, Product `index_revision`, tenant Channel identity generation, and
-   resolved UUID membership under `REPEATABLE READ`, `READ ONLY`;
-2. writes membership through `ProductSalesChannelIndexRelationStore`;
-3. re-observes current owner facts;
-4. requires the second UUID set to equal retained relation membership;
-5. records the second observation through `ProductSalesChannelIndexRelationFreshnessStore`.
+Current Product graph rules require:
 
-The Product owner accepts a freshness witness only for a live Product and the current retained
-`relation_epoch`, under lock order Product row -> relation advisory lock -> freshness advisory lock.
-Direct SQL inserts use the same DDL guard and lock order.
+- Product: current projection/revision/relation freshness/Channel generation/visibility request/locale;
+- ProductVariant: live same tenant/UUID with `product_variants.index_revision == source_version`;
+- SalesChannel: live same tenant/UUID with `channels.index_revision == source_version`.
 
-Live Product replay and Product locale absence fail closed unless the latest witness for the exact
-projection relation epoch matches current visibility and current tenant Channel identity generation. A
-witness Product watermark may be older than current Product revision only when visibility remains
-unchanged; unrelated Product updates therefore do not falsely stale the relation. Product hard-delete
-replay removes the graph and does not require a live freshness witness.
+This fences stale target payload participation. It does **not** yet define authoritative semantics for a
+link that exists while its target has not been materialized or is temporarily unavailable.
 
-## Automatic owner-change relation convergence source complete
+## Recreate monotonicity source complete
 
-Product owns two additional durable surfaces:
+A post-#3179 recheck confirmed no new owner clocks are required.
 
-- append-only exact Product requests for INSERT/canonical `channel_visibility` changes;
-- one tenant convergence state with exact request cursor, completed opaque Channel generation,
-  in-progress Channel sweep generation/Product cursor, bounded lease, retry availability, attempt
-  count, and error marker.
+Product migration `m20260731_000004_add_product_index_tombstones` already preserves ProductVariant
+reincarnation ordering:
 
-The selected distribution registers `product_sales_channel_relation_convergence` through the existing
-generic `ModuleWorkScheduler` only when Product and Channel are both selected. One work item processes
-either one exact Product request or one bounded 64-Product convergence page, calling the existing exact
-resolver for each Product. Product-owned `FOR UPDATE` claim state makes duplicate due discovery across
-hosts harmless. Lease expiry preserves request/sweep progress across restart.
+- delete retains `OLD.index_revision + 1`;
+- same tenant/UUID insert seeds live `index_revision` above retained source version;
+- tombstone clears only after strict live supersession.
 
-Channel identity changes during a sweep cannot be skipped: the pass checkpoints only the generation it
-started with, so a newer current Channel generation remains due for another pass. Product visibility
-requests remain tenant ordered and exact; deleted Products advance their obsolete request cursor without
-requiring a live witness.
+Channel migration `m20260731_000011_add_channel_index_tombstones` provides the same guarantee for
+SalesChannel.
 
-Rejected Product owner data is isolated from tenant progress. Invalid visibility, oversized allowlists,
-or too many resolved Channel targets leave that Product individually source-stale without blocking
-later Products in the same tenant. Correcting Product visibility creates a new exact request; a
-Channel-side correction advances Channel generation and schedules another tenant pass. Retryable
-concurrency/storage/relation/freshness failures preserve the current page for retry.
+Therefore old materialized target versions cannot collide with a recreated incarnation's current owner
+revision. Do not add another ProductVariant/SalesChannel version ledger for this purpose.
 
-The Product DDL state machine prevents direct SQL from skipping visibility requests, changing an
-in-progress sweep generation, resetting a partial Product cursor, forging a completed Channel
-checkpoint, or deleting convergence state. Product still does not read Channel storage or depend on
-`rustok-channel`/`rustok-index`.
+## Retained M7 PostgreSQL packets
 
-## Materialized/query freshness fence source complete
+Four packets are source-ready and execution/admission pending:
 
-The previous source-read -> mutation-apply window is now fenced at the root query boundary.
+1. `product_materialized_query_freshness_postgres.rs`
+   - delayed Product scalar mutation;
+   - locale deletion after source read;
+   - stale physical row excluded before filter/order/cursor/limit/exact count.
+2. `product_channel_convergence_postgres.rs`
+   - two generic scheduler hosts;
+   - active lease exclusion/reclaim;
+   - rejected Product isolation;
+   - Product visibility race;
+   - unchanged-membership freshness-only Channel transition;
+   - changed-membership relation/projection transition.
+3. `product_channel_identity_transitions_postgres.rs`
+   - Channel create/delete;
+   - tenant move affecting both tenant generations;
+   - same UUID delete+recreate before convergence with unchanged membership and freshness-only Product
+     recovery.
+4. `product_linked_target_recreate_postgres.rs`
+   - ProductVariant same UUID delete+recreate monotonic owner revision;
+   - SalesChannel same UUID delete+recreate monotonic owner revision;
+   - old target rows deliberately left physically materialized;
+   - Product root brought back to current owner state;
+   - stale Variant/Channel payload excluded from nested Product projections;
+   - current target mutation restores the recreated payload.
 
-`rustok-index` owns a module-neutral `PostgresQueryRootAdmission` and exact-schema admission catalog.
-The canonical query runtime snapshots those rules, rejects rules for schemas absent from the immutable
-schema registry, and applies an admission predicate to the compiler-owned root `index_entities`
-baseline in the same `REPEATABLE READ`, `READ ONLY` transaction as query execution.
-
-Admission is applied before user filter, cursor, order, pagination/limit, and exact count. The same
-predicate is inserted into exact-count SQL. It changes no bind values, selected columns, plan
-fingerprint, or cursor contract and fails closed if the compiler baseline no longer matches the exact
-expected anchor.
-
-The Product rule requires:
-
-- live Product and exact locale translation;
-- materialized `index_entities.source_version` equal to latest Product `projection_epoch`;
-- projection Product component equal current `products.index_revision`;
-- freshness witness for the projection relation epoch;
-- witness Channel generation equal current tenant Channel generation;
-- no visibility convergence request newer than the witness Product revision.
-
-This closes the materialized/query freshness fence at source level without a new Product schema,
-duplicate relation membership, a query-time visibility parser, or a new Index watermark.
-
-## Product materialized freshness PostgreSQL packet 1
-
-`crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs` is source-ready and
-execution-pending. It uses real Product/Index migrations, real Product source loading,
-`PostgresMutationStore`, persisted schema registration, and the canonical shared Index query runtime.
-
-The packet deliberately materializes a stale Product mutation after owner state has advanced, proves
-the stale source version is physically present in `index_entities`, and requires it to be excluded
-before title filter/order/cursor lookahead/limit/exact-count. It then applies the current mutation and
-proves normal two-page cursor behavior. A second scenario applies a delayed locale upsert after the
-owner translation is deleted and requires the physically stored row to remain query-inadmissible with
-exact count zero.
-
-This is retained source, not admitted evidence. No PostgreSQL execution result is claimed.
-
-## Product visibility / Channel convergence PostgreSQL packet 2
-
-`crates/rustok-distribution/tests/product_channel_convergence_postgres.rs` is source-ready and
-execution-pending. It uses real Channel/Product/Index migrations, two independent generic
-`ModuleWorkScheduler` hosts, Product-owned convergence state, the real Product replay source, generic
-Index mutation storage, persisted schema readiness, and the canonical Product query fence.
-
-The retained scenarios cover:
-
-- a one-second Product-owned lease claimed by host A, active-lease exclusion on host B, expiry, and
-  reclaim/completion by host B without resetting visibility progress;
-- malformed Product visibility remaining without relation/freshness while a later valid Product still
-  converges and the tenant Channel-generation sweep completes;
-- Product visibility `alpha -> beta` after source read, physical old Index materialization, query
-  exclusion, relation/projection advancement, and corrective current Product mutation;
-- Channel slug identity change with unchanged unrestricted UUID membership, where query admission fails
-  until freshness reaches the new generation but relation/projection remain unchanged and the same Index
-  row becomes admissible again;
-- a later Channel slug identity change that removes restricted membership, advances relation/projection,
-  leaves the old restricted Index row inadmissible, and requires the current Product mutation before
-  query authority returns.
-
-Detailed contract:
-`m7-product-channel-convergence-postgres-harness.md`.
-
-This packet is retained source only. No PostgreSQL execution result is claimed.
-
-## Event-contract admission status
-
-Canonical Product typed Index events remain blocked on event-contract digest admission. This pass does
-not run the generator or claim retained verify evidence.
-
-Required sequence remains:
-
-1. establish canonical digest status for reviewed `main`;
-2. commit reviewed generator output if drift exists;
-3. retain successful verify evidence;
-4. add the one canonical Product typed event family;
-5. register concrete routes/consumers and retain redelivery evidence.
+None has been executed or admitted by the implementation agent.
 
 ## M5 incremental ingestion
 
@@ -219,8 +156,8 @@ Required sequence remains:
 - [x] Mutation-event registry and commit-before-ack orchestration.
 - [x] Exact source-refresh worker with owner revision fence.
 - [x] Product locale/ProductVariant refresh ledgers and durable relay step.
-- [ ] Retain canonical event-contract digest admission for current main.
-- [ ] Add canonical Product Index typed event family and concrete routes/consumers.
+- [ ] Retain canonical event-contract digest admission for current `main`.
+- [ ] Add the one canonical Product Index typed event family and concrete routes/consumers.
 - [ ] Retain crash-between-commit-and-ack/redelivery evidence.
 
 ## M6 replay, reconciliation, diagnosis, and repair
@@ -232,64 +169,66 @@ Required sequence remains:
 - [x] Concrete missing-entity/orphan-link repair and prepared-command recovery.
 - [x] Real-migration PostgreSQL repair harness and retained-evidence admission tooling.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
-- [ ] Retain multi-host/restart/graceful-shutdown/command-transport evidence.
+- [ ] Retain remaining multi-host/restart/graceful-shutdown/command-transport evidence.
 - [ ] Add remaining locale/partition checkpoint dimensions and explicit rebuild modes.
 
 ## M7 Product/ProductVariant/SalesChannel production graph
 
-- [x] Canonical Product, ProductVariant and SalesChannel bounded sources.
+- [x] Canonical Product, ProductVariant, and SalesChannel bounded sources.
 - [x] Product `variants` and `sales_channels` links.
-- [x] Product/ProductVariant retained delete semantics.
+- [x] Product/ProductVariant/SalesChannel retained delete identities.
 - [x] Product-to-SalesChannel relation membership ledger and bounded resolver.
 - [x] Canonical Product graph projection epoch and projection-aware Product absence.
-- [x] Product-SalesChannel freshness witness.
-- [x] Channel identity generation.
-- [x] Canonical Product replay/absence fail-closed source freshness gate.
-- [x] Product visibility convergence request ledger and tenant lease/checkpoint state.
-- [x] Automatic bounded Product visibility / Channel identity relation convergence through generic
-      ModuleWork composition, including rejected-Product poison isolation.
-- [x] Implement/admit a materialized/query freshness fence for the source-read -> mutation-apply
-      in-flight window at source level.
-- [x] Add source-ready PostgreSQL packet for delayed Product scalar mutation and locale deletion query
-      admission across filter/order/cursor/limit/exact-count.
-- [x] Add source-ready PostgreSQL Product visibility + Channel-generation convergence packet with
-      multi-host lease expiry/restart, unchanged/changed membership, and rejected-Product evidence.
+- [x] Product-to-SalesChannel freshness witness and Channel identity generation.
+- [x] Product visibility convergence requests and bounded automatic generic ModuleWork convergence.
+- [x] Rejected-Product poison isolation.
+- [x] Product materialized root freshness fence.
+- [x] Entity-level stale linked-target freshness fence for ProductVariant and SalesChannel.
+- [x] ProductVariant/SalesChannel recreate-safe monotonic `index_revision` via retained tombstones.
+- [x] Source-ready Product delayed-mutation/locale-deletion PostgreSQL packet.
+- [x] Source-ready Product visibility/Channel convergence multi-host PostgreSQL packet.
+- [x] Source-ready Channel create/delete/tenant-move/delete-recreate PostgreSQL packet.
+- [x] Source-ready ProductVariant/SalesChannel linked-target recreate PostgreSQL packet.
 - [x] Remove parallel Product/ProductVariant compatibility implementations.
-- [ ] Execute/admit the Product materialized freshness PostgreSQL packet.
-- [ ] Execute/admit the Product visibility + Channel-generation convergence PostgreSQL packet.
-- [ ] Retain any remaining Channel create/delete/tenant-move/delete-recreate identity evidence.
-- [ ] Execute PostgreSQL evidence for schema readiness, relation/freshness storage, projection
-      concurrency/delete ordering, and canonical replay not already covered by the two Product packets.
+- [ ] Define fail-closed semantics for **link present but target materialization unavailable/stale** so
+      unavailable target data cannot be interpreted as authoritative null/empty relation state.
+- [ ] Retain PostgreSQL query-equivalence evidence for that availability policy across nested
+      projection, linked filtering, aggregate ordering, exact count, delete, recreate, and restart.
+- [ ] Execute/admit the four retained Product M7 PostgreSQL packets.
+- [ ] Execute any remaining schema-readiness/relation/freshness/projection concurrency evidence not
+      already covered by those packets.
 - [ ] Admit canonical Product typed wire events/routes/consumers after digest verification.
-- [ ] Retain remaining out-of-order, locale fan-out, and linked-target availability evidence.
-- [ ] Prove complete Product/Variant/Channel query parity, including linked-target availability.
-- [ ] Move Storefront traffic only after readiness/equivalence/materialized-freshness evidence passes.
+- [ ] Retain remaining out-of-order and locale fan-out evidence.
+- [ ] Prove complete Product/ProductVariant/SalesChannel query parity.
+- [ ] Move Storefront traffic only after readiness/equivalence/freshness/availability evidence passes.
 
 ## Next implementation step
 
-Primary owner step remains: execute and admit the locked M6 repair PostgreSQL packet.
+Primary owner step remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-The two largest Product freshness/convergence M7 runtime packets are now source-ready. The next
-unblocked M7 source step is to retain the remaining Channel identity transition evidence that is not
-covered by slug changes: Channel create/delete, tenant move, and delete-recreate behavior, including
-Product query admission and relation/projection consequences. After that, continue complete
-Product/Variant/Channel linked-target query parity. Do not add another Product schema or freshness
-clock. Keep typed Product event work separately blocked until digest admission.
+The next unblocked M7 source-design step is now **linked-target availability admission**: distinguish a
+legitimately absent Product link from a link whose ProductVariant/SalesChannel target exists in the link
+set but is not currently authoritative/materialized. Define one generic fail-closed behavior that works
+for ordinary joins and many projection/filter/order SQL without adding owner-specific logic to the Index
+compiler.
 
-## Maintainer verification for this slice
+After that, retain a PostgreSQL equivalence packet for target-missing/stale/delete/recreate/restart
+behavior. Do not add another Product schema, relation copy, or freshness clock. Typed Product event work
+remains separately blocked until event-contract digest admission.
+
+## Maintainer verification for current M7 packets
 
 ```bash
 cargo test -p rustok-distribution --features mod-product --test product_materialized_query_freshness_postgres -- --nocapture
 cargo test -p rustok-distribution --features mod-product --test product_channel_convergence_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_channel_identity_transitions_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_linked_target_recreate_postgres -- --nocapture
 node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
 node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
+node scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
-node scripts/verify/verify-index-product-channel-relation-convergence.mjs
-node scripts/verify/verify-index-product-channel-relation-freshness.mjs
-node scripts/verify/verify-index-product-channel-relation-resolver.mjs
-node scripts/verify/verify-index-product-channel-relation-ledger.mjs
-node scripts/verify/verify-index-product-graph-projection-ledger.mjs
-node scripts/verify/verify-index-product-absence-postgres-harness.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-channel --all-targets
 cargo check -p rustok-product --all-targets

--- a/crates/rustok-index/docs/m7-linked-target-recreate-postgres-harness.md
+++ b/crates/rustok-index/docs/m7-linked-target-recreate-postgres-harness.md
@@ -1,0 +1,123 @@
+# M7 linked-target recreate PostgreSQL harness
+
+Status: `source_ready_execution_pending`.
+
+## Purpose
+
+The canonical Product graph already has retained tombstone protocols that keep ProductVariant and
+SalesChannel `index_revision` monotonic across hard delete followed by recreation of the same UUID.
+This packet retains a real PostgreSQL proof that those owner clocks compose with the generic entity
+query admission introduced for linked targets.
+
+It adds no owner clock, no Index schema, and no compatibility version.
+
+## Existing owner monotonicity
+
+### ProductVariant
+
+`m20260731_000004_add_product_index_tombstones` owns `product_variant_index_tombstones`.
+
+On hard delete it retains `OLD.index_revision + 1`. Before a later insert of the same tenant/variant
+UUID, `rustok_product_variant_seed_index_revision_from_tombstone` raises the new live
+`index_revision` to at least `retained_source_version + 1`. The retained tombstone is cleared only
+after the inserted live revision strictly supersedes it.
+
+Therefore a recreated ProductVariant cannot reuse the source version of an older materialized target.
+
+### SalesChannel
+
+`m20260731_000011_add_channel_index_tombstones` provides the same invariant for
+`channel_index_tombstones` and `channels.index_revision`.
+
+On hard delete it retains `OLD.index_revision + 1`; before recreation of the same tenant/Channel UUID,
+`rustok_channel_seed_index_revision_from_tombstone` seeds the live revision above the retained delete
+version. The tombstone is cleared only after the live row supersedes it.
+
+Channel identity generation remains a separate tenant freshness clock for Product-to-SalesChannel
+membership resolution. It is not the SalesChannel Index mutation source version.
+
+## Harness path
+
+`crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs` uses real Channel,
+Product, and Index migrations; selected Index + Channel + Product distribution composition; persisted
+tenant schema registration; the real Product, ProductVariant, and SalesChannel source adapters; generic
+`PostgresMutationStore`; the canonical shared query runtime; and the registered generic Product/Channel
+convergence `ModuleWorkScheduler` worker.
+
+No private resolver or query implementation is called directly.
+
+## ProductVariant scenario
+
+The packet first materializes one current Product, ProductVariant, and SalesChannel and requires the
+Product nested projection to expose the initial Variant SKU and Channel name.
+
+Then it:
+
+1. hard-deletes the owner ProductVariant without delivering the target delete mutation to Index;
+2. requires a retained ProductVariant tombstone source version newer than the old materialized Variant;
+3. recreates the same Variant UUID with a different SKU;
+4. requires the new live `index_revision` to be newer than both the tombstone and old materialized
+   target source version;
+5. requires the retained Variant tombstone to clear only after that superseding live revision;
+6. materializes the current Product projection because Variant membership delete/insert advanced the
+   Product owner clock;
+7. proves the old ProductVariant target source version is still physically present in `index_entities`;
+8. requires the current Product root to remain visible while its `variants` nested payload is empty —
+   the stale old SKU must not leak through entity admission;
+9. applies only the current ProductVariant mutation and requires the recreated SKU to appear.
+
+The empty nested payload in step 8 is stale-target exclusion evidence only. It is not a claim that
+link-present/target-unavailable should ultimately be authoritative empty semantics.
+
+## SalesChannel scenario
+
+The packet then keeps the same Product-to-SalesChannel UUID membership while deleting and recreating
+the Channel before convergence:
+
+1. record current Product `relation_epoch`, `projection_epoch`, materialized Product source version,
+   and Channel generation;
+2. hard-delete the Channel without delivering the target delete to Index;
+3. require the retained Channel tombstone to be newer than the old materialized SalesChannel source
+   version and Channel generation to advance;
+4. recreate the same Channel UUID/canonical slug with a different name;
+5. require the new live `channels.index_revision` to exceed the tombstone and old materialized source
+   version, require the tombstone to clear, and require Channel generation to advance again;
+6. require Product root query admission to fail before convergence because the Product relation witness
+   still carries the old Channel generation;
+7. run only the registered generic convergence scheduler;
+8. require final membership to be unchanged, so Product `relation_epoch` and `projection_epoch` remain
+   unchanged and the existing Product materialized source version is not replaced;
+9. require freshness to reach the recreated Channel generation;
+10. prove the old SalesChannel source version is still physically materialized while the Product root
+    is query-admissible again;
+11. require the Product `sales_channels` nested payload to be empty, proving the stale old Channel name
+    cannot leak through the linked target row;
+12. apply only the current SalesChannel mutation and require the recreated Channel name to appear.
+
+This isolates Product relation freshness from target entity freshness: the Product root may be current
+while a linked SalesChannel target still needs its own current materialization.
+
+## Deliberate boundary
+
+This packet does **not** define the final authoritative semantics for a link that exists while its target
+is absent or not yet materialized. Current SQL represents a filtered/unavailable many target as an empty
+nested projection. Before Storefront cutover, complete query parity still needs an explicit fail-closed
+policy deciding whether that window should fail the root query rather than appear as empty/null.
+
+The packet also does not claim execution success until the maintainer runs it.
+
+## Maintainer verification
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-distribution --features mod-product \
+  --test product_linked_target_recreate_postgres -- --nocapture
+node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-query-freshness.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -1,21 +1,16 @@
 # M7 Product materialized/query freshness fence
 
-Status: `source_complete_linked_target_fence_execution_pending`.
+Status: `source_complete_linked_target_recreate_packet_execution_pending`.
 
-## Problem closed at source level
+## Query freshness boundary
 
 Product source admission and automatic Product-to-SalesChannel convergence protect source reads, but an
 already-produced Index mutation can still arrive after owner state changes. A post-result freshness
 check is too late because stale root or linked rows may already have affected filtering, ordering,
 cursor pagination, many projections, aggregate ordering, and exact count.
 
-The query boundary therefore treats owner freshness as an admission property of every materialized
-`index_entities` relation used by the compiler, not only the root row.
-
-## Generic entity query admission
-
-`rustok-index` owns `PostgresQueryEntityAdmission`, a trusted schema-scoped PostgreSQL entity-admission
-contract.
+`rustok-index` therefore owns `PostgresQueryEntityAdmission`, a trusted schema-scoped PostgreSQL
+entity-admission contract applied to every compiler-owned materialized `index_entities` relation.
 
 A rule:
 
@@ -23,128 +18,130 @@ A rule:
 - cannot contain bind placeholders, SQL statement boundaries, or comments;
 - is bounded to 32 KiB;
 - changes no user bind, selected column, plan fingerprint, or cursor contract;
-- is applied to every compiler-owned materialized entity alias in page and exact-count SQL;
-- fails closed when the compiler emits an unknown entity alias family or omits the canonical
-  `is_deleted = FALSE` entity anchor.
+- is applied to page and exact-count SQL;
+- fails closed for unknown compiler entity alias families or missing canonical `is_deleted = FALSE`
+  anchors.
 
-Current compiler alias families covered by the admission boundary are:
+Current compiler alias families covered are `tN`, `mpN_tN`, `mx_tN`, and `mo_tN`, covering root and
+ordinary joins, many projections, many-filter `EXISTS`, and many aggregate ordering.
 
-- `tN` for root and ordinary outer-join entity relations;
-- `mpN_tN` for many-cardinality projections;
-- `mx_tN` for many-cardinality filter `EXISTS` relations;
-- `mo_tN` for many-cardinality aggregate-order relations.
-
-`PostgresIndexQueryAdmissionCatalog` still owns at most one owner rule per exact `SchemaRef`. At runtime
-those owner rules are compiled into one schema-dispatch predicate. If at least one owner rule exists,
-the immutable runtime adds local pass-through descriptors for otherwise ungoverned registered root
-schemas. Those pass-through descriptors are not published owner rules; they only ensure that a query
-rooted elsewhere still applies governed freshness rules to linked targets.
+`PostgresIndexQueryAdmissionCatalog` keeps at most one owner rule per exact `SchemaRef`. Runtime-local
+pass-through descriptors let an otherwise ungoverned root still apply governed rules to linked targets.
 
 ## Product graph owner rules
 
-The selected Product distribution registers current entity admission for Product and ProductVariant.
-When Channel is selected it also registers SalesChannel admission. No new Index schema or freshness
-clock is introduced.
+The selected Product distribution registers entity admission for Product and ProductVariant. When
+Channel is selected it also registers SalesChannel admission. No new Index schema or freshness clock is
+introduced.
 
 ### Product
 
-A Product materialized row is admitted only when, in the same PostgreSQL `REPEATABLE READ, READ ONLY`
-query snapshot:
-
-- the owner Product and exact locale translation still exist;
-- materialized `source_version` equals current Product `projection_epoch`;
-- the projection Product component equals current `products.index_revision`;
-- an exact relation freshness witness exists;
-- witness Channel generation equals current tenant Channel generation;
-- no visibility convergence request is newer than the witness Product revision.
-
-This is the existing Product source-read -> mutation-apply fence, now reusable when Product appears as
-any governed materialized entity relation.
+A Product materialized row requires live Product + exact locale, materialized `source_version` equal to
+current Product `projection_epoch`, current Product owner revision reflected in that projection, a
+matching relation freshness witness, current Channel generation, and no newer Product visibility
+convergence request.
 
 ### ProductVariant
 
-A ProductVariant row is admitted only when a live owner `product_variants` row exists for the same
-tenant/UUID and:
+A ProductVariant materialized row requires a live owner row for the same tenant/UUID and:
 
 `product_variants.index_revision = index_entities.source_version`.
 
-A delayed stale ProductVariant row therefore cannot contribute its old payload to Product `variants`
-projection/filter/order semantics after the owner revision has advanced or the owner row has been
-deleted.
-
 ### SalesChannel
 
-A SalesChannel row is admitted only when a live owner `channels` row exists for the same tenant/UUID
-and:
+A SalesChannel materialized row requires a live owner row for the same tenant/UUID and:
 
 `channels.index_revision = index_entities.source_version`.
 
-A stale/deleted SalesChannel row therefore cannot contribute its old payload to Product
-`sales_channels` projection/filter/order semantics while the Product root itself remains current.
+These linked-target rules prevent stale/deleted target payloads from participating in ordinary joins,
+nested many projections, many filters, aggregate ordering, and other materialized target paths.
 
-## Query surfaces fenced against stale target payloads
+## Recreate monotonicity is already source complete
 
-The same composite admission is applied before or inside every materialized target relation used by:
+A post-#3179 source recheck corrected an earlier assumption: ProductVariant and SalesChannel do **not**
+need a new recreate clock. Their existing retained tombstone migrations already preserve the same
+`index_revision` clock monotonically through hard delete and recreation of the same tenant/UUID.
 
-- root predicates and exact count;
-- ordinary linked projection/filter/order joins;
-- many-cardinality nested projections;
-- many-cardinality `EXISTS` filters;
-- many-cardinality `MIN`/`MAX` aggregate ordering;
-- exact-count recompilation of the same plan.
+### ProductVariant retained identity
 
-This closes the stale-materialized-target participation path without making generic Index code
-understand Product, ProductVariant, or SalesChannel owner storage.
+`m20260731_000004_add_product_index_tombstones`:
 
-It does **not** yet prove complete linked-target availability semantics. In particular, a source link
-may exist while its target has not yet been materialized, and existing left-join / many-subquery
-semantics can represent an unavailable target as a missing/null relation. Complete Product graph parity
-still requires retained evidence and an explicit fail-closed policy for that availability window so a
-missing target cannot be mistaken for authoritative owner null/absence semantics.
+- stores ProductVariant delete evidence at `OLD.index_revision + 1`;
+- before insert of the same tenant/Variant UUID, seeds `NEW.index_revision` to at least retained
+  `source_version + 1`;
+- rejects exhausted revisions;
+- clears the retained tombstone only after the live revision strictly supersedes it;
+- retains equivalent move/identity safety.
+
+Therefore an old materialized ProductVariant source version cannot equal the recreated incarnation's
+current source version.
+
+### SalesChannel retained identity
+
+`m20260731_000011_add_channel_index_tombstones` provides the same protocol for SalesChannel:
+
+- delete tombstone at `OLD.index_revision + 1`;
+- recreate seed above the retained tombstone;
+- fail closed at exhaustion;
+- clear only after strict live supersession;
+- retain identity-move safety.
+
+Channel identity generation remains separate: it drives Product relation freshness/convergence and is
+not a replacement for SalesChannel `index_revision`.
+
+No new ProductVariant/SalesChannel ledger or schema version should be added for recreate ordering.
 
 ## Retained PostgreSQL packets
 
-The existing retained packets remain execution-pending:
+Four M7 packets are source-ready and execution/admission pending:
 
 1. `product_materialized_query_freshness_postgres.rs` — delayed Product scalar mutation and locale
    deletion;
 2. `product_channel_convergence_postgres.rs` — Product visibility / Channel identity convergence,
    lease reclaim, rejected Product isolation, changed and unchanged membership;
 3. `product_channel_identity_transitions_postgres.rs` — Channel create/delete/tenant-move and
-   delete+recreate Product relation/freshness behavior.
+   delete+recreate Product relation/freshness behavior;
+4. `product_linked_target_recreate_postgres.rs` — ProductVariant/SalesChannel retained recreate
+   monotonicity plus stale linked-target payload exclusion and current-target recovery.
 
-They have not been executed or admitted by the implementation agent.
+Detailed contract for packet 4:
+`m7-linked-target-recreate-postgres-harness.md`.
 
-## Explicit remaining recreate boundary
+None of these packets has been executed or admitted by the implementation agent.
 
-ProductVariant and SalesChannel currently use their live owner `index_revision` as source version. A
-hard delete followed by recreation of the same UUID can reset that owner-local revision to an earlier
-numeric value. Equality-based entity admission cannot distinguish a new incarnation when the recreated
-row happens to reuse the same revision as an old materialized row.
+## Remaining linked-target availability boundary
 
-Therefore this slice does **not** claim delete+recreate identity safety for ProductVariant or
-SalesChannel target materialization. The next source slice must make those two owner source clocks
-monotonic across retained tombstone/recreate history, while preserving the current ProductVariant and
-SalesChannel SchemaRefs. Do not add another Product schema or compatibility version.
+The entity-admission fence proves that a stale linked target payload cannot be authoritative. It does
+**not** yet define the final semantics when a Product link exists but the target has not yet been
+materialized or is temporarily filtered as stale.
+
+Current left-join/many-subquery SQL can represent that situation as null/empty nested data. Complete
+Product graph parity still needs an explicit fail-closed policy and retained PostgreSQL equivalence
+proof so target unavailability cannot be mistaken for authoritative owner null/absence semantics.
+
+This link-present/target-missing policy is now the next unblocked M7 source-design gap. Recreate source
+ordering itself is no longer a gap.
 
 ## Remaining M7 admission
 
 Still required before Storefront cutover:
 
-- implement recreate-safe monotonic ProductVariant and SalesChannel source clocks;
 - define and retain fail-closed linked-target availability semantics for link-present / target-missing
   windows;
-- retain PostgreSQL linked-target stale/delete/recreate/query evidence after those source changes;
-- execute/admit the retained Product freshness/convergence/identity packets;
+- execute/admit the linked-target recreate packet and the other retained Product packets;
 - complete Product/ProductVariant/SalesChannel query equivalence and linked-target availability proof;
 - admit canonical Product typed events only after event-contract digest verification;
-- pass schema readiness, equivalence, convergence, freshness, and restart evidence.
+- pass schema readiness, equivalence, convergence, freshness, restart, and retained PostgreSQL evidence.
 
 ## Maintainer verification
 
 Suggested commands, intentionally not run by the implementation agent:
 
 ```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-distribution --features mod-product \
+  --test product_linked_target_recreate_postgres -- --nocapture
+node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-query-runtime-composition.mjs

--- a/scripts/verify/verify-index-linked-target-query-freshness.mjs
+++ b/scripts/verify/verify-index-linked-target-query-freshness.mjs
@@ -61,8 +61,7 @@ forbidMarkers(compilerPath, compiler, [
   'SALES_CHANNEL_QUERY_MATERIALIZED_FRESHNESS',
 ]);
 
-const catalogPath = 'crates/rustok-index/src/infrastructure/postgres/query_admission.rs';
-requireMarkers(catalogPath, [
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_admission.rs', [
   'rule: Option<PostgresQueryEntityAdmission>',
   'pub(crate) fn ensure_runtime_schema(',
   'rule: None',
@@ -71,9 +70,7 @@ requireMarkers(catalogPath, [
   'schema_guard(schema)',
   'PostgresQueryEntityAdmission::new(format!(',
 ]);
-
-const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/query_runtime.rs';
-requireMarkers(runtimePath, [
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_runtime.rs', [
   'if !admissions.is_empty()',
   'for registered in registry.registry().iter()',
   'admissions.ensure_runtime_schema(registered.schema.reference.clone())?',
@@ -92,37 +89,58 @@ const owner = requireMarkers(ownerPath, [
   'owner_channel.tenant_id = {{entity}}.tenant_id',
   'owner_channel.id = {{entity}}.entity_id',
   'owner_channel.index_revision = {{entity}}.source_version',
-  'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
 ]);
 forbidMarkers(ownerPath, owner, ['index_entities', 'index_links', '$1']);
 
-const variantSource = requireMarkers('crates/rustok-distribution/src/product_variant_index.rs', [
+requireMarkers('crates/rustok-distribution/src/product_variant_index.rs', [
   'v.index_revision',
   'tombstone.source_version AS index_revision',
   'PRODUCT_VARIANT_SCHEMA_VERSION: u32 = 2',
 ]);
-const channelSource = requireMarkers('crates/rustok-distribution/src/channel_index.rs', [
+requireMarkers('crates/rustok-distribution/src/channel_index.rs', [
   'c.index_revision',
   'tombstone.source_version AS index_revision',
   'SchemaVersion::INITIAL',
 ]);
-for (const [relative, source] of [
-  ['crates/rustok-distribution/src/product_variant_index.rs', variantSource],
-  ['crates/rustok-distribution/src/channel_index.rs', channelSource],
-]) {
-  if (!source.includes('index_revision')) fail(`${relative} lost current owner source revision`);
-}
 
-requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
-  'Query surfaces fenced against stale target payloads',
-  'many-cardinality nested projections',
-  'many-cardinality `EXISTS` filters',
-  'many-cardinality `MIN`/`MAX` aggregate ordering',
-  'does **not** yet prove complete linked-target availability semantics',
-  'link exists while its target has not yet been materialized',
-  'Explicit remaining recreate boundary',
-  'hard delete followed by recreation of the same UUID can reset',
-  'next source slice must make those two owner source clocks monotonic',
+const variantTombstoneMigration =
+  'crates/rustok-product/src/migrations/m20260731_000004_add_product_index_tombstones.rs';
+requireMarkers(variantTombstoneMigration, [
+  'CREATE TABLE product_variant_index_tombstones',
+  'OLD.index_revision + 1',
+  'rustok_product_variant_seed_index_revision_from_tombstone',
+  'NEW.index_revision := GREATEST(NEW.index_revision, retained_source_version + 1)',
+  'rustok_product_variant_clear_inserted_index_tombstone',
+  'tombstone.source_version >= live_source_version',
 ]);
 
-console.log('[verify-index-linked-target-query-freshness] linked target stale-payload fence and remaining availability gate verified');
+const channelTombstoneMigration =
+  'crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs';
+requireMarkers(channelTombstoneMigration, [
+  'CREATE TABLE channel_index_tombstones',
+  'OLD.index_revision + 1',
+  'rustok_channel_seed_index_revision_from_tombstone',
+  'NEW.index_revision := GREATEST(NEW.index_revision, retained_source_version + 1)',
+  'rustok_channel_clear_inserted_index_tombstone',
+  'tombstone.source_version >= live_source_version',
+]);
+
+const freshnessDoc = requireMarkers(
+  'crates/rustok-index/docs/m7-product-materialized-query-freshness.md',
+  [
+    'Recreate monotonicity is already source complete',
+    'do **not** need a new recreate clock',
+    'm20260731_000004_add_product_index_tombstones',
+    'm20260731_000011_add_channel_index_tombstones',
+    'No new ProductVariant/SalesChannel ledger or schema version should be added',
+    'Remaining linked-target availability boundary',
+    'link exists but the target has not yet been materialized',
+    'product_linked_target_recreate_postgres.rs',
+  ],
+);
+forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', freshnessDoc, [
+  'next source slice must make those two owner source clocks monotonic',
+  'implement recreate-safe monotonic ProductVariant and SalesChannel source clocks',
+]);
+
+console.log('[verify-index-linked-target-query-freshness] linked target freshness and retained recreate monotonicity verified');

--- a/scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+++ b/scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
@@ -107,7 +107,7 @@ requireMarkers('crates/rustok-index/docs/m7-linked-target-recreate-postgres-harn
   'It adds no owner clock, no Index schema, and no compatibility version.',
   'ProductVariant scenario',
   'SalesChannel scenario',
-  'link exists while its target',
+  'link that exists while its target',
   'does not claim execution success',
 ]);
 

--- a/scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+++ b/scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-linked-target-recreate-postgres-harness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const harnessPath = 'crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs';
+const harness = requireMarkers(harnessPath, [
+  '#![cfg(feature = "mod-product")]',
+  'rustok_channel::migrations::migrations()',
+  'rustok_product::migrations::migrations()',
+  'IndexModule.migrations()',
+  '.register(IndexModule)',
+  '.register(rustok_channel::ChannelModule)',
+  '.register(rustok_product::ProductModule)',
+  'PostgresSchemaRegistrationStore::new',
+  'materialize_postgres_index_sources',
+  'materialize_index_source_registry',
+  'materialize_postgres_index_query_runtime',
+  'PostgresMutationStore::new',
+  'ModuleWorkRegistrations',
+  'ModuleWorkScheduler::new()',
+  'scheduler.run_once().await?',
+  'PRODUCT_SOURCE: &str = "product-postgres-primary"',
+  'PRODUCT_VARIANT_SOURCE: &str = "product-variant-postgres-primary"',
+  'SALES_CHANNEL_SOURCE: &str = "sales-channel-postgres-primary"',
+  'FieldPath::linked(',
+  'LinkName::new("variants")',
+  'LinkName::new("sales_channels")',
+  'delete_variant(&database.writer).await?',
+  'variant_tombstone_version(&database.writer)',
+  'recreate_variant(&database.writer).await?',
+  'recreated_variant_version > variant_tombstone',
+  'variant_tombstone_version(&database.writer).await?.is_none()',
+  'assert_materialized_target_version(',
+  '"product_variant"',
+  'assert_graph_payloads(&runtime.query, &[], &[OLD_CHANNEL_NAME])',
+  'delete_channel(&database.writer).await?',
+  'channel_tombstone_version(&database.writer)',
+  'recreate_channel(&database.writer).await?',
+  'recreated_channel_version > channel_tombstone',
+  'channel_tombstone_version(&database.writer).await?.is_none()',
+  'assert_product_root_visible(&runtime.query, false)',
+  'run_scheduler_until_idle(&runtime.scheduler, 20)',
+  'latest_relation_epoch(&database.writer)',
+  'latest_projection_epoch(&database.writer)',
+  'latest_freshness_generation(&database.writer)',
+  '"sales_channel"',
+  'assert_graph_payloads(&runtime.query, &[NEW_VARIANT_SKU], &[])',
+  'assert_graph_payloads(',
+  '&[NEW_VARIANT_SKU]',
+  '&[NEW_CHANNEL_NAME]',
+]);
+forbidMarkers(harnessPath, harness, [
+  'tokio::spawn',
+  'loop {',
+  'CREATE TABLE product_variant_index_tombstones',
+  'CREATE TABLE channel_index_tombstones',
+  'ALTER TABLE product_variants',
+  'ALTER TABLE channels',
+  'PostgresQueryEntityAdmission::new',
+]);
+
+requireMarkers(
+  'crates/rustok-product/src/migrations/m20260731_000004_add_product_index_tombstones.rs',
+  [
+    'OLD.index_revision + 1',
+    'rustok_product_variant_seed_index_revision_from_tombstone',
+    'retained_source_version + 1',
+    'rustok_product_variant_clear_inserted_index_tombstone',
+  ],
+);
+requireMarkers(
+  'crates/rustok-channel/src/migrations/m20260731_000011_add_channel_index_tombstones.rs',
+  [
+    'OLD.index_revision + 1',
+    'rustok_channel_seed_index_revision_from_tombstone',
+    'retained_source_version + 1',
+    'rustok_channel_clear_inserted_index_tombstone',
+  ],
+);
+requireMarkers('crates/rustok-distribution/src/product_index/query_admission.rs', [
+  'owner_variant.index_revision = {{entity}}.source_version',
+  'owner_channel.index_revision = {{entity}}.source_version',
+]);
+requireMarkers('crates/rustok-index/docs/m7-linked-target-recreate-postgres-harness.md', [
+  'Status: `source_ready_execution_pending`',
+  'It adds no owner clock, no Index schema, and no compatibility version.',
+  'ProductVariant scenario',
+  'SalesChannel scenario',
+  'link exists while its target',
+  'does not claim execution success',
+]);
+
+console.log('[verify-index-linked-target-recreate-postgres-harness] source-ready packet verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -86,8 +86,7 @@ const port = requireMarkers(portPath, [
 ]);
 forbidMarkers(portPath, port, ['tokio::spawn', 'IndexMutation::']);
 
-const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/query_runtime.rs';
-requireMarkers(runtimePath, [
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_runtime.rs', [
   'let mut admissions = extensions',
   '.get::<PostgresIndexQueryAdmissionCatalog>()',
   'AdmissionSchemaMissing',
@@ -95,8 +94,6 @@ requireMarkers(runtimePath, [
   'for registered in registry.registry().iter()',
   'admissions.ensure_runtime_schema(registered.schema.reference.clone())?',
   'PostgresIndexQueryPort::with_admissions(',
-  'registry.shared()',
-  'admissions,',
 ]);
 
 const productAdmissionPath = 'crates/rustok-distribution/src/product_index/query_admission.rs';
@@ -142,16 +139,26 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'PostgresQueryEntityAdmissionApplyError',
   'PostgresQueryEntityAdmissionError',
 ]);
-requireMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', [
-  'Status: `source_complete_linked_target_fence_execution_pending`',
-  '`PostgresQueryEntityAdmission`',
-  '`mpN_tN`',
-  '`mx_tN`',
-  '`mo_tN`',
-  'ProductVariant',
-  'SalesChannel',
-  'Explicit remaining recreate boundary',
+const freshnessDoc = requireMarkers(
+  'crates/rustok-index/docs/m7-product-materialized-query-freshness.md',
+  [
+    'Status: `source_complete_linked_target_recreate_packet_execution_pending`',
+    '`PostgresQueryEntityAdmission`',
+    '`mpN_tN`',
+    '`mx_tN`',
+    '`mo_tN`',
+    'ProductVariant',
+    'SalesChannel',
+    'Recreate monotonicity is already source complete',
+    'm20260731_000004_add_product_index_tombstones',
+    'm20260731_000011_add_channel_index_tombstones',
+    'Remaining linked-target availability boundary',
+    'product_linked_target_recreate_postgres.rs',
+  ],
+);
+forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', freshnessDoc, [
   'does **not** claim delete+recreate identity safety',
+  'next source slice must make those two owner source clocks monotonic',
 ]);
 
-console.log('[verify-index-product-materialized-query-freshness] Product graph entity freshness fence verified');
+console.log('[verify-index-product-materialized-query-freshness] Product graph entity freshness and recreate boundary verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -71,6 +71,7 @@ const scripts = [
   'verify-index-product-channel-relation-convergence.mjs',
   'verify-index-product-materialized-query-freshness.mjs',
   'verify-index-linked-target-query-freshness.mjs',
+  'verify-index-linked-target-recreate-postgres-harness.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- correct the post-#3179 source assumption that ProductVariant/SalesChannel need a new recreate clock: their existing retained tombstone migrations already keep the current owner `index_revision` monotonic through hard delete and same-UUID recreation;
- add a source-ready PostgreSQL integration packet using real Channel, Product, and Index migrations, real source adapters, generic mutation storage, persisted schema readiness, canonical entity query admission, and the registered generic Product/Channel convergence scheduler;
- retain ProductVariant delete→recreate evidence where the tombstone source version exceeds the old materialized target, the recreated live revision exceeds the tombstone, the tombstone clears only after supersession, and the stale old Variant payload remains physically materialized but is excluded from Product nested projection until the current Variant mutation applies;
- retain SalesChannel delete→recreate evidence where the same UUID/canonical slug restores unchanged Product membership, Product relation/projection clocks remain unchanged after freshness-only convergence, the same Product materialized row becomes query-authoritative again, but the stale old Channel target payload remains excluded until the current SalesChannel mutation applies;
- update linked-target/materialized freshness guards and the canonical current implementation cursor;
- add no production source, no migration, no owner clock, no Index schema, and no compatibility version.

## Corrected owner invariant

Product migration `m20260731_000004_add_product_index_tombstones` already stores ProductVariant delete identity at `OLD.index_revision + 1`, seeds a recreated same tenant/UUID row above that retained source version before insert, and clears the tombstone only after strict live supersession.

Channel migration `m20260731_000011_add_channel_index_tombstones` already provides the same protocol for SalesChannel. Channel identity generation remains a separate Product relation freshness/convergence watermark; it is not the SalesChannel entity mutation source version.

Therefore the next M7 source gap is not a new target version ledger. It is the explicit fail-closed semantics for **link present but target materialization unavailable/stale**.

## Retained packet

`crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs` deliberately leaves old ProductVariant and SalesChannel rows physically materialized while owner rows are deleted/recreated under the same UUID.

For ProductVariant it refreshes the Product root after membership-driven Product revision/projection changes but does not deliver target delete/recreate mutations. The current Product root must be query-visible while the stale old Variant SKU is absent from the nested `variants` projection. Applying only the current Variant mutation restores the recreated SKU.

For SalesChannel it deletes/recreates the Channel before convergence, requires Channel generation to advance twice, then runs only the registered generic convergence scheduler. Final Product membership is unchanged, so `relation_epoch`, `projection_epoch`, and the existing Product materialized source version remain unchanged while freshness catches up. The Product root becomes query-visible again, but the old physically materialized Channel name remains excluded by target entity admission until only the current SalesChannel mutation is applied.

## Deliberate boundary

The packet proves stale target payload exclusion and recreate-safe owner ordering. It does **not** declare empty/null nested data authoritative when a link exists but a target is not yet materialized. Current SQL can represent that availability window as empty/null; complete Product graph parity still needs a generic fail-closed availability policy and retained equivalence evidence before Storefront cutover.

## Main recheck

The branch started from `main@68d8c86b1371929bc096576f204f730a7a7b9bb9` (#3179). Current `main@6ea6f6d65d4a336d58633e00dfcb76e968917298` advanced through Commerce/Pages/Product read-port work only. Compare shows no overlap with Product/Channel migrations or any of this PR's eight evidence/doc/verifier files.

## Validation

Per maintainer instruction this remains **source-ready, execution-pending**. No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.