### PR TITLE
refactor(commerce): cut Product effective-form read to owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # RusToK ecommerce implementation plan
 
-Last reviewed: 2026-08-07
+Last reviewed: 2026-08-08
 
 ## Source of truth
 
@@ -229,13 +229,17 @@ These are source-contract defects, not verification-only tasks.
   `productAttributeSchemas` to it with current-tenant/permission admission,
   authenticated actor, trimmed locale, request channel, bounded deadline, and the
   shared stable Product GraphQL public error mapper.
-- [ ] Cut remaining mounted Product schema reads (`productEffectiveForm`,
-  `productAttributeValues`, and `storefrontCatalogSearchOptions`), schema writes,
-  REST delete/publish/unpublish lifecycle commands, and remaining GraphQL Product
-  lifecycle operations over to host-composed Product owner ports. Direct Product
-  entities, `CatalogService`, and `ProductCatalogSchemaService` remain explicit source
-  debt; repeatable lifecycle commands need an explicit caller idempotency contract
-  before cutover.
+- [x] Cut mounted GraphQL `productEffectiveForm` to the host-selected
+  `ProductCatalogSchemaReadPort::read_effective_form`, preserving current-tenant and
+  `PRODUCTS_READ` admission, authenticated actor, trimmed locale, request channel,
+  bounded deadline, existing product/category input precedence, and the shared stable
+  Product GraphQL public error mapper.
+- [ ] Cut remaining mounted Product schema reads (`productAttributeValues` and
+  `storefrontCatalogSearchOptions`), schema writes, REST delete/publish/unpublish
+  lifecycle commands, and remaining GraphQL Product lifecycle operations over to
+  host-composed Product owner ports. Direct Product entities, `CatalogService`, and
+  `ProductCatalogSchemaService` remain explicit source debt; repeatable lifecycle
+  commands need an explicit caller idempotency contract before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -864,7 +868,10 @@ Source inspection is not execution evidence.
 - [x] Publish the optional Product schema-directory read capability on the host-selected
   Product read runtime and cut `productAttributes`, `catalogCategories`, and
   `productAttributeSchemas` away from direct `ProductCatalogSchemaService` construction;
-  effective-form/value/search-option schema reads and Product writes remain open.
+  value/search-option schema reads and Product writes remain open.
+- [x] Cut mounted `productEffectiveForm` to the host-selected Product schema read port,
+  preserving tenant/permission/actor/channel/locale/deadline context and moving aggregate
+  reconstruction plus invariant handling back behind the Product owner boundary.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -2,32 +2,40 @@
 
 ## Scope
 
-Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`.
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`, then continued the Product schema-read cutover from `aaa496887fd1492f3feca8ac52261458ce25705e`.
 
 The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
 
 ## Recheck findings
 
-1. `ProductCatalogSchemaReadPort` already publishes the effective-form aggregate capability added by PR #3182, but the mounted `productEffectiveForm` resolver still constructs `ProductCatalogSchemaService` directly. The plan correctly keeps the remaining Product schema-read cutover open.
-2. The mounted `productAttributeValues` resolver also constructs `ProductCatalogSchemaService` directly. Before this slice there was no transport-neutral schema-read capability for that projection, so a consumer-only cutover would have bypassed the owner boundary contract.
-3. `storefrontCatalogSearchOptions` remains a direct `ProductCatalogSchemaService` consumer and is still explicit follow-up debt.
+1. `ProductCatalogSchemaReadPort` publishes the effective-form aggregate capability added by PR #3182. The mounted `productEffectiveForm` resolver was still constructing `ProductCatalogSchemaService` directly and is cut over in the continuation slice below.
+2. The mounted `productAttributeValues` resolver still constructs `ProductCatalogSchemaService` directly. PR #3203 published the transport-neutral owner capability needed for its next consumer cutover.
+3. `storefrontCatalogSearchOptions` remains a direct `ProductCatalogSchemaService` consumer and still needs an owner projection/cutover.
 4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths use `ProductCatalogReadRuntime`, while legacy mounted `product`/`products` roots in `query::CommerceQuery` still contain direct `CatalogService`/Product entity read paths. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path must remain open; source inspection does not justify a status promotion.
 
-## Source change in this slice
+## PR #3203 source change
 
