### PR TITLE
test(index): retain linked target replay redelivery packet

### DIFF
--- a/crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs
@@ -1,0 +1,685 @@
+#![cfg(feature = "mod-product")]
+
+use std::{
+    env,
+    error::Error,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation, IndexQuery,
+    IndexQueryPort, IndexQueryScope, IndexReplayCheckpoint, IndexReplayCheckpointKey,
+    IndexReplayCheckpointStore, IndexReplayError, IndexReplayFailure, IndexReplayMutationOutcome,
+    IndexReplayMutationSink, IndexReplayPageRequest, IndexReplayPageStatus, IndexReplayWorker,
+    IndexSourceLoadRequest, IndexValue, LinkName, LocaleKey, ModuleName, MutationApplyOutcome,
+    MutationDelivery, Pagination, PostgresMutationStore, PostgresSchemaRegistrationStore, SchemaRef,
+    SchemaVersion, SharedIndexQueryRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+    materialize_index_source_registry, materialize_postgres_index_query_runtime,
+    materialize_postgres_index_sources,
+};
+use rustok_runtime::{HostRuntimeContext, ModuleWorkRegistrations, ModuleWorkScheduler};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_INDEX_TEST_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const PRODUCT_VARIANT_SOURCE: &str = "product-variant-postgres-primary";
+
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const PRODUCT_ID: Uuid = Uuid::from_u128(101);
+const PRODUCT_TRANSLATION_ID: Uuid = Uuid::from_u128(111);
+const VARIANT_ID: Uuid = Uuid::from_u128(201);
+const CHANNEL_ID: Uuid = Uuid::from_u128(301);
+
+const INITIAL_SKU: &str = "variant-v1";
+const HISTORICAL_SKU: &str = "variant-v2-never-applied";
+const CURRENT_SKU: &str = "variant-v3-current";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[derive(Clone)]
+struct FailOnceCheckpointStore {
+    checkpoint: Arc<Mutex<Option<IndexReplayCheckpoint>>>,
+    fail_next_commit: Arc<AtomicBool>,
+}
+
+impl FailOnceCheckpointStore {
+    fn new() -> Self {
+        Self {
+            checkpoint: Arc::new(Mutex::new(None)),
+            fail_next_commit: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn checkpoint(&self) -> Option<IndexReplayCheckpoint> {
+        self.checkpoint
+            .lock()
+            .expect("checkpoint test mutex must not be poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl IndexReplayCheckpointStore for FailOnceCheckpointStore {
+    async fn load_replay_checkpoint(
+        &self,
+        _key: &IndexReplayCheckpointKey,
+    ) -> Result<Option<IndexReplayCheckpoint>, IndexReplayFailure> {
+        Ok(self.checkpoint())
+    }
+
+    async fn commit_replay_checkpoint(
+        &self,
+        checkpoint: &IndexReplayCheckpoint,
+    ) -> Result<(), IndexReplayFailure> {
+        if self.fail_next_commit.swap(false, Ordering::SeqCst) {
+            return Err(
+                IndexReplayFailure::retryable("injected_checkpoint_commit_failure")
+                    .expect("static replay failure code is valid"),
+            );
+        }
+        *self
+            .checkpoint
+            .lock()
+            .expect("checkpoint test mutex must not be poisoned") = Some(checkpoint.clone());
+        Ok(())
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    migration: DatabaseConnection,
+    work: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    writer: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping linked-target replay/redelivery harness"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_link_replay_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_link_replay_migration_{suffix}"),
+        )
+        .await?;
+        create_migration_prerequisites(&migration).await?;
+        let manager = SchemaManager::new(&migration);
+        for step in rustok_channel::migrations::migrations() {
+            step.up(&manager).await?;
+        }
+        for step in rustok_product::migrations::migrations() {
+            step.up(&manager).await?;
+        }
+        for step in IndexModule.migrations() {
+            step.up(&manager).await?;
+        }
+        seed_owner_rows(&migration).await?;
+
+        Ok(Some(Self {
+            control,
+            migration,
+            work: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_replay_work_{suffix}"),
+            )
+            .await?,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_replay_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_replay_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_replay_query_{suffix}"),
+            )
+            .await?,
+            writer: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_link_replay_writer_{suffix}"),
+            )
+            .await?,
+            database_url,
+            schema_name,
+        }))
+    }
+
+    async fn fresh_query_runtime(&self) -> TestResult<SharedIndexQueryRuntime> {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let query = scoped_connection(
+            &self.database_url,
+            &self.schema_name,
+            &format!("idx_link_replay_restart_query_{suffix}"),
+        )
+        .await?;
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(rustok_channel::ChannelModule)
+            .register(rustok_product::ProductModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+        materialize_postgres_index_query_runtime(&mut extensions, query)?
+            .ok_or_else(|| std::io::Error::other("fresh Index query runtime is missing").into())
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.migration.close().await?;
+        self.work.close().await?;
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.writer.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct Runtime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+    scheduler: ModuleWorkScheduler,
+}
+
+#[tokio::test]
+async fn replay_checkpoint_failure_duplicate_retry_and_late_stale_target_keep_graph_authoritative(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let result = run_scenario(&database).await;
+    let cleanup = database.cleanup().await;
+    result?;
+    cleanup
+}
+
+async fn run_scenario(database: &TestDatabase) -> TestResult<()> {
+    let runtime = build_runtime(database).await?;
+    run_scheduler_until_idle(&runtime.scheduler, 24).await?;
+
+    apply_current_source_mutation(&runtime, PRODUCT_SOURCE, product_key()?).await?;
+    let initial_variant = load_current_source_mutation(&runtime.sources, variant_key()?).await?;
+    let initial_version = initial_variant.source_version();
+    assert_eq!(initial_version, 1);
+    assert_eq!(
+        apply_mutation(
+            &runtime,
+            PRODUCT_VARIANT_SOURCE,
+            initial_variant.clone(),
+        )
+        .await?,
+        MutationApplyOutcome::Applied {
+            source_version: initial_version,
+        }
+    );
+    assert_graph_payload(&runtime.query, INITIAL_SKU).await?;
+
+    // Produce a canonical intermediate owner mutation but intentionally never deliver it.
+    update_variant_sku(&database.writer, HISTORICAL_SKU).await?;
+    let historical = load_current_source_mutation(&runtime.sources, variant_key()?).await?;
+    let historical_version = historical.source_version();
+    assert!(historical_version > initial_version);
+
+    // Advance the owner again. Product membership/projection is unchanged, so the Product root remains
+    // current while its Variant target is now two revisions behind and the linked graph must fail closed.
+    update_variant_sku(&database.writer, CURRENT_SKU).await?;
+    let current = load_current_source_mutation(&runtime.sources, variant_key()?).await?;
+    let current_version = current.source_version();
+    assert!(current_version > historical_version);
+    assert_scalar_product_visible(&runtime.query, true).await?;
+    assert_graph_visible(&runtime.query, false).await?;
+    assert_eq!(
+        materialized_variant_version(&database.mutation).await?,
+        initial_version
+    );
+
+    let checkpoint_store = FailOnceCheckpointStore::new();
+    let request = IndexReplayPageRequest::new(TENANT_ID, variant_schema_ref()?, 32)?;
+    let worker = IndexReplayWorker::new(
+        runtime.sources.clone(),
+        runtime.schemas.shared(),
+        runtime.mutations.clone(),
+        checkpoint_store.clone(),
+    );
+
+    // Canonical source scan returns only current owner state. PostgreSQL mutation durability succeeds,
+    // then the injected checkpoint commit failure simulates process loss after mutation commit.
+    assert!(matches!(
+        worker.run_next_page(request.clone()).await,
+        Err(IndexReplayError::CheckpointCommitFailed(_))
+    ));
+    assert!(checkpoint_store.checkpoint().is_none());
+    assert_eq!(materialized_variant_version(&database.mutation).await?, current_version);
+    assert_graph_payload(&runtime.query, CURRENT_SKU).await?;
+
+    // A separately composed query runtime observes the durable current target immediately even though
+    // replay cursor durability failed. Query authority has no process-local checkpoint dependency.
+    let restarted_query = database.fresh_query_runtime().await?;
+    assert_graph_payload(&restarted_query, CURRENT_SKU).await?;
+
+    // Recreate the replay worker after the simulated crash. With no checkpoint, it scans the same
+    // current owner row and derives the same stable event UUID. The PostgreSQL inbox reports Duplicate;
+    // only then does the retry commit the completed checkpoint.
+    let restarted_worker = IndexReplayWorker::new(
+        runtime.sources.clone(),
+        runtime.schemas.shared(),
+        runtime.mutations.clone(),
+        checkpoint_store.clone(),
+    );
+    let retry = restarted_worker.run_next_page(request).await?;
+    assert_eq!(retry.status(), IndexReplayPageStatus::Complete);
+    assert_eq!(retry.mutation_count(), 1);
+    assert_eq!(retry.applied_count(), 0);
+    assert_eq!(retry.duplicate_count(), 1);
+    assert_eq!(retry.stale_count(), 0);
+    let checkpoint = checkpoint_store
+        .checkpoint()
+        .ok_or_else(|| std::io::Error::other("replay checkpoint was not committed on retry"))?;
+    assert!(checkpoint.is_complete());
+    assert_eq!(checkpoint.source_version(), Some(current_version));
+    assert_eq!(checkpoint.last_delivery_id(), Some(current.event_id().to_string().as_str()));
+
+    // Deliver the never-before-applied intermediate canonical mutation after current v3 is durable.
+    // The replay sink must classify it as stale rather than regressing target payload or source version.
+    assert_eq!(
+        runtime
+            .mutations
+            .apply_replay_mutation(
+                runtime.schemas.registry(),
+                PRODUCT_VARIANT_SOURCE,
+                &historical,
+            )
+            .await?,
+        IndexReplayMutationOutcome::StaleIgnored
+    );
+    assert_eq!(materialized_variant_version(&database.mutation).await?, current_version);
+    assert_graph_payload(&runtime.query, CURRENT_SKU).await?;
+    assert_graph_payload(&restarted_query, CURRENT_SKU).await?;
+
+    // Exact current redelivery remains Duplicate and equally cannot disturb graph authority.
+    assert_eq!(
+        runtime
+            .mutations
+            .apply_replay_mutation(
+                runtime.schemas.registry(),
+                PRODUCT_VARIANT_SOURCE,
+                &current,
+            )
+            .await?,
+        IndexReplayMutationOutcome::Duplicate
+    );
+    assert_eq!(materialized_variant_version(&database.mutation).await?, current_version);
+    assert_graph_payload(&runtime.query, CURRENT_SKU).await?;
+    Ok(())
+}
+
+async fn build_runtime(database: &TestDatabase) -> TestResult<Runtime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Index schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for registered in schemas.registry().iter() {
+        schema_store.register(TENANT_ID, &registered.schema).await?;
+    }
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Index source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Index query runtime is missing"))?;
+    let registrations = extensions
+        .get::<ModuleWorkRegistrations>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product convergence work is missing"))?;
+    let scheduler = ModuleWorkScheduler::new();
+    registrations
+        .register_all(&HostRuntimeContext::new(database.work.clone()), &scheduler)
+        .await?;
+    Ok(Runtime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+        scheduler,
+    })
+}
+
+async fn run_scheduler_until_idle(
+    scheduler: &ModuleWorkScheduler,
+    maximum_iterations: usize,
+) -> TestResult<usize> {
+    let mut executed = 0;
+    for _ in 0..maximum_iterations {
+        let current = scheduler.run_once().await?;
+        if current == 0 {
+            return Ok(executed);
+        }
+        executed += current;
+    }
+    Err(std::io::Error::other(format!(
+        "ModuleWork scheduler did not become idle after {maximum_iterations} bounded iterations"
+    ))
+    .into())
+}
+
+async fn load_current_source_mutation(
+    sources: &SharedIndexSourceRegistry,
+    key: EntityKey,
+) -> TestResult<IndexMutation> {
+    let request = IndexSourceLoadRequest::new(vec![key])?;
+    let mut mutations = sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected exactly one source mutation, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    Ok(mutations.remove(0))
+}
+
+async fn apply_current_source_mutation(
+    runtime: &Runtime,
+    source_name: &str,
+    key: EntityKey,
+) -> TestResult<u64> {
+    let mutation = load_current_source_mutation(&runtime.sources, key).await?;
+    let source_version = mutation.source_version();
+    match apply_mutation(runtime, source_name, mutation).await? {
+        MutationApplyOutcome::Applied {
+            source_version: applied,
+        } if applied == source_version => Ok(source_version),
+        other => Err(std::io::Error::other(format!(
+            "expected source mutation {source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn apply_mutation(
+    runtime: &Runtime,
+    source_name: &str,
+    mutation: IndexMutation,
+) -> TestResult<MutationApplyOutcome> {
+    let delivery = MutationDelivery::from_event(source_name, mutation)?;
+    Ok(runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?)
+}
+
+fn product_key() -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: product_schema_ref()?,
+        entity_id: PRODUCT_ID,
+        locale: Some(LocaleKey::new("en")?),
+    })
+}
+
+fn variant_key() -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: variant_schema_ref()?,
+        entity_id: VARIANT_ID,
+        locale: None,
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        version: SchemaVersion::new(3),
+    })
+}
+
+fn variant_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product_variant")?,
+        version: SchemaVersion::new(2),
+    })
+}
+
+fn scalar_product_query() -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: TENANT_ID,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: product_schema_ref()?,
+        fields: vec![FieldPath::new(FieldName::new("title")?)],
+        filter: Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("id")?),
+            IndexValue::Uuid(PRODUCT_ID),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+fn variant_graph_query() -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: TENANT_ID,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: product_schema_ref()?,
+        fields: vec![
+            FieldPath::new(FieldName::new("title")?),
+            FieldPath::linked(
+                [LinkName::new("variants")?],
+                FieldName::new("sku")?,
+            ),
+        ],
+        filter: Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("id")?),
+            IndexValue::Uuid(PRODUCT_ID),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+async fn assert_scalar_product_visible(
+    query: &SharedIndexQueryRuntime,
+    expected: bool,
+) -> TestResult<()> {
+    let page = query.execute_query(scalar_product_query()?).await?;
+    let expected_rows = if expected { 1 } else { 0 };
+    let expected_count = if expected { 1 } else { 0 };
+    assert_eq!(page.items.len(), expected_rows);
+    assert_eq!(page.exact_count, Some(expected_count));
+    Ok(())
+}
+
+async fn assert_graph_visible(query: &SharedIndexQueryRuntime, expected: bool) -> TestResult<()> {
+    let page = query.execute_query(variant_graph_query()?).await?;
+    let expected_rows = if expected { 1 } else { 0 };
+    let expected_count = if expected { 1 } else { 0 };
+    assert_eq!(page.items.len(), expected_rows);
+    assert_eq!(page.exact_count, Some(expected_count));
+    Ok(())
+}
+
+async fn assert_graph_payload(query: &SharedIndexQueryRuntime, expected_sku: &str) -> TestResult<()> {
+    let page = query.execute_query(variant_graph_query()?).await?;
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.exact_count, Some(1));
+    let variants = page.items[0]
+        .nested_relations
+        .iter()
+        .find(|projection| projection.path == vec![LinkName::new("variants")?])
+        .ok_or_else(|| std::io::Error::other("variants nested projection is missing"))?;
+    assert_eq!(variants.items.len(), 1);
+    let sku_path = FieldPath::linked(
+        [LinkName::new("variants")?],
+        FieldName::new("sku")?,
+    );
+    let sku = variants.items[0]
+        .fields
+        .iter()
+        .find(|field| field.path == sku_path)
+        .ok_or_else(|| std::io::Error::other("variants.sku projection is missing"))?;
+    assert_eq!(sku.value, IndexValue::String(expected_sku.to_owned()));
+    Ok(())
+}
+
+async fn update_variant_sku(db: &DatabaseConnection, sku: &str) -> TestResult<()> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE product_variants SET sku = $3 WHERE tenant_id = $1 AND id = $2",
+            vec![TENANT_ID.into(), VARIANT_ID.into(), sku.to_owned().into()],
+        ))
+        .await?;
+    assert_eq!(result.rows_affected(), 1);
+    Ok(())
+}
+
+async fn materialized_variant_version(db: &DatabaseConnection) -> TestResult<u64> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT CAST(source_version AS TEXT) AS source_version_text
+FROM index_entities
+WHERE tenant_id = $1
+  AND module_name = 'rustok-product'
+  AND entity_name = 'product_variant'
+  AND schema_version = 2
+  AND entity_id = $2
+  AND locale_key = ''
+  AND is_deleted = FALSE
+"#,
+            vec![TENANT_ID.into(), VARIANT_ID.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("materialized ProductVariant row is missing"))?;
+    let value: String = row.try_get("", "source_version_text")?;
+    Ok(value.parse()?)
+}
+
+async fn create_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE oauth_apps (
+    id UUID PRIMARY KEY
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_owner_rows(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+
+INSERT INTO channels (id, tenant_id, slug, name) VALUES
+    ('{CHANNEL_ID}', '{TENANT_ID}', 'alpha', 'Alpha');
+
+INSERT INTO products (id, tenant_id, metadata) VALUES
+    ('{PRODUCT_ID}', '{TENANT_ID}', '{{"channel_visibility":{{"allowed_channel_slugs":["alpha"]}}}}'::jsonb);
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{PRODUCT_TRANSLATION_ID}', '{PRODUCT_ID}', '{TENANT_ID}', 'en', 'Replay Product', 'replay-product');
+
+INSERT INTO product_variants (id, product_id, tenant_id, sku) VALUES
+    ('{VARIANT_ID}', '{PRODUCT_ID}', '{TENANT_ID}', '{INITIAL_SKU}');
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs
@@ -314,7 +314,8 @@ async fn run_scenario(database: &TestDatabase) -> TestResult<()> {
         .ok_or_else(|| std::io::Error::other("replay checkpoint was not committed on retry"))?;
     assert!(checkpoint.is_complete());
     assert_eq!(checkpoint.source_version(), Some(current_version));
-    assert_eq!(checkpoint.last_delivery_id(), Some(current.event_id().to_string().as_str()));
+    let current_delivery_id = current.event_id().to_string();
+    assert_eq!(checkpoint.last_delivery_id(), Some(current_delivery_id.as_str()));
 
     // Deliver the never-before-applied intermediate canonical mutation after current v3 is durable.
     // The replay sink must classify it as stale rather than regressing target payload or source version.
@@ -557,14 +558,15 @@ async fn assert_graph_payload(query: &SharedIndexQueryRuntime, expected_sku: &st
     let page = query.execute_query(variant_graph_query()?).await?;
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.exact_count, Some(1));
+    let variants_link = LinkName::new("variants")?;
     let variants = page.items[0]
         .nested_relations
         .iter()
-        .find(|projection| projection.path == vec![LinkName::new("variants")?])
+        .find(|projection| projection.path == vec![variants_link.clone()])
         .ok_or_else(|| std::io::Error::other("variants nested projection is missing"))?;
     assert_eq!(variants.items.len(), 1);
     let sku_path = FieldPath::linked(
-        [LinkName::new("variants")?],
+        [variants_link],
         FieldName::new("sku")?,
     );
     let sku = variants.items[0]
@@ -572,7 +574,7 @@ async fn assert_graph_payload(query: &SharedIndexQueryRuntime, expected_sku: &st
         .iter()
         .find(|field| field.path == sku_path)
         .ok_or_else(|| std::io::Error::other("variants.sku projection is missing"))?;
-    assert_eq!(sku.value, IndexValue::String(expected_sku.to_owned()));
+    assert_eq!(&sku.value, &IndexValue::String(expected_sku.to_owned()));
     Ok(())
 }
 

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-07.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-07
 
-Status overlay rechecked from `main@be388f9795581b15e88b718e82952a7a0c107dc4` and continued on
-`agent/index-link-target-availability-equivalence-20260807`.
+Status overlay rechecked from `main@283522e39d51b92e4fd3abef64f057edc375d546` and continued on
+`agent/index-linked-target-replay-redelivery-evidence-20260807`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
 cursor.
@@ -34,11 +34,13 @@ inspection. Independent M7 source work continues while that owner-execution gate
 - Product, ProductVariant, and SalesChannel owner freshness rules;
 - recreate-safe ProductVariant and SalesChannel `index_revision` through retained tombstone seed/clear;
 - generic query-path-scoped linked-target availability admission for Product graph queries;
-- source-ready linked-target filter/order/exact-count/runtime-recomposition PostgreSQL equivalence.
+- source-ready linked-target filter/order/exact-count/runtime-recomposition PostgreSQL equivalence;
+- source-ready canonical ProductVariant replay checkpoint-failure / duplicate / late-stale composition
+  evidence through real PostgreSQL mutation storage and Product graph queries.
 
 No parallel Product/ProductVariant compatibility source is selected. Generic numeric `SchemaVersion`
 values remain Index storage/routing keys only; do not introduce a new Product schema/version to solve
-freshness, availability, or ordering.
+freshness, availability, replay, or ordering.
 
 ## Clock and ownership boundaries
 
@@ -54,10 +56,13 @@ The Product graph keeps separate durable facts:
 6. SalesChannel `index_revision` — SalesChannel entity mutation source version;
 7. entity query admission — owner freshness of a physically materialized entity row;
 8. link-target availability admission — authority of a current link when a query actually traverses
-   that link.
+   that link;
+9. replay checkpoint — source progress only; it never replaces entity source-version authority.
 
 A freshness-only Channel transition must not fabricate Product relation/projection epochs. Target entity
 updates/recreates must not advance Product membership clocks merely to make target payload current.
+Replay checkpoint loss after a durable mutation must not make the durable target non-authoritative or
+allow an older target mutation to regress it.
 
 ## Product/Channel convergence source complete
 
@@ -168,9 +173,40 @@ For SalesChannel:
 
 This packet is source-ready and execution-pending. It does not claim runtime test success.
 
+## Linked-target replay/redelivery composition source complete
+
+`product_linked_target_replay_redelivery_postgres.rs` reuses the canonical ProductVariant source and
+generic `IndexReplayWorker` with real PostgreSQL `PostgresMutationStore`.
+
+The packet starts with Variant v1 materialized, captures canonical Variant v2 without delivering it, then
+advances owner state to v3. Product membership/projection stays current while the linked graph fails
+closed because Variant materialization is still v1.
+
+A bounded fail-once checkpoint adapter injects the exact generic crash boundary after v3 mutation
+durability but before checkpoint durability:
+
+- first replay applies canonical v3 into real PostgreSQL storage;
+- checkpoint commit fails and remains absent;
+- original and freshly composed query runtimes already expose v3 because target authority is durable and
+  independent of replay cursor state;
+- a newly created replay worker retries from the absent checkpoint, scans the same current owner state,
+  derives the same stable event UUID and records `Duplicate` rather than rewriting the entity;
+- retry commits a complete checkpoint at v3;
+- the never-before-delivered canonical v2 mutation is then delivered late through the same replay sink
+  and records `StaleIgnored`;
+- a final exact v3 redelivery remains `Duplicate`;
+- durable ProductVariant source version/payload and linked Product graph remain v3 throughout the late
+  deliveries.
+
+The injected checkpoint adapter is only a deterministic failure boundary. Durable PostgreSQL
+checkpoint/job lease ownership remains the existing generic M6 contract; no Product-specific checkpoint
+state is added.
+
+This packet is source-ready and execution-pending.
+
 ## Retained M7 PostgreSQL packets
 
-Five packets are source-ready and execution/admission pending:
+Six packets are source-ready and execution/admission pending:
 
 1. `product_materialized_query_freshness_postgres.rs`
    - delayed Product scalar mutation and locale deletion;
@@ -198,6 +234,12 @@ Five packets are source-ready and execution/admission pending:
    - exact-count parity;
    - fresh query-runtime recomposition while target is stale;
    - target-only mutation recovery for both ProductVariant and SalesChannel.
+6. `product_linked_target_replay_redelivery_postgres.rs`
+   - canonical ProductVariant source replay;
+   - crash after PostgreSQL mutation durability/before checkpoint;
+   - replay-worker restart and exact stable-event duplicate;
+   - late never-delivered lower source version -> `StaleIgnored`;
+   - query-runtime recomposition and graph authority preserved throughout.
 
 None has been executed or admitted by the implementation agent.
 
@@ -210,7 +252,7 @@ None has been executed or admitted by the implementation agent.
 - [x] Product locale/ProductVariant refresh ledgers and durable relay step.
 - [ ] Retain canonical event-contract digest admission for current `main`.
 - [ ] Add the one canonical Product Index typed event family and concrete routes/consumers.
-- [ ] Retain crash-between-commit-and-ack/redelivery evidence.
+- [ ] Retain crash-between-commit-and-ack/redelivery evidence for the typed incremental event route.
 
 ## M6 replay, reconciliation, diagnosis, and repair
 
@@ -242,17 +284,18 @@ None has been executed or admitted by the implementation agent.
 - [x] Source-ready nested projection/exact-count target recreate packet.
 - [x] Source-ready linked filter/many aggregate order/exact-count/runtime-recomposition equivalence
       packet for ProductVariant and SalesChannel target lag.
+- [x] Source-ready replay-worker checkpoint-failure / duplicate / late-stale linked-target composition
+      packet using canonical ProductVariant replay and real PostgreSQL mutation storage.
 - [x] Source-ready Product delayed-mutation/locale-deletion PostgreSQL packet.
 - [x] Source-ready Product visibility/Channel convergence multi-host PostgreSQL packet.
 - [x] Source-ready Channel create/delete/tenant-move/delete-recreate PostgreSQL packet.
 - [x] Remove parallel Product/ProductVariant compatibility implementations.
-- [ ] Execute/admit the five retained Product M7 PostgreSQL packets.
-- [ ] Retain explicit replay-worker / crash-redelivery ordering evidence for linked target recovery if
-      not already satisfied by M5 replay evidence.
+- [ ] Execute/admit the six retained Product M7 PostgreSQL packets.
 - [ ] Execute any remaining schema-readiness/relation/freshness/projection concurrency evidence not
       already covered by those packets.
 - [ ] Admit canonical Product typed wire events/routes/consumers after digest verification.
-- [ ] Retain remaining out-of-order and locale fan-out evidence.
+- [ ] Retain typed incremental-route crash-between-commit-and-ack/redelivery evidence.
+- [ ] Retain remaining locale fan-out evidence.
 - [ ] Prove complete Storefront Product/ProductVariant/SalesChannel query parity.
 - [ ] Move Storefront traffic only after readiness/equivalence/freshness/availability evidence passes.
 
@@ -260,12 +303,14 @@ None has been executed or admitted by the implementation agent.
 
 Primary owner step remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-The next unblocked M7 source step is now **replay/redelivery ordering evidence for linked target
-recovery**, not another query policy, schema, relation copy, or clock. Reuse the existing replay/mutation
-contracts and prove that duplicate/out-of-order target delivery cannot make a linked Product query
-authoritative before the current target source version is materialized, including after runtime restart.
+The replay/redelivery ordering source gap for linked target recovery is now covered without adding a new
+clock or Product-specific replay mechanism. The next unblocked M7/M5 source step is **canonical event-
+contract digest admission for current `main`**. Recheck the actual event contract/evidence first; then
+admit exactly one current Product Index typed event family and routes/consumers only if that digest gate
+is source-complete. Do not introduce v2/v3 event branches or compatibility routes.
 
-Typed Product event work remains separately blocked until event-contract digest admission.
+After typed route admission, retain its separate crash-between-commit-and-ack/redelivery and locale
+fan-out evidence. Storefront cutover remains evidence-gated.
 
 ## Maintainer verification for current M7 source
 
@@ -275,11 +320,14 @@ cargo test -p rustok-distribution --features mod-product --test product_channel_
 cargo test -p rustok-distribution --features mod-product --test product_channel_identity_transitions_postgres -- --nocapture
 cargo test -p rustok-distribution --features mod-product --test product_linked_target_recreate_postgres -- --nocapture
 cargo test -p rustok-distribution --features mod-product --test product_linked_target_availability_equivalence_postgres -- --nocapture
+cargo test -p rustok-distribution --features mod-product --test product_linked_target_replay_redelivery_postgres -- --nocapture
 node scripts/verify/verify-index-product-materialized-query-freshness-postgres-harness.mjs
 node scripts/verify/verify-index-product-channel-convergence-postgres-harness.mjs
 node scripts/verify/verify-index-product-channel-identity-transitions-postgres-harness.mjs
 node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
 node scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-link-target-availability.mjs
 node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs

--- a/crates/rustok-index/docs/m7-linked-target-replay-redelivery-postgres-harness.md
+++ b/crates/rustok-index/docs/m7-linked-target-replay-redelivery-postgres-harness.md
@@ -1,0 +1,159 @@
+# M7 linked-target replay/redelivery PostgreSQL harness
+
+Status: `source_ready_execution_pending`.
+
+## Purpose
+
+`product_linked_target_replay_redelivery_postgres.rs` composes the existing generic replay contract with
+the canonical ProductVariant source, real PostgreSQL mutation storage, Product linked-target availability,
+and query-runtime recomposition.
+
+No new replay mechanism, owner clock, Product schema, relation ledger, or compatibility version is added.
+The packet exists because generic M5 unit evidence already proves the replay ordering contract in
+isolation, while Product M7 still needed retained composition evidence that duplicate/out-of-order target
+delivery cannot regress linked graph authority.
+
+## Existing generic replay contract reused
+
+`IndexReplayWorker` already:
+
+- scans one bounded current source page;
+- validates event UUIDs before persistence;
+- applies every mutation before checkpoint commit;
+- leaves the checkpoint unchanged if checkpoint commit fails after mutation durability;
+- repeats the same source page/event after that failure;
+- reports `Applied`, `Duplicate`, and `StaleIgnored` independently.
+
+`PostgresMutationStore` already:
+
+- derives replay delivery identity from the stable mutation event UUID;
+- stores inbox and entity/link mutation atomically;
+- reports exact stable-event redelivery as `Duplicate`;
+- serializes one exact entity key before comparing source versions;
+- ignores a never-before-delivered mutation whose source version is not newer than the current durable
+  entity version;
+- never rewrites current payload/links for `Duplicate` or `StaleIgnored` outcomes.
+
+This packet does not replace those generic contracts. It proves their Product graph composition.
+
+## Fixture
+
+One tenant owns:
+
+- Product with one English translation;
+- one ProductVariant;
+- one SalesChannel `alpha`;
+- Product visibility restricted to `alpha` through canonical owner metadata.
+
+Real Channel, Product, and Index migrations are applied. The selected Index + Channel + Product
+distribution runtime provides:
+
+- canonical Product and ProductVariant schemas/sources;
+- persisted tenant schema readiness;
+- generic Product/Channel convergence work for initial relation/freshness state;
+- generic `PostgresMutationStore`;
+- canonical shared Index query runtime.
+
+Only `variants` is traversed by the graph query, so the query-path-scoped availability policy does not
+require SalesChannel target materialization.
+
+## Initial state
+
+The Product mutation and Variant v1 mutation are loaded from the canonical source registry and applied
+to PostgreSQL. The Product graph query must expose Variant SKU `variant-v1` with exact count 1.
+
+Then the owner Variant is updated twice without changing Variant identity/membership:
+
+1. v2 SKU `variant-v2-never-applied` is loaded from the canonical source adapter and retained in memory,
+   but deliberately never delivered;
+2. owner advances again to v3 SKU `variant-v3-current`, also loaded from the canonical source adapter.
+
+The Product owner/projection stays current because SKU-only updates do not trigger Product membership
+revision. The materialized Variant remains v1, so scalar Product query stays authoritative while the
+linked `variants` graph query fails closed with exact count 0.
+
+## Crash after mutation durability, before checkpoint
+
+The packet constructs a real `IndexReplayWorker` over:
+
+- the canonical `SharedIndexSourceRegistry`;
+- the canonical shared schema registry;
+- real PostgreSQL `PostgresMutationStore`;
+- a bounded fail-once checkpoint adapter used only to inject the exact crash boundary.
+
+The checkpoint adapter is intentionally not a replacement persistence implementation. Generic M5
+already owns durable PostgreSQL checkpoint/lease semantics. Here it deterministically fails only the
+first checkpoint commit so the packet can prove Product graph behavior at the mutation/checkpoint
+boundary without adding test-only hooks to production storage.
+
+On the first replay page:
+
+1. canonical ProductVariant scan returns current v3 only;
+2. real PostgreSQL mutation persistence applies v3;
+3. checkpoint commit is injected to fail;
+4. worker returns `CheckpointCommitFailed` and checkpoint remains absent.
+
+Even though replay cursor durability failed, the durable target is already current. Both the existing
+query runtime and a separately composed query runtime on a fresh PostgreSQL session must expose
+`variant-v3-current` with exact count 1. Query authority therefore does not depend on process-local replay
+checkpoint state.
+
+## Worker restart and exact redelivery
+
+A new `IndexReplayWorker` instance is created with the same canonical source registry, PostgreSQL
+mutation store, and still-empty checkpoint state.
+
+The retry scans current v3 again and derives the same stable event UUID. The PostgreSQL inbox must
+classify the mutation as `Duplicate`; the page must report:
+
+- `mutation_count = 1`;
+- `applied_count = 0`;
+- `duplicate_count = 1`;
+- `stale_count = 0`;
+- `Complete` checkpoint with source version v3 and the exact current event UUID.
+
+Graph payload remains v3 throughout.
+
+## Late never-delivered historical mutation
+
+The retained canonical v2 mutation has a stable event UUID but was never previously written to the
+inbox. After v3 is durable, it is delivered through the same `IndexReplayMutationSink` implementation on
+`PostgresMutationStore`.
+
+The sink must report `StaleIgnored`. Durable target source version and payload remain v3 in both the
+original and freshly composed query runtimes.
+
+A final exact v3 redelivery must report `Duplicate` and likewise leave graph authority unchanged.
+
+This distinguishes two important late-delivery classes:
+
+- exact current replay after checkpoint loss -> inbox `Duplicate`;
+- previously unseen lower source version -> monotonic `StaleIgnored`.
+
+Neither can regress Product linked-target authority.
+
+## Evidence boundary
+
+The fail-once checkpoint adapter injects the failure boundary but does not claim to execute the durable
+PostgreSQL replay-job/checkpoint lease store in this packet. That owner machinery already has separate
+M6 source/evidence contracts. If maintainer execution reveals a checkpoint-store-specific integration
+gap, retain that separately rather than adding Product-specific replay state.
+
+This packet is source-ready and unexecuted.
+
+## Maintainer verification
+
+```bash
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-distribution --features mod-product \
+  --test product_linked_target_replay_redelivery_postgres -- --nocapture
+node scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
+node scripts/verify/verify-index-link-target-availability.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
+++ b/crates/rustok-index/docs/m7-product-materialized-query-freshness.md
@@ -129,28 +129,49 @@ Together the recreate and equivalence packets cover nested projection, linked fi
 ordering, exact-count parity, target-only update lag, same-UUID recreate lag, and fresh query-runtime
 recomposition without introducing process-local availability state.
 
+## Replay/redelivery composition packet
+
+`product_linked_target_replay_redelivery_postgres.rs` is source-ready and execution-pending. It composes
+canonical ProductVariant replay with real PostgreSQL mutation storage and Product graph queries.
+
+The packet keeps Product membership/projection unchanged while Variant owner state advances from
+materialized v1 through an undelivered canonical v2 to current v3. Before v3 materialization, scalar
+Product remains visible while the `variants` graph query fails closed.
+
+A fail-once checkpoint adapter injects a crash boundary after the real PostgreSQL v3 mutation commit but
+before replay checkpoint durability. The original query runtime and a newly composed query runtime both
+immediately expose v3. A newly constructed replay worker then replays the same stable v3 event, receives
+`Duplicate`, and commits the checkpoint. The previously unseen v2 event arrives later and receives
+`StaleIgnored`; a final v3 redelivery remains `Duplicate`. Neither late delivery can regress target source
+version, payload, or graph authority.
+
+The fail-once adapter is only a deterministic test boundary. Generic PostgreSQL replay-job/checkpoint
+lease persistence remains owned by the existing M6 replay contract; no Product-specific checkpoint
+state is introduced.
+
 ## Retained M7 PostgreSQL packets
 
-Five packets are source-ready and execution/admission pending:
+Six packets are source-ready and execution/admission pending:
 
 1. `product_materialized_query_freshness_postgres.rs`;
 2. `product_channel_convergence_postgres.rs`;
 3. `product_channel_identity_transitions_postgres.rs`;
 4. `product_linked_target_recreate_postgres.rs`;
-5. `product_linked_target_availability_equivalence_postgres.rs`.
+5. `product_linked_target_availability_equivalence_postgres.rs`;
+6. `product_linked_target_replay_redelivery_postgres.rs`.
 
 None has been executed or admitted by the implementation agent.
 
 ## Remaining M7 evidence
 
-The linked-target query availability source contract and query-equivalence packet are now source
-complete. Remaining work before Storefront cutover is no longer another query policy or owner clock:
+The linked-target query freshness, availability, equivalence, and replay/redelivery composition source
+contracts are now complete. Remaining work before Storefront cutover is no longer another query/replay
+policy or owner clock:
 
-- execute/admit the five retained Product PostgreSQL packets;
-- retain explicit replay-worker / duplicate-redelivery / crash-ordering evidence for target recovery if
-  the generic M5 replay packet does not already prove the required Product graph sequence;
+- execute/admit the six retained Product PostgreSQL packets;
 - finish canonical Product typed event admission after event-contract digest verification;
-- retain remaining out-of-order/locale fan-out evidence;
+- retain the typed incremental route's separate crash-between-commit-and-ack/redelivery evidence;
+- retain remaining locale fan-out evidence;
 - complete Storefront Product/ProductVariant/SalesChannel query parity and cutover evidence.
 
 ## Maintainer verification
@@ -164,9 +185,14 @@ RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
 RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
   cargo test -p rustok-distribution --features mod-product \
   --test product_linked_target_availability_equivalence_postgres -- --nocapture
+RUSTOK_INDEX_TEST_DATABASE_URL=postgresql://... \
+  cargo test -p rustok-distribution --features mod-product \
+  --test product_linked_target_replay_redelivery_postgres -- --nocapture
 node scripts/verify/verify-index-link-target-availability.mjs
 node scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
 node scripts/verify/verify-index-linked-target-availability-equivalence-postgres-harness.mjs
+node scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
+node scripts/verify/verify-index-source-replay-contract.mjs
 node scripts/verify/verify-index-linked-target-query-freshness.mjs
 node scripts/verify/verify-index-product-materialized-query-freshness.mjs
 node scripts/verify/verify-index-query-contract.mjs

--- a/scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
+++ b/scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-linked-target-replay-redelivery-postgres-harness] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const harnessPath = 'crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs';
+const harness = requireMarkers(harnessPath, [
+  '#![cfg(feature = "mod-product")]',
+  'replay_checkpoint_failure_duplicate_retry_and_late_stale_target_keep_graph_authoritative',
+  'IndexReplayWorker::new(',
+  'IndexReplayPageRequest::new(TENANT_ID, variant_schema_ref()?, 32)',
+  'FailOnceCheckpointStore::new()',
+  'IndexReplayFailure::retryable("injected_checkpoint_commit_failure")',
+  'Err(IndexReplayError::CheckpointCommitFailed(_))',
+  'assert!(checkpoint_store.checkpoint().is_none())',
+  'let restarted_query = database.fresh_query_runtime().await?',
+  'let restarted_worker = IndexReplayWorker::new(',
+  'retry.status(), IndexReplayPageStatus::Complete',
+  'retry.applied_count(), 0',
+  'retry.duplicate_count(), 1',
+  'retry.stale_count(), 0',
+  'checkpoint.source_version(), Some(current_version)',
+  'checkpoint.last_delivery_id(), Some(current_delivery_id.as_str())',
+  'HISTORICAL_SKU: &str = "variant-v2-never-applied"',
+  'CURRENT_SKU: &str = "variant-v3-current"',
+  '.apply_replay_mutation(',
+  'IndexReplayMutationOutcome::StaleIgnored',
+  'IndexReplayMutationOutcome::Duplicate',
+  'materialized_variant_version(&database.mutation).await?, current_version',
+  'assert_scalar_product_visible(&runtime.query, true)',
+  'assert_graph_visible(&runtime.query, false)',
+  'assert_graph_payload(&runtime.query, CURRENT_SKU)',
+  'assert_graph_payload(&restarted_query, CURRENT_SKU)',
+  'materialize_postgres_index_sources',
+  'materialize_index_source_registry',
+  'materialize_postgres_index_query_runtime',
+  'PostgresMutationStore::new',
+  'PostgresSchemaRegistrationStore::new',
+  'ModuleWorkRegistrations',
+  'scheduler.run_once().await?',
+  'rustok_channel::migrations::migrations()',
+  'rustok_product::migrations::migrations()',
+  'IndexModule.migrations()',
+]);
+forbidMarkers(harnessPath, harness, [
+  'tokio::spawn',
+  'loop {',
+  'CREATE TABLE index_entities',
+  'CREATE TABLE index_links',
+  'INSERT INTO index_entities',
+  'INSERT INTO index_links',
+  'PostgresQueryEntityAdmission::new',
+  'register_postgres_index_query_link_target_availability',
+  'PostgresIndexReplayCheckpointStore::new',
+]);
+
+const replayWorkerPath = 'crates/rustok-index/src/application/source_replay.rs';
+requireMarkers(replayWorkerPath, [
+  'pub struct IndexReplayWorker',
+  '.apply_replay_mutation(',
+  '.commit_replay_checkpoint(&checkpoint)',
+  'IndexReplayMutationOutcome::Applied => applied_count += 1',
+  'IndexReplayMutationOutcome::Duplicate => duplicate_count += 1',
+  'IndexReplayMutationOutcome::StaleIgnored => stale_count += 1',
+  'CheckpointCommitFailed',
+]);
+const replaySinkPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
+requireMarkers(replaySinkPath, [
+  'impl IndexReplayMutationSink for PostgresMutationStore',
+  'MutationDelivery::from_event(source_name, mutation.clone())',
+  'MutationApplyOutcome::Applied { .. } => IndexReplayMutationOutcome::Applied',
+  'MutationApplyOutcome::Duplicate { .. } => IndexReplayMutationOutcome::Duplicate',
+  'MutationApplyOutcome::StaleIgnored { .. } =>',
+  'IndexReplayMutationOutcome::StaleIgnored',
+]);
+const mutationStorePath = 'crates/rustok-index/src/infrastructure/postgres/mutation_store.rs';
+requireMarkers(mutationStorePath, [
+  'MutationApplyOutcome::Duplicate { source_version: stored_source_version }',
+  'if source_version <= current_source_version',
+  'MutationApplyOutcome::StaleIgnored',
+  'self.lock_entity_key(transaction, mutation, backend).await?',
+  'self.delete_existing_links(transaction, mutation, backend)',
+]);
+requireMarkers('crates/rustok-index/src/application/source_replay_tests.rs', [
+  'checkpoint_failure_replays_the_same_event_delivery',
+  'interruption_before_checkpoint_replays_applied_mutation_without_advancing_cursor',
+  'vec![event_id, event_id]',
+]);
+requireMarkers('crates/rustok-index/docs/m7-linked-target-replay-redelivery-postgres-harness.md', [
+  'Status: `source_ready_execution_pending`',
+  'Crash after mutation durability, before checkpoint',
+  'Worker restart and exact redelivery',
+  'Late never-delivered historical mutation',
+  'exact current replay after checkpoint loss -> inbox `Duplicate`',
+  'previously unseen lower source version -> monotonic `StaleIgnored`',
+  'fail-once checkpoint adapter',
+  'source-ready and unexecuted',
+]);
+
+console.log('[verify-index-linked-target-replay-redelivery-postgres-harness] source-ready replay/redelivery composition packet verified');

--- a/scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
+++ b/scripts/verify/verify-index-linked-target-replay-redelivery-postgres-harness.mjs
@@ -95,9 +95,12 @@ requireMarkers(replaySinkPath, [
 ]);
 const mutationStorePath = 'crates/rustok-index/src/infrastructure/postgres/mutation_store.rs';
 requireMarkers(mutationStorePath, [
-  'MutationApplyOutcome::Duplicate { source_version: stored_source_version }',
+  '"applied" => Ok(MutationApplyOutcome::Duplicate {',
+  'source_version: stored_source_version,',
   'if source_version <= current_source_version',
-  'MutationApplyOutcome::StaleIgnored',
+  'MutationApplyOutcome::StaleIgnored {',
+  'incoming_source_version: source_version,',
+  'current_source_version,',
   'self.lock_entity_key(transaction, mutation, backend).await?',
   'self.delete_existing_links(transaction, mutation, backend)',
 ]);

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -74,6 +74,7 @@ const scripts = [
   'verify-index-link-target-availability.mjs',
   'verify-index-linked-target-recreate-postgres-harness.mjs',
   'verify-index-linked-target-availability-equivalence-postgres-harness.mjs',
+  'verify-index-linked-target-replay-redelivery-postgres-harness.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- add a source-ready ProductVariant replay/redelivery composition packet using the canonical source registry, generic `IndexReplayWorker`, real PostgreSQL `PostgresMutationStore`, persisted schema readiness, Product graph availability, and fresh query-runtime recomposition;
- reuse the existing generic replay/mutation contracts rather than adding Product-specific replay state, a new clock, schema, relation ledger, or compatibility version;
- start with Variant v1 materialized, capture a canonical v2 mutation without delivering it, then advance owner state to current v3 while Product membership/projection remains unchanged and the linked graph fails closed;
- inject one deterministic checkpoint commit failure only after real PostgreSQL v3 mutation durability to model crash-after-mutation/before-checkpoint;
- prove original and freshly composed query runtimes immediately see durable v3 despite missing replay checkpoint;
- recreate the replay worker with the same absent checkpoint and prove the same canonical v3 event is classified as `Duplicate`, after which the completed checkpoint records v3 and the exact stable event UUID;
- deliver the never-before-applied canonical v2 mutation late through the same replay sink and require `StaleIgnored`, then exact-redeliver v3 and require `Duplicate` again;
- require target source version, payload, and linked Product graph to remain v3 throughout all late deliveries;
- document the deliberate boundary: the fail-once checkpoint adapter only injects the generic crash point; durable PostgreSQL replay-job/checkpoint lease persistence remains the separate M6 owner contract;
- add a dedicated static guard, include it in the aggregate Index contract, update Product freshness docs, and advance the current plan to event-contract digest admission.

## Generic contract reused

`IndexReplayWorker` already applies page mutations before checkpoint commit and retries the same current source page when checkpoint durability fails. `PostgresMutationStore` already maps stable event redelivery to `Duplicate` and a previously unseen non-newer source version to `StaleIgnored` under the entity-key lock.

The canonical ProductVariant adapter uses the same `ProductVariantRow::into_mutation()` and deterministic event derivation for scan and targeted load, so the v3 mutation captured before replay and the v3 mutation scanned after worker restart share the exact event UUID.

## Product graph sequence

1. Product and Variant v1 are materialized; `variants.sku` is authoritative.
2. Variant owner advances to v2; the canonical v2 mutation is captured but never delivered.
3. Variant owner advances to v3; Product owner/projection is still current because SKU-only updates do not change membership, while the linked graph fails closed because target materialization remains v1.
4. Replay applies current v3 to PostgreSQL; injected checkpoint commit fails.
5. Existing and fresh query runtimes expose v3 immediately.
6. New replay worker retries from absent checkpoint; same stable v3 event becomes `Duplicate`; checkpoint completes at v3.
7. Never-delivered v2 arrives late and becomes `StaleIgnored`.
8. Exact v3 redelivery remains `Duplicate`.

No late delivery can regress the current target or make stale linked payload authoritative.

## Main recheck

The branch started from `main@283522e39d51b92e4fd3abef64f057edc375d546` (#3188). Current `main` advanced only through Moderation/Forum #3189; compare shows no overlap with this six-file Index/distribution evidence/doc/verifier set.

## Validation

Per maintainer instruction this remains source-ready, execution-pending. No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.