### PR TITLE
feat(index): scope replacement source events by schema

### DIFF
--- a/crates/rustok-index/docs/m4-single-current-schema-supersession.md
+++ b/crates/rustok-index/docs/m4-single-current-schema-supersession.md
@@ -52,16 +52,17 @@ additional rows.
 Trying to declare an older historical key current after a later key exists fails with
 `NonMonotonicVersion`, even when that older exact contract is still present in storage.
 
-## Why retirement is enough for the authority boundary
+## Historical storage and authority boundary
 
 `index_entities` and `index_links` retain the numeric schema key and schema fingerprint in their storage
-identity/foreign-key chain. Supersession does **not** rewrite or delete those historical rows.
+identity/foreign-key chain. Replay/rebuild checkpoints also include `schema_version` in their primary
+identity. Supersession does **not** rewrite or delete those historical rows.
 
 That is intentional:
 
-- historical rows keep valid foreign keys to their immutable schema row;
-- replacement mutations use a different routing key and therefore cannot collide with old entity,
-  link, inbox, checkpoint, or replay identities;
+- historical entity/link rows keep valid foreign keys to their immutable schema row;
+- replacement entity/link/checkpoint state uses a different routing key and cannot collide with lower
+  schema keys;
 - tenant schema readiness requires the exact runtime-selected `SchemaRef`, fingerprint, JSON, and
   `status = active`;
 - PostgreSQL query execution performs the same exact persisted-schema status/fingerprint/contract
@@ -69,6 +70,28 @@ That is intentional:
 - an old runtime/schema reference therefore fails closed once its persisted contract is retired.
 
 Retirement is an authority transition, not a data purge.
+
+## Inbox delivery identity is a separate boundary
+
+`index_inbox` intentionally stores `schema_version`, but its deduplication primary key is
+`(tenant_id, source_name, delivery_id)`. Therefore a replacement source cannot rely on the new numeric
+schema key alone to separate historical and replacement deliveries.
+
+The legacy `derive_index_source_event_id` remains stable for existing sources and is **not** changed by
+supersession work. It hashes the owner-selected domain, tenant, entity, locale, and source version, but
+not the `SchemaRef`.
+
+A source that replays the same owner mutation/source-version pair under a replacement schema routing key
+must instead use `derive_index_schema_source_event_id`. The schema-scoped helper additionally hashes the
+exact schema module, entity, and numeric routing key. This gives:
+
+- stable delivery UUIDs for retries of the same exact replacement schema;
+- a different delivery UUID for the same owner mutation under a different schema key;
+- no collision with a historical inbox row merely because source name, owner domain, entity, locale,
+  and source version are unchanged.
+
+The schema-scoped helper is an internal storage/replay identity mechanism. It does not introduce a
+versioned event family or compatibility route.
 
 ## Recommended staged rebuild sequence
 
@@ -78,11 +101,14 @@ materialization is ready:
 1. source code defines **one** replacement current schema; no old compatibility branch is added;
 2. use ordinary `register` to stage the monotonically higher immutable routing key while the lower
    persisted key remains active;
-3. replay/rebuild the replacement key completely;
-4. verify exact persisted readiness, parity, freshness, and restart evidence for the replacement key;
-5. call `register_current` with that already-staged exact contract;
-6. in that final transaction every lower active key becomes `retired`;
-7. cut authoritative consumers to the replacement runtime only after that authority transition.
+3. ensure the replacement source derives deterministic replay delivery IDs with
+   `derive_index_schema_source_event_id` before rebuilding the new key;
+4. replay/rebuild the replacement key completely;
+5. verify exact persisted readiness, parity, freshness, inbox isolation, and restart evidence for the
+   replacement key;
+6. call `register_current` with that already-staged exact contract;
+7. in that final transaction every lower active key becomes `retired`;
+8. cut authoritative consumers to the replacement runtime only after that authority transition.
 
 A rolling deployment can temporarily have old and new process generations, and staging can temporarily
 leave two persisted keys `active`, but source code still contains only one replacement implementation.
@@ -101,16 +127,19 @@ The current Product Index contract cannot be expanded under its existing persist
 that would change the fingerprint. The Storefront parity gate also rejects introducing parallel Product
 v4/v5 compatibility branches.
 
