### PR TITLE
feat(index): define localized query contract

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,14 +1,14 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@aaa496887fd1492f3feca8ac52261458ce25705e` (#3203) and continued on
-`agent/index-storefront-localized-query-architecture-20260808`.
+Status overlay rechecked from `main@0a8d09a84688e4c0f3d6007d9b90d7f41b2a53a3` (#3204) and continued on
+`agent/index-localized-query-contract-20260808`.
 
 `implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
 history for the linked-target/replay sequence, but this file is the current execution cursor.
 
 ## Recheck result
 
-The previous current plan was stale after the following merged Index/Product work:
+The current Product/Index sequence now includes:
 
 - #3190 retained linked-target replay/redelivery source evidence;
 - #3192 added the fail-closed Product Storefront parity gate;
@@ -19,21 +19,21 @@ The previous current plan was stale after the following merged Index/Product wor
 - #3199 replaced Product runtime code with one current 15-field Product contract on internal routing key
   `4`, with lower keys historical only;
 - #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
-  projection is requested-locale -> fallback-locale.
+  projection is requested-locale -> fallback-locale;
+- #3204 selected the one generic localized-entity fold architecture and kept Storefront cutover
+  fail-closed pending implementation/evidence.
 
-`main` subsequently advanced through #3203. The intervening work does not resolve the localized Product
-identity mismatch: one generic `rustok-index` change exposes trusted PostgreSQL query-admission rendering;
-#3202 is Moderation/RBAC; #3203 publishes a Product attribute-values schema-read owner capability for a
-separate ecommerce boundary. None changes `list_published_products_with_query`, the physical Product Index
-locale model, Product routing key `4`, or the Storefront parity gate described here.
+No newer `main` commit exists at the start of this source slice. The current branch implements the first
+runtime-independent fold contract without changing Product traffic, Product schema, ordinary Index query
+semantics, or event contracts.
 
 ## Old execution branch
 
 `agent/index-linked-target-replay-redelivery-evidence-20260807` is no longer a valid continuation base.
-It diverges from current `main` and contains source content that was already squash-merged through #3190.
-Do not cherry-pick or continue development from that branch.
+It diverges from current `main` and contains source content already squash-merged through #3190. Do not
+cherry-pick or continue development from that branch.
 
-The old branch should be deleted after this current work is safely on `main`. Branch deletion is repository
+The old branch should be deleted when repository tooling permits it. Branch deletion is repository
 hygiene only; it is not part of Index correctness.
 
 ## Current primary owner gate
@@ -76,12 +76,12 @@ mismatch:
 
 A scalar substring/LIKE operator on the current exact-locale query is therefore insufficient.
 
-## Localized Product query architecture
+## Localized Product query architecture and contract
 
-Source decision: complete in
+Architecture decision: complete in
 `m7-product-storefront-localized-query-architecture.md`.
 
-Selected architecture:
+Selected architecture remains:
 
 - preserve owner Storefront semantics;
 - keep exactly one current Product schema/routing key;
@@ -94,7 +94,21 @@ Selected architecture:
 - forbid client-side merging of independently paginated locale queries;
 - keep existing schema readiness, Product freshness, and linked-target availability admission.
 
-Implementation and retained evidence remain pending. Storefront traffic remains owner-native.
+This source slice makes the **query contract and cursor identity source-complete**:
+
+- `LocalizedEntityQuery` is explicit and does not reinterpret ordinary `IndexQuery`;
+- requested locale remains `query.scope.locale`;
+- equal fallback locale collapses through `canonical_fallback_locale()`;
+- `any_locale_filter` is a separate root-only existential predicate;
+- ordinary + any-locale filters share one bounded complexity budget;
+- `SchemaRegistry::validate_localized_entity_query` requires `LocaleMode::Required` and reuses canonical
+  field/operator/value validation;
+- `LocalizedCursorCodec` uses dedicated scoped wire version `3` and binds fold mode, requested/fallback,
+  ordinary filter, any-locale filter, order shape and schema fingerprint;
+- ordinary exact-locale cursor wire version `2` remains unchanged and cannot be accepted by the fold.
+
+No localized query execution port exists yet. PostgreSQL fold compilation, decode/execution and retained
+evidence remain pending. Storefront traffic remains owner-native.
 
 ## Retained M7 PostgreSQL packets
 
@@ -164,8 +178,11 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 - [x] Recheck and document owner all-translations search + requested/fallback projection mismatch.
 - [x] Choose one generic localized Product query identity/fallback architecture without another Product
       routing key.
-- [ ] Implement the generic localized-entity fold in `rustok-index` while keeping ordinary exact-locale
+- [x] Add explicit generic localized query shape/validation while keeping ordinary exact-locale
       `IndexQuery` unchanged.
