### PR TITLE
test(index): retain linked target availability equivalence packet

### DIFF
--- a/crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs
@@ -1,0 +1,783 @@
+#![cfg(feature = "mod-product")]
+
+use std::{collections::BTreeSet, env, error::Error};
+
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation, IndexQuery,
+    IndexQueryPage, IndexQueryPort, IndexQueryScope, IndexSourceLoadRequest, IndexValue, LinkName,
+    LocaleKey, ModuleName, MutationApplyOutcome, MutationDelivery, OrderDirection, OrderExpr,
+    Pagination, PostgresMutationStore, PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion,
+    SharedIndexQueryRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+    materialize_index_source_registry, materialize_postgres_index_query_runtime,
+    materialize_postgres_index_sources,
+};
+use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistrations, ModuleWorkScheduler};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const PRODUCT_VARIANT_SOURCE: &str = "product-variant-postgres-primary";
+const SALES_CHANNEL_SOURCE: &str = "sales-channel-postgres-primary";
+
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const PRODUCT_A_ID: Uuid = Uuid::from_u128(101);
+const PRODUCT_B_ID: Uuid = Uuid::from_u128(102);
+const PRODUCT_A_TRANSLATION_ID: Uuid = Uuid::from_u128(111);
+const PRODUCT_B_TRANSLATION_ID: Uuid = Uuid::from_u128(112);
+const VARIANT_A_ID: Uuid = Uuid::from_u128(201);
+const VARIANT_B_ID: Uuid = Uuid::from_u128(202);
+const CHANNEL_A_ID: Uuid = Uuid::from_u128(301);
+const CHANNEL_B_ID: Uuid = Uuid::from_u128(302);
+
+const VARIANT_A_OLD_SKU: &str = "middle-stale-sku";
+const VARIANT_A_CURRENT_SKU: &str = "alpha-current-sku";
+const VARIANT_B_SKU: &str = "zulu-stable-sku";
+const CHANNEL_A_OLD_NAME: &str = "Middle stale channel";
+const CHANNEL_A_CURRENT_NAME: &str = "Alpha current channel";
+const CHANNEL_B_NAME: &str = "Zulu stable channel";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    migration: DatabaseConnection,
+    work: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    writer: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping linked-target availability equivalence harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_link_availability_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_link_availability_migration_{suffix}"),
+        )
+        .await?;
+        create_migration_prerequisites(&migration).await?;
+        let manager = SchemaManager::new(&migration);
+        for step in rustok_channel::migrations::migrations() {
+            step.up(&manager).await?;
+        }
+        for step in rustok_product::migrations::migrations() {
+            step.up(&manager).await?;
+        }
+        for step in IndexModule.migrations() {
+            step.up(&manager).await?;
+        }
+        seed_owner_rows(&migration).await?;
+
+        Ok(Some(Self {
+            control,
+            migration,
+            work: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_availability_work_{suffix}"),
+            )
+            .await?,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_availability_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_availability_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_availability_query_{suffix}"),
+            )
+            .await?,
+            writer: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_availability_writer_{suffix}"),
+            )
+            .await?,
+            database_url,
+            schema_name,
+        }))
+    }
+
+    async fn fresh_query_runtime(&self) -> TestResult<SharedIndexQueryRuntime> {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let query = scoped_connection(
+            &self.database_url,
+            &self.schema_name,
+            &format!("idx_link_availability_restart_query_{suffix}"),
+        )
+        .await?;
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(rustok_channel::ChannelModule)
+            .register(rustok_product::ProductModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+        materialize_postgres_index_query_runtime(&mut extensions, query)?
+            .ok_or_else(|| std::io::Error::other("fresh Index query runtime is missing").into())
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.migration.close().await?;
+        self.work.close().await?;
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.writer.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct Runtime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+    scheduler: ModuleWorkScheduler,
+}
+
+#[tokio::test]
+async fn linked_target_availability_preserves_filter_order_count_and_runtime_restart_parity(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let result = run_scenarios(&database).await;
+    let cleanup = database.cleanup().await;
+    result?;
+    cleanup
+}
+
+async fn run_scenarios(database: &TestDatabase) -> TestResult<()> {
+    let runtime = build_runtime(database).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 40).await?;
+
+    for product_id in [PRODUCT_A_ID, PRODUCT_B_ID] {
+        materialize_current(&runtime, PRODUCT_SOURCE, product_key(product_id)?).await?;
+    }
+    let variant_a_materialized =
+        materialize_current(&runtime, PRODUCT_VARIANT_SOURCE, variant_key(VARIANT_A_ID)?).await?;
+    materialize_current(&runtime, PRODUCT_VARIANT_SOURCE, variant_key(VARIANT_B_ID)?).await?;
+    let channel_a_materialized =
+        materialize_current(&runtime, SALES_CHANNEL_SOURCE, channel_key(CHANNEL_A_ID)?).await?;
+    materialize_current(&runtime, SALES_CHANNEL_SOURCE, channel_key(CHANNEL_B_ID)?).await?;
+
+    assert_ids_unordered(
+        runtime.query.execute_query(variant_stale_match_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    assert_ids_ordered(
+        runtime.query.execute_query(variant_order_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    assert_ids_unordered(
+        runtime.query.execute_query(channel_stale_match_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    assert_ids_ordered(
+        runtime.query.execute_query(channel_order_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+
+    // A target-only ProductVariant update changes target source_version but not Product link membership
+    // or Product projection. Keep the old Variant mutation physically materialized.
+    update_variant_a_sku(&database.writer).await?;
+    let variant_a_current = live_variant_revision(&database.writer, VARIANT_A_ID).await?;
+    assert!(variant_a_current > variant_a_materialized);
+    assert_eq!(
+        materialized_target_version(
+            &database.mutation,
+            "rustok-product",
+            "product_variant",
+            2,
+            VARIANT_A_ID,
+        )
+        .await?,
+        variant_a_materialized
+    );
+
+    // The stale old SKU must not leak through linked filtering. Product B remains fully authoritative,
+    // so page and exact count contain only B rather than hiding the whole query result.
+    assert_ids_unordered(
+        runtime.query.execute_query(variant_stale_match_query()?).await?,
+        &[PRODUCT_B_ID],
+        1,
+    );
+    assert_ids_ordered(
+        runtime.query.execute_query(variant_order_query()?).await?,
+        &[PRODUCT_B_ID],
+        1,
+    );
+
+    // Recompose the immutable query runtime on a fresh PostgreSQL session while the target is stale.
+    // The same availability boundary must survive runtime restart without owner-specific recovery state.
+    let restarted_query = database.fresh_query_runtime().await?;
+    assert_ids_unordered(
+        restarted_query.execute_query(variant_stale_match_query()?).await?,
+        &[PRODUCT_B_ID],
+        1,
+    );
+    assert_ids_ordered(
+        restarted_query.execute_query(variant_order_query()?).await?,
+        &[PRODUCT_B_ID],
+        1,
+    );
+
+    let applied_variant =
+        materialize_current(&runtime, PRODUCT_VARIANT_SOURCE, variant_key(VARIANT_A_ID)?).await?;
+    assert_eq!(applied_variant, variant_a_current);
+    assert_ids_unordered(
+        runtime.query.execute_query(variant_current_match_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    assert_ids_ordered(
+        runtime.query.execute_query(variant_order_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    assert_ids_unordered(
+        restarted_query.execute_query(variant_current_match_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+
+    // Channel name changes bump SalesChannel index_revision but deliberately do not bump Channel
+    // identity generation, so Product owner/relation freshness stays current. Availability alone must
+    // fence the stale target payload.
+    let generation_before_name_update = channel_generation(&database.writer).await?;
+    update_channel_a_name(&database.writer).await?;
+    let generation_after_name_update = channel_generation(&database.writer).await?;
+    assert_eq!(generation_after_name_update, generation_before_name_update);
+    let channel_a_current = live_channel_revision(&database.writer, CHANNEL_A_ID).await?;
+    assert!(channel_a_current > channel_a_materialized);
+    assert_eq!(
+        materialized_target_version(
+            &database.mutation,
+            "rustok-channel",
+            "sales_channel",
+            1,
+            CHANNEL_A_ID,
+        )
+        .await?,
+        channel_a_materialized
+    );
+
+    assert_ids_unordered(
+        runtime.query.execute_query(channel_stale_match_query()?).await?,
+        &[PRODUCT_B_ID],
+        1,
+    );
+    assert_ids_ordered(
+        runtime.query.execute_query(channel_order_query()?).await?,
+        &[PRODUCT_B_ID],
+        1,
+    );
+
+    let applied_channel =
+        materialize_current(&runtime, SALES_CHANNEL_SOURCE, channel_key(CHANNEL_A_ID)?).await?;
+    assert_eq!(applied_channel, channel_a_current);
+    assert_ids_unordered(
+        runtime.query.execute_query(channel_current_match_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    assert_ids_ordered(
+        runtime.query.execute_query(channel_order_query()?).await?,
+        &[PRODUCT_A_ID, PRODUCT_B_ID],
+        2,
+    );
+    Ok(())
+}
+
+async fn build_runtime(database: &TestDatabase) -> TestResult<Runtime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Index schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for registered in schemas.registry().iter() {
+        schema_store.register(TENANT_ID, &registered.schema).await?;
+    }
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Index source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Index query runtime is missing"))?;
+    let registrations = extensions
+        .get::<ModuleWorkRegistrations>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product convergence work is missing"))?;
+    let scheduler = ModuleWorkScheduler::new();
+    registrations
+        .register_all(&HostRuntimeContext::new(database.work.clone()), &scheduler)
+        .await?;
+    Ok(Runtime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+        scheduler,
+    })
+}
+
+async fn run_scheduler_until_idle(
+    scheduler: &ModuleWorkScheduler,
+    maximum_iterations: usize,
+) -> TestResult<usize> {
+    let mut executed = 0;
+    for _ in 0..maximum_iterations {
+        let current = scheduler.run_once().await?;
+        if current == 0 {
+            return Ok(executed);
+        }
+        executed += current;
+    }
+    Err(std::io::Error::other(format!(
+        "ModuleWork scheduler did not become idle after {maximum_iterations} bounded iterations"
+    ))
+    .into())
+}
+
+async fn materialize_current(
+    runtime: &Runtime,
+    source_name: &str,
+    key: EntityKey,
+) -> TestResult<u64> {
+    let request = IndexSourceLoadRequest::new(vec![key])?;
+    let mut mutations = runtime.sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected one mutation from {source_name}, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    let mutation: IndexMutation = mutations.remove(0);
+    let source_version = mutation.source_version();
+    let delivery = MutationDelivery::from_event(source_name, mutation)?;
+    let outcome = runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?;
+    match outcome {
+        MutationApplyOutcome::Applied {
+            source_version: applied,
+        } if applied == source_version => Ok(source_version),
+        other => Err(std::io::Error::other(format!(
+            "expected {source_name} mutation {source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+fn product_key(product_id: Uuid) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: product_schema_ref()?,
+        entity_id: product_id,
+        locale: Some(LocaleKey::new("en")?),
+    })
+}
+
+fn variant_key(variant_id: Uuid) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: variant_schema_ref()?,
+        entity_id: variant_id,
+        locale: None,
+    })
+}
+
+fn channel_key(channel_id: Uuid) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: channel_schema_ref()?,
+        entity_id: channel_id,
+        locale: None,
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        version: SchemaVersion::new(3),
+    })
+}
+
+fn variant_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product_variant")?,
+        version: SchemaVersion::new(2),
+    })
+}
+
+fn channel_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-channel")?,
+        entity: EntityName::new("sales_channel")?,
+        version: SchemaVersion::INITIAL,
+    })
+}
+
+fn variants_sku_path() -> TestResult<FieldPath> {
+    Ok(FieldPath::linked(
+        [LinkName::new("variants")?],
+        FieldName::new("sku")?,
+    ))
+}
+
+fn sales_channels_name_path() -> TestResult<FieldPath> {
+    Ok(FieldPath::linked(
+        [LinkName::new("sales_channels")?],
+        FieldName::new("name")?,
+    ))
+}
+
+fn base_product_query() -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: TENANT_ID,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: product_schema_ref()?,
+        fields: vec![
+            FieldPath::new(FieldName::new("id")?),
+            FieldPath::new(FieldName::new("title")?),
+        ],
+        filter: None,
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+fn variant_stale_match_query() -> TestResult<IndexQuery> {
+    let mut query = base_product_query()?;
+    query.filter = Some(FilterExpr::In(
+        variants_sku_path()?,
+        vec![
+            IndexValue::String(VARIANT_A_OLD_SKU.to_owned()),
+            IndexValue::String(VARIANT_B_SKU.to_owned()),
+        ],
+    ));
+    Ok(query)
+}
+
+fn variant_current_match_query() -> TestResult<IndexQuery> {
+    let mut query = base_product_query()?;
+    query.filter = Some(FilterExpr::In(
+        variants_sku_path()?,
+        vec![
+            IndexValue::String(VARIANT_A_CURRENT_SKU.to_owned()),
+            IndexValue::String(VARIANT_B_SKU.to_owned()),
+        ],
+    ));
+    Ok(query)
+}
+
+fn variant_order_query() -> TestResult<IndexQuery> {
+    let mut query = base_product_query()?;
+    query.order_by = vec![OrderExpr {
+        field: variants_sku_path()?,
+        direction: OrderDirection::MinAsc,
+    }];
+    Ok(query)
+}
+
+fn channel_stale_match_query() -> TestResult<IndexQuery> {
+    let mut query = base_product_query()?;
+    query.filter = Some(FilterExpr::In(
+        sales_channels_name_path()?,
+        vec![
+            IndexValue::String(CHANNEL_A_OLD_NAME.to_owned()),
+            IndexValue::String(CHANNEL_B_NAME.to_owned()),
+        ],
+    ));
+    Ok(query)
+}
+
+fn channel_current_match_query() -> TestResult<IndexQuery> {
+    let mut query = base_product_query()?;
+    query.filter = Some(FilterExpr::In(
+        sales_channels_name_path()?,
+        vec![
+            IndexValue::String(CHANNEL_A_CURRENT_NAME.to_owned()),
+            IndexValue::String(CHANNEL_B_NAME.to_owned()),
+        ],
+    ));
+    Ok(query)
+}
+
+fn channel_order_query() -> TestResult<IndexQuery> {
+    let mut query = base_product_query()?;
+    query.order_by = vec![OrderExpr {
+        field: sales_channels_name_path()?,
+        direction: OrderDirection::MinAsc,
+    }];
+    Ok(query)
+}
+
+fn assert_ids_unordered(page: IndexQueryPage, expected: &[Uuid], exact_count: u64) {
+    let actual = page
+        .items
+        .iter()
+        .map(|item| item.entity_id)
+        .collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected);
+    assert_eq!(page.exact_count, Some(exact_count));
+}
+
+fn assert_ids_ordered(page: IndexQueryPage, expected: &[Uuid], exact_count: u64) {
+    let actual = page
+        .items
+        .iter()
+        .map(|item| item.entity_id)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+    assert_eq!(page.exact_count, Some(exact_count));
+}
+
+async fn update_variant_a_sku(db: &DatabaseConnection) -> TestResult<()> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE product_variants SET sku = $3 WHERE tenant_id = $1 AND id = $2",
+            vec![
+                TENANT_ID.into(),
+                VARIANT_A_ID.into(),
+                VARIANT_A_CURRENT_SKU.to_owned().into(),
+            ],
+        ))
+        .await?;
+    assert_eq!(result.rows_affected(), 1);
+    Ok(())
+}
+
+async fn update_channel_a_name(db: &DatabaseConnection) -> TestResult<()> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE channels SET name = $3 WHERE tenant_id = $1 AND id = $2",
+            vec![
+                TENANT_ID.into(),
+                CHANNEL_A_ID.into(),
+                CHANNEL_A_CURRENT_NAME.to_owned().into(),
+            ],
+        ))
+        .await?;
+    assert_eq!(result.rows_affected(), 1);
+    Ok(())
+}
+
+async fn live_variant_revision(db: &DatabaseConnection, variant_id: Uuid) -> TestResult<u64> {
+    live_revision(
+        db,
+        "SELECT index_revision FROM product_variants WHERE tenant_id = $1 AND id = $2",
+        variant_id,
+        "ProductVariant",
+    )
+    .await
+}
+
+async fn live_channel_revision(db: &DatabaseConnection, channel_id: Uuid) -> TestResult<u64> {
+    live_revision(
+        db,
+        "SELECT index_revision FROM channels WHERE tenant_id = $1 AND id = $2",
+        channel_id,
+        "SalesChannel",
+    )
+    .await
+}
+
+async fn live_revision(
+    db: &DatabaseConnection,
+    sql: &str,
+    entity_id: Uuid,
+    label: &str,
+) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            vec![TENANT_ID.into(), entity_id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other(format!("{label} owner row is missing")))?;
+    let revision: i64 = row.try_get("", "index_revision")?;
+    Ok(u64::try_from(revision)?)
+}
+
+async fn channel_generation(db: &DatabaseConnection) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT generation FROM channel_index_identity_generations WHERE tenant_id = $1",
+            vec![TENANT_ID.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("Channel identity generation is missing"))?;
+    let generation: i64 = row.try_get("", "generation")?;
+    Ok(u64::try_from(generation)?)
+}
+
+async fn materialized_target_version(
+    db: &DatabaseConnection,
+    module_name: &str,
+    entity_name: &str,
+    schema_version: i64,
+    entity_id: Uuid,
+) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(source_version AS TEXT) AS source_version_text
+FROM index_entities
+WHERE tenant_id = $1
+  AND module_name = $2
+  AND entity_name = $3
+  AND schema_version = $4
+  AND entity_id = $5
+  AND is_deleted = FALSE
+"#,
+            vec![
+                TENANT_ID.into(),
+                module_name.to_owned().into(),
+                entity_name.to_owned().into(),
+                schema_version.into(),
+                entity_id.into(),
+            ],
+        ))
+        .await?
+        .ok_or_else(|| {
+            std::io::Error::other(format!(
+                "materialized {module_name}/{entity_name} row is missing"
+            ))
+        })?;
+    let value: String = row.try_get("", "source_version_text")?;
+    Ok(value.parse()?)
+}
+
+async fn create_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE oauth_apps (
+    id UUID PRIMARY KEY
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_owner_rows(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+
+INSERT INTO channels (id, tenant_id, slug, name) VALUES
+    ('{CHANNEL_A_ID}', '{TENANT_ID}', 'alpha', '{CHANNEL_A_OLD_NAME}'),
+    ('{CHANNEL_B_ID}', '{TENANT_ID}', 'beta', '{CHANNEL_B_NAME}');
+
+INSERT INTO products (id, tenant_id, metadata) VALUES
+    ('{PRODUCT_A_ID}', '{TENANT_ID}', '{{"channel_visibility":{{"allowed_channel_slugs":["alpha"]}}}}'::jsonb),
+    ('{PRODUCT_B_ID}', '{TENANT_ID}', '{{"channel_visibility":{{"allowed_channel_slugs":["beta"]}}}}'::jsonb);
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{PRODUCT_A_TRANSLATION_ID}', '{PRODUCT_A_ID}', '{TENANT_ID}', 'en', 'Product A', 'product-a'),
+    ('{PRODUCT_B_TRANSLATION_ID}', '{PRODUCT_B_ID}', '{TENANT_ID}', 'en', 'Product B', 'product-b');
+
+INSERT INTO product_variants (id, product_id, tenant_id, sku) VALUES
+    ('{VARIANT_A_ID}', '{PRODUCT_A_ID}', '{TENANT_ID}', '{VARIANT_A_OLD_SKU}'),
+    ('{VARIANT_B_ID}', '{PRODUCT_B_ID}', '{TENANT_ID}', '{VARIANT_B_SKU}');
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-07
 
-Status overlay rechecked from `main@02994951bdfe69b27a92de0aff2103f00ceb80ec` and continued on
-`agent/index-link-target-availability-admission-20260807`.
+Status overlay rechecked from `main@be388f9795581b15e88b718e82952a7a0c107dc4` and continued on
+`agent/index-link-target-availability-equivalence-20260807`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
 cursor.
@@ -33,7 +33,8 @@ inspection. Independent M7 source work continues while that owner-execution gate
 - generic PostgreSQL entity freshness admission for every compiler-owned materialized entity alias;
 - Product, ProductVariant, and SalesChannel owner freshness rules;
 - recreate-safe ProductVariant and SalesChannel `index_revision` through retained tombstone seed/clear;
-- generic **query-path-scoped linked-target availability admission** for Product graph queries.
+- generic query-path-scoped linked-target availability admission for Product graph queries;
+- source-ready linked-target filter/order/exact-count/runtime-recomposition PostgreSQL equivalence.
 
 No parallel Product/ProductVariant compatibility source is selected. Generic numeric `SchemaVersion`
 values remain Index storage/routing keys only; do not introduce a new Product schema/version to solve
@@ -98,10 +99,10 @@ Product registers exactly one generic link-target availability policy for its cu
 `SchemaRef`.
 
 The query runtime uses validated `IndexQuery::referenced_paths()` to derive only the first-hop link names
-that the current query actually traverses across selection, filtering, or ordering.
+that the current query traverses across selection, filtering, or ordering.
 
 For scalar-only Product queries with no linked path, no availability predicate is injected. Such queries
-therefore remain independent of unrelated ProductVariant/SalesChannel materialization.
+remain independent of unrelated ProductVariant/SalesChannel materialization.
 
 For a Product query that references `variants` and/or `sales_channels`, the query port injects the same
 root precondition into page SQL and exact-count SQL before ordinary entity admission:
@@ -113,7 +114,7 @@ root precondition into page SQL and exact-count SQL before ordinary entity admis
 - require that target row to pass the same owner freshness dispatcher used by normal query aliases;
 - exclude the Product root if any current queried link target is missing, stale, or deleted.
 
-This produces the intended authority states:
+Authority states are therefore:
 
 - no current link row = authoritative absent relation;
 - current link + current owner-admitted target = authoritative linked relation;
@@ -140,9 +141,36 @@ Product migration `m20260731_000004_add_product_index_tombstones` and Channel mi
 
 Old materialized target versions therefore cannot collide with recreated incarnations.
 
+## Linked-target availability equivalence source complete
+
+`product_linked_target_availability_equivalence_postgres.rs` adds two Product roots with independent
+Variant and SalesChannel targets.
+
+For ProductVariant:
+
+- SKU-only update increments Variant `index_revision` without changing Product membership/projection;
+- stale old target remains physically materialized;
+- linked `IN` filter that would otherwise match the stale old SKU returns only the unrelated current
+  Product;
+- `MIN(variants.sku)` ordering returns only the unrelated current Product;
+- exact count is 1 on both query paths;
+- a fresh query runtime on a new PostgreSQL session sees the same boundary;
+- applying only the current Variant mutation restores the affected Product and exact count 2.
+
+For SalesChannel:
+
+- name-only update increments Channel `index_revision` without changing tenant Channel identity
+  generation;
+- Product relation/projection freshness therefore stays current;
+- linked stale-name filtering and `MIN(sales_channels.name)` ordering return only the unrelated current
+  Product with exact count 1;
+- applying only the current Channel mutation restores both Products and exact count 2.
+
+This packet is source-ready and execution-pending. It does not claim runtime test success.
+
 ## Retained M7 PostgreSQL packets
 
-Four packets are source-ready and execution/admission pending:
+Five packets are source-ready and execution/admission pending:
 
 1. `product_materialized_query_freshness_postgres.rs`
    - delayed Product scalar mutation and locale deletion;
@@ -164,6 +192,12 @@ Four packets are source-ready and execution/admission pending:
    - graph query returns zero rows/exact count while a referenced current link target is stale or
      unavailable;
    - applying the current target mutation restores the graph payload.
+5. `product_linked_target_availability_equivalence_postgres.rs`
+   - two-root linked filter isolation;
+   - many `MIN` aggregate ordering isolation;
+   - exact-count parity;
+   - fresh query-runtime recomposition while target is stale;
+   - target-only mutation recovery for both ProductVariant and SalesChannel.
 
 None has been executed or admitted by the implementation agent.
 
@@ -203,43 +237,35 @@ None has been executed or admitted by the implementation agent.
 - [x] Product materialized root freshness fence.
 - [x] Entity-level stale linked-target freshness fence for ProductVariant and SalesChannel.
 - [x] ProductVariant/SalesChannel recreate-safe monotonic `index_revision` via retained tombstones.
-- [x] Define fail-closed semantics for **link present but queried target materialization unavailable or
-      stale**, while keeping scalar-only Product queries independent of unused links.
-- [x] Update linked-target recreate packet to retain fail-closed nested projection/exact-count source
-      evidence.
+- [x] Define fail-closed semantics for link-present queried target materialization unavailable/stale.
+- [x] Keep scalar-only Product queries independent of unused links.
+- [x] Source-ready nested projection/exact-count target recreate packet.
+- [x] Source-ready linked filter/many aggregate order/exact-count/runtime-recomposition equivalence
+      packet for ProductVariant and SalesChannel target lag.
 - [x] Source-ready Product delayed-mutation/locale-deletion PostgreSQL packet.
 - [x] Source-ready Product visibility/Channel convergence multi-host PostgreSQL packet.
 - [x] Source-ready Channel create/delete/tenant-move/delete-recreate PostgreSQL packet.
-- [x] Source-ready ProductVariant/SalesChannel linked-target recreate PostgreSQL packet.
 - [x] Remove parallel Product/ProductVariant compatibility implementations.
-- [ ] Retain PostgreSQL equivalence evidence for target-unavailable/current transitions across linked
-      filtering and many aggregate ordering, including exact count.
-- [ ] Retain restart/replay ordering evidence around link-present/target-unavailable recovery.
-- [ ] Execute/admit the four retained Product M7 PostgreSQL packets.
+- [ ] Execute/admit the five retained Product M7 PostgreSQL packets.
+- [ ] Retain explicit replay-worker / crash-redelivery ordering evidence for linked target recovery if
+      not already satisfied by M5 replay evidence.
 - [ ] Execute any remaining schema-readiness/relation/freshness/projection concurrency evidence not
       already covered by those packets.
 - [ ] Admit canonical Product typed wire events/routes/consumers after digest verification.
 - [ ] Retain remaining out-of-order and locale fan-out evidence.
-- [ ] Prove complete Product/ProductVariant/SalesChannel query parity.
+- [ ] Prove complete Storefront Product/ProductVariant/SalesChannel query parity.
 - [ ] Move Storefront traffic only after readiness/equivalence/freshness/availability evidence passes.
 
 ## Next implementation step
 
 Primary owner step remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-The next unblocked M7 source step is now retained **linked-target availability equivalence evidence**,
-not another runtime clock or schema:
+The next unblocked M7 source step is now **replay/redelivery ordering evidence for linked target
+recovery**, not another query policy, schema, relation copy, or clock. Reuse the existing replay/mutation
+contracts and prove that duplicate/out-of-order target delivery cannot make a linked Product query
+authoritative before the current target source version is materialized, including after runtime restart.
 
-1. two or more Products so one current queried target can be deliberately unavailable without hiding
-   unrelated roots;
-2. linked filter semantics while a ProductVariant/SalesChannel target is unavailable/current;
-3. many aggregate ordering semantics with unavailable/current targets;
-4. exact-count parity under the same availability predicate;
-5. restart/replay or rematerialization recovery showing the graph returns only after the current target
-   mutation becomes authoritative.
-
-Do not add another Product schema, relation copy, or freshness clock. Typed Product event work remains
-separately blocked until event-contract digest admission.
+Typed Product event work remains separately blocked until event-contract digest admission.
 
 ## Maintainer verification for current M7 source
 
@@ -248,10 +274,12 @@ cargo test -p rustok-distribution --features mod-product --test product_material
 cargo test -p rustok-distribution --features mod-product --test product_channel_convergence_postgres -- --nocapture
 cargo test -p rustok-distribution --features mod-product --test product_channel_identity_transitions_postgres -- --nocapture
 cargo test -p rustok-distribution --features mod-product --test product_linked_target_recreate_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_linked_target_availability_equivalence_postgres -- --nocapture
 node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
 node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
 node scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
 node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
 node scripts/verify/verify-index-link-target-availability.mjs
 node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs

--- a/crates/rustok-index/docs/m7-linked-target-availability-equivalence-postgres-harness.md
+++ b/crates/rustok-index/docs/m7-linked-target-availability-equivalence-postgres-harness.md
@@ -1,0 +1,131 @@
+# M7 linked-target availability equivalence PostgreSQL harness
+
+Status: `source_ready_execution_pending`.
+
+## Purpose
+
+`product_linked_target_availability_equivalence_postgres.rs` retains the missing query-equivalence
+packet for the Product graph availability policy introduced by #3186.
+
+The packet does not change production code. It proves, on real PostgreSQL migrations and the canonical
+query runtime, that a stale linked target excludes only the Product root that depends on that target and
+that the same boundary applies before linked filtering, many aggregate ordering, pagination, and exact
+count.
+
+It also recomposes a fresh query runtime on a new PostgreSQL session while a target is stale and proves
+that recovery requires only the current target mutation, not process-local availability state.
+
+## Fixture topology
+
+One tenant owns two independent graph roots:
+
+- Product A -> Variant A -> SalesChannel `alpha`;
+- Product B -> Variant B -> SalesChannel `beta`.
+
+Product channel visibility is restricted through canonical owner metadata so Product A links only to
+`alpha` and Product B only to `beta`. The initial generic Product/Channel convergence scheduler is run to
+idle before Index materialization.
+
+The packet then materializes both current Products, both current ProductVariants, and both current
+SalesChannels through the real source registry and generic `PostgresMutationStore`.
+
+The two-root topology is intentional: when Product A has an unavailable target, Product B must remain in
+the result. A whole-query failure or whole-query empty result would not satisfy the contract.
+
+## ProductVariant availability scenario
+
+Variant A starts with SKU `middle-stale-sku`; Variant B uses `zulu-stable-sku`.
+
+The packet first proves baseline filter and `MIN(variants.sku)` ordering return both Products with exact
+count 2. Then it updates only Variant A SKU to `alpha-current-sku`.
+
+Existing owner migrations provide the isolation required by the scenario:
+
+- `m20260730_000002_add_product_variant_index_revision` increments Variant A `index_revision` on every
+  update;
+- `m20260731_000003_bump_product_index_revision_for_variant_membership` bumps Product revision only for
+  Variant identity/membership changes (`id`, `tenant_id`, `product_id`), not SKU changes.
+
+Therefore Product A remains owner-current while its materialized Variant target becomes stale.
+
+Before applying the current Variant mutation, the packet requires:
+
+- the old Variant source version is still physically present in `index_entities`;
+- linked `IN` filtering that would otherwise match the stale old SKU returns only Product B;
+- `MIN(variants.sku)` ordering returns only Product B;
+- exact count is 1 on both query shapes.
+
+A fresh `SharedIndexQueryRuntime` is then recomposed on a new PostgreSQL session while the same stale
+row remains materialized. It must produce the same Product-B-only filter/order results and exact count.
+This proves the authority boundary is reconstructed from durable Index/owner state rather than an
+in-memory latch.
+
+After only the current Variant mutation is applied, both the original and restarted query runtimes see
+Product A again. The current-SKU linked filter returns both Products with exact count 2, and aggregate
+ordering is `Product A, Product B` because `alpha-current-sku < zulu-stable-sku`.
+
+## SalesChannel availability scenario
+
+Channel A starts with name `Middle stale channel`; Channel B uses `Zulu stable channel`.
+
+The packet updates only Channel A name to `Alpha current channel`.
+
+Two existing Channel clocks are deliberately separated:
+
+- `m20260730_000010_add_channel_index_revision` increments Channel A `index_revision` on the name update;
+- `m20260807_000012_add_channel_index_identity_generation` observes only insert/delete or updates of
+  `id`, `tenant_id`, or `slug`, so a name-only update must leave tenant Channel identity generation
+  unchanged.
+
+The packet explicitly checks that identity generation does not change. Product relation/projection
+freshness therefore remains authoritative; only the linked SalesChannel target is stale.
+
+Before applying the current Channel mutation, linked filtering on the stale old Channel name and
+`MIN(sales_channels.name)` ordering must return only Product B with exact count 1. After applying only
+the current SalesChannel mutation, the current-name filter and aggregate ordering return both Products
+with exact count 2 and order `Product A, Product B`.
+
+## Contracts exercised
+
+The packet uses:
+
+- real Channel, Product, and Index migrations;
+- canonical selected Index + Channel + Product distribution composition;
+- persisted tenant schema registration;
+- generic Product/Channel ModuleWork convergence for initial relation state;
+- canonical Product, ProductVariant, and SalesChannel source adapters;
+- generic `PostgresMutationStore`;
+- canonical `SharedIndexQueryRuntime`;
+- linked `FilterExpr::In` many traversal;
+- `OrderDirection::MinAsc` many aggregate ordering;
+- page filtering and exact-count recompilation under the same availability predicate;
+- fresh query-runtime composition on a new PostgreSQL connection while target materialization is stale.
+
+The harness does not call private resolver/query implementations directly and does not create or alter
+Index storage tables itself.
+
+## Remaining evidence boundary
+
+This packet is source-ready but unexecuted. It covers target-only update lag, filter/order/count parity,
+and runtime recomposition/recovery. Remaining M7 evidence is primarily:
+
+- execute/admit this packet and the other retained Product packets;
+- retain any explicit replay-worker/crash-redelivery ordering evidence still required by M5/M6;
+- finish canonical Product typed event admission after event-contract digest verification;
+- complete Storefront query parity before cutover.
+
+## Maintainer verification
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-distribution --features mod-product \
+  --test product_linked_target_availability_equivalence_postgres -- --nocapture
+node scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
+node scripts/verify/verify-index-link-target-availability.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -1,6 +1,6 @@
 # M7 Product materialized/query freshness fence
 
-Status: `source_complete_link_target_availability_execution_pending`.
+Status: `source_complete_link_target_availability_equivalence_execution_pending`.
 
 ## Query freshness boundary
 
@@ -83,9 +83,9 @@ and clear tombstones only after strict live supersession.
 Therefore an old materialized ProductVariant/SalesChannel source version cannot collide with the
 recreated incarnation's current owner revision.
 
-## Updated linked-target PostgreSQL packet
+## Recreate availability packet
 
-`product_linked_target_recreate_postgres.rs` remains source-ready and execution-pending, now with the
+`product_linked_target_recreate_postgres.rs` remains source-ready and execution-pending with the
 canonical availability semantics.
 
 For ProductVariant recreate, the old target row remains physically materialized while Product is
@@ -99,32 +99,59 @@ version remain unchanged. Scalar-only Product query becomes visible again, but a
 `sales_channels` stays fail closed while the old physical Channel target is stale. Applying only the
 current SalesChannel mutation restores the recreated Channel name.
 
-This proves Product owner authority and linked-target authority are separate without interpreting target
-unavailability as empty relation state.
+## Filter/order/count/runtime equivalence packet
+
+`product_linked_target_availability_equivalence_postgres.rs` is also source-ready and execution-pending.
+It uses two Product roots so one stale linked target can be isolated without hiding unrelated current
+results.
+
+For ProductVariant target lag:
+
+- Variant A SKU-only update increments ProductVariant `index_revision` without changing Product
+  membership or Product projection;
+- the old Variant row stays physically materialized;
+- linked `IN` filtering that would otherwise match the stale old SKU returns only Product B;
+- `MIN(variants.sku)` ordering returns only Product B;
+- exact count is 1 on both query paths;
+- a newly composed query runtime on a fresh PostgreSQL session observes the same boundary;
+- applying only the current Variant mutation restores Product A and exact count 2.
+
+For SalesChannel target lag:
+
+- Channel A name-only update increments SalesChannel `index_revision`;
+- Channel identity generation is explicitly required to remain unchanged, so Product relation/projection
+  freshness remains current;
+- linked stale-name filtering and `MIN(sales_channels.name)` ordering return only Product B with exact
+  count 1;
+- applying only the current SalesChannel mutation restores both Products and exact count 2.
+
+Together the recreate and equivalence packets cover nested projection, linked filtering, many aggregate
+ordering, exact-count parity, target-only update lag, same-UUID recreate lag, and fresh query-runtime
+recomposition without introducing process-local availability state.
 
 ## Retained M7 PostgreSQL packets
 
-Four packets are source-ready and execution/admission pending:
+Five packets are source-ready and execution/admission pending:
 
 1. `product_materialized_query_freshness_postgres.rs`;
 2. `product_channel_convergence_postgres.rs`;
 3. `product_channel_identity_transitions_postgres.rs`;
-4. `product_linked_target_recreate_postgres.rs`.
+4. `product_linked_target_recreate_postgres.rs`;
+5. `product_linked_target_availability_equivalence_postgres.rs`.
 
 None has been executed or admitted by the implementation agent.
 
 ## Remaining M7 evidence
 
-The source-level availability policy is complete. Before Storefront cutover the remaining linked-target
-work is evidence/equivalence rather than another runtime clock:
+The linked-target query availability source contract and query-equivalence packet are now source
+complete. Remaining work before Storefront cutover is no longer another query policy or owner clock:
 
-- retain PostgreSQL cases for linked filtering and many aggregate ordering while target materialization
-  is unavailable/current;
-- retain restart/replay ordering around link-present/target-missing recovery;
-- execute/admit the existing linked-target recreate packet;
-- complete Product/ProductVariant/SalesChannel query equivalence across projection/filter/order/count;
-- execute/admit the other Product freshness/convergence packets;
-- admit canonical Product typed events only after event-contract digest verification.
+- execute/admit the five retained Product PostgreSQL packets;
+- retain explicit replay-worker / duplicate-redelivery / crash-ordering evidence for target recovery if
+  the generic M5 replay packet does not already prove the required Product graph sequence;
+- finish canonical Product typed event admission after event-contract digest verification;
+- retain remaining out-of-order/locale fan-out evidence;
+- complete Storefront Product/ProductVariant/SalesChannel query parity and cutover evidence.
 
 ## Maintainer verification
 
@@ -134,8 +161,12 @@ Suggested commands, intentionally not run by the implementation agent:
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   cargo test -p rustok-distribution --features mod-product \
   --test product_linked_target_recreate_postgres -- --nocapture
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-distribution --features mod-product \
+  --test product_linked_target_availability_equivalence_postgres -- --nocapture
 node scripts/verify/verify-index-link-target-availability.mjs
 node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
 node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-query-contract.mjs

--- a/scripts/verify/verify-index-link-target-availability.mjs
+++ b/scripts/verify/verify-index-link-target-availability.mjs
@@ -123,17 +123,20 @@ forbidMarkers(compilerPath, compiler, [
 const freshnessDoc = requireMarkers(
   'crates/rustok-index/docs/m7-product-materialized-query-freshness.md',
   [
-    'Status: `source_complete_link_target_availability_execution_pending`',
+    'Status: `source_complete_link_target_availability_equivalence_execution_pending`',
     'Query-path-scoped linked-target availability',
     'scalar-only Product queries do not become dependent',
     'source identity **and source_version**',
     'current link row + missing/stale/deleted target = query fails closed',
+    'Filter/order/count/runtime equivalence packet',
+    'product_linked_target_availability_equivalence_postgres.rs',
     'Remaining M7 evidence',
   ],
 );
 forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', freshnessDoc, [
   'next unblocked M7 source-design gap',
   'define and retain fail-closed linked-target availability semantics',
+  'retain PostgreSQL cases for linked filtering and many aggregate ordering',
 ]);
 
 console.log('[verify-index-link-target-availability] query-scoped fail-closed availability source contract verified');

--- a/scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
+++ b/scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-linked-target-availability-equivalence-postgres-harness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const harnessPath = 'crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs';
+const harness = requireMarkers(harnessPath, [
+  '#![cfg(feature = "mod-product")]',
+  'linked_target_availability_preserves_filter_order_count_and_runtime_restart_parity',
+  'rustok_channel::migrations::migrations()',
+  'rustok_product::migrations::migrations()',
+  'IndexModule.migrations()',
+  '.register(IndexModule)',
+  '.register(rustok_channel::ChannelModule)',
+  '.register(rustok_product::ProductModule)',
+  'PostgresSchemaRegistrationStore::new',
+  'materialize_postgres_index_sources',
+  'materialize_index_source_registry',
+  'materialize_postgres_index_query_runtime',
+  'PostgresMutationStore::new',
+  'ModuleWorkRegistrations',
+  'scheduler.run_once().await?',
+  'PRODUCT_VARIANT_SOURCE: &str = "product-variant-postgres-primary"',
+  'SALES_CHANNEL_SOURCE: &str = "sales-channel-postgres-primary"',
+  'FilterExpr::In(',
+  'direction: OrderDirection::MinAsc',
+  'LinkName::new("variants")',
+  'LinkName::new("sales_channels")',
+  'update_variant_a_sku(&database.writer).await?',
+  'variant_a_current > variant_a_materialized',
+  'variant_stale_match_query()',
+  'variant_current_match_query()',
+  'let restarted_query = database.fresh_query_runtime().await?',
+  'update_channel_a_name(&database.writer).await?',
+  'generation_after_name_update, generation_before_name_update',
+  'channel_a_current > channel_a_materialized',
+  'channel_stale_match_query()',
+  'channel_current_match_query()',
+  'assert_ids_unordered(',
+  'assert_ids_ordered(',
+  '&[PRODUCT_B_ID]',
+  '&[PRODUCT_A_ID, PRODUCT_B_ID]',
+]);
+forbidMarkers(harnessPath, harness, [
+  'tokio::spawn',
+  'loop {',
+  'CREATE TABLE index_entities',
+  'CREATE TABLE index_links',
+  'PostgresQueryEntityAdmission::new',
+  'register_postgres_index_query_link_target_availability',
+]);
+
+requireMarkers('crates/rustok-product/src/migrations/m20260730_000002_add_product_variant_index_revision.rs', [
+  'BEFORE UPDATE ON product_variants',
+  'NEW.index_revision := OLD.index_revision + 1',
+]);
+requireMarkers('crates/rustok-product/src/migrations/m20260731_000003_bump_product_index_revision_for_variant_membership.rs', [
+  'AFTER UPDATE OF id, tenant_id, product_id ON product_variants',
+  'OLD.id IS NOT DISTINCT FROM NEW.id',
+]);
+requireMarkers('crates/rustok-channel/src/migrations/m20260730_000010_add_channel_index_revision.rs', [
+  'BEFORE UPDATE ON channels',
+  'NEW.index_revision := OLD.index_revision + 1',
+]);
+requireMarkers('crates/rustok-channel/src/migrations/m20260807_000012_add_channel_index_identity_generation.rs', [
+  'AFTER INSERT OR DELETE OR UPDATE OF id, tenant_id, slug ON channels',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_admission.rs', [
+  'query.referenced_paths()',
+  'path.links().first()',
+  'apply_root_predicate(&mut compiled.sql, &predicate)?',
+  'compiled.exact_count.as_mut()',
+  '{link}.source_version = {root}.source_version',
+  'owner_dispatch_for_alias(&owner_rules, AVAILABILITY_TARGET_ALIAS)',
+]);
+
+console.log('[verify-index-linked-target-availability-equivalence-postgres-harness] source-ready equivalence packet verified');

--- a/scripts/verify/verify-index-linked-target-query-freshness.mjs
+++ b/scripts/verify/verify-index-linked-target-query-freshness.mjs
@@ -69,14 +69,17 @@ requireMarkers(catalogPath, [
   'required_link_targets: BTreeMap<SchemaRef, String>',
   'pub fn require_current_link_targets(',
   'pub(crate) fn apply_link_target_availability(',
+  'fn referenced_first_hop_links(query: &IndexQuery)',
   'query.referenced_paths()',
   'path.links().first()',
-  'availability_link.source_version = {root}.source_version',
-  'availability_link.link_name IN ({requested_links})',
-  'availability_target.is_deleted = FALSE',
+  '{link}.source_version = {root}.source_version',
+  '{link}.link_name IN ({requested_links})',
+  '{target}.is_deleted = FALSE',
   'owner_dispatch_for_alias(&owner_rules, AVAILABILITY_TARGET_ALIAS)',
-  'scalar_only_query_does_not_require_unreferenced_link_targets',
-  'queried_link_requires_current_owner_admitted_target_in_page_and_count',
+  'scalar_only_query_has_no_referenced_link_targets',
+  'linked_query_collects_only_first_hop_link_names',
+  'availability_predicate_uses_current_source_link_and_owner_admitted_target',
+  'root_availability_predicate_applies_to_page_and_count_anchor_shape',
 ]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_runtime.rs', [
   'LinkAvailabilitySchemaMissing',
@@ -137,13 +140,15 @@ requireMarkers(
 const freshnessDoc = requireMarkers(
   'crates/rustok-index/docs/m7-product-materialized-query-freshness.md',
   [
-    'Status: `source_complete_link_target_availability_execution_pending`',
+    'Status: `source_complete_link_target_availability_equivalence_execution_pending`',
     'Query-path-scoped linked-target availability',
     'scalar-only Product queries do not become dependent',
     'current link row + missing/stale/deleted target = query fails closed',
     'Recreate monotonicity remains source complete',
-    'Remaining M7 evidence',
+    'Filter/order/count/runtime equivalence packet',
     'product_linked_target_recreate_postgres.rs',
+    'product_linked_target_availability_equivalence_postgres.rs',
+    'Remaining M7 evidence',
   ],
 );
 forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', freshnessDoc, [
@@ -151,6 +156,7 @@ forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.
   'next unblocked M7 source-design gap',
   'define and retain fail-closed linked-target availability semantics',
   'next source slice must make those two owner source clocks monotonic',
+  'retain PostgreSQL cases for linked filtering and many aggregate ordering',
 ]);
 
-console.log('[verify-index-linked-target-query-freshness] linked target freshness, recreate monotonicity, and availability source contract verified');
+console.log('[verify-index-linked-target-query-freshness] linked target freshness, recreate monotonicity, availability and equivalence source contracts verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -61,9 +61,10 @@ const catalog = requireMarkers(catalogPath, [
   'pub(crate) fn ensure_runtime_schema(',
   'pub(crate) fn apply_link_target_availability(',
   'fn rebuild_owner_composite(',
+  'fn referenced_first_hop_links(query: &IndexQuery)',
   'query.referenced_paths()',
-  'availability_link.source_version = {root}.source_version',
-  'availability_target.is_deleted = FALSE',
+  '{link}.source_version = {root}.source_version',
+  '{target}.is_deleted = FALSE',
 ]);
 forbidMarkers(catalogPath, catalog, [
   'PostgresQueryRootAdmission',
@@ -155,7 +156,7 @@ requireMarkers('crates/rustok-index/src/application/mod.rs', [
 const freshnessDoc = requireMarkers(
   'crates/rustok-index/docs/m7-product-materialized-query-freshness.md',
   [
-    'Status: `source_complete_link_target_availability_execution_pending`',
+    'Status: `source_complete_link_target_availability_equivalence_execution_pending`',
     '`PostgresQueryEntityAdmission`',
     '`mpN_tN`',
     '`mx_tN`',
@@ -167,8 +168,10 @@ const freshnessDoc = requireMarkers(
     'Recreate monotonicity remains source complete',
     'm20260731_000004_add_product_index_tombstones',
     'm20260731_000011_add_channel_index_tombstones',
-    'Remaining M7 evidence',
+    'Filter/order/count/runtime equivalence packet',
     'product_linked_target_recreate_postgres.rs',
+    'product_linked_target_availability_equivalence_postgres.rs',
+    'Remaining M7 evidence',
   ],
 );
 forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.md', freshnessDoc, [
@@ -176,6 +179,7 @@ forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.
   'does **not** claim delete+recreate identity safety',
   'next source slice must make those two owner source clocks monotonic',
   'define and retain fail-closed linked-target availability semantics',
+  'retain PostgreSQL cases for linked filtering and many aggregate ordering',
 ]);
 
-console.log('[verify-index-product-materialized-query-freshness] Product graph freshness and fail-closed linked target availability verified');
+console.log('[verify-index-product-materialized-query-freshness] Product graph freshness, availability and equivalence source contracts verified');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -73,6 +73,7 @@ const scripts = [
   'verify-index-linked-target-query-freshness.mjs',
   'verify-index-link-target-availability.mjs',
   'verify-index-linked-target-recreate-postgres-harness.mjs',
+  'verify-index-linked-target-availability-equivalence-postgres-harness.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- add a source-ready PostgreSQL equivalence packet for the query-path-scoped linked-target availability policy merged in #3186;
- use two independent Product roots so one stale target excludes only the affected Product while an unrelated current Product remains authoritative;
- cover ProductVariant target-only lag with linked `IN` filtering, `MIN(variants.sku)` aggregate ordering, exact count, fresh query-runtime recomposition on a new PostgreSQL session, and recovery after only the current Variant mutation materializes;
- cover SalesChannel target-only lag with linked name filtering, `MIN(sales_channels.name)` aggregate ordering, exact count, and recovery after only the current Channel mutation materializes;
- explicitly prove a Channel name-only update increments SalesChannel `index_revision` without changing tenant Channel identity generation, so Product owner/relation freshness remains current and only target availability is under test;
- keep the packet on real Channel/Product/Index migrations, selected distribution composition, persisted schema readiness, generic ModuleWork convergence for initial relation state, canonical source adapters, generic mutation storage, and canonical query runtime;
- add a dedicated static guard, include it in the aggregate Index contract, update stale availability/freshness guards left from #3186, and advance the current M7 cursor;
- change no production source, migration, schema, compatibility version, relation ledger, or freshness clock.

## ProductVariant evidence

The fixture has Product A -> Variant A and Product B -> Variant B. Initially both linked filter and `MIN(variants.sku)` order queries return A+B with exact count 2.

A SKU-only owner update moves Variant A `index_revision` forward while the Product membership trigger remains untouched because it only observes `id`, `tenant_id`, and `product_id`. The old Variant A row remains physically materialized in Index. During that window:

- a linked filter that would otherwise match the stale old SKU returns only Product B;
- `MIN(variants.sku)` ordering returns only Product B;
- exact count is 1;
- a freshly composed query runtime on a new PostgreSQL session sees the same B-only result.

Applying only the current Variant A mutation restores Product A. A current-SKU filter and aggregate ordering return A+B with exact count 2, including through the runtime composed while the target was stale.

## SalesChannel evidence

Products are restricted to independent `alpha` / `beta` channels through canonical Product owner metadata. A name-only update on Channel A moves its Index revision forward. The Channel identity-generation trigger listens only to insert/delete or changes to `id`, `tenant_id`, or `slug`; the packet explicitly requires generation to remain unchanged.

Therefore Product relation/projection freshness remains current while only the SalesChannel target is stale. During that window stale-name filtering and `MIN(sales_channels.name)` ordering return only Product B with exact count 1. Applying only the current Channel A mutation restores A+B and exact count 2.

## Boundary

This is retained source evidence, not executed evidence. It proves target-update lag, linked filtering, many aggregate ordering, exact-count parity and query-runtime recomposition. Explicit replay-worker/crash-redelivery ordering remains a separate M5/M7 evidence step if the generic replay packet does not already cover the Product graph sequence.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.