### PR TITLE
docs(index): fail-close Storefront locale search parity

### DIFF
--- a/crates/rustok-index/docs/m7-product-graph-source.md
+++ b/crates/rustok-index/docs/m7-product-graph-source.md
@@ -1,6 +1,6 @@
 # M7 canonical Product graph source
 
-Status: `single_current_storefront_source_complete_rebuild_and_query_evidence_pending`.
+Status: `single_current_product_source_complete_storefront_locale_query_gap_open`.
 
 The selected distribution publishes one current Product Index contract and one current ProductVariant
 contract. Parallel Product compatibility implementations remain removed.
@@ -31,6 +31,22 @@ Localized tag names remain Taxonomy-owned; Product Index stores only stable tag 
 Physical Product/translation deletes remain represented by Product-owned tombstones and canonical
 `IndexMutation::Delete` mutations.
 
+## Localized identity boundary
+
+One Product Index entity corresponds to one **physically stored** `product_translations.locale` row.
+The source does not fabricate requested-locale records from a fallback translation. The absence provider
+correctly treats a missing exact locale as absent.
+
+That generic source rule is not yet Storefront-equivalent. Owner Storefront list search currently
+matches title through any Product translation, and owner result localization can return a fallback
+translation when the requested locale is absent. A current-locale scalar title filter or a second
+independent fallback query cannot by itself preserve the same global admission, de-duplication, ordering,
+page boundary, and exact count.
+
+This is now an explicit Storefront query/source gap. Do not add another Product routing key or parallel
+Product schema merely to work around it. The effective localized Storefront identity/search architecture
+must be resolved at the generic query/owner-contract layer first.
+
 ## Single-current immutable replacement
 
 The previous Product schema fingerprint was not changed in place. Current runtime code uses one
@@ -59,8 +75,8 @@ boundary. Resolved SalesChannel membership advances under `relation_epoch`.
 revision and joins the exact retained relation epoch referenced by projection state.
 
 The current source additionally materializes Product-owned tag UUIDs and canonical typed EAV terms in
-the same PostgreSQL source read. EAV commands already advance Product `index_revision` and graph
-projection before their refresh ledger is captured.
+the same PostgreSQL source read. EAV commands advance Product `index_revision` and graph projection
+before their refresh ledger is captured.
 
 Product hard-delete replay also uses projection epoch but does not decode live Storefront fields or
 require a live relation freshness witness because the mutation removes the Product graph.
@@ -89,11 +105,12 @@ Detailed contracts:
 
 ## Still open
 
-Source coverage is complete, but production/Storefront admission still requires:
+The Product source contract itself is current, but production/Storefront admission still requires:
 
 - staged current-key rebuild and final persisted supersession;
-- retained PostgreSQL replay/freshness/concurrency/restart/delete-recreate execution;
-- generic scalar text substring filtering needed to reproduce owner title search;
+- actualization and execution of retained PostgreSQL packets on the current key/15-field contract;
+- an explicit effective localized Product list identity/search/fallback architecture;
+- any generic text-pattern primitive required by that chosen architecture;
 - Storefront query translation and bounded Taxonomy tag-name hydration;
 - full owner-vs-Index Storefront equivalence;
 - Product typed event family/routes after event-contract digest admission;

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,129 +1,150 @@
 # M7 Product Storefront Index parity gate
 
-Status: `source_complete_query_adapter_and_evidence_pending`.
+Status: `source_gap_locale_search_and_fallback_adapter_evidence_pending`.
 
 ## Purpose
 
-The Product Storefront catalog remains owner-native until a retained owner-vs-Index equivalence packet
-is executed and admitted. The single current Product Index source now materializes the Storefront fields
-and typed EAV query state that were previously missing, but source coverage alone does not authorize a
-traffic cutover.
+The Product Storefront catalog remains owner-native. The single current Product Index source now
+materializes the Storefront scalar fields, stable tag identities, and typed EAV query state that were
+previously missing, but a fresh owner-vs-Index recheck found a remaining **localized Product identity
+mismatch**. Source coverage must not be described as complete until that boundary is resolved.
 