+- [x] Add dedicated localized cursor identity/version bound to requested/fallback/filter/order semantics.
+- [ ] Compile the localized-entity fold to one PostgreSQL page/exact-count contract and expose execution
+      only after decode/admission semantics are complete.
 - [ ] Add generic scalar text-pattern matching inside the folded any-locale identity predicate.
 - [ ] Implement the Product Storefront Index adapter and Taxonomy tag hydration boundary.
 - [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` and the 15-field source.
@@ -179,9 +196,13 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 
 Primary maintainer gate remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-Next source-code step: **implement the generic localized-entity fold in `rustok-index`** according to the
-selected architecture. Keep the existing exact-locale `IndexQuery` contract stable; do not silently
-reinterpret `IndexQueryScope.locale` as a locale union.
+Next source-code step: **compile `LocalizedEntityQuery` into one PostgreSQL identity-fold page/count
+contract**. Reuse current schema readiness and owner/link admission on every participating physical locale
+row, group before limit/count, and use `LocalizedCursorCodec` for continuation. Do not add
+`execute_localized_query` to the public runtime until compiler + decoder semantics are source-complete.
+
+After the folded execution path exists, add the generic scalar text-pattern primitive inside
+`any_locale_filter`, then implement the Product Storefront adapter/equivalence packet.
 
 In parallel, the retained Product PostgreSQL packets need a mechanical source actualization to routing key
 `4`/15-field Product contract before they can be treated as current evidence. No historical-key runtime
@@ -189,19 +210,16 @@ compatibility path is allowed.
 
 Typed Product events remain separately blocked on maintainer event-digest admission.
 
-## Maintainer verification after the next source slices
+## Maintainer verification after this source slice
 
-The implementation agent has not run these commands. Maintainer verification should include the relevant
-focused tests plus the aggregate guards, for example:
+The implementation agent has not run these commands. Maintainer verification should include:
 
 ```bash
+node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
-node scripts/verify/verify-index-product-source.mjs
-node scripts/verify/verify-index-product-attribute-term-contract.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
-cargo check -p rustok-distribution --features mod-product --all-targets
 git diff --check
 ```
 

--- a/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
+++ b/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront localized query architecture
 
-Status: `source_decision_complete_implementation_and_evidence_pending`.
+Status: `query_contract_source_complete_compiler_and_evidence_pending`.
 
 ## Decision
 
@@ -56,6 +56,50 @@ It then reasons over all current/admitted physical locale rows for each root ide
 A consumer must not emulate this contract by issuing independent locale queries and merging pages in
 memory.
 
+## Implemented query contract slice
+
+The first implementation slice is source-complete in `rustok-index` and deliberately stops before SQL
+execution:
+
+- `LocalizedEntityQuery` wraps an ordinary validated `IndexQuery` without changing its exact-locale
+  meaning;
+- `query.scope.locale` is the requested locale;
+- `fallback_locale` is a second projection role and `canonical_fallback_locale()` collapses a fallback
+  equal to requested;
+- `any_locale_filter` is a separate identity-level existential predicate and does not silently rewrite
+  the ordinary query filter;
+- ordinary filter nodes plus any-locale filter nodes share one bounded complexity budget;
+- `SchemaRegistry::validate_localized_entity_query` permits the mode only for `LocaleMode::Required`;
+- the any-locale predicate is root-only in this contract slice, so linked traversal cannot accidentally
+  acquire unspecified cross-locale semantics;
+- field/filter/operator/type validation is reused from the ordinary canonical query validator rather
+  than duplicated with a second rule set.
+
+No query port method named `execute_localized_query` exists yet. That is intentional: publishing runtime
+execution before the folded PostgreSQL compiler and decoder exist would make a partial semantic path look
+authoritative.
+
+## Dedicated cursor identity
+
+`LocalizedCursorCodec` and `LocalizedIndexCursor` provide a separate continuation identity for the fold.
+The localized scoped cursor uses wire version `3`; the ordinary exact-locale cursor wire version `2`
+remains unchanged.
+
+The localized query fingerprint binds:
+
+- explicit fold mode `localized_entity_fold_v1`;
+- tenant and exact schema;
+- requested locale;
+- canonical fallback locale;
+- ordinary filter;
+- `any_locale_filter`;
+- ordering shape.
+
+The cursor payload also retains the registered schema fingerprint, identity-level order values, and root
+entity UUID. Therefore an exact-locale cursor cannot be accepted by the folded path, a folded cursor
+cannot be accepted by the ordinary path, and changing fallback/search/order semantics invalidates the
+folded continuation.
+
 ## Search semantics
 
 Any-locale title search is an identity predicate:
@@ -96,8 +140,8 @@ Grouping happens **before** pagination and exact count.
 - page limit/lookahead is applied to grouped Product identities, not physical translation rows;
 - the Storefront ordering tuple remains the owner tuple (`published_at`/`created_at`, companion
   timestamp, Product ID) and must be evaluated from the identity-level current Product state;
-- continuation state must bind requested locale, fallback locale, localized-fold mode, schema
-  fingerprint, filter/order shape, and the same identity-level ordering tuple;
+- continuation state binds requested locale, fallback locale, localized-fold mode, schema fingerprint,
+  filter/order shape, and the same identity-level ordering tuple;
 - a cursor from an ordinary exact-locale query must not be accepted by the folded query path, and vice
   versa.
 
@@ -121,7 +165,7 @@ introduced.
 ## Storefront adapter boundary
 
 The future Storefront adapter may translate owner inputs to the generic localized fold only after the
-Index-side contract exists. It must then:
+Index-side execution contract exists. It must then:
 
 - map Active + published-only/category/channel visibility predicates;
 - resolve public Product attribute/option codes to canonical `attribute_terms`;
@@ -154,10 +198,11 @@ Until these packets are source-ready, executed, and admitted, Storefront remains
 
 ## Deliberate limits
 
-This source decision does not yet:
+This slice does not yet:
 
-- change `IndexQueryScope` or public Index query types;
-- add the generic localized fold implementation;
+- change ordinary `IndexQueryScope` or exact-locale query behavior;
+- compile the localized fold to PostgreSQL;
+- expose localized execution through `IndexQueryPort`/`SharedIndexQueryRuntime`;
 - add scalar text-pattern SQL compilation;
 - implement the Storefront Index adapter;
 - actualize the retained Product PostgreSQL packets to the current Product routing key;
@@ -169,10 +214,18 @@ This source decision does not yet:
 
 ## Next implementation slice
 
-Implement the generic localized-entity fold in `rustok-index` as a separate controlled query mode with
-identity-level page/count/cursor semantics. Keep ordinary exact-locale `IndexQuery` behavior unchanged.
-Only after that fold exists should scalar text-pattern matching be wired into its any-locale identity
-predicate and consumed by a Product Storefront adapter.
+Compile `LocalizedEntityQuery` into one PostgreSQL identity-fold statement and matching exact-count
+statement. Reuse the existing admission descriptors on every physical locale row participating in
+identity admission/projection/anchor selection, group before limit/count, and decode page cursors through
+`LocalizedCursorCodec`. Only after that execution path exists should scalar text-pattern matching be wired
+into `any_locale_filter` and consumed by a Product Storefront adapter.
+
+## Source guard
+
+`scripts/verify/verify-index-localized-query-contract.mjs` locks the explicit query type, required-locale
+validation, root-only any-locale predicate, canonical fallback de-duplication, dedicated cursor version
+and separation from ordinary cursor identity. It also fails if this source-only contract slice starts
+claiming `execute_localized_query` before the compiler exists.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,14 +1,14 @@
 # M7 Product Storefront Index parity gate
 
-Status: `source_architecture_selected_implementation_and_evidence_pending`.
+Status: `localized_query_contract_source_complete_compiler_and_evidence_pending`.
 
 ## Purpose
 
 The Product Storefront catalog remains owner-native. The single current Product Index source now
 materializes the Storefront scalar fields, stable tag identities, and typed EAV query state that were
-previously missing. A fresh owner-vs-Index recheck found a remaining **localized Product identity
-mismatch**; the query-layer architecture for that mismatch is now selected, but implementation and
-retained evidence are still pending.
+previously missing. The remaining localized Product identity mismatch now has both a selected architecture
+and an explicit query/cursor contract, but PostgreSQL fold execution and retained equivalence evidence are
+still pending.
 
 Storefront must continue to execute `CatalogService::list_published_products_with_query`.
 
@@ -78,6 +78,24 @@ ordering, cursor, freshness, and retained-evidence contract.
 Do **not** add another Product routing key merely to patch this query semantic. The current Product
 contract remains the only runtime Product implementation.
 
+## Implemented generic query contract
+
+`rustok-index` now exposes the source-level contract required before the SQL compiler can exist safely:
+
+- `LocalizedEntityQuery` explicitly wraps the ordinary exact-locale query shape;
+- requested locale remains `query.scope.locale` and fallback is a separate canonical role;
+- `any_locale_filter` is an explicit root-only identity predicate;
+- `SchemaRegistry::validate_localized_entity_query` reuses ordinary field/operator/type validation and
+  requires a locale-required schema;
+- `LocalizedCursorCodec` uses dedicated scoped wire version `3`, while ordinary exact-locale cursors
+  remain on version `2`;
+- the folded continuation binds requested/fallback/filter/any-locale-filter/order/schema identity and
+  cannot be reused as an ordinary query cursor.
+
+The public query runtime still has no `execute_localized_query` method. PostgreSQL compiler, page decoder,
+exact-count execution and admission composition must be source-complete before that capability is
+published.
+
 ## Typed EAV representation
 
 Dynamic EAV attributes do not create dynamic Index fields. Public Product attribute/option codes are
@@ -114,8 +132,8 @@ Lower persisted Product keys are historical storage identities only. Promotion r
 
 Storefront traffic stays blocked until all of these are complete:
 
-1. implement the selected generic localized-entity identity fold without changing ordinary exact-locale
-   `IndexQuery` semantics;
+1. compile the selected localized-entity identity fold into one PostgreSQL page/exact-count execution
+   contract and expose runtime execution only after decoder/admission semantics are complete;
 2. add the required generic scalar text-pattern primitive inside the folded any-locale identity
    predicate;
 3. translate Active + published-only, category, visibility, EAV, timestamp ordering, ID tie-break,
@@ -135,26 +153,22 @@ Storefront traffic stays blocked until all of these are complete:
 mismatch and keeps Storefront owner-native.
 
 `scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs` locks the selected
-query-layer decision:
+query-layer decision and its implemented query/cursor contract.
 
-- owner title search remains all-translations unless the same PR deliberately changes the owner
-  contract;
-- owner result projection still has requested/fallback translation selection;
-- Product Index source remains one physical translation locale per entity and does not fabricate
-  fallback rows;
-- one current Product routing key (`4`) and schema-scoped replay identity remain selected;
-- the localized fold is identity-level and happens before page/count semantics;
-- implementation/evidence remain pending and traffic stays fail-closed.
+`scripts/verify/verify-index-localized-query-contract.mjs` specifically locks `LocalizedEntityQuery`,
+required-locale validation, root-only `any_locale_filter`, fallback de-duplication and dedicated cursor
+identity while rejecting premature public runtime execution.
 
 ## Deliberate limits
 
-This slice selects and documents the localized query architecture but does not implement the fold, change
-owner Storefront semantics, add another Product routing key, implement the Storefront Index adapter,
-execute tenant rebuild, add public typed Product events, or switch traffic.
+This slice does not compile or execute the fold, change owner Storefront semantics, add another Product
+routing key, implement the Storefront Index adapter, execute tenant rebuild, add public typed Product
+events, or switch traffic.
 
 ## Maintainer verification
 
 ```bash
+node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-product-source.mjs

--- a/crates/rustok-index/src/application/localized_cursor.rs
+++ b/crates/rustok-index/src/application/localized_cursor.rs
@@ -36,7 +36,7 @@ struct LocalizedCursorQueryIdentity<'a> {
     mode: &'static str,
     tenant_id: Uuid,
     schema: &'a SchemaRef,
-    requested_locale: &'a LocaleKey,
+    requested_locale: Option<&'a LocaleKey>,
     fallback_locale: Option<&'a LocaleKey>,
     filter: &'a Option<FilterExpr>,
     any_locale_filter: &'a Option<FilterExpr>,
@@ -162,14 +162,11 @@ fn decode_payload<T: DeserializeOwned>(
 fn query_fingerprint(
     query: &LocalizedEntityQuery,
 ) -> Result<[u8; 32], LocalizedCursorCodecError> {
-    let requested_locale = query
-        .requested_locale()
-        .expect("validated localized queries always carry a requested locale");
     let identity = LocalizedCursorQueryIdentity {
         mode: "localized_entity_fold_v1",
         tenant_id: query.query.scope.tenant_id,
         schema: &query.query.schema,
-        requested_locale,
+        requested_locale: query.requested_locale(),
         fallback_locale: query.canonical_fallback_locale(),
         filter: &query.query.filter,
         any_locale_filter: &query.any_locale_filter,
@@ -351,7 +348,8 @@ mod tests {
             order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
             entity_id: Uuid::new_v4(),
         };
-        let standard_encoded = CursorCodec::encode_for_query(&standard, &original.query, &registry).unwrap();
+        let standard_encoded =
+            CursorCodec::encode_for_query(&standard, &original.query, &registry).unwrap();
         assert!(matches!(
             LocalizedCursorCodec::decode_scoped_for_query(&standard_encoded, &original, &registry),
             Err(LocalizedCursorValidationError::Codec(

--- a/crates/rustok-index/src/application/localized_cursor.rs
+++ b/crates/rustok-index/src/application/localized_cursor.rs
@@ -1,0 +1,386 @@
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::domain::{
+    FieldPath, FilterExpr, IndexValue, IndexValueType, LocaleKey, LocalizedEntityQuery, OrderExpr,
+    SchemaFingerprint, SchemaRef,
+};
+
+use super::{LocalizedEntityQueryValidationError, SchemaRegistry, SchemaRegistryError};
+
+const LOCALIZED_SCOPED_CURSOR_VERSION: u8 = 3;
+const CHECKSUM_LEN: usize = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalizedIndexCursor {
+    pub tenant_id: Uuid,
+    pub schema: SchemaRef,
+    pub schema_fingerprint: SchemaFingerprint,
+    pub requested_locale: LocaleKey,
+    pub fallback_locale: Option<LocaleKey>,
+    pub order_values: Vec<IndexValue>,
+    pub entity_id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LocalizedScopedCursorEnvelope {
+    query_fingerprint: [u8; 32],
+    cursor: LocalizedIndexCursor,
+}
+
+#[derive(Serialize)]
+struct LocalizedCursorQueryIdentity<'a> {
+    mode: &'static str,
+    tenant_id: Uuid,
+    schema: &'a SchemaRef,
+    requested_locale: &'a LocaleKey,
+    fallback_locale: Option<&'a LocaleKey>,
+    filter: &'a Option<FilterExpr>,
+    any_locale_filter: &'a Option<FilterExpr>,
+    order_by: &'a [OrderExpr],
+}
+
+#[derive(Debug, Error)]
+pub enum LocalizedCursorCodecError {
+    #[error("localized cursor encoding is invalid: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("localized cursor payload is too short")]
+    TooShort,
+    #[error("unsupported localized cursor version: {0}")]
+    UnsupportedVersion(u8),
+    #[error("localized cursor checksum is invalid")]
+    InvalidChecksum,
+    #[error("localized cursor payload serialization failed: {0}")]
+    Postcard(#[from] postcard::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum LocalizedCursorValidationError {
+    #[error(transparent)]
+    Codec(#[from] LocalizedCursorCodecError),
+    #[error(transparent)]
+    Query(#[from] LocalizedEntityQueryValidationError),
+    #[error(transparent)]
+    Registry(#[from] SchemaRegistryError),
+    #[error("localized cursor tenant does not match query tenant")]
+    TenantMismatch,
+    #[error("localized cursor schema does not match query schema")]
+    SchemaMismatch,
+    #[error("localized cursor schema fingerprint is stale")]
+    SchemaFingerprintMismatch,
+    #[error("localized cursor requested locale does not match query")]
+    RequestedLocaleMismatch,
+    #[error("localized cursor fallback locale does not match canonical query fallback")]
+    FallbackLocaleMismatch,
+    #[error("localized cursor query fingerprint does not match fold/filter/order semantics")]
+    QueryFingerprintMismatch,
+    #[error("localized cursor contains {actual} order values but query defines {expected} order expressions")]
+    OrderArityMismatch { expected: usize, actual: usize },
+    #[error("localized cursor order field contract is missing at position {index}")]
+    OrderFieldContractMissing { index: usize },
+    #[error(
+        "localized cursor order value at position {index} has type {actual:?}, expected {expected:?}"
+    )]
+    OrderValueTypeMismatch {
+        index: usize,
+        expected: IndexValueType,
+        actual: Option<IndexValueType>,
+    },
+    #[error("localized cursor entity id must not be nil")]
+    NilEntityId,
+}
+
+pub struct LocalizedCursorCodec;
+
+impl LocalizedCursorCodec {
+    pub fn encode_for_query(
+        cursor: &LocalizedIndexCursor,
+        query: &LocalizedEntityQuery,
+        registry: &SchemaRegistry,
+    ) -> Result<String, LocalizedCursorValidationError> {
+        validate_cursor(cursor, query, registry)?;
+        let envelope = LocalizedScopedCursorEnvelope {
+            query_fingerprint: query_fingerprint(query)?,
+            cursor: cursor.clone(),
+        };
+        Ok(encode_payload(LOCALIZED_SCOPED_CURSOR_VERSION, &envelope)?)
+    }
+
+    pub fn decode_scoped_for_query(
+        encoded: &str,
+        query: &LocalizedEntityQuery,
+        registry: &SchemaRegistry,
+    ) -> Result<LocalizedIndexCursor, LocalizedCursorValidationError> {
+        let envelope: LocalizedScopedCursorEnvelope =
+            decode_payload(encoded, LOCALIZED_SCOPED_CURSOR_VERSION)?;
+        if envelope.query_fingerprint != query_fingerprint(query)? {
+            return Err(LocalizedCursorValidationError::QueryFingerprintMismatch);
+        }
+        validate_cursor(&envelope.cursor, query, registry)?;
+        Ok(envelope.cursor)
+    }
+}
+
+fn encode_payload<T: Serialize>(
+    version: u8,
+    value: &T,
+) -> Result<String, LocalizedCursorCodecError> {
+    let payload = postcard::to_stdvec(value)?;
+    let checksum = Sha256::digest(&payload);
+    let mut envelope = Vec::with_capacity(1 + payload.len() + CHECKSUM_LEN);
+    envelope.push(version);
+    envelope.extend_from_slice(&payload);
+    envelope.extend_from_slice(&checksum[..CHECKSUM_LEN]);
+    Ok(URL_SAFE_NO_PAD.encode(envelope))
+}
+
+fn decode_payload<T: DeserializeOwned>(
+    encoded: &str,
+    expected_version: u8,
+) -> Result<T, LocalizedCursorCodecError> {
+    let envelope = URL_SAFE_NO_PAD.decode(encoded)?;
+    if envelope.len() < 1 + CHECKSUM_LEN {
+        return Err(LocalizedCursorCodecError::TooShort);
+    }
+    let version = envelope[0];
+    if version != expected_version {
+        return Err(LocalizedCursorCodecError::UnsupportedVersion(version));
+    }
+    let payload_end = envelope.len() - CHECKSUM_LEN;
+    let payload = &envelope[1..payload_end];
+    let checksum = &envelope[payload_end..];
+    let expected = Sha256::digest(payload);
+    if checksum != &expected[..CHECKSUM_LEN] {
+        return Err(LocalizedCursorCodecError::InvalidChecksum);
+    }
+    Ok(postcard::from_bytes(payload)?)
+}
+
+fn query_fingerprint(
+    query: &LocalizedEntityQuery,
+) -> Result<[u8; 32], LocalizedCursorCodecError> {
+    let requested_locale = query
+        .requested_locale()
+        .expect("validated localized queries always carry a requested locale");
+    let identity = LocalizedCursorQueryIdentity {
+        mode: "localized_entity_fold_v1",
+        tenant_id: query.query.scope.tenant_id,
+        schema: &query.query.schema,
+        requested_locale,
+        fallback_locale: query.canonical_fallback_locale(),
+        filter: &query.query.filter,
+        any_locale_filter: &query.any_locale_filter,
+        order_by: &query.query.order_by,
+    };
+    let bytes = postcard::to_stdvec(&identity)?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"rustok-index-localized-cursor-query-v1");
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    Ok(hasher.finalize().into())
+}
+
+fn validate_cursor(
+    cursor: &LocalizedIndexCursor,
+    query: &LocalizedEntityQuery,
+    registry: &SchemaRegistry,
+) -> Result<(), LocalizedCursorValidationError> {
+    registry.validate_localized_entity_query(query)?;
+    let requested_locale = query
+        .requested_locale()
+        .expect("validated localized queries always carry a requested locale");
+    if cursor.tenant_id != query.query.scope.tenant_id {
+        return Err(LocalizedCursorValidationError::TenantMismatch);
+    }
+    if cursor.schema != query.query.schema {
+        return Err(LocalizedCursorValidationError::SchemaMismatch);
+    }
+    if &cursor.requested_locale != requested_locale {
+        return Err(LocalizedCursorValidationError::RequestedLocaleMismatch);
+    }
+    if cursor.fallback_locale.as_ref() != query.canonical_fallback_locale() {
+        return Err(LocalizedCursorValidationError::FallbackLocaleMismatch);
+    }
+    if cursor.entity_id.is_nil() {
+        return Err(LocalizedCursorValidationError::NilEntityId);
+    }
+
+    let registered = registry
+        .get(&query.query.schema)
+        .ok_or_else(|| SchemaRegistryError::SchemaNotFound(query.query.schema.clone()))?;
+    if cursor.schema_fingerprint != registered.fingerprint {
+        return Err(LocalizedCursorValidationError::SchemaFingerprintMismatch);
+    }
+    if cursor.order_values.len() != query.query.order_by.len() {
+        return Err(LocalizedCursorValidationError::OrderArityMismatch {
+            expected: query.query.order_by.len(),
+            actual: cursor.order_values.len(),
+        });
+    }
+
+    for (index, (order, value)) in query
+        .query
+        .order_by
+        .iter()
+        .zip(&cursor.order_values)
+        .enumerate()
+    {
+        if matches!(value, IndexValue::Null) {
+            continue;
+        }
+        let expected = resolve_order_value_type(registry, &query.query.schema, &order.field)
+            .ok_or(LocalizedCursorValidationError::OrderFieldContractMissing { index })?;
+        let actual = value.value_type();
+        if actual != Some(expected) {
+            return Err(LocalizedCursorValidationError::OrderValueTypeMismatch {
+                index,
+                expected,
+                actual,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn resolve_order_value_type(
+    registry: &SchemaRegistry,
+    root: &SchemaRef,
+    path: &FieldPath,
+) -> Option<IndexValueType> {
+    let mut registered = registry.get(root)?;
+    for link_name in path.links() {
+        let link = registered
+            .schema
+            .links
+            .iter()
+            .find(|link| link.name == *link_name)?;
+        registered = registry.get(&link.target_schema)?;
+    }
+    registered
+        .schema
+        .fields
+        .iter()
+        .find(|field| field.name == *path.field())
+        .map(|field| field.value_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexQuery, IndexQueryScope, IndexSchema,
+        LocaleMode, ModuleName, OrderDirection, Pagination, SchemaVersion,
+    };
+    use crate::{CursorCodec, IndexCursor};
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("rustok-product").unwrap(),
+                entity: EntityName::new("product").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::Required,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn query(schema: &IndexSchema, fallback: Option<&str>) -> LocalizedEntityQuery {
+        LocalizedEntityQuery::new(
+            IndexQuery {
+                scope: IndexQueryScope {
+                    tenant_id: Uuid::new_v4(),
+                    locale: Some(LocaleKey::new("en-US").unwrap()),
+                },
+                schema: schema.reference.clone(),
+                fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+                filter: None,
+                order_by: vec![OrderExpr {
+                    field: FieldPath::new(FieldName::new("id").unwrap()),
+                    direction: OrderDirection::Asc,
+                }],
+                pagination: Pagination::Cursor {
+                    first: 20,
+                    after: None,
+                },
+                include_exact_count: true,
+            },
+            fallback.map(|value| LocaleKey::new(value).unwrap()),
+            None,
+        )
+    }
+
+    #[test]
+    fn localized_cursor_is_bound_to_fallback_and_has_separate_wire_version() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let original = query(&schema, Some("en"));
+        let cursor = LocalizedIndexCursor {
+            tenant_id: original.query.scope.tenant_id,
+            schema: schema.reference.clone(),
+            schema_fingerprint: schema.fingerprint().unwrap(),
+            requested_locale: LocaleKey::new("en-US").unwrap(),
+            fallback_locale: Some(LocaleKey::new("en").unwrap()),
+            order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
+            entity_id: Uuid::new_v4(),
+        };
+        let encoded = LocalizedCursorCodec::encode_for_query(&cursor, &original, &registry).unwrap();
+        assert_eq!(
+            LocalizedCursorCodec::decode_scoped_for_query(&encoded, &original, &registry).unwrap(),
+            cursor
+        );
+
+        let standard = IndexCursor {
+            tenant_id: original.query.scope.tenant_id,
+            schema: schema.reference.clone(),
+            schema_fingerprint: schema.fingerprint().unwrap(),
+            locale: original.query.scope.locale.clone(),
+            order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
+            entity_id: Uuid::new_v4(),
+        };
+        let standard_encoded = CursorCodec::encode_for_query(&standard, &original.query, &registry).unwrap();
+        assert!(matches!(
+            LocalizedCursorCodec::decode_scoped_for_query(&standard_encoded, &original, &registry),
+            Err(LocalizedCursorValidationError::Codec(
+                LocalizedCursorCodecError::UnsupportedVersion(2)
+            ))
+        ));
+    }
+
+    #[test]
+    fn localized_cursor_cannot_cross_fallback_semantics() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let original = query(&schema, Some("en"));
+        let cursor = LocalizedIndexCursor {
+            tenant_id: original.query.scope.tenant_id,
+            schema: schema.reference.clone(),
+            schema_fingerprint: schema.fingerprint().unwrap(),
+            requested_locale: LocaleKey::new("en-US").unwrap(),
+            fallback_locale: Some(LocaleKey::new("en").unwrap()),
+            order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
+            entity_id: Uuid::new_v4(),
+        };
+        let encoded = LocalizedCursorCodec::encode_for_query(&cursor, &original, &registry).unwrap();
+        let mut changed = original.clone();
+        changed.fallback_locale = Some(LocaleKey::new("fr").unwrap());
+        assert!(matches!(
+            LocalizedCursorCodec::decode_scoped_for_query(&encoded, &changed, &registry),
+            Err(LocalizedCursorValidationError::QueryFingerprintMismatch)
+        ));
+    }
+}

--- a/crates/rustok-index/src/application/localized_validation.rs
+++ b/crates/rustok-index/src/application/localized_validation.rs
@@ -1,0 +1,173 @@
+use thiserror::Error;
+
+use crate::domain::{FieldPath, LocalizedEntityQuery, LocaleMode, SchemaRef};
+
+use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum LocalizedEntityQueryValidationError {
+    #[error(transparent)]
+    Query(#[from] QueryValidationError),
+    #[error(transparent)]
+    Registry(#[from] SchemaRegistryError),
+    #[error("localized entity fold requires a locale-required root schema: {0}")]
+    LocaleRequiredSchema(SchemaRef),
+    #[error("any-locale identity predicate must reference root fields only: {0:?}")]
+    AnyLocaleLinkedPath(FieldPath),
+}
+
+impl SchemaRegistry {
+    /// Validate the explicit localized-entity fold request without changing ordinary `IndexQuery`
+    /// validation semantics.
+    pub fn validate_localized_entity_query(
+        &self,
+        query: &LocalizedEntityQuery,
+    ) -> Result<(), LocalizedEntityQueryValidationError> {
+        query
+            .validate_shape()
+            .map_err(QueryValidationError::from)?;
+
+        let registered = self
+            .get(&query.query.schema)
+            .ok_or_else(|| SchemaRegistryError::SchemaNotFound(query.query.schema.clone()))?;
+        if registered.schema.locale_mode != LocaleMode::Required {
+            return Err(LocalizedEntityQueryValidationError::LocaleRequiredSchema(
+                query.query.schema.clone(),
+            ));
+        }
+
+        // The embedded query remains a normal, fully validated exact-locale query shape. Fold mode is
+        // additive and cannot weaken selection/filter/order/pagination/schema checks.
+        self.validate_query(&query.query)?;
+
+        if let Some(path) = query
+            .any_locale_referenced_paths()
+            .into_iter()
+            .find(|path| !path.links().is_empty())
+        {
+            return Err(LocalizedEntityQueryValidationError::AnyLocaleLinkedPath(
+                path.clone(),
+            ));
+        }
+
+        // Reuse the canonical filter validator by substituting only the existential root predicate.
+        // This keeps field existence/filterability/operator/value rules exactly aligned with ordinary
+        // Index queries while preserving the separate any-locale semantic role.
+        if let Some(filter) = &query.any_locale_filter {
+            let mut probe = query.query.clone();
+            probe.filter = Some(filter.clone());
+            self.validate_query(&probe)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldCardinality, FieldName, FieldPath, FilterExpr, IndexField, IndexQuery,
+        IndexQueryScope, IndexSchema, IndexValue, IndexValueType, LocaleKey, ModuleName, Pagination,
+        SchemaRef, SchemaVersion,
+    };
+
+    fn schema(locale_mode: LocaleMode) -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("rustok-product").unwrap(),
+                entity: EntityName::new("product").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode,
+            fields: vec![
+                IndexField {
+                    name: FieldName::new("id").unwrap(),
+                    value_type: IndexValueType::Uuid,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: true,
+                },
+                IndexField {
+                    name: FieldName::new("title").unwrap(),
+                    value_type: IndexValueType::String,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: true,
+                },
+            ],
+            links: Vec::new(),
+        }
+    }
+
+    fn localized_query(schema: &IndexSchema) -> LocalizedEntityQuery {
+        LocalizedEntityQuery::new(
+            IndexQuery {
+                scope: IndexQueryScope {
+                    tenant_id: Uuid::new_v4(),
+                    locale: Some(LocaleKey::new("en-US").unwrap()),
+                },
+                schema: schema.reference.clone(),
+                fields: vec![FieldPath::new(FieldName::new("title").unwrap())],
+                filter: None,
+                order_by: Vec::new(),
+                pagination: Pagination::Cursor {
+                    first: 20,
+                    after: None,
+                },
+                include_exact_count: true,
+            },
+            Some(LocaleKey::new("en").unwrap()),
+            Some(FilterExpr::Eq(
+                FieldPath::new(FieldName::new("title").unwrap()),
+                IndexValue::String("needle".to_owned()),
+            )),
+        )
+    }
+
+    #[test]
+    fn validates_explicit_fold_only_for_locale_required_schema() {
+        let required = schema(LocaleMode::Required);
+        let mut registry = SchemaRegistry::new();
+        registry.register(required.clone()).unwrap();
+        assert!(
+            registry
+                .validate_localized_entity_query(&localized_query(&required))
+                .is_ok()
+        );
+
+        let plain = schema(LocaleMode::None);
+        let mut registry = SchemaRegistry::new();
+        registry.register(plain.clone()).unwrap();
+        let mut query = localized_query(&plain);
+        query.query.scope.locale = None;
+        assert!(matches!(
+            registry.validate_localized_entity_query(&query),
+            Err(LocalizedEntityQueryValidationError::LocaleRequiredSchema(_))
+        ));
+    }
+
+    #[test]
+    fn any_locale_predicate_reuses_filterability_and_type_validation() {
+        let schema = schema(LocaleMode::Required);
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let mut query = localized_query(&schema);
+        query.any_locale_filter = Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("title").unwrap()),
+            IndexValue::Uuid(Uuid::new_v4()),
+        ));
+        assert!(matches!(
+            registry.validate_localized_entity_query(&query),
+            Err(LocalizedEntityQueryValidationError::Query(
+                QueryValidationError::InvalidFilterValue { .. }
+            ))
+        ));
+    }
+}

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -6,6 +6,8 @@ mod drift_digest;
 mod drift_finding_lifecycle;
 mod drift_repair;
 mod drift_repair_recovery;
+mod localized_cursor;
+mod localized_validation;
 mod mutation_event;
 mod planner;
 mod postgres_compiler;
@@ -103,6 +105,11 @@ pub use drift_repair_recovery::{
     IndexDriftRepairRecoveryStore, IndexDriftRepairRecoveryStoreOutcome,
     IndexDriftRepairRecoveryValidationError,
 };
+pub use localized_cursor::{
+    LocalizedCursorCodec, LocalizedCursorCodecError, LocalizedCursorValidationError,
+    LocalizedIndexCursor,
+};
+pub use localized_validation::LocalizedEntityQueryValidationError;
 pub use mutation_event::{
     IndexMutationAcknowledgeFailure, IndexMutationAcknowledgeFailureKind,
     IndexMutationEventAcknowledger, IndexMutationEventCatalog, IndexMutationEventDelivery,

--- a/crates/rustok-index/src/domain/localized_query.rs
+++ b/crates/rustok-index/src/domain/localized_query.rs
@@ -1,0 +1,129 @@
+use serde::{Deserialize, Serialize};
+
+use super::{DomainError, FieldPath, FilterExpr, IndexQuery, LocaleKey};
+
+const MAX_LOCALIZED_FILTER_NODES: usize = 128;
+
+/// Explicit localized-entity fold request layered on top of the ordinary exact-locale query shape.
+///
+/// `query.scope.locale` remains the requested locale. `fallback_locale` is a secondary projection
+/// locale only; when it equals the requested locale it is canonically treated as absent. The ordinary
+/// query filter keeps its exact planned semantics, while `any_locale_filter` is reserved for the
+/// identity-level existential predicate evaluated across admitted physical locale rows by the folded
+/// PostgreSQL compiler.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalizedEntityQuery {
+    pub query: IndexQuery,
+    pub fallback_locale: Option<LocaleKey>,
+    pub any_locale_filter: Option<FilterExpr>,
+}
+
+impl LocalizedEntityQuery {
+    pub fn new(
+        query: IndexQuery,
+        fallback_locale: Option<LocaleKey>,
+        any_locale_filter: Option<FilterExpr>,
+    ) -> Self {
+        Self {
+            query,
+            fallback_locale,
+            any_locale_filter,
+        }
+    }
+
+    pub fn requested_locale(&self) -> Option<&LocaleKey> {
+        self.query.scope.locale.as_ref()
+    }
+
+    /// Return the canonical fallback role used by planning, cursor identity and execution.
+    ///
+    /// Equal requested/fallback locales collapse to one role instead of creating duplicate physical
+    /// locale work or a second cursor identity for equivalent semantics.
+    pub fn canonical_fallback_locale(&self) -> Option<&LocaleKey> {
+        self.fallback_locale
+            .as_ref()
+            .filter(|fallback| Some(*fallback) != self.requested_locale())
+    }
+
+    pub fn validate_shape(&self) -> Result<(), DomainError> {
+        self.query.validate_shape()?;
+        let ordinary_nodes = self
+            .query
+            .filter
+            .as_ref()
+            .map_or(0, FilterExpr::node_count);
+        let any_locale_nodes = self
+            .any_locale_filter
+            .as_ref()
+            .map_or(0, FilterExpr::node_count);
+        if ordinary_nodes + any_locale_nodes > MAX_LOCALIZED_FILTER_NODES {
+            return Err(DomainError::FilterTooComplex);
+        }
+        Ok(())
+    }
+
+    pub fn any_locale_referenced_paths(&self) -> Vec<&FieldPath> {
+        let mut paths = Vec::new();
+        if let Some(filter) = &self.any_locale_filter {
+            filter.field_paths(&mut paths);
+        }
+        paths
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldName, FieldPath, IndexQueryScope, IndexValue, ModuleName, Pagination,
+        SchemaRef, SchemaVersion,
+    };
+
+    fn base_query(requested: &str) -> IndexQuery {
+        IndexQuery {
+            scope: IndexQueryScope {
+                tenant_id: Uuid::new_v4(),
+                locale: Some(LocaleKey::new(requested).unwrap()),
+            },
+            schema: SchemaRef {
+                module: ModuleName::new("rustok-product").unwrap(),
+                entity: EntityName::new("product").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+            filter: None,
+            order_by: Vec::new(),
+            pagination: Pagination::Cursor {
+                first: 20,
+                after: None,
+            },
+            include_exact_count: true,
+        }
+    }
+
+    #[test]
+    fn equal_fallback_locale_is_canonically_collapsed() {
+        let query = LocalizedEntityQuery::new(
+            base_query("en-US"),
+            Some(LocaleKey::new("en-US").unwrap()),
+            None,
+        );
+        assert!(query.canonical_fallback_locale().is_none());
+    }
+
+    #[test]
+    fn any_locale_paths_are_reported_separately_from_exact_query_paths() {
+        let title = FieldPath::new(FieldName::new("title").unwrap());
+        let query = LocalizedEntityQuery::new(
+            base_query("en-US"),
+            Some(LocaleKey::new("en").unwrap()),
+            Some(FilterExpr::Eq(
+                title.clone(),
+                IndexValue::String("needle".to_owned()),
+            )),
+        );
+        assert_eq!(query.any_locale_referenced_paths(), vec![&title]);
+    }
+}

--- a/crates/rustok-index/src/domain/mod.rs
+++ b/crates/rustok-index/src/domain/mod.rs
@@ -1,5 +1,6 @@
 mod error;
 mod identifiers;
+mod localized_query;
 mod mutation;
 mod query;
 mod record;
@@ -11,6 +12,7 @@ pub use identifiers::{
     EntityKey, EntityName, FieldName, FieldPath, LinkName, LocaleKey, ModuleName, SchemaIdentity,
     SchemaRef, SchemaVersion,
 };
+pub use localized_query::LocalizedEntityQuery;
 pub use mutation::IndexMutation;
 pub use query::{
     FilterExpr, IndexQuery, IndexQueryScope, ManyOrderAggregate, OrderDirection, OrderExpr,

--- a/scripts/verify/verify-index-localized-query-contract.mjs
+++ b/scripts/verify/verify-index-localized-query-contract.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-localized-query-contract] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-index/src/domain/localized_query.rs', [
+  'pub struct LocalizedEntityQuery',
+  'pub query: IndexQuery',
+  'pub fallback_locale: Option<LocaleKey>',
+  'pub any_locale_filter: Option<FilterExpr>',
+  'pub fn canonical_fallback_locale(&self)',
+  'Some(*fallback) != self.requested_locale()',
+  'ordinary_nodes + any_locale_nodes > MAX_LOCALIZED_FILTER_NODES',
+  'pub fn any_locale_referenced_paths(&self)',
+]);
+requireMarkers('crates/rustok-index/src/domain/mod.rs', [
+  'mod localized_query;',
+  'pub use localized_query::LocalizedEntityQuery;',
+]);
+
+requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
+  'pub enum LocalizedEntityQueryValidationError',
+  'LocaleRequiredSchema(SchemaRef)',
+  'AnyLocaleLinkedPath(FieldPath)',
+  'pub fn validate_localized_entity_query(',
+  'registered.schema.locale_mode != LocaleMode::Required',
+  'self.validate_query(&query.query)?;',
+  '.find(|path| !path.links().is_empty())',
+  'probe.filter = Some(filter.clone());',
+  'self.validate_query(&probe)?;',
+]);
+
+requireMarkers('crates/rustok-index/src/application/localized_cursor.rs', [
+  'const LOCALIZED_SCOPED_CURSOR_VERSION: u8 = 3;',
+  'pub struct LocalizedIndexCursor',
+  'pub requested_locale: LocaleKey',
+  'pub fallback_locale: Option<LocaleKey>',
+  'pub struct LocalizedCursorCodec;',
+  'mode: "localized_entity_fold_v1"',
+  'fallback_locale: query.canonical_fallback_locale()',
+  'any_locale_filter: &query.any_locale_filter',
+  'b"rustok-index-localized-cursor-query-v1"',
+  'cursor.fallback_locale.as_ref() != query.canonical_fallback_locale()',
+  'LocalizedCursorCodecError::UnsupportedVersion(2)',
+]);
+
+const ordinaryCursor = requireMarkers('crates/rustok-index/src/application/cursor.rs', [
+  'const SCOPED_CURSOR_VERSION: u8 = 2;',
+  'b"rustok-index-cursor-query-v1"',
+  'pub struct IndexCursor',
+]);
+if (ordinaryCursor.includes('localized_entity_fold_v1')) {
+  fail('ordinary cursor codec must not absorb localized fold identity');
+}
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod localized_cursor;',
+  'mod localized_validation;',
+  'LocalizedCursorCodec, LocalizedCursorCodecError, LocalizedCursorValidationError,',
+  'LocalizedIndexCursor,',
+  'pub use localized_validation::LocalizedEntityQueryValidationError;',
+]);
+
+const port = read('crates/rustok-index/src/application/query_port.rs');
+if (port.includes('execute_localized_query')) {
+  fail('this contract slice must not claim PostgreSQL localized execution before the folded compiler exists');
+}
+
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
+  'Status: `query_contract_source_complete_compiler_and_evidence_pending`',
+  '`LocalizedEntityQuery`',
+  '`LocalizedCursorCodec`',
+  'wire version `3`',
+  'ordinary exact-locale cursor wire version `2` remains unchanged',
+]);
+
+console.log('[verify-index-localized-query-contract] explicit fold query validation and cursor identity are source-locked; compiler/execution remain pending');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -61,37 +61,37 @@ if (productSource.includes('SchemaVersion::new(3)')) {
 
 const architecturePath = 'crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md';
 requireMarkers(architecturePath, [
-  'Status: `source_decision_complete_implementation_and_evidence_pending`',
+  'Status: `query_contract_source_complete_compiler_and_evidence_pending`',
   'Keep the current owner Storefront behavior and keep exactly one current Product Index schema.',
   '`(tenant_id, schema_ref, entity_id)`',
-  'requested locale',
-  'fallback locale',
+  '`LocalizedEntityQuery` wraps an ordinary validated `IndexQuery`',
+  '`any_locale_filter` is a separate identity-level existential predicate',
+  '`SchemaRegistry::validate_localized_entity_query` permits the mode only for `LocaleMode::Required`',
+  '`LocalizedCursorCodec` and `LocalizedIndexCursor` provide a separate continuation identity',
+  'wire version `3`',
+  'ordinary exact-locale cursor wire version `2` remains unchanged',
   'Any-locale title search is an identity predicate',
   'the row that satisfied search does **not** become the result locale merely because it matched',
-  'requested-locale row',
-  'fallback-locale row',
   'Grouping happens **before** pagination and exact count.',
   'exact count is the number of distinct admitted Product identities',
   'a cursor from an ordinary exact-locale query must not be accepted by the folded query path',
-  'A consumer must not emulate this contract by issuing independent locale queries',
   'Existing schema readiness, Product entity freshness, and queried link-target availability remain',
-  'Storefront remains owner-native.',
-  'Implement the generic localized-entity fold in `rustok-index`',
+  'Compile `LocalizedEntityQuery` into one PostgreSQL identity-fold statement',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `source_architecture_selected_implementation_and_evidence_pending`',
   'm7-product-storefront-localized-query-architecture.md',
   'A scalar substring/LIKE operator alone cannot close Storefront parity',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@aaa496887fd1492f3feca8ac52261458ce25705e` (#3203)',
+  'Status overlay rechecked from `main@0a8d09a84688e4c0f3d6007d9b90d7f41b2a53a3` (#3204)',
   'one current Product schema on internal routing key `4`',
-  'Choose one generic localized Product query identity/fallback architecture',
-  'implement the generic localized-entity fold in `rustok-index`',
+  'Add explicit generic localized query shape/validation',
+  'Add dedicated localized cursor identity/version',
+  'compile `LocalizedEntityQuery` into one PostgreSQL identity-fold page/count',
   'Do not add a runtime alias for key `3`',
 ]);
 
-console.log('[verify-index-product-storefront-localized-query-architecture] localized Product identity/fallback decision is locked; implementation and evidence remain pending');
+console.log('[verify-index-product-storefront-localized-query-architecture] localized Product architecture plus query/cursor contract are locked; compiler and evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -151,12 +151,14 @@ requireMarkers(schemaStorePath, [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `source_architecture_selected_implementation_and_evidence_pending`',
+  'Status: `localized_query_contract_source_complete_compiler_and_evidence_pending`',
   'does **not** restrict that search row to the requested or fallback locale',
   'owner list can still return the Product using its fallback translation',
   'one Index entity for each physically stored `product_translations.locale`',
   'A scalar substring/LIKE operator alone cannot close Storefront parity',
   'localized-entity identity fold',
+  '`LocalizedEntityQuery` explicitly wraps the ordinary exact-locale query shape',
+  '`LocalizedCursorCodec` uses dedicated scoped wire version `3`',
   'm7-product-storefront-localized-query-architecture.md',
   'Do **not** add another Product routing key merely to patch this query semantic.',
   'actualize retained Product PostgreSQL packets',
@@ -168,4 +170,4 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains fail-closed while the selected localized identity fold is implementation/evidence pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains fail-closed while localized fold compiler/evidence are pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -81,6 +81,7 @@ const scripts = [
   'verify-index-linked-target-replay-redelivery-postgres-harness.mjs',
   'verify-index-product-storefront-parity-gate.mjs',
   'verify-index-product-storefront-localized-query-architecture.mjs',
+  'verify-index-localized-query-contract.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- continue the Product Storefront localized-query plan selected in #3204 with the first runtime-independent `rustok-index` contract slice;
- add explicit `LocalizedEntityQuery` without changing ordinary exact-locale `IndexQuery` semantics;
- keep `query.scope.locale` as the requested locale and canonicalize an equal fallback locale away;
- add a separate root-only `any_locale_filter` identity predicate and share one bounded filter-complexity budget with the ordinary filter;
- add `SchemaRegistry::validate_localized_entity_query`, requiring `LocaleMode::Required` and reusing canonical field/filter/operator/value validation;
- add `LocalizedIndexCursor` / `LocalizedCursorCodec` with dedicated scoped wire version `3`, bound to fold mode, requested/fallback locales, ordinary filter, any-locale filter, ordering and schema fingerprint;
- keep ordinary exact-locale cursor wire version `2` unchanged so continuation tokens cannot cross modes;
- advance the current `rustok-index` plan, Storefront parity docs and static guards to PostgreSQL fold compiler/decoder as the next source step;
- deliberately do not publish `execute_localized_query` before the folded PostgreSQL page/count compiler and decoder exist.

## Main recheck

The branch started from `main@0a8d09a84688e4c0f3d6007d9b90d7f41b2a53a3` (#3204). Before PR creation, current `main@4e83e2ecf63c2907be5d4a34d67073c830ded77e` had advanced through #3205 (Page Builder contribution version pinning) and #3206 (Moderation recovery GraphQL transport). Those changes are disjoint from this `rustok-index`/Index-guard slice; final compare contains only the expected Index docs, domain/application contract files and verifier scripts.

## Boundary

This PR does not compile or execute the localized fold, add scalar substring matching, change Product schema/routing key, add Product events, switch Storefront traffic, or claim PostgreSQL equivalence. Storefront remains owner-native and fail-closed.

The next source slice is one PostgreSQL identity-fold page/exact-count compiler + decoder that applies existing readiness/entity/link admission to every participating physical locale row and uses `LocalizedCursorCodec` for continuation.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.