### PR TITLE
feat(index): define canonical Product attribute terms

### DIFF
--- a/crates/rustok-distribution/Cargo.toml
+++ b/crates/rustok-distribution/Cargo.toml
@@ -49,6 +49,9 @@ ai-translation = ["mod-ai", "mod-translation", "dep:rustok-ai-translation"]
 
 [dependencies]
 async-trait.workspace = true
+chrono.workspace = true
+hex.workspace = true
+rust_decimal.workspace = true
 sea-orm.workspace = true
 rustok-core.workspace = true
 rustok-api.workspace = true

--- a/crates/rustok-distribution/Cargo.toml
+++ b/crates/rustok-distribution/Cargo.toml
@@ -9,7 +9,7 @@ description = "Selected RusToK distribution module composition"
 default = []
 mod-cart = ["dep:rustok-cart"]
 mod-customer = ["dep:rustok-customer"]
-mod-product = ["dep:rustok-product", "mod-taxonomy"]
+mod-product = ["dep:rustok-product", "mod-taxonomy", "dep:chrono", "dep:hex", "dep:rust_decimal"]
 mod-profiles = ["dep:rustok-profiles", "mod-media", "mod-taxonomy"]
 mod-groups = ["dep:rustok-groups"]
 mod-region = ["dep:rustok-region"]
@@ -49,9 +49,9 @@ ai-translation = ["mod-ai", "mod-translation", "dep:rustok-ai-translation"]
 
 [dependencies]
 async-trait.workspace = true
-chrono.workspace = true
-hex.workspace = true
-rust_decimal.workspace = true
+chrono = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+rust_decimal = { workspace = true, optional = true }
 sea-orm.workspace = true
 rustok-core.workspace = true
 rustok-api.workspace = true

