### PR TITLE
feat(moderation): add fresh-revision rereview workflow

### DIFF
--- a/apps/server/src/graphql/moderation_recovery.rs
+++ b/apps/server/src/graphql/moderation_recovery.rs
@@ -1,20 +1,26 @@
 use std::time::Duration;
 
-use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use async_graphql::{Context, FieldError, Json, Object, Result, SimpleObject};
 use rustok_api::graphql::{GraphQLError, require_module_enabled};
 use rustok_api::{
     AuthContext, ChannelContext, Permission, PortContext, PortError, PortErrorKind, RequestContext,
     TenantContext, has_effective_permission,
 };
 use rustok_moderation::{
-    ModerationApplicationRecoveryRecord, ModerationRecoveryCommandPort, ModerationService,
-    ReconcileLegacyModerationApplicationCommand, RequeueModerationApplicationCommand,
+    AssignModerationCaseCommand, DecideModerationCaseCommand, ModerationApplicationRecoveryRecord,
+    ModerationCaseRecord, ModerationCaseStatus, ModerationCommandPort, ModerationDecisionEffect,
+    ModerationDecisionKind, ModerationReadPort, ModerationReasonCode, ModerationRecoveryCommandPort,
+    ModerationService, OpenModerationCaseCommand, ReconcileLegacyModerationApplicationCommand,
+    RequeueModerationApplicationCommand,
 };
 use sea_orm::DatabaseConnection;
+use serde_json::{Value as JsonValue, json};
 use uuid::Uuid;
 
 const MODULE_SLUG: &str = "moderation";
 const RECOVERY_PORT_DEADLINE: Duration = Duration::from_secs(5);
+const MAX_REREVIEW_REASON_BYTES: usize = 1_000;
+const REREVIEW_METADATA_KEY: &str = "operator_rereview";
 
 #[derive(Default)]
 pub struct ModerationRecoveryMutation;
@@ -74,6 +80,142 @@ impl ModerationRecoveryMutation {
         .map(Into::into)
         .map_err(map_port_error)
     }
+
+    /// Create a new case and immutable decision for a producer-supplied fresh subject revision.
+    ///
+    /// The historical case/decision are never mutated or retargeted. Subject identity, scope,
+    /// queue and policy routing are copied from the source case; only the monotonic subject
+    /// revision and the newly reviewed decision/effect/policy snapshot come from this request.
+    async fn create_moderation_rereview(
+        &self,
+        ctx: &Context<'_>,
+        idempotency_key: Uuid,
+        source_decision_id: Uuid,
+        fresh_subject_revision: i64,
+        rereview_reason: String,
+        decision_kind: String,
+        reason_code: String,
+        effect: Json<JsonValue>,
+        policy_snapshot: Json<JsonValue>,
+    ) -> Result<ModerationRereviewPayload> {
+        let auth = require_recovery_authority(ctx)?;
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let service = moderation_service(ctx)?;
+        let base_context = recovery_port_context(ctx, auth, idempotency_key)?;
+
+        let rereview_reason = normalize_rereview_reason(rereview_reason)?;
+        let decision_kind = parse_decision_kind(decision_kind)?;
+        let reason_code = parse_reason_code(reason_code)?;
+        let effect = parse_decision_effect(effect.0, decision_kind)?;
+        let policy_snapshot = policy_snapshot.0;
+        if !policy_snapshot.is_object() {
+            return Err(<FieldError as GraphQLError>::bad_user_input(
+                "moderation rereview policy snapshot must be a JSON object",
+            ));
+        }
+
+        let source_decision = ModerationReadPort::read_decision(
+            &service,
+            base_context.clone(),
+            source_decision_id,
+        )
+        .await
+        .map_err(map_port_error)?
+        .ok_or_else(|| {
+            <FieldError as GraphQLError>::not_found("source moderation decision was not found")
+        })?;
+        let source_case = ModerationReadPort::read_case(
+            &service,
+            base_context.clone(),
+            source_decision.case_id,
+        )
+        .await
+        .map_err(map_port_error)?
+        .ok_or_else(|| {
+            <FieldError as GraphQLError>::internal_error(
+                "source moderation decision references a missing case",
+            )
+        })?;
+
+        validate_rereview_source(
+            &source_case,
+            source_decision.case_id,
+            source_decision.subject_revision,
+            fresh_subject_revision,
+        )?;
+
+        let metadata = rereview_metadata(
+            idempotency_key,
+            &source_case,
+            source_decision_id,
+            fresh_subject_revision,
+            rereview_reason.as_str(),
+        );
+        let mut fresh_subject = source_case.subject.clone();
+        fresh_subject.revision = fresh_subject_revision;
+
+        let opened = ModerationCommandPort::open_case(
+            &service,
+            rereview_step_context(&base_context, idempotency_key, "open"),
+            OpenModerationCaseCommand {
+                scope: source_case.scope.clone(),
+                subject: fresh_subject,
+                queue_key: source_case.queue_key.clone(),
+                priority: source_case.priority,
+                policy_id: source_case.policy_id,
+                policy_version: source_case.policy_version,
+                report_ids: Vec::new(),
+                metadata,
+            },
+        )
+        .await
+        .map_err(map_port_error)?;
+
+        require_owned_rereview_case(
+            &opened,
+            idempotency_key,
+            source_case.id,
+            source_decision_id,
+            fresh_subject_revision,
+        )?;
+
+        let assigned = ModerationCommandPort::assign_case(
+            &service,
+            rereview_step_context(&base_context, idempotency_key, "assign"),
+            AssignModerationCaseCommand {
+                case_id: opened.id,
+                expected_revision: opened.revision,
+                moderator_id: auth.user_id,
+            },
+        )
+        .await
+        .map_err(map_port_error)?;
+
+        let decision = ModerationCommandPort::decide_case(
+            &service,
+            rereview_step_context(&base_context, idempotency_key, "decide"),
+            DecideModerationCaseCommand {
+                case_id: assigned.id,
+                expected_revision: assigned.revision,
+                decision_kind,
+                reason_code,
+                effect,
+                policy_snapshot,
+            },
+        )
+        .await
+        .map_err(map_port_error)?;
+
+        Ok(ModerationRereviewPayload {
+            source_case_id: source_case.id,
+            source_decision_id,
+            case_id: assigned.id,
+            decision_id: decision.id,
+            subject_revision: fresh_subject_revision,
+            decision_kind: decision.decision_kind.as_str().to_string(),
+            decision_hash: decision.decision_hash,
+        })
+    }
 }
 
 #[derive(SimpleObject)]
