### PR TITLE
fix(product): advance Index owner clock for EAV changes

### DIFF
--- a/crates/rustok-product/docs/index-locale-refresh-ledger.md
+++ b/crates/rustok-product/docs/index-locale-refresh-ledger.md
@@ -4,13 +4,14 @@ Status: `owner_source_complete_wire_and_consumer_pending`.
 
 ## Purpose
 
-Product lifecycle events existed before the generic Index mutation route and carry only a
-`product_id`. That payload cannot safely drive localized incremental ingestion because it does not
-identify removed locales or expose the trigger-owned Product `index_revision`.
+Product owner events existed before the generic Index mutation route and carry only a `product_id`.
+That payload cannot safely drive localized incremental ingestion because it does not identify removed
+locales or expose the trigger-owned Product `index_revision`.
 
-The Product module now retains one append-only owner row for every exact localized identity affected
-by a Product lifecycle command. The ledger is written in the same database transaction as the
-existing root event and Product mutation.
+The Product module retains one append-only owner row for every exact localized identity affected by a
+Product lifecycle command. Product EAV value commands now use the same Product locale-refresh boundary:
+the existing `ProductAttributeValuesChanged` event first advances the Product Index clock in the same
+transaction, then captures every current Product locale at that new owner version.
 
 This is an owner boundary, not an Index table. `rustok-product` still has no dependency on
 `rustok-index` and never creates `IndexMutation` values.
@@ -21,7 +22,7 @@ This is an owner boundary, not an Index table. `rustok-product` still has no dep
 
 - monotonic `sequence_no` for bounded tenant-local paging;
 - unique `refresh_id`, reserved as the future typed event and Index inbox identity;
-- `root_event_id`, the exact durable Product lifecycle envelope that caused the row;
+- `root_event_id`, the exact durable Product owner envelope that caused the row;
 - exact `tenant_id`, `product_id`, and `locale` identity;
 - positive `source_version` read from Product-owned live or tombstone storage;
 - owner timestamp for diagnostics only.
@@ -29,39 +30,67 @@ This is an owner boundary, not an Index table. `rustok-product` still has no dep
 The database rejects updates and deletes. A root event may produce several rows, but one exact
 `(root_event_id, product_id, locale)` may be recorded only once.
 
-## Transaction order
+## Product owner clock
 
-`ProductWriteTransaction::publish` performs the following steps:
+`products.index_revision` remains the single Product owner input watermark. No EAV-specific Index clock
+is added.
 
-1. classify whether the root event is `ProductCreated`, `ProductUpdated`, `ProductPublished`, or
-   `ProductDeleted`;
-2. write the existing root event through the transactional outbox and retain its envelope UUID;
-3. query exact Product locale state after all owner writes and trigger execution;
-4. insert bounded append-only refresh rows;
+Normal Product and translation writes already advance that revision through Product-owned triggers.
+Standalone EAV value commands previously changed `product_attribute_values`, localized value rows, or
+option memberships without updating `products`, so their final state could not be represented by a new
+Product source version.
+
+`ProductWriteTransaction::publish` now treats the existing `ProductAttributeValuesChanged` event as one
+Product-only clock boundary on PostgreSQL:
+
+1. before publishing the event, execute an exact tenant/Product `UPDATE products SET index_revision =
+   index_revision`;
+2. `trg_products_bump_index_revision` owns the actual `+1` and exhaustion guard;
+3. the canonical Product graph projection trigger observes that new Product source version;
+4. publish the existing ProductAttributeValuesChanged envelope in the same transaction;
+5. capture Product locale refresh rows at the final revision;
+6. do **not** fan the EAV command out to unchanged ProductVariant refresh rows.
+
+The touch statement changes only `index_revision`. Product-SalesChannel convergence listens to Product
+`metadata`, tenant, or identity changes, so an EAV-only command does not fabricate relation-convergence
+work.
+
+Non-PostgreSQL Product profiles keep their existing event behavior and do not claim the PostgreSQL Index
+clock/refresh guarantee.
+
+## Lifecycle transaction order
+
+For `ProductCreated`, `ProductUpdated`, `ProductPublished`, and `ProductDeleted`, the established
+transaction order remains:
+
+1. write the existing root event through the transactional outbox and retain its envelope UUID;
+2. query exact Product locale state after all owner writes and trigger execution;
+3. insert bounded append-only Product locale refresh rows;
+4. capture ProductVariant refresh rows for the same lifecycle/Product command;
 5. allow the caller to commit the Product transaction.
 