--- a/crates/rustok-distribution/src/product_index/attribute_terms.rs
+++ b/crates/rustok-distribution/src/product_index/attribute_terms.rs
@@ -359,7 +359,7 @@ mod tests {
     fn option_and_datetime_terms_use_stable_storage_identities() {
         let attribute_id = Uuid::from_u128(1);
         let option_id = Uuid::from_u128(2);
-        let timestamp = DateTime::from_timestamp_micros(1_725_000_123_456_789).unwrap();
+        let timestamp = DateTime::<Utc>::from_timestamp_micros(1_725_000_123_456_789).unwrap();
         assert!(
             option_term(attribute_id, option_id)
                 .unwrap()

--- a/crates/rustok-distribution/src/product_index/attribute_terms.rs
+++ b/crates/rustok-distribution/src/product_index/attribute_terms.rs
@@ -1,0 +1,386 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use rustok_index::{FieldName, FieldPath, FilterExpr, IndexValue, LocaleKey};
+use thiserror::Error;
+use uuid::Uuid;
+
+pub(crate) const PRODUCT_ATTRIBUTE_TERMS_FIELD: &str = "attribute_terms";
+
+/// PostgreSQL CTE fragment used by the replacement Product source to materialize every active,
+/// Product-scoped, filterable EAV value into the same canonical term grammar produced below in Rust.
+///
+/// The fragment is tenant-scoped by `$1` and intentionally aggregates terms by Product rather than by
+/// Product translation locale. Localized text terms carry their own canonical locale identity, so one
+/// localized Product record can express the exact requested-locale/fallback-locale predicate without a
+/// dynamic Index schema field per attribute code.
+pub(crate) const PRODUCT_ATTRIBUTE_TERMS_CTE: &str = r#"
+product_filterable_attribute_values AS (
+    SELECT
+        pav.id AS value_id,
+        pav.product_id,
+        pa.id AS attribute_id,
+        pa.value_type,
+        pa.is_localized,
+        pav.value_text,
+        pav.value_integer,
+        pav.value_decimal,
+        pav.value_boolean,
+        pav.value_date,
+        pav.value_datetime
+    FROM product_attribute_values pav
+    JOIN product_attributes pa
+      ON pa.id = pav.attribute_id
+     AND pa.tenant_id = pav.tenant_id
+    WHERE pav.tenant_id = $1
+      AND pav.detached_at IS NULL
+      AND pa.archived_at IS NULL
+      AND pa.is_filterable = TRUE
+      AND pa.scope IN ('product', 'both')
+),
+product_attribute_term_rows AS (
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|text||'
+            || encode(convert_to(value.value_text, 'UTF8'), 'hex') AS term
+    FROM product_filterable_attribute_values value
+    WHERE value.value_type IN ('text', 'textarea', 'richtext')
+      AND value.is_localized = FALSE
+      AND value.value_text IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|localized_text|'
+            || encode(convert_to(translation.locale, 'UTF8'), 'hex') || '|'
+            || encode(convert_to(translation.value_text, 'UTF8'), 'hex') AS term
+    FROM product_filterable_attribute_values value
+    JOIN product_attribute_value_translations translation
+      ON translation.value_id = value.value_id
+    WHERE value.value_type IN ('text', 'textarea', 'richtext')
+      AND value.is_localized = TRUE
+      AND translation.value_text IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|localized_present|'
+            || encode(convert_to(translation.locale, 'UTF8'), 'hex') || '|' AS term
+    FROM product_filterable_attribute_values value
+    JOIN product_attribute_value_translations translation
+      ON translation.value_id = value.value_id
+    WHERE value.value_type IN ('text', 'textarea', 'richtext')
+      AND value.is_localized = TRUE
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|integer||'
+            || encode(convert_to(value.value_integer::text, 'UTF8'), 'hex') AS term
+    FROM product_filterable_attribute_values value
+    WHERE value.value_type = 'integer'
+      AND value.value_integer IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|decimal||'
+            || encode(convert_to(trim_scale(value.value_decimal)::text, 'UTF8'), 'hex') AS term
+    FROM product_filterable_attribute_values value
+    WHERE value.value_type = 'decimal'
+      AND value.value_decimal IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|boolean||'
+            || encode(
+                convert_to(CASE WHEN value.value_boolean THEN 'true' ELSE 'false' END, 'UTF8'),
+                'hex'
+            ) AS term
+    FROM product_filterable_attribute_values value
+    WHERE value.value_type = 'boolean'
+      AND value.value_boolean IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|date||'
+            || encode(convert_to(value.value_date::text, 'UTF8'), 'hex') AS term
+    FROM product_filterable_attribute_values value
+    WHERE value.value_type = 'date'
+      AND value.value_date IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|datetime||'
+            || encode(
+                convert_to(
+                    ((extract(epoch FROM value.value_datetime) * 1000000)::bigint)::text,
+                    'UTF8'
+                ),
+                'hex'
+            ) AS term
+    FROM product_filterable_attribute_values value
+    WHERE value.value_type = 'datetime'
+      AND value.value_datetime IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        value.product_id,
+        value.attribute_id::text || '|option||'
+            || encode(convert_to(option_value.option_id::text, 'UTF8'), 'hex') AS term
+    FROM product_filterable_attribute_values value
+    JOIN product_attribute_value_options option_value
+      ON option_value.value_id = value.value_id
+     AND option_value.tenant_id = $1
+    WHERE value.value_type IN ('select', 'multiselect')
+),
+product_attribute_terms AS (
+    SELECT
+        product_id,
+        jsonb_agg(term ORDER BY term) AS attribute_terms
+    FROM (
+        SELECT DISTINCT product_id, term
+        FROM product_attribute_term_rows
+    ) canonical_term
+    GROUP BY product_id
+)
+"#;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum ProductAttributeTermError {
+    #[error("Product attribute term attribute id must not be nil")]
+    NilAttributeId,
+    #[error("Product attribute term option id must not be nil")]
+    NilOptionId,
+}
+
+pub(crate) fn text_term(
+    attribute_id: Uuid,
+    value: &str,
+) -> Result<String, ProductAttributeTermError> {
+    term(attribute_id, "text", None, value)
+}
+
+pub(crate) fn localized_text_term(
+    attribute_id: Uuid,
+    locale: &LocaleKey,
+    value: &str,
+) -> Result<String, ProductAttributeTermError> {
+    term(attribute_id, "localized_text", Some(locale), value)
+}
+
+pub(crate) fn localized_presence_term(
+    attribute_id: Uuid,
+    locale: &LocaleKey,
+) -> Result<String, ProductAttributeTermError> {
+    term(attribute_id, "localized_present", Some(locale), "")
+}
+
+pub(crate) fn integer_term(
+    attribute_id: Uuid,
+    value: i64,
+) -> Result<String, ProductAttributeTermError> {
+    term(attribute_id, "integer", None, value.to_string().as_str())
+}
+
+pub(crate) fn decimal_term(
+    attribute_id: Uuid,
+    value: Decimal,
+) -> Result<String, ProductAttributeTermError> {
+    term(
+        attribute_id,
+        "decimal",
+        None,
+        value.normalize().to_string().as_str(),
+    )
+}
+
+pub(crate) fn boolean_term(
+    attribute_id: Uuid,
+    value: bool,
+) -> Result<String, ProductAttributeTermError> {
+    term(
+        attribute_id,
+        "boolean",
+        None,
+        if value { "true" } else { "false" },
+    )
+}
+
+pub(crate) fn date_term(
+    attribute_id: Uuid,
+    value: NaiveDate,
+) -> Result<String, ProductAttributeTermError> {
+    term(
+        attribute_id,
+        "date",
+        None,
+        value.format("%Y-%m-%d").to_string().as_str(),
+    )
+}
+
+pub(crate) fn datetime_term(
+    attribute_id: Uuid,
+    value: DateTime<Utc>,
+) -> Result<String, ProductAttributeTermError> {
+    term(
+        attribute_id,
+        "datetime",
+        None,
+        value.timestamp_micros().to_string().as_str(),
+    )
+}
+
+pub(crate) fn option_term(
+    attribute_id: Uuid,
+    option_id: Uuid,
+) -> Result<String, ProductAttributeTermError> {
+    if option_id.is_nil() {
+        return Err(ProductAttributeTermError::NilOptionId);
+    }
+    term(attribute_id, "option", None, option_id.to_string().as_str())
+}
+
+pub(crate) fn contains_term_filter(term: String) -> FilterExpr {
+    FilterExpr::Contains(attribute_terms_path(), IndexValue::String(term))
+}
+
+/// Reproduces the owner localized-text predicate exactly:
+///
+/// requested-value OR (requested-locale-absent AND fallback-value).
+pub(crate) fn localized_text_filter(
+    attribute_id: Uuid,
+    requested_locale: &LocaleKey,
+    fallback_locale: &LocaleKey,
+    value: &str,
+) -> Result<FilterExpr, ProductAttributeTermError> {
+    let requested = contains_term_filter(localized_text_term(
+        attribute_id,
+        requested_locale,
+        value,
+    )?);
+    if requested_locale == fallback_locale {
+        return Ok(requested);
+    }
+
+    let requested_present = contains_term_filter(localized_presence_term(
+        attribute_id,
+        requested_locale,
+    )?);
+    let fallback = contains_term_filter(localized_text_term(
+        attribute_id,
+        fallback_locale,
+        value,
+    )?);
+    Ok(FilterExpr::Or(vec![
+        requested,
+        FilterExpr::And(vec![FilterExpr::Not(Box::new(requested_present)), fallback]),
+    ]))
+}
+
+fn attribute_terms_path() -> FieldPath {
+    FieldPath::new(
+        FieldName::new(PRODUCT_ATTRIBUTE_TERMS_FIELD)
+            .expect("static Product attribute term field name must be valid"),
+    )
+}
+
+fn term(
+    attribute_id: Uuid,
+    kind: &str,
+    locale: Option<&LocaleKey>,
+    value: &str,
+) -> Result<String, ProductAttributeTermError> {
+    if attribute_id.is_nil() {
+        return Err(ProductAttributeTermError::NilAttributeId);
+    }
+    let locale = locale
+        .map(|locale| hex::encode(locale.as_str().as_bytes()))
+        .unwrap_or_default();
+    Ok(format!(
+        "{}|{}|{}|{}",
+        attribute_id,
+        kind,
+        locale,
+        hex::encode(value.as_bytes())
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_terms_are_collision_safe_and_normalized() {
+        let attribute_id = Uuid::from_u128(1);
+        assert_eq!(
+            text_term(attribute_id, "A|b").unwrap(),
+            "00000000-0000-0000-0000-000000000001|text||417c62"
+        );
+        assert_eq!(
+            decimal_term(attribute_id, Decimal::new(12_300, 3)).unwrap(),
+            "00000000-0000-0000-0000-000000000001|decimal||31322e33"
+        );
+        assert_eq!(
+            boolean_term(attribute_id, true).unwrap(),
+            "00000000-0000-0000-0000-000000000001|boolean||74727565"
+        );
+    }
+
+    #[test]
+    fn localized_filter_preserves_requested_presence_fallback_semantics() {
+        let attribute_id = Uuid::from_u128(1);
+        let requested = LocaleKey::new("de-DE").unwrap();
+        let fallback = LocaleKey::new("en-US").unwrap();
+        let filter = localized_text_filter(attribute_id, &requested, &fallback, "Red").unwrap();
+        let FilterExpr::Or(branches) = filter else {
+            panic!("localized fallback must be an OR expression");
+        };
+        assert_eq!(branches.len(), 2);
+        let FilterExpr::And(fallback_branch) = &branches[1] else {
+            panic!("fallback branch must combine absence and fallback value");
+        };
+        assert_eq!(fallback_branch.len(), 2);
+        assert!(matches!(fallback_branch[0], FilterExpr::Not(_)));
+        assert!(matches!(fallback_branch[1], FilterExpr::Contains(_, _)));
+    }
+
+    #[test]
+    fn option_and_datetime_terms_use_stable_storage_identities() {
+        let attribute_id = Uuid::from_u128(1);
+        let option_id = Uuid::from_u128(2);
+        let timestamp = DateTime::from_timestamp_micros(1_725_000_123_456_789).unwrap();
+        assert!(
+            option_term(attribute_id, option_id)
+                .unwrap()
+                .ends_with("|option||30303030303030302d303030302d303030302d303030302d303030303030303030303032")
+        );
+        assert!(
+            datetime_term(attribute_id, timestamp)
+                .unwrap()
+                .ends_with("|datetime||31373235303030313233343536373839")
+        );
+    }
+
+    #[test]
+    fn nil_storage_identities_fail_closed() {
+        assert_eq!(
+            text_term(Uuid::nil(), "x"),
+            Err(ProductAttributeTermError::NilAttributeId)
+        );
+        assert_eq!(
+            option_term(Uuid::from_u128(1), Uuid::nil()),
+            Err(ProductAttributeTermError::NilOptionId)
+        );
+    }
+}

--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -1,4 +1,5 @@
 mod absence;
+mod attribute_terms;
 mod channel_relation_convergence;
 pub(crate) mod channel_relation_resolver;
 mod channel_visibility;

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -9,8 +9,8 @@ This directory contains the detailed technical architecture documentation for `r
 | Indexing Approach | Write Overhead | Cross-Module Filtering | Zero N+1 Queries | Consistency Model | Infrastructure Complexity |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Traditional SQL JOINs** | Low | Slow (Multi-table JOIN bottlenecks) | No (N+1 HTTP calls across microservices) | Immediate | Single DB |
-| **EAV Tables (Magento / Legacy CMS)** | High DDL & Row Bloat | Complex self-JOINs & lock contention | No (N+1 HTTP calls across microservices) | Immediate | Single DB |
-| **External Search Sync (Elasticsearch / Algolia)** | High DDL & Row Bloat | Fast | Yes | Eventual (Lag & drift risks) | Heavy JVM/Cloud cluster |
+| **EAV Tables (Magento / Legacy CMS)** | High DDL & Row Bloat | Complex self-JOINs & lock contention | Immediate | High |
+| **External Search Sync (Elasticsearch / Algolia)** | High | Fast | Yes | Eventual (lag & drift risks) | Heavy JVM/Cloud cluster |
 | **`rustok-index` (JSONB + Keyset Engine)** | **Low (Transactional Outbox Inbox)** | **Ultra-Fast (Derived B-Tree / GIN Indexes)** | **Yes (Single REPEATABLE READ query)** | **Immediate (Transactional Outbox)** | **Pure Rust + PostgreSQL (Zero external dependencies)** |
 
 ---
@@ -80,6 +80,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M7 Product-SalesChannel Freshness Witness](../../rustok-product/docs/index-sales-channel-relation-freshness.md)
 - [M7 Product-SalesChannel Cross-owner Resolver](./m7-product-sales-channel-resolver.md)
 - [M7 Product Graph Projection Ledger](../../rustok-product/docs/index-graph-projection-ledger.md)
+- [M7 Product Attribute Term Contract](./m7-product-attribute-term-contract.md)
 - [M7 Product Storefront Index Parity Gate](./m7-product-storefront-parity-gate.md)
 - [M4 Source-owned Schema Registry](./m4-source-schema-registry.md)
 - [M4 Single-current Schema Supersession](./m4-single-current-schema-supersession.md)

--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -9,8 +9,8 @@ This directory contains the detailed technical architecture documentation for `r
 | Indexing Approach | Write Overhead | Cross-Module Filtering | Zero N+1 Queries | Consistency Model | Infrastructure Complexity |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Traditional SQL JOINs** | Low | Slow (Multi-table JOIN bottlenecks) | No (N+1 HTTP calls across microservices) | Immediate | Single DB |
-| **EAV Tables (Magento / Legacy CMS)** | High DDL & Row Bloat | Complex self-JOINs & lock contention | Immediate | High |
-| **External Search Sync (Elasticsearch / Algolia)** | High | Fast | Yes | Eventual (lag & drift risks) | Heavy JVM/Cloud cluster |
+| **EAV Tables (Magento / Legacy CMS)** | High DDL & Row Bloat | Complex self-JOINs & lock contention | No (N+1 HTTP calls across microservices) | Immediate | Single DB |
+| **External Search Sync (Elasticsearch / Algolia)** | High DDL & Row Bloat | Fast | Yes | Eventual (Lag & drift risks) | Heavy JVM/Cloud cluster |
 | **`rustok-index` (JSONB + Keyset Engine)** | **Low (Transactional Outbox Inbox)** | **Ultra-Fast (Derived B-Tree / GIN Indexes)** | **Yes (Single REPEATABLE READ query)** | **Immediate (Transactional Outbox)** | **Pure Rust + PostgreSQL (Zero external dependencies)** |
 
 ---

--- a/crates/rustok-index/docs/m7-product-attribute-term-contract.md
+++ b/crates/rustok-index/docs/m7-product-attribute-term-contract.md
@@ -1,0 +1,166 @@
+# M7 Product attribute term contract
+
+Status: `source_complete_materialization_pending`.
+
+## Purpose
+
+Product Storefront accepts dynamic typed EAV filters by attribute `code`, but Index schemas are immutable
+and static. Adding one Index field per Product attribute would turn tenant data into runtime schema drift
+and would require a new schema fingerprint whenever an attribute is added, renamed, archived, or made
+filterable.
+
+The canonical representation is therefore one static Product field:
+
+`attribute_terms: Many<String>`
+
+The field is filterable and is intended to be non-sortable. Attribute definitions remain Product-owned;
+a future Storefront Index adapter resolves the public `code=value` request to an exact Product attribute
+UUID/type and builds one or more `Contains(attribute_terms, term)` predicates.
+
+This contract introduces no dynamic Index field and no versioned compatibility family.
+
+## Term grammar
+
+Each term has exactly four pipe-separated components:
+
+`<attribute_uuid>|<kind>|<locale_hex>|<value_hex>`
+
+There is deliberately no format-version prefix. The current code owns exactly one grammar.
+
+- `attribute_uuid` is the canonical lower-case UUID of `product_attributes.id`;
+- `kind` is one of the fixed semantic kinds below;
+- `locale_hex` is lower-case hexadecimal UTF-8 for a canonical locale, or empty for non-localized
+  values;
+- `value_hex` is lower-case hexadecimal UTF-8 for the canonical typed value, or empty for a locale
+  presence marker.
+
+Hex encoding makes the delimiter collision-free while preserving exact owner text bytes.
+
+## Canonical kinds
+
+The current grammar uses:
+
+- `text` for non-localized text/textarea/richtext equality;
+- `localized_text` for one localized text value;
+- `localized_present` for the existence of a localized value row, regardless of whether its
+  `value_text` is null;
+- `integer` for base-10 signed i64;
+- `decimal` for normalized decimal text with insignificant trailing scale removed;
+- `boolean` for `true` or `false`;
+- `date` for `YYYY-MM-DD`;
+- `datetime` for UTC Unix epoch microseconds;
+- `option` for canonical option UUID text used by select/multiselect.
+
+`json` attributes are intentionally absent because the owner Storefront contract rejects JSON
+`attribute_filters`.
+
+## Stable identity choices
+
+Terms use `product_attributes.id`, not the mutable public attribute code. A code rename therefore does
+not force Product rematerialization merely to rewrite every term; the Storefront adapter resolves the
+current code to the stable UUID before querying Index.
+
+Select/multiselect terms use `product_attribute_options.id`, not option code. The current owner contract
+accepts a raw option UUID directly. When a public request supplies an option code, the future adapter
+must resolve only a non-archived option code to its UUID before constructing the same term.
+
+Product tag names are not represented by this EAV grammar. The replacement Product schema will retain
+stable taxonomy term UUIDs and localize their names through the Taxonomy owner boundary rather than
+copying Taxonomy translations into the Product clock.
+
+## Localized text fallback equivalence
+
+The owner predicate for localized text is:
+
+1. requested-locale row exists with the requested value; or
+2. **no requested-locale row exists at all**, and fallback-locale row exists with the requested value.
+
+The second condition cannot be represented by value terms alone. Therefore source materialization emits
+both:
+
+- `localized_text` for non-null translation values;
+- `localized_present` for every translation row, including rows whose value text is null.
+
+The Index filter is exactly:
+
+- if requested locale equals fallback locale: requested `localized_text` term;
+- otherwise: `requested-value OR (NOT requested-present AND fallback-value)`.
+
+`attribute_terms.rs::localized_text_filter` builds that `FilterExpr` shape directly.
+
+## PostgreSQL source equivalence
+
+`PRODUCT_ATTRIBUTE_TERMS_CTE` is the canonical set-based source fragment. It reads only:
+
+- non-detached `product_attribute_values`;
+- non-archived `product_attributes`;
+- `is_filterable = TRUE`;
+- Product or both scope;
+- localized value translations where applicable;
+- option memberships for select/multiselect.
+
+Those predicates match the owner catalog filter admission boundary.
+
+The CTE normalizes scalar values to the same bytes as the Rust term helpers and emits a sorted,
+deduplicated JSONB term array per Product. It is tenant-scoped by the Product source `$1` parameter and
+does not join through Product translation locale.
+
+Localized EAV terms intentionally carry all available locales in every localized Product Index record;
+that is what allows requested/fallback EAV filtering to remain exact even when Product translation
+fallback is resolved separately.
+
+## Owner clock boundary
+
+PR #3197 made the existing `ProductAttributeValuesChanged` command advance the canonical Product
+`index_revision` and locale refresh ledger in the same transaction. Therefore materializing these terms
+does not require an EAV-specific clock.
+
+Product graph mutation ordering remains `projection_epoch`; the Product owner component remains
+`products.index_revision`.
+
+## Replacement schema use
+
+The next single-current Product replacement may add `attribute_terms` exactly once alongside the other
+Storefront parity fields. Because the existing Product schema fingerprint is immutable, that replacement
+must:
+
+1. use one monotonically higher internal Product routing key;
+2. publish only that replacement Product schema in new runtime code;
+3. switch Product deterministic replay delivery IDs to `derive_index_schema_source_event_id`;
+4. materialize `PRODUCT_ATTRIBUTE_TERMS_CTE` into the Product record;
+5. stage/rebuild the new key through ordinary schema registration;
+6. prove readiness/parity/freshness/restart evidence;
+7. promote it through `register_current` so lower persisted Product keys become retired;
+8. keep Storefront owner-native until retained owner-vs-Index equivalence is admitted.
+
+The numeric key is an internal storage/replay identity, not a public Product API version or a parallel
+compatibility implementation.
+
+## Deliberate limits
+
+This slice does not:
+
+- change the current Product schema or numeric routing key;
+- write `attribute_terms` into Index rows yet;
+- switch Storefront traffic;
+- add public event contracts;
+- execute schema registration/rebuild/supersession;
+- copy localized taxonomy tag names into Product Index;
+- claim PostgreSQL execution evidence.
+
+## Maintainer verification
+
+Suggested commands, intentionally not run by the implementation agent:
+
+```bash
+cargo test -p rustok-distribution --features mod-product attribute_terms --lib -- --nocapture
+node scripts/verify/verify-index-product-attribute-term-contract.mjs
+node scripts/verify/verify-index-product-eav-owner-clock.mjs
+node scripts/verify/verify-index-product-storefront-parity-gate.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-attribute-term-contract.mjs
+++ b/scripts/verify/verify-index-product-attribute-term-contract.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-attribute-term-contract] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const modulePath = 'crates/rustok-distribution/src/product_index/attribute_terms.rs';
+const source = requireMarkers(modulePath, [
+  'pub(crate) const PRODUCT_ATTRIBUTE_TERMS_FIELD: &str = "attribute_terms";',
+  'pub(crate) const PRODUCT_ATTRIBUTE_TERMS_CTE: &str',
+  "pa.archived_at IS NULL",
+  'pa.is_filterable = TRUE',
+  "pa.scope IN ('product', 'both')",
+  'pav.detached_at IS NULL',
+  "value.value_type IN ('text', 'textarea', 'richtext')",
+  "value.attribute_id::text || '|text||'",
+  "value.attribute_id::text || '|localized_text|'",
+  "value.attribute_id::text || '|localized_present|'",
+  "value.attribute_id::text || '|integer||'",
+  "value.attribute_id::text || '|decimal||'",
+  'trim_scale(value.value_decimal)::text',
+  "value.attribute_id::text || '|boolean||'",
+  "value.attribute_id::text || '|date||'",
+  "value.attribute_id::text || '|datetime||'",
+  'extract(epoch FROM value.value_datetime) * 1000000',
+  "value.attribute_id::text || '|option||'",
+  'product_attribute_value_options option_value',
+  'SELECT DISTINCT product_id, term',
+  'jsonb_agg(term ORDER BY term)',
+  'hex::encode(locale.as_str().as_bytes())',
+  'hex::encode(value.as_bytes())',
+  'value.normalize().to_string()',
+  'value.timestamp_micros().to_string()',
+  'pub(crate) fn localized_text_filter(',
+  'FilterExpr::Or(vec![',
+  'FilterExpr::Not(Box::new(requested_present))',
+]);
+if (source.includes('attribute code')) {
+  fail(`${modulePath} must key persisted terms by stable attribute UUID rather than mutable public code`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod attribute_terms;',
+]);
+requireMarkers('crates/rustok-distribution/Cargo.toml', [
+  'chrono.workspace = true',
+  'hex.workspace = true',
+  'rust_decimal.workspace = true',
+]);
+
+requireMarkers('crates/rustok-product/src/services/catalog/attribute_filters.rs', [
+  'AND archived_at IS NULL',
+  'AND is_filterable = TRUE',
+  "AND scope IN ('product', 'both')",
+  'AND pav.detached_at IS NULL',
+  'AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext',
+  'AttributeValueType::Integer',
+  'AttributeValueType::Decimal',
+  'AttributeValueType::Boolean',
+  'AttributeValueType::Date',
+  'AttributeValueType::Datetime',
+  'AttributeValueType::Select | AttributeValueType::Multiselect',
+  'AttributeValueType::Json',
+  'NOT EXISTS (',
+  'requested_any',
+  'pao.archived_at IS NULL',
+]);
+
+requireMarkers('crates/rustok-product/src/services/write_transaction.rs', [
+  'DomainEvent::ProductAttributeValuesChanged { product_id } => Some(*product_id)',
+  'UPDATE products SET index_revision = index_revision',
+]);
+
+const productSourcePath = 'crates/rustok-distribution/src/product_index/product.rs';
+const productSource = read(productSourcePath);
+if (productSource.includes('many_field("attribute_terms"')) {
+  fail(`${productSourcePath} already materializes attribute_terms; update this source-complete/materialization-pending gate in the same replacement PR`);
+}
+
+requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
+  'Status: `source_complete_materialization_pending`',
+  '`attribute_terms: Many<String>`',
+  '`<attribute_uuid>|<kind>|<locale_hex>|<value_hex>`',
+  'There is deliberately no format-version prefix.',
+  '`localized_present`',
+  '`requested-value OR (NOT requested-present AND fallback-value)`',
+  '`derive_index_schema_source_event_id`',
+  'use one monotonically higher internal Product routing key',
+  'numeric key is an internal storage/replay identity',
+]);
+
+console.log('[verify-index-product-attribute-term-contract] canonical Product typed EAV term contract is source complete and materialization pending');

--- a/scripts/verify/verify-index-product-attribute-term-contract.mjs
+++ b/scripts/verify/verify-index-product-attribute-term-contract.mjs
@@ -49,7 +49,7 @@ const source = requireMarkers(modulePath, [
   'FilterExpr::Or(vec![',
   'FilterExpr::Not(Box::new(requested_present))',
 ]);
-if (source.includes('attribute code')) {
+if (source.includes('pa.code ||') || source.includes('pa.code::text ||')) {
   fail(`${modulePath} must key persisted terms by stable attribute UUID rather than mutable public code`);
 }
 

--- a/scripts/verify/verify-index-product-attribute-term-contract.mjs
+++ b/scripts/verify/verify-index-product-attribute-term-contract.mjs
@@ -57,9 +57,10 @@ requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'mod attribute_terms;',
 ]);
 requireMarkers('crates/rustok-distribution/Cargo.toml', [
-  'chrono.workspace = true',
-  'hex.workspace = true',
-  'rust_decimal.workspace = true',
+  'mod-product = ["dep:rustok-product", "mod-taxonomy", "dep:chrono", "dep:hex", "dep:rust_decimal"]',
+  'chrono = { workspace = true, optional = true }',
+  'hex = { workspace = true, optional = true }',
+  'rust_decimal = { workspace = true, optional = true }',
 ]);
 
 requireMarkers('crates/rustok-product/src/services/catalog/attribute_filters.rs', [

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -64,6 +64,7 @@ const scripts = [
   'verify-index-product-source.mjs',
   'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-eav-owner-clock.mjs',
+  'verify-index-product-attribute-term-contract.mjs',
   'verify-index-product-variant-refresh-ledger.mjs',
   'verify-index-product-refresh-canonical-writer.mjs',
   'verify-index-product-refresh-relay-step.mjs',


### PR DESCRIPTION
## Summary

- define one static canonical `attribute_terms: Many<String>` representation for dynamic Product Storefront EAV filters without creating one Index field per attribute code;
- add collision-safe term grammar `<attribute_uuid>|<kind>|<locale_hex>|<value_hex>` with no format-version prefix or compatibility family;
- key terms by stable Product attribute UUID, not mutable public code;
- normalize integer, decimal, boolean, date, datetime and option identities consistently between Rust query construction and PostgreSQL source materialization;
- represent localized text with both `localized_text` and `localized_present` terms so the owner predicate `requested value OR (requested locale absent AND fallback value)` is expressible exactly;
- provide `localized_text_filter` that builds the corresponding generic Index `FilterExpr` using `Contains` over the one many-string field;
- add `PRODUCT_ATTRIBUTE_TERMS_CTE`, a tenant-scoped set-based PostgreSQL source fragment matching owner admission: non-detached values, non-archived filterable Product/both attributes, translations and option memberships;
- intentionally omit JSON because the current owner Storefront rejects JSON attribute filters;
- keep Product schema/routing key unchanged in this PR; materialization happens in the subsequent single-current Product replacement;
- scope chrono/hex/rust_decimal dependencies to `mod-product` only;
- add architecture docs and static guards wired into the aggregate Index contract.

## Why this representation

Storefront attribute definitions are dynamic tenant data. Encoding each attribute code as an Index schema field would make ordinary catalog configuration mutate the immutable Index schema fingerprint. This contract keeps the schema static while preserving typed equality and localized fallback semantics.

Attribute and option UUIDs are stable storage identities. A future Storefront Index adapter resolves public attribute/option codes through Product owner metadata, then builds the same canonical terms. Product tag names remain Taxonomy-owned and are not copied into this Product EAV clock.

## Owner clock

PR #3197 already makes the existing `ProductAttributeValuesChanged` command advance Product `index_revision`, graph `projection_epoch`, and Product locale refresh state atomically. No EAV-specific clock is introduced here.

## Next replacement boundary

The next Product replacement PR can now add `attribute_terms` together with Storefront scalar fields using one monotonically higher internal routing key, switch deterministic Product replay delivery IDs to `derive_index_schema_source_event_id`, stage/rebuild the new key, and later promote it through `register_current`. New runtime code will publish only the replacement Product contract; the old key remains historical storage, not a compatibility implementation.

## Main recheck

The branch starts from current `main@6e16861634e329f5fc29bd4503fc04eed598d2f9`. No newer main commit is present at PR creation.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.