@@ -97,6 +239,17 @@ impl From<ModerationApplicationRecoveryRecord> for ModerationApplicationRecovery
             changed: value.changed,
         }
     }
+}
+
+#[derive(SimpleObject)]
+pub struct ModerationRereviewPayload {
+    pub source_case_id: Uuid,
+    pub source_decision_id: Uuid,
+    pub case_id: Uuid,
+    pub decision_id: Uuid,
+    pub subject_revision: i64,
+    pub decision_kind: String,
+    pub decision_hash: String,
 }
 
 fn moderation_service(ctx: &Context<'_>) -> Result<ModerationService> {
@@ -164,7 +317,7 @@ fn recovery_port_context(
         tenant.id.to_string(),
         auth.port_actor(),
         locale,
-        format!("graphql-moderation-recovery-{}", Uuid::new_v4()),
+        format!("graphql-moderation-recovery-{idempotency_key}"),
     )
     .with_deadline(RECOVERY_PORT_DEADLINE)
     .with_idempotency_key(idempotency_key.to_string());
@@ -177,6 +330,140 @@ fn recovery_port_context(
     }
 
     Ok(context)
+}
+
+fn rereview_step_context(
+    base: &PortContext,
+    root_idempotency_key: Uuid,
+    step: &str,
+) -> PortContext {
+    let mut context = base.clone();
+    context.idempotency_key = Some(format!("{root_idempotency_key}:rereview:{step}"));
+    context.correlation_id = format!("graphql-moderation-rereview-{root_idempotency_key}");
+    context
+}
+
+fn normalize_rereview_reason(reason: String) -> Result<String> {
+    let reason = reason.trim().to_string();
+    if reason.is_empty() || reason.len() > MAX_REREVIEW_REASON_BYTES {
+        return Err(<FieldError as GraphQLError>::bad_user_input(format!(
+            "moderation rereview reason must contain 1 to {MAX_REREVIEW_REASON_BYTES} bytes",
+        )));
+    }
+    Ok(reason)
+}
+
+fn parse_decision_kind(value: String) -> Result<ModerationDecisionKind> {
+    let value = value.trim().to_ascii_lowercase();
+    ModerationDecisionKind::parse(value.as_str()).ok_or_else(|| {
+        <FieldError as GraphQLError>::bad_user_input("unknown moderation rereview decision kind")
+    })
+}
+
+fn parse_reason_code(value: String) -> Result<ModerationReasonCode> {
+    let value = value.trim().to_ascii_lowercase();
+    ModerationReasonCode::parse(value.as_str()).ok_or_else(|| {
+        <FieldError as GraphQLError>::bad_user_input("unknown moderation rereview reason code")
+    })
+}
+
+fn parse_decision_effect(
+    value: JsonValue,
+    decision_kind: ModerationDecisionKind,
+) -> Result<ModerationDecisionEffect> {
+    let effect = serde_json::from_value::<ModerationDecisionEffect>(value).map_err(|_| {
+        <FieldError as GraphQLError>::bad_user_input("invalid moderation rereview decision effect")
+    })?;
+    effect
+        .validate_for_decision_kind(decision_kind)
+        .map_err(|error| <FieldError as GraphQLError>::bad_user_input(&error.to_string()))?;
+    Ok(effect)
+}
+
+fn validate_rereview_source(
+    source_case: &ModerationCaseRecord,
+    decision_case_id: Uuid,
+    decision_subject_revision: i64,
+    fresh_subject_revision: i64,
+) -> Result<()> {
+    if source_case.id != decision_case_id
+        || source_case.subject.revision != decision_subject_revision
+    {
+        return Err(<FieldError as GraphQLError>::internal_error(
+            "source moderation decision/case identity is inconsistent",
+        ));
+    }
+    if source_case.status != ModerationCaseStatus::Escalated {
+        return Err(<FieldError as GraphQLError>::bad_user_input(
+            "moderation rereview requires an escalated source case",
+        ));
+    }
+    if fresh_subject_revision <= source_case.subject.revision {
+        return Err(<FieldError as GraphQLError>::bad_user_input(
+            "moderation rereview requires a subject revision newer than the historical review",
+        ));
+    }
+    Ok(())
+}
+
+fn rereview_metadata(
+    root_idempotency_key: Uuid,
+    source_case: &ModerationCaseRecord,
+    source_decision_id: Uuid,
+    fresh_subject_revision: i64,
+    reason: &str,
+) -> JsonValue {
+    json!({
+        REREVIEW_METADATA_KEY: {
+            "root_idempotency_key": root_idempotency_key,
+            "source_case_id": source_case.id,
+            "source_decision_id": source_decision_id,
+            "source_subject_revision": source_case.subject.revision,
+            "fresh_subject_revision": fresh_subject_revision,
+            "reason": reason,
+        }
+    })
+}
+
+fn require_owned_rereview_case(
+    case: &ModerationCaseRecord,
+    root_idempotency_key: Uuid,
+    source_case_id: Uuid,
+    source_decision_id: Uuid,
+    fresh_subject_revision: i64,
+) -> Result<()> {
+    let marker = case
+        .metadata
+        .get(REREVIEW_METADATA_KEY)
+        .and_then(JsonValue::as_object)
+        .ok_or_else(|| {
+            <FieldError as GraphQLError>::bad_user_input(
+                "an existing active moderation case already owns this fresh subject revision",
+            )
+        })?;
+
+    let expected = [
+        ("root_idempotency_key", root_idempotency_key.to_string()),
+        ("source_case_id", source_case_id.to_string()),
+        ("source_decision_id", source_decision_id.to_string()),
+        ("fresh_subject_revision", fresh_subject_revision.to_string()),
+    ];
+    let matches = expected.iter().all(|(field, expected)| {
+        marker
+            .get(*field)
+            .map(|value| match value {
+                JsonValue::String(value) => value == expected,
+                JsonValue::Number(value) => value.to_string() == *expected,
+                _ => false,
+            })
+            .unwrap_or(false)
+    });
+    if !matches {
+        return Err(<FieldError as GraphQLError>::bad_user_input(
+            "an existing active moderation case already owns this fresh subject revision",
+        ));
+    }
+    Ok(())
 }
 
 fn map_port_error(error: PortError) -> FieldError {
@@ -200,6 +487,7 @@ fn map_port_error(error: PortError) -> FieldError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustok_moderation::{ModerationCasePriority, ModerationScopeRef, ModerationSubjectKind, ModerationSubjectRef};
 
     #[test]
     fn recovery_permission_is_not_inherited_from_forum_moderation() {
@@ -213,5 +501,63 @@ mod tests {
             Permission::FORUM_TOPICS_MODERATE,
             Permission::FORUM_REPLIES_MODERATE,
         ]));
