### PR TITLE
docs(index): select localized Storefront query architecture

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -26,7 +26,7 @@ This directory contains the detailed technical architecture documentation for `r
 
 ## Reference Documents
 
-- [Current Implementation Plan — 2026-08-07](./implementation-plan-current-2026-08-07.md)
+- [Current Implementation Plan — 2026-08-08](./implementation-plan-current-2026-08-08.md)
 - [Historical Milestone Plan](./implementation-plan.md)
 - [Source Module Integration Contract](./module-source-integration.md)
 - [M5 Mutation Event Commit/Ack Contract](./m5-mutation-event-ack-contract.md)
@@ -82,6 +82,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M7 Product Graph Projection Ledger](../../rustok-product/docs/index-graph-projection-ledger.md)
 - [M7 Product Attribute Term Contract](./m7-product-attribute-term-contract.md)
 - [M7 Product Storefront Index Parity Gate](./m7-product-storefront-parity-gate.md)
+- [M7 Product Storefront Localized Query Architecture](./m7-product-storefront-localized-query-architecture.md)
 - [M4 Source-owned Schema Registry](./m4-source-schema-registry.md)
 - [M4 Single-current Schema Supersession](./m4-single-current-schema-supersession.md)
 - [M4 Query Runtime Composition](./m4-query-runtime-composition.md)

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,6 +1,6 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@dfddce9f57916a712d531db38e75c87e7c45e8cf` (#3202) and continued on
+Status overlay rechecked from `main@aaa496887fd1492f3feca8ac52261458ce25705e` (#3203) and continued on
 `agent/index-storefront-localized-query-architecture-20260808`.
 
 `implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
@@ -21,10 +21,11 @@ The previous current plan was stale after the following merged Index/Product wor
 - #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
   projection is requested-locale -> fallback-locale.
 
-`main` subsequently advanced through #3202. Those intervening changes are outside the Product Storefront
-parity/doc/guard file set. One generic `rustok-index` change exposes trusted PostgreSQL query-admission
-rendering; it does not resolve the localized Product identity mismatch. #3202 itself is Moderation/RBAC
-work and does not overlap this Index slice.
+`main` subsequently advanced through #3203. The intervening work does not resolve the localized Product
+identity mismatch: one generic `rustok-index` change exposes trusted PostgreSQL query-admission rendering;
+#3202 is Moderation/RBAC; #3203 publishes a Product attribute-values schema-read owner capability for a
+separate ecommerce boundary. None changes `list_published_products_with_query`, the physical Product Index
+locale model, Product routing key `4`, or the Storefront parity gate described here.
 
 ## Old execution branch
 

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,6 +1,6 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@5f9e2fe4783d8bb5e6dad29adeff2dffc8296990` and continued on
+Status overlay rechecked from `main@dfddce9f57916a712d531db38e75c87e7c45e8cf` (#3202) and continued on
 `agent/index-storefront-localized-query-architecture-20260808`.
 
 `implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
@@ -21,9 +21,10 @@ The previous current plan was stale after the following merged Index/Product wor
 - #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
   projection is requested-locale -> fallback-locale.
 
-`main` then advanced by two commits outside the Product Storefront parity/doc/guard file set. One of those
-commits only changes the generic PostgreSQL query admission rendering API in `rustok-index`; it does not
-resolve the localized Product identity mismatch.
+`main` subsequently advanced through #3202. Those intervening changes are outside the Product Storefront
+parity/doc/guard file set. One generic `rustok-index` change exposes trusted PostgreSQL query-admission
+rendering; it does not resolve the localized Product identity mismatch. #3202 itself is Moderation/RBAC
+work and does not overlap this Index slice.
 
 ## Old execution branch
 

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,0 +1,207 @@
+# Current `rustok-index` implementation plan — 2026-08-08
+
+Status overlay rechecked from `main@5f9e2fe4783d8bb5e6dad29adeff2dffc8296990` and continued on
+`agent/index-storefront-localized-query-architecture-20260808`.
+
+`implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
+history for the linked-target/replay sequence, but this file is the current execution cursor.
+
+## Recheck result
+
+The previous current plan was stale after the following merged Index/Product work:
+
+- #3190 retained linked-target replay/redelivery source evidence;
+- #3192 added the fail-closed Product Storefront parity gate;
+- #3193 added staged single-current schema supersession;
+- #3194 added schema-scoped source delivery IDs for replacement rebuilds;
+- #3197 advanced the canonical Product owner clock for EAV writes;
+- #3198 defined canonical typed Product `attribute_terms`;
+- #3199 replaced Product runtime code with one current 15-field Product contract on internal routing key
+  `4`, with lower keys historical only;
+- #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
+  projection is requested-locale -> fallback-locale.
+
+`main` then advanced by two commits outside the Product Storefront parity/doc/guard file set. One of those
+commits only changes the generic PostgreSQL query admission rendering API in `rustok-index`; it does not
+resolve the localized Product identity mismatch.
+
+## Old execution branch
+
+`agent/index-linked-target-replay-redelivery-evidence-20260807` is no longer a valid continuation base.
+It diverges from current `main` and contains source content that was already squash-merged through #3190.
+Do not cherry-pick or continue development from that branch.
+
+The old branch should be deleted after this current work is safely on `main`. Branch deletion is repository
+hygiene only; it is not part of Index correctness.
+
+## Current primary owner gate
+
+`M6 - execute and admit concrete repair PostgreSQL evidence`
+
+The concrete repair implementation, recovery policy, PostgreSQL harness, and retained-evidence admission
+source remain complete. Maintainer execution/admission is still required and is not claimed by source
+inspection.
+
+## Current Product/Storefront source state
+
+The canonical Product graph keeps one current Product runtime contract and the existing ProductVariant and
+SalesChannel target contracts.
+
+Current Product source/runtime facts:
+
+- one current Product schema on internal routing key `4`;
+- 15 fields: `id`, `status`, `title`, `handle`, `description`, `seller_id`, `vendor`, `product_type`,
+  `primary_category_id`, `tag_ids`, `created_at`, `published_at`, `attribute_terms`, `variant_ids`, and
+  `sales_channel_ids`;
+- `variants` and `sales_channels` links unchanged;
+- Product replay IDs are schema-scoped through `derive_index_schema_source_event_id`;
+- lower Product routing keys are historical persisted identities, not compatibility implementations;
+- EAV writes advance the same Product owner `index_revision` / graph `projection_epoch` clock;
+- dynamic Product EAV filters use stable UUID-keyed typed `attribute_terms`;
+- ProductVariant/SalesChannel recreate ordering still uses retained tombstone-backed `index_revision`;
+- Product root freshness and linked-target availability remain fail-closed.
+
+## Corrected Storefront parity boundary
+
+The 15-field replacement fixed the old missing-field/EAV gap, but #3200 proved a separate query identity
+mismatch:
+
+1. owner title search can match any Product translation;
+2. owner result projection prefers requested translation, then fallback translation;
+3. Product Index physically stores one entity per actual translation locale;
+4. ordinary `IndexQuery` scopes one exact locale and therefore cannot by itself preserve owner search,
+   fallback, global pagination, de-duplication, and exact count.
+
+A scalar substring/LIKE operator on the current exact-locale query is therefore insufficient.
+
+## Localized Product query architecture
+
+Source decision: complete in
+`m7-product-storefront-localized-query-architecture.md`.
+
+Selected architecture:
+
+- preserve owner Storefront semantics;
+- keep exactly one current Product schema/routing key;
+- add a generic Index query-layer localized-entity fold whose logical page identity is
+  `(tenant_id, schema_ref, entity_id)` while physical storage remains locale-keyed;
+- evaluate any-locale title search as an identity predicate across current/admitted locale rows;
+- choose result localization independently: requested locale -> fallback locale -> no localized row;
+- apply exact count, sort, lookahead, and cursor semantics to grouped Product identities before page
+  truncation;
+- forbid client-side merging of independently paginated locale queries;
+- keep existing schema readiness, Product freshness, and linked-target availability admission.
+
+Implementation and retained evidence remain pending. Storefront traffic remains owner-native.
+
+## Retained M7 PostgreSQL packets
+
+The six packets retained before the Product replacement remain valuable historical scenario definitions,
+but they are **not yet current replacement evidence** because several fixtures still hardcode historical
+Product routing key `3` and pre-replacement assumptions.
+
+Packets requiring source actualization before execution/admission:
+
+1. `product_materialized_query_freshness_postgres.rs`;
+2. `product_channel_convergence_postgres.rs`;
+3. `product_channel_identity_transitions_postgres.rs`;
+4. `product_linked_target_recreate_postgres.rs`;
+5. `product_linked_target_availability_equivalence_postgres.rs`;
+6. `product_linked_target_replay_redelivery_postgres.rs`.
+
+The separate Product locale-absence retained packet and related static guards must also be rechecked for
+historical key assumptions.
+
+Do not add a runtime alias for key `3` to make these tests pass. Evidence must follow the one current
+Product contract.
+
+## M5 incremental ingestion
+
+- [x] Source replay registry and bounded source failures.
+- [x] Inbox deduplication and monotonic source versions.
+- [x] Mutation-event registry and commit-before-ack orchestration.
+- [x] Exact source-refresh worker with owner revision fence.
+- [x] Product locale/ProductVariant refresh ledgers and durable relay step.
+- [ ] Execute canonical event-contract digest admission on current reviewed `main` and commit the
+      generated canonical digest artifact through its own reviewed PR.
+- [ ] Add exactly one canonical Product Index typed event family and concrete routes/consumers only after
+      the digest gate is valid.
+- [ ] Retain crash-between-commit-and-ack/redelivery evidence for the typed incremental route.
+
+The digest workflow remains a maintainer execution gate. Source inspection must not fabricate the digest.
+
+## M6 replay, reconciliation, diagnosis, and repair
+
+- [x] Bounded scan/load and stable replay identities.
+- [x] Durable jobs, leases, checkpoints, multi-page replay, cancellation, and reconciliation.
+- [x] Source timeout, dry-run, cooperative interruption, retry and dead-letter recovery.
+- [x] Drift discovery/confirmation/finding lifecycle and targeted repair.
+- [x] Concrete missing-entity/orphan-link repair and prepared-command recovery.
+- [x] Real-migration PostgreSQL repair harness and retained-evidence admission tooling.
+- [ ] Execute and admit the concrete repair PostgreSQL packet.
+- [ ] Retain remaining multi-host/restart/graceful-shutdown/command-transport evidence.
+- [ ] Add remaining locale/partition checkpoint dimensions and explicit rebuild modes.
+
+## M7 Product/ProductVariant/SalesChannel production graph
+
+- [x] Canonical Product, ProductVariant, and SalesChannel bounded sources.
+- [x] Product `variants` and `sales_channels` links.
+- [x] Product/ProductVariant/SalesChannel retained delete identities.
+- [x] Product-to-SalesChannel relation membership ledger and bounded resolver.
+- [x] Canonical Product graph projection epoch and projection-aware Product absence.
+- [x] Product-to-SalesChannel freshness witness and Channel identity generation.
+- [x] Product visibility convergence requests and bounded automatic generic ModuleWork convergence.
+- [x] Rejected-Product poison isolation.
+- [x] Product materialized root freshness fence.
+- [x] Entity-level stale linked-target freshness fence for ProductVariant and SalesChannel.
+- [x] ProductVariant/SalesChannel recreate-safe monotonic `index_revision` via retained tombstones.
+- [x] Query-path-scoped fail-closed linked-target availability semantics.
+- [x] One current 15-field Product Storefront-capable source contract.
+- [x] Schema-safe single-current replacement/promotion mechanism.
+- [x] Canonical typed EAV term representation and Product EAV owner clock.
+- [x] Recheck and document owner all-translations search + requested/fallback projection mismatch.
+- [x] Choose one generic localized Product query identity/fallback architecture without another Product
+      routing key.
+- [ ] Implement the generic localized-entity fold in `rustok-index` while keeping ordinary exact-locale
+      `IndexQuery` unchanged.
+- [ ] Add generic scalar text-pattern matching inside the folded any-locale identity predicate.
+- [ ] Implement the Product Storefront Index adapter and Taxonomy tag hydration boundary.
+- [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` and the 15-field source.
+- [ ] Retain source-ready folded-query owner-vs-Index PostgreSQL equivalence packets.
+- [ ] Execute/admit current replacement Product PostgreSQL packets.
+- [ ] Stage/rebuild/promote the current Product schema for a tenant.
+- [ ] Move Storefront traffic only after readiness/equivalence/freshness/availability/restart evidence
+      passes.
+
+## Next implementation step
+
+Primary maintainer gate remains: **execute and admit the locked M6 repair PostgreSQL packet**.
+
+Next source-code step: **implement the generic localized-entity fold in `rustok-index`** according to the
+selected architecture. Keep the existing exact-locale `IndexQuery` contract stable; do not silently
+reinterpret `IndexQueryScope.locale` as a locale union.
+
+In parallel, the retained Product PostgreSQL packets need a mechanical source actualization to routing key
+`4`/15-field Product contract before they can be treated as current evidence. No historical-key runtime
+compatibility path is allowed.
+
+Typed Product events remain separately blocked on maintainer event-digest admission.
+
+## Maintainer verification after the next source slices
+
+The implementation agent has not run these commands. Maintainer verification should include the relevant
+focused tests plus the aggregate guards, for example:
+
+```bash
+node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+node scripts/verify/verify-index-product-storefront-parity-gate.mjs
+node scripts/verify/verify-index-product-source.mjs
+node scripts/verify/verify-index-product-attribute-term-contract.mjs
+node scripts/verify/verify-index-query-contract.mjs
+cargo check -p rustok-index --all-targets
+cargo check -p rustok-distribution --features mod-product --all-targets
+git diff --check
+```
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
+++ b/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
@@ -1,0 +1,178 @@
+# M7 Product Storefront localized query architecture
+
+Status: `source_decision_complete_implementation_and_evidence_pending`.
+
+## Decision
+
+Keep the current owner Storefront behavior and keep exactly one current Product Index schema. Close the
+remaining locale/search mismatch in the **Index query layer** with a generic localized-entity identity
+fold over the existing physical locale rows.
+
+This decision deliberately rejects both shortcuts that would make parity ambiguous:
+
+- do not narrow Product owner search/fallback semantics merely to fit the current single-locale
+  `IndexQueryScope`;
+- do not add another Product routing key, compatibility source, or Storefront-only Product schema.
+
+The current Product routing key remains an internal storage/replay identity. Localized Storefront query
+semantics are a query-shape concern, not a new Product schema version.
+
+## Owner contract preserved
+
+`CatalogService::list_published_products_with_query` remains authoritative until cutover evidence passes.
+The replacement query path must preserve these existing semantics exactly:
+
+- one result identity per Product;
+- title search may match **any** Product translation;
+- result localization prefers the requested locale, then the fallback locale;
+- if neither requested nor fallback translation is present, owner projection uses its existing
+  placeholder behavior rather than selecting an unrelated translation as user-visible content;
+- Product status/publication/category/channel/EAV predicates apply to Product identity;
+- ordering is by `published_at`/`created_at` plus stable Product ID tie-break;
+- pagination and exact count operate on distinct Product identities, never translation rows.
+
+Product creation currently requires at least one translation. Retained parity evidence must still cover
+translation removal/lifecycle boundaries instead of assuming that creation-time invariant is sufficient
+forever.
+
+## Generic Index model
+
+The localized fold operates only for a schema whose locale mode is `Required` and only when a caller
+explicitly requests the fold. Ordinary `IndexQuery` remains exact-locale and unchanged.
+
+For one folded query, the logical root identity is:
+
+`(tenant_id, schema_ref, entity_id)`
+
+Locale is intentionally excluded from that **query result identity** while remaining part of physical
+Index storage, mutation, replay, absence, freshness, and ordinary query identity.
+
+The fold receives two canonical locale roles:
+
+1. requested locale;
+2. fallback locale, de-duplicated when equal to requested.
+
+It then reasons over all current/admitted physical locale rows for each root identity in one SQL query.
+A consumer must not emulate this contract by issuing independent locale queries and merging pages in
+memory.
+
+## Search semantics
+
+Any-locale title search is an identity predicate:
+
+- a Product identity is admitted when at least one current/admitted physical locale row satisfies the
+  requested text predicate;
+- the row that satisfied search does **not** become the result locale merely because it matched;
+- stale/deleted/unready locale rows cannot admit an identity;
+- search matching and result localization are therefore independent, matching the owner Storefront
+  contract.
+
+The future generic text-pattern primitive must be applied inside this identity predicate. Adding scalar
+substring/LIKE support to an exact-locale query alone remains insufficient and is not admitted by this
+decision.
+
+## Effective localized projection
+
+For an admitted Product identity, effective localized projection is selected independently from search:
+
+1. current/admitted requested-locale row;
+2. otherwise current/admitted fallback-locale row;
+3. otherwise no effective localized row.
+
+When there is no effective localized row, the Storefront adapter must preserve the owner placeholder
+contract for localized fields. It must not expose title/handle/description from an arbitrary third
+locale.
+
+Locale-invariant Product fields may be read from a deterministic current/admitted identity anchor only
+under the current single Product source invariant that those values are repeated identically across
+locale rows for one Product source version. Retained PostgreSQL evidence must prove this together with
+partial locale delivery and replay/restart cases before Storefront cutover.
+
+## Pagination, sorting, and exact count
+
+Grouping happens **before** pagination and exact count.
+
+- exact count is the number of distinct admitted Product identities;
+- page limit/lookahead is applied to grouped Product identities, not physical translation rows;
+- the Storefront ordering tuple remains the owner tuple (`published_at`/`created_at`, companion
+  timestamp, Product ID) and must be evaluated from the identity-level current Product state;
+- continuation state must bind requested locale, fallback locale, localized-fold mode, schema
+  fingerprint, filter/order shape, and the same identity-level ordering tuple;
+- a cursor from an ordinary exact-locale query must not be accepted by the folded query path, and vice
+  versa.
+
+An implementation that separately pages requested/fallback/other locales and merges afterward cannot
+provide this contract and is forbidden.
+
+## Freshness and graph availability
+
+Existing schema readiness, Product entity freshness, and queried link-target availability remain
+mandatory. The localized fold does not weaken them.
+
+Every physical row used to admit search, supply requested/fallback projection, or act as the deterministic
+identity anchor must already satisfy the same current query admission rules that protect ordinary Product
+queries. A stale translation row cannot keep a Product visible or satisfy search after the owner Product
+clock has advanced.
+
+ProductVariant/SalesChannel linked paths remain one-hop and use the existing query-path-scoped target
+availability policy after Product identity admission. No new Product graph clock or relation ledger is
+introduced.
+
+## Storefront adapter boundary
+
+The future Storefront adapter may translate owner inputs to the generic localized fold only after the
+Index-side contract exists. It must then:
+
+- map Active + published-only/category/channel visibility predicates;
+- resolve public Product attribute/option codes to canonical `attribute_terms`;
+- use the folded any-locale title search primitive;
+- preserve requested/fallback localized Product projection;
+- batch-hydrate localized Taxonomy tag names after the Product page is fixed;
+- preserve owner page/per-page, exact count, ordering, and stable ID tie-break semantics.
+
+Taxonomy localization remains Taxonomy-owned. Product Index continues to store stable tag UUIDs only.
+
+## Required retained evidence
+
+Before Storefront traffic can move, PostgreSQL equivalence must cover at least:
+
+1. requested translation present;
+2. requested absent + fallback present;
+3. requested/fallback absent while another translation exists;
+4. search match only in requested locale;
+5. search match only in fallback locale;
+6. search match only in a third locale while projection still uses requested/fallback rules;
+7. duplicate matches in multiple locales yielding one Product identity and exact count of one;
+8. two Products whose locale rows interleave physically but whose global timestamp+ID order is stable;
+9. page boundary and exact-count parity across locale combinations;
+10. delayed/stale locale materialization excluded by owner freshness;
+11. restart/recomposition and replay redelivery preserving the same grouped identity page;
+12. ProductVariant/SalesChannel target lag on a folded Product query;
+13. current Product routing-key rebuild/promotion rather than any lower historical key.
+
+Until these packets are source-ready, executed, and admitted, Storefront remains owner-native.
+
+## Deliberate limits
+
+This source decision does not yet:
+
+- change `IndexQueryScope` or public Index query types;
+- add the generic localized fold implementation;
+- add scalar text-pattern SQL compilation;
+- implement the Storefront Index adapter;
+- actualize the retained Product PostgreSQL packets to the current Product routing key;
+- execute or admit PostgreSQL evidence;
+- run the event-contract digest admission workflow;
+- add Product typed wire events;
+- stage/rebuild/promote a tenant Product schema;
+- switch Storefront traffic.
+
+## Next implementation slice
+
+Implement the generic localized-entity fold in `rustok-index` as a separate controlled query mode with
+identity-level page/count/cursor semantics. Keep ordinary exact-locale `IndexQuery` behavior unchanged.
+Only after that fold exists should scalar text-pattern matching be wired into its any-locale identity
+predicate and consumed by a Product Storefront adapter.
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,13 +1,14 @@
 # M7 Product Storefront Index parity gate
 
-Status: `source_gap_locale_search_and_fallback_adapter_evidence_pending`.
+Status: `source_architecture_selected_implementation_and_evidence_pending`.
 
 ## Purpose
 
 The Product Storefront catalog remains owner-native. The single current Product Index source now
 materializes the Storefront scalar fields, stable tag identities, and typed EAV query state that were
-previously missing, but a fresh owner-vs-Index recheck found a remaining **localized Product identity
-mismatch**. Source coverage must not be described as complete until that boundary is resolved.
+previously missing. A fresh owner-vs-Index recheck found a remaining **localized Product identity
+mismatch**; the query-layer architecture for that mismatch is now selected, but implementation and
+retained evidence are still pending.
 
 Storefront must continue to execute `CatalogService::list_published_products_with_query`.
 
@@ -47,10 +48,10 @@ The source emits **one Index entity for each physically stored `product_translat
 not fabricate a requested-locale row when that translation is absent. The Product absence provider
 correctly reports that exact locale identity as absent; it is not a Storefront fallback synthesizer.
 
-This is correct for the generic localized Index source contract, but it is not yet equivalent to the
-owner Storefront list semantics above.
+This physical storage model remains correct. Storefront equivalence is resolved at query composition,
+not by introducing another Product schema or fabricating locale rows during replay.
 
-## Remaining locale/search source gap
+## Selected locale/search architecture
 
 A scalar substring/LIKE operator alone cannot close Storefront parity:
 
@@ -61,14 +62,21 @@ A scalar substring/LIKE operator alone cannot close Storefront parity:
 - issuing an independent fallback query after the requested query would not automatically preserve one
   owner-equivalent global sort, page boundary, exact count, and de-duplication contract.
 
-Therefore the next Storefront query work must first choose and prove one explicit architecture for
-**effective localized Product list identity**. Acceptable designs must preserve owner semantics without
-adding another parallel Product compatibility schema. Examples include a generic bounded localized
-fallback/union query capability or an explicitly changed owner Storefront contract, but no choice is
-claimed by this document yet.
+The selected design is a generic **localized-entity identity fold** in the Index query layer. The
+physical Index rows remain locale-keyed, but the folded Storefront page is grouped by Product entity
+identity before exact count and pagination. Any current/admitted locale row may satisfy title search;
+result localization is selected independently as requested locale, then fallback locale, then no
+localized row. Existing schema readiness, Product freshness, and queried link-target availability remain
+mandatory for every row participating in the fold.
+
+Ordinary exact-locale `IndexQuery` remains unchanged. A consumer must not approximate the folded contract
+by independently paging multiple locales and merging them afterward.
+
+See `m7-product-storefront-localized-query-architecture.md` for the identity, search, projection,
+ordering, cursor, freshness, and retained-evidence contract.
 
 Do **not** add another Product routing key merely to patch this query semantic. The current Product
-contract remains the only runtime Product implementation while this query-layer decision is pending.
+contract remains the only runtime Product implementation.
 
 ## Typed EAV representation
 
@@ -106,8 +114,10 @@ Lower persisted Product keys are historical storage identities only. Promotion r
 
 Storefront traffic stays blocked until all of these are complete:
 
-1. resolve the effective localized Product identity/search/fallback architecture described above;
-2. add any required generic text-pattern/query primitive only after that architecture is fixed;
+1. implement the selected generic localized-entity identity fold without changing ordinary exact-locale
+   `IndexQuery` semantics;
+2. add the required generic scalar text-pattern primitive inside the folded any-locale identity
+   predicate;
 3. translate Active + published-only, category, visibility, EAV, timestamp ordering, ID tie-break,
    pagination, and exact count to Index;
 4. resolve Product attribute/option codes to canonical EAV terms;
@@ -119,29 +129,33 @@ Storefront traffic stays blocked until all of these are complete:
 8. stage/rebuild/promote the current Product key for the tenant;
 9. only then select Index traffic.
 
-## Source guard
+## Source guards
 
-`scripts/verify/verify-index-product-storefront-parity-gate.mjs` intentionally locks both sides of the
-current mismatch:
+`scripts/verify/verify-index-product-storefront-parity-gate.mjs` locks both sides of the current physical
+mismatch and keeps Storefront owner-native.
+
+`scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs` locks the selected
+query-layer decision:
 
 - owner title search remains all-translations unless the same PR deliberately changes the owner
   contract;
 - owner result projection still has requested/fallback translation selection;
 - Product Index source remains one physical translation locale per entity and does not fabricate
   fallback rows;
-- native Storefront traffic has not silently switched to Index;
-- one current 15-field Product schema and schema-scoped replay identity remain selected;
-- cutover remains fail-closed.
+- one current Product routing key (`4`) and schema-scoped replay identity remain selected;
+- the localized fold is identity-level and happens before page/count semantics;
+- implementation/evidence remain pending and traffic stays fail-closed.
 
 ## Deliberate limits
 
-This slice does not choose a new locale-union/fallback architecture, change owner Storefront semantics,
-add another Product routing key, implement the Storefront Index adapter, execute tenant rebuild, add
-public typed Product events, or switch traffic.
+This slice selects and documents the localized query architecture but does not implement the fold, change
+owner Storefront semantics, add another Product routing key, implement the Storefront Index adapter,
+execute tenant rebuild, add public typed Product events, or switch traffic.
 
 ## Maintainer verification
 
 ```bash
+node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-product-source.mjs
 node scripts/verify/verify-index-product-attribute-term-contract.mjs

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -87,7 +87,7 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', 
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  '`main@5f9e2fe4783d8bb5e6dad29adeff2dffc8296990`',
+  'Status overlay rechecked from `main@dfddce9f57916a712d531db38e75c87e7c45e8cf` (#3202)',
   'one current Product schema on internal routing key `4`',
   'Choose one generic localized Product query identity/fallback architecture',
   'implement the generic localized-entity fold in `rustok-index`',

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-localized-query-architecture] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const ownerQueryPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const ownerQuery = requireMarkers(ownerQueryPath, [
+  'pub async fn list_published_products_with_query(',
+  'let total = query.clone().count(&self.db).await?',
+  'pick_product_translation(items.as_slice(), locale, fallback_locale)',
+  'fn product_title_search_condition(',
+  'FROM product_translations pt',
+  'pt.product_id = products.id',
+  'pt.title LIKE $1',
+]);
+const titleSearchStart = ownerQuery.indexOf('fn product_title_search_condition(');
+if (titleSearchStart < 0) fail(`${ownerQueryPath} title-search helper is missing`);
+const titleSearch = ownerQuery.slice(titleSearchStart);
+if (titleSearch.includes('pt.locale')) {
+  fail(`${ownerQueryPath} title search became locale-scoped; revisit the localized identity architecture in the same PR`);
+}
+
+requireMarkers('crates/rustok-product/src/services/catalog/commands.rs', [
+  'if input.translations.is_empty()',
+  'At least one translation is required',
+]);
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+  'Lower keys are historical storage identities only.',
+]);
+const productSourcePath = 'crates/rustok-distribution/src/product_index/product.rs';
+const productSource = requireMarkers(productSourcePath, [
+  'locale_mode: LocaleMode::Required',
+  'JOIN product_translations t',
+  't.locale',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'derive_index_schema_source_event_id(',
+  'many_field("attribute_terms", IndexValueType::String, false, true)?',
+  'name: link_name("variants")?',
+  'name: link_name("sales_channels")?',
+]);
+if (productSource.includes('SchemaVersion::new(3)')) {
+  fail(`${productSourcePath} must not restore historical Product routing key 3`);
+}
+
+const architecturePath = 'crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md';
+requireMarkers(architecturePath, [
+  'Status: `source_decision_complete_implementation_and_evidence_pending`',
+  'Keep the current owner Storefront behavior and keep exactly one current Product Index schema.',
+  '`(tenant_id, schema_ref, entity_id)`',
+  'requested locale',
+  'fallback locale',
+  'Any-locale title search is an identity predicate',
+  'the row that satisfied search does **not** become the result locale merely because it matched',
+  'requested-locale row',
+  'fallback-locale row',
+  'Grouping happens **before** pagination and exact count.',
+  'exact count is the number of distinct admitted Product identities',
+  'a cursor from an ordinary exact-locale query must not be accepted by the folded query path',
+  'A consumer must not emulate this contract by issuing independent locale queries and merging pages in\n memory.',
+  'Existing schema readiness, Product entity freshness, and queried link-target availability remain\nmandatory.',
+  'Storefront remains owner-native.',
+  'Implement the generic localized-entity fold in `rustok-index`',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
+  'Status: `source_architecture_selected_implementation_and_evidence_pending`',
+  'm7-product-storefront-localized-query-architecture.md',
+  'A scalar substring/LIKE operator alone cannot close Storefront parity',
+  'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  '`main@5f9e2fe4783d8bb5e6dad29adeff2dffc8296990`',
+  'one current Product schema on internal routing key `4`',
+  'Choose one generic localized Product query identity/fallback architecture',
+  'implement the generic localized-entity fold in `rustok-index`',
+  'Do not add a runtime alias for key `3`',
+]);
+
+console.log('[verify-index-product-storefront-localized-query-architecture] localized Product identity/fallback decision is locked; implementation and evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -73,8 +73,8 @@ requireMarkers(architecturePath, [
   'Grouping happens **before** pagination and exact count.',
   'exact count is the number of distinct admitted Product identities',
   'a cursor from an ordinary exact-locale query must not be accepted by the folded query path',
-  'A consumer must not emulate this contract by issuing independent locale queries and merging pages in\n memory.',
-  'Existing schema readiness, Product entity freshness, and queried link-target availability remain\nmandatory.',
+  'A consumer must not emulate this contract by issuing independent locale queries',
+  'Existing schema readiness, Product entity freshness, and queried link-target availability remain',
   'Storefront remains owner-native.',
   'Implement the generic localized-entity fold in `rustok-index`',
 ]);

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -87,7 +87,7 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', 
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@dfddce9f57916a712d531db38e75c87e7c45e8cf` (#3202)',
+  'Status overlay rechecked from `main@aaa496887fd1492f3feca8ac52261458ce25705e` (#3203)',
   'one current Product schema on internal routing key `4`',
   'Choose one generic localized Product query identity/fallback architecture',
   'implement the generic localized-entity fold in `rustok-index`',

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -151,11 +151,13 @@ requireMarkers(schemaStorePath, [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `source_gap_locale_search_and_fallback_adapter_evidence_pending`',
+  'Status: `source_architecture_selected_implementation_and_evidence_pending`',
   'does **not** restrict that search row to the requested or fallback locale',
   'owner list can still return the Product using its fallback translation',
   'one Index entity for each physically stored `product_translations.locale`',
   'A scalar substring/LIKE operator alone cannot close Storefront parity',
+  'localized-entity identity fold',
+  'm7-product-storefront-localized-query-architecture.md',
   'Do **not** add another Product routing key merely to patch this query semantic.',
   'actualize retained Product PostgreSQL packets',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
@@ -166,4 +168,4 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains fail-closed on the explicit locale search/fallback mismatch');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains fail-closed while the selected localized identity fold is implementation/evidence pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -80,6 +80,7 @@ const scripts = [
   'verify-index-linked-target-availability-equivalence-postgres-harness.mjs',
   'verify-index-linked-target-replay-redelivery-postgres-harness.mjs',
   'verify-index-product-storefront-parity-gate.mjs',
+  'verify-index-product-storefront-localized-query-architecture.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- recheck the current `rustok-index` execution plan through `main@aaa496887fd1492f3feca8ac52261458ce25705e` (#3203)
- replace the stale 2026-08-07 execution cursor with the current 2026-08-08 plan
- record that the old linked-target replay branch is a diverged, already-squash-merged continuation base and must not be reused
- select one generic localized-entity identity fold for Product Storefront parity: any-locale search, requested -> fallback projection, identity-level ordering/page/exact-count, one current Product routing key
- advance the Storefront parity gate from architecture-pending to implementation/evidence-pending
- add a static architecture guard and wire it into the aggregate Index query contract
- flag retained Product PostgreSQL packets that still carry historical routing-key `3` assumptions for source actualization before current evidence

## Recheck notes

Current Product runtime remains one 15-field Product schema on internal routing key `4`. Owner Storefront title search still admits a Product from any translation, while projection still prefers requested locale then fallback. Ordinary `IndexQuery` is exact-locale, so scalar LIKE support alone cannot preserve global de-duplication, ordering, pagination, and exact count.

The latest #3202/#3203 work does not resolve or overlap this Storefront localized-query boundary.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatters, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed in this slice.