### PR TITLE
feat(moderation): expose authorized recovery GraphQL transport

### DIFF
--- a/apps/server/src/graphql/mod.rs
+++ b/apps/server/src/graphql/mod.rs
@@ -6,6 +6,8 @@ pub mod index_drift_diagnosis;
 pub mod index_drift_source_page_diagnosis;
 pub mod legacy_disable_user;
 pub mod loaders;
+#[cfg(feature = "mod-moderation")]
+pub mod moderation_recovery;
 pub mod module_security;
 pub mod mutations;
 pub mod observability;

--- a/apps/server/src/graphql/moderation_recovery.rs
+++ b/apps/server/src/graphql/moderation_recovery.rs
@@ -1,0 +1,217 @@
+use std::time::Duration;
+
+use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use rustok_api::graphql::{GraphQLError, require_module_enabled};
+use rustok_api::{
+    AuthContext, ChannelContext, Permission, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext, has_effective_permission,
+};
+use rustok_moderation::{
+    ModerationApplicationRecoveryRecord, ModerationRecoveryCommandPort, ModerationService,
+    ReconcileLegacyModerationApplicationCommand, RequeueModerationApplicationCommand,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+const MODULE_SLUG: &str = "moderation";
+const RECOVERY_PORT_DEADLINE: Duration = Duration::from_secs(5);
+
+#[derive(Default)]
+pub struct ModerationRecoveryMutation;
+
+#[Object]
+impl ModerationRecoveryMutation {
+    /// Requeue the same immutable decision after an explicit operator review.
+    async fn requeue_moderation_application(
+        &self,
+        ctx: &Context<'_>,
+        idempotency_key: Uuid,
+        decision_id: Uuid,
+        expected_case_revision: i64,
+        reason: String,
+    ) -> Result<ModerationApplicationRecoveryPayload> {
+        let auth = require_recovery_authority(ctx)?;
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let service = moderation_service(ctx)?;
+
+        ModerationRecoveryCommandPort::requeue_application(
+            &service,
+            recovery_port_context(ctx, auth, idempotency_key)?,
+            RequeueModerationApplicationCommand {
+                decision_id,
+                expected_case_revision,
+                reason,
+            },
+        )
+        .await
+        .map(Into::into)
+        .map_err(map_port_error)
+    }
+
+    /// Align a legacy terminal application with its Moderation case without invoking a domain adapter.
+    async fn reconcile_legacy_moderation_application(
+        &self,
+        ctx: &Context<'_>,
+        idempotency_key: Uuid,
+        decision_id: Uuid,
+        expected_case_revision: i64,
+        reason: String,
+    ) -> Result<ModerationApplicationRecoveryPayload> {
+        let auth = require_recovery_authority(ctx)?;
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let service = moderation_service(ctx)?;
+
+        ModerationRecoveryCommandPort::reconcile_legacy_application(
+            &service,
+            recovery_port_context(ctx, auth, idempotency_key)?,
+            ReconcileLegacyModerationApplicationCommand {
+                decision_id,
+                expected_case_revision,
+                reason,
+            },
+        )
+        .await
+        .map(Into::into)
+        .map_err(map_port_error)
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct ModerationApplicationRecoveryPayload {
+    pub decision_id: Uuid,
+    pub case_id: Uuid,
+    pub operation_status: String,
+    pub case_status: String,
+    pub case_revision: i64,
+    pub changed: bool,
+}
+
+impl From<ModerationApplicationRecoveryRecord> for ModerationApplicationRecoveryPayload {
+    fn from(value: ModerationApplicationRecoveryRecord) -> Self {
+        Self {
+            decision_id: value.decision_id,
+            case_id: value.case_id,
+            operation_status: value.operation_status.as_str().to_string(),
+            case_status: value.case_status.as_str().to_string(),
+            case_revision: value.case_revision,
+            changed: value.changed,
+        }
+    }
+}
+
+fn moderation_service(ctx: &Context<'_>) -> Result<ModerationService> {
+    Ok(ModerationService::new(
+        ctx.data::<DatabaseConnection>()?.clone(),
+    ))
+}
+
+fn require_recovery_authority<'a>(ctx: &'a Context<'a>) -> Result<&'a AuthContext> {
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    let tenant = ctx.data::<TenantContext>().map_err(|_| {
+        <FieldError as GraphQLError>::internal_error(
+            "Moderation tenant context is not registered",
+        )
+    })?;
+
+    if auth.tenant_id != tenant.id {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "moderation tenant mismatch",
+        ));
+    }
+    if !auth.is_human_user_principal() {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "moderation application recovery requires a human operator",
+        ));
+    }
+    if !has_recovery_permission(&auth.permissions) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: moderation_cases:override required",
+        ));
+    }
+
+    Ok(auth)
+}
+
+fn has_recovery_permission(permissions: &[Permission]) -> bool {
+    has_effective_permission(permissions, &Permission::MODERATION_CASES_OVERRIDE)
+}
+
+fn recovery_port_context(
+    ctx: &Context<'_>,
+    auth: &AuthContext,
+    idempotency_key: Uuid,
+) -> Result<PortContext> {
+    if idempotency_key.is_nil() {
+        return Err(<FieldError as GraphQLError>::bad_user_input(
+            "moderation recovery idempotency key must not be nil",
+        ));
+    }
+
+    let tenant = ctx.data::<TenantContext>().map_err(|_| {
+        <FieldError as GraphQLError>::internal_error(
+            "Moderation tenant context is not registered",
+        )
+    })?;
+    let locale = ctx
+        .data_opt::<RequestContext>()
+        .map(|request| request.locale.clone())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or_else(|| tenant.default_locale.clone());
+
+    let mut context = PortContext::new(
+        tenant.id.to_string(),
+        auth.port_actor(),
+        locale,
+        format!("graphql-moderation-recovery-{}", Uuid::new_v4()),
+    )
+    .with_deadline(RECOVERY_PORT_DEADLINE)
+    .with_idempotency_key(idempotency_key.to_string());
+
+    for permission in &auth.permissions {
+        context = context.with_claim(permission.to_string());
+    }
+    if let Some(channel) = ctx.data_opt::<ChannelContext>() {
+        context = context.with_channel(channel.slug.clone());
+    }
+
+    Ok(context)
+}
+
+fn map_port_error(error: PortError) -> FieldError {
+    match error.kind {
+        PortErrorKind::Validation | PortErrorKind::Conflict => {
+            <FieldError as GraphQLError>::bad_user_input(&error.message)
+        }
+        PortErrorKind::NotFound => <FieldError as GraphQLError>::not_found(&error.message),
+        PortErrorKind::Forbidden => <FieldError as GraphQLError>::permission_denied(&error.message),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => {
+            <FieldError as GraphQLError>::internal_error(
+                "Moderation recovery service is temporarily unavailable",
+            )
+        }
+        PortErrorKind::InvariantViolation => <FieldError as GraphQLError>::internal_error(
+            "Moderation recovery operation requires operator review",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_permission_is_not_inherited_from_forum_moderation() {
+        assert!(has_recovery_permission(&[
+            Permission::MODERATION_CASES_OVERRIDE
+        ]));
+        assert!(has_recovery_permission(&[
+            Permission::MODERATION_CASES_MANAGE
+        ]));
+        assert!(!has_recovery_permission(&[
+            Permission::FORUM_TOPICS_MODERATE,
+            Permission::FORUM_REPLIES_MODERATE,
+        ]));
+    }
+}

--- a/apps/server/src/graphql/schema.rs
+++ b/apps/server/src/graphql/schema.rs
@@ -23,6 +23,8 @@ use super::index_drift_diagnosis::IndexDriftDiagnosisMutation;
 use super::index_drift_source_page_diagnosis::IndexDriftSourcePageDiagnosisMutation;
 use super::legacy_disable_user::LegacyDisableUserPolicy;
 use super::loaders::TenantNameLoader;
+#[cfg(feature = "mod-moderation")]
+use super::moderation_recovery::ModerationRecoveryMutation;
 use super::module_security::GraphqlModuleSecurityPolicy;
 use super::mutations::RootMutation;
 use super::observability::GraphqlObservability;
@@ -86,6 +88,8 @@ pub struct Mutation(
     RootMutation,
     IndexDriftDiagnosisMutation,
     IndexDriftSourcePageDiagnosisMutation,
+    #[cfg(feature = "mod-moderation")]
+    ModerationRecoveryMutation,
     #[cfg(all(
         feature = "mod-content",
         feature = "mod-blog",

--- a/crates/rustok-moderation/docs/application-operator-recovery.md
+++ b/crates/rustok-moderation/docs/application-operator-recovery.md
@@ -1,10 +1,10 @@
 # Moderation application operator recovery
 
-Status: **bounded source-ready slice / maintainer execution pending**
+Status: **owner recovery + authorized GraphQL transport source-ready / maintainer execution pending**
 
 ## Scope
 
-This slice adds Moderation-owned, replay-safe operator commands over the existing durable application operation and case lifecycle. It does not add an admin transport/UI, a new queue, a new scheduler, a new decision type, a migration, or another domain-application path.
+This slice covers Moderation-owned, replay-safe operator commands over the existing durable application operation and case lifecycle plus the host-owned authenticated GraphQL transport that enters them through the dedicated recovery port. It does not add an admin UI, a new queue, a new scheduler, a new decision type, a migration, or another domain-application path.
 
 Two owner commands are source-ready:
 
@@ -12,6 +12,29 @@ Two owner commands are source-ready:
 - `operator_reconcile_legacy_application_replay_safe` for truthful case-state reconciliation of a pre-audit terminal operation.
 
 Both commands require write semantics, a human `PortActorKind::User` with UUID identity, a positive expected case revision, a bounded non-empty reason, and the existing Moderation command idempotency receipt.
+
+The dedicated `ModerationRecoveryCommandPort` additionally requires the trusted caller permission snapshot to contain `moderation_cases:override` or the effective `moderation_cases:manage` authority. Ordinary Forum moderation permissions do not authorize Moderation application recovery.
+
+## Authorized GraphQL transport
+
+When `rustok-server` is compiled with `mod-moderation`, the host schema exposes two administrative mutations:
+
+- `requeueModerationApplication(idempotencyKey, decisionId, expectedCaseRevision, reason)`;
+- `reconcileLegacyModerationApplication(idempotencyKey, decisionId, expectedCaseRevision, reason)`.
+
+The transport is intentionally host-owned rather than adding a GraphQL dependency to the Moderation owner crate. Before entering the recovery port it requires:
+
+1. an authenticated `AuthContext` whose tenant matches the request `TenantContext`;
+2. a human-user principal; OAuth service principals fail closed;
+3. effective `moderation_cases:override` authority, with `moderation_cases:manage` satisfying that authority through the shared permission semantics;
+4. the `moderation` tenant module to be enabled through the shared GraphQL module guard;
+5. a non-nil UUID idempotency key.
+
+The transport then builds a five-second `PortContext` from trusted tenant/actor/locale/permission facts, preserves the authenticated permission snapshot as port claims, carries the resolved channel when present, and uses the supplied UUID as the owner command idempotency key. It calls only `ModerationRecoveryCommandPort`; it does not bypass the port to call recovery owner methods directly.
+
+The response is a bounded recovery payload containing decision ID, case ID, operation status, case status, resulting case revision and whether reconciliation changed state. Owner `PortError` kinds are mapped to the existing public GraphQL error classes without exposing storage details.
+
+The port remains a second authorization boundary beneath GraphQL. A transport regression therefore cannot make ordinary `forum_topics:moderate` or `forum_replies:moderate` authority sufficient for recovery.
 
 ## Same-decision operator requeue
 
@@ -68,7 +91,7 @@ A stale reviewed subject revision is part of the immutable decision identity. Ch
 
 Therefore a true re-review must use a **new moderation case and new immutable decision** built from a freshly authorized producer-supplied subject revision. The old escalated case/decision remains historical truth. This slice adds no automatic producer read, no old-decision rewrite and no hidden replacement decision.
 
-Admin transport/UI for creating that fresh review remains separate work.
+Admin UI and the transport/workflow for creating that fresh review remain separate work.
 
 ## Concurrency and replay
 
@@ -82,6 +105,8 @@ A second recovery request with another idempotency key cannot silently duplicate
 
 Moderation remains the sole owner of reports, cases, immutable decisions, application operations, operator recovery and cross-domain moderation audit.
 
+The server transport owns only authenticated GraphQL adaptation. It supplies trusted request facts and calls the Moderation recovery port; it does not own or reproduce Moderation persistence, lifecycle or replay logic.
+
 Forum is not involved in recovery persistence and is never called for legacy reconciliation. Forum continues to own only its topic/reply state, moderation subject revision and domain-side application receipt/effect transaction.
 
 This slice is unrelated to Reactions. Existing `rustok-reactions` remains the sole reaction catalog/state/command/aggregate/event/repair owner and `rustok-reactions-storefront` remains the reusable presentation owner. No duplicate Forum reactions subsystem is created.
@@ -94,7 +119,7 @@ This slice does not add:
 - requeue of an already-applied decision;
 - producer current-revision lookup from Moderation;
 - domain adapter invocation from recovery;
-- admin GraphQL/HTTP/UI recovery transport;
+- admin UI or fresh-review creation transport/workflow;
 - public typed recovery event contracts;
 - a migration or new persistence table;
 - retained runtime, PostgreSQL, SQLite or concurrency evidence.
@@ -105,14 +130,17 @@ Suggested checks, intentionally not run while preparing this slice:
 
 ```bash
 node scripts/verify/verify-moderation-application-operator-recovery.mjs
+node scripts/verify/verify-moderation-recovery-graphql-transport.mjs
 node scripts/verify/verify-moderation-application-audit-lifecycle.mjs
 node scripts/verify/verify-moderation-application-dispatch-once.mjs
 cargo check -p rustok-moderation --all-targets
+cargo check -p rustok-server --features mod-moderation
 cargo test -p rustok-moderation
+cargo test -p rustok-server moderation_recovery
 cargo xtask module validate moderation
 git diff --check
 ```
 
-Retained evidence should cover human-actor enforcement; receipt replay/changed-request conflict; expected case revision contention; rejected/operator-review requeue; applied requeue rejection; requeue from current escalated and legacy decided case state; next scheduler claim after requeue; preservation of immutable decision UUID domain idempotency; terminal identity/evidence corruption fail-closed behavior; applied legacy reconciliation to closed at reconciliation time with active-key release; rejected/operator-review legacy reconciliation to escalated; already-consistent reconciliation no-op; no domain adapter invocation during reconciliation; rollback on audit/receipt failure; and PostgreSQL/SQLite parity.
+Retained evidence should cover GraphQL tenant mismatch/module-disabled/service-principal/permission denial; `moderation_cases:manage` effective authorization; ordinary Forum moderation permission denial; non-nil UUID idempotency propagation; human-actor enforcement at the owner boundary; receipt replay/changed-request conflict; expected case revision contention; rejected/operator-review requeue; applied requeue rejection; requeue from current escalated and legacy decided case state; next scheduler claim after requeue; preservation of immutable decision UUID domain idempotency; terminal identity/evidence corruption fail-closed behavior; applied legacy reconciliation to closed at reconciliation time with active-key release; rejected/operator-review legacy reconciliation to escalated; already-consistent reconciliation no-op; no domain adapter invocation during reconciliation; rollback on audit/receipt failure; and PostgreSQL/SQLite parity.
 
 No tests, Cargo commands, Node verifiers, formatting, migrations, database scenarios, workflows, CI or `git diff --check` were executed while preparing this source slice.

--- a/scripts/verify/verify-moderation-recovery-graphql-transport.mjs
+++ b/scripts/verify/verify-moderation-recovery-graphql-transport.mjs
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+
+const transport = fs.readFileSync(
+  "apps/server/src/graphql/moderation_recovery.rs",
+  "utf8",
+);
+const graphqlMod = fs.readFileSync("apps/server/src/graphql/mod.rs", "utf8");
+const schema = fs.readFileSync("apps/server/src/graphql/schema.rs", "utf8");
+const serverCargo = fs.readFileSync("apps/server/Cargo.toml", "utf8");
+const ports = fs.readFileSync("crates/rustok-moderation/src/ports.rs", "utf8");
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+function forbidText(source, needle, message) {
+  if (source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  "pub struct ModerationRecoveryMutation",
+  "requeue_moderation_application",
+  "reconcile_legacy_moderation_application",
+  'const MODULE_SLUG: &str = "moderation"',
+  "require_module_enabled(ctx, MODULE_SLUG).await?",
+  "auth.tenant_id != tenant.id",
+  "auth.is_human_user_principal()",
+  "Permission::MODERATION_CASES_OVERRIDE",
+  "has_effective_permission",
+  "idempotency_key.is_nil()",
+  "RECOVERY_PORT_DEADLINE",
+  ".with_idempotency_key(idempotency_key.to_string())",
+  "context.with_claim(permission.to_string())",
+  "ModerationRecoveryCommandPort::requeue_application",
+  "ModerationRecoveryCommandPort::reconcile_legacy_application",
+  "ModerationApplicationRecoveryPayload",
+]) {
+  requireText(transport, marker, `Moderation recovery GraphQL transport is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "operator_requeue_application_replay_safe",
+  "operator_reconcile_legacy_application_replay_safe",
+  "dispatch_application_operation_once",
+]) {
+  forbidText(
+    transport,
+    forbidden,
+    `GraphQL recovery transport must enter only through the recovery port: ${forbidden}`,
+  );
+}
+
+requireText(
+  transport,
+  "Permission::FORUM_TOPICS_MODERATE",
+  "Transport guard must retain explicit evidence that Forum moderation permission is insufficient",
+);
+requireText(
+  transport,
+  "Permission::FORUM_REPLIES_MODERATE",
+  "Transport guard must retain explicit evidence that Forum reply moderation permission is insufficient",
+);
+requireText(
+  graphqlMod,
+  '#[cfg(feature = "mod-moderation")]\npub mod moderation_recovery;',
+  "Server GraphQL module must feature-gate Moderation recovery transport",
+);
+requireText(
+  schema,
+  '#[cfg(feature = "mod-moderation")]\nuse super::moderation_recovery::ModerationRecoveryMutation;',
+  "Server schema must import the Moderation recovery mutation only with mod-moderation",
+);
+requireText(
+  schema,
+  '#[cfg(feature = "mod-moderation")]\n    ModerationRecoveryMutation,',
+  "Server schema must merge the Moderation recovery mutation only with mod-moderation",
+);
+requireText(
+  serverCargo,
+  'mod-moderation = ["dep:rustok-moderation", "rustok-distribution/mod-moderation"]',
+  "Server mod-moderation feature must retain the Moderation owner dependency",
+);
+requireText(
+  ports,
+  "pub trait ModerationRecoveryCommandPort",
+  "Moderation owner must retain the dedicated recovery command port",
+);
+requireText(
+  ports,
+  "moderation_cases:override",
+  "Moderation recovery port must retain its dedicated permission boundary",
+);
+
+console.log("Moderation recovery GraphQL transport source guard passed");


### PR DESCRIPTION
## Summary
- add host-owned GraphQL mutations for Moderation application requeue and legacy terminal reconciliation under `mod-moderation`
- require authenticated tenant match, human-user principal, effective `moderation_cases:override` authority, enabled Moderation tenant module, and a non-nil UUID idempotency key
- enter recovery only through `ModerationRecoveryCommandPort`, preserving the owner port as a second authorization boundary
- carry trusted locale, channel and permission snapshot into a bounded five-second `PortContext`
- map owner port failures to the existing public GraphQL error classes without exposing storage details
- update the operator-recovery handoff document and add a source guard for the transport boundary

## Plan context
This continues the Forum/Moderation recovery milestone after #3202. Same-decision requeue and legacy-terminal reconciliation are now owner-ready and have an authorized host GraphQL transport. Admin UI and the explicit fresh producer revision -> new case -> new immutable decision re-review workflow remain separate follow-up work; historical decisions are not retargeted in place.

The canonical implementation-plan cursor is intentionally not rewritten in this PR because `main` is moving concurrently and the available file-write API replaces that large document wholesale. The focused recovery document is updated here; the top-level cursor can be safely advanced together with the UI/re-review slice.

## Verification
Static source review only. Tests, Cargo commands, Node verifiers, formatters, migrations, database scenarios, workflows and CI were intentionally not run per request.