+    }
+
+    #[test]
+    fn rereview_step_keys_are_stable_and_distinct() {
+        let root = Uuid::from_u128(1);
+        let base = PortContext::new("tenant", rustok_api::PortActor::user(Uuid::from_u128(2).to_string()), "en", "corr")
+            .with_deadline(RECOVERY_PORT_DEADLINE)
+            .with_idempotency_key(root.to_string());
+        assert_eq!(
+            rereview_step_context(&base, root, "open").idempotency_key.as_deref(),
+            Some("00000000-0000-0000-0000-000000000001:rereview:open")
+        );
+        assert_ne!(
+            rereview_step_context(&base, root, "assign").idempotency_key,
+            rereview_step_context(&base, root, "decide").idempotency_key,
+        );
+    }
+
+    #[test]
+    fn rereview_metadata_proves_case_ownership() {
+        let source_case_id = Uuid::from_u128(3);
+        let source_decision_id = Uuid::from_u128(4);
+        let root = Uuid::from_u128(5);
+        let source_case = ModerationCaseRecord {
+            id: source_case_id,
+            tenant_id: Uuid::from_u128(6),
+            scope: ModerationScopeRef::platform(),
+            subject: ModerationSubjectRef {
+                module: "forum".to_string(),
+                kind: ModerationSubjectKind::ForumPost,
+                id: Uuid::from_u128(7),
+                revision: 10,
+            },
+            queue_key: "content".to_string(),
+            policy_id: None,
+            policy_version: 1,
+            priority: ModerationCasePriority::Normal,
+            status: ModerationCaseStatus::Escalated,
+            assigned_moderator_id: None,
+            revision: 4,
+            metadata: json!({}),
+            opened_at: chrono::Utc::now(),
+            started_at: None,
+            decided_at: None,
+            closed_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let case = ModerationCaseRecord {
+            subject: rustok_moderation::ModerationSubjectRef {
+                revision: 11,
+                ..source_case.subject.clone()
+            },
+            metadata: rereview_metadata(root, &source_case, source_decision_id, 11, "fresh review"),
+            ..source_case.clone()
+        };
+        assert!(require_owned_rereview_case(&case, root, source_case_id, source_decision_id, 11).is_ok());
+        assert!(require_owned_rereview_case(&case, Uuid::from_u128(8), source_case_id, source_decision_id, 11).is_err());
     }
 }

--- a/apps/server/src/graphql/moderation_recovery.rs
+++ b/apps/server/src/graphql/moderation_recovery.rs
@@ -15,6 +15,7 @@ use rustok_moderation::{
 };
 use sea_orm::DatabaseConnection;
 use serde_json::{Value as JsonValue, json};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 const MODULE_SLUG: &str = "moderation";
@@ -113,6 +114,15 @@ impl ModerationRecoveryMutation {
                 "moderation rereview policy snapshot must be a JSON object",
             ));
         }