-- Publish `ProductAttributeValuesRequest` and optional `ProductCatalogSchemaReadPort::read_product_attribute_values`.
-- Keep existing adapters source-compatible with a stable fail-closed `product.attribute_values_unavailable` default.
-- Implement the in-process Product owner capability through `ProductCatalogSchemaService::load_product_attribute_values`, preserving canonical `PortContext` policy, tenant, locale, deadline, correlation, and stable public `PortError` mapping.
-- Extend `verify-product-catalog-schema-read-port.mjs` so the owner capability is locked in source while the mounted `productAttributeValues` consumer is explicitly required to remain uncut in this capability-only slice.
+- Published `ProductAttributeValuesRequest` and optional `ProductCatalogSchemaReadPort::read_product_attribute_values`.
+- Kept existing adapters source-compatible with a stable fail-closed `product.attribute_values_unavailable` default.
+- Implemented the in-process Product owner capability through `ProductCatalogSchemaService::load_product_attribute_values`, preserving canonical `PortContext` policy, tenant, locale, deadline, correlation, and stable public `PortError` mapping.
+- Extended `verify-product-catalog-schema-read-port.mjs` so the owner capability is locked in source while the mounted `productAttributeValues` consumer remains explicit follow-up debt.
+
+## Effective-form continuation
+
+- Cut mounted `productEffectiveForm` to the host-selected `ProductCatalogSchemaReadPort::read_effective_form` capability.
+- Preserve current-tenant admission, `PRODUCTS_READ`, authenticated actor, trimmed locale, request channel, bounded deadline, and the shared correlation-aware Product GraphQL public error mapper.
+- Preserve the existing GraphQL input rule: `product_id` wins when supplied; otherwise `category_id` is required.
+- Consume the Product-owned aggregate projection directly, so Commerce no longer reconstructs group labels, definitions, options, and missing-definition invariants for this resolver.
+- Extend the schema-read source guard to require the mounted effective-form owner-port path and forbid direct `ProductCatalogSchemaService` construction in it.
 
 ## Remaining execution order
 
-1. Cut mounted `productEffectiveForm` to `ProductCatalogSchemaReadPort::read_effective_form`.
-2. Cut mounted `productAttributeValues` to `ProductCatalogSchemaReadPort::read_product_attribute_values`.
-3. Publish/cut the owner projection needed by `storefrontCatalogSearchOptions`.
-4. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
+1. Cut mounted `productAttributeValues` to `ProductCatalogSchemaReadPort::read_product_attribute_values`.
+2. Publish/cut the owner projection needed by `storefrontCatalogSearchOptions`.
+3. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
+4. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
 5. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 
 ## Verification state
 
-No tests, checks, formatters, or runtime verification were executed in this slice per maintainer instruction. All execution/promotion gates remain unchanged.
+No tests, checks, formatters, or runtime verification were executed in these slices per maintainer instruction. All execution/promotion gates remain unchanged.

--- a/crates/rustok-commerce/src/graphql/query.rs
+++ b/crates/rustok-commerce/src/graphql/query.rs
@@ -1742,7 +1742,7 @@ impl CommerceQuery {
     ) -> Result<Option<GqlProductEffectiveForm>> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_READ],
             "Permission denied: products:read required",
@@ -1750,96 +1750,73 @@ impl CommerceQuery {
 
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
         let locale = locale.trim();
-        let form = match (product_id, category_id) {
-            (Some(product_id), _) => service
-                .load_effective_form_for_product(tenant_id, product_id)
-                .await
-                .map_err(|error| map_product_service_error(error, "product_query"))?,
-            (None, Some(category_id)) => Some(
-                service
-                    .load_effective_form_for_category(tenant_id, category_id, &[])
-                    .await
-                    .map_err(|error| map_product_service_error(error, "product_query"))?,
-            ),
+        let subject = match (product_id, category_id) {
+            (Some(product_id), _) => {
+                rustok_product::ProductEffectiveFormSubject::Product { product_id }
+            }
+            (None, Some(category_id)) => {
+                rustok_product::ProductEffectiveFormSubject::Category { category_id }
+            }
             (None, None) => {
                 return Err(async_graphql::Error::new(
                     "Either product_id or category_id is required",
                 ));
             }
         };
+        let port_context = product_schema_read_port_context(
+            ctx,
+            tenant_id,
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale,
+            "product_effective_form",
+        );
+        let schema_read_port =
+            product_schema_read_port(db, event_bus, &port_context, "product_effective_form")?;
+        let form = schema_read_port
+            .read_effective_form(
+                port_context.clone(),
+                rustok_product::ProductEffectiveFormRequest { subject },
+            )
+            .await
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "product_effective_form",
+                ))
+            })?;
         let Some(form) = form else {
             return Ok(None);
         };
-        let group_labels = service
-            .load_effective_form_group_labels(tenant_id, form.category_id, locale)
-            .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?;
-
-        let definitions = service
-            .list_attributes(tenant_id, locale)
-            .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
-            .into_iter()
-            .map(|attribute| (attribute.id, attribute))
-            .collect::<HashMap<_, _>>();
-        let effective_attribute_ids = form
-            .attributes
-            .iter()
-            .map(|binding| binding.attribute_id)
-            .collect::<Vec<_>>();
-        let mut options_by_attribute = service
-            .list_attribute_options(tenant_id, &effective_attribute_ids, locale)
-            .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
-            .into_iter()
-            .fold(
-                HashMap::<Uuid, Vec<GqlProductAttributeOption>>::new(),
-                |mut map, option| {
-                    map.entry(option.attribute_id)
-                        .or_default()
-                        .push(GqlProductAttributeOption {
-                            id: option.id,
-                            code: option.code,
-                            label: option.label,
-                            position: option.position,
-                        });
-                    map
-                },
-            );
 
         let attributes = form
             .attributes
             .into_iter()