-This generic supersession primitive provides the missing persistence mechanism for a future
+This generic supersession path provides the persistence/replay identity mechanisms for a future
 **single-current** Product replacement:
 
 - one monotonically higher internal routing key;
 - only that replacement contract published by new Product runtime code;
+- schema-scoped deterministic Product replay delivery IDs;
 - staged new-key replay/rebuild before authority transition;
 - all lower persisted Product keys retired atomically per tenant at final supersession;
 - no old Product source/query compatibility branch selected in the replacement runtime.
 
-This slice does not change the Product routing key or Product schema yet.
+This slice does not change the Product routing key or Product schema yet. The future replacement Product
+source must switch from `derive_index_source_event_id` to `derive_index_schema_source_event_id` in the
+same PR that changes its current routing key.
 
 ## Deliberate limits
 
@@ -121,7 +150,7 @@ This primitive does not:
 - register schemas automatically for every tenant;
 - run replay/rebuild jobs;
 - delete old Index materialization;
-- change event contracts;
+- change public event contracts;
 - authorize Storefront cutover.
 
 Those are separate owner/execution/evidence decisions.
@@ -131,7 +160,9 @@ Those are separate owner/execution/evidence decisions.
 Suggested commands, intentionally not run by the implementation agent:
 
 ```bash
+cargo test -p rustok-index source_event_id --lib -- --nocapture
 cargo test -p rustok-index schema_registration --lib -- --nocapture
+node scripts/verify/verify-index-schema-scoped-source-event-id.mjs
 node scripts/verify/verify-index-schema-supersession.mjs
 node scripts/verify/verify-index-schema-readiness.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -77,9 +77,9 @@ pub use drift_finding_lifecycle::{
     IndexDriftFindingLifecycleFailure, IndexDriftFindingLifecycleFailureError,
     IndexDriftFindingLifecycleFailureKind, IndexDriftFindingLifecycleNotAppliedReason,
     IndexDriftFindingLifecycleOutcome, IndexDriftFindingLifecycleReceipt,
-    IndexDriftFindingLifecycleService, IndexDriftFindingLifecycleState,
-    IndexDriftFindingLifecycleStore, IndexDriftFindingLifecycleStoreOutcome,
-    IndexDriftFindingLifecycleValidationError, IndexDriftFindingState,
+    IndexDriftFindingLifecycleService, IndexDriftFindingLifecycleStore,
+    IndexDriftFindingLifecycleStoreOutcome, IndexDriftFindingLifecycleValidationError,
+    IndexDriftFindingState,
 };
 pub use drift_repair::{
     IndexDriftAuthorizedRepairCommand, IndexDriftRepairAuthorization,

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -77,9 +77,9 @@ pub use drift_finding_lifecycle::{
     IndexDriftFindingLifecycleFailure, IndexDriftFindingLifecycleFailureError,
     IndexDriftFindingLifecycleFailureKind, IndexDriftFindingLifecycleNotAppliedReason,
     IndexDriftFindingLifecycleOutcome, IndexDriftFindingLifecycleReceipt,
-    IndexDriftFindingLifecycleService, IndexDriftFindingLifecycleStore,
-    IndexDriftFindingLifecycleStoreOutcome, IndexDriftFindingLifecycleValidationError,
-    IndexDriftFindingState,
+    IndexDriftFindingLifecycleService, IndexDriftFindingLifecycleState,
+    IndexDriftFindingLifecycleStore, IndexDriftFindingLifecycleStoreOutcome,
+    IndexDriftFindingLifecycleValidationError, IndexDriftFindingState,
 };
 pub use drift_repair::{
     IndexDriftAuthorizedRepairCommand, IndexDriftRepairAuthorization,
@@ -143,7 +143,9 @@ pub use source_continuation::{
     IndexSourceContinuationCodec, IndexSourceContinuationError, IndexSourceContinuationScope,
     IndexSourceContinuationToken,
 };
-pub use source_event_id::{IndexSourceEventIdError, derive_index_source_event_id};
+pub use source_event_id::{
+    IndexSourceEventIdError, derive_index_schema_source_event_id, derive_index_source_event_id,
+};
 pub use source_refresh_event::{
     IndexSourceRefreshEventDelivery, IndexSourceRefreshEventError,
     IndexSourceRefreshEventProcessError, IndexSourceRefreshEventProcessOutcome,

--- a/crates/rustok-index/src/application/source_event_id.rs
+++ b/crates/rustok-index/src/application/source_event_id.rs
@@ -2,7 +2,7 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::LocaleKey;
+use crate::{LocaleKey, SchemaRef};
 
 const MAX_SOURCE_EVENT_DOMAIN_BYTES: usize = 128;
 
@@ -12,6 +12,8 @@ pub enum IndexSourceEventIdError {
     InvalidDomain(String),
     #[error("Index source event identity tenant cannot be nil")]
     NilTenantId,
+    #[error("Index source event identity schema version must be positive")]
+    ZeroSchemaVersion,
     #[error("Index source event identity entity cannot be nil")]
     NilEntityId,
     #[error("Index source event identity source version must be positive")]
@@ -22,8 +24,10 @@ pub enum IndexSourceEventIdError {
 ///
 /// Source adapters use this helper instead of inventing random replay delivery IDs. The identity is
 /// stable across retries and changes when tenant, entity, locale, source version, or the
-/// owner-selected versioned domain changes. The helper performs no I/O and does not expose the hash
-/// bytes as a public persistence contract.
+/// owner-selected domain changes. This legacy form intentionally does not include a `SchemaRef`; a
+/// source that may rebuild the same owner mutation under a replacement schema routing key must use
+/// [`derive_index_schema_source_event_id`] instead so historical inbox deliveries cannot collide with
+/// the replacement schema.
 pub fn derive_index_source_event_id(
     domain: &str,
     tenant_id: Uuid,
@@ -31,6 +35,58 @@ pub fn derive_index_source_event_id(
     locale: Option<&LocaleKey>,
     source_version: u64,
 ) -> Result<Uuid, IndexSourceEventIdError> {
+    validate_scope(domain, tenant_id, entity_id, source_version)?;
+
+    let mut hasher = Sha256::new();
+    write_bytes(&mut hasher, b"rustok-index-source-event-id-v1");
+    write_bytes(&mut hasher, domain.as_bytes());
+    hasher.update(tenant_id.as_bytes());
+    hasher.update(entity_id.as_bytes());
+    write_locale(&mut hasher, locale);
+    hasher.update(source_version.to_be_bytes());
+
+    Ok(event_id_from_hasher(hasher))
+}
+
+/// Derives one deterministic delivery UUID scoped to an exact immutable Index schema reference.
+///
+/// This form is required for staged schema supersession/rebuilds. `index_inbox` deduplicates by
+/// `(tenant_id, source_name, delivery_id)`, so replaying the same owner entity/source-version pair under
+/// a monotonically higher schema routing key must produce a different delivery ID while remaining
+/// stable for retries of that exact replacement schema.
+pub fn derive_index_schema_source_event_id(
+    domain: &str,
+    tenant_id: Uuid,
+    schema: &SchemaRef,
+    entity_id: Uuid,
+    locale: Option<&LocaleKey>,
+    source_version: u64,
+) -> Result<Uuid, IndexSourceEventIdError> {
+    validate_scope(domain, tenant_id, entity_id, source_version)?;
+    if schema.version.get() == 0 {
+        return Err(IndexSourceEventIdError::ZeroSchemaVersion);
+    }
+
+    let mut hasher = Sha256::new();
+    write_bytes(&mut hasher, b"rustok-index-schema-source-event-id-v1");
+    write_bytes(&mut hasher, domain.as_bytes());
+    hasher.update(tenant_id.as_bytes());
+    write_bytes(&mut hasher, schema.module.as_str().as_bytes());
+    write_bytes(&mut hasher, schema.entity.as_str().as_bytes());
+    hasher.update(schema.version.get().to_be_bytes());
+    hasher.update(entity_id.as_bytes());
+    write_locale(&mut hasher, locale);
+    hasher.update(source_version.to_be_bytes());
+
+    Ok(event_id_from_hasher(hasher))
+}
+
+fn validate_scope(
+    domain: &str,
+    tenant_id: Uuid,
+    entity_id: Uuid,
+    source_version: u64,
+) -> Result<(), IndexSourceEventIdError> {
     validate_domain(domain)?;
     if tenant_id.is_nil() {
         return Err(IndexSourceEventIdError::NilTenantId);
@@ -41,29 +97,7 @@ pub fn derive_index_source_event_id(
     if source_version == 0 {
         return Err(IndexSourceEventIdError::ZeroSourceVersion);
     }
-
-    let mut hasher = Sha256::new();
-    write_bytes(&mut hasher, b"rustok-index-source-event-id-v1");
-    write_bytes(&mut hasher, domain.as_bytes());
-    hasher.update(tenant_id.as_bytes());
-    hasher.update(entity_id.as_bytes());
-    match locale {
-        Some(locale) => {
-            hasher.update([1]);
-            write_bytes(&mut hasher, locale.as_str().as_bytes());
-        }
-        None => hasher.update([0]),
-    }
-    hasher.update(source_version.to_be_bytes());
-
-    let digest = hasher.finalize();
-    let mut bytes = [0u8; 16];
-    bytes.copy_from_slice(&digest[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x50;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    let event_id = Uuid::from_bytes(bytes);
-    debug_assert!(!event_id.is_nil());
-    Ok(event_id)
+    Ok(())
 }
 
 fn validate_domain(domain: &str) -> Result<(), IndexSourceEventIdError> {
@@ -81,6 +115,27 @@ fn validate_domain(domain: &str) -> Result<(), IndexSourceEventIdError> {
     }
 }
 
+fn write_locale(hasher: &mut Sha256, locale: Option<&LocaleKey>) {
+    match locale {
+        Some(locale) => {
+            hasher.update([1]);
+            write_bytes(hasher, locale.as_str().as_bytes());
+        }
+        None => hasher.update([0]),
+    }
+}
+
+fn event_id_from_hasher(hasher: Sha256) -> Uuid {
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x50;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    let event_id = Uuid::from_bytes(bytes);
+    debug_assert!(!event_id.is_nil());
+    event_id
+}
+
 fn write_bytes(hasher: &mut Sha256, bytes: &[u8]) {
     hasher.update((bytes.len() as u64).to_be_bytes());
     hasher.update(bytes);
@@ -89,6 +144,15 @@ fn write_bytes(hasher: &mut Sha256, bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{EntityName, ModuleName, SchemaVersion};
+
+    fn schema(version: u32) -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("rustok-product").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::new(version),
+        }
+    }
 
     #[test]
     fn source_event_identity_is_stable_and_scope_sensitive() {
@@ -138,22 +202,111 @@ mod tests {
     }
 
     #[test]
+    fn schema_scoped_source_event_identity_is_stable_and_schema_sensitive() {
+        let tenant_id = Uuid::from_u128(1);
+        let entity_id = Uuid::from_u128(2);
+        let locale = LocaleKey::new("en-US").unwrap();
+        let current = schema(3);
+        let replacement = schema(4);
+
+        let first = derive_index_schema_source_event_id(
+            "rustok-product.product-replay",
+            tenant_id,
+            &replacement,
+            entity_id,
+            Some(&locale),
+            7,
+        )
+        .unwrap();
+        let retry = derive_index_schema_source_event_id(
+            "rustok-product.product-replay",
+            tenant_id,
+            &replacement,
+            entity_id,
+            Some(&locale),
+            7,
+        )
+        .unwrap();
+        assert_eq!(first, retry);
+        assert_ne!(
+            first,
+            derive_index_schema_source_event_id(
+                "rustok-product.product-replay",
+                tenant_id,
+                &current,
+                entity_id,
+                Some(&locale),
+                7,
+            )
+            .unwrap()
+        );
+        assert_ne!(
+            first,
+            derive_index_schema_source_event_id(
+                "rustok-product.product-replay",
+                tenant_id,
+                &replacement,
+                entity_id,
+                Some(&locale),
+                8,
+            )
+            .unwrap()
+        );
+        assert!(!first.is_nil());
+    }
+
+    #[test]
     fn source_event_identity_rejects_invalid_scope() {
         assert!(matches!(
-            derive_index_source_event_id("BAD DOMAIN", Uuid::from_u128(1), Uuid::from_u128(2), None, 1),
+            derive_index_source_event_id(
+                "BAD DOMAIN",
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                None,
+                1,
+            ),
             Err(IndexSourceEventIdError::InvalidDomain(_))
         ));
         assert_eq!(
-            derive_index_source_event_id("source.v1", Uuid::nil(), Uuid::from_u128(2), None, 1),
+            derive_index_source_event_id(
+                "source.v1",
+                Uuid::nil(),
+                Uuid::from_u128(2),
+                None,
+                1,
+            ),
             Err(IndexSourceEventIdError::NilTenantId)
         );
         assert_eq!(
-            derive_index_source_event_id("source.v1", Uuid::from_u128(1), Uuid::nil(), None, 1),
+            derive_index_source_event_id(
+                "source.v1",
+                Uuid::from_u128(1),
+                Uuid::nil(),
+                None,
+                1,
+            ),
             Err(IndexSourceEventIdError::NilEntityId)
         );
         assert_eq!(
-            derive_index_source_event_id("source.v1", Uuid::from_u128(1), Uuid::from_u128(2), None, 0),
+            derive_index_source_event_id(
+                "source.v1",
+                Uuid::from_u128(1),
+                Uuid::from_u128(2),
+                None,
+                0,
+            ),
             Err(IndexSourceEventIdError::ZeroSourceVersion)
+        );
+        assert_eq!(
+            derive_index_schema_source_event_id(
+                "source.v1",
+                Uuid::from_u128(1),
+                &schema(0),
+                Uuid::from_u128(2),
+                None,
+                1,
+            ),
+            Err(IndexSourceEventIdError::ZeroSchemaVersion)
         );
     }
 }

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -19,6 +19,7 @@ const scripts = [
   'verify-index-source-schema-registry.mjs',
   'verify-index-schema-readiness.mjs',
   'verify-index-schema-supersession.mjs',
+  'verify-index-schema-scoped-source-event-id.mjs',
   'verify-index-source-replay-contract.mjs',
   'verify-index-source-refresh-event.mjs',
   'verify-index-source-absence-watermark.mjs',

--- a/scripts/verify/verify-index-schema-scoped-source-event-id.mjs
+++ b/scripts/verify/verify-index-schema-scoped-source-event-id.mjs
@@ -45,7 +45,7 @@ const inbox = requireMarkers(inboxPath, [
   '.col(IndexInbox::TenantId)',
   '.col(IndexInbox::SourceName)',
   '.col(IndexInbox::DeliveryId)',
-  '.col(ColumnDef::new(IndexInbox::SchemaVersion)',
+  'ColumnDef::new(IndexInbox::SchemaVersion)',
 ]);
 const inboxPrimaryKey = inbox.slice(
   inbox.indexOf('.name("pk_index_inbox")'),

--- a/scripts/verify/verify-index-schema-scoped-source-event-id.mjs
+++ b/scripts/verify/verify-index-schema-scoped-source-event-id.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-schema-scoped-source-event-id] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const helperPath = 'crates/rustok-index/src/application/source_event_id.rs';
+requireMarkers(helperPath, [
+  'pub fn derive_index_source_event_id(',
+  'pub fn derive_index_schema_source_event_id(',
+  'schema: &SchemaRef',
+  'rustok-index-source-event-id-v1',
+  'rustok-index-schema-source-event-id-v1',
+  'schema.module.as_str().as_bytes()',
+  'schema.entity.as_str().as_bytes()',
+  'schema.version.get().to_be_bytes()',
+  'IndexSourceEventIdError::ZeroSchemaVersion',
+  'schema_scoped_source_event_identity_is_stable_and_schema_sensitive',
+  'let current = schema(3);',
+  'let replacement = schema(4);',
+]);
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'derive_index_schema_source_event_id',
+  'derive_index_source_event_id',
+]);
+
+const inboxPath = 'crates/rustok-index/src/migrations/m20260727_000002_create_index_delivery_state.rs';
+const inbox = requireMarkers(inboxPath, [
+  '.name("pk_index_inbox")',
+  '.col(IndexInbox::TenantId)',
+  '.col(IndexInbox::SourceName)',
+  '.col(IndexInbox::DeliveryId)',
+  '.col(ColumnDef::new(IndexInbox::SchemaVersion)',
+]);
+const inboxPrimaryKey = inbox.slice(
+  inbox.indexOf('.name("pk_index_inbox")'),
+  inbox.indexOf('.foreign_key(', inbox.indexOf('.name("pk_index_inbox")')),
+);
+if (inboxPrimaryKey.includes('.col(IndexInbox::SchemaVersion)')) {
+  fail(`${inboxPath} inbox primary key unexpectedly includes schema version; update schema-scoped delivery identity rationale`);
+}
+
+requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.md', [
+  'Inbox delivery identity is a separate boundary',
+  '`(tenant_id, source_name, delivery_id)`',
+  '`derive_index_schema_source_event_id`',
+  'schema-scoped deterministic Product replay delivery IDs',
+  'switch from `derive_index_source_event_id` to `derive_index_schema_source_event_id`',
+]);
+
+console.log('[verify-index-schema-scoped-source-event-id] schema supersession replay deliveries are schema-scoped without changing legacy source IDs');

--- a/scripts/verify/verify-index-schema-supersession.mjs
+++ b/scripts/verify/verify-index-schema-supersession.mjs
@@ -83,11 +83,20 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_port.rs', 
   'PersistedSchemaReadinessFailure::Inactive',
 ]);
 
+requireMarkers('crates/rustok-index/src/application/source_event_id.rs', [
+  'pub fn derive_index_schema_source_event_id(',
+  'rustok-index-schema-source-event-id-v1',
+]);
+
 requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.md', [
   'Status: `source_complete_execution_pending`',
   '`PostgresSchemaRegistrationStore::register_current`',
+  'Inbox delivery identity is a separate boundary',
+  '`(tenant_id, source_name, delivery_id)`',
+  '`derive_index_schema_source_event_id`',
   'Recommended staged rebuild sequence',
   'use ordinary `register` to stage',
+  'schema-scoped deterministic Product replay delivery IDs',
   'call `register_current` with that already-staged exact contract',
   'Historical rows may be purged later',
   'single-current',


### PR DESCRIPTION
## Summary

- add `derive_index_schema_source_event_id` as an additive deterministic source-delivery helper scoped to the exact immutable `SchemaRef`;
- preserve the existing `derive_index_source_event_id` hash input order/prefix so all existing source delivery UUIDs remain byte-for-byte stable;
- hash schema module, entity, and numeric routing key only in the new helper, so the same owner mutation replayed under a replacement schema produces a distinct delivery UUID while retries of that exact schema remain stable;
- export the helper from `rustok-index` application API;
- correct the single-current supersession runbook: entity/link/checkpoint identities are schema-keyed, but `index_inbox` deduplicates on `(tenant_id, source_name, delivery_id)`, so replacement rebuilds need schema-scoped delivery IDs;
- add static guards for the inbox PK boundary, legacy/new helper coexistence, schema-sensitive identity tests, and aggregate verifier wiring;
- change no Product schema, Product routing key, Product source name, Product runtime source, Storefront traffic, public event contract, or existing source delivery identity.

## Root cause

PR #3193 introduced the correct staged schema supersession flow, but source recheck found one independent persistence identity boundary: `index_inbox` stores `schema_version` yet its primary dedupe key is `(tenant_id, source_name, delivery_id)`. The canonical Product source currently uses an unversioned source name/domain and derives delivery UUID from tenant/entity/locale/source-version only. A future higher Product routing key could therefore replay an owner mutation with the same historical delivery UUID and collide with the lower-key inbox row.

This PR closes that prerequisite without retroactively changing any existing source identity.

## Replacement contract

A source that changes immutable schema routing key must use `derive_index_schema_source_event_id` before staged rebuild. The helper hashes:

- owner-selected domain;
- tenant;
- exact schema module/entity/routing key;
- entity;
- locale presence/value;
- source version.

The numeric schema key remains an internal storage/replay identity, not a parallel public versioned event family.

## Product boundary

The current Product source still uses its existing helper and current routing key in this PR. The future single-current Product replacement must switch its event derivation to the schema-scoped helper in the same PR that changes its internal routing key. No Product v4/v5 compatibility source or dual query path is introduced.

## Main recheck

The branch starts from `main@d8620668b00eb829954d87af7260c81c2848ffe3` (#3193). Current `main` is unchanged at that commit.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.