+        let request_hash = rereview_request_hash(
+            source_decision_id,
+            fresh_subject_revision,
+            rereview_reason.as_str(),
+            decision_kind,
+            reason_code,
+            &effect,
+            &policy_snapshot,
+        )?;
 
         let source_decision = ModerationReadPort::read_decision(
             &service,
@@ -150,6 +160,7 @@ impl ModerationRecoveryMutation {
             source_decision_id,
             fresh_subject_revision,
             rereview_reason.as_str(),
+            request_hash.as_str(),
         );
         let mut fresh_subject = source_case.subject.clone();
         fresh_subject.revision = fresh_subject_revision;
@@ -177,6 +188,7 @@ impl ModerationRecoveryMutation {
             source_case.id,
             source_decision_id,
             fresh_subject_revision,
+            request_hash.as_str(),
         )?;
 
         let assigned = ModerationCommandPort::assign_case(
@@ -380,6 +392,33 @@ fn parse_decision_effect(
     Ok(effect)
 }
 
+fn rereview_request_hash(
+    source_decision_id: Uuid,
+    fresh_subject_revision: i64,
+    rereview_reason: &str,
+    decision_kind: ModerationDecisionKind,
+    reason_code: ModerationReasonCode,
+    effect: &ModerationDecisionEffect,
+    policy_snapshot: &JsonValue,
+) -> Result<String> {
+    let payload = json!({
+        "version": 1,
+        "source_decision_id": source_decision_id,
+        "fresh_subject_revision": fresh_subject_revision,
+        "rereview_reason": rereview_reason,
+        "decision_kind": decision_kind,
+        "reason_code": reason_code,
+        "effect": effect,
+        "policy_snapshot": policy_snapshot,
+    });
+    let encoded = serde_json::to_vec(&payload).map_err(|_| {
+        <FieldError as GraphQLError>::internal_error(
+            "Moderation rereview request could not be normalized",
+        )
+    })?;
+    Ok(hex::encode(Sha256::digest(encoded)))
+}
+
 fn validate_rereview_source(
     source_case: &ModerationCaseRecord,
     decision_case_id: Uuid,
@@ -412,10 +451,12 @@ fn rereview_metadata(
     source_decision_id: Uuid,
     fresh_subject_revision: i64,
     reason: &str,
+    request_hash: &str,
 ) -> JsonValue {
     json!({
         "operator_rereview": {
             "root_idempotency_key": root_idempotency_key,
+            "request_hash": request_hash,
             "source_case_id": source_case.id,
             "source_decision_id": source_decision_id,
             "source_subject_revision": source_case.subject.revision,
@@ -431,6 +472,7 @@ fn require_owned_rereview_case(
     source_case_id: Uuid,
     source_decision_id: Uuid,
     fresh_subject_revision: i64,
+    request_hash: &str,
 ) -> Result<()> {
     let marker = case
         .metadata
@@ -444,6 +486,7 @@ fn require_owned_rereview_case(
 
     let expected = [
         ("root_idempotency_key", root_idempotency_key.to_string()),
+        ("request_hash", request_hash.to_string()),
         ("source_case_id", source_case_id.to_string()),
         ("source_decision_id", source_decision_id.to_string()),
         ("fresh_subject_revision", fresh_subject_revision.to_string()),
@@ -529,6 +572,36 @@ mod tests {
     }
 
     #[test]
+    fn rereview_request_hash_changes_with_decision_payload() {
+        let source_decision_id = Uuid::from_u128(3);
+        let effect = ModerationDecisionEffect::v1(
+            rustok_moderation::ModerationDecisionEffectAction::NoDomainMutation,
+        )
+        .unwrap();
+        let first = rereview_request_hash(
+            source_decision_id,
+            11,
+            "fresh review",
+            ModerationDecisionKind::Warning,
+            ModerationReasonCode::Other,
+            &effect,
+            &json!({"policy": 1}),
+        )
+        .unwrap();
+        let second = rereview_request_hash(
+            source_decision_id,
+            11,
+            "fresh review",
+            ModerationDecisionKind::Warning,
+            ModerationReasonCode::Other,
+            &effect,
+            &json!({"policy": 2}),
+        )
+        .unwrap();
+        assert_ne!(first, second);
+    }
+
+    #[test]
     fn rereview_metadata_proves_case_ownership() {
         let source_case_id = Uuid::from_u128(3);
         let source_decision_id = Uuid::from_u128(4);
@@ -558,16 +631,32 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
+        let request_hash = "request-hash";
         let case = ModerationCaseRecord {
             subject: ModerationSubjectRef {
                 revision: 11,
                 ..source_case.subject.clone()
             },
-            metadata: rereview_metadata(root, &source_case, source_decision_id, 11, "fresh review"),
+            metadata: rereview_metadata(
+                root,
+                &source_case,
+                source_decision_id,
+                11,
+                "fresh review",
+                request_hash,
+            ),
             ..source_case.clone()
         };
         assert!(
-            require_owned_rereview_case(&case, root, source_case_id, source_decision_id, 11).is_ok()
+            require_owned_rereview_case(
+                &case,
+                root,
+                source_case_id,
+                source_decision_id,
+                11,
+                request_hash,
+            )
+            .is_ok()
         );
         assert!(
             require_owned_rereview_case(
@@ -575,7 +664,8 @@ mod tests {
                 Uuid::from_u128(8),
                 source_case_id,
                 source_decision_id,
-                11
+                11,
+                request_hash,
             )
             .is_err()
         );

--- a/apps/server/src/graphql/moderation_recovery.rs
+++ b/apps/server/src/graphql/moderation_recovery.rs
@@ -414,7 +414,7 @@ fn rereview_metadata(
     reason: &str,
 ) -> JsonValue {
     json!({
-        REREVIEW_METADATA_KEY: {
+        "operator_rereview": {
             "root_idempotency_key": root_idempotency_key,
             "source_case_id": source_case.id,
             "source_decision_id": source_decision_id,
@@ -487,7 +487,9 @@ fn map_port_error(error: PortError) -> FieldError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustok_moderation::{ModerationCasePriority, ModerationScopeRef, ModerationSubjectKind, ModerationSubjectRef};
+    use rustok_moderation::{
+        ModerationCasePriority, ModerationScopeRef, ModerationSubjectKind, ModerationSubjectRef,
+    };
 
     #[test]
     fn recovery_permission_is_not_inherited_from_forum_moderation() {
@@ -506,11 +508,18 @@ mod tests {
     #[test]
     fn rereview_step_keys_are_stable_and_distinct() {
         let root = Uuid::from_u128(1);
-        let base = PortContext::new("tenant", rustok_api::PortActor::user(Uuid::from_u128(2).to_string()), "en", "corr")
-            .with_deadline(RECOVERY_PORT_DEADLINE)
-            .with_idempotency_key(root.to_string());
+        let base = PortContext::new(
+            "tenant",
+            rustok_api::PortActor::user(Uuid::from_u128(2).to_string()),
+            "en",
+            "corr",
+        )
+        .with_deadline(RECOVERY_PORT_DEADLINE)
+        .with_idempotency_key(root.to_string());
         assert_eq!(
-            rereview_step_context(&base, root, "open").idempotency_key.as_deref(),
+            rereview_step_context(&base, root, "open")
+                .idempotency_key
+                .as_deref(),
             Some("00000000-0000-0000-0000-000000000001:rereview:open")
         );
         assert_ne!(
@@ -550,14 +559,25 @@ mod tests {
             updated_at: chrono::Utc::now(),
         };
         let case = ModerationCaseRecord {
-            subject: rustok_moderation::ModerationSubjectRef {
+            subject: ModerationSubjectRef {
                 revision: 11,
                 ..source_case.subject.clone()
             },
             metadata: rereview_metadata(root, &source_case, source_decision_id, 11, "fresh review"),
             ..source_case.clone()
         };
-        assert!(require_owned_rereview_case(&case, root, source_case_id, source_decision_id, 11).is_ok());
-        assert!(require_owned_rereview_case(&case, Uuid::from_u128(8), source_case_id, source_decision_id, 11).is_err());
+        assert!(
+            require_owned_rereview_case(&case, root, source_case_id, source_decision_id, 11).is_ok()
+        );
+        assert!(
+            require_owned_rereview_case(
+                &case,
+                Uuid::from_u128(8),
+                source_case_id,
+                source_decision_id,
+                11
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/rustok-moderation/docs/application-operator-recovery.md
+++ b/crates/rustok-moderation/docs/application-operator-recovery.md
@@ -1,40 +1,39 @@
 # Moderation application operator recovery
 
-Status: **owner recovery + authorized GraphQL transport source-ready / maintainer execution pending**
+Status: **owner recovery + authorized GraphQL recovery/re-review transport source-ready / maintainer execution pending**
 
 ## Scope
 
-This slice covers Moderation-owned, replay-safe operator commands over the existing durable application operation and case lifecycle plus the host-owned authenticated GraphQL transport that enters them through the dedicated recovery port. It does not add an admin UI, a new queue, a new scheduler, a new decision type, a migration, or another domain-application path.
+This slice covers Moderation-owned replay-safe operator recovery over the existing durable application operation and case lifecycle, plus the host-owned authenticated GraphQL transport that enters those owner ports. It also defines the explicit fresh-revision re-review workflow as a composition of the existing replay-safe case commands. It does not add an admin UI, a new queue, a new scheduler, a migration, a replacement decision table, or another domain-application path.
 
-Two owner commands are source-ready:
+Two owner recovery commands remain source-ready:
 
 - `operator_requeue_application_replay_safe` for an explicit same-decision retry;
 - `operator_reconcile_legacy_application_replay_safe` for truthful case-state reconciliation of a pre-audit terminal operation.
 
 Both commands require write semantics, a human `PortActorKind::User` with UUID identity, a positive expected case revision, a bounded non-empty reason, and the existing Moderation command idempotency receipt.
 
-The dedicated `ModerationRecoveryCommandPort` additionally requires the trusted caller permission snapshot to contain `moderation_cases:override` or the effective `moderation_cases:manage` authority. Ordinary Forum moderation permissions do not authorize Moderation application recovery.
+The dedicated `ModerationRecoveryCommandPort` additionally requires the trusted caller permission snapshot to contain `moderation_cases:override` or effective `moderation_cases:manage` authority. Ordinary Forum moderation permissions do not authorize Moderation application recovery or re-review orchestration.
 
 ## Authorized GraphQL transport
 
-When `rustok-server` is compiled with `mod-moderation`, the host schema exposes two administrative mutations:
+When `rustok-server` is compiled with `mod-moderation`, the host schema exposes three administrative mutations:
 
 - `requeueModerationApplication(idempotencyKey, decisionId, expectedCaseRevision, reason)`;
-- `reconcileLegacyModerationApplication(idempotencyKey, decisionId, expectedCaseRevision, reason)`.
+- `reconcileLegacyModerationApplication(idempotencyKey, decisionId, expectedCaseRevision, reason)`;
+- `createModerationRereview(idempotencyKey, sourceDecisionId, freshSubjectRevision, rereviewReason, decisionKind, reasonCode, effect, policySnapshot)`.
 
-The transport is intentionally host-owned rather than adding a GraphQL dependency to the Moderation owner crate. Before entering the recovery port it requires:
+The transport is intentionally host-owned rather than adding a GraphQL dependency to the Moderation owner crate. Before entering recovery/re-review it requires:
 
 1. an authenticated `AuthContext` whose tenant matches the request `TenantContext`;
 2. a human-user principal; OAuth service principals fail closed;
-3. effective `moderation_cases:override` authority, with `moderation_cases:manage` satisfying that authority through the shared permission semantics;
+3. effective `moderation_cases:override` authority, with `moderation_cases:manage` satisfying that authority through shared permission semantics;
 4. the `moderation` tenant module to be enabled through the shared GraphQL module guard;
-5. a non-nil UUID idempotency key.
+5. a non-nil UUID root idempotency key.
 
-The transport then builds a five-second `PortContext` from trusted tenant/actor/locale/permission facts, preserves the authenticated permission snapshot as port claims, carries the resolved channel when present, and uses the supplied UUID as the owner command idempotency key. It calls only `ModerationRecoveryCommandPort`; it does not bypass the port to call recovery owner methods directly.
+The transport builds a five-second `PortContext` from trusted tenant/actor/locale/permission facts, preserves the authenticated permission snapshot as port claims, carries the resolved channel when present, and maps owner `PortError` kinds to existing public GraphQL error classes without exposing storage details.
 
-The response is a bounded recovery payload containing decision ID, case ID, operation status, case status, resulting case revision and whether reconciliation changed state. Owner `PortError` kinds are mapped to the existing public GraphQL error classes without exposing storage details.
-
-The port remains a second authorization boundary beneath GraphQL. A transport regression therefore cannot make ordinary `forum_topics:moderate` or `forum_replies:moderate` authority sufficient for recovery.
+Same-decision requeue and legacy reconciliation call only `ModerationRecoveryCommandPort`; the transport does not bypass the port to call `operator_*` owner methods directly. Re-review composes only the public `ModerationReadPort` and `ModerationCommandPort` operations described below.
 
 ## Same-decision operator requeue
 
@@ -52,15 +51,11 @@ A successful operator requeue commits in the command receipt transaction:
 6. `application_operator_requeued` and `case_application_requeued` owner audit facts containing operator UUID, reason and previous terminal state/error facts;
 7. completion of the Moderation command receipt.
 
-The next scheduler claim still increments `attempt_count` and still invokes the existing one-attempt dispatcher. Recovery never invokes a subject adapter directly.
-
-The domain idempotency key therefore remains the immutable decision UUID. If a domain owner already retained a terminal receipt for that decision, the retry reaches that same receipt instead of creating a new domain mutation identity.
+The next scheduler claim still increments `attempt_count` and invokes the existing one-attempt dispatcher. Recovery never invokes a subject adapter directly. The domain idempotency key remains the immutable decision UUID.
 
 ## Legacy terminal reconciliation
 
 `ReconcileLegacyModerationApplicationCommand` is only for terminal `applied`, `rejected`, or `operator_review` rows whose case state may predate the atomic application-audit lifecycle.
-
-The command validates exact immutable decision/case/operation identity and terminal storage shape before changing the case.
 
 Target mapping is fixed:
 
@@ -70,58 +65,81 @@ Target mapping is fixed:
 
 For an `applied` row, stored `applied_revision >= reviewed_revision` and stored `applied_at` are required. Rejected/operator-review rows must not contain applied evidence. All terminal rows must have no lease tuple.
 
-If the case is already in the correct terminal state, reconciliation is an idempotent no-op (`changed = false`). A consistent already-closed applied case must have `closed_at` and no active deduplication key.
-
-If the case is still `decided` or `applying_decision`, reconciliation advances it to the mapped terminal state with one revision CAS. Closing happens at the **current reconciliation time** and releases `active_deduplication_key`; this does not pretend the case historically closed at the domain's older `applied_at` timestamp. Escalation preserves the active case identity.
+If the case is already in the correct terminal state, reconciliation is an idempotent no-op (`changed = false`). If the case is still `decided` or `applying_decision`, reconciliation advances it with one revision CAS. Closing happens at the **current reconciliation time** and releases `active_deduplication_key`; it does not pretend the case historically closed at the older domain `applied_at` timestamp.
 
 The command writes only present-time reconciliation audit facts:
 
 - `application_legacy_terminal_reconciled`;
 - `case_legacy_terminal_reconciled`.
 
-It does **not** fabricate historical `case_application_started`, `application_applied`, `application_rejected`, `application_operator_review`, `case_closed`, or `case_escalated` facts.
+Legacy reconciliation never invokes a domain adapter.
 
-Most importantly, legacy reconciliation never invokes a domain adapter. It trusts only already persisted terminal operation truth after validating its immutable decision/case identity and evidence shape.
+## Fresh-revision re-review
 
-## Re-review semantics
+Re-review is not mutation of an old case or decision. `createModerationRereview` creates a **new moderation case and new immutable decision** from an explicit producer/admin-supplied subject revision while preserving the historical source case/decision unchanged.
 
-Re-review is intentionally **not** implemented as mutation of an old case or decision.
+The source decision is resolved through `ModerationReadPort`, then its source case is read and checked. Re-review is admitted only when:
 
-A stale reviewed subject revision is part of the immutable decision identity. Changing that revision would silently retarget a decision that was made against different owner state.
+- the source decision points to that exact case;
+- the source decision reviewed the same stored source-case subject revision;
+- the source case is currently `escalated`;
+- `freshSubjectRevision` is strictly greater than the historical reviewed revision.
 
-Therefore a true re-review must use a **new moderation case and new immutable decision** built from a freshly authorized producer-supplied subject revision. The old escalated case/decision remains historical truth. This slice adds no automatic producer read, no old-decision rewrite and no hidden replacement decision.
+The caller cannot supply a replacement module, kind, subject UUID, scope, queue, priority, policy ID or policy version. The workflow copies those facts from the source case and changes only the subject revision. This prevents an administrative re-review request from silently retargeting historical Moderation identity to another domain subject.
 
-Admin UI and the transport/workflow for creating that fresh review remain separate work.
+The fresh case deliberately attaches no historical report IDs. Existing reports are revision-bound evidence for the old subject state and cannot truthfully be reused as if they were submitted against the new revision.
+
+The caller supplies a new decision kind, reason code, typed/versioned effect and policy snapshot. Effect/kind compatibility is validated before owner commands run, and `decide_case` validates the same contract again before persisting the new immutable decision/effect/pending application operation.
+
+### Replay-safe orchestration
+
+One non-nil root UUID becomes three deterministic owner receipt identities:
+
+- `<root>:rereview:open`;
+- `<root>:rereview:assign`;
+- `<root>:rereview:decide`.
+
+The workflow therefore composes the existing `open_case -> assign_case -> decide_case` replay-safe owner operations without adding an orchestration table. A caller retry after a lost response re-enters the same owner receipts rather than creating another command identity.
+
+Fresh case metadata contains a bounded `operator_rereview` ownership marker with root idempotency key, source case ID, source decision ID, old subject revision, fresh subject revision and operator reason. Because `open_case` uses active-case deduplication, it can truthfully return an already-existing case for the same fresh scope/subject/queue/policy identity. Before assign/decide, the transport verifies that the returned case carries the exact marker for this root workflow. If another active case already owns that fresh revision, orchestration fails closed instead of adopting or mutating it.
+
+The assigned moderator is the authenticated human operator. `assign_case` and `decide_case` retain their normal expected-revision CAS boundaries, so concurrent edits cannot be silently overwritten.
+
+### Producer revision truth
+
+Moderation still does not invent or fetch a producer's current revision. `freshSubjectRevision` is an explicit input fact supplied by the authorized producer/admin flow. A fabricated, future or already-stale revision cannot be silently retargeted during application: the subject-owner adapter fences the current domain revision and returns a conflict when it does not equal the immutable decision's reviewed revision.
+
+A later neutral producer-read contract may improve operator ergonomics, but it is not required to keep this workflow fail-closed.
 
 ## Concurrency and replay
 
-Both recovery commands use the existing `moderation_receipts` command ledger. The request hash binds actor plus command payload, including decision ID, expected case revision and reason. Same-key replay returns the stored recovery response; changed input conflicts.
+Same-decision recovery commands use the existing `moderation_receipts` ledger. Re-review uses that same ledger indirectly through the existing open/assign/decide owner commands with deterministic per-step keys.
 
-Case revision is an explicit optimistic CAS boundary. Requeue also CASes the exact prior application terminal status. Any operation/case/audit/receipt failure rolls back the owner transaction.
+Case revision remains an explicit optimistic CAS boundary. Requeue also CASes the exact prior application terminal status. Re-review cannot adopt a foreign active case because ownership metadata is checked before assignment. Any individual owner command remains transactionally atomic; a retry resumes by replaying completed steps and executing the first unfinished step.
 
-A second recovery request with another idempotency key cannot silently duplicate the state change: after successful requeue the operation is no longer terminal, and after successful reconciliation the case is already in the target terminal state.
+No workflow rewrites the historical source case, historical decision hash, historical reviewed revision or old domain receipt identity.
 
 ## Ownership boundaries
 
-Moderation remains the sole owner of reports, cases, immutable decisions, application operations, operator recovery and cross-domain moderation audit.
+Moderation remains the sole owner of reports, cases, immutable decisions, application operations, operator recovery, re-review workflow facts and cross-domain moderation audit.
 
-The server transport owns only authenticated GraphQL adaptation. It supplies trusted request facts and calls the Moderation recovery port; it does not own or reproduce Moderation persistence, lifecycle or replay logic.
+The server transport owns only authenticated GraphQL adaptation/orchestration. It supplies trusted request facts and composes public Moderation ports; it does not reproduce Moderation persistence, lifecycle or decision-application logic.
 
 Forum is not involved in recovery persistence and is never called for legacy reconciliation. Forum continues to own only its topic/reply state, moderation subject revision and domain-side application receipt/effect transaction.
 
-This slice is unrelated to Reactions. Existing `rustok-reactions` remains the sole reaction catalog/state/command/aggregate/event/repair owner and `rustok-reactions-storefront` remains the reusable presentation owner. No duplicate Forum reactions subsystem is created.
+This slice is unrelated to Reactions. Existing `rustok-reactions` remains the sole reaction catalog/state/command/aggregate/event/repair owner and `rustok-reactions-storefront` remains the reusable presentation owner.
 
 ## Explicitly not claimed
 
 This slice does not add:
 
-- automatic re-review or decision rewriting;
+- mutation or retargeting of an old moderation decision;
 - requeue of an already-applied decision;
-- producer current-revision lookup from Moderation;
-- domain adapter invocation from recovery;
-- admin UI or fresh-review creation transport/workflow;
-- public typed recovery event contracts;
-- a migration or new persistence table;
+- automatic producer current-revision lookup from Moderation;
+- domain adapter invocation from recovery/reconciliation/re-review creation;
+- admin UI;
+- public typed recovery/re-review event contracts;
+- a migration, orchestration table or new persistence owner;
 - retained runtime, PostgreSQL, SQLite or concurrency evidence.
 
 ## Maintainer verification handoff
@@ -141,6 +159,6 @@ cargo xtask module validate moderation
 git diff --check
 ```
 
-Retained evidence should cover GraphQL tenant mismatch/module-disabled/service-principal/permission denial; `moderation_cases:manage` effective authorization; ordinary Forum moderation permission denial; non-nil UUID idempotency propagation; human-actor enforcement at the owner boundary; receipt replay/changed-request conflict; expected case revision contention; rejected/operator-review requeue; applied requeue rejection; requeue from current escalated and legacy decided case state; next scheduler claim after requeue; preservation of immutable decision UUID domain idempotency; terminal identity/evidence corruption fail-closed behavior; applied legacy reconciliation to closed at reconciliation time with active-key release; rejected/operator-review legacy reconciliation to escalated; already-consistent reconciliation no-op; no domain adapter invocation during reconciliation; rollback on audit/receipt failure; and PostgreSQL/SQLite parity.
+Retained evidence should cover GraphQL tenant mismatch/module-disabled/service-principal/permission denial; effective `moderation_cases:manage` authorization; ordinary Forum moderation permission denial; root and per-step idempotency replay; source-decision/case identity mismatch; non-escalated source denial; equal/older fresh revision denial; preservation of source subject/scope/queue/policy identity; no historical report reuse; active-case dedup collision with foreign ownership marker; assign/decide revision contention; fresh typed decision enqueue; stale/fabricated producer revision conflict at domain application; rejected/operator-review requeue; applied requeue rejection; legacy terminal reconciliation/no-op; and PostgreSQL/SQLite parity.
 
 No tests, Cargo commands, Node verifiers, formatting, migrations, database scenarios, workflows, CI or `git diff --check` were executed while preparing this source slice.

--- a/crates/rustok-moderation/src/commands/case_open.rs
+++ b/crates/rustok-moderation/src/commands/case_open.rs
@@ -181,23 +181,28 @@ async fn open_case_in_transaction(
         .exec(&receipt.transaction)
         .await?;
 
-    append_event(
-        &receipt.transaction,
-        tenant_id,
-        "case",
-        stored.id,
-        if created {
-            "case_opened"
-        } else {
-            "reports_attached"
-        },
-        serde_json::json!({
-            "created": created,
-            "report_ids": command.report_ids,
-            "deduplication_key": deduplication_key,
-            "subject_revision": stored.subject_revision,
-        }),
-    )
-    .await?;
+    // A deduplicated open with no reports is a pure admission/read outcome. Do not forge a
+    // `reports_attached` audit fact when there was nothing to attach. This also lets higher-level
+    // workflows inspect active-case ownership without mutating an unrelated case's audit stream.
+    if created || !command.report_ids.is_empty() {
+        append_event(
+            &receipt.transaction,
+            tenant_id,
+            "case",
+            stored.id,
+            if created {
+                "case_opened"
+            } else {
+                "reports_attached"
+            },
+            serde_json::json!({
+                "created": created,
+                "report_ids": command.report_ids,
+                "deduplication_key": deduplication_key,
+                "subject_revision": stored.subject_revision,
+            }),
+        )
+        .await?;
+    }
     map_case(stored)
 }

--- a/scripts/verify/verify-moderation-recovery-graphql-transport.mjs
+++ b/scripts/verify/verify-moderation-recovery-graphql-transport.mjs
@@ -8,6 +8,10 @@ const graphqlMod = fs.readFileSync("apps/server/src/graphql/mod.rs", "utf8");
 const schema = fs.readFileSync("apps/server/src/graphql/schema.rs", "utf8");
 const serverCargo = fs.readFileSync("apps/server/Cargo.toml", "utf8");
 const ports = fs.readFileSync("crates/rustok-moderation/src/ports.rs", "utf8");
+const caseOpen = fs.readFileSync(
+  "crates/rustok-moderation/src/commands/case_open.rs",
+  "utf8",
+);
 
 function requireText(source, needle, message) {
   if (!source.includes(needle)) throw new Error(message);
@@ -68,10 +72,13 @@ for (const rereviewMarker of [
   "report_ids: Vec::new()",
   '"operator_rereview"',
   '"root_idempotency_key"',
+  '"request_hash"',
   '"source_case_id"',
   '"source_decision_id"',
   '"source_subject_revision"',
   '"fresh_subject_revision"',
+  "rereview_request_hash",
+  "Sha256::digest",
   "require_owned_rereview_case",
   "ModerationCommandPort::open_case",
   "ModerationCommandPort::assign_case",
@@ -101,6 +108,17 @@ for (const forbiddenRereview of [
     `Rereview must not mutate historical identity: ${forbiddenRereview}`,
   );
 }
+
+requireText(
+  caseOpen,
+  "if created || !command.report_ids.is_empty()",
+  "Deduplicated open with no reports must not emit a reports-attached audit fact",
+);
+requireText(
+  caseOpen,
+  '"reports_attached"',
+  "Real report attachment must retain the canonical audit event",
+);
 
 requireText(
   transport,

--- a/scripts/verify/verify-moderation-recovery-graphql-transport.mjs
+++ b/scripts/verify/verify-moderation-recovery-graphql-transport.mjs
@@ -21,6 +21,7 @@ for (const marker of [
   "pub struct ModerationRecoveryMutation",
   "requeue_moderation_application",
   "reconcile_legacy_moderation_application",
+  "create_moderation_rereview",
   'const MODULE_SLUG: &str = "moderation"',
   "require_module_enabled(ctx, MODULE_SLUG).await?",
   "auth.tenant_id != tenant.id",
@@ -34,6 +35,7 @@ for (const marker of [
   "ModerationRecoveryCommandPort::requeue_application",
   "ModerationRecoveryCommandPort::reconcile_legacy_application",
   "ModerationApplicationRecoveryPayload",
+  "ModerationRereviewPayload",
 ]) {
   requireText(transport, marker, `Moderation recovery GraphQL transport is missing ${marker}`);
 }
@@ -46,7 +48,57 @@ for (const forbidden of [
   forbidText(
     transport,
     forbidden,
-    `GraphQL recovery transport must enter only through the recovery port: ${forbidden}`,
+    `GraphQL recovery transport must enter only through public owner ports: ${forbidden}`,
+  );
+}
+
+for (const rereviewMarker of [
+  "fresh_subject_revision",
+  "source_decision_id",
+  "ModerationReadPort::read_decision",
+  "ModerationReadPort::read_case",
+  "ModerationCaseStatus::Escalated",
+  "fresh_subject_revision <= source_case.subject.revision",
+  "let mut fresh_subject = source_case.subject.clone()",
+  "fresh_subject.revision = fresh_subject_revision",
+  "scope: source_case.scope.clone()",
+  "queue_key: source_case.queue_key.clone()",
+  "policy_id: source_case.policy_id",
+  "policy_version: source_case.policy_version",
+  "report_ids: Vec::new()",
+  '"operator_rereview"',
+  '"root_idempotency_key"',
+  '"source_case_id"',
+  '"source_decision_id"',
+  '"source_subject_revision"',
+  '"fresh_subject_revision"',
+  "require_owned_rereview_case",
+  "ModerationCommandPort::open_case",
+  "ModerationCommandPort::assign_case",
+  "ModerationCommandPort::decide_case",
+  "rereview_step_context",
+  '"open"',
+  '"assign"',
+  '"decide"',
+  '":rereview:{step}"',
+]) {
+  requireText(
+    transport,
+    rereviewMarker,
+    `Moderation rereview workflow is missing ${rereviewMarker}`,
+  );
+}
+
+for (const forbiddenRereview of [
+  "source_case.subject.id =",
+  "source_case.subject.module =",
+  "source_case.subject.kind =",
+  "source_decision.subject_revision =",
+]) {
+  forbidText(
+    transport,
+    forbiddenRereview,
+    `Rereview must not mutate historical identity: ${forbiddenRereview}`,
   );
 }
 
@@ -91,4 +143,4 @@ requireText(
   "Moderation recovery port must retain its dedicated permission boundary",
 );
 
-console.log("Moderation recovery GraphQL transport source guard passed");
+console.log("Moderation recovery and rereview GraphQL transport source guard passed");


### PR DESCRIPTION
## Summary
- add `createModerationRereview` to the authorized Moderation recovery GraphQL surface
- create a new case + new immutable decision from an explicit fresh subject revision instead of mutating/retargeting historical decisions
- resolve source decision/case through Moderation read ports and require an exact escalated historical case with a strictly newer revision
- copy immutable subject identity, scope, queue, priority and policy routing from the source case; historical report IDs are deliberately not reused
- compose existing replay-safe `open_case -> assign_case -> decide_case` owner ports with deterministic per-step idempotency keys
- bind the root workflow UUID to the full rereview decision/effect/policy payload via SHA-256 so partial retries cannot change the intended decision
- mark the fresh case with rereview ownership metadata and fail closed if active-case dedup returns an unrelated case
- avoid emitting a false `reports_attached` audit event when `open_case` deduplicates with an empty report set
- extend the recovery transport source guard and focused operator-recovery handoff docs

## Plan context
This continues the Forum/Moderation recovery milestone after #3206. Same-decision recovery, legacy reconciliation, authorized GraphQL recovery transport, and explicit fresh-revision/new-case/new-decision rereview orchestration are now source-ready. The historical source case/decision remain immutable truth.

The producer/current revision is still an explicit authorized input fact rather than something Moderation invents or fetches. A stale/fabricated revision remains fail-closed because the domain subject adapter fences the actual current revision during application.

Admin UI remains separate work. I did not place Moderation recovery UI inside `rustok-forum-admin`; the correct separate `rustok-moderation-admin` package requires synchronized workspace/Cargo.lock work and should preserve the Moderation-owned admin boundary.

## Verification
Static source review only. Tests, Cargo commands, Node verifiers, formatters, migrations, database scenarios, workflows and CI were intentionally not run per request.