-Storefront must continue to execute `CatalogService::list_published_products_with_query` until the
-remaining adapter, tag hydration, staged rebuild/readiness, and equivalence gates are complete.
+Storefront must continue to execute `CatalogService::list_published_products_with_query`.
 
 ## Owner Storefront contract
 
-`StorefrontProductListQuery` accepts:
-
-- optional title search;
-- optional primary category UUID;
-- sort by `published_at` or `created_at`;
-- ascending or descending direction;
-- up to eight typed `code=value` Product attribute predicates;
-- page/per-page pagination.
+`StorefrontProductListQuery` accepts optional title search/category, `published_at` or `created_at`
+sorting in either direction, up to eight typed Product EAV predicates, and page/per-page pagination.
 
 Owner execution additionally enforces tenant scope, Active status, non-null `published_at`, public
-SalesChannel visibility, category/title filtering, typed EAV predicates, stable timestamp+ID ordering,
-exact count, Product translation fallback, and localized tag projection.
+SalesChannel visibility, exact count, stable timestamp+ID ordering, Product translation fallback, and
+localized tag projection.
 
-The result payload returns `id`, `status`, `title`, `handle`, `seller_id`, `vendor`, `product_type`,
-localized tag names, `created_at`, and `published_at`.
+Two translation details are authoritative today:
+
+1. `product_title_search_condition` uses an `EXISTS` over `product_translations` for the Product and does
+   **not** restrict that search row to the requested or fallback locale. A title match in any Product
+   translation can therefore admit the Product.
+2. Result projection calls `pick_product_translation(items, requested, fallback)`. If the requested
+   translation is absent, the owner list can still return the Product using its fallback translation.
+
+The public item then returns `id`, `status`, effective `title`, effective `handle`, `seller_id`, `vendor`,
+`product_type`, localized tag names, `created_at`, and `published_at`.
 
 ## Single current Product Index coverage
 
 Current Product runtime code publishes one Product schema with 15 fields and two links:
 
-- existing graph/content fields: `id`, `status`, `title`, `handle`, `description`, `vendor`,
-  `product_type`, `primary_category_id`, `variant_ids`, `sales_channel_ids`;
-- Storefront scalar fields: `seller_id`, `created_at`, `published_at`;
-- stable Taxonomy tag identities: `tag_ids`;
+- identity/content: `id`, `status`, `title`, `handle`, `description`;
+- Storefront owner scalars: `seller_id`, `vendor`, `product_type`, `primary_category_id`, `created_at`,
+  `published_at`;
+- stable Taxonomy identities: `tag_ids`;
 - typed EAV query machinery: `attribute_terms`;
+- graph membership: `variant_ids`, `sales_channel_ids`;
 - links `variants` and `sales_channels`.
 
-`created_at` and `published_at` are sortable. `published_at` is nullable/filterable so published-only
-admission can be represented explicitly. `attribute_terms` is a non-selectable filterable
-`Many<String>` field using the canonical Product attribute-term grammar.
+The source emits **one Index entity for each physically stored `product_translations.locale`**. It does
+not fabricate a requested-locale row when that translation is absent. The Product absence provider
+correctly reports that exact locale identity as absent; it is not a Storefront fallback synthesizer.
 
-The Product source still uses `projection_epoch` as its complete mutation clock and retains existing
-Product/SalesChannel freshness plus linked-target availability rules.
+This is correct for the generic localized Index source contract, but it is not yet equivalent to the
+owner Storefront list semantics above.
 
-## Tags remain Taxonomy-owned
+## Remaining locale/search source gap
 
-Index stores stable `product_tags.term_id` UUIDs, not localized Taxonomy names. Copying Taxonomy
-translations into Product Index would create a second freshness clock that Product does not own.
+A scalar substring/LIKE operator alone cannot close Storefront parity:
 
