### PR TITLE
fix(parity): restore version-pinned Page Builder contributions

### DIFF
--- a/crates/fly-ui/src/contribution_manifest/assemble.rs
+++ b/crates/fly-ui/src/contribution_manifest/assemble.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use std::collections::{BTreeMap, BTreeSet};
 
+const PROVIDER_VERSION_METADATA_KEY: &str = "providerVersion";
+
 pub fn build_admin_contribution_registry_from_manifests(
     manifests: impl IntoIterator<Item = ModuleContributionManifest>,
     policy: &ContributionAssemblyPolicy,
@@ -137,7 +139,22 @@ fn register_surface_contributions(
         }
 
         let target_provider = contribution.provider.trim();
-        if !manifest.allows_target_provider(target_provider) {
+        let target_version = match contribution_provider_version(contribution) {
+            Ok(version) => version,
+            Err((code, message)) => {
+                skip_contribution(
+                    result,
+                    ContributionAssemblySeverity::Error,
+                    code,
+                    manifest,
+                    contribution,
+                    message,
+                );
+                continue;
+            }
+        };
+
+        let Some(expected_version) = allowed_target_version(manifest, target_provider) else {
             let allowed = allowed_target_summary(manifest);
             skip_contribution(
                 result,
@@ -145,7 +162,23 @@ fn register_surface_contributions(
                 "contribution_target_provider_forbidden",
                 manifest,
                 contribution,
-                format!("contribution targets `{target_provider}`; allowed targets: {allowed}"),
+                format!(
+                    "contribution targets `{target_provider}@{target_version}`; allowed targets: {allowed}"
+                ),
+            );
+            continue;
+        };
+
+        if !manifest.allows_target_provider(target_provider, target_version) {
+            skip_contribution(
+                result,
+                ContributionAssemblySeverity::Error,
+                "contribution_target_provider_version_mismatch",
+                manifest,
+                contribution,
+                format!(
+                    "contribution targets `{target_provider}@{target_version}`, expected `{target_provider}@{expected_version}`"
+                ),
             );
             continue;
         }
@@ -180,6 +213,55 @@ fn register_surface_contributions(
     }
 }
 
+fn contribution_provider_version(
+    contribution: &ContributionDescriptor,
+) -> Result<&str, (&'static str, String)> {
+    let Some(value) = contribution.metadata.get(PROVIDER_VERSION_METADATA_KEY) else {
+        return Err((
+            "contribution_provider_version_missing",
+            format!(
+                "contribution `{}` does not declare `{PROVIDER_VERSION_METADATA_KEY}`",
+                contribution.id.trim()
+            ),
+        ));
+    };
+    let Some(version) = value.as_str() else {
+        return Err((
+            "contribution_provider_version_invalid",
+            format!(
+                "contribution `{}` has a non-string `{PROVIDER_VERSION_METADATA_KEY}`",
+                contribution.id.trim()
+            ),
+        ));
+    };
+    let version = version.trim();
+    if version.is_empty() {
+        Err((
+            "contribution_provider_version_invalid",
+            format!(
+                "contribution `{}` has an empty `{PROVIDER_VERSION_METADATA_KEY}`",
+                contribution.id.trim()
+            ),
+        ))
+    } else {
+        Ok(version)
+    }
+}
+
+fn allowed_target_version<'a>(
+    manifest: &'a ModuleContributionManifest,
+    provider: &str,
+) -> Option<&'a str> {
+    if provider == manifest.owner_provider.trim() {
+        Some(manifest.owner_version.trim())
+    } else {
+        manifest
+            .target_providers
+            .get(provider)
+            .map(|version| version.trim())
+    }
+}
+
 fn skip_contribution(
     result: &mut ContributionAssemblyResult,
     severity: ContributionAssemblySeverity,
@@ -202,8 +284,11 @@ fn allowed_target_summary(manifest: &ModuleContributionManifest) -> String {
     manifest
         .target_providers
         .iter()
-        .cloned()
-        .chain(std::iter::once(manifest.owner_provider.clone()))
+        .map(|(provider, version)| format!("{provider}@{version}"))
+        .chain(std::iter::once(format!(
+            "{}@{}",
+            manifest.owner_provider, manifest.owner_version
+        )))
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>()
@@ -215,10 +300,31 @@ fn normalize_manifest(
 ) -> Result<ModuleContributionManifest, String> {
     manifest.module_id = required(&manifest.module_id, "module_id")?;
     manifest.owner_provider = required(&manifest.owner_provider, "owner_provider")?;
+    manifest.owner_version = required(&manifest.owner_version, "owner_version")?;
     manifest.dependencies = normalize_set(manifest.dependencies, "dependency")?;
     manifest.required_permissions =
         normalize_set(manifest.required_permissions, "required permission")?;
-    manifest.target_providers = normalize_set(manifest.target_providers, "target provider")?;
+
+    let mut target_providers = BTreeMap::new();
+    for (provider, version) in manifest.target_providers {
+        let provider = required(&provider, "target provider")?;
+        let version = required(&version, "target provider version")?;
+        if provider == manifest.owner_provider {
+            if version != manifest.owner_version {
+                return Err(format!(
+                    "target provider `{provider}@{version}` conflicts with owner version `{}`",
+                    manifest.owner_version
+                ));
+            }
+            continue;
+        }
+        if target_providers.insert(provider.clone(), version).is_some() {
+            return Err(format!(
+                "target provider `{provider}` is duplicated after normalization"
+            ));
+        }
+    }
+    manifest.target_providers = target_providers;
     Ok(manifest)
 }
 

--- a/crates/fly-ui/src/contribution_manifest/model.rs
+++ b/crates/fly-ui/src/contribution_manifest/model.rs
@@ -1,13 +1,20 @@
 use crate::ContributionDescriptor;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
+/// Module-owned contribution metadata with an explicit, version-pinned target-provider allowlist.
+///
+/// `owner_provider` identifies the module that owns lifecycle, policy and health. A contribution's
+/// `provider` identifies the component contract that its renderer/editor extends. When
+/// `target_providers` is empty, only the owner provider is allowed. Cross-provider extensions must
+/// therefore be declared intentionally, for example `rustok.pages -> fly.builtin@1`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ModuleContributionManifest {
     pub module_id: String,
     pub owner_provider: String,
+    pub owner_version: String,
     #[serde(default)]
-    pub target_providers: BTreeSet<String>,
+    pub target_providers: BTreeMap<String, String>,
     #[serde(default)]
     pub dependencies: BTreeSet<String>,
     #[serde(default)]
@@ -19,8 +26,14 @@ pub struct ModuleContributionManifest {
 }
 
 impl ModuleContributionManifest {
-    pub fn allows_target_provider(&self, provider: &str) -> bool {
+    pub fn allows_target_provider(&self, provider: &str, version: &str) -> bool {
         let provider = provider.trim();
-        provider == self.owner_provider.trim() || self.target_providers.contains(provider)
+        let version = version.trim();
+        if provider == self.owner_provider.trim() && version == self.owner_version.trim() {
+            return true;
+        }
+        self.target_providers
+            .get(provider)
+            .is_some_and(|allowed| allowed.trim() == version)
     }
 }

--- a/crates/fly-ui/src/contribution_manifest/tests.rs
+++ b/crates/fly-ui/src/contribution_manifest/tests.rs
@@ -1,9 +1,12 @@
 use super::*;
 use crate::{ContributionAssemblyPolicy, ContributionDescriptor, ContributionProviderHealth};
-use serde_json::Map;
+use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
-fn contribution(id: &str, provider: &str) -> ContributionDescriptor {
+const OWNER_VERSION: &str = "0.1.0";
+const TARGET_VERSION: &str = "1";
+
+fn contribution(id: &str, provider: &str, provider_version: &str) -> ContributionDescriptor {
     ContributionDescriptor {
         id: id.to_string(),
         provider: provider.to_string(),
@@ -12,7 +15,10 @@ fn contribution(id: &str, provider: &str) -> ContributionDescriptor {
         renderers: Vec::new(),
         property_editors: Vec::new(),
         messages: BTreeMap::new(),
-        metadata: Map::new(),
+        metadata: Map::from_iter([(
+            "providerVersion".to_string(),
+            Value::String(provider_version.to_string()),
+        )]),
     }
 }
 
@@ -20,7 +26,8 @@ fn manifest(admin: Vec<ContributionDescriptor>) -> ModuleContributionManifest {
     ModuleContributionManifest {
         module_id: "pages".to_string(),
         owner_provider: "rustok.pages".to_string(),
-        target_providers: BTreeSet::new(),
+        owner_version: OWNER_VERSION.to_string(),
+        target_providers: BTreeMap::new(),
         dependencies: BTreeSet::new(),
         required_permissions: BTreeSet::new(),
         admin,
@@ -29,15 +36,25 @@ fn manifest(admin: Vec<ContributionDescriptor>) -> ModuleContributionManifest {
 }
 
 fn cross_provider_manifest() -> ModuleContributionManifest {
-    let mut manifest = manifest(vec![contribution("pages.blocks", "fly.builtin")]);
-    manifest.target_providers.insert("fly.builtin".to_string());
+    let mut manifest = manifest(vec![contribution(
+        "pages.blocks",
+        "fly.builtin",
+        TARGET_VERSION,
+    )]);
+    manifest
+        .target_providers
+        .insert("fly.builtin".to_string(), TARGET_VERSION.to_string());
     manifest
 }
 
 #[test]
 fn owner_provider_is_the_only_implicit_target() {
     let result = build_admin_contribution_registry_from_manifests(
-        [manifest(vec![contribution("pages.blocks", "fly.builtin")])],
+        [manifest(vec![contribution(
+            "pages.blocks",
+            "fly.builtin",
+            TARGET_VERSION,
+        )])],
         &ContributionAssemblyPolicy::default(),
     );
     assert!(!result.is_valid());
@@ -51,7 +68,7 @@ fn owner_provider_is_the_only_implicit_target() {
 }
 
 #[test]
-fn explicit_target_provider_is_allowed() {
+fn explicit_versioned_target_provider_is_allowed() {
     let result = build_admin_contribution_registry_from_manifests(
         [cross_provider_manifest()],
         &ContributionAssemblyPolicy::default(),
@@ -59,6 +76,39 @@ fn explicit_target_provider_is_allowed() {
     assert!(result.is_valid());
     assert_eq!(result.registered_contributions, 1);
     assert!(result.registry.get("pages.blocks").is_some());
+}
+
+#[test]
+fn target_provider_version_mismatch_is_rejected() {
+    let mut manifest = cross_provider_manifest();
+    manifest.admin[0].metadata.insert(
+        "providerVersion".to_string(),
+        Value::String("2".to_string()),
+    );
+    let result = build_admin_contribution_registry_from_manifests(
+        [manifest],
+        &ContributionAssemblyPolicy::default(),
+    );
+    assert!(!result.is_valid());
+    assert!(result.registry.is_empty());
+    assert!(result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "contribution_target_provider_version_mismatch"
+    }));
+}
+
+#[test]
+fn missing_provider_version_is_rejected() {
+    let mut manifest = cross_provider_manifest();
+    manifest.admin[0].metadata.remove("providerVersion");
+    let result = build_admin_contribution_registry_from_manifests(
+        [manifest],
+        &ContributionAssemblyPolicy::default(),
+    );
+    assert!(!result.is_valid());
+    assert!(result.registry.is_empty());
+    assert!(result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "contribution_provider_version_missing"
+    }));
 }
 
 #[test]
@@ -99,8 +149,16 @@ fn owner_and_target_provider_allowlist_enables_cross_provider_extension() {
 
 #[test]
 fn admin_and_storefront_surfaces_remain_separate() {
-    let mut manifest = manifest(vec![contribution("pages.admin.blocks", "rustok.pages")]);
-    manifest.storefront = vec![contribution("pages.storefront.renderer", "rustok.pages")];
+    let mut manifest = manifest(vec![contribution(
+        "pages.admin.blocks",
+        "rustok.pages",
+        OWNER_VERSION,
+    )]);
+    manifest.storefront = vec![contribution(
+        "pages.storefront.renderer",
+        "rustok.pages",
+        OWNER_VERSION,
+    )];
     let admin = build_admin_contribution_registry_from_manifests(
         [manifest.clone()],
         &ContributionAssemblyPolicy::default(),
@@ -142,16 +200,21 @@ fn target_provider_health_can_block_cross_provider_extensions() {
 }
 
 #[test]
-fn direct_target_lookup_trims_provider_names() {
+fn direct_target_lookup_trims_owner_and_versions() {
     let manifest = ModuleContributionManifest {
         module_id: "pages".to_string(),
         owner_provider: " rustok.pages ".to_string(),
-        target_providers: BTreeSet::from(["fly.builtin".to_string()]),
+        owner_version: " 0.1.0 ".to_string(),
+        target_providers: BTreeMap::from([(
+            "fly.builtin".to_string(),
+            " 1 ".to_string(),
+        )]),
         dependencies: BTreeSet::new(),
         required_permissions: BTreeSet::new(),
         admin: Vec::new(),
         storefront: Vec::new(),
     };
-    assert!(manifest.allows_target_provider("rustok.pages"));
-    assert!(manifest.allows_target_provider("fly.builtin"));
+    assert!(manifest.allows_target_provider("rustok.pages", "0.1.0"));
+    assert!(manifest.allows_target_provider("fly.builtin", "1"));
+    assert!(!manifest.allows_target_provider("fly.builtin", "2"));
 }

--- a/crates/rustok-pages/admin/src/contributions.rs
+++ b/crates/rustok-pages/admin/src/contributions.rs
@@ -12,7 +12,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 pub const PAGES_MODULE_ID: &str = "pages";
 pub const PAGES_OWNER_PROVIDER: &str = "rustok.pages";
+pub const PAGES_OWNER_PROVIDER_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const FLY_BUILTIN_PROVIDER: &str = "fly.builtin";
+pub const FLY_BUILTIN_PROVIDER_VERSION: &str = "1";
 pub const PAGES_LANDING_BLOCKS_CONTRIBUTION_ID: &str = "rustok.pages.landing-blocks";
 pub const PAGES_METADATA_CONTRIBUTION_ID: &str = "rustok.pages.metadata";
 pub const PAGES_METADATA_PROPERTY_EDITOR_ID: &str = "rustok.pages.metadata.editor";
@@ -33,13 +35,17 @@ pub const PAGES_LANDING_BLOCK_IDS: &[&str] = &[
 /// Module-owned metadata used by the generated Fly admin contribution registry.
 ///
 /// Pages owns document lifecycle and metadata persistence. Landing blocks explicitly target
-/// `fly.builtin`, while the executable metadata editor remains under the `rustok.pages` owner
-/// provider and calls the consumer facade rather than mutating the Fly document.
+/// `fly.builtin@1`, while the executable metadata editor remains under the version-pinned
+/// `rustok.pages` owner provider and calls the consumer facade rather than mutating the Fly document.
 pub fn pages_contribution_manifest() -> ModuleContributionManifest {
     ModuleContributionManifest {
         module_id: PAGES_MODULE_ID.to_string(),
         owner_provider: PAGES_OWNER_PROVIDER.to_string(),
-        target_providers: BTreeSet::from([FLY_BUILTIN_PROVIDER.to_string()]),
+        owner_version: PAGES_OWNER_PROVIDER_VERSION.to_string(),
+        target_providers: BTreeMap::from([(
+            FLY_BUILTIN_PROVIDER.to_string(),
+            FLY_BUILTIN_PROVIDER_VERSION.to_string(),
+        )]),
         dependencies: BTreeSet::new(),
         required_permissions: BTreeSet::new(),
         admin: vec![
@@ -69,6 +75,10 @@ pub fn pages_landing_blocks_contribution() -> ContributionDescriptor {
             (
                 "ownerProvider".to_string(),
                 Value::String(PAGES_OWNER_PROVIDER.to_string()),
+            ),
+            (
+                "providerVersion".to_string(),
+                Value::String(FLY_BUILTIN_PROVIDER_VERSION.to_string()),
             ),
             ("format".to_string(), Value::String("grapesjs".to_string())),
             ("surface".to_string(), Value::String("admin".to_string())),
@@ -182,6 +192,10 @@ pub fn pages_metadata_contribution() -> ContributionDescriptor {
                 Value::String(PAGES_OWNER_PROVIDER.to_string()),
             ),
             (
+                "providerVersion".to_string(),
+                Value::String(PAGES_OWNER_PROVIDER_VERSION.to_string()),
+            ),
+            (
                 "persistence".to_string(),
                 Value::String("consumer_facade".to_string()),
             ),
@@ -243,9 +257,16 @@ mod tests {
     #[test]
     fn manifest_targets_fly_blocks_and_keeps_metadata_under_pages_owner() {
         let manifest = pages_contribution_manifest();
-        assert!(manifest.allows_target_provider(FLY_BUILTIN_PROVIDER));
-        assert!(manifest.allows_target_provider(PAGES_OWNER_PROVIDER));
-        assert!(!manifest.allows_target_provider("other.provider"));
+        assert!(manifest.allows_target_provider(
+            FLY_BUILTIN_PROVIDER,
+            FLY_BUILTIN_PROVIDER_VERSION,
+        ));
+        assert!(manifest.allows_target_provider(
+            PAGES_OWNER_PROVIDER,
+            PAGES_OWNER_PROVIDER_VERSION,
+        ));
+        assert!(!manifest.allows_target_provider("other.provider", "1"));
+        assert!(!manifest.allows_target_provider(FLY_BUILTIN_PROVIDER, "2"));
     }
 
     #[test]
@@ -304,5 +325,10 @@ mod tests {
                 "Pages module manifest is missing builder capability `{capability}`"
             );
         }
+    }
+
+    #[test]
+    fn storefront_surface_stays_empty_until_a_real_adapter_exists() {
+        assert!(pages_contribution_manifest().storefront.is_empty());
     }
 }

--- a/crates/rustok-pages/admin/src/lib.rs
+++ b/crates/rustok-pages/admin/src/lib.rs
@@ -43,13 +43,14 @@ pub use contribution_browser_intent::{
     dispatch_pages_browser_intent_with_store_and_capabilities, pages_palette_block_access,
 };
 pub use contributions::{
-    FLY_BUILTIN_PROVIDER, PAGES_BUILDER_CAPABILITIES, PAGES_LANDING_BLOCK_CAPABILITIES,
-    PAGES_LANDING_BLOCK_IDS, PAGES_LANDING_BLOCKS_CONTRIBUTION_ID, PAGES_METADATA_CAPABILITIES,
+    FLY_BUILTIN_PROVIDER, FLY_BUILTIN_PROVIDER_VERSION, PAGES_BUILDER_CAPABILITIES,
+    PAGES_LANDING_BLOCK_CAPABILITIES, PAGES_LANDING_BLOCK_IDS,
+    PAGES_LANDING_BLOCKS_CONTRIBUTION_ID, PAGES_METADATA_CAPABILITIES,
     PAGES_METADATA_COMPONENT_TYPE, PAGES_METADATA_CONTRIBUTION_ID,
     PAGES_METADATA_PROPERTY_EDITOR_ID, PAGES_MODULE_ID, PAGES_OWNER_PROVIDER,
-    build_pages_admin_contribution_registry, pages_admin_contribution_policy,
-    pages_contribution_manifest, pages_landing_blocks_contribution, pages_metadata_contribution,
-    pages_metadata_property_schema,
+    PAGES_OWNER_PROVIDER_VERSION, build_pages_admin_contribution_registry,
+    pages_admin_contribution_policy, pages_contribution_manifest,
+    pages_landing_blocks_contribution, pages_metadata_contribution, pages_metadata_property_schema,
 };
 pub use fly_browser::BrowserIntentEnvelope;
 

--- a/docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md
@@ -1,0 +1,63 @@
+# Pages / Page Builder Contribution Parity Actualization — 2026-08-08
+
+Status: current-source-overlay / pages-repair-lineage-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / execution-open
+
+## Why this actualization exists
+
+A fresh source recheck found that the shared Pages/Page Builder continuation cursor still stopped at PR #3063 even though later source slices had already advanced both owners:
+
+- PR #3191 made Pages recovery tolerate repeated physical loss of previously rebuilt immutable artifacts while preserving bounded repair/rollback lineage;
+- PR #3196 connected Page Builder provider rollout/degraded controls to the admin capability path and kept absent live health explicitly `unobserved`;
+- the current Fly contribution factories already separate admin/storefront assembly and already filter by tenant module, permission, capability, provider policy and provider health with duplicate, missing-dependency, cycle and missing-provider diagnostics.
+
+The remaining Phase 9 source mismatch was version parity. The static contribution guard still described the intended owner-safe version-pinned manifest contract, while the live Rust model had regressed to an unversioned owner/target set.
+
+## Source changes in this slice
+
+The contribution manifest is version-pinned again:
+
+- `ModuleContributionManifest` carries `owner_version`;
+- cross-provider targets are `provider -> exact version` mappings;
+- manifest normalization rejects empty/conflicting owner and target versions;
+- manifest assembly requires every manifest-routed contribution to declare `metadata.providerVersion`;
+- missing, non-string and empty provider versions fail closed;
+- a provider-name allowlist match with the wrong version produces `contribution_target_provider_version_mismatch` and is not registered;
+- provider allow/deny, tenant enablement, capability, permission, health, duplicate, dependency and cycle behavior remains layered after the version boundary.
+
+Pages is the first current consumer of the restored contract:
+
+- owner target: `rustok.pages@<crate version>`;
+- Fly built-in target: `fly.builtin@1`;
+- landing-block contribution declares `providerVersion = 1`;
+- Pages metadata contribution declares `providerVersion = <crate version>`;
+- existing executable metadata property-editor contribution remains present and continues to use consumer-owned persistence rather than mutating the Fly document.
+
+No fallback unversioned contribution route is added.
+
+## Rechecked parity state
+
+### Pages
+
+Source-ready through repeated immutable-artifact-loss recovery, including latest-repair-state-per-locale reconstruction and rollback continuity. Execution remains maintainer-owned and pending.
+
+### Page Builder provider controls
+
+Source-ready for rollout flags, fail-closed unavailable state, degraded publish suppression and Pages consumer wiring. There is still no authoritative live Page Builder SLO observation source in the repository, so Pages must continue to expose health as `unobserved`; this slice does not fabricate latency/error/sanitize observations from unrelated telemetry.
+
+### Contribution registry Phase 9
+
+- [x] Separate admin/storefront factories.
+- [ ] Generate the complete contribution registry directly from canonical module metadata. Pages still constructs its `ModuleContributionManifest` in module-owned Rust and only cross-checks selected capability metadata against `rustok-module.toml`.
+- [x] Filter by tenant, permission, capability, provider policy and health.
+- [x] Duplicate, missing-provider, missing-dependency, cycle and provider-version diagnostics.
+
+## Next source cursor
+
+1. Define one canonical module-metadata representation for Fly contribution descriptors/version targets and generate `ModuleContributionManifest` from that authority instead of maintaining a parallel handwritten declaration.
+2. Keep provider health `unobserved` until a real Page Builder SLO collector/source exists; then connect that source to `PageBuilderAdminProviderStatus` without allowing health to grant capabilities denied by RBAC/policy.
+3. Preserve Pages as persistence/publication/repair owner and Page Builder/Fly as reviewed-document/runtime owner.
+4. Retain all execution, browser, database, Cargo and static-verifier evidence as maintainer-owned until explicitly run.
+
+## Validation boundary
+
+Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, database scenarios, workflows, CI or `git diff --check` are executed by this implementation slice.

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
-Date: 2026-08-06  
-Status: source-parity-current / authenticated-authoring-route-source-ready / inline-edit-asset-delivery-source-ready / admin-launch-source-ready / release-composition-source-ready / execution-browser-rollout-pending
+Date: 2026-08-08  
+Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / observed-health-open / module-metadata-generation-open / execution-browser-rollout-pending
 Scope: `rustok-pages` admin/storefront FFA and `rustok-page-builder` document, publication, artifact, routing, cache, authenticated inline-authoring and deterministic deployment boundaries
 
 ## Source-of-truth policy
@@ -21,7 +21,39 @@ Pages and Page Builder remain one vertical pipeline with explicit owners:
 
 Optional external event and delivery infrastructure remain outside the active Pages cursor.
 
+## 2026-08-08 current source reconciliation
+
+This section overrides older source-state/cursor wording retained below for compatibility with historical static guards.
+
+The recheck includes all relevant merged source after the former PR #3063 cursor, especially:
+
+- PR #3191 — repeated physical loss of rebuilt immutable Pages artifacts can recover again from the latest accepted repair state per locale while preserving bounded repair/rollback lineage; execution remains open;
+- PR #3196 — Page Builder admin provider rollout/degraded controls are connected through the Pages consumer; absent live SLO evidence remains explicitly `unobserved` and no health state is fabricated;
+- the existing `fly-ui` contribution path already has separate admin/storefront factories, tenant/permission/capability/provider-policy/provider-health filtering, and duplicate/missing-provider/missing-dependency/cycle diagnostics;
+- the contribution static guard still required owner/target version parity while the live Rust manifest model had regressed to an unversioned provider set.
+
+The current source slice restores that version boundary without changing Pages persistence or publication ownership:
+
+- `ModuleContributionManifest` carries an exact `owner_version` and exact target-provider version map;
+- manifest-routed contributions must declare `metadata.providerVersion`;
+- missing/invalid provider versions fail closed;
+- allowed provider names with the wrong version fail with `contribution_target_provider_version_mismatch`;
+- Pages pins `rustok.pages@<crate version>` and `fly.builtin@1` while retaining its existing landing-block and executable metadata-property contributions.
+
+Rechecked Page Builder Phase 9 source state:
+
+- [x] Separate admin/storefront factories.
+- [ ] Generate complete contribution manifests directly from canonical module metadata; Pages still builds its contribution manifest in module-owned Rust and only cross-checks selected capability metadata against `rustok-module.toml`.
+- [x] Filter by tenant, permission, capability, provider policy and health.
+- [x] Duplicate, missing-provider, missing-dependency, cycle and provider-version diagnostics.
+
+The next source cursor is therefore module-metadata generation for contribution manifests. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
+
+Detailed evidence for this reconciliation is retained in `docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md`.
+
 ## Rechecked merged cursor
+
+The following #2955–#3063 list is a retained historical snapshot; the 2026-08-08 reconciliation above is authoritative for current source state.
 
 Current `main` through PR #3063 contains the retained Pages/Page Builder sequence:
 
@@ -66,6 +98,9 @@ No build, workflow, Docker, HTTP or browser execution is claimed.
 - `inline-edit-asset-delivery-source-ready` — dedicated binary-embedded authoring assets source-ready.
 - `inline-edit-admin-launch-source-ready` — admin launch source-ready.
 - `inline-edit-release-composition-source-ready` — release/rebuild/Docker composition source-ready.
+- `pages-repeated-artifact-loss-recovery-source-ready` — repeated physical loss of a rebuilt immutable artifact can recover from the latest accepted repair lineage.
+- `provider-degraded-controls-source-ready` — rollout/degraded provider controls are connected without fabricating observed health.
+- `contribution-registry-version-parity-source-ready` — contribution owner/target provider versions are pinned and fail closed on missing/mismatched versions.
 
 ## Current parity state
 
@@ -202,12 +237,25 @@ Anonymous default/CSR/hydrate/SSR profiles do not enable inline edit, authoring 
 
 Graph and built-artifact execution evidence remain pending.
 
+### Repeated immutable-artifact loss recovery: source-ready
+
+Pages keeps repair identity and latest accepted repair state per locale bounded. A previously rebuilt immutable artifact that is physically lost again can be reconstructed from the latest accepted repair lineage, and rollback continuity uses the same authority. This remains source-ready only until maintainer execution evidence is produced.
+
+### Provider degraded controls and observed health: source-ready / observation-open
+
+Page Builder provider flags can only narrow an already authorized capability set. Invalid/disabled builder state is unavailable, partial rollout or degraded health suppresses publish, and Pages exposes the same flags used by server composition. No live SLO source exists yet, so Pages health remains explicitly `unobserved`.
+
+### Contribution registry version parity: source-ready / metadata-generation-open
+
+Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Complete generation from canonical module metadata remains open; handwritten module-owned contribution manifests are not treated as generated authority.
+
 ## Parity matrix
 
 | Capability | Source state | Execution state |
 | --- | --- | --- |
 | Registered metadata and owner port | Complete | Browser/conflict execution pending |
 | Reviewed publish and immutable rollback | Complete | DB/runtime execution pending |
+| Repeated immutable-artifact loss recovery | Source-ready | Repair/rollback execution pending |
 | Public locale fallback | Source-ready | Native/GraphQL execution pending |
 | Published aliases, tombstones and history import | Source-ready | SQLite/PostgreSQL/host execution pending |
 | Host canonical/redirect/gone response | Source-ready | HTTP/SSR execution pending |
@@ -224,6 +272,8 @@ Graph and built-artifact execution evidence remain pending.
 | Runtime-only release image | Unchanged/source-ready | Image execution pending |
 | Anonymous dependency graph | Source-ready | `cargo metadata` execution pending |
 | Anonymous SSR built artifact | Inspector source-ready | Build/inspection pending |
+| Provider degraded controls | Source-ready | Live observed-health evidence pending |
+| Version-pinned contribution registry | Source-ready | Metadata generation / execution pending |
 | Tenant rollout and FFA/FBA | Open | Not promoted |
 
 ## Historical compatibility markers
@@ -244,7 +294,7 @@ These exact phrases are retained only because earlier static guards consume the 
 
 ## Boundaries
 
-This slice changes deterministic build and release composition source only.
+The historical deployment slice below remains unchanged; the 2026-08-08 reconciliation additionally restores contribution version parity and updates the source cursor.
 
 It does not:
 
@@ -256,30 +306,25 @@ It does not:
 - enable same-origin launch in standalone admin builds;
 - add runtime build tooling to `apps/server/Dockerfile.release`;
 - claim verifier, Cargo, npm, Trunk, WASM, server, Docker, workflow, HTTP, browser or rollout execution;
+- fabricate Page Builder provider-health observations;
 - promote FFA or FBA.
 
-## Next cursor: execution evidence
+## Next cursor
 
-1. Apply and review `release-infra-approved` for the protected source changes.
-2. Run Pages consumer, route, asset, launch and release-composition static guards.
-3. Run release infrastructure, supply-chain and readiness guards.
-4. Run focused Cargo/tests for opt-in admin/storefront/server profiles.
-5. Build the full composition twice in isolated target directories.
-6. Retain embedded admin JS/WASM, authoring JS/WASM, server binary and archive hashes/sizes.
-7. Confirm identical archive digest across build and reproducibility jobs.
-8. Build production Docker and retain image digest.
-9. Prove authoring asset `200`/`304`, MIME, ETag, cache, CORP and CSP behavior.
-10. Prove launch visible/hidden states and exact-locale same-origin navigation.
-11. Execute direct-user allowed and anonymous/service/delegated/permission-denied cases.
-12. Observe edit/save/replacement grant/stale revision/replay/expiry behavior.
-13. Re-run anonymous graph and built-artifact exclusion evidence.
-14. Record tenant rollout and rollback evidence before promotion.
+Source continuation:
+
+1. Generate complete Fly contribution manifests from canonical module metadata instead of maintaining a parallel handwritten declaration.
+2. Keep current Pages repair/recovery and Page Builder degraded-control source boundaries unchanged while that registry authority is centralized.
+3. Connect real provider-health observation only after an authoritative Page Builder SLO source exists.
+
+Maintainer-owned execution evidence remains pending for the earlier release, browser, database and recovery slices.
 
 ## Maintainer validation
 
 Suggested commands, intentionally not run in this slice:
 
 ```bash
+node scripts/verify/verify-fly-ui-contributions.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-release-composition.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-admin-launch.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-asset-delivery.mjs


### PR DESCRIPTION
## Summary

Recheck and continue the Pages / Page Builder parity cursor.

- reconcile the canonical shared plan with the later Pages repeated-artifact-loss recovery and Page Builder degraded-provider-control slices;
- restore the owner-safe version-pinned Fly contribution manifest boundary that the static guard still requires;
- fail closed when manifest-routed contributions omit, invalidate, or mismatch their provider version;
- pin Pages contributions to `rustok.pages@<crate version>` and `fly.builtin@1` while preserving the current executable Pages metadata property editor and consumer-owned persistence;
- record the current Phase 9 state: separate admin/storefront factories, policy/health filtering, structural/version diagnostics are source-ready; complete generation from canonical module metadata remains the next source gap;
- keep provider health explicitly `unobserved` because no authoritative live Page Builder SLO observation source exists yet.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, database scenarios, workflows, CI, or `git diff --check` were run in this slice.