-            .map(|binding| {
-                let definition = definitions.get(&binding.attribute_id).ok_or_else(|| {
-                    async_graphql::Error::new(format!(
-                        "attribute definition {} is missing",
-                        binding.attribute_id
-                    ))
-                })?;
-                Ok(GqlProductEffectiveFormAttribute {
-                    attribute_id: binding.attribute_id,
-                    code: definition.code.clone(),
-                    label: definition.label.clone(),
-                    value_type: definition.value_type.as_str().to_string(),
-                    is_localized: definition.is_localized,
-                    options: options_by_attribute
-                        .remove(&binding.attribute_id)
-                        .unwrap_or_default(),
-                    group_label: binding
-                        .group_code
-                        .as_ref()
-                        .and_then(|code| group_labels.get(code).cloned()),
-                    group_code: binding.group_code,
-                    is_required: binding.is_required,
-                    is_disabled: binding.is_disabled,
-                    position: binding.position,
-                    source: effective_attribute_source_name(binding.source).to_string(),
-                })
+            .map(|attribute| GqlProductEffectiveFormAttribute {
+                attribute_id: attribute.attribute_id,
+                code: attribute.code,
+                label: attribute.label,
+                value_type: attribute.value_type.as_str().to_string(),
+                is_localized: attribute.is_localized,
+                options: attribute
+                    .options
+                    .into_iter()
+                    .map(|option| GqlProductAttributeOption {
+                        id: option.id,
+                        code: option.code,
+                        label: option.label,
+                        position: option.position,
+                    })
+                    .collect(),
+                group_code: attribute.group_code,
+                group_label: attribute.group_label,
+                is_required: attribute.is_required,
+                is_disabled: attribute.is_disabled,
+                position: attribute.position,
+                source: effective_attribute_source_name(attribute.source).to_string(),
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect();
 
         Ok(Some(GqlProductEffectiveForm {
             category_id: form.category_id,

--- a/scripts/verify/verify-product-catalog-schema-read-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-read-port.mjs
@@ -116,6 +116,7 @@ const resolvers = [
   ["product_attributes", "catalog_categories", ".list_attributes("],
   ["catalog_categories", "product_attribute_schemas", ".list_categories("],
   ["product_attribute_schemas", "product_effective_form", ".list_schemas("],
+  ["product_effective_form", "product_attribute_values", ".read_effective_form("],
 ];
 for (const [name, nextName, ownerCall] of resolvers) {
   const resolver = resolverSlice(commerceQuery, name, nextName);
@@ -142,16 +143,17 @@ const effectiveForm = resolverSlice(
   "product_effective_form",
   "product_attribute_values",
 );
-requireText(
-  effectiveForm,
-  "ProductCatalogSchemaService::new",
-  "productEffectiveForm consumer cutover must remain explicit follow-up debt in this capability slice",
-);
-forbidText(
-  effectiveForm,
-  ".read_effective_form(",
-  "productEffectiveForm must not be marked cut over by the capability-only source guard",
-);
+for (const required of [
+  "rustok_product::ProductEffectiveFormSubject::Product",
+  "rustok_product::ProductEffectiveFormSubject::Category",
+  "rustok_product::ProductEffectiveFormRequest",
+]) {
+  requireText(
+    effectiveForm,
+    required,
+    `productEffectiveForm owner-port cutover must contain ${required}`,
+  );
+}
 
 const attributeValues = resolverSlice(
   commerceQuery,
@@ -161,12 +163,12 @@ const attributeValues = resolverSlice(
 requireText(
   attributeValues,
   "ProductCatalogSchemaService::new",
-  "productAttributeValues consumer cutover must remain explicit follow-up debt in this capability slice",
+  "productAttributeValues consumer cutover must remain explicit follow-up debt in this slice",
 );
 forbidText(
   attributeValues,
   ".read_product_attribute_values(",
-  "productAttributeValues must not be marked cut over by the capability-only source guard",
+  "productAttributeValues must not be marked cut over before its consumer slice",
 );
 
 if (!process.exitCode) {


### PR DESCRIPTION
## Summary

- cut mounted GraphQL `productEffectiveForm` from direct `ProductCatalogSchemaService` construction to the host-selected `ProductCatalogSchemaReadPort::read_effective_form`
- preserve current-tenant admission, `PRODUCTS_READ`, authenticated actor, trimmed locale, request channel, bounded deadline, and existing product/category input precedence
- use the shared correlation-aware Product GraphQL public error mapper and consume the Product-owned aggregate projection instead of reconstructing schema details in Commerce
- extend the Product schema-read source guard and actualize the canonical ecommerce plan/recheck packet
- keep `productAttributeValues`, `storefrontCatalogSearchOptions`, legacy Product roots, schema writes, and lifecycle cutovers explicitly open

## Verification

Not run per maintainer instruction. No tests, checks, formatter, FBA/FFA promotion, or runtime verification status is claimed by this PR.