-A Storefront Index adapter must therefore hydrate localized tag names from Taxonomy after Product page
-selection, preserving the same requested/fallback locale behavior as the owner path. That hydration must
-be bounded/batched and included in parity evidence before cutover.
+- searching only the current Index entity's `title` would miss owner matches that exist in another
+  translation;
+- querying only the requested locale would omit Products for which the owner list returns a fallback
+  translation;
+- issuing an independent fallback query after the requested query would not automatically preserve one
+  owner-equivalent global sort, page boundary, exact count, and de-duplication contract.
+
+Therefore the next Storefront query work must first choose and prove one explicit architecture for
+**effective localized Product list identity**. Acceptable designs must preserve owner semantics without
+adding another parallel Product compatibility schema. Examples include a generic bounded localized
+fallback/union query capability or an explicitly changed owner Storefront contract, but no choice is
+claimed by this document yet.
+
+Do **not** add another Product routing key merely to patch this query semantic. The current Product
+contract remains the only runtime Product implementation while this query-layer decision is pending.
 
 ## Typed EAV representation
 
 Dynamic EAV attributes do not create dynamic Index fields. Public Product attribute/option codes are
-resolved through Product owner metadata to stable attribute/option UUIDs; the adapter then builds
-`Contains(attribute_terms, term)` expressions.
+resolved through Product owner metadata to stable UUIDs; the adapter then builds
+`Contains(attribute_terms, term)` predicates.
 
-Localized text uses the exact owner predicate:
+Localized text EAV uses the exact owner predicate:
 
 `requested-value OR (NOT requested-present AND fallback-value)`
 
-See `m7-product-attribute-term-contract.md` for the current grammar and normalization.
+See `m7-product-attribute-term-contract.md`.
+
+## Tags remain Taxonomy-owned
+
+Index stores stable `product_tags.term_id` UUIDs, not localized Taxonomy names. A future Storefront Index
+adapter must batch-hydrate requested/fallback tag names from Taxonomy after Product page selection. That
+boundary remains evidence-gated and does not require Product to own Taxonomy translation freshness.
 
 ## Immutable replacement boundary
 
-The old Product fingerprint was not modified in place. Current runtime code uses one monotonically
-higher internal Product routing key, derives replay IDs with `derive_index_schema_source_event_id`, and
-publishes no lower Product compatibility implementation.
+The previous Product fingerprint was not modified in place. Current runtime code publishes one higher
+internal routing key, derives replay IDs with `derive_index_schema_source_event_id`, and publishes no
+lower Product compatibility implementation.
 
-Lower persisted Product keys are historical storage identities only. Promotion remains an operator and
-evidence action:
+Lower persisted Product keys are historical storage identities only. Promotion remains staged:
 
 1. ordinary-register the current key;
-2. rebuild/replay the current key completely;
-3. prove exact schema readiness, parity, freshness, restart, and inbox isolation;
+2. rebuild/replay it completely;
+3. prove exact readiness, freshness, inbox isolation, and query parity;
 4. call `PostgresSchemaRegistrationStore::register_current` to retire lower active persisted keys;
-5. only then allow authoritative Storefront selection.
+5. only then allow an authoritative consumer cutover.
 
-There is no same-key fingerprint replacement and no parallel Product v4/v5 route.
+## Remaining work before Storefront cutover
 
-## Remaining source/evidence work before cutover
+Storefront traffic stays blocked until all of these are complete:
 
-The schema/source gap is closed, but Storefront traffic stays blocked until all of these are complete:
-
-1. translate `StorefrontProductListQuery` to the current `IndexQuery` contract;
-2. resolve Product attribute and option codes to canonical term predicates;
-3. preserve Active + published-only admission, title/category filters, both sort keys/directions, stable
-   ID tie-break, pagination, and exact count;
-4. decode the current Product projection into the public Storefront result;
-5. batch-hydrate localized tag names through Taxonomy with requested/fallback parity;
-6. retain and execute PostgreSQL owner-vs-Index equivalence for the full matrix, including locale,
-   visibility, typed EAV, ordering, pagination, exact count, stale linked targets, and restart;
-7. stage/rebuild/promote the current Product key for the tenant before traffic selection.
+1. resolve the effective localized Product identity/search/fallback architecture described above;
+2. add any required generic text-pattern/query primitive only after that architecture is fixed;
+3. translate Active + published-only, category, visibility, EAV, timestamp ordering, ID tie-break,
+   pagination, and exact count to Index;
+4. resolve Product attribute/option codes to canonical EAV terms;
+5. batch-hydrate localized Taxonomy tag names;
+6. actualize retained Product PostgreSQL packets to the current Product routing key/source contract;
+7. retain and execute full owner-vs-Index equivalence for requested locale present/absent, fallback,
+   cross-locale title matches, EAV, visibility, ordering, pagination, exact count, target lag, and
+   restart;
+8. stage/rebuild/promote the current Product key for the tenant;
+9. only then select Index traffic.
 
 ## Source guard
 
