### PR TITLE
feat(index): replace Product with one Storefront-capable contract

### DIFF
--- a/crates/rustok-distribution/src/product_index/absence.rs
+++ b/crates/rustok-distribution/src/product_index/absence.rs
@@ -8,7 +8,7 @@ use rustok_index::{
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
 use serde_json::Value as JsonValue;
 
-use super::channel_visibility::decode_product_visibility;
+use super::{PRODUCT_SCHEMA_ROUTING_KEY, channel_visibility::decode_product_visibility};
 
 pub(crate) const PRODUCT_ABSENCE_WATERMARK_FACTORY: &str =
     "product-locale-absence-watermark";
@@ -220,9 +220,7 @@ fn product_schema_ref() -> Result<SchemaRef, String> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product").map_err(|error| error.to_string())?,
         entity: EntityName::new("product").map_err(|error| error.to_string())?,
-        // Index core requires a positive schema key. Only this current Product contract is
-        // registered; this number is not a compatibility branch.
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY),
     })
 }
 

--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -15,6 +15,12 @@ mod variant;
 #[cfg(test)]
 pub(crate) use variant::PRODUCT_VARIANT_INDEX_SOURCE;
 
+/// Internal persisted routing key for the one Product schema published by current runtime code.
+///
+/// Lower keys are historical storage identities only. They are never selected as compatibility
+/// implementations by this module.
+pub(crate) const PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4;
+
 pub(crate) fn register(
     extensions: &mut rustok_core::ModuleRuntimeExtensions,
 ) -> rustok_core::Result<()> {

--- a/crates/rustok-distribution/src/product_index/product.rs
+++ b/crates/rustok-distribution/src/product_index/product.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use rustok_core::ModuleRuntimeExtensions;
 use rustok_index::{
     DomainError, EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexLink,
@@ -8,7 +9,7 @@ use rustok_index::{
     IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
     IndexSourceScanRequest, IndexValue, IndexValueType, LinkCardinality, LinkName, LinkedEntityKey,
     LocaleKey, LocaleMode, ModuleName, PostgresIndexSourceFactory, SchemaRef, SchemaVersion,
-    derive_index_source_event_id, register_index_schema_source, register_index_source,
+    derive_index_schema_source_event_id, register_index_schema_source, register_index_source,
     register_postgres_index_source_factory,
 };
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, Value};
@@ -17,13 +18,25 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use uuid::Uuid;
 
-use super::channel_visibility::decode_product_visibility;
+use super::{
+    PRODUCT_SCHEMA_ROUTING_KEY,
+    attribute_terms::PRODUCT_ATTRIBUTE_TERMS_CTE,
+    channel_visibility::decode_product_visibility,
+};
 
 pub(crate) const PRODUCT_INDEX_SOURCE: &str = "product-postgres-primary";
 const PRODUCT_EVENT_DOMAIN: &str = "rustok-product.product-replay";
 const PRODUCT_RELATION_FRESHNESS_PENDING_CODE: &str = "product_index_relation_freshness_pending";
 
 const PRODUCT_ROWS_CTE: &str = r#"
+product_tag_ids AS (
+    SELECT
+        product_tag.product_id,
+        jsonb_agg(product_tag.term_id ORDER BY product_tag.term_id) AS tag_ids
+    FROM product_tags product_tag
+    WHERE product_tag.tenant_id = $1
+    GROUP BY product_tag.product_id
+),
 channel_identity_generation AS (
     SELECT COALESCE(
         (
@@ -82,13 +95,18 @@ product_index_union AS (
         projection.current_channel_identity_generation,
         p.metadata,
         p.status::text AS status,
+        p.seller_id,
         p.vendor,
         p.product_type,
         p.primary_category_id,
+        p.created_at,
+        p.published_at,
         t.locale,
         t.title,
         t.handle,
         t.description,
+        COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids,
+        COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms,
         COALESCE(
             (
                 SELECT jsonb_agg(v.id ORDER BY v.id)
@@ -106,6 +124,10 @@ product_index_union AS (
     LEFT JOIN product_graph_projection projection
       ON projection.tenant_id = p.tenant_id
      AND projection.product_id = p.id
+    LEFT JOIN product_tag_ids tags
+      ON tags.product_id = p.id
+    LEFT JOIN product_attribute_terms attributes
+      ON attributes.product_id = p.id
     WHERE p.tenant_id = $1
 
     UNION ALL
@@ -124,13 +146,18 @@ product_index_union AS (
         projection.current_channel_identity_generation,
         NULL::jsonb AS metadata,
         NULL::text AS status,
+        NULL::text AS seller_id,
         NULL::text AS vendor,
         NULL::text AS product_type,
         NULL::uuid AS primary_category_id,
+        NULL::timestamptz AS created_at,
+        NULL::timestamptz AS published_at,
         tombstone.locale,
         NULL::text AS title,
         NULL::text AS handle,
         NULL::text AS description,
+        '[]'::jsonb AS tag_ids,
+        '[]'::jsonb AS attribute_terms,
         '[]'::jsonb AS variant_ids,
         projection.channel_ids AS sales_channel_ids
     FROM product_index_tombstones tombstone
@@ -165,13 +192,18 @@ SELECT
     row.current_channel_identity_generation,
     row.metadata,
     row.status,
+    row.seller_id,
     row.vendor,
     row.product_type,
     row.primary_category_id,
+    row.created_at,
+    row.published_at,
     row.locale,
     row.title,
     row.handle,
     row.description,
+    row.tag_ids,
+    row.attribute_terms,
     row.variant_ids,
     row.sales_channel_ids
 FROM product_index_rows row
@@ -227,6 +259,7 @@ fn product_schema() -> Result<IndexSchema, ProductIndexBridgeError> {
             scalar_field("title", IndexValueType::String, false, true, true)?,
             scalar_field("handle", IndexValueType::String, false, true, true)?,
             scalar_field("description", IndexValueType::String, true, false, false)?,
+            scalar_field("seller_id", IndexValueType::String, true, false, false)?,
             scalar_field("vendor", IndexValueType::String, true, true, true)?,
             scalar_field("product_type", IndexValueType::String, true, true, true)?,
             scalar_field(
@@ -236,8 +269,12 @@ fn product_schema() -> Result<IndexSchema, ProductIndexBridgeError> {
                 true,
                 false,
             )?,
-            many_field("variant_ids", IndexValueType::Uuid, true)?,
-            many_field("sales_channel_ids", IndexValueType::Uuid, true)?,
+            many_field("tag_ids", IndexValueType::Uuid, true, false)?,
+            scalar_field("created_at", IndexValueType::Timestamp, false, false, true)?,
+            scalar_field("published_at", IndexValueType::Timestamp, true, true, true)?,
+            many_field("attribute_terms", IndexValueType::String, false, true)?,
+            many_field("variant_ids", IndexValueType::Uuid, true, true)?,
+            many_field("sales_channel_ids", IndexValueType::Uuid, true, true)?,
         ],
         links: vec![
             IndexLink {
@@ -271,7 +308,7 @@ fn product_schema_ref() -> Result<SchemaRef, ProductIndexBridgeError> {
             .map_err(ProductIndexBridgeError::InvalidContract)?,
         entity: EntityName::new("product")
             .map_err(ProductIndexBridgeError::InvalidContract)?,
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY),
     })
 }
 
@@ -316,6 +353,7 @@ fn scalar_field(
 fn many_field(
     name: &str,
     value_type: IndexValueType,
+    selectable: bool,
     filterable: bool,
 ) -> Result<IndexField, ProductIndexBridgeError> {
     Ok(IndexField {
@@ -323,7 +361,7 @@ fn many_field(
         value_type,
         cardinality: FieldCardinality::Many,
         nullable: false,
-        selectable: true,
+        selectable,
         filterable,
         sortable: false,
     })
@@ -373,7 +411,7 @@ impl ProductPostgresIndexSource {
         let (sql, values): (String, Vec<Value>) = match cursor {
             Some(cursor) => (
                 format!(
-                    "WITH {PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nWHERE (row.product_id, row.locale) > ($2, $3)\nORDER BY row.product_id ASC, row.locale ASC\nLIMIT $4"
+                    "WITH {PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nWHERE (row.product_id, row.locale) > ($2, $3)\nORDER BY row.product_id ASC, row.locale ASC\nLIMIT $4"
                 ),
                 vec![
                     request.tenant_id().into(),
@@ -384,7 +422,7 @@ impl ProductPostgresIndexSource {
             ),
             None => (
                 format!(
-                    "WITH {PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nORDER BY row.product_id ASC, row.locale ASC\nLIMIT $2"
+                    "WITH {PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nORDER BY row.product_id ASC, row.locale ASC\nLIMIT $2"
                 ),
                 vec![request.tenant_id().into(), fetch_limit.into()],
             ),
@@ -418,7 +456,7 @@ impl ProductPostgresIndexSource {
             parameter += 2;
         }
         let sql = format!(
-            "WITH requested(product_id, locale) AS (VALUES {}),\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nJOIN requested requested_key ON requested_key.product_id = row.product_id AND requested_key.locale = row.locale\nORDER BY row.product_id ASC, row.locale ASC",
+            "WITH requested(product_id, locale) AS (VALUES {}),\n{PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nJOIN requested requested_key ON requested_key.product_id = row.product_id AND requested_key.locale = row.locale\nORDER BY row.product_id ASC, row.locale ASC",
             tuples.join(", ")
         );
         self.db
@@ -550,9 +588,14 @@ struct ProductLiveFields {
     title: String,
     handle: String,
     description: Option<String>,
+    seller_id: Option<String>,
     vendor: Option<String>,
     product_type: Option<String>,
     primary_category_id: Option<Uuid>,
+    tag_ids: Vec<Uuid>,
+    created_at: DateTime<Utc>,
+    published_at: Option<DateTime<Utc>>,
+    attribute_terms: Vec<String>,
     variant_ids: Vec<Uuid>,
     sales_channel_ids: Vec<Uuid>,
 }
@@ -593,7 +636,8 @@ impl ProductRow {
         }
 
         // Projection and retained relation membership remain mandatory for delete replay. A deleted
-        // Product does not require a live freshness witness because its graph is being removed.
+        // Product does not require live Storefront fields or a live freshness witness because its graph
+        // is being removed.
         let sales_channel_ids = decode_uuid_json_list(&row, "sales_channel_ids")?;
 
         if is_deleted {
@@ -666,9 +710,14 @@ impl ProductRow {
                 title: required_string(&row, "title")?,
                 handle: required_string(&row, "handle")?,
                 description: optional_string(&row, "description")?,
+                seller_id: optional_string(&row, "seller_id")?,
                 vendor: optional_string(&row, "vendor")?,
                 product_type: optional_string(&row, "product_type")?,
                 primary_category_id,
+                tag_ids: decode_uuid_json_list(&row, "tag_ids")?,
+                created_at: required_timestamp(&row, "created_at")?,
+                published_at: optional_timestamp(&row, "published_at")?,
+                attribute_terms: decode_string_json_list(&row, "attribute_terms")?,
                 variant_ids: decode_uuid_json_list(&row, "variant_ids")?,
                 sales_channel_ids,
             }),
@@ -683,9 +732,11 @@ impl ProductRow {
     }
 
     fn into_mutation(self) -> Result<IndexMutation, ProductIndexBridgeError> {
-        let event_id = derive_index_source_event_id(
+        let schema = product_schema_ref()?;
+        let event_id = derive_index_schema_source_event_id(
             PRODUCT_EVENT_DOMAIN,
             self.tenant_id,
+            &schema,
             self.product_id,
             Some(&self.locale),
             self.source_version,
@@ -693,7 +744,7 @@ impl ProductRow {
         .map_err(|_| ProductIndexBridgeError::InvalidRow)?;
         let key = EntityKey {
             tenant_id: self.tenant_id,
-            schema: product_schema_ref()?,
+            schema,
             entity_id: self.product_id,
             locale: Some(self.locale),
         };
@@ -716,6 +767,10 @@ impl ProductRow {
                 optional_string_value(live.description.take()),
             ),
             (
+                field_name("seller_id")?,
+                optional_string_value(live.seller_id.take()),
+            ),
+            (
                 field_name("vendor")?,
                 optional_string_value(live.vendor.take()),
             ),
@@ -728,6 +783,33 @@ impl ProductRow {
                 live.primary_category_id
                     .map(IndexValue::Uuid)
                     .unwrap_or(IndexValue::Null),
+            ),
+            (
+                field_name("tag_ids")?,
+                IndexValue::List(
+                    live.tag_ids
+                        .iter()
+                        .copied()
+                        .map(IndexValue::Uuid)
+                        .collect(),
+                ),
+            ),
+            (field_name("created_at")?, IndexValue::Timestamp(live.created_at)),
+            (
+                field_name("published_at")?,
+                live.published_at
+                    .map(IndexValue::Timestamp)
+                    .unwrap_or(IndexValue::Null),
+            ),
+            (
+                field_name("attribute_terms")?,
+                IndexValue::List(
+                    live.attribute_terms
+                        .iter()
+                        .cloned()
+                        .map(IndexValue::String)
+                        .collect(),
+                ),
             ),
             (
                 field_name("variant_ids")?,
@@ -803,6 +885,24 @@ fn decode_uuid_json_list(
         let raw = value.as_str().ok_or(ProductIndexBridgeError::InvalidRow)?;
         let id = Uuid::parse_str(raw).map_err(|_| ProductIndexBridgeError::InvalidRow)?;
         if id.is_nil() || !unique.insert(id) {
+            return Err(ProductIndexBridgeError::InvalidRow);
+        }
+    }
+    Ok(unique.into_iter().collect())
+}
+
+fn decode_string_json_list(
+    row: &QueryResult,
+    column: &str,
+) -> Result<Vec<String>, ProductIndexBridgeError> {
+    let value = row
+        .try_get::<JsonValue>("", column)
+        .map_err(|_| ProductIndexBridgeError::InvalidRow)?;
+    let values = value.as_array().ok_or(ProductIndexBridgeError::InvalidRow)?;
+    let mut unique = BTreeSet::new();
+    for value in values {
+        let raw = value.as_str().ok_or(ProductIndexBridgeError::InvalidRow)?;
+        if raw.is_empty() || !unique.insert(raw.to_owned()) {
             return Err(ProductIndexBridgeError::InvalidRow);
         }
     }
@@ -894,6 +994,22 @@ fn optional_string(
         .map_err(|_| ProductIndexBridgeError::InvalidRow)
 }
 
+fn required_timestamp(
+    row: &QueryResult,
+    column: &str,
+) -> Result<DateTime<Utc>, ProductIndexBridgeError> {
+    row.try_get::<DateTime<Utc>>("", column)
+        .map_err(|_| ProductIndexBridgeError::InvalidRow)
+}
+
+fn optional_timestamp(
+    row: &QueryResult,
+    column: &str,
+) -> Result<Option<DateTime<Utc>>, ProductIndexBridgeError> {
+    row.try_get::<Option<DateTime<Utc>>>("", column)
+        .map_err(|_| ProductIndexBridgeError::InvalidRow)
+}
+
 fn optional_string_value(value: Option<String>) -> IndexValue {
     value.map(IndexValue::String).unwrap_or(IndexValue::Null)
 }
@@ -911,17 +1027,47 @@ mod tests {
     use super::*;
 
     #[test]
-    fn canonical_product_schema_contains_only_current_fields_and_links() {
+    fn canonical_product_schema_contains_only_current_storefront_graph_contract() {
         let schema = product_schema().unwrap();
         assert_eq!(schema.reference, product_schema_ref().unwrap());
-        assert_eq!(schema.fields.len(), 10);
+        assert_eq!(schema.reference.version.get(), PRODUCT_SCHEMA_ROUTING_KEY);
+        assert_eq!(schema.fields.len(), 15);
         assert_eq!(schema.links.len(), 2);
-        assert!(
-            schema
-                .fields
-                .iter()
-                .any(|field| field.name.as_str() == "sales_channel_ids")
-        );
+        for field in [
+            "id",
+            "status",
+            "title",
+            "handle",
+            "description",
+            "seller_id",
+            "vendor",
+            "product_type",
+            "primary_category_id",
+            "tag_ids",
+            "created_at",
+            "published_at",
+            "attribute_terms",
+            "variant_ids",
+            "sales_channel_ids",
+        ] {
+            assert!(schema.fields.iter().any(|candidate| candidate.name.as_str() == field));
+        }
+        let attribute_terms = schema
+            .fields
+            .iter()
+            .find(|field| field.name.as_str() == "attribute_terms")
+            .unwrap();
+        assert_eq!(attribute_terms.cardinality, FieldCardinality::Many);
+        assert!(attribute_terms.filterable);
+        assert!(!attribute_terms.selectable);
+        let published_at = schema
+            .fields
+            .iter()
+            .find(|field| field.name.as_str() == "published_at")
+            .unwrap();
+        assert!(published_at.nullable);
+        assert!(published_at.filterable);
+        assert!(published_at.sortable);
         assert!(
             !schema
                 .fields
@@ -935,15 +1081,7 @@ mod tests {
                 .any(|field| field.name.as_str() == "allowed_channel_slugs")
         );
         assert_eq!(schema.links[0].name.as_str(), "variants");
-        assert_eq!(
-            schema.links[0].target_schema,
-            product_variant_schema_ref().unwrap()
-        );
         assert_eq!(schema.links[1].name.as_str(), "sales_channels");
-        assert_eq!(
-            schema.links[1].target_schema,
-            sales_channel_schema_ref().unwrap()
-        );
     }
 
     #[test]
@@ -971,18 +1109,26 @@ mod tests {
     }
 
     #[test]
-    fn canonical_product_projection_sql_requires_owner_projection_relation_and_freshness() {
-        assert!(PRODUCT_ROWS_CTE.contains("product_index_graph_projection_snapshots"));
-        assert!(PRODUCT_ROWS_CTE.contains("product_sales_channel_index_relation_snapshots"));
-        assert!(
-            PRODUCT_ROWS_CTE.contains("product_sales_channel_index_relation_freshness_snapshots")
-        );
-        assert!(PRODUCT_ROWS_CTE.contains("channel_index_identity_generations"));
-        assert!(PRODUCT_ROWS_CTE.contains("projection.projection_epoch AS source_version"));
-        assert!(PRODUCT_ROWS_CTE.contains("projection.channel_ids AS sales_channel_ids"));
-        assert!(PRODUCT_ROWS_CTE.contains("freshness.visibility_key"));
-        assert!(PRODUCT_ROWS_CTE.contains("COUNT(*) OVER"));
-        assert!(PRODUCT_ROWS_CTE.contains("product_index_tombstones"));
+    fn canonical_product_sql_materializes_storefront_graph_and_eav_state() {
+        for marker in [
+            "product_index_graph_projection_snapshots",
+            "product_sales_channel_index_relation_snapshots",
+            "product_sales_channel_index_relation_freshness_snapshots",
+            "channel_index_identity_generations",
+            "projection.projection_epoch AS source_version",
+            "projection.channel_ids AS sales_channel_ids",
+            "product_tags product_tag",
+            "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
+            "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
+            "p.seller_id",
+            "p.created_at",
+            "p.published_at",
+            "COUNT(*) OVER",
+            "product_index_tombstones",
+        ] {
+            assert!(PRODUCT_ROWS_CTE.contains(marker), "missing {marker}");
+        }
+        assert!(PRODUCT_ATTRIBUTE_TERMS_CTE.contains("product_filterable_attribute_values"));
     }
 
     #[test]
@@ -993,7 +1139,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_product_row_emits_canonical_delete_mutation() {
+    fn retained_product_row_emits_current_schema_delete_mutation() {
         let product = ProductRow {
             tenant_id: Uuid::from_u128(1),
             product_id: Uuid::from_u128(2),

--- a/crates/rustok-distribution/src/product_index/query_admission.rs
+++ b/crates/rustok-distribution/src/product_index/query_admission.rs
@@ -5,6 +5,8 @@ use rustok_index::{
     register_postgres_index_query_link_target_availability,
 };
 
+use super::PRODUCT_SCHEMA_ROUTING_KEY;
+
 const PRODUCT_QUERY_MATERIALIZED_FRESHNESS: &str = r#"
 EXISTS (
     SELECT 1
@@ -146,7 +148,12 @@ fn register_rule(
 }
 
 fn product_schema_ref() -> rustok_core::Result<SchemaRef> {
-    schema_ref("rustok-product", "product", SchemaVersion::new(3), "Product")
+    schema_ref(
+        "rustok-product",
+        "product",
+        SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY),
+        "Product",
+    )
 }
 
 fn product_variant_schema_ref() -> rustok_core::Result<SchemaRef> {

--- a/crates/rustok-index/docs/m7-product-attribute-term-contract.md
+++ b/crates/rustok-index/docs/m7-product-attribute-term-contract.md
@@ -1,23 +1,16 @@
 # M7 Product attribute term contract
 
-Status: `source_complete_materialization_pending`.
+Status: `source_complete_materialized_rebuild_pending`.
 
 ## Purpose
 
-Product Storefront accepts dynamic typed EAV filters by attribute `code`, but Index schemas are immutable
-and static. Adding one Index field per Product attribute would turn tenant data into runtime schema drift
-and would require a new schema fingerprint whenever an attribute is added, renamed, archived, or made
-filterable.
-
-The canonical representation is therefore one static Product field:
+Product Storefront accepts dynamic typed EAV filters by attribute `code`, while Index schemas are
+immutable and static. The single current Product source therefore materializes one static field:
 
 `attribute_terms: Many<String>`
 
-The field is filterable and is intended to be non-sortable. Attribute definitions remain Product-owned;
-a future Storefront Index adapter resolves the public `code=value` request to an exact Product attribute
-UUID/type and builds one or more `Contains(attribute_terms, term)` predicates.
-
-This contract introduces no dynamic Index field and no versioned compatibility family.
+No Index field is created per tenant attribute. Public codes remain Product-owned lookup inputs; Index
+terms use stable owner identities.
 
 ## Term grammar
 
@@ -25,16 +18,18 @@ Each term has exactly four pipe-separated components:
 
 `<attribute_uuid>|<kind>|<locale_hex>|<value_hex>`
 
-There is deliberately no format-version prefix. The current code owns exactly one grammar.
+There is deliberately no format-version prefix. Current code owns exactly one grammar.
 
-- `attribute_uuid` is the canonical lower-case UUID of `product_attributes.id`;
-- `kind` is one of the fixed semantic kinds below;
-- `locale_hex` is lower-case hexadecimal UTF-8 for a canonical locale, or empty for non-localized
+- `attribute_uuid` is `product_attributes.id`;
+- `kind` is one fixed semantic kind;
+- `locale_hex` is lower-case hexadecimal UTF-8 of the owner locale string, or empty for non-localized
   values;
-- `value_hex` is lower-case hexadecimal UTF-8 for the canonical typed value, or empty for a locale
-  presence marker.
+- `value_hex` is lower-case hexadecimal UTF-8 of the canonical typed value, or empty for a presence
+  marker.
 
-Hex encoding makes the delimiter collision-free while preserving exact owner text bytes.
+The Storefront request path supplies canonical requested/fallback locale strings. Owner SQL and Index
+term filters therefore compare the same strings. An old non-canonical EAV locale row that the owner
+query would not match is not made authoritative merely by Index materialization.
 
 ## Canonical kinds
 
@@ -42,8 +37,7 @@ The current grammar uses:
 
 - `text` for non-localized text/textarea/richtext equality;
 - `localized_text` for one localized text value;
-- `localized_present` for the existence of a localized value row, regardless of whether its
-  `value_text` is null;
+- `localized_present` for existence of a localized row even when `value_text` is null;
 - `integer` for base-10 signed i64;
 - `decimal` for normalized decimal text with insignificant trailing scale removed;
 - `boolean` for `true` or `false`;
@@ -51,110 +45,91 @@ The current grammar uses:
 - `datetime` for UTC Unix epoch microseconds;
 - `option` for canonical option UUID text used by select/multiselect.
 
-`json` attributes are intentionally absent because the owner Storefront contract rejects JSON
-`attribute_filters`.
+JSON is intentionally absent because the owner Storefront contract rejects JSON attribute filters.
 
 ## Stable identity choices
 
-Terms use `product_attributes.id`, not the mutable public attribute code. A code rename therefore does
-not force Product rematerialization merely to rewrite every term; the Storefront adapter resolves the
-current code to the stable UUID before querying Index.
+Terms use Product attribute UUID, not mutable public attribute code. Select/multiselect terms use option
+UUID, not option code. A future Storefront Index adapter resolves current code/option input through
+Product owner metadata before constructing the same term.
 
-Select/multiselect terms use `product_attribute_options.id`, not option code. The current owner contract
-accepts a raw option UUID directly. When a public request supplies an option code, the future adapter
-must resolve only a non-archived option code to its UUID before constructing the same term.
+Product tags are separate from EAV. The single current Product schema materializes stable Taxonomy
+`tag_ids`; localized tag names remain Taxonomy-owned and are hydrated after Index selection rather than
+copied into the Product clock.
 
-Product tag names are not represented by this EAV grammar. The replacement Product schema will retain
-stable taxonomy term UUIDs and localize their names through the Taxonomy owner boundary rather than
-copying Taxonomy translations into the Product clock.
+## Localized fallback equivalence
 
-## Localized text fallback equivalence
+Owner localized text filtering is:
 
-The owner predicate for localized text is:
+1. requested-locale row has the requested value; or
+2. no requested-locale row exists at all and the fallback-locale row has the requested value.
 
-1. requested-locale row exists with the requested value; or
-2. **no requested-locale row exists at all**, and fallback-locale row exists with the requested value.
+The source therefore materializes both `localized_text` and `localized_present`. The Index predicate is:
 
-The second condition cannot be represented by value terms alone. Therefore source materialization emits
-both:
+`requested-value OR (NOT requested-present AND fallback-value)`
 
-- `localized_text` for non-null translation values;
-- `localized_present` for every translation row, including rows whose value text is null.
+`attribute_terms.rs::localized_text_filter` constructs that exact `FilterExpr` shape.
 
-The Index filter is exactly:
+## PostgreSQL materialization
 
-- if requested locale equals fallback locale: requested `localized_text` term;
-- otherwise: `requested-value OR (NOT requested-present AND fallback-value)`.
+`PRODUCT_ATTRIBUTE_TERMS_CTE` is used directly by the single current Product source. It reads only:
 
-`attribute_terms.rs::localized_text_filter` builds that `FilterExpr` shape directly.
-
-## PostgreSQL source equivalence
-
-`PRODUCT_ATTRIBUTE_TERMS_CTE` is the canonical set-based source fragment. It reads only:
-
-- non-detached `product_attribute_values`;
-- non-archived `product_attributes`;
-- `is_filterable = TRUE`;
-- Product or both scope;
-- localized value translations where applicable;
+- non-detached Product attribute values;
+- non-archived, filterable Product/both attributes;
+- localized value rows where applicable;
 - option memberships for select/multiselect.
 
-Those predicates match the owner catalog filter admission boundary.
+The CTE normalizes values to the same bytes as the Rust helpers and emits one sorted, deduplicated JSONB
+term array per Product. Localized EAV terms for all owner locales are carried in every localized Product
+Index record so requested/fallback EAV filtering remains independent from Product translation fallback.
 
-The CTE normalizes scalar values to the same bytes as the Rust term helpers and emits a sorted,
-deduplicated JSONB term array per Product. It is tenant-scoped by the Product source `$1` parameter and
-does not join through Product translation locale.
-
-Localized EAV terms intentionally carry all available locales in every localized Product Index record;
-that is what allows requested/fallback EAV filtering to remain exact even when Product translation
-fallback is resolved separately.
+`attribute_terms` is filterable, non-sortable, and non-selectable. It is query machinery, not public
+Storefront payload.
 
 ## Owner clock boundary
 
-PR #3197 made the existing `ProductAttributeValuesChanged` command advance the canonical Product
-`index_revision` and locale refresh ledger in the same transaction. Therefore materializing these terms
-does not require an EAV-specific clock.
+The existing `ProductAttributeValuesChanged` command advances Product `index_revision`, graph
+`projection_epoch`, and Product locale refresh state in one owner transaction. No EAV-specific clock was
+added.
 
-Product graph mutation ordering remains `projection_epoch`; the Product owner component remains
-`products.index_revision`.
+## Single-current replacement
 
-## Replacement schema use
+Current Product runtime code now publishes one higher internal routing key and only one Product schema.
+The Product source:
 
-The next single-current Product replacement may add `attribute_terms` exactly once alongside the other
-Storefront parity fields. Because the existing Product schema fingerprint is immutable, that replacement
-must:
+- materializes `attribute_terms`;
+- derives deterministic replay delivery IDs with `derive_index_schema_source_event_id`;
+- retains `projection_epoch` as the complete Product mutation clock;
+- keeps the same ProductVariant and SalesChannel graph links.
 
-1. use one monotonically higher internal Product routing key;
-2. publish only that replacement Product schema in new runtime code;
-3. switch Product deterministic replay delivery IDs to `derive_index_schema_source_event_id`;
-4. materialize `PRODUCT_ATTRIBUTE_TERMS_CTE` into the Product record;
-5. stage/rebuild the new key through ordinary schema registration;
-6. prove readiness/parity/freshness/restart evidence;
-7. promote it through `register_current` so lower persisted Product keys become retired;
-8. keep Storefront owner-native until retained owner-vs-Index equivalence is admitted.
+Lower persisted Product keys are historical storage identities only. Production promotion still follows
+the explicit staged sequence:
+
+1. ordinary-register the current key;
+2. rebuild/replay it fully;
+3. prove readiness/parity/freshness/restart evidence;
+4. call `register_current` to retire lower active persisted keys;
+5. only then allow an authoritative consumer cutover.
 
 The numeric key is an internal storage/replay identity, not a public Product API version or a parallel
 compatibility implementation.
 
 ## Deliberate limits
 
-This slice does not:
+This source slice does not:
 
-- change the current Product schema or numeric routing key;
-- write `attribute_terms` into Index rows yet;
+- execute tenant schema registration, rebuild, or supersession;
 - switch Storefront traffic;
-- add public event contracts;
-- execute schema registration/rebuild/supersession;
-- copy localized taxonomy tag names into Product Index;
+- add public typed Product event contracts;
+- copy localized Taxonomy tag names into Product Index;
 - claim PostgreSQL execution evidence.
 
 ## Maintainer verification
 
-Suggested commands, intentionally not run by the implementation agent:
-
 ```bash
 cargo test -p rustok-distribution --features mod-product attribute_terms --lib -- --nocapture
 node scripts/verify/verify-index-product-attribute-term-contract.mjs
+node scripts/verify/verify-index-product-source.mjs
 node scripts/verify/verify-index-product-eav-owner-clock.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-query-contract.mjs

--- a/crates/rustok-index/docs/m7-product-graph-source.md
+++ b/crates/rustok-index/docs/m7-product-graph-source.md
@@ -1,90 +1,103 @@
 # M7 canonical Product graph source
 
-Status: `canonical_source_and_freshness_gate_complete_runtime_evidence_pending`.
+Status: `single_current_storefront_source_complete_rebuild_and_query_evidence_pending`.
 
 The selected distribution publishes one current Product Index contract and one current ProductVariant
 contract. Parallel Product compatibility implementations remain removed.
 
-The generic Index `SchemaRef` still contains a positive numeric `SchemaVersion` because that is a core
-storage/routing key, not a Product compatibility matrix.
+The generic Index `SchemaRef` still contains a positive numeric routing key because it participates in
+persisted schema/entity/link/inbox/replay identities. Current Product runtime code owns exactly one such
+key; lower keys are historical storage identities only.
 
 ## Canonical Product graph
 
-`product-postgres-primary` emits one locale-required Product record with current Product scalars,
-`variant_ids`, and `sales_channel_ids`. It materializes exactly two many-cardinality links:
+`product-postgres-primary` emits one locale-required Product record with 15 fields:
 
-- `variants` to ProductVariant identity;
-- `sales_channels` to SalesChannel identity.
+- identity/content: `id`, `status`, `title`, `handle`, `description`;
+- Storefront owner scalars: `seller_id`, `vendor`, `product_type`, `primary_category_id`;
+- stable Taxonomy identities: `tag_ids`;
+- Storefront ordering/publication state: `created_at`, `published_at`;
+- typed EAV query state: `attribute_terms`;
+- graph membership: `variant_ids`, `sales_channel_ids`.
 
-Product visibility slugs are resolver input only; they are not duplicated as transitional Index
-fields.
+It materializes exactly two many-cardinality links:
+
+- `variants` to current ProductVariant identity;
+- `sales_channels` to current SalesChannel identity.
+
+Product visibility slugs are resolver input only; they are not duplicated as transitional Index fields.
+Localized tag names remain Taxonomy-owned; Product Index stores only stable tag UUIDs.
 
 Physical Product/translation deletes remain represented by Product-owned tombstones and canonical
 `IndexMutation::Delete` mutations.
 
+## Single-current immutable replacement
+
+The previous Product schema fingerprint was not changed in place. Current runtime code uses one
+monotonically higher internal routing key and derives deterministic Product replay UUIDs with
+`derive_index_schema_source_event_id`, so rebuild deliveries cannot collide with lower-key historical
+`index_inbox` rows.
+
+The replacement source does not register or select the lower Product runtime contract. Production
+promotion remains staged:
+
+1. ordinary-register the current immutable key;
+2. replay/rebuild it completely;
+3. prove exact readiness/freshness/parity/restart evidence;
+4. call `register_current` to retire lower active persisted Product keys;
+5. only then select an authoritative consumer.
+
+This is one current contract, not a Product version matrix.
+
 ## Complete mutation ordering
 
-Product scalar/translation/Variant-membership state advances under `products.index_revision`; resolved
-SalesChannel membership advances under `relation_epoch`.
+Product scalar/translation/Variant-membership/EAV/tag state advances under the Product owner revision
+boundary. Resolved SalesChannel membership advances under `relation_epoch`.
 
-`product_index_graph_projection_snapshots.projection_epoch` is the only complete Product mutation
-`source_version`. Live replay requires the current projection Product watermark to equal the current
-Product revision and joins the exact retained relation epoch referenced by projection state.
+`product_index_graph_projection_snapshots.projection_epoch` remains the only complete Product mutation
+`source_version`. Live replay requires the projection Product watermark to equal the current Product
+revision and joins the exact retained relation epoch referenced by projection state.
 
-Product hard-delete replay also uses projection epoch but does not require a live relation freshness
-witness, because the mutation removes the Product graph.
+The current source additionally materializes Product-owned tag UUIDs and canonical typed EAV terms in
+the same PostgreSQL source read. EAV commands already advance Product `index_revision` and graph
+projection before their refresh ledger is captured.
+
+Product hard-delete replay also uses projection epoch but does not decode live Storefront fields or
+require a live relation freshness witness because the mutation removes the Product graph.
 
 ## Relation freshness gate
 
-The Product relation owner now also retains
-`product_sales_channel_index_relation_freshness_snapshots`. A witness identifies the exact retained
-relation epoch and records:
+`product_sales_channel_index_relation_freshness_snapshots` identifies the exact retained relation epoch
+and records observed Product source version, canonical Product visibility key, and tenant Channel
+identity generation.
 
-- observed Product source version;
-- canonical Product visibility key;
-- observed tenant Channel identity generation.
+For every live Product row, the source fails closed unless the witness matches current visibility and
+Channel identity generation and is not newer than current Product owner revision. Missing/stale
+freshness therefore cannot publish a live Product mutation. Product locale absence uses the same gate.
 
-`rustok-channel` owns `channel_index_identity_generations`, which advances transactionally for Channel
-insert/delete/id/tenant/canonical-slug changes.
-
-For every live Product row, the source derives the current visibility key from Product metadata and
-reads the current tenant Channel generation in the same PostgreSQL statement. It fails closed unless a
-witness for the projection's exact relation epoch has:
-
-- the same visibility key;
-- the same Channel identity generation;
-- a positive Product source watermark not newer than the current Product revision.
-
-A missing or stale witness therefore cannot publish a live Product mutation. Product locale absence
-uses the same gate and returns no absence watermark when freshness is stale.
-
-Freshness-only changes do not advance `relation_epoch` or `projection_epoch` when the resolved UUID
-membership and complete Product record are unchanged. The witness can advance independently.
+Freshness-only Channel changes do not fabricate Product relation/projection epochs when resolved UUID
+membership and Product record state are unchanged.
 
 Detailed contracts:
 
 - [Product graph projection ledger](../../rustok-product/docs/index-graph-projection-ledger.md)
 - [Product-SalesChannel relation ledger](../../rustok-product/docs/index-sales-channel-relation-ledger.md)
 - [Product-SalesChannel freshness witness](../../rustok-product/docs/index-sales-channel-relation-freshness.md)
+- [Product typed EAV terms](./m7-product-attribute-term-contract.md)
+- [Storefront parity gate](./m7-product-storefront-parity-gate.md)
 - [Cross-owner resolver](./m7-product-sales-channel-resolver.md)
-
-## Ownership
-
-`rustok-product` owns Product/Variant persistence, tombstones, relation membership, freshness witness
-storage, and graph projection epochs. It still has no `rustok-index` or `rustok-channel` dependency.
-
-`rustok-channel` owns the tenant identity generation. `rustok-distribution` owns cross-owner
-observation/resolution and Index conversion.
 
 ## Still open
 
-The source-level freshness gap is closed, but production admission still requires:
+Source coverage is complete, but production/Storefront admission still requires:
 
-- retained PostgreSQL replay/freshness/concurrency/restart/delete-recreate evidence;
-- automatic convergence scheduling/triggering if the desired latency requires it;
-- persisted tenant schema readiness evidence;
+- staged current-key rebuild and final persisted supersession;
+- retained PostgreSQL replay/freshness/concurrency/restart/delete-recreate execution;
+- generic scalar text substring filtering needed to reproduce owner title search;
+- Storefront query translation and bounded Taxonomy tag-name hydration;
+- full owner-vs-Index Storefront equivalence;
 - Product typed event family/routes after event-contract digest admission;
-- tombstone retention admission, query equivalence, and Storefront cutover evidence.
+- final traffic cutover evidence.
 
 ## Validation ownership
 

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,22 +1,18 @@
 # M7 Product Storefront Index parity gate
 
-Status: `source_complete_cutover_blocked_by_contract_gap`.
+Status: `source_complete_query_adapter_and_evidence_pending`.
 
 ## Purpose
 
-The Product Storefront catalog remains owner-native. This gate prevents an Index traffic cutover from
-being described as ready merely because the canonical Product graph can answer basic Product, Variant,
-and SalesChannel queries.
+The Product Storefront catalog remains owner-native until a retained owner-vs-Index equivalence packet
+is executed and admitted. The single current Product Index source now materializes the Storefront fields
+and typed EAV query state that were previously missing, but source coverage alone does not authorize a
+traffic cutover.
 
-The current Storefront list contract and the current immutable Product Index schema do **not** have full
-query/result parity. Until that gap is closed through one deliberately admitted current contract, the
-Storefront must continue to execute `CatalogService::list_published_products_with_query` and must not
-silently switch to `SharedIndexQueryRuntime`.
+Storefront must continue to execute `CatalogService::list_published_products_with_query` until the
+remaining adapter, tag hydration, staged rebuild/readiness, and equivalence gates are complete.
 
-This slice changes no traffic, Product schema, schema key, migration, query semantics, owner clock, or
-compatibility route.
-
-## Current owner Storefront contract
+## Owner Storefront contract
 
 `StorefrontProductListQuery` accepts:
 
@@ -27,154 +23,107 @@ compatibility route.
 - up to eight typed `code=value` Product attribute predicates;
 - page/per-page pagination.
 
-`CatalogService::list_published_products_with_query` additionally enforces:
+Owner execution additionally enforces tenant scope, Active status, non-null `published_at`, public
+SalesChannel visibility, category/title filtering, typed EAV predicates, stable timestamp+ID ordering,
+exact count, Product translation fallback, and localized tag projection.
 
-- tenant scope;
-- `ProductStatus::Active`;
-- non-null `published_at`;
-- public SalesChannel visibility from Product owner metadata;
-- category filtering;
-- title search over Product translations;
-- typed EAV attribute filtering through active Product-scoped filterable definitions;
-- stable `published_at/created_at/id` ordering;
-- exact total before page slicing;
-- locale/fallback translation selection;
-- owner tag projection.
+The result payload returns `id`, `status`, `title`, `handle`, `seller_id`, `vendor`, `product_type`,
+localized tag names, `created_at`, and `published_at`.
 
-The public `StorefrontProductListItem` returns:
+## Single current Product Index coverage
 
-- `id`;
-- `status`;
-- `title`;
-- `handle`;
-- `seller_id`;
-- `vendor`;
-- `product_type`;
-- `tags`;
-- `created_at`;
-- `published_at`.
+Current Product runtime code publishes one Product schema with 15 fields and two links:
 
-## Current canonical Product Index coverage
-
-The selected Product Index contract currently has exactly one runtime Product schema and exposes:
-
-- `id`;
-- `status`;
-- `title`;
-- `handle`;
-- `description`;
-- `vendor`;
-- `product_type`;
-- `primary_category_id`;
-- `variant_ids`;
-- `sales_channel_ids`;
+- existing graph/content fields: `id`, `status`, `title`, `handle`, `description`, `vendor`,
+  `product_type`, `primary_category_id`, `variant_ids`, `sales_channel_ids`;
+- Storefront scalar fields: `seller_id`, `created_at`, `published_at`;
+- stable Taxonomy tag identities: `tag_ids`;
+- typed EAV query machinery: `attribute_terms`;
 - links `variants` and `sales_channels`.
 
-That contract already covers tenant/locale scoping, current Product authority, title/category filtering,
-Product-to-SalesChannel visibility membership, exact count, linked target freshness/availability, and
-keyset/offset query execution.
+`created_at` and `published_at` are sortable. `published_at` is nullable/filterable so published-only
+admission can be represented explicitly. `attribute_terms` is a non-selectable filterable
+`Many<String>` field using the canonical Product attribute-term grammar.
 
-It does **not** currently materialize these Storefront list requirements:
+The Product source still uses `projection_epoch` as its complete mutation clock and retains existing
+Product/SalesChannel freshness plus linked-target availability rules.
 
-- `seller_id` result payload;
-- Product `tags` result/filter semantics;
-- `created_at` result + sort key;
-- `published_at` result + non-null published-only admission + sort key;
-- dynamic typed EAV `attribute_filters`.
+## Tags remain Taxonomy-owned
 
-Therefore current Index rows cannot reproduce the owner Storefront list contract exactly.
+Index stores stable `product_tags.term_id` UUIDs, not localized Taxonomy names. Copying Taxonomy
+translations into Product Index would create a second freshness clock that Product does not own.
 
-## Why the missing fields cannot be appended silently
+A Storefront Index adapter must therefore hydrate localized tag names from Taxonomy after Product page
+selection, preserving the same requested/fallback locale behavior as the owner path. That hydration must
+be bounded/batched and included in parity evidence before cutover.
 
-`PostgresSchemaRegistrationStore` treats one `(tenant, module, entity, schema_version)` contract as
-immutable. Re-registering the same `SchemaRef` with a different fingerprint or JSON contract returns
-`VersionConflict`; inserting a non-increasing schema version returns `NonMonotonicVersion`.
+## Typed EAV representation
 
-The current Product routing key is already persisted and intentionally represents the one selected
-canonical Product contract. Appending Storefront-only fields under that same key would create
-fingerprint drift and fail schema readiness. It would not be a safe "current code only" change.
+Dynamic EAV attributes do not create dynamic Index fields. Public Product attribute/option codes are
+resolved through Product owner metadata to stable attribute/option UUIDs; the adapter then builds
+`Contains(attribute_terms, term)` expressions.
 
-Conversely, adding a `Product v4` compatibility branch only to make Storefront work would violate the
-single-current-contract direction. This gate therefore rejects both shortcuts:
+Localized text uses the exact owner predicate:
 
-- no silent same-key fingerprint replacement;
-- no parallel v4/v5 compatibility source/route.
+`requested-value OR (NOT requested-present AND fallback-value)`
 
-## Single-current replacement persistence is source complete
+See `m7-product-attribute-term-contract.md` for the current grammar and normalization.
 
-Generic Index persistence now has an explicit replacement primitive documented in
-`m4-single-current-schema-supersession.md`:
+## Immutable replacement boundary
 
-`PostgresSchemaRegistrationStore::register_current`.
+The old Product fingerprint was not modified in place. Current runtime code uses one monotonically
+higher internal Product routing key, derives replay IDs with `derive_index_schema_source_event_id`, and
+publishes no lower Product compatibility implementation.
 
-Ordinary `register` can first stage one monotonically higher immutable routing key while lower persisted
-keys remain active for the rebuild window. After that staged key is completely rebuilt and verified,
-`register_current` resolves the exact same staged contract and atomically marks every lower active key
-`retired` in the final authority-transition transaction.
+Lower persisted Product keys are historical storage identities only. Promotion remains an operator and
+evidence action:
 
-Retirement does not rewrite or delete historical entity/link/inbox/replay rows. Their immutable schema
-rows remain for foreign-key integrity, while exact persisted readiness and query execution reject a
-retired schema as non-authoritative.
+1. ordinary-register the current key;
+2. rebuild/replay the current key completely;
+3. prove exact schema readiness, parity, freshness, restart, and inbox isolation;
+4. call `PostgresSchemaRegistrationStore::register_current` to retire lower active persisted keys;
+5. only then allow authoritative Storefront selection.
 
-This solves the persistence-side **single-current** replacement mechanism without adding a parallel
-runtime compatibility branch. It does not by itself expand Product or make a replacement Product key
-ready.
+There is no same-key fingerprint replacement and no parallel Product v4/v5 route.
 
-## Cutover admission rule
+## Remaining source/evidence work before cutover
 
-Product Storefront Index cutover remains **false** until one future Product replacement proves all of the
-following:
+The schema/source gap is closed, but Storefront traffic stays blocked until all of these are complete:
 
-1. one current Product Index contract covers every Storefront result field and ordering/filter input
-   that is claimed by the cutover;
-2. typed Product attribute predicates have an admitted Index representation and exact owner parity, or
-   the Storefront contract explicitly stops claiming those filters before cutover;
-3. the replacement immutable Product contract is staged through ordinary registration and complete
-   new-key rebuild/replay, then made authoritative through explicit single-current supersession — never
-   through same-key fingerprint replacement;
-4. every lower persisted Product key is retired at final supersession and no old Product schema is
-   runtime-selected in parallel by the replacement code;
-5. exact tenant schema readiness succeeds for the replacement key before final consumer cutover;
-6. retained PostgreSQL equivalence compares owner-native and Index results for locale fallback,
-   visibility, search, category, typed attributes, both sort keys/directions, pagination, exact count,
-   and linked-target lag;
-7. only after those checks may the Storefront transport select Index as an authoritative provider.
-
-Until then, owner-native PostgreSQL remains authoritative for the catalog list.
+1. translate `StorefrontProductListQuery` to the current `IndexQuery` contract;
+2. resolve Product attribute and option codes to canonical term predicates;
+3. preserve Active + published-only admission, title/category filters, both sort keys/directions, stable
+   ID tie-break, pagination, and exact count;
+4. decode the current Product projection into the public Storefront result;
+5. batch-hydrate localized tag names through Taxonomy with requested/fallback parity;
+6. retain and execute PostgreSQL owner-vs-Index equivalence for the full matrix, including locale,
+   visibility, typed EAV, ordering, pagination, exact count, stale linked targets, and restart;
+7. stage/rebuild/promote the current Product key for the tenant before traffic selection.
 
 ## Source guard
 
-`scripts/verify/verify-index-product-storefront-parity-gate.mjs` intentionally checks the current gap as
-well as the current traffic boundary. If Product Index coverage changes, the same PR must update this
-parity document/guard instead of silently making the guard pass by removing requirements.
+`scripts/verify/verify-index-product-storefront-parity-gate.mjs` checks that:
 
-The guard verifies that:
-
-- Storefront native transport still invokes the Product owner service and does not import Index runtime
-  query types;
-- owner query/DTO source still exposes the required controls/result fields listed above;
-- the current Product Index schema still lacks the known missing Storefront fields;
-- same-key schema fingerprint reuse remains rejected by generic Index registration;
-- staged single-current supersession remains available for a future replacement;
-- the current Index implementation plan keeps Storefront traffic cutover evidence-gated.
+- native Storefront traffic has not silently switched to Index;
+- the owner query/DTO contract remains explicit;
+- the single current Product schema contains the required Storefront fields and canonical EAV terms;
+- Product replay identity is schema-scoped;
+- old Product runtime compatibility branches are absent;
+- same-key schema replacement remains rejected and staged supersession remains available;
+- cutover remains query-adapter/evidence gated.
 
 ## Deliberate limits
 
-This slice does not change the Product routing key or Product fields. It does not purge persisted Product
-Index state, invent a second Storefront Product entity, duplicate EAV data, weaken schema
-fingerprint/readiness checks, or switch traffic.
-
-The next Product schema replacement must use one higher internal routing key as a storage identity while
-publishing only that one replacement Product contract in new runtime code. The old key is historical
-storage, not a compatibility implementation.
+This source slice does not execute tenant rebuild/supersession, implement the Storefront Index adapter,
+hydrate Taxonomy tags through Index traffic, add public typed Product event contracts, or switch traffic.
 
 ## Maintainer verification
 
-Suggested commands, intentionally not run by the implementation agent:
-
 ```bash
-node scripts/verify/verify-index-schema-supersession.mjs
+node scripts/verify/verify-index-product-source.mjs
+node scripts/verify/verify-index-product-attribute-term-contract.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
+node scripts/verify/verify-index-schema-supersession.mjs
 node scripts/verify/verify-index-query-contract.mjs
 node scripts/verify/verify-product-storefront-boundary.mjs
 cargo check -p rustok-index --all-targets

--- a/scripts/verify/verify-index-product-attribute-term-contract.mjs
+++ b/scripts/verify/verify-index-product-attribute-term-contract.mjs
@@ -55,6 +55,7 @@ if (source.includes('pa.code ||') || source.includes('pa.code::text ||')) {
 
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'mod attribute_terms;',
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
 ]);
 requireMarkers('crates/rustok-distribution/Cargo.toml', [
   'mod-product = ["dep:rustok-product", "mod-taxonomy", "dep:chrono", "dep:hex", "dep:rust_decimal"]',
@@ -86,22 +87,24 @@ requireMarkers('crates/rustok-product/src/services/write_transaction.rs', [
   'UPDATE products SET index_revision = index_revision',
 ]);
 
-const productSourcePath = 'crates/rustok-distribution/src/product_index/product.rs';
-const productSource = read(productSourcePath);
-if (productSource.includes('many_field("attribute_terms"')) {
-  fail(`${productSourcePath} already materializes attribute_terms; update this source-complete/materialization-pending gate in the same replacement PR`);
-}
+requireMarkers('crates/rustok-distribution/src/product_index/product.rs', [
+  'many_field("attribute_terms", IndexValueType::String, false, true)?',
+  'PRODUCT_ATTRIBUTE_TERMS_CTE',
+  "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
+  'decode_string_json_list(&row, "attribute_terms")?',
+  'field_name("attribute_terms")?',
+  'derive_index_schema_source_event_id(',
+]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
-  'Status: `source_complete_materialization_pending`',
+  'Status: `source_complete_materialized_rebuild_pending`',
   '`attribute_terms: Many<String>`',
   '`<attribute_uuid>|<kind>|<locale_hex>|<value_hex>`',
   'There is deliberately no format-version prefix.',
   '`localized_present`',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
   '`derive_index_schema_source_event_id`',
-  'use one monotonically higher internal Product routing key',
   'numeric key is an internal storage/replay identity',
 ]);
 
-console.log('[verify-index-product-attribute-term-contract] canonical Product typed EAV term contract is source complete and materialization pending');
+console.log('[verify-index-product-attribute-term-contract] canonical Product typed EAV terms are materialized by the single current source; rebuild remains pending');

--- a/scripts/verify/verify-index-product-channel-relation-admission.mjs
+++ b/scripts/verify/verify-index-product-channel-relation-admission.mjs
@@ -27,6 +27,7 @@ requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'pub(crate) mod relation_admission;',
   'mod channel_relation_convergence;',
   'mod query_admission;',
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
 ]);
 
 const admissionPath = 'crates/rustok-distribution/src/product_index/relation_admission.rs';
@@ -61,17 +62,20 @@ forbidMarkers(admissionPath, admission, [
 
 const productPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const product = requireMarkers(productPath, [
-  'many_field("sales_channel_ids", IndexValueType::Uuid, true)?',
+  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)?',
   'name: link_name("sales_channels")?',
   'target_schema: sales_channel_schema_ref()?',
   'projection.channel_ids AS sales_channel_ids',
   'product_index_graph_projection_snapshots',
   'product_sales_channel_index_relation_freshness_snapshots',
   'channel_index_identity_generations',
-  'assert_eq!(schema.fields.len(), 10);',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'derive_index_schema_source_event_id(',
+  'assert_eq!(schema.fields.len(), 15);',
   'assert_eq!(schema.links.len(), 2);',
 ]);
 forbidMarkers(productPath, product, [
+  'SchemaVersion::new(3)',
   'ProductSchemaVersion',
   'product_v1_schema',
   'product_v2_schema',
@@ -109,4 +113,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-materialized-query-freshness.mjs'",
 ]);
 
-console.log('[verify-index-product-channel-relation-admission] relation, freshness, convergence, and query fence admission verified');
+console.log('[verify-index-product-channel-relation-admission] current relation, freshness, convergence, and query fence admission verified');

--- a/scripts/verify/verify-index-product-materialized-query-freshness.mjs
+++ b/scripts/verify/verify-index-product-materialized-query-freshness.mjs
@@ -123,14 +123,16 @@ const productAdmission = requireMarkers(productAdmissionPath, [
   'owner_channel.index_revision = {{entity}}.source_version',
   'register_postgres_index_query_link_target_availability',
   'PostgresQueryEntityAdmission::new(template)',
+  'PRODUCT_SCHEMA_ROUTING_KEY',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'product_variant_schema_ref()',
   'sales_channel_schema_ref()',
   'extensions.contains::<rustok_channel::ChannelRuntimeSelected>()',
-  'SchemaVersion::new(3)',
   'SchemaVersion::new(2)',
   'SchemaVersion::INITIAL',
 ]);
 forbidMarkers(productAdmissionPath, productAdmission, [
+  'SchemaVersion::new(3)',
   'PostgresQueryRootAdmission',
   '{{root}}',
   'index_entities',
@@ -142,6 +144,7 @@ forbidMarkers(productAdmissionPath, productAdmission, [
 ]);
 
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
   'query_admission::register(extensions)?;',
   'assert_eq!(admissions.len(), 2)',
   'assert_eq!(admissions.len(), 3)',
@@ -182,4 +185,4 @@ forbidMarkers('crates/rustok-index/docs/m7-product-materialized-query-freshness.
   'retain PostgreSQL cases for linked filtering and many aggregate ordering',
 ]);
 
-console.log('[verify-index-product-materialized-query-freshness] Product graph freshness, availability and equivalence source contracts verified');
+console.log('[verify-index-product-materialized-query-freshness] current Product graph freshness, availability and equivalence source contracts verified');

--- a/scripts/verify/verify-index-product-source.mjs
+++ b/scripts/verify/verify-index-product-source.mjs
@@ -29,17 +29,17 @@ forbidMarkers('crates/rustok-product/Cargo.toml', productCargo, ['rustok-index',
 
 const modulePath = 'crates/rustok-distribution/src/product_index/mod.rs';
 const moduleSource = requireMarkers(modulePath, [
+  'mod attribute_terms;',
   'mod channel_visibility;',
   'mod product;',
   'mod variant;',
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+  'Lower keys are historical storage identities only.',
   'product::register(extensions)?;',
   'variant::register(extensions)?;',
   'absence::register(extensions)?;',
   'query_admission::register(extensions)?;',
   'selected_product_bridge_registers_two_current_schemas_three_factories_and_entity_admissions',
-  'selected_product_and_channel_bridge_registers_channel_admission_and_convergence_work',
-  'assert_eq!(admissions.len(), 2)',
-  'assert_eq!(admissions.len(), 3)',
 ]);
 forbidMarkers(modulePath, moduleSource, ['mod graph;', 'graph::', 'four_schemas']);
 
@@ -51,51 +51,57 @@ for (const removed of [
   'scripts/verify/verify-index-product-graph-source.mjs',
   'scripts/verify/verify-index-product-v3-projection-ledger.mjs',
 ]) {
-  if (fs.existsSync(resolve(removed))) {
-    fail(`removed Product compatibility artifact still exists: ${removed}`);
-  }
+  if (fs.existsSync(resolve(removed))) fail(`removed Product compatibility artifact still exists: ${removed}`);
 }
 
 const sourcePath = 'crates/rustok-distribution/src/product_index/product.rs';
 const source = requireMarkers(sourcePath, [
   'PRODUCT_INDEX_SOURCE: &str = "product-postgres-primary"',
   'PRODUCT_EVENT_DOMAIN: &str = "rustok-product.product-replay"',
+  'derive_index_schema_source_event_id',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'fn product_schema()',
   'locale_mode: LocaleMode::Required',
-  'many_field("variant_ids", IndexValueType::Uuid, true)?',
-  'many_field("sales_channel_ids", IndexValueType::Uuid, true)?',
+  'scalar_field("seller_id", IndexValueType::String, true, false, false)?',
+  'many_field("tag_ids", IndexValueType::Uuid, true, false)?',
+  'scalar_field("created_at", IndexValueType::Timestamp, false, false, true)?',
+  'scalar_field("published_at", IndexValueType::Timestamp, true, true, true)?',
+  'many_field("attribute_terms", IndexValueType::String, false, true)?',
+  'many_field("variant_ids", IndexValueType::Uuid, true, true)?',
+  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)?',
   'name: link_name("variants")?',
   'name: link_name("sales_channels")?',
-  'target_schema: product_variant_schema_ref()?',
-  'target_schema: sales_channel_schema_ref()?',
-  'assert_eq!(schema.fields.len(), 10);',
+  'assert_eq!(schema.fields.len(), 15);',
   'assert_eq!(schema.links.len(), 2);',
   'product_index_graph_projection_snapshots',
   'product_sales_channel_index_relation_snapshots',
   'product_sales_channel_index_relation_freshness_snapshots',
   'channel_index_identity_generations',
   'projection.projection_epoch AS source_version',
+  'product_tags product_tag',
+  "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
+  "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
+  'p.seller_id',
+  'p.created_at',
+  'p.published_at',
   'projection.channel_ids AS sales_channel_ids',
-  'freshness.visibility_key AS freshness_visibility_key',
-  'freshness.channel_identity_generation AS freshness_channel_identity_generation',
   'decode_product_visibility(&metadata)',
   'freshness_visibility_key != current_visibility_key',
-  'freshness_channel_identity_generation != current_channel_identity_generation',
+  'freshness_channel_identity_generation < current_channel_identity_generation',
   'freshness_product_source_version > observed_product_source_version',
   'projected_product_source_version != observed_product_source_version',
-  'does not require a live freshness witness',
+  'does not require live Storefront fields or a live freshness witness',
   'FROM products p',
   'JOIN product_translations t',
   'FROM product_index_tombstones tombstone',
   'jsonb_agg(v.id ORDER BY v.id)',
   '(row.product_id, row.locale) > ($2, $3)',
-  'ORDER BY row.product_id ASC, row.locale ASC',
   'WITH requested(product_id, locale) AS (VALUES {})',
   'IndexMutation::Delete {',
   'IndexMutation::Upsert {',
-  'canonical_product_schema_contains_only_current_fields_and_links',
+  'canonical_product_schema_contains_only_current_storefront_graph_contract',
   'canonical_product_registration_publishes_one_schema_and_one_source_factory',
-  'canonical_product_projection_sql_requires_owner_projection_relation_and_freshness',
+  'canonical_product_sql_materializes_storefront_graph_and_eav_state',
 ]);
 forbidMarkers(sourcePath, source, [
   'ProductSchemaVersion',
@@ -105,6 +111,8 @@ forbidMarkers(sourcePath, source, [
   'PRODUCT_EVENT_DOMAIN_V2',
   'product-replay-v1',
   'product-replay-v2',
+  'derive_index_source_event_id(',
+  'SchemaVersion::new(3)',
   'FROM channels',
   'JOIN channels',
   'index_entities',
@@ -114,57 +122,28 @@ forbidMarkers(sourcePath, source, [
   'loop {',
 ]);
 
-const absencePath = 'crates/rustok-distribution/src/product_index/absence.rs';
-const absence = requireMarkers(absencePath, [
-  'PRODUCT_ABSENCE_WATERMARK_FACTORY',
-  'product-locale-absence-postgres',
-  '[product_schema_ref()?]',
-  'product_index_graph_projection_snapshots',
-  'projection.product_source_version = product.index_revision',
-  'product_sales_channel_index_relation_snapshots',
-  'product_sales_channel_index_relation_freshness_snapshots',
-  'channel_index_identity_generations',
-  'decode_product_visibility(&metadata)',
-  'freshness_visibility_key != current_visibility_key',
-  'freshness_channel_identity_generation != current_channel_identity_generation',
-  'FROM product_translations translation',
-  'FROM product_index_tombstones tombstone',
-  'IndexSourceAbsenceWatermark::new(key, source_version)',
-]);
-forbidMarkers(absencePath, absence, [
-  'product_schema_ref(1)',
-  'product_schema_ref(2)',
-  'product_index_graph_v3_projection_snapshots',
-  'CAST(product.index_revision AS TEXT)',
-  'INSERT ',
-  'UPDATE ',
-  'DELETE FROM',
-  'index_entities',
-  'index_links',
-  'tokio::spawn',
-  'loop {',
-]);
+for (const currentConsumer of [
+  'crates/rustok-distribution/src/product_index/absence.rs',
+  'crates/rustok-distribution/src/product_index/query_admission.rs',
+]) {
+  const consumer = requireMarkers(currentConsumer, [
+    'PRODUCT_SCHEMA_ROUTING_KEY',
+    'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  ]);
+  forbidMarkers(currentConsumer, consumer, ['SchemaVersion::new(3)']);
+}
 
-const canonicalMigration = requireMarkers(
-  'crates/rustok-product/src/migrations/m20260807_000010_canonicalize_product_index_graph_projection.rs',
-  [
-    'product_index_graph_projection_snapshots',
-    'rustok_product_guard_index_graph_projection_snapshot',
-    'rustok_product_reconcile_index_graph_projection',
-    'trg_products_zz_index_graph_projection_delete',
-    'trg_product_channel_relation_index_graph_projection_insert',
-  ],
-);
-forbidMarkers(
-  'crates/rustok-product/src/migrations/m20260807_000010_canonicalize_product_index_graph_projection.rs',
-  canonicalMigration,
-  ['FROM channels', 'JOIN channels', 'index_entities', 'index_links', 'IndexMutation'],
-);
+requireMarkers('crates/rustok-distribution/src/product_index/attribute_terms.rs', [
+  'PRODUCT_ATTRIBUTE_TERMS_CTE',
+  'localized_text_filter(',
+  'localized_present',
+]);
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-source.mjs'",
+  "'verify-index-product-attribute-term-contract.mjs'",
   "'verify-index-product-channel-relation-freshness.mjs'",
   "'verify-index-linked-target-query-freshness.mjs'",
 ]);
 
-console.log('[verify-index-product-source] canonical Product source and graph entity admission verified');
+console.log('[verify-index-product-source] single-current Storefront-capable Product source verified');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -90,9 +90,14 @@ for (const marker of [
   'scalar_field("title"',
   'scalar_field("handle"',
   'scalar_field("description"',
+  'scalar_field("seller_id"',
   'scalar_field("vendor"',
   'scalar_field("product_type"',
   '"primary_category_id"',
+  'many_field("tag_ids"',
+  'scalar_field("created_at"',
+  'scalar_field("published_at"',
+  'many_field("attribute_terms"',
   'many_field("variant_ids"',
   'many_field("sales_channel_ids"',
   'name: link_name("variants")?',
@@ -100,32 +105,32 @@ for (const marker of [
 ]) {
   if (!productSchema.includes(marker)) fail(`${productIndexPath} schema is missing ${marker}`);
 }
-for (const missingStorefrontField of [
-  'scalar_field("seller_id"',
-  'many_field("tags"',
-  'scalar_field("created_at"',
-  'scalar_field("published_at"',
-]) {
-  if (productSchema.includes(missingStorefrontField)) {
-    fail(`${productIndexPath} changed Storefront parity coverage without updating this gate: ${missingStorefrontField}`);
-  }
+if (!productIndex.includes('assert_eq!(schema.fields.len(), 15);')) {
+  fail(`${productIndexPath} current single Product field-count assertion is not 15`);
 }
-if (!productIndex.includes('assert_eq!(schema.fields.len(), 10);')) {
-  fail(`${productIndexPath} current canonical Product field-count assertion changed without parity-gate review`);
-}
+forbidMarkers(productIndexPath, productIndex, [
+  'SchemaVersion::new(3)',
+  'derive_index_source_event_id(',
+  'ProductSchemaVersion',
+  'product_v1_schema',
+  'product_v2_schema',
+]);
+requireMarkers(productIndexPath, [
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'derive_index_schema_source_event_id(',
+  "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
+  "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
+]);
 
 const schemaStorePath = 'crates/rustok-index/src/infrastructure/postgres/schema_registration.rs';
 requireMarkers(schemaStorePath, [
   'VersionConflict { reference: SchemaRef }',
   'NonMonotonicVersion {',
   'schema {reference} is already registered with another contract',
-  'schema version must increase for {identity}',
   'existing.fingerprint != fingerprint.to_string() || existing.schema_json != *schema_json',
-  'Err(SchemaRegistrationError::VersionConflict {',
   'pub async fn register_current(',
   'retire_lower_active_schemas(',
   "status = 'retired'",
-  "schema_version < $4 AND status = 'active'",
 ]);
 forbidMarkers(schemaStorePath, read(schemaStorePath), [
   'DELETE FROM index_schemas',
@@ -133,33 +138,29 @@ forbidMarkers(schemaStorePath, read(schemaStorePath), [
   'DELETE FROM index_links',
 ]);
 
-const parityDocPath = 'crates/rustok-index/docs/m7-product-storefront-parity-gate.md';
-requireMarkers(parityDocPath, [
-  'Status: `source_complete_cutover_blocked_by_contract_gap`',
-  'seller_id',
-  'Product `tags`',
-  '`created_at` result + sort key',
-  '`published_at` result + non-null published-only admission + sort key',
-  'dynamic typed EAV `attribute_filters`',
-  'no silent same-key fingerprint replacement',
-  'no parallel v4/v5 compatibility source/route',
-  'Single-current replacement persistence is source complete',
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
+  'Status: `source_complete_query_adapter_and_evidence_pending`',
+  'Current Product runtime code publishes one Product schema with 15 fields and two links',
+  '`seller_id`, `created_at`, `published_at`',
+  '`tag_ids`',
+  '`attribute_terms`',
+  'Tags remain Taxonomy-owned',
+  'query-adapter/evidence gated',
+  'ordinary-register the current key',
   '`PostgresSchemaRegistrationStore::register_current`',
-  'every lower persisted Product key is retired',
+  'There is no same-key fingerprint replacement and no parallel Product v4/v5 route.',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
+  'Status: `source_complete_materialized_rebuild_pending`',
+  '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.md', [
   'Status: `source_complete_execution_pending`',
   'single-current',
-  'This slice does not change the Product routing key or Product schema yet.',
+  '`derive_index_schema_source_event_id`',
 ]);
 
-const currentPlanPath = 'crates/rustok-index/docs/implementation-plan-current-2026-08-07.md';
-requireMarkers(currentPlanPath, [
-  'Prove complete Storefront Product/ProductVariant/SalesChannel query parity.',
-  'Move Storefront traffic only after readiness/equivalence/freshness/availability evidence passes.',
-  'do not introduce a new Product schema/version to solve',
-]);
-
-console.log('[verify-index-product-storefront-parity-gate] Storefront cutover remains fail-closed on one immutable current Product Index contract');
+console.log('[verify-index-product-storefront-parity-gate] Product source coverage is complete; Storefront cutover remains fail-closed on adapter, rebuild and retained parity evidence');


### PR DESCRIPTION
## Summary

- replace the current Product Index runtime contract in place at the source-code level with one higher internal storage routing key; lower Product keys remain historical persisted identities only and are not runtime-selected;
- expand the one Product schema from 10 to 15 fields: add `seller_id`, stable Taxonomy `tag_ids`, `created_at`, `published_at`, and canonical filter-only `attribute_terms`;
- keep exactly the existing `variants` and `sales_channels` links and keep `projection_epoch` as the complete Product mutation clock;
- materialize tag UUIDs from `product_tags` and canonical typed EAV terms from `PRODUCT_ATTRIBUTE_TERMS_CTE` in the same PostgreSQL Product source read;
- make `created_at` sortable and `published_at` nullable/filterable/sortable for Storefront publication and ordering semantics;
- keep `attribute_terms` non-selectable, filterable, and non-sortable;
- switch Product replay delivery identity from the legacy helper to `derive_index_schema_source_event_id`, so new-key rebuild deliveries cannot collide with historical lower-key inbox rows;
- move Product locale absence and Product query admission to the same single current routing key;
- preserve Product-SalesChannel freshness, link-target availability, retained tombstones, locale identity, and ProductVariant/SalesChannel target contracts;
- update canonical source/EAV/Storefront docs and guards;
- do not switch Storefront traffic or add typed Product wire events.

## Storefront boundary

Source coverage is now complete for the owner result/query state except for query-layer behavior that is intentionally still gated. In particular, generic Index currently has no scalar string substring operator matching owner title `ILIKE %search%`; `Contains` is many-cardinality only. This PR does not fake substring search with equality.

Storefront remains owner-native until a later generic scalar text-contains slice, Storefront query adapter, bounded Taxonomy tag-name hydration, staged rebuild/promotion, and retained owner-vs-Index equivalence are complete.

## Single-current replacement

The previous Product schema fingerprint is not changed under its old key. Current runtime code publishes one higher key from `PRODUCT_SCHEMA_ROUTING_KEY` and no lower Product compatibility schema/source.

Operational promotion remains:

1. ordinary-register the new immutable key;
2. rebuild/replay it completely using schema-scoped delivery IDs;
3. prove readiness/freshness/parity/restart evidence;
4. call `PostgresSchemaRegistrationStore::register_current` to retire lower active persisted Product keys;
5. only then allow an authoritative consumer cutover.

The numeric key is internal storage/replay identity, not a public Product API version or a compatibility matrix.

## Retained evidence packet boundary

Existing Product PostgreSQL retained packets still contain historical hardcoded Product key `3` fixtures. They are not claimed as current replacement evidence by this PR. A separate immediate follow-up PR will actualize those packets/guards to the current key and 15-field source contract; no runtime alias for key `3` is added.

## Main recheck

The branch starts from and current `main` remains `4d06cb5b9ed43e9acd91986891ac8f67a56c6c11` (#3198).

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.