### PR TITLE
feat(product): publish attribute-values schema read capability

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -1,0 +1,33 @@
+# Ecommerce Product schema read recheck — 2026-08-08
+
+## Scope
+
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`.
+
+The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
+
+## Recheck findings
+
+1. `ProductCatalogSchemaReadPort` already publishes the effective-form aggregate capability added by PR #3182, but the mounted `productEffectiveForm` resolver still constructs `ProductCatalogSchemaService` directly. The plan correctly keeps the remaining Product schema-read cutover open.
+2. The mounted `productAttributeValues` resolver also constructs `ProductCatalogSchemaService` directly. Before this slice there was no transport-neutral schema-read capability for that projection, so a consumer-only cutover would have bypassed the owner boundary contract.
+3. `storefrontCatalogSearchOptions` remains a direct `ProductCatalogSchemaService` consumer and is still explicit follow-up debt.
+4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths use `ProductCatalogReadRuntime`, while legacy mounted `product`/`products` roots in `query::CommerceQuery` still contain direct `CatalogService`/Product entity read paths. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path must remain open; source inspection does not justify a status promotion.
+
+## Source change in this slice
+
+- Publish `ProductAttributeValuesRequest` and optional `ProductCatalogSchemaReadPort::read_product_attribute_values`.
+- Keep existing adapters source-compatible with a stable fail-closed `product.attribute_values_unavailable` default.
+- Implement the in-process Product owner capability through `ProductCatalogSchemaService::load_product_attribute_values`, preserving canonical `PortContext` policy, tenant, locale, deadline, correlation, and stable public `PortError` mapping.
+- Extend `verify-product-catalog-schema-read-port.mjs` so the owner capability is locked in source while the mounted `productAttributeValues` consumer is explicitly required to remain uncut in this capability-only slice.
+
+## Remaining execution order
+
+1. Cut mounted `productEffectiveForm` to `ProductCatalogSchemaReadPort::read_effective_form`.
+2. Cut mounted `productAttributeValues` to `ProductCatalogSchemaReadPort::read_product_attribute_values`.
+3. Publish/cut the owner projection needed by `storefrontCatalogSearchOptions`.
+4. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
+5. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
+
+## Verification state
+
+No tests, checks, formatters, or runtime verification were executed in this slice per maintainer instruction. All execution/promotion gates remain unchanged.

--- a/crates/rustok-product/src/catalog_schema_read_port.rs
+++ b/crates/rustok-product/src/catalog_schema_read_port.rs
@@ -7,13 +7,14 @@ use uuid::Uuid;
 use crate::services::{
     AttributeValueType, CatalogCategoryListRecord, EffectiveAttributeSource,
     ProductAttributeListRecord, ProductAttributeOptionListRecord, ProductAttributeSchemaListRecord,
-    ProductCatalogSchemaService,
+    ProductAttributeValueRecord, ProductCatalogSchemaService,
 };
 
 const LIST_ATTRIBUTES_OPERATION: &str = "list_catalog_attributes";
 const LIST_CATEGORIES_OPERATION: &str = "list_catalog_categories";
 const LIST_SCHEMAS_OPERATION: &str = "list_attribute_schemas";
 const READ_EFFECTIVE_FORM_OPERATION: &str = "read_effective_product_form";
+const READ_PRODUCT_ATTRIBUTE_VALUES_OPERATION: &str = "read_product_attribute_values";
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -50,7 +51,13 @@ pub struct ProductEffectiveFormAttributeProjection {
     pub source: EffectiveAttributeSource,
 }
 
-/// Optional Product-owned read boundary for catalog schema directory and effective-form projections.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProductAttributeValuesRequest {
+    pub product_id: Uuid,
+}
+
+/// Optional Product-owned read boundary for catalog schema directory, effective-form,
+/// and product attribute-value projections.
 #[async_trait]
 pub trait ProductCatalogSchemaReadPort: Send + Sync {
     async fn list_attributes(
@@ -78,6 +85,19 @@ pub trait ProductCatalogSchemaReadPort: Send + Sync {
         Err(PortError::unavailable(
             "product.effective_form_unavailable",
             "product effective form is unavailable",
+        ))
+    }
+
+    /// Optional product attribute-value projection. Existing schema-directory adapters
+    /// remain source-compatible until they explicitly support this owner read.
+    async fn read_product_attribute_values(
+        &self,
+        _context: PortContext,
+        _request: ProductAttributeValuesRequest,
+    ) -> Result<Vec<ProductAttributeValueRecord>, PortError> {
+        Err(PortError::unavailable(
+            "product.attribute_values_unavailable",
+            "product attribute values are unavailable",
         ))
     }
 }
@@ -234,6 +254,24 @@ impl ProductCatalogSchemaReadPort for ProductCatalogSchemaService {
             attributes,
             detached_attribute_ids: form.detached_attribute_ids,
         }))
+    }
+
+    async fn read_product_attribute_values(
+        &self,
+        context: PortContext,
+        request: ProductAttributeValuesRequest,
+    ) -> Result<Vec<ProductAttributeValueRecord>, PortError> {
+        let owner_operation = READ_PRODUCT_ATTRIBUTE_VALUES_OPERATION;
+        require_schema_read_context(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        ProductCatalogSchemaService::load_product_attribute_values(
+            self,
+            tenant_id,
+            request.product_id,
+            context.locale.as_str(),
+        )
+        .await
+        .map_err(|error| schema_error_to_port_error(&context, owner_operation, error))
     }
 }
 

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -28,8 +28,9 @@ pub mod services;
 
 pub use catalog_command_port::ProductCatalogCommandPort;
 pub use catalog_schema_read_port::{
-    ProductCatalogSchemaReadPort, ProductEffectiveFormAttributeProjection,
-    ProductEffectiveFormProjection, ProductEffectiveFormRequest, ProductEffectiveFormSubject,
+    ProductAttributeValuesRequest, ProductCatalogSchemaReadPort,
+    ProductEffectiveFormAttributeProjection, ProductEffectiveFormProjection,
+    ProductEffectiveFormRequest, ProductEffectiveFormSubject,
 };
 pub use error::{CommerceError, CommerceResult};
 pub use ports::*;

--- a/scripts/verify/verify-product-catalog-schema-read-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-read-port.mjs
@@ -41,12 +41,16 @@ for (const required of [
   "async fn list_categories(",
   "async fn list_schemas(",
   "async fn read_effective_form(",
+  "async fn read_product_attribute_values(",
   "pub enum ProductEffectiveFormSubject",
   "pub struct ProductEffectiveFormRequest",
   "pub struct ProductEffectiveFormProjection",
   "pub struct ProductEffectiveFormAttributeProjection",
+  "pub struct ProductAttributeValuesRequest",
   '"product.effective_form_unavailable"',
   "product effective form is unavailable",
+  '"product.attribute_values_unavailable"',
+  "product attribute values are unavailable",
   "require_policy(PortCallPolicy::read())",
   "ProductCatalogSchemaService::list_attributes(",
   "ProductCatalogSchemaService::list_categories(",
@@ -55,6 +59,7 @@ for (const required of [
   "ProductCatalogSchemaService::load_effective_form_for_category(",
   "ProductCatalogSchemaService::load_effective_form_group_labels(",
   "ProductCatalogSchemaService::list_attribute_options(",
+  "ProductCatalogSchemaService::load_product_attribute_values(",
   '"product.attribute_definition_missing"',
   "correlation_id = %context.correlation_id",
   '"product.database_unavailable"',
@@ -79,6 +84,7 @@ for (const required of [
   "mod catalog_schema_read_port;",
   "pub use catalog_schema_read_port::{",
   "ProductCatalogSchemaReadPort",
+  "ProductAttributeValuesRequest",
   "ProductEffectiveFormAttributeProjection",
   "ProductEffectiveFormProjection",
   "ProductEffectiveFormRequest",
@@ -145,6 +151,22 @@ forbidText(
   effectiveForm,
   ".read_effective_form(",
   "productEffectiveForm must not be marked cut over by the capability-only source guard",
+);
+
+const attributeValues = resolverSlice(
+  commerceQuery,
+  "product_attribute_values",
+  "storefront_catalog_search_options",
+);
+requireText(
+  attributeValues,
+  "ProductCatalogSchemaService::new",
+  "productAttributeValues consumer cutover must remain explicit follow-up debt in this capability slice",
+);
+forbidText(
+  attributeValues,
+  ".read_product_attribute_values(",
+  "productAttributeValues must not be marked cut over by the capability-only source guard",
 );
 
 if (!process.exitCode) {


### PR DESCRIPTION
## Summary

- recheck the canonical ecommerce Product schema-read work against current `main`
- publish optional `ProductCatalogSchemaReadPort::read_product_attribute_values` with a fail-closed compatibility default
- implement the in-process owner capability through `ProductCatalogSchemaService::load_product_attribute_values`
- extend the schema-read source guard while deliberately keeping the mounted `productAttributeValues` consumer marked as follow-up debt
- record the recheck finding that legacy mounted Product GraphQL roots still leave the broad every-production-path FBA invariant open

## Verification

Not run per maintainer instruction. No FBA/FFA or runtime verification status is promoted by this PR.