-`scripts/verify/verify-index-product-storefront-parity-gate.mjs` checks that:
+`scripts/verify/verify-index-product-storefront-parity-gate.mjs` intentionally locks both sides of the
+current mismatch:
 
+- owner title search remains all-translations unless the same PR deliberately changes the owner
+  contract;
+- owner result projection still has requested/fallback translation selection;
+- Product Index source remains one physical translation locale per entity and does not fabricate
+  fallback rows;
 - native Storefront traffic has not silently switched to Index;
-- the owner query/DTO contract remains explicit;
-- the single current Product schema contains the required Storefront fields and canonical EAV terms;
-- Product replay identity is schema-scoped;
-- old Product runtime compatibility branches are absent;
-- same-key schema replacement remains rejected and staged supersession remains available;
-- cutover remains query-adapter/evidence gated.
+- one current 15-field Product schema and schema-scoped replay identity remain selected;
+- cutover remains fail-closed.
 
 ## Deliberate limits
 
-This source slice does not execute tenant rebuild/supersession, implement the Storefront Index adapter,
-hydrate Taxonomy tags through Index traffic, add public typed Product event contracts, or switch traffic.
+This slice does not choose a new locale-union/fallback architecture, change owner Storefront semantics,
+add another Product routing key, implement the Storefront Index adapter, execute tenant rebuild, add
+public typed Product events, or switch traffic.
 
 ## Maintainer verification
 
 ```bash
+node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-product-source.mjs
 node scripts/verify/verify-index-product-attribute-term-contract.mjs
-node scripts/verify/verify-index-product-storefront-parity-gate.mjs
-node scripts/verify/verify-index-schema-supersession.mjs
 node scripts/verify/verify-index-query-contract.mjs
 node scripts/verify/verify-product-storefront-boundary.mjs
 cargo check -p rustok-index --all-targets

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -60,7 +60,7 @@ requireMarkers(typesPath, [
 ]);
 
 const ownerQueryPath = 'crates/rustok-product/src/services/catalog/queries.rs';
-requireMarkers(ownerQueryPath, [
+const ownerQuery = requireMarkers(ownerQueryPath, [
   'ProductStatus::Active',
   'Column::PublishedAt.is_not_null()',
   'product_channel_visibility_condition(',
@@ -74,7 +74,16 @@ requireMarkers(ownerQueryPath, [
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
   'load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))',
+  'fn product_title_search_condition(',
+  'FROM product_translations pt',
+  'pt.product_id = products.id',
+  'pt.title LIKE $1',
 ]);
+const titleSearchStart = ownerQuery.indexOf('fn product_title_search_condition(');
+const titleSearch = ownerQuery.slice(titleSearchStart);
+if (titleSearch.includes('pt.locale')) {
+  fail(`${ownerQueryPath} title search became locale-scoped; update the parity architecture and guard in the same PR`);
+}
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = read(productIndexPath);
@@ -108,47 +117,47 @@ for (const marker of [
 if (!productIndex.includes('assert_eq!(schema.fields.len(), 15);')) {
   fail(`${productIndexPath} current single Product field-count assertion is not 15`);
 }
+requireMarkers(productIndexPath, [
+  'JOIN product_translations t',
+  't.locale',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'derive_index_schema_source_event_id(',
+  "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
+  "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
+]);
 forbidMarkers(productIndexPath, productIndex, [
   'SchemaVersion::new(3)',
   'derive_index_source_event_id(',
   'ProductSchemaVersion',
   'product_v1_schema',
   'product_v2_schema',
+  'COALESCE(requested_translation',
+  'fallback_translation AS title',
 ]);
-requireMarkers(productIndexPath, [
+
+const absencePath = 'crates/rustok-distribution/src/product_index/absence.rs';
+requireMarkers(absencePath, [
+  'translation.locale = $3',
+  'return Ok(None);',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
-  'derive_index_schema_source_event_id(',
-  "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
-  "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
 ]);
 
 const schemaStorePath = 'crates/rustok-index/src/infrastructure/postgres/schema_registration.rs';
 requireMarkers(schemaStorePath, [
   'VersionConflict { reference: SchemaRef }',
-  'NonMonotonicVersion {',
-  'schema {reference} is already registered with another contract',
-  'existing.fingerprint != fingerprint.to_string() || existing.schema_json != *schema_json',
   'pub async fn register_current(',
   'retire_lower_active_schemas(',
   "status = 'retired'",
 ]);
-forbidMarkers(schemaStorePath, read(schemaStorePath), [
-  'DELETE FROM index_schemas',
-  'DELETE FROM index_entities',
-  'DELETE FROM index_links',
-]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `source_complete_query_adapter_and_evidence_pending`',
-  'Current Product runtime code publishes one Product schema with 15 fields and two links',
-  '`seller_id`, `created_at`, `published_at`',
-  '`tag_ids`',
-  '`attribute_terms`',
-  'Tags remain Taxonomy-owned',
-  'query-adapter/evidence gated',
-  'ordinary-register the current key',
-  '`PostgresSchemaRegistrationStore::register_current`',
-  'There is no same-key fingerprint replacement and no parallel Product v4/v5 route.',
+  'Status: `source_gap_locale_search_and_fallback_adapter_evidence_pending`',
+  'does **not** restrict that search row to the requested or fallback locale',
+  'owner list can still return the Product using its fallback translation',
+  'one Index entity for each physically stored `product_translations.locale`',
+  'A scalar substring/LIKE operator alone cannot close Storefront parity',
+  'Do **not** add another Product routing key merely to patch this query semantic.',
+  'actualize retained Product PostgreSQL packets',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 
@@ -157,10 +166,4 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.md', [
-  'Status: `source_complete_execution_pending`',
-  'single-current',
-  '`derive_index_schema_source_event_id`',
-]);
-
-console.log('[verify-index-product-storefront-parity-gate] Product source coverage is complete; Storefront cutover remains fail-closed on adapter, rebuild and retained parity evidence');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains fail-closed on the explicit locale search/fallback mismatch');


### PR DESCRIPTION
## Summary

- correct the Product Storefront parity status after a fresh owner-query recheck;
- record that owner title search currently matches **any** `product_translations` row for the Product and is not restricted to requested/fallback locale;
- record that owner result projection can return fallback translation when the requested translation is absent;
- contrast that with the current Product Index source, which emits one entity only for each physically stored translation locale and correctly reports a missing exact locale as absent;
- make explicit that a scalar LIKE/substring operator alone cannot preserve owner-equivalent admission, fallback, global ordering, pagination, de-duplication and exact count;
- forbid solving this mismatch by adding another Product routing key or parallel Product schema;
- update the source guard to machine-lock the current owner all-translations search, fallback projection, physical-locale Index source, and owner-native traffic boundary;
- change no production runtime code, Product schema, routing key, event contract or traffic.

## Why this correction is required

PR #3199 correctly replaced Product with one current 15-field contract, but its first Storefront parity wording was too optimistic. Source inspection after merge found that owner Storefront localization semantics are not reducible to querying one current-locale Product Index entity:

- `product_title_search_condition` uses `EXISTS` over `product_translations` with `pt.title LIKE pattern` and no locale predicate;
- `pick_product_translation(items, requested, fallback)` can return fallback content when requested locale is absent;
- the canonical Index source joins the physical `product_translations t` row and emits only `t.locale`; the absence provider does not synthesize fallback records.

A separate fallback query would not automatically preserve one owner-equivalent sort/page/count contract. The architecture must therefore be chosen explicitly at the query/owner-contract layer before adding a generic text-pattern primitive for Storefront.

## Next source decision

Choose and prove one effective localized Product list identity/search/fallback architecture without another Product schema key. Only after that decision should generic text-pattern support and the Storefront Index adapter be implemented.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI or `git diff --check` were executed by the implementation agent.