-A source query or ledger insert failure rolls back the Product mutation and root event. No refresh
-row can commit independently from its owner command.
+A clock update, source query, ledger insert, or outbox failure rolls back the entire owner transaction.
+No refresh row can commit independently from its owner command.
 
 ## Live and delete versions
 
-For a live translation, the row records the final positive `products.index_revision` after all
-Product and translation triggers have completed.
+For a live translation, the row records the final positive `products.index_revision` after all Product,
+translation, or EAV-command clock updates have completed.
 
 For a removed locale or hard-deleted Product, the row records the exact positive
-`product_index_tombstones.source_version`. Live identities suppress an older retained tombstone for
-the same locale.
+`product_index_tombstones.source_version`. Live identities suppress an older retained tombstone for the
+same locale.
 
-A later Product command may emit an older retained tombstone again. This is deliberate and safe:
-the future generic Index consumer will use a new delivery identity while source-version monotonicity
+A later Product command may emit an older retained tombstone again. This is deliberate and safe: the
+future generic Index consumer uses a distinct delivery identity while source-version monotonicity
 classifies the older state as stale.
 
 ## Bounded owner API
 
 `ProductIndexLocaleRefreshSource::list` exposes at most 256 rows for one exact tenant after one
-non-negative sequence cursor. It returns only identities, versions, causation, and sequence data.
-It does not return Product payload, execute an Index write, acknowledge a broker delivery, or mark
-ledger rows mutable/consumed.
+non-negative sequence cursor. It returns only identities, versions, causation, and sequence data. It
+does not return Product payload, execute an Index write, acknowledge a broker delivery, or mark ledger
+rows mutable/consumed.
 
 PostgreSQL is the authoritative production backend. Non-PostgreSQL Product test profiles keep their
 existing root-event behavior but do not claim an Index refresh ledger.
@@ -72,22 +101,25 @@ This slice does not:
 
 - add or change a `rustok-events` wire family or committed digest;
 - publish typed Product locale refresh events;
-- register the Product v2 mutation route;
+- add a parallel Product schema or compatibility route;
 - start a broker relay or consumer;
 - acknowledge deliveries or implement retry/DLQ policy;
-- cover ProductVariant refresh identities;
+- make Product EAV fields part of the current Index schema yet;
 - expose public HTTP, GraphQL, or admin transport;
 - alter the separate concrete-repair evidence gate.
 
-ProductVariant requires a separate owner slice because the current retained variant tombstone does
-not preserve its parent `product_id`, which is needed for product-scoped change enumeration.
+The purpose is narrower: make Product EAV state eligible for one future canonical Product Index payload
+by ensuring the existing Product source clock and owner refresh ledger advance atomically when EAV values
+change.
 
 ## Maintainer verification
 
 ```bash
+node scripts/verify/verify-index-product-eav-owner-clock.mjs
 node scripts/verify/verify-index-product-locale-refresh-ledger.mjs
 cargo check -p rustok-product --all-targets
 git diff --check
 ```
 
-No validation command or database scenario was executed by the implementation agent.
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
 use crate::{
-    error::CommerceResult,
+    error::{CommerceError, CommerceResult},
     services::index_refresh::{
-        product_locale_refresh_target, record_product_locale_refreshes_in_tx,
-        record_product_variant_refreshes_in_tx,
+        product_locale_refresh_target, product_variant_refresh_target,
+        record_product_locale_refreshes_in_tx, record_product_variant_refreshes_in_tx,
     },
 };
 use rustok_events::DomainEvent;
@@ -42,16 +42,21 @@ impl ProductWriteTransaction {
         actor_id: Option<Uuid>,
         event: DomainEvent,
     ) -> CommerceResult<()> {
-        let product_id = product_locale_refresh_target(&event);
+        if let Some(product_id) = product_index_revision_touch_target(&event) {
+            self.bump_product_index_revision(tenant_id, product_id)
+                .await?;
+        }
+
+        let product_locale_id = product_locale_refresh_target(&event);
+        let product_variant_id = product_variant_refresh_target(&event);
         let root_event_id = self
             .event_bus
             .publish_in_tx_with_envelope_id(&self.transaction, tenant_id, actor_id, event)
             .await?;
 
-        if let Some(product_id) = product_id {
-            // Capture the exact post-command Product and ProductVariant source state.
-            // Any source/ledger failure rolls back both the owner mutation and its event publication.
-            // The same atomic boundary includes both refresh ledgers.
+        if let Some(product_id) = product_locale_id {
+            // Capture the exact post-command Product source state. Any source/ledger failure rolls
+            // back both the owner mutation and its event publication.
             record_product_locale_refreshes_in_tx(
                 &self.transaction,
                 tenant_id,
@@ -59,6 +64,11 @@ impl ProductWriteTransaction {
                 root_event_id,
             )
             .await?;
+        }
+
+        if let Some(product_id) = product_variant_id {
+            // ProductVariant fan-out is limited to lifecycle/Product commands that can affect the
+            // variant graph. Product-only EAV changes must not re-emit every unchanged variant.
             record_product_variant_refreshes_in_tx(
                 &self.transaction,
                 tenant_id,
@@ -71,9 +81,45 @@ impl ProductWriteTransaction {
         Ok(())
     }
 
+    async fn bump_product_index_revision(
+        &self,
+        tenant_id: Uuid,
+        product_id: Uuid,
+    ) -> CommerceResult<()> {
+        if self.transaction.get_database_backend() != DbBackend::Postgres {
+            return Ok(());
+        }
+
+        // `trg_products_bump_index_revision` owns the actual +1 operation. Updating only the clock
+        // column avoids fabricating Product-SalesChannel convergence work because that trigger listens
+        // only to metadata/tenant/id changes. The update is in the same transaction as EAV writes,
+        // outbox publication, graph projection and refresh-ledger capture.
+        let result = self
+            .transaction
+            .execute(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                "UPDATE products SET index_revision = index_revision WHERE tenant_id = $1 AND id = $2",
+                vec![tenant_id.into(), product_id.into()],
+            ))
+            .await?;
+        if result.rows_affected() != 1 {
+            return Err(CommerceError::Validation(
+                "Product attribute Index revision target is missing".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) async fn commit(self) -> CommerceResult<()> {
         self.transaction.commit().await?;
         Ok(())
+    }
+}
+
+fn product_index_revision_touch_target(event: &DomainEvent) -> Option<Uuid> {
+    match event {
+        DomainEvent::ProductAttributeValuesChanged { product_id } => Some(*product_id),
+        _ => None,
     }
 }
 

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -3,8 +3,8 @@ use std::ops::Deref;
 use crate::{
     error::{CommerceError, CommerceResult},
     services::index_refresh::{
-        product_locale_refresh_target, product_variant_refresh_target,
-        record_product_locale_refreshes_in_tx, record_product_variant_refreshes_in_tx,
+        product_locale_refresh_target, record_product_locale_refreshes_in_tx,
+        record_product_variant_refreshes_in_tx,
     },
 };
 use rustok_events::DomainEvent;
@@ -42,13 +42,18 @@ impl ProductWriteTransaction {
         actor_id: Option<Uuid>,
         event: DomainEvent,
     ) -> CommerceResult<()> {
-        if let Some(product_id) = product_index_revision_touch_target(&event) {
+        let product_attribute_id = product_index_revision_touch_target(&event);
+        if let Some(product_id) = product_attribute_id {
             self.bump_product_index_revision(tenant_id, product_id)
                 .await?;
         }
 
-        let product_locale_id = product_locale_refresh_target(&event);
-        let product_variant_id = product_variant_refresh_target(&event);
+        // Existing lifecycle Product events keep their established Product + ProductVariant fan-out.
+        // ProductAttributeValuesChanged is Product-only: it advances the Product clock and locale
+        // refresh ledger but must not re-emit every unchanged ProductVariant.
+        let lifecycle_product_id = product_locale_refresh_target(&event);
+        let product_locale_id = lifecycle_product_id.or(product_attribute_id);
+        let product_variant_id = lifecycle_product_id;
         let root_event_id = self
             .event_bus
             .publish_in_tx_with_envelope_id(&self.transaction, tenant_id, actor_id, event)
@@ -67,8 +72,6 @@ impl ProductWriteTransaction {
         }
 
         if let Some(product_id) = product_variant_id {
-            // ProductVariant fan-out is limited to lifecycle/Product commands that can affect the
-            // variant graph. Product-only EAV changes must not re-emit every unchanged variant.
             record_product_variant_refreshes_in_tx(
                 &self.transaction,
                 tenant_id,

--- a/scripts/verify/verify-index-product-eav-owner-clock.mjs
+++ b/scripts/verify/verify-index-product-eav-owner-clock.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-eav-owner-clock] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const valuesPath = 'crates/rustok-product/src/services/catalog_schema_service/values.rs';
+requireMarkers(valuesPath, [
+  'pub async fn save_product_attribute_values(',
+  'pub async fn clear_detached_product_attribute_values(',
+  'DomainEvent::ProductAttributeValuesChanged { product_id }',
+]);
+
+const transactionPath = 'crates/rustok-product/src/services/write_transaction.rs';
+const transaction = requireMarkers(transactionPath, [
+  'let product_attribute_id = product_index_revision_touch_target(&event);',
+  'self.bump_product_index_revision(tenant_id, product_id)',
+  'let lifecycle_product_id = product_locale_refresh_target(&event);',
+  'let product_locale_id = lifecycle_product_id.or(product_attribute_id);',
+  'let product_variant_id = lifecycle_product_id;',
+  'DomainEvent::ProductAttributeValuesChanged { product_id } => Some(*product_id)',
+  'DbBackend::Postgres',
+  'UPDATE products SET index_revision = index_revision WHERE tenant_id = $1 AND id = $2',
+  'result.rows_affected() != 1',
+  'record_product_locale_refreshes_in_tx(',
+  'record_product_variant_refreshes_in_tx(',
+]);
+const bumpPosition = transaction.indexOf('self.bump_product_index_revision(tenant_id, product_id)');
+const publishPosition = transaction.indexOf('.publish_in_tx_with_envelope_id(');
+const localePosition = transaction.indexOf('record_product_locale_refreshes_in_tx(');
+if (bumpPosition < 0 || publishPosition <= bumpPosition || localePosition <= publishPosition) {
+  fail(`${transactionPath} must bump Product source state before publishing and capture locale refresh after the durable root event id`);
+}
+
+requireMarkers('crates/rustok-product/src/migrations/m20260730_000001_add_product_index_revision.rs', [
+  'CREATE TRIGGER trg_products_bump_index_revision',
+  'NEW.index_revision := OLD.index_revision + 1',
+  "RAISE EXCEPTION 'product index revision exhausted",
+]);
+requireMarkers('crates/rustok-product/src/migrations/m20260807_000010_canonicalize_product_index_graph_projection.rs', [
+  'CREATE TRIGGER trg_products_index_graph_projection_update',
+  'AFTER UPDATE OF index_revision ON products',
+  'rustok_product_reconcile_index_graph_projection',
+]);
+requireMarkers('crates/rustok-product/src/migrations/m20260807_000012_add_product_sales_channel_relation_convergence.rs', [
+  'CREATE TRIGGER trg_products_enqueue_channel_relation_convergence_update',
+  'AFTER UPDATE OF metadata, tenant_id, id ON products',
+]);
+
+requireMarkers('crates/rustok-product/docs/index-locale-refresh-ledger.md', [
+  'Product EAV value commands now use the same Product locale-refresh boundary',
+  '`ProductAttributeValuesChanged` event first advances the Product Index clock',
+  '`products.index_revision` remains the single Product owner input watermark',
+  'do **not** fan the EAV command out to unchanged ProductVariant refresh rows',
+  'does not fabricate relation-convergence work',
+  'make Product EAV fields part of the current Index schema yet',
+]);
+
+console.log('[verify-index-product-eav-owner-clock] Product EAV changes advance the canonical Product clock and Product-only refresh boundary');

--- a/scripts/verify/verify-index-product-locale-refresh-ledger.mjs
+++ b/scripts/verify/verify-index-product-locale-refresh-ledger.mjs
@@ -81,8 +81,13 @@ for (const forbidden of [
 const transactionPath = 'crates/rustok-product/src/services/write_transaction.rs';
 const transaction = requireMarkers(transactionPath, [
   'product_locale_refresh_target(&event)',
+  'product_index_revision_touch_target(&event)',
+  'DomainEvent::ProductAttributeValuesChanged { product_id } => Some(*product_id)',
+  'let product_locale_id = lifecycle_product_id.or(product_attribute_id);',
+  'let product_variant_id = lifecycle_product_id;',
   '.publish_in_tx_with_envelope_id(',
   'record_product_locale_refreshes_in_tx(',
+  'record_product_variant_refreshes_in_tx(',
   'root_event_id',
   'rolls back both the owner mutation and its event publication',
 ]);
@@ -111,13 +116,15 @@ if (cargo.includes('rustok-index')) {
 requireMarkers('crates/rustok-product/docs/index-locale-refresh-ledger.md', [
   'Status: `owner_source_complete_wire_and_consumer_pending`',
   '`refresh_id`, reserved as the future typed event and Index inbox identity',
-  '`root_event_id`, the exact durable Product lifecycle envelope',
+  '`root_event_id`, the exact durable Product owner envelope',
+  '`products.index_revision` remains the single Product owner input watermark',
+  '`ProductAttributeValuesChanged` event first advances the Product Index clock',
   'final positive `products.index_revision`',
   '`product_index_tombstones.source_version`',
   '`ProductIndexLocaleRefreshSource::list` exposes at most 256 rows',
   'does not add or change a `rustok-events` wire family',
-  'ProductVariant requires a separate owner slice',
-  'No validation command or database scenario was executed',
+  'does not fabricate relation-convergence work',
+  'No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI',
 ]);
 
 console.log('[verify-index-product-locale-refresh-ledger] Product locale owner ledger contract verified');

--- a/scripts/verify/verify-index-product-locale-refresh-ledger.mjs
+++ b/scripts/verify/verify-index-product-locale-refresh-ledger.mjs
@@ -89,7 +89,8 @@ const transaction = requireMarkers(transactionPath, [
   'record_product_locale_refreshes_in_tx(',
   'record_product_variant_refreshes_in_tx(',
   'root_event_id',
-  'rolls back both the owner mutation and its event publication',
+  'Any source/ledger failure rolls',
+  'back both the owner mutation and its event publication',
 ]);
 const publishPosition = transaction.indexOf('.publish_in_tx_with_envelope_id(');
 const recordPosition = transaction.indexOf('record_product_locale_refreshes_in_tx(');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -63,6 +63,7 @@ const scripts = [
   'verify-index-replay-dead-letter-admission.mjs',
   'verify-index-product-source.mjs',
   'verify-index-product-locale-refresh-ledger.mjs',
+  'verify-index-product-eav-owner-clock.mjs',
   'verify-index-product-variant-refresh-ledger.mjs',
   'verify-index-product-refresh-canonical-writer.mjs',
   'verify-index-product-refresh-relay-step.mjs',


### PR DESCRIPTION
## Summary

- make the existing `DomainEvent::ProductAttributeValuesChanged` advance the canonical Product owner `index_revision` exactly once per Product EAV command on PostgreSQL;
- perform the clock touch inside the same `ProductWriteTransaction` before durable outbox publication, so EAV state, Product revision, Product graph projection, root event and locale refresh ledger share one rollback boundary;
- rely on the existing `trg_products_bump_index_revision` for the actual `+1` and exhaustion guard rather than adding a second Product/EAV clock;
- capture Product locale refresh rows at the final bumped revision for EAV commands;
- keep existing lifecycle Product events on their established Product + ProductVariant refresh fan-out;
- keep EAV commands Product-only so unchanged ProductVariants are not re-emitted;
- touch only `index_revision`, so the Product-SalesChannel convergence trigger (`UPDATE OF metadata, tenant_id, id`) is not fabricated by EAV-only changes;
- add/actualize static guards and owner ledger documentation;
- make no Product Index schema/routing-key change yet and add no event contract, migration, Storefront traffic switch, or compatibility route.

## Root cause

Standalone Product EAV writes mutate `product_attribute_values`, localized value translations and option memberships and publish the already-existing `ProductAttributeValuesChanged` domain event, but they do not update `products`. The canonical Product Index source clock is derived from `products.index_revision` and then folded into the Product graph `projection_epoch`.

Without a Product revision transition, a future canonical Product payload containing EAV filter terms could change while retaining the same owner source version. That would be stale-by-design and unsafe for replay/readiness/cutover.

## Clock contract

For `ProductAttributeValuesChanged`, `ProductWriteTransaction::publish` now:

1. identifies the Product as an EAV clock target;
2. on PostgreSQL executes an exact tenant/Product `UPDATE products SET index_revision = index_revision`;
3. the existing Product BEFORE UPDATE trigger owns the real monotonic increment;
4. the existing graph projection trigger observes `UPDATE OF index_revision`;
5. the existing root domain event is published;
6. Product locale refresh rows are captured at the final owner revision;
7. ProductVariant refresh fan-out is intentionally skipped.

All steps are in the same transaction.

## Relation boundary

The touch statement changes only `index_revision`. Product-SalesChannel convergence is triggered only by Product `metadata`, tenant or identity updates, so EAV-only changes do not create relation convergence requests.

## Main recheck

The branch started from `main@0a49d7905f74c40fb8508241cf2a4243a88815a7` (#3194). Current `main@4cd4d13e322a4c91df397bf48125acf89b21424e` advanced only through Moderation/Forum operator recovery; compare shows no overlap with this Product/docs/verifier slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.