### PR TITLE
feat(index): compile localized identity fold

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@0a8d09a84688e4c0f3d6007d9b90d7f41b2a53a3` (#3204) and continued on
-`agent/index-localized-query-contract-20260808`.
+Status overlay rechecked from `main@678606a78916ed631669e40c617c60a031097138` (#3208) and continued on
+`agent/index-localized-query-postgres-fold-20260808`.
 
 `implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
 history for the linked-target/replay sequence, but this file is the current execution cursor.
@@ -21,11 +21,13 @@ The current Product/Index sequence now includes:
 - #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
   projection is requested-locale -> fallback-locale;
 - #3204 selected the one generic localized-entity fold architecture and kept Storefront cutover
-  fail-closed pending implementation/evidence.
+  fail-closed pending implementation/evidence;
+- #3208 added the explicit generic localized query shape, fail-closed validation, dedicated cursor wire
+  identity, and kept ordinary exact-locale `IndexQuery` unchanged.
 
-No newer `main` commit exists at the start of this source slice. The current branch implements the first
-runtime-independent fold contract without changing Product traffic, Product schema, ordinary Index query
-semantics, or event contracts.
+This source slice continues directly from #3208. It makes the root-only PostgreSQL localized fold compiler
+and decoder source-complete without publishing a production execution method, changing Product traffic,
+changing Product schema, or bypassing retained evidence gates.
 
 ## Old execution branch
 
@@ -74,9 +76,9 @@ mismatch:
 4. ordinary `IndexQuery` scopes one exact locale and therefore cannot by itself preserve owner search,
    fallback, global pagination, de-duplication, and exact count.
 
-A scalar substring/LIKE operator on the current exact-locale query is therefore insufficient.
+A scalar substring/LIKE operator on the current exact-locale query remains insufficient.
 
-## Localized Product query architecture and contract
+## Localized Product query architecture, contract, compiler and decoder
 
 Architecture decision: complete in
 `m7-product-storefront-localized-query-architecture.md`.
@@ -85,30 +87,45 @@ Selected architecture remains:
 
 - preserve owner Storefront semantics;
 - keep exactly one current Product schema/routing key;
-- add a generic Index query-layer localized-entity fold whose logical page identity is
+- use a generic Index query-layer localized-entity fold whose logical page identity is
   `(tenant_id, schema_ref, entity_id)` while physical storage remains locale-keyed;
 - evaluate any-locale title search as an identity predicate across current/admitted locale rows;
 - choose result localization independently: requested locale -> fallback locale -> no localized row;
-- apply exact count, sort, lookahead, and cursor semantics to grouped Product identities before page
-  truncation;
+- apply exact count, sort, lookahead, and cursor semantics to Product identities before page truncation;
 - forbid client-side merging of independently paginated locale queries;
-- keep existing schema readiness, Product freshness, and linked-target availability admission.
+- keep existing schema readiness and Product owner freshness admission mandatory.
 
-This source slice makes the **query contract and cursor identity source-complete**:
+The query/cursor contract from #3208 remains source-complete and this slice closes the compiler/decoder
+source gap:
 
-- `LocalizedEntityQuery` is explicit and does not reinterpret ordinary `IndexQuery`;
-- requested locale remains `query.scope.locale`;
-- equal fallback locale collapses through `canonical_fallback_locale()`;
-- `any_locale_filter` is a separate root-only existential predicate;
-- ordinary + any-locale filters share one bounded complexity budget;
-- `SchemaRegistry::validate_localized_entity_query` requires `LocaleMode::Required` and reuses canonical
-  field/operator/value validation;
-- `LocalizedCursorCodec` uses dedicated scoped wire version `3` and binds fold mode, requested/fallback,
-  ordinary filter, any-locale filter, order shape and schema fingerprint;
-- ordinary exact-locale cursor wire version `2` remains unchanged and cannot be accepted by the fold.
+- `LocalizedEntityQuery` stays explicit and ordinary `IndexQuery` remains exact-locale;
+- `localized_projection_fields` explicitly identifies selected root scalar fields that must be projected
+  requested -> fallback -> null instead of leaking a third-locale identity anchor;
+- localized projection fields cannot drive the ordinary identity filter or identity ordering;
+- the first compiler deliberately accepts root-only query paths; linked folded paths remain a later
+  capability/evidence step;
+- `SchemaRegistry::compile_postgres_localized_page_query` emits one page statement and matching exact
+  count using canonical physical aliases `t0` anchor, `t1` requested, `t2` fallback, `t3` any-locale
+  predicate and `t4` lower-locale anti-duplicate candidate;
+- all physical row roles retain the ordinary `is_deleted = FALSE` compiler anchor so generic
+  `PostgresQueryEntityAdmission` can inject owner freshness into every participating row;
+- one admitted identity anchor survives before ordering/lookahead/limit/count by excluding a lower-locale
+  admitted `t4` row;
+- requested/fallback projection uses row-presence `CASE`, so a present requested row with a nullable field
+  never incorrectly falls through to fallback;
+- exact count uses the same identity/admission boundary but does not depend on requested/fallback
+  projection-row availability;
+- `LocalizedQueryPlanFingerprint` separately binds canonical fallback, any-locale predicate and localized
+  projection roles on top of the ordinary query plan fingerprint;
+- `SchemaRegistry::decode_postgres_localized_query_page` checks both plan fingerprints, exact column/count
+  shape and lookahead bounds;
+- SQL null is accepted for a physically non-null field only when that field is explicitly listed as a
+  localized projection field, meaning no requested/fallback row was admitted;
+- lookahead emits only the dedicated `LocalizedCursorCodec` wire-version-3 continuation.
 
-No localized query execution port exists yet. PostgreSQL fold compilation, decode/execution and retained
-evidence remain pending. Storefront traffic remains owner-native.
+No `execute_localized_query` runtime method exists yet. The compiler/decoder output is therefore not an
+authoritative production query path until the PostgreSQL port wires readiness, admission and one
+repeatable-read execution snapshot around it.
 
 ## Retained M7 PostgreSQL packets
 
@@ -171,7 +188,8 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 - [x] Product materialized root freshness fence.
 - [x] Entity-level stale linked-target freshness fence for ProductVariant and SalesChannel.
 - [x] ProductVariant/SalesChannel recreate-safe monotonic `index_revision` via retained tombstones.
-- [x] Query-path-scoped fail-closed linked-target availability semantics.
+- [x] Query-path-scoped fail-closed linked-target availability semantics for ordinary Product graph
+      queries.
 - [x] One current 15-field Product Storefront-capable source contract.
 - [x] Schema-safe single-current replacement/promotion mechanism.
 - [x] Canonical typed EAV term representation and Product EAV owner clock.
@@ -180,11 +198,15 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
       routing key.
 - [x] Add explicit generic localized query shape/validation while keeping ordinary exact-locale
       `IndexQuery` unchanged.
-- [x] Add dedicated localized cursor identity/version bound to requested/fallback/filter/order semantics.
-- [ ] Compile the localized-entity fold to one PostgreSQL page/exact-count contract and expose execution
-      only after decode/admission semantics are complete.
+- [x] Add dedicated localized cursor identity/version bound to requested/fallback/filter/projection/order
+      semantics.
+- [x] Compile the root-only localized-entity fold to one PostgreSQL page/exact-count contract.
+- [x] Add the localized page decoder with explicit requested/fallback-null semantics and dedicated cursor.
+- [ ] Wire localized execution through the PostgreSQL query port using persisted readiness, generic
+      entity admission and one read-only repeatable-read snapshot.
 - [ ] Add generic scalar text-pattern matching inside the folded any-locale identity predicate.
 - [ ] Implement the Product Storefront Index adapter and Taxonomy tag hydration boundary.
+- [ ] Extend folded execution to linked paths only with dedicated target-availability evidence.
 - [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` and the 15-field source.
 - [ ] Retain source-ready folded-query owner-vs-Index PostgreSQL equivalence packets.
 - [ ] Execute/admit current replacement Product PostgreSQL packets.
@@ -196,13 +218,15 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 
 Primary maintainer gate remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-Next source-code step: **compile `LocalizedEntityQuery` into one PostgreSQL identity-fold page/count
-contract**. Reuse current schema readiness and owner/link admission on every participating physical locale
-row, group before limit/count, and use `LocalizedCursorCodec` for continuation. Do not add
-`execute_localized_query` to the public runtime until compiler + decoder semantics are source-complete.
+Next source-code step: **wire explicit localized execution into the PostgreSQL Index query port**. Reuse
+the current persisted-schema readiness verifier, `PostgresQueryEntityAdmission`, page/exact-count statement
+mapping and one read-only repeatable-read transaction. Admission/preparation failures must fail closed
+before page/count storage execution, and results must be decoded only through
+`decode_postgres_localized_query_page`.
 
-After the folded execution path exists, add the generic scalar text-pattern primitive inside
-`any_locale_filter`, then implement the Product Storefront adapter/equivalence packet.
+Do not publish Product Storefront traffic in that runtime slice. After the runtime boundary exists, add the
+generic scalar text-pattern primitive inside `any_locale_filter`, then implement the Product Storefront
+adapter and retained equivalence packet.
 
 In parallel, the retained Product PostgreSQL packets need a mechanical source actualization to routing key
 `4`/15-field Product contract before they can be treated as current evidence. No historical-key runtime
@@ -216,6 +240,7 @@ The implementation agent has not run these commands. Maintainer verification sho
 
 ```bash
 node scripts/verify/verify-index-localized-query-contract.mjs
+node scripts/verify/verify-index-localized-query-postgres-fold.mjs
 node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-query-contract.mjs

--- a/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
+++ b/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
@@ -1,180 +1,150 @@
 # M7 Product Storefront localized query architecture
 
-Status: `query_contract_source_complete_compiler_and_evidence_pending`.
+Status: `compiler_decoder_source_complete_runtime_and_evidence_pending`.
 
 ## Decision
 
-Keep the current owner Storefront behavior and keep exactly one current Product Index schema. Close the
+Keep the current owner Storefront behavior and exactly one current Product Index schema. Close the
 remaining locale/search mismatch in the **Index query layer** with a generic localized-entity identity
 fold over the existing physical locale rows.
 
-This decision deliberately rejects both shortcuts that would make parity ambiguous:
-
-- do not narrow Product owner search/fallback semantics merely to fit the current single-locale
-  `IndexQueryScope`;
-- do not add another Product routing key, compatibility source, or Storefront-only Product schema.
-
-The current Product routing key remains an internal storage/replay identity. Localized Storefront query
-semantics are a query-shape concern, not a new Product schema version.
+Do not narrow Product owner search/fallback semantics merely to fit `IndexQueryScope`, and do not add a
+Storefront-only Product routing key or compatibility source. Locale folding is a query-shape concern, not
+a new immutable Product schema version.
 
 ## Owner contract preserved
 
 `CatalogService::list_published_products_with_query` remains authoritative until cutover evidence passes.
-The replacement query path must preserve these existing semantics exactly:
+The replacement path must preserve:
 
 - one result identity per Product;
-- title search may match **any** Product translation;
-- result localization prefers the requested locale, then the fallback locale;
-- if neither requested nor fallback translation is present, owner projection uses its existing
-  placeholder behavior rather than selecting an unrelated translation as user-visible content;
-- Product status/publication/category/channel/EAV predicates apply to Product identity;
-- ordering is by `published_at`/`created_at` plus stable Product ID tie-break;
-- pagination and exact count operate on distinct Product identities, never translation rows.
+- title search matching any Product translation;
+- requested locale -> fallback locale result projection;
+- owner placeholder behavior when neither requested nor fallback translation exists;
+- Product status/publication/category/channel/EAV identity predicates;
+- timestamp ordering with stable Product identity tie-break;
+- pagination/exact count over Product identities, not physical translation rows.
 
-Product creation currently requires at least one translation. Retained parity evidence must still cover
-translation removal/lifecycle boundaries instead of assuming that creation-time invariant is sufficient
-forever.
+## Generic identity model
 
-## Generic Index model
+The fold operates only for `LocaleMode::Required`. Ordinary `IndexQuery` stays exact-locale and unchanged.
+The folded logical identity is `(tenant_id, schema_ref, entity_id)` while physical storage, mutation,
+replay, absence and freshness remain locale-keyed.
 
-The localized fold operates only for a schema whose locale mode is `Required` and only when a caller
-explicitly requests the fold. Ordinary `IndexQuery` remains exact-locale and unchanged.
+`LocalizedEntityQuery` keeps `query.scope.locale` as requested locale, stores canonical fallback separately,
+and exposes a separate root-only `any_locale_filter` for identity-level existential matching.
 
-For one folded query, the logical root identity is:
+Generic Index schemas intentionally do not label fields as owner-localized. The fold therefore has an
+explicit `localized_projection_fields` role set. A listed field is projected only from:
 
-`(tenant_id, schema_ref, entity_id)`
+1. an admitted requested-locale row;
+2. otherwise an admitted fallback-locale row;
+3. otherwise SQL null.
 
-Locale is intentionally excluded from that **query result identity** while remaining part of physical
-Index storage, mutation, replay, absence, freshness, and ordinary query identity.
+Unlisted fields are read from a deterministic admitted identity anchor. This explicit classification is
+required so a third-locale anchor can never leak `title`, `handle` or other localized content when the
+requested/fallback rows are absent. It does not change the Product schema fingerprint.
 
-The fold receives two canonical locale roles:
+The initial compiler is intentionally root-only. Linked query paths fail validation until linked fold
+semantics and their own evidence are added. This still covers the current Product Storefront list contract,
+which can express its identity predicates through root fields such as `sales_channel_ids` and
+`attribute_terms`.
 
-1. requested locale;
-2. fallback locale, de-duplicated when equal to requested.
+## Query validation and cursor identity
 
-It then reasons over all current/admitted physical locale rows for each root identity in one SQL query.
-A consumer must not emulate this contract by issuing independent locale queries and merging pages in
-memory.
+`SchemaRegistry::validate_localized_entity_query`:
 
-## Implemented query contract slice
+- requires `LocaleMode::Required`;
+- reuses ordinary field/operator/value validation;
+- shares one bounded node budget between ordinary and any-locale filters;
+- rejects linked paths in this compiler slice;
+- requires every `localized_projection_fields` entry to be a selected root scalar field;
+- rejects localized projection fields from the ordinary identity filter and identity ordering.
 
-The first implementation slice is source-complete in `rustok-index` and deliberately stops before SQL
-execution:
+`LocalizedCursorCodec` uses scoped wire version `3`; ordinary exact-locale cursors remain on version `2`.
+Its fingerprint binds fold mode, tenant/schema, requested/fallback roles, ordinary filter,
+`any_locale_filter`, canonical localized projection roles and ordering. A token cannot cross fold modes or
+be reused after changing projection/search/fallback semantics.
 
-- `LocalizedEntityQuery` wraps an ordinary validated `IndexQuery` without changing its exact-locale
-  meaning;
-- `query.scope.locale` is the requested locale;
-- `fallback_locale` is a second projection role and `canonical_fallback_locale()` collapses a fallback
-  equal to requested;
-- `any_locale_filter` is a separate identity-level existential predicate and does not silently rewrite
-  the ordinary query filter;
-- ordinary filter nodes plus any-locale filter nodes share one bounded complexity budget;
-- `SchemaRegistry::validate_localized_entity_query` permits the mode only for `LocaleMode::Required`;
-- the any-locale predicate is root-only in this contract slice, so linked traversal cannot accidentally
-  acquire unspecified cross-locale semantics;
-- field/filter/operator/type validation is reused from the ordinary canonical query validator rather
-  than duplicated with a second rule set.
+## PostgreSQL fold compiler — source complete
 
-No query port method named `execute_localized_query` exists yet. That is intentional: publishing runtime
-execution before the folded PostgreSQL compiler and decoder exist would make a partial semantic path look
-authoritative.
+`SchemaRegistry::compile_postgres_localized_page_query` compiles one page statement and optional exact
+count without modifying the ordinary PostgreSQL compiler.
 
-## Dedicated cursor identity
+The page compiler uses canonical physical aliases:
 
-`LocalizedCursorCodec` and `LocalizedIndexCursor` provide a separate continuation identity for the fold.
-The localized scoped cursor uses wire version `3`; the ordinary exact-locale cursor wire version `2`
-remains unchanged.
+- `t0` — deterministic admitted identity anchor;
+- `t1` — requested-locale projection row;
+- `t2` — fallback-locale projection row when distinct from requested;
+- `t3` — any-locale existential predicate row;
+- `t4` — lower-locale anti-duplicate anchor candidate.
 
-The localized query fingerprint binds:
+Every physical role is an `index_entities AS "tN"` relation with the ordinary
+`"tN".is_deleted = FALSE` anchor. This is deliberate: the existing generic
+`PostgresQueryEntityAdmission` can inject current owner freshness rules into every participating row role
+without a Product-specific compiler branch.
 
-- explicit fold mode `localized_entity_fold_v1`;
-- tenant and exact schema;
-- requested locale;
-- canonical fallback locale;
-- ordinary filter;
-- `any_locale_filter`;
-- ordering shape.
+One Product identity survives page/count selection by choosing the lexicographically lowest **admitted**
+physical locale row as `t0`: an identity is rejected as a duplicate when an admitted same-identity `t4`
+with a lower locale key exists. Grouping/de-duplication therefore happens before ordering, lookahead,
+limit and exact count.
 
-The cursor payload also retains the registered schema fingerprint, identity-level order values, and root
-entity UUID. Therefore an exact-locale cursor cannot be accepted by the folded path, a folded cursor
-cannot be accepted by the ordinary path, and changing fallback/search/order semantics invalidates the
-folded continuation.
+Ordinary identity filters and ordering are evaluated on `t0`. `any_locale_filter` is compiled into an
+`EXISTS` over `t3`. Localized projected fields use row-presence `CASE`, not value-level `COALESCE`, so a
+present requested row with a nullable field does not incorrectly fall through to fallback content.
+
+Exact count uses the same `t0`/`t3`/`t4` identity boundary but intentionally omits `t1`/`t2`: requested or
+fallback projection availability does not change owner Product identity count.
+
+The compiler emits a dedicated `LocalizedQueryPlanFingerprint` in addition to the ordinary plan
+fingerprint. It binds the canonical fallback, any-locale predicate and localized projection roles.
+
+## Decoder — source complete
+
+`SchemaRegistry::decode_postgres_localized_query_page` verifies both ordinary and localized plan
+fingerprints, exact column contracts, lookahead bounds and exact-count shape.
+
+For unlisted fields it preserves the ordinary schema nullability/type/cardinality contract. For an explicit
+localized projection field only, SQL null is additionally valid and means that neither requested nor
+fallback physical row was admitted. That null is an Index-level absence signal; the later Product
+Storefront adapter must apply the existing owner placeholder behavior instead of selecting an arbitrary
+third translation.
+
+Lookahead produces `LocalizedIndexCursor` through `LocalizedCursorCodec`; no ordinary exact-locale cursor
+is emitted or accepted by this path.
+
+## Admission and runtime boundary
+
+The compiler/decoder are not yet published through `IndexQueryPort` or `SharedIndexQueryRuntime`.
+`execute_localized_query` intentionally does not exist yet.
+
+The next runtime slice must execute page + exact count in the same read-only repeatable-read snapshot as
+ordinary Index queries, verify persisted schema readiness, and apply the existing entity admission to the
+compiled `t0`/`t1`/`t2`/`t3`/`t4` relations **before execution**. Until that wiring exists, compiled fold
+SQL is not an authoritative production query path.
+
+Because the current fold rejects linked paths, generic link-target availability injection is not needed
+for this source slice. Linked folded queries remain a later capability/evidence step.
 
 ## Search semantics
 
-Any-locale title search is an identity predicate:
-
-- a Product identity is admitted when at least one current/admitted physical locale row satisfies the
-  requested text predicate;
-- the row that satisfied search does **not** become the result locale merely because it matched;
-- stale/deleted/unready locale rows cannot admit an identity;
-- search matching and result localization are therefore independent, matching the owner Storefront
-  contract.
-
-The future generic text-pattern primitive must be applied inside this identity predicate. Adding scalar
-substring/LIKE support to an exact-locale query alone remains insufficient and is not admitted by this
-decision.
-
-## Effective localized projection
-
-For an admitted Product identity, effective localized projection is selected independently from search:
-
-1. current/admitted requested-locale row;
-2. otherwise current/admitted fallback-locale row;
-3. otherwise no effective localized row.
-
-When there is no effective localized row, the Storefront adapter must preserve the owner placeholder
-contract for localized fields. It must not expose title/handle/description from an arbitrary third
-locale.
-
-Locale-invariant Product fields may be read from a deterministic current/admitted identity anchor only
-under the current single Product source invariant that those values are repeated identically across
-locale rows for one Product source version. Retained PostgreSQL evidence must prove this together with
-partial locale delivery and replay/restart cases before Storefront cutover.
-
-## Pagination, sorting, and exact count
-
-Grouping happens **before** pagination and exact count.
-
-- exact count is the number of distinct admitted Product identities;
-- page limit/lookahead is applied to grouped Product identities, not physical translation rows;
-- the Storefront ordering tuple remains the owner tuple (`published_at`/`created_at`, companion
-  timestamp, Product ID) and must be evaluated from the identity-level current Product state;
-- continuation state binds requested locale, fallback locale, localized-fold mode, schema fingerprint,
-  filter/order shape, and the same identity-level ordering tuple;
-- a cursor from an ordinary exact-locale query must not be accepted by the folded query path, and vice
-  versa.
-
-An implementation that separately pages requested/fallback/other locales and merges afterward cannot
-provide this contract and is forbidden.
-
-## Freshness and graph availability
-
-Existing schema readiness, Product entity freshness, and queried link-target availability remain
-mandatory. The localized fold does not weaken them.
-
-Every physical row used to admit search, supply requested/fallback projection, or act as the deterministic
-identity anchor must already satisfy the same current query admission rules that protect ordinary Product
-queries. A stale translation row cannot keep a Product visible or satisfy search after the owner Product
-clock has advanced.
-
-ProductVariant/SalesChannel linked paths remain one-hop and use the existing query-path-scoped target
-availability policy after Product identity admission. No new Product graph clock or relation ledger is
-introduced.
+Any-locale title search remains an identity predicate. A matching physical locale row may admit an
+identity, but that row never becomes result localization merely because it matched. The future scalar
+text-pattern primitive must be compiled inside `any_locale_filter`; adding LIKE/substring to ordinary
+exact-locale filtering alone remains insufficient.
 
 ## Storefront adapter boundary
 
-The future Storefront adapter may translate owner inputs to the generic localized fold only after the
-Index-side execution contract exists. It must then:
+After runtime execution and text-pattern support exist, the Product adapter must:
 
 - map Active + published-only/category/channel visibility predicates;
 - resolve public Product attribute/option codes to canonical `attribute_terms`;
-- use the folded any-locale title search primitive;
-- preserve requested/fallback localized Product projection;
+- classify `title`/`handle` and other returned localized fields in `localized_projection_fields`;
+- use folded any-locale title search;
 - batch-hydrate localized Taxonomy tag names after the Product page is fixed;
-- preserve owner page/per-page, exact count, ordering, and stable ID tie-break semantics.
+- preserve owner page/per-page, exact count, ordering and ID tie-break semantics.
 
-Taxonomy localization remains Taxonomy-owned. Product Index continues to store stable tag UUIDs only.
+Taxonomy localization stays Taxonomy-owned; Product Index stores stable tag UUIDs only.
 
 ## Required retained evidence
 
@@ -185,47 +155,42 @@ Before Storefront traffic can move, PostgreSQL equivalence must cover at least:
 3. requested/fallback absent while another translation exists;
 4. search match only in requested locale;
 5. search match only in fallback locale;
-6. search match only in a third locale while projection still uses requested/fallback rules;
-7. duplicate matches in multiple locales yielding one Product identity and exact count of one;
-8. two Products whose locale rows interleave physically but whose global timestamp+ID order is stable;
-9. page boundary and exact-count parity across locale combinations;
-10. delayed/stale locale materialization excluded by owner freshness;
-11. restart/recomposition and replay redelivery preserving the same grouped identity page;
-12. ProductVariant/SalesChannel target lag on a folded Product query;
-13. current Product routing-key rebuild/promotion rather than any lower historical key.
+6. search match only in a third locale while projection still follows requested/fallback roles;
+7. duplicate matches in multiple locales yielding one Product identity/exact count;
+8. interleaved physical locale rows with stable global identity ordering/page boundaries;
+9. cursor continuation and exact-count parity;
+10. delayed/stale locale rows excluded by owner freshness;
+11. restart/recomposition/replay redelivery preserving the same grouped page;
+12. current Product routing-key rebuild/promotion rather than a historical lower key.
 
-Until these packets are source-ready, executed, and admitted, Storefront remains owner-native.
+Linked-target lag evidence remains required before adding linked paths to folded execution.
 
 ## Deliberate limits
 
-This slice does not yet:
+This slice does not:
 
-- change ordinary `IndexQueryScope` or exact-locale query behavior;
-- compile the localized fold to PostgreSQL;
-- expose localized execution through `IndexQueryPort`/`SharedIndexQueryRuntime`;
-- add scalar text-pattern SQL compilation;
+- change ordinary `IndexQuery` or its compiler/cursor;
+- publish localized runtime execution;
+- add scalar text-pattern matching;
 - implement the Storefront Index adapter;
-- actualize the retained Product PostgreSQL packets to the current Product routing key;
-- execute or admit PostgreSQL evidence;
-- run the event-contract digest admission workflow;
-- add Product typed wire events;
-- stage/rebuild/promote a tenant Product schema;
+- actualize/execute retained Product PostgreSQL packets;
+- add Product typed events or bypass event-digest admission;
+- rebuild/promote a tenant Product schema;
 - switch Storefront traffic.
 
 ## Next implementation slice
 
-Compile `LocalizedEntityQuery` into one PostgreSQL identity-fold statement and matching exact-count
-statement. Reuse the existing admission descriptors on every physical locale row participating in
-identity admission/projection/anchor selection, group before limit/count, and decode page cursors through
-`LocalizedCursorCodec`. Only after that execution path exists should scalar text-pattern matching be wired
-into `any_locale_filter` and consumed by a Product Storefront adapter.
+Wire `CompiledPostgresLocalizedPageQuery` into the PostgreSQL query port behind a separate explicit
+localized execution method. Reuse persisted readiness, read-only repeatable-read execution and
+`PostgresQueryEntityAdmission`, fail closed before storage execution on admission/preparation errors, and
+decode with `decode_postgres_localized_query_page`. Only after that runtime boundary is complete should
+generic scalar text-pattern matching be added to `any_locale_filter`.
 
-## Source guard
+## Source guards
 
-`scripts/verify/verify-index-localized-query-contract.mjs` locks the explicit query type, required-locale
-validation, root-only any-locale predicate, canonical fallback de-duplication, dedicated cursor version
-and separation from ordinary cursor identity. It also fails if this source-only contract slice starts
-claiming `execute_localized_query` before the compiler exists.
+- `scripts/verify/verify-index-localized-query-contract.mjs` locks query/projection/cursor roles.
+- `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks the root-only page/count compiler,
+  physical alias/admission anchors and decoder while forbidding premature runtime publication.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,14 +1,14 @@
 # M7 Product Storefront Index parity gate
 
-Status: `localized_query_contract_source_complete_compiler_and_evidence_pending`.
+Status: `localized_compiler_decoder_source_complete_runtime_and_evidence_pending`.
 
 ## Purpose
 
-The Product Storefront catalog remains owner-native. The single current Product Index source now
-materializes the Storefront scalar fields, stable tag identities, and typed EAV query state that were
-previously missing. The remaining localized Product identity mismatch now has both a selected architecture
-and an explicit query/cursor contract, but PostgreSQL fold execution and retained equivalence evidence are
-still pending.
+The Product Storefront catalog remains owner-native. The single current Product Index source materializes
+the Storefront scalar fields, stable tag identities, and typed EAV query state that were previously
+missing. The remaining localized Product identity mismatch now has a selected architecture, explicit
+query/cursor contract, and root-only PostgreSQL fold compiler/decoder. Production runtime execution and
+retained owner-vs-Index equivalence evidence are still pending.
 
 Storefront must continue to execute `CatalogService::list_published_products_with_query`.
 
@@ -62,39 +62,77 @@ A scalar substring/LIKE operator alone cannot close Storefront parity:
 - issuing an independent fallback query after the requested query would not automatically preserve one
   owner-equivalent global sort, page boundary, exact count, and de-duplication contract.
 
-The selected design is a generic **localized-entity identity fold** in the Index query layer. The
-physical Index rows remain locale-keyed, but the folded Storefront page is grouped by Product entity
-identity before exact count and pagination. Any current/admitted locale row may satisfy title search;
-result localization is selected independently as requested locale, then fallback locale, then no
-localized row. Existing schema readiness, Product freshness, and queried link-target availability remain
-mandatory for every row participating in the fold.
+The selected design is a generic **localized-entity identity fold** in the Index query layer. Physical
+Index rows remain locale-keyed, while the folded page is de-duplicated by Product entity identity before
+exact count and pagination. Any admitted locale row may satisfy title search; result localization is
+selected independently as requested locale, then fallback locale, then no localized row.
 
 Ordinary exact-locale `IndexQuery` remains unchanged. A consumer must not approximate the folded contract
 by independently paging multiple locales and merging them afterward.
 
 See `m7-product-storefront-localized-query-architecture.md` for the identity, search, projection,
-ordering, cursor, freshness, and retained-evidence contract.
+ordering, cursor, freshness, compiler/decoder, and retained-evidence contracts.
 
 Do **not** add another Product routing key merely to patch this query semantic. The current Product
 contract remains the only runtime Product implementation.
 
-## Implemented generic query contract
+## Generic query/cursor contract — source complete
 
-`rustok-index` now exposes the source-level contract required before the SQL compiler can exist safely:
+`rustok-index` now exposes:
 
-- `LocalizedEntityQuery` explicitly wraps the ordinary exact-locale query shape;
-- requested locale remains `query.scope.locale` and fallback is a separate canonical role;
-- `any_locale_filter` is an explicit root-only identity predicate;
-- `SchemaRegistry::validate_localized_entity_query` reuses ordinary field/operator/type validation and
-  requires a locale-required schema;
-- `LocalizedCursorCodec` uses dedicated scoped wire version `3`, while ordinary exact-locale cursors
-  remain on version `2`;
-- the folded continuation binds requested/fallback/filter/any-locale-filter/order/schema identity and
-  cannot be reused as an ordinary query cursor.
+- `LocalizedEntityQuery`, keeping requested locale in `query.scope.locale` and fallback as a separate
+  canonical role;
+- `any_locale_filter` as a separate root-only identity predicate;
+- `localized_projection_fields` as an explicit selected root-scalar role set for requested -> fallback ->
+  null projection, preventing arbitrary third-locale content leakage without changing schema fingerprint;
+- `SchemaRegistry::validate_localized_entity_query`, reusing ordinary field/operator/type validation and
+  requiring a locale-required schema;
+- `LocalizedCursorCodec` with dedicated scoped wire version `3`; ordinary exact-locale cursors remain on
+  version `2`;
+- continuation fingerprint binding requested/fallback, ordinary filter, any-locale filter, localized
+  projection roles, order and schema identity.
 
-The public query runtime still has no `execute_localized_query` method. PostgreSQL compiler, page decoder,
-exact-count execution and admission composition must be source-complete before that capability is
-published.
+The initial fold is deliberately root-only. Linked folded paths remain a later capability/evidence step.
+
+## PostgreSQL fold compiler/decoder — source complete
+
+`SchemaRegistry::compile_postgres_localized_page_query` emits one root identity-fold page statement and
+matching exact-count statement. It uses canonical physical aliases:
+
+- `t0` deterministic admitted identity anchor;
+- `t1` requested projection row;
+- `t2` fallback projection row;
+- `t3` any-locale existential predicate row;
+- `t4` lower-locale anti-duplicate anchor candidate.
+
+Each physical role keeps the ordinary `is_deleted = FALSE` compiler anchor, allowing the existing generic
+`PostgresQueryEntityAdmission` to apply owner freshness to every row role. One identity survives before
+order/lookahead/limit/count by excluding an admitted lower-locale `t4` row.
+
+Localized output uses row-presence `CASE`: an admitted requested row wins even when a selected field itself
+is nullable; fallback is used only when the requested physical row is absent. Exact count uses the same
+identity/search boundary but does not depend on requested/fallback projection availability.
+
+`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary plus localized plan fingerprints,
+column/count contracts and lookahead. SQL null is additionally accepted only for fields explicitly listed
+in `localized_projection_fields`, representing absence of both admitted requested and fallback rows.
+Lookahead emits only `LocalizedCursorCodec` continuation tokens.
+
+## Runtime remains fail-closed
+
+The public query runtime still has no `execute_localized_query` method. The compiler/decoder are not yet
+an authoritative production execution path.
+
+The next slice must wire them into the PostgreSQL query port with:
+
+- persisted schema readiness verification;
+- generic entity admission applied before storage execution;
+- one read-only repeatable-read transaction for page + exact count;
+- result decoding only through `decode_postgres_localized_query_page`;
+- fail-closed preparation/admission/readiness errors.
+
+Because the current compiler rejects linked paths, link-target availability is not widened silently in
+this slice.
 
 ## Typed EAV representation
 
@@ -132,8 +170,8 @@ Lower persisted Product keys are historical storage identities only. Promotion r
 
 Storefront traffic stays blocked until all of these are complete:
 
-1. compile the selected localized-entity identity fold into one PostgreSQL page/exact-count execution
-   contract and expose runtime execution only after decoder/admission semantics are complete;
+1. wire localized compiler/decoder through the production PostgreSQL query runtime with readiness and
+   owner admission;
 2. add the required generic scalar text-pattern primitive inside the folded any-locale identity
    predicate;
 3. translate Active + published-only, category, visibility, EAV, timestamp ordering, ID tie-break,
@@ -142,33 +180,32 @@ Storefront traffic stays blocked until all of these are complete:
 5. batch-hydrate localized Taxonomy tag names;
 6. actualize retained Product PostgreSQL packets to the current Product routing key/source contract;
 7. retain and execute full owner-vs-Index equivalence for requested locale present/absent, fallback,
-   cross-locale title matches, EAV, visibility, ordering, pagination, exact count, target lag, and
-   restart;
-8. stage/rebuild/promote the current Product key for the tenant;
-9. only then select Index traffic.
+   cross-locale title matches, EAV, visibility, ordering, pagination, exact count and restart;
+8. extend folded linked paths only with explicit target-lag availability evidence;
+9. stage/rebuild/promote the current Product key for the tenant;
+10. only then select Index traffic.
 
 ## Source guards
 
-`scripts/verify/verify-index-product-storefront-parity-gate.mjs` locks both sides of the current physical
-mismatch and keeps Storefront owner-native.
-
-`scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs` locks the selected
-query-layer decision and its implemented query/cursor contract.
-
-`scripts/verify/verify-index-localized-query-contract.mjs` specifically locks `LocalizedEntityQuery`,
-required-locale validation, root-only `any_locale_filter`, fallback de-duplication and dedicated cursor
-identity while rejecting premature public runtime execution.
+- `scripts/verify/verify-index-product-storefront-parity-gate.mjs` keeps Storefront owner-native and locks
+  the physical/source boundary.
+- `scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs` locks the selected
+  identity-fold architecture plus source-complete query/compiler/decoder contracts.
+- `scripts/verify/verify-index-localized-query-contract.mjs` locks query/projection/cursor roles.
+- `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks the page/count compiler and
+  decoder while forbidding premature runtime publication.
 
 ## Deliberate limits
 
-This slice does not compile or execute the fold, change owner Storefront semantics, add another Product
-routing key, implement the Storefront Index adapter, execute tenant rebuild, add public typed Product
-events, or switch traffic.
+This slice does not publish localized runtime execution, change owner Storefront semantics, add another
+Product routing key, implement the Storefront Index adapter, execute tenant rebuild, add public typed
+Product events, or switch traffic.
 
 ## Maintainer verification
 
 ```bash
 node scripts/verify/verify-index-localized-query-contract.mjs
+node scripts/verify/verify-index-localized-query-postgres-fold.mjs
 node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-product-source.mjs

--- a/crates/rustok-index/src/application/localized_cursor.rs
+++ b/crates/rustok-index/src/application/localized_cursor.rs
@@ -40,6 +40,7 @@ struct LocalizedCursorQueryIdentity<'a> {
     fallback_locale: Option<&'a LocaleKey>,
     filter: &'a Option<FilterExpr>,
     any_locale_filter: &'a Option<FilterExpr>,
+    localized_projection_fields: Vec<&'a FieldPath>,
     order_by: &'a [OrderExpr],
 }
 
@@ -75,7 +76,7 @@ pub enum LocalizedCursorValidationError {
     RequestedLocaleMismatch,
     #[error("localized cursor fallback locale does not match canonical query fallback")]
     FallbackLocaleMismatch,
-    #[error("localized cursor query fingerprint does not match fold/filter/order semantics")]
+    #[error("localized cursor query fingerprint does not match fold/filter/projection/order semantics")]
     QueryFingerprintMismatch,
     #[error("localized cursor contains {actual} order values but query defines {expected} order expressions")]
     OrderArityMismatch { expected: usize, actual: usize },
@@ -162,6 +163,11 @@ fn decode_payload<T: DeserializeOwned>(
 fn query_fingerprint(
     query: &LocalizedEntityQuery,
 ) -> Result<[u8; 32], LocalizedCursorCodecError> {
+    let mut localized_projection_fields = query
+        .localized_projection_fields
+        .iter()
+        .collect::<Vec<_>>();
+    localized_projection_fields.sort();
     let identity = LocalizedCursorQueryIdentity {
         mode: "localized_entity_fold_v1",
         tenant_id: query.query.scope.tenant_id,
@@ -170,6 +176,7 @@ fn query_fingerprint(
         fallback_locale: query.canonical_fallback_locale(),
         filter: &query.query.filter,
         any_locale_filter: &query.any_locale_filter,
+        localized_projection_fields,
         order_by: &query.query.order_by,
     };
     let bytes = postcard::to_stdvec(&identity)?;
@@ -281,15 +288,26 @@ mod tests {
                 version: SchemaVersion::INITIAL,
             },
             locale_mode: LocaleMode::Required,
-            fields: vec![IndexField {
-                name: FieldName::new("id").unwrap(),
-                value_type: IndexValueType::Uuid,
-                cardinality: FieldCardinality::One,
-                nullable: false,
-                selectable: true,
-                filterable: true,
-                sortable: true,
-            }],
+            fields: vec![
+                IndexField {
+                    name: FieldName::new("id").unwrap(),
+                    value_type: IndexValueType::Uuid,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: true,
+                },
+                IndexField {
+                    name: FieldName::new("title").unwrap(),
+                    value_type: IndexValueType::String,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: false,
+                },
+            ],
             links: Vec::new(),
         }
     }
@@ -302,7 +320,10 @@ mod tests {
                     locale: Some(LocaleKey::new("en-US").unwrap()),
                 },
                 schema: schema.reference.clone(),
-                fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+                fields: vec![
+                    FieldPath::new(FieldName::new("id").unwrap()),
+                    FieldPath::new(FieldName::new("title").unwrap()),
+                ],
                 filter: None,
                 order_by: vec![OrderExpr {
                     field: FieldPath::new(FieldName::new("id").unwrap()),
@@ -317,6 +338,7 @@ mod tests {
             fallback.map(|value| LocaleKey::new(value).unwrap()),
             None,
         )
+        .with_localized_projection_fields([FieldPath::new(FieldName::new("title").unwrap())])
     }
 
     #[test]
@@ -359,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn localized_cursor_cannot_cross_fallback_semantics() {
+    fn localized_cursor_cannot_cross_fallback_or_projection_semantics() {
         let schema = schema();
         let mut registry = SchemaRegistry::new();
         registry.register(schema.clone()).unwrap();
@@ -374,10 +396,26 @@ mod tests {
             entity_id: Uuid::new_v4(),
         };
         let encoded = LocalizedCursorCodec::encode_for_query(&cursor, &original, &registry).unwrap();
-        let mut changed = original.clone();
-        changed.fallback_locale = Some(LocaleKey::new("fr").unwrap());
+
+        let mut changed_fallback = original.clone();
+        changed_fallback.fallback_locale = Some(LocaleKey::new("fr").unwrap());
         assert!(matches!(
-            LocalizedCursorCodec::decode_scoped_for_query(&encoded, &changed, &registry),
+            LocalizedCursorCodec::decode_scoped_for_query(
+                &encoded,
+                &changed_fallback,
+                &registry
+            ),
+            Err(LocalizedCursorValidationError::QueryFingerprintMismatch)
+        ));
+
+        let mut changed_projection = original.clone();
+        changed_projection.localized_projection_fields.clear();
+        assert!(matches!(
+            LocalizedCursorCodec::decode_scoped_for_query(
+                &encoded,
+                &changed_projection,
+                &registry
+            ),
             Err(LocalizedCursorValidationError::QueryFingerprintMismatch)
         ));
     }

--- a/crates/rustok-index/src/application/localized_validation.rs
+++ b/crates/rustok-index/src/application/localized_validation.rs
@@ -1,6 +1,10 @@
+use std::collections::BTreeSet;
+
 use thiserror::Error;
 
-use crate::domain::{FieldPath, LocalizedEntityQuery, LocaleMode, SchemaRef};
+use crate::domain::{
+    FieldCardinality, FieldPath, LocalizedEntityQuery, LocaleMode, SchemaRef,
+};
 
 use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
 
@@ -12,8 +16,22 @@ pub enum LocalizedEntityQueryValidationError {
     Registry(#[from] SchemaRegistryError),
     #[error("localized entity fold requires a locale-required root schema: {0}")]
     LocaleRequiredSchema(SchemaRef),
+    #[error("localized entity fold compiler currently accepts root-only query paths: {0:?}")]
+    LinkedPathPending(FieldPath),
     #[error("any-locale identity predicate must reference root fields only: {0:?}")]
     AnyLocaleLinkedPath(FieldPath),
+    #[error("localized projection field is duplicated: {0:?}")]
+    DuplicateLocalizedProjection(FieldPath),
+    #[error("localized projection field must be selected by the embedded query: {0:?}")]
+    LocalizedProjectionNotSelected(FieldPath),
+    #[error("localized projection field must reference the root entity: {0:?}")]
+    LocalizedProjectionLinkedPath(FieldPath),
+    #[error("localized projection field must be scalar in the initial fold compiler: {0:?}")]
+    LocalizedProjectionMany(FieldPath),
+    #[error("localized projection field must not be evaluated by the ordinary identity filter: {0:?}")]
+    LocalizedProjectionInOrdinaryFilter(FieldPath),
+    #[error("localized projection field must not drive identity ordering: {0:?}")]
+    LocalizedProjectionInOrder(FieldPath),
 }
 
 impl SchemaRegistry {
@@ -40,6 +58,20 @@ impl SchemaRegistry {
         // additive and cannot weaken selection/filter/order/pagination/schema checks.
         self.validate_query(&query.query)?;
 
+        // The first folded PostgreSQL compiler is intentionally root-only. This exactly covers the
+        // Product Storefront list contract while keeping linked traversal/availability semantics out of
+        // the slice until they can be introduced with dedicated retained evidence.
+        if let Some(path) = query
+            .query
+            .referenced_paths()
+            .into_iter()
+            .find(|path| !path.links().is_empty())
+        {
+            return Err(LocalizedEntityQueryValidationError::LinkedPathPending(
+                path.clone(),
+            ));
+        }
+
         if let Some(path) = query
             .any_locale_referenced_paths()
             .into_iter()
@@ -59,6 +91,63 @@ impl SchemaRegistry {
             self.validate_query(&probe)?;
         }
 
+        let mut ordinary_filter_paths = Vec::new();
+        if let Some(filter) = &query.query.filter {
+            filter.field_paths(&mut ordinary_filter_paths);
+        }
+        let ordinary_filter_paths = ordinary_filter_paths.into_iter().collect::<BTreeSet<_>>();
+        let order_paths = query
+            .query
+            .order_by
+            .iter()
+            .map(|order| &order.field)
+            .collect::<BTreeSet<_>>();
+
+        let mut localized = BTreeSet::new();
+        for path in &query.localized_projection_fields {
+            if !localized.insert(path) {
+                return Err(
+                    LocalizedEntityQueryValidationError::DuplicateLocalizedProjection(path.clone()),
+                );
+            }
+            if !path.links().is_empty() {
+                return Err(
+                    LocalizedEntityQueryValidationError::LocalizedProjectionLinkedPath(path.clone()),
+                );
+            }
+            if !query.query.fields.iter().any(|selected| selected == path) {
+                return Err(
+                    LocalizedEntityQueryValidationError::LocalizedProjectionNotSelected(path.clone()),
+                );
+            }
+            let field = registered
+                .schema
+                .fields
+                .iter()
+                .find(|field| field.name == *path.field())
+                .ok_or_else(|| QueryValidationError::UnknownField {
+                    schema: query.query.schema.clone(),
+                    field: path.field().clone(),
+                })?;
+            if field.cardinality != FieldCardinality::One {
+                return Err(LocalizedEntityQueryValidationError::LocalizedProjectionMany(
+                    path.clone(),
+                ));
+            }
+            if ordinary_filter_paths.contains(path) {
+                return Err(
+                    LocalizedEntityQueryValidationError::LocalizedProjectionInOrdinaryFilter(
+                        path.clone(),
+                    ),
+                );
+            }
+            if order_paths.contains(path) {
+                return Err(
+                    LocalizedEntityQueryValidationError::LocalizedProjectionInOrder(path.clone()),
+                );
+            }
+        }
+
         Ok(())
     }
 }
@@ -69,9 +158,9 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        EntityName, FieldCardinality, FieldName, FieldPath, FilterExpr, IndexField, IndexQuery,
-        IndexQueryScope, IndexSchema, IndexValue, IndexValueType, LocaleKey, ModuleName, Pagination,
-        SchemaRef, SchemaVersion,
+        EntityName, FieldName, FieldPath, FilterExpr, IndexField, IndexQuery, IndexQueryScope,
+        IndexSchema, IndexValue, IndexValueType, LocaleKey, ModuleName, OrderDirection, OrderExpr,
+        Pagination, SchemaRef, SchemaVersion,
     };
 
     fn schema(locale_mode: LocaleMode) -> IndexSchema {
@@ -129,6 +218,7 @@ mod tests {
                 IndexValue::String("needle".to_owned()),
             )),
         )
+        .with_localized_projection_fields([FieldPath::new(FieldName::new("title").unwrap())])
     }
 
     #[test]
@@ -168,6 +258,33 @@ mod tests {
             Err(LocalizedEntityQueryValidationError::Query(
                 QueryValidationError::InvalidFilterValue { .. }
             ))
+        ));
+    }
+
+    #[test]
+    fn localized_projection_cannot_drive_anchor_filter_or_order() {
+        let schema = schema(LocaleMode::Required);
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+
+        let mut filtered = localized_query(&schema);
+        filtered.query.filter = Some(FilterExpr::Eq(
+            FieldPath::new(FieldName::new("title").unwrap()),
+            IndexValue::String("requested-only".to_owned()),
+        ));
+        assert!(matches!(
+            registry.validate_localized_entity_query(&filtered),
+            Err(LocalizedEntityQueryValidationError::LocalizedProjectionInOrdinaryFilter(_))
+        ));
+
+        let mut ordered = localized_query(&schema);
+        ordered.query.order_by = vec![OrderExpr {
+            field: FieldPath::new(FieldName::new("title").unwrap()),
+            direction: OrderDirection::Asc,
+        }];
+        assert!(matches!(
+            registry.validate_localized_entity_query(&ordered),
+            Err(LocalizedEntityQueryValidationError::LocalizedProjectionInOrder(_))
         ));
     }
 }

--- a/crates/rustok-index/src/application/localized_validation.rs
+++ b/crates/rustok-index/src/application/localized_validation.rs
@@ -95,17 +95,20 @@ impl SchemaRegistry {
         if let Some(filter) = &query.query.filter {
             filter.field_paths(&mut ordinary_filter_paths);
         }
-        let ordinary_filter_paths = ordinary_filter_paths.into_iter().collect::<BTreeSet<_>>();
+        let ordinary_filter_paths = ordinary_filter_paths
+            .into_iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
         let order_paths = query
             .query
             .order_by
             .iter()
-            .map(|order| &order.field)
+            .map(|order| order.field.clone())
             .collect::<BTreeSet<_>>();
 
         let mut localized = BTreeSet::new();
         for path in &query.localized_projection_fields {
-            if !localized.insert(path) {
+            if !localized.insert(path.clone()) {
                 return Err(
                     LocalizedEntityQueryValidationError::DuplicateLocalizedProjection(path.clone()),
                 );

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -11,6 +11,8 @@ mod localized_validation;
 mod mutation_event;
 mod planner;
 mod postgres_compiler;
+mod postgres_localized_query;
+mod postgres_localized_query_result;
 mod postgres_query_admission;
 mod postgres_query_result;
 mod postgres_query_sql;
@@ -125,6 +127,11 @@ pub use postgres_compiler::{
     CompiledManyRelationColumn, CompiledPostgresCount, CompiledPostgresQuery,
     CompiledQueryColumn, PostgresBindValue, PostgresQueryBuildError, PostgresQueryCompileError,
 };
+pub use postgres_localized_query::{
+    CompiledPostgresLocalizedPageQuery, LocalizedQueryPlanFingerprint,
+    PostgresLocalizedQueryBuildError,
+};
+pub use postgres_localized_query_result::PostgresLocalizedQueryDecodeError;
 pub use postgres_query_admission::{
     PostgresQueryEntityAdmission, PostgresQueryEntityAdmissionApplyError,
     PostgresQueryEntityAdmissionError,

--- a/crates/rustok-index/src/application/postgres_localized_query.rs
+++ b/crates/rustok-index/src/application/postgres_localized_query.rs
@@ -1,0 +1,846 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::domain::{
+    FieldPath, FilterExpr, IndexValue, IndexValueType, LocalizedEntityQuery, OrderDirection,
+    Pagination,
+};
+
+use super::{
+    CompiledPostgresCount, CompiledPostgresQuery, CompiledQueryColumn, ExecutableQueryPlan,
+    LocalizedCursorCodec, LocalizedCursorValidationError, LocalizedEntityQueryValidationError,
+    LocalizedIndexCursor, PlannedField, PostgresBindValue, PostgresQueryCompileError, QueryPlanError,
+    QueryPlanFingerprint, SchemaRegistry,
+    postgres_compiler::quote_identifier,
+};
+
+const ROOT_ALIAS: &str = "t0";
+const REQUESTED_ALIAS: &str = "t1";
+const FALLBACK_ALIAS: &str = "t2";
+const ANY_LOCALE_ALIAS: &str = "t3";
+const EARLIER_ANCHOR_ALIAS: &str = "t4";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LocalizedQueryPlanFingerprint([u8; 32]);
+
+impl LocalizedQueryPlanFingerprint {
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn to_hex(self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+impl fmt::Display for LocalizedQueryPlanFingerprint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self.0))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledPostgresLocalizedPageQuery {
+    compiled: CompiledPostgresQuery,
+    requested_page_size: u32,
+    localized_plan_fingerprint: LocalizedQueryPlanFingerprint,
+}
+
+impl CompiledPostgresLocalizedPageQuery {
+    pub fn compiled(&self) -> &CompiledPostgresQuery {
+        &self.compiled
+    }
+
+    pub fn compiled_mut(&mut self) -> &mut CompiledPostgresQuery {
+        &mut self.compiled
+    }
+
+    pub fn requested_page_size(&self) -> u32 {
+        self.requested_page_size
+    }
+
+    pub fn localized_plan_fingerprint(&self) -> LocalizedQueryPlanFingerprint {
+        self.localized_plan_fingerprint
+    }
+
+    pub fn into_compiled(self) -> CompiledPostgresQuery {
+        self.compiled
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PostgresLocalizedQueryBuildError {
+    #[error(transparent)]
+    Validation(#[from] LocalizedEntityQueryValidationError),
+    #[error(transparent)]
+    Plan(#[from] QueryPlanError),
+    #[error(transparent)]
+    Cursor(#[from] LocalizedCursorValidationError),
+    #[error(transparent)]
+    Compile(#[from] PostgresQueryCompileError),
+}
+
+#[derive(Serialize)]
+struct LocalizedPlanIdentity<'a> {
+    mode: &'static str,
+    ordinary_plan_fingerprint: &'a [u8; 32],
+    fallback_locale: Option<&'a crate::domain::LocaleKey>,
+    any_locale_filter: &'a Option<FilterExpr>,
+    localized_projection_fields: Vec<&'a FieldPath>,
+}
+
+impl SchemaRegistry {
+    /// Compile one root-only localized-entity fold page and optional exact-count statement.
+    ///
+    /// The compiler deliberately emits only ordinary canonical `tN` materialized entity aliases and
+    /// an `is_deleted = FALSE` anchor for each physical row role. Existing trusted owner admission can
+    /// therefore be applied to anchor/requested/fallback/search/anti-duplicate rows without learning a
+    /// Product-specific query shape. Runtime execution is published only in a later slice after
+    /// admission composition is wired and retained PostgreSQL evidence exists.
+    pub fn compile_postgres_localized_page_query(
+        &self,
+        query: &LocalizedEntityQuery,
+    ) -> Result<CompiledPostgresLocalizedPageQuery, PostgresLocalizedQueryBuildError> {
+        self.validate_localized_entity_query(query)?;
+        let plan = self.plan_query(&query.query)?;
+        let any_locale_plan = match &query.any_locale_filter {
+            Some(filter) => {
+                let mut probe = query.query.clone();
+                probe.filter = Some(filter.clone());
+                Some(self.plan_query(&probe)?)
+            }
+            None => None,
+        };
+        let cursor = match &query.query.pagination {
+            Pagination::Cursor {
+                after: Some(encoded),
+                ..
+            } => Some(LocalizedCursorCodec::decode_scoped_for_query(
+                encoded, query, self,
+            )?),
+            _ => None,
+        };
+        compile_localized_page(query, &plan, any_locale_plan.as_ref(), cursor.as_ref())
+            .map_err(Into::into)
+    }
+}
+
+fn compile_localized_page(
+    query: &LocalizedEntityQuery,
+    plan: &ExecutableQueryPlan,
+    any_locale_plan: Option<&ExecutableQueryPlan>,
+    cursor: Option<&LocalizedIndexCursor>,
+) -> Result<CompiledPostgresLocalizedPageQuery, PostgresQueryCompileError> {
+    let requested_page_size = page_size(&plan.pagination);
+    let mut bindings = Bindings::default();
+    let base = compile_base(query, plan, &mut bindings, true)?;
+    let mut select = vec![format!(
+        "{}.entity_id AS {}",
+        quote_identifier(ROOT_ALIAS),
+        quote_identifier("__t0_entity_id")
+    )];
+    let mut columns = vec![CompiledQueryColumn::EntityId {
+        output_alias: "__t0_entity_id".to_owned(),
+        relation_alias: ROOT_ALIAS.to_owned(),
+    }];
+
+    for (index, field) in plan.projection.iter().enumerate() {
+        let raw = if query.is_localized_projection_path(&field.path) {
+            localized_projection_sql(query, field, &mut bindings)
+        } else {
+            field_sql_for_alias(field, ROOT_ALIAS, &mut bindings).raw
+        };
+        let output_alias = format!("f{index}");
+        select.push(format!("{raw} AS {}", quote_identifier(&output_alias)));
+        columns.push(CompiledQueryColumn::Field {
+            output_alias,
+            field: field.clone(),
+        });
+    }
+
+    for (index, order) in plan.order_by.iter().enumerate() {
+        let sql = field_sql_for_alias(&order.field, ROOT_ALIAS, &mut bindings);
+        let output_alias = format!("__order_{index}");
+        select.push(format!(
+            "{} AS {}",
+            sql.raw,
+            quote_identifier(&output_alias)
+        ));
+        columns.push(CompiledQueryColumn::OrderValue {
+            output_alias,
+            field: order.field.clone(),
+        });
+    }
+
+    let mut predicates = base.predicates;
+    if let Some(filter) = &plan.filter {
+        predicates.push(compile_filter_for_alias(
+            plan,
+            filter,
+            ROOT_ALIAS,
+            &mut bindings,
+        )?);
+    }
+    if let (Some(filter), Some(any_plan)) = (&query.any_locale_filter, any_locale_plan) {
+        predicates.push(compile_any_locale_exists(
+            plan,
+            any_plan,
+            filter,
+            &mut bindings,
+        )?);
+    }
+    if let Some(cursor) = cursor {
+        predicates.push(compile_keyset(plan, cursor, &mut bindings)?);
+    }
+
+    let order = compile_order(plan, &mut bindings)?;
+    let pagination = compile_pagination_with_lookahead(&plan.pagination, &mut bindings)?;
+    let sql = format!(
+        "SELECT {} {} WHERE {} {order} {pagination}",
+        select.join(", "),
+        base.from_sql,
+        predicates.join(" AND "),
+    );
+    let exact_count = plan
+        .include_exact_count
+        .then(|| compile_exact_count(query, plan, any_locale_plan))
+        .transpose()?;
+    let ordinary_plan_fingerprint = plan.fingerprint()?;
+    let localized_plan_fingerprint =
+        localized_plan_fingerprint(query, ordinary_plan_fingerprint)?;
+
+    Ok(CompiledPostgresLocalizedPageQuery {
+        compiled: CompiledPostgresQuery {
+            sql,
+            binds: bindings.values,
+            columns,
+            many_relations: Vec::new(),
+            exact_count,
+            plan_fingerprint: ordinary_plan_fingerprint,
+        },
+        requested_page_size,
+        localized_plan_fingerprint,
+    })
+}
+
+pub(super) fn localized_plan_fingerprint(
+    query: &LocalizedEntityQuery,
+    ordinary_plan_fingerprint: QueryPlanFingerprint,
+) -> Result<LocalizedQueryPlanFingerprint, PostgresQueryCompileError> {
+    let mut localized_projection_fields = query
+        .localized_projection_fields
+        .iter()
+        .collect::<Vec<_>>();
+    localized_projection_fields.sort();
+    let identity = LocalizedPlanIdentity {
+        mode: "localized_entity_fold_plan_v1",
+        ordinary_plan_fingerprint: ordinary_plan_fingerprint.as_bytes(),
+        fallback_locale: query.canonical_fallback_locale(),
+        any_locale_filter: &query.any_locale_filter,
+        localized_projection_fields,
+    };
+    let bytes = postcard::to_stdvec(&identity)?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"rustok-index-localized-plan-v1");
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    Ok(LocalizedQueryPlanFingerprint(hasher.finalize().into()))
+}
+
+struct LocalizedBase {
+    from_sql: String,
+    predicates: Vec<String>,
+}
+
+fn compile_base(
+    query: &LocalizedEntityQuery,
+    plan: &ExecutableQueryPlan,
+    bindings: &mut Bindings,
+    include_projection_rows: bool,
+) -> Result<LocalizedBase, PostgresQueryCompileError> {
+    let root = quote_identifier(ROOT_ALIAS);
+    let tenant = bindings.push(PostgresBindValue::Uuid(plan.scope.tenant_id));
+    let module = bindings.push(PostgresBindValue::Text(
+        plan.root_schema.module.as_str().to_owned(),
+    ));
+    let entity = bindings.push(PostgresBindValue::Text(
+        plan.root_schema.entity.as_str().to_owned(),
+    ));
+    let version = bindings.push(PostgresBindValue::Integer(i64::from(
+        plan.root_schema.version.get(),
+    )));
+
+    let mut from_sql = format!("FROM index_entities AS {root}");
+    if include_projection_rows {
+        let requested = quote_identifier(REQUESTED_ALIAS);
+        let requested_locale = bindings.push(PostgresBindValue::Text(
+            query
+                .requested_locale()
+                .expect("validated localized query carries requested locale")
+                .as_str()
+                .to_owned(),
+        ));
+        from_sql.push_str(&format!(
+            " LEFT JOIN index_entities AS {requested} ON {} AND {requested}.locale_key = {requested_locale} AND {requested}.is_deleted = FALSE",
+            same_identity_predicate(REQUESTED_ALIAS, ROOT_ALIAS),
+        ));
+        if let Some(fallback) = query.canonical_fallback_locale() {
+            let fallback_alias = quote_identifier(FALLBACK_ALIAS);
+            let fallback_locale =
+                bindings.push(PostgresBindValue::Text(fallback.as_str().to_owned()));
+            from_sql.push_str(&format!(
+                " LEFT JOIN index_entities AS {fallback_alias} ON {} AND {fallback_alias}.locale_key = {fallback_locale} AND {fallback_alias}.is_deleted = FALSE",
+                same_identity_predicate(FALLBACK_ALIAS, ROOT_ALIAS),
+            ));
+        }
+    }
+
+    let earlier = quote_identifier(EARLIER_ANCHOR_ALIAS);
+    let root_predicate = format!(
+        "{root}.tenant_id = {tenant} AND {root}.module_name = {module} AND {root}.entity_name = {entity} AND {root}.schema_version = {version} AND {root}.locale_key IS NOT NULL AND {root}.is_deleted = FALSE"
+    );
+    let anchor_predicate = format!(
+        "NOT EXISTS (SELECT 1 FROM index_entities AS {earlier} WHERE {} AND {earlier}.locale_key IS NOT NULL AND {earlier}.locale_key < {root}.locale_key AND {earlier}.is_deleted = FALSE)",
+        same_identity_predicate(EARLIER_ANCHOR_ALIAS, ROOT_ALIAS),
+    );
+
+    Ok(LocalizedBase {
+        from_sql,
+        predicates: vec![root_predicate, anchor_predicate],
+    })
+}
+
+fn same_identity_predicate(candidate: &str, root: &str) -> String {
+    let candidate = quote_identifier(candidate);
+    let root = quote_identifier(root);
+    format!(
+        "{candidate}.tenant_id = {root}.tenant_id AND {candidate}.module_name = {root}.module_name AND {candidate}.entity_name = {root}.entity_name AND {candidate}.schema_version = {root}.schema_version AND {candidate}.entity_id = {root}.entity_id"
+    )
+}
+
+fn localized_projection_sql(
+    query: &LocalizedEntityQuery,
+    field: &PlannedField,
+    bindings: &mut Bindings,
+) -> String {
+    let requested = quote_identifier(REQUESTED_ALIAS);
+    let requested_raw = field_sql_for_alias(field, REQUESTED_ALIAS, bindings).raw;
+    match query.canonical_fallback_locale() {
+        Some(_) => {
+            let fallback = quote_identifier(FALLBACK_ALIAS);
+            let fallback_raw = field_sql_for_alias(field, FALLBACK_ALIAS, bindings).raw;
+            format!(
+                "CASE WHEN {requested}.entity_id IS NOT NULL THEN {requested_raw} WHEN {fallback}.entity_id IS NOT NULL THEN {fallback_raw} ELSE NULL::jsonb END"
+            )
+        }
+        None => format!(
+            "CASE WHEN {requested}.entity_id IS NOT NULL THEN {requested_raw} ELSE NULL::jsonb END"
+        ),
+    }
+}
+
+fn compile_any_locale_exists(
+    root_plan: &ExecutableQueryPlan,
+    any_locale_plan: &ExecutableQueryPlan,
+    filter: &FilterExpr,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let any_alias = quote_identifier(ANY_LOCALE_ALIAS);
+    let filter = compile_filter_for_alias(
+        any_locale_plan,
+        filter,
+        ANY_LOCALE_ALIAS,
+        bindings,
+    )?;
+    Ok(format!(
+        "EXISTS (SELECT 1 FROM index_entities AS {any_alias} WHERE {} AND {any_alias}.locale_key IS NOT NULL AND {any_alias}.is_deleted = FALSE AND ({filter}))",
+        same_identity_predicate(ANY_LOCALE_ALIAS, &root_plan.root_alias),
+    ))
+}
+
+fn compile_filter_for_alias(
+    plan: &ExecutableQueryPlan,
+    filter: &FilterExpr,
+    alias: &str,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    match filter {
+        FilterExpr::And(children) => compile_logical(plan, children, alias, "AND", bindings),
+        FilterExpr::Or(children) => compile_logical(plan, children, alias, "OR", bindings),
+        FilterExpr::Not(child) => Ok(format!(
+            "NOT ({})",
+            compile_filter_for_alias(plan, child, alias, bindings)?
+        )),
+        FilterExpr::Eq(path, value) => {
+            let sql = field_sql_for_path(plan, path, alias, bindings)?;
+            let value = bindings.push(scalar_bind(path, value)?);
+            Ok(format!("COALESCE({} = {value}, FALSE)", sql.scalar))
+        }
+        FilterExpr::Ne(path, value) => {
+            let sql = field_sql_for_path(plan, path, alias, bindings)?;
+            let value = bindings.push(scalar_bind(path, value)?);
+            Ok(format!(
+                "({} IS NOT NULL AND {} <> {value})",
+                sql.scalar, sql.scalar
+            ))
+        }
+        FilterExpr::In(path, values) => {
+            let sql = field_sql_for_path(plan, path, alias, bindings)?;
+            let values = values
+                .iter()
+                .map(|value| Ok(bindings.push(scalar_bind(path, value)?)))
+                .collect::<Result<Vec<_>, PostgresQueryCompileError>>()?;
+            Ok(format!(
+                "COALESCE({} IN ({}), FALSE)",
+                sql.scalar,
+                values.join(", ")
+            ))
+        }
+        FilterExpr::Gt(path, value) => {
+            compile_range(plan, path, value, alias, ">", bindings)
+        }
+        FilterExpr::Gte(path, value) => {
+            compile_range(plan, path, value, alias, ">=", bindings)
+        }
+        FilterExpr::Lt(path, value) => {
+            compile_range(plan, path, value, alias, "<", bindings)
+        }
+        FilterExpr::Lte(path, value) => {
+            compile_range(plan, path, value, alias, "<=", bindings)
+        }
+        FilterExpr::Contains(path, value) => {
+            let sql = field_sql_for_path(plan, path, alias, bindings)?;
+            let encoded = serde_json::to_value(vec![value.clone()])?;
+            let value = bindings.push(PostgresBindValue::Json(encoded));
+            Ok(format!(
+                "COALESCE({} @> {value}::jsonb, FALSE)",
+                sql.list_values
+            ))
+        }
+        FilterExpr::IsNull(path, expected_null) => {
+            let sql = field_sql_for_path(plan, path, alias, bindings)?;
+            if *expected_null {
+                Ok(format!("({})", sql.null_predicate))
+            } else {
+                Ok(format!("NOT ({})", sql.null_predicate))
+            }
+        }
+    }
+}
+
+fn compile_logical(
+    plan: &ExecutableQueryPlan,
+    children: &[FilterExpr],
+    alias: &str,
+    operator: &str,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let children = children
+        .iter()
+        .map(|child| compile_filter_for_alias(plan, child, alias, bindings))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(format!("({})", children.join(&format!(" {operator} "))))
+}
+
+fn compile_range(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    value: &IndexValue,
+    alias: &str,
+    operator: &str,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let sql = field_sql_for_path(plan, path, alias, bindings)?;
+    let value = bindings.push(scalar_bind(path, value)?);
+    Ok(format!(
+        "COALESCE({} {operator} {value}, FALSE)",
+        sql.scalar
+    ))
+}
+
+fn field_sql_for_path(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    alias: &str,
+    bindings: &mut Bindings,
+) -> Result<FieldSql, PostgresQueryCompileError> {
+    let field = plan
+        .field(path)
+        .ok_or_else(|| PostgresQueryCompileError::MissingFieldPlan(path.clone()))?;
+    Ok(field_sql_for_alias(field, alias, bindings))
+}
+
+fn compile_keyset(
+    plan: &ExecutableQueryPlan,
+    cursor: &LocalizedIndexCursor,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let mut equalities = Vec::new();
+    let mut disjuncts = Vec::new();
+    for (order, cursor_value) in plan.order_by.iter().zip(&cursor.order_values) {
+        let sql = field_sql_for_alias(&order.field, ROOT_ALIAS, bindings);
+        let (equal, after) = cursor_field_predicates(
+            &order.field.path,
+            &sql,
+            order.direction.base_direction(),
+            cursor_value,
+            bindings,
+        )?;
+        disjuncts.push(conjunction(&equalities, &after));
+        equalities.push(equal);
+    }
+
+    let entity_id = bindings.push(PostgresBindValue::Uuid(cursor.entity_id));
+    let root_after = format!(
+        "{}.entity_id > {entity_id}",
+        quote_identifier(ROOT_ALIAS)
+    );
+    disjuncts.push(conjunction(&equalities, &root_after));
+    Ok(format!("({})", disjuncts.join(" OR ")))
+}
+
+fn cursor_field_predicates(
+    path: &FieldPath,
+    sql: &FieldSql,
+    direction: OrderDirection,
+    cursor_value: &IndexValue,
+    bindings: &mut Bindings,
+) -> Result<(String, String), PostgresQueryCompileError> {
+    let non_null = format!("NOT ({})", sql.null_predicate);
+    if matches!(cursor_value, IndexValue::Null) {
+        let after = match direction {
+            OrderDirection::Asc => "FALSE".to_owned(),
+            OrderDirection::Desc => non_null,
+            _ => unreachable!("cursor predicates receive a normalized direction"),
+        };
+        return Ok((format!("({})", sql.null_predicate), after));
+    }
+
+    let value = bindings.push(scalar_bind(path, cursor_value)?);
+    let equal = format!("({non_null} AND {} = {value})", sql.scalar);
+    let after = match direction {
+        OrderDirection::Asc => format!(
+            "(({}) OR ({non_null} AND {} > {value}))",
+            sql.null_predicate, sql.scalar
+        ),
+        OrderDirection::Desc => {
+            format!("({non_null} AND {} < {value})", sql.scalar)
+        }
+        _ => unreachable!("cursor predicates receive a normalized direction"),
+    };
+    Ok((equal, after))
+}
+
+fn conjunction(prefix: &[String], final_predicate: &str) -> String {
+    let mut predicates = prefix.to_vec();
+    predicates.push(final_predicate.to_owned());
+    format!("({})", predicates.join(" AND "))
+}
+
+fn compile_order(
+    plan: &ExecutableQueryPlan,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let mut terms = plan
+        .order_by
+        .iter()
+        .map(|order| {
+            let sql = field_sql_for_alias(&order.field, ROOT_ALIAS, bindings);
+            Ok(match order.direction.base_direction() {
+                OrderDirection::Asc => format!("{} ASC NULLS LAST", sql.scalar),
+                OrderDirection::Desc => format!("{} DESC NULLS FIRST", sql.scalar),
+                _ => unreachable!("validated root-only localized ordering has no aggregate mode"),
+            })
+        })
+        .collect::<Result<Vec<_>, PostgresQueryCompileError>>()?;
+    terms.push(format!("{}.entity_id ASC", quote_identifier(ROOT_ALIAS)));
+    Ok(format!("ORDER BY {}", terms.join(", ")))
+}
+
+fn compile_pagination_with_lookahead(
+    pagination: &Pagination,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    match pagination {
+        Pagination::Cursor { first, .. } => {
+            let limit = bindings.push(PostgresBindValue::Integer(i64::from(*first) + 1));
+            Ok(format!("LIMIT {limit}"))
+        }
+        Pagination::Offset { limit, offset } => {
+            let limit = bindings.push(PostgresBindValue::Integer(i64::from(*limit) + 1));
+            let offset_value = i64::try_from(*offset)
+                .map_err(|_| PostgresQueryCompileError::OffsetOutOfRange(*offset))?;
+            let offset = bindings.push(PostgresBindValue::Integer(offset_value));
+            Ok(format!("LIMIT {limit} OFFSET {offset}"))
+        }
+    }
+}
+
+fn compile_exact_count(
+    query: &LocalizedEntityQuery,
+    plan: &ExecutableQueryPlan,
+    any_locale_plan: Option<&ExecutableQueryPlan>,
+) -> Result<CompiledPostgresCount, PostgresQueryCompileError> {
+    let mut bindings = Bindings::default();
+    let base = compile_base(query, plan, &mut bindings, false)?;
+    let mut predicates = base.predicates;
+    if let Some(filter) = &plan.filter {
+        predicates.push(compile_filter_for_alias(
+            plan,
+            filter,
+            ROOT_ALIAS,
+            &mut bindings,
+        )?);
+    }
+    if let (Some(filter), Some(any_plan)) = (&query.any_locale_filter, any_locale_plan) {
+        predicates.push(compile_any_locale_exists(
+            plan,
+            any_plan,
+            filter,
+            &mut bindings,
+        )?);
+    }
+    Ok(CompiledPostgresCount {
+        sql: format!(
+            "SELECT COUNT(*)::bigint AS \"__exact_count\" {} WHERE {}",
+            base.from_sql,
+            predicates.join(" AND "),
+        ),
+        binds: bindings.values,
+    })
+}
+
+fn page_size(pagination: &Pagination) -> u32 {
+    match pagination {
+        Pagination::Cursor { first, .. } => *first,
+        Pagination::Offset { limit, .. } => *limit,
+    }
+}
+
+struct FieldSql {
+    raw: String,
+    scalar: String,
+    list_values: String,
+    type_text: String,
+    null_predicate: String,
+}
+
+fn field_sql_for_alias(
+    field: &PlannedField,
+    relation_alias: &str,
+    bindings: &mut Bindings,
+) -> FieldSql {
+    let relation_alias = quote_identifier(relation_alias);
+    let field_name = bindings.push(PostgresBindValue::Text(
+        field.path.field().as_str().to_owned(),
+    ));
+    let raw = format!("jsonb_extract_path({relation_alias}.payload, {field_name}::text)");
+    let scalar_text = format!(
+        "jsonb_extract_path_text({relation_alias}.payload, {field_name}::text, 'value')"
+    );
+    let type_text = format!(
+        "jsonb_extract_path_text({relation_alias}.payload, {field_name}::text, 'type')"
+    );
+    let scalar = match field.value_type {
+        IndexValueType::Boolean => format!("({scalar_text})::boolean"),
+        IndexValueType::Integer => format!("({scalar_text})::bigint"),
+        IndexValueType::Decimal => format!("({scalar_text})::numeric"),
+        IndexValueType::String => format!("({scalar_text} COLLATE \"C\")"),
+        IndexValueType::Uuid => format!("({scalar_text})::uuid"),
+        IndexValueType::Timestamp => format!("({scalar_text})::timestamptz"),
+    };
+    let null_predicate =
+        format!("{raw} IS NULL OR {type_text} IS NULL OR {type_text} = 'null'");
+    FieldSql {
+        raw,
+        scalar,
+        list_values: format!(
+            "jsonb_extract_path({relation_alias}.payload, {field_name}::text, 'value')"
+        ),
+        type_text,
+        null_predicate,
+    }
+}
+
+fn scalar_bind(
+    path: &FieldPath,
+    value: &IndexValue,
+) -> Result<PostgresBindValue, PostgresQueryCompileError> {
+    match value {
+        IndexValue::Boolean(value) => Ok(PostgresBindValue::Boolean(*value)),
+        IndexValue::Integer(value) => Ok(PostgresBindValue::Integer(*value)),
+        IndexValue::Decimal(value) => Ok(PostgresBindValue::Decimal(value.to_owned())),
+        IndexValue::String(value) => Ok(PostgresBindValue::Text(value.clone())),
+        IndexValue::Uuid(value) => Ok(PostgresBindValue::Uuid(*value)),
+        IndexValue::Timestamp(value) => Ok(PostgresBindValue::Timestamp(value.to_owned())),
+        IndexValue::Null | IndexValue::List(_) => {
+            Err(PostgresQueryCompileError::InvalidScalarValue(path.clone()))
+        }
+    }
+}
+
+#[derive(Default)]
+struct Bindings {
+    values: Vec<PostgresBindValue>,
+}
+
+impl Bindings {
+    fn push(&mut self, value: PostgresBindValue) -> String {
+        self.values.push(value);
+        format!("${}", self.values.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldCardinality, FieldName, IndexField, IndexQuery, IndexQueryScope, IndexSchema,
+        LocaleKey, LocaleMode, ModuleName, OrderExpr, SchemaRef, SchemaVersion,
+    };
+    use crate::PostgresQueryEntityAdmission;
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("rustok-product").unwrap(),
+                entity: EntityName::new("product").unwrap(),
+                version: SchemaVersion::new(4),
+            },
+            locale_mode: LocaleMode::Required,
+            fields: vec![
+                IndexField {
+                    name: FieldName::new("id").unwrap(),
+                    value_type: IndexValueType::Uuid,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: true,
+                },
+                IndexField {
+                    name: FieldName::new("title").unwrap(),
+                    value_type: IndexValueType::String,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: false,
+                },
+                IndexField {
+                    name: FieldName::new("status").unwrap(),
+                    value_type: IndexValueType::String,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: false,
+                },
+            ],
+            links: Vec::new(),
+        }
+    }
+
+    fn query(schema: &IndexSchema) -> LocalizedEntityQuery {
+        LocalizedEntityQuery::new(
+            IndexQuery {
+                scope: IndexQueryScope {
+                    tenant_id: Uuid::new_v4(),
+                    locale: Some(LocaleKey::new("fi").unwrap()),
+                },
+                schema: schema.reference.clone(),
+                fields: vec![
+                    FieldPath::new(FieldName::new("id").unwrap()),
+                    FieldPath::new(FieldName::new("title").unwrap()),
+                    FieldPath::new(FieldName::new("status").unwrap()),
+                ],
+                filter: Some(FilterExpr::Eq(
+                    FieldPath::new(FieldName::new("status").unwrap()),
+                    IndexValue::String("active".to_owned()),
+                )),
+                order_by: vec![OrderExpr {
+                    field: FieldPath::new(FieldName::new("id").unwrap()),
+                    direction: OrderDirection::Asc,
+                }],
+                pagination: Pagination::Cursor {
+                    first: 20,
+                    after: None,
+                },
+                include_exact_count: true,
+            },
+            Some(LocaleKey::new("en").unwrap()),
+            Some(FilterExpr::Eq(
+                FieldPath::new(FieldName::new("title").unwrap()),
+                IndexValue::String("needle".to_owned()),
+            )),
+        )
+        .with_localized_projection_fields([FieldPath::new(FieldName::new("title").unwrap())])
+    }
+
+    #[test]
+    fn compiler_groups_by_one_admitted_anchor_before_page_and_count() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let query = query(&schema);
+        let compiled = registry
+            .compile_postgres_localized_page_query(&query)
+            .unwrap();
+        let sql = &compiled.compiled().sql;
+        assert!(sql.contains("index_entities AS \"t0\""));
+        assert!(sql.contains("index_entities AS \"t1\""));
+        assert!(sql.contains("index_entities AS \"t2\""));
+        assert!(sql.contains("index_entities AS \"t3\""));
+        assert!(sql.contains("index_entities AS \"t4\""));
+        assert!(sql.contains("\"t4\".locale_key < \"t0\".locale_key"));
+        assert!(sql.contains("CASE WHEN \"t1\".entity_id IS NOT NULL"));
+        assert!(sql.contains("WHEN \"t2\".entity_id IS NOT NULL"));
+        assert_eq!(compiled.requested_page_size(), 20);
+        let count = compiled.compiled().exact_count.as_ref().unwrap();
+        assert!(count.sql.contains("index_entities AS \"t0\""));
+        assert!(count.sql.contains("index_entities AS \"t3\""));
+        assert!(count.sql.contains("index_entities AS \"t4\""));
+        assert!(!count.sql.contains("index_entities AS \"t1\""));
+    }
+
+    #[test]
+    fn canonical_entity_admission_can_cover_every_fold_physical_row_role() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let query = query(&schema);
+        let mut compiled = registry
+            .compile_postgres_localized_page_query(&query)
+            .unwrap();
+        let admission =
+            PostgresQueryEntityAdmission::new("{{entity}}.source_version > 0").unwrap();
+        admission.apply(compiled.compiled_mut()).unwrap();
+        for alias in ["t0", "t1", "t2", "t3", "t4"] {
+            let marker = format!(
+                "\"{alias}\".is_deleted = FALSE AND (\"{alias}\".source_version > 0)"
+            );
+            assert!(compiled.compiled().sql.contains(&marker), "missing {marker}");
+        }
+        for alias in ["t0", "t3", "t4"] {
+            let marker = format!(
+                "\"{alias}\".is_deleted = FALSE AND (\"{alias}\".source_version > 0)"
+            );
+            assert!(
+                compiled
+                    .compiled()
+                    .exact_count
+                    .as_ref()
+                    .unwrap()
+                    .sql
+                    .contains(&marker),
+                "missing count {marker}"
+            );
+        }
+    }
+}

--- a/crates/rustok-index/src/application/postgres_localized_query_result.rs
+++ b/crates/rustok-index/src/application/postgres_localized_query_result.rs
@@ -1,0 +1,492 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::domain::{
+    FieldCardinality, IndexValue, LocalizedEntityQuery, Pagination,
+};
+
+use super::{
+    CompiledPostgresCell, CompiledPostgresLocalizedPageQuery, CompiledPostgresRow,
+    CompiledQueryColumn, IndexProjectedValue, IndexQueryItem, IndexQueryPage,
+    LocalizedCursorCodec, LocalizedCursorValidationError, LocalizedEntityQueryValidationError,
+    LocalizedIndexCursor, PostgresQueryCompileError, PostgresQueryDecodeError, QueryPlanError,
+    SchemaRegistry, SchemaRegistryError,
+    postgres_localized_query::localized_plan_fingerprint,
+};
+
+const EXACT_COUNT_ALIAS: &str = "__exact_count";
+
+#[derive(Debug, Error)]
+pub enum PostgresLocalizedQueryDecodeError {
+    #[error(transparent)]
+    Validation(#[from] LocalizedEntityQueryValidationError),
+    #[error(transparent)]
+    Plan(#[from] QueryPlanError),
+    #[error(transparent)]
+    Cursor(#[from] LocalizedCursorValidationError),
+    #[error(transparent)]
+    Compile(#[from] PostgresQueryCompileError),
+    #[error(transparent)]
+    Row(#[from] PostgresQueryDecodeError),
+    #[error("localized compiled query fingerprint does not match the requested fold contract")]
+    LocalizedPlanFingerprintMismatch,
+}
+
+impl SchemaRegistry {
+    /// Decode one localized identity-fold page after PostgreSQL execution.
+    ///
+    /// Localized projection fields intentionally accept SQL null even when the immutable physical
+    /// field contract is non-null: null means neither requested nor fallback physical locale row was
+    /// admitted. The owner adapter may then apply its documented placeholder behavior. Every unlisted
+    /// field keeps the ordinary schema nullability/type/cardinality decoder contract.
+    pub fn decode_postgres_localized_query_page(
+        &self,
+        query: &LocalizedEntityQuery,
+        page_query: &CompiledPostgresLocalizedPageQuery,
+        rows: Vec<CompiledPostgresRow>,
+        exact_count_row: Option<CompiledPostgresRow>,
+    ) -> Result<IndexQueryPage, PostgresLocalizedQueryDecodeError> {
+        self.validate_localized_entity_query(query)?;
+        let plan = self.plan_query(&query.query)?;
+        let expected_ordinary = plan.fingerprint().map_err(PostgresQueryCompileError::from)?;
+        let compiled = page_query.compiled();
+        if compiled.plan_fingerprint != expected_ordinary {
+            return Err(PostgresQueryDecodeError::PlanFingerprintMismatch {
+                expected: expected_ordinary,
+                actual: compiled.plan_fingerprint,
+            }
+            .into());
+        }
+        let expected_localized = localized_plan_fingerprint(query, expected_ordinary)?;
+        if page_query.localized_plan_fingerprint() != expected_localized {
+            return Err(PostgresLocalizedQueryDecodeError::LocalizedPlanFingerprintMismatch);
+        }
+
+        let expected_columns = expected_columns(&plan);
+        let unique_aliases = compiled
+            .columns
+            .iter()
+            .map(column_output_alias)
+            .collect::<BTreeSet<_>>();
+        if unique_aliases.len() != compiled.columns.len()
+            || compiled.columns != expected_columns
+            || !compiled.many_relations.is_empty()
+        {
+            return Err(PostgresQueryDecodeError::ColumnContractMismatch.into());
+        }
+
+        let requested_page_size = page_size(&query.query.pagination);
+        if page_query.requested_page_size() != requested_page_size {
+            return Err(PostgresQueryDecodeError::PageSizeMismatch {
+                compiled: page_query.requested_page_size(),
+                query: requested_page_size,
+            }
+            .into());
+        }
+        let maximum = requested_page_size as usize + 1;
+        if rows.len() > maximum {
+            return Err(PostgresQueryDecodeError::TooManyRows {
+                maximum,
+                actual: rows.len(),
+            }
+            .into());
+        }
+
+        let exact_count = decode_exact_count(query, compiled.exact_count.is_some(), exact_count_row.as_ref())?;
+        let has_more = rows.len() > requested_page_size as usize;
+        let decoded = rows
+            .iter()
+            .take(requested_page_size as usize)
+            .map(|row| decode_row(query, compiled, row))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let next_cursor = if has_more
+            && matches!(&query.query.pagination, Pagination::Cursor { .. })
+        {
+            let last = decoded
+                .last()
+                .ok_or(PostgresQueryDecodeError::MissingCursorItem)?;
+            let registered = self.get(&query.query.schema).ok_or_else(|| {
+                QueryPlanError::Registry(SchemaRegistryError::SchemaNotFound(
+                    query.query.schema.clone(),
+                ))
+            })?;
+            let cursor = LocalizedIndexCursor {
+                tenant_id: query.query.scope.tenant_id,
+                schema: query.query.schema.clone(),
+                schema_fingerprint: registered.fingerprint,
+                requested_locale: query
+                    .requested_locale()
+                    .expect("validated localized query carries requested locale")
+                    .clone(),
+                fallback_locale: query.canonical_fallback_locale().cloned(),
+                order_values: last.order_values.clone(),
+                entity_id: last.item.entity_id,
+            };
+            Some(LocalizedCursorCodec::encode_for_query(&cursor, query, self)?)
+        } else {
+            None
+        };
+
+        Ok(IndexQueryPage {
+            items: decoded.into_iter().map(|row| row.item).collect(),
+            exact_count,
+            has_more,
+            next_cursor,
+        })
+    }
+}
+
+fn expected_columns(plan: &super::ExecutableQueryPlan) -> Vec<CompiledQueryColumn> {
+    let mut columns = vec![CompiledQueryColumn::EntityId {
+        output_alias: "__t0_entity_id".to_owned(),
+        relation_alias: "t0".to_owned(),
+    }];
+    columns.extend(
+        plan.projection
+            .iter()
+            .enumerate()
+            .map(|(index, field)| CompiledQueryColumn::Field {
+                output_alias: format!("f{index}"),
+                field: field.clone(),
+            }),
+    );
+    columns.extend(
+        plan.order_by
+            .iter()
+            .enumerate()
+            .map(|(index, order)| CompiledQueryColumn::OrderValue {
+                output_alias: format!("__order_{index}"),
+                field: order.field.clone(),
+            }),
+    );
+    columns
+}
+
+fn column_output_alias(column: &CompiledQueryColumn) -> &str {
+    match column {
+        CompiledQueryColumn::EntityId { output_alias, .. }
+        | CompiledQueryColumn::Field { output_alias, .. }
+        | CompiledQueryColumn::OrderValue { output_alias, .. } => output_alias,
+    }
+}
+
+struct DecodedLocalizedRow {
+    item: IndexQueryItem,
+    order_values: Vec<IndexValue>,
+}
+
+fn decode_row(
+    query: &LocalizedEntityQuery,
+    compiled: &super::CompiledPostgresQuery,
+    row: &CompiledPostgresRow,
+) -> Result<DecodedLocalizedRow, PostgresLocalizedQueryDecodeError> {
+    let root_entity_id = match required_cell(row, "__t0_entity_id")? {
+        CompiledPostgresCell::Uuid(value) if !value.is_nil() => *value,
+        CompiledPostgresCell::Uuid(_) | CompiledPostgresCell::Null => {
+            return Err(PostgresQueryDecodeError::NullRootIdentity(
+                "__t0_entity_id".to_owned(),
+            )
+            .into());
+        }
+        _ => {
+            return Err(PostgresQueryDecodeError::UnexpectedCellType {
+                alias: "__t0_entity_id".to_owned(),
+                expected: "a non-nil UUID",
+            }
+            .into());
+        }
+    };
+
+    let mut fields = Vec::new();
+    let mut order_values = Vec::new();
+    for column in &compiled.columns {
+        match column {
+            CompiledQueryColumn::Field {
+                output_alias,
+                field,
+            } => {
+                let value = decode_value(row, output_alias)?;
+                validate_value(
+                    field,
+                    &value,
+                    query.is_localized_projection_path(&field.path),
+                )?;
+                fields.push(IndexProjectedValue {
+                    path: field.path.clone(),
+                    value,
+                });
+            }
+            CompiledQueryColumn::OrderValue {
+                output_alias,
+                field,
+            } => {
+                let value = decode_value(row, output_alias)?;
+                validate_value(field, &value, false)?;
+                order_values.push(value);
+            }
+            CompiledQueryColumn::EntityId { .. } => {}
+        }
+    }
+
+    Ok(DecodedLocalizedRow {
+        item: IndexQueryItem {
+            entity_id: root_entity_id,
+            relations: Vec::new(),
+            fields,
+            nested_relations: Vec::new(),
+        },
+        order_values,
+    })
+}
+
+fn decode_value(
+    row: &CompiledPostgresRow,
+    output_alias: &str,
+) -> Result<IndexValue, PostgresLocalizedQueryDecodeError> {
+    match required_cell(row, output_alias)? {
+        CompiledPostgresCell::Null => Ok(IndexValue::Null),
+        CompiledPostgresCell::Json(value) => serde_json::from_value::<IndexValue>(value.clone())
+            .map_err(|source| {
+                PostgresQueryDecodeError::InvalidTaggedValue {
+                    alias: output_alias.to_owned(),
+                    source,
+                }
+                .into()
+            }),
+        _ => Err(PostgresQueryDecodeError::UnexpectedCellType {
+            alias: output_alias.to_owned(),
+            expected: "tagged IndexValue JSON or SQL null",
+        }
+        .into()),
+    }
+}
+
+fn validate_value(
+    field: &super::PlannedField,
+    value: &IndexValue,
+    localized_absence_allowed: bool,
+) -> Result<(), PostgresLocalizedQueryDecodeError> {
+    if matches!(value, IndexValue::Null) {
+        if field.nullable || localized_absence_allowed {
+            return Ok(());
+        }
+        return Err(PostgresQueryDecodeError::UnexpectedFieldNull {
+            path: field.path.clone(),
+        }
+        .into());
+    }
+    let valid = match value {
+        IndexValue::List(values) => {
+            field.cardinality == FieldCardinality::Many
+                && values
+                    .iter()
+                    .all(|value| value.value_type() == Some(field.value_type))
+        }
+        value => {
+            field.cardinality == FieldCardinality::One
+                && value.value_type() == Some(field.value_type)
+        }
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(PostgresQueryDecodeError::InvalidFieldValue {
+            path: field.path.clone(),
+        }
+        .into())
+    }
+}
+
+fn required_cell<'a>(
+    row: &'a CompiledPostgresRow,
+    output_alias: &str,
+) -> Result<&'a CompiledPostgresCell, PostgresLocalizedQueryDecodeError> {
+    row.get(output_alias).ok_or_else(|| {
+        PostgresQueryDecodeError::MissingColumn(output_alias.to_owned()).into()
+    })
+}
+
+fn decode_exact_count(
+    query: &LocalizedEntityQuery,
+    compiled_has_count: bool,
+    row: Option<&CompiledPostgresRow>,
+) -> Result<Option<u64>, PostgresLocalizedQueryDecodeError> {
+    match (
+        query.query.include_exact_count,
+        compiled_has_count,
+        row,
+    ) {
+        (false, false, None) => Ok(None),
+        (true, true, Some(row)) => match required_cell(row, EXACT_COUNT_ALIAS)? {
+            CompiledPostgresCell::Integer(value) if *value >= 0 => Ok(Some(*value as u64)),
+            CompiledPostgresCell::Integer(value) => {
+                Err(PostgresQueryDecodeError::NegativeExactCount(*value).into())
+            }
+            _ => Err(PostgresQueryDecodeError::UnexpectedCellType {
+                alias: EXACT_COUNT_ALIAS.to_owned(),
+                expected: "a non-negative bigint",
+            }
+            .into()),
+        },
+        _ => Err(PostgresQueryDecodeError::ExactCountContractMismatch.into()),
+    }
+}
+
+fn page_size(pagination: &Pagination) -> u32 {
+    match pagination {
+        Pagination::Cursor { first, .. } => *first,
+        Pagination::Offset { limit, .. } => *limit,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        EntityName, FieldCardinality, FieldName, FieldPath, IndexField, IndexQuery, IndexQueryScope,
+        IndexSchema, IndexValueType, LocaleKey, LocaleMode, ModuleName, OrderDirection, OrderExpr,
+        Pagination, SchemaRef, SchemaVersion,
+    };
+    use serde_json::json;
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("rustok-product").unwrap(),
+                entity: EntityName::new("product").unwrap(),
+                version: SchemaVersion::new(4),
+            },
+            locale_mode: LocaleMode::Required,
+            fields: vec![
+                IndexField {
+                    name: FieldName::new("id").unwrap(),
+                    value_type: IndexValueType::Uuid,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: true,
+                },
+                IndexField {
+                    name: FieldName::new("title").unwrap(),
+                    value_type: IndexValueType::String,
+                    cardinality: FieldCardinality::One,
+                    nullable: false,
+                    selectable: true,
+                    filterable: true,
+                    sortable: false,
+                },
+            ],
+            links: Vec::new(),
+        }
+    }
+
+    fn query(schema: &IndexSchema) -> LocalizedEntityQuery {
+        LocalizedEntityQuery::new(
+            IndexQuery {
+                scope: IndexQueryScope {
+                    tenant_id: Uuid::new_v4(),
+                    locale: Some(LocaleKey::new("fi").unwrap()),
+                },
+                schema: schema.reference.clone(),
+                fields: vec![
+                    FieldPath::new(FieldName::new("id").unwrap()),
+                    FieldPath::new(FieldName::new("title").unwrap()),
+                ],
+                filter: None,
+                order_by: vec![OrderExpr {
+                    field: FieldPath::new(FieldName::new("id").unwrap()),
+                    direction: OrderDirection::Asc,
+                }],
+                pagination: Pagination::Cursor {
+                    first: 1,
+                    after: None,
+                },
+                include_exact_count: true,
+            },
+            Some(LocaleKey::new("en").unwrap()),
+            None,
+        )
+        .with_localized_projection_fields([FieldPath::new(FieldName::new("title").unwrap())])
+    }
+
+    #[test]
+    fn decoder_allows_absent_effective_localized_field_but_not_invariant_field() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let query = query(&schema);
+        let compiled = registry
+            .compile_postgres_localized_page_query(&query)
+            .unwrap();
+        let id = Uuid::new_v4();
+        let row = CompiledPostgresRow::from_values([
+            ("__t0_entity_id".to_owned(), CompiledPostgresCell::Uuid(id)),
+            (
+                "f0".to_owned(),
+                CompiledPostgresCell::Json(json!({"type":"uuid","value":id})),
+            ),
+            ("f1".to_owned(), CompiledPostgresCell::Null),
+            (
+                "__order_0".to_owned(),
+                CompiledPostgresCell::Json(json!({"type":"uuid","value":id})),
+            ),
+        ]);
+        let count = CompiledPostgresRow::from_values([(
+            EXACT_COUNT_ALIAS.to_owned(),
+            CompiledPostgresCell::Integer(1),
+        )]);
+        let page = registry
+            .decode_postgres_localized_query_page(&query, &compiled, vec![row], Some(count))
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert!(matches!(page.items[0].fields[1].value, IndexValue::Null));
+        assert_eq!(page.exact_count, Some(1));
+    }
+
+    #[test]
+    fn lookahead_emits_dedicated_localized_cursor() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let query = query(&schema);
+        let compiled = registry
+            .compile_postgres_localized_page_query(&query)
+            .unwrap();
+        let ids = [Uuid::new_v4(), Uuid::new_v4()];
+        let rows = ids
+            .iter()
+            .map(|id| {
+                CompiledPostgresRow::from_values([
+                    (
+                        "__t0_entity_id".to_owned(),
+                        CompiledPostgresCell::Uuid(*id),
+                    ),
+                    (
+                        "f0".to_owned(),
+                        CompiledPostgresCell::Json(json!({"type":"uuid","value":id})),
+                    ),
+                    ("f1".to_owned(), CompiledPostgresCell::Null),
+                    (
+                        "__order_0".to_owned(),
+                        CompiledPostgresCell::Json(json!({"type":"uuid","value":id})),
+                    ),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let count = CompiledPostgresRow::from_values([(
+            EXACT_COUNT_ALIAS.to_owned(),
+            CompiledPostgresCell::Integer(2),
+        )]);
+        let page = registry
+            .decode_postgres_localized_query_page(&query, &compiled, rows, Some(count))
+            .unwrap();
+        assert!(page.has_more);
+        let cursor = page.next_cursor.expect("localized lookahead cursor");
+        assert!(LocalizedCursorCodec::decode_scoped_for_query(&cursor, &query, &registry).is_ok());
+    }
+}

--- a/crates/rustok-index/src/domain/localized_query.rs
+++ b/crates/rustok-index/src/domain/localized_query.rs
@@ -11,11 +11,19 @@ const MAX_LOCALIZED_FILTER_NODES: usize = 128;
 /// query filter keeps its exact planned semantics, while `any_locale_filter` is reserved for the
 /// identity-level existential predicate evaluated across admitted physical locale rows by the folded
 /// PostgreSQL compiler.
+///
+/// `localized_projection_fields` is explicit because generic Index schema fields intentionally do not
+/// encode owner-specific localization semantics. A listed root field is projected only from the
+/// requested row, then fallback row, then SQL null. Unlisted root fields are read from the deterministic
+/// admitted identity anchor. This prevents a third-locale anchor from becoming visible localized
+/// content when requested/fallback rows are absent without changing the immutable schema fingerprint.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalizedEntityQuery {
     pub query: IndexQuery,
     pub fallback_locale: Option<LocaleKey>,
     pub any_locale_filter: Option<FilterExpr>,
+    #[serde(default)]
+    pub localized_projection_fields: Vec<FieldPath>,
 }
 
 impl LocalizedEntityQuery {
@@ -28,7 +36,16 @@ impl LocalizedEntityQuery {
             query,
             fallback_locale,
             any_locale_filter,
+            localized_projection_fields: Vec::new(),
         }
+    }
+
+    pub fn with_localized_projection_fields(
+        mut self,
+        fields: impl IntoIterator<Item = FieldPath>,
+    ) -> Self {
+        self.localized_projection_fields = fields.into_iter().collect();
+        self
     }
 
     pub fn requested_locale(&self) -> Option<&LocaleKey> {
@@ -43,6 +60,12 @@ impl LocalizedEntityQuery {
         self.fallback_locale
             .as_ref()
             .filter(|fallback| Some(*fallback) != self.requested_locale())
+    }
+
+    pub fn is_localized_projection_path(&self, path: &FieldPath) -> bool {
+        self.localized_projection_fields
+            .iter()
+            .any(|localized| localized == path)
     }
 
     pub fn validate_shape(&self) -> Result<(), DomainError> {
@@ -125,5 +148,14 @@ mod tests {
             )),
         );
         assert_eq!(query.any_locale_referenced_paths(), vec![&title]);
+    }
+
+    #[test]
+    fn localized_projection_roles_are_explicit_and_default_empty() {
+        let title = FieldPath::new(FieldName::new("title").unwrap());
+        let plain = LocalizedEntityQuery::new(base_query("en-US"), None, None);
+        assert!(!plain.is_localized_projection_path(&title));
+        let localized = plain.with_localized_projection_fields([title.clone()]);
+        assert!(localized.is_localized_projection_path(&title));
     }
 }

--- a/scripts/verify/verify-index-localized-query-contract.mjs
+++ b/scripts/verify/verify-index-localized-query-contract.mjs
@@ -23,39 +23,37 @@ requireMarkers('crates/rustok-index/src/domain/localized_query.rs', [
   'pub query: IndexQuery',
   'pub fallback_locale: Option<LocaleKey>',
   'pub any_locale_filter: Option<FilterExpr>',
+  'pub localized_projection_fields: Vec<FieldPath>',
+  'pub fn with_localized_projection_fields(',
   'pub fn canonical_fallback_locale(&self)',
   'Some(*fallback) != self.requested_locale()',
+  'pub fn is_localized_projection_path(&self, path: &FieldPath)',
   'ordinary_nodes + any_locale_nodes > MAX_LOCALIZED_FILTER_NODES',
-  'pub fn any_locale_referenced_paths(&self)',
-]);
-requireMarkers('crates/rustok-index/src/domain/mod.rs', [
-  'mod localized_query;',
-  'pub use localized_query::LocalizedEntityQuery;',
 ]);
 
 requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
   'pub enum LocalizedEntityQueryValidationError',
   'LocaleRequiredSchema(SchemaRef)',
+  'LinkedPathPending(FieldPath)',
   'AnyLocaleLinkedPath(FieldPath)',
-  'pub fn validate_localized_entity_query(',
+  'DuplicateLocalizedProjection(FieldPath)',
+  'LocalizedProjectionInOrdinaryFilter(FieldPath)',
+  'LocalizedProjectionInOrder(FieldPath)',
   'registered.schema.locale_mode != LocaleMode::Required',
   'self.validate_query(&query.query)?;',
-  '.find(|path| !path.links().is_empty())',
   'probe.filter = Some(filter.clone());',
-  'self.validate_query(&probe)?;',
+  'field.cardinality != FieldCardinality::One',
 ]);
 
 requireMarkers('crates/rustok-index/src/application/localized_cursor.rs', [
   'const LOCALIZED_SCOPED_CURSOR_VERSION: u8 = 3;',
   'pub struct LocalizedIndexCursor',
-  'pub requested_locale: LocaleKey',
-  'pub fallback_locale: Option<LocaleKey>',
-  'pub struct LocalizedCursorCodec;',
+  'localized_projection_fields: Vec<&\'a FieldPath>',
   'mode: "localized_entity_fold_v1"',
   'fallback_locale: query.canonical_fallback_locale()',
   'any_locale_filter: &query.any_locale_filter',
+  'localized_projection_fields.sort();',
   'b"rustok-index-localized-cursor-query-v1"',
-  'cursor.fallback_locale.as_ref() != query.canonical_fallback_locale()',
   'LocalizedCursorCodecError::UnsupportedVersion(2)',
 ]);
 
@@ -71,22 +69,21 @@ if (ordinaryCursor.includes('localized_entity_fold_v1')) {
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'mod localized_cursor;',
   'mod localized_validation;',
-  'LocalizedCursorCodec, LocalizedCursorCodecError, LocalizedCursorValidationError,',
-  'LocalizedIndexCursor,',
   'pub use localized_validation::LocalizedEntityQueryValidationError;',
 ]);
 
 const port = read('crates/rustok-index/src/application/query_port.rs');
 if (port.includes('execute_localized_query')) {
-  fail('this contract slice must not claim PostgreSQL localized execution before the folded compiler exists');
+  fail('localized execution must remain unpublished until runtime admission/readiness wiring is complete');
 }
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
-  'Status: `query_contract_source_complete_compiler_and_evidence_pending`',
+  'Status: `compiler_decoder_source_complete_runtime_and_evidence_pending`',
   '`LocalizedEntityQuery`',
+  '`localized_projection_fields`',
   '`LocalizedCursorCodec`',
   'wire version `3`',
   'ordinary exact-locale cursor wire version `2` remains unchanged',
 ]);
 
-console.log('[verify-index-localized-query-contract] explicit fold query validation and cursor identity are source-locked; compiler/execution remain pending');
+console.log('[verify-index-localized-query-contract] localized query/projection/cursor contract is source-locked; runtime publication remains pending');

--- a/scripts/verify/verify-index-localized-query-postgres-fold.mjs
+++ b/scripts/verify/verify-index-localized-query-postgres-fold.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-localized-query-postgres-fold] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const compilerPath = 'crates/rustok-index/src/application/postgres_localized_query.rs';
+const compiler = requireMarkers(compilerPath, [
+  'pub struct CompiledPostgresLocalizedPageQuery',
+  'pub struct LocalizedQueryPlanFingerprint',
+  'pub fn compile_postgres_localized_page_query(',
+  'const ROOT_ALIAS: &str = "t0";',
+  'const REQUESTED_ALIAS: &str = "t1";',
+  'const FALLBACK_ALIAS: &str = "t2";',
+  'const ANY_LOCALE_ALIAS: &str = "t3";',
+  'const EARLIER_ANCHOR_ALIAS: &str = "t4";',
+  'LEFT JOIN index_entities AS {requested}',
+  'LEFT JOIN index_entities AS {fallback_alias}',
+  'NOT EXISTS (SELECT 1 FROM index_entities AS {earlier}',
+  '{earlier}.locale_key < {root}.locale_key',
+  'EXISTS (SELECT 1 FROM index_entities AS {any_alias}',
+  'CASE WHEN {requested}.entity_id IS NOT NULL THEN {requested_raw}',
+  'WHEN {fallback}.entity_id IS NOT NULL THEN {fallback_raw}',
+  'localized_plan_fingerprint(query, ordinary_plan_fingerprint)',
+  'mode: "localized_entity_fold_plan_v1"',
+  'b"rustok-index-localized-plan-v1"',
+  'compile_pagination_with_lookahead',
+  'SELECT COUNT(*)::bigint AS "__exact_count"',
+  'compiled_mut(&mut self) -> &mut CompiledPostgresQuery',
+]);
+for (const alias of ['t0', 't1', 't2', 't3', 't4']) {
+  if (!compiler.includes(`is_deleted = FALSE`)) {
+    fail(`${compilerPath} does not retain canonical is_deleted anchors`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/application/postgres_localized_query_result.rs', [
+  'pub enum PostgresLocalizedQueryDecodeError',
+  'pub fn decode_postgres_localized_query_page(',
+  'LocalizedPlanFingerprintMismatch',
+  'compiled.columns != expected_columns',
+  'compiled.many_relations.is_empty()',
+  'localized_absence_allowed: bool',
+  'field.nullable || localized_absence_allowed',
+  'LocalizedIndexCursor {',
+  'LocalizedCursorCodec::encode_for_query(&cursor, query, self)',
+  'IndexQueryPage {',
+]);
+
+requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
+  'LinkedPathPending(FieldPath)',
+  'LocalizedProjectionMany(FieldPath)',
+  'LocalizedProjectionInOrdinaryFilter(FieldPath)',
+  'LocalizedProjectionInOrder(FieldPath)',
+]);
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod postgres_localized_query;',
+  'mod postgres_localized_query_result;',
+  'CompiledPostgresLocalizedPageQuery, LocalizedQueryPlanFingerprint,',
+  'PostgresLocalizedQueryBuildError,',
+  'pub use postgres_localized_query_result::PostgresLocalizedQueryDecodeError;',
+]);
+
+const ordinaryCompiler = read('crates/rustok-index/src/application/postgres_query_sql.rs');
+if (ordinaryCompiler.includes('localized_entity_fold_plan_v1')) {
+  fail('ordinary exact-locale SQL compiler must not absorb localized fold semantics');
+}
+
+const port = read('crates/rustok-index/src/application/query_port.rs');
+if (port.includes('execute_localized_query')) {
+  fail('compiler/decoder slice must not publish runtime localized execution yet');
+}
+
+console.log('[verify-index-localized-query-postgres-fold] localized root identity fold page/count compiler and decoder are source-locked; runtime admission remains pending');

--- a/scripts/verify/verify-index-localized-query-postgres-fold.mjs
+++ b/scripts/verify/verify-index-localized-query-postgres-fold.mjs
@@ -19,7 +19,7 @@ const requireMarkers = (relative, markers) => {
 };
 
 const compilerPath = 'crates/rustok-index/src/application/postgres_localized_query.rs';
-const compiler = requireMarkers(compilerPath, [
+requireMarkers(compilerPath, [
   'pub struct CompiledPostgresLocalizedPageQuery',
   'pub struct LocalizedQueryPlanFingerprint',
   'pub fn compile_postgres_localized_page_query(',
@@ -29,24 +29,25 @@ const compiler = requireMarkers(compilerPath, [
   'const ANY_LOCALE_ALIAS: &str = "t3";',
   'const EARLIER_ANCHOR_ALIAS: &str = "t4";',
   'LEFT JOIN index_entities AS {requested}',
+  '{requested}.is_deleted = FALSE',
   'LEFT JOIN index_entities AS {fallback_alias}',
+  '{fallback_alias}.is_deleted = FALSE',
   'NOT EXISTS (SELECT 1 FROM index_entities AS {earlier}',
   '{earlier}.locale_key < {root}.locale_key',
+  '{earlier}.is_deleted = FALSE',
   'EXISTS (SELECT 1 FROM index_entities AS {any_alias}',
+  '{any_alias}.is_deleted = FALSE',
+  '{root}.is_deleted = FALSE',
   'CASE WHEN {requested}.entity_id IS NOT NULL THEN {requested_raw}',
   'WHEN {fallback}.entity_id IS NOT NULL THEN {fallback_raw}',
   'localized_plan_fingerprint(query, ordinary_plan_fingerprint)',
   'mode: "localized_entity_fold_plan_v1"',
   'b"rustok-index-localized-plan-v1"',
   'compile_pagination_with_lookahead',
-  'SELECT COUNT(*)::bigint AS "__exact_count"',
+  'COUNT(*)::bigint AS',
+  '__exact_count',
   'compiled_mut(&mut self) -> &mut CompiledPostgresQuery',
 ]);
-for (const alias of ['t0', 't1', 't2', 't3', 't4']) {
-  if (!compiler.includes(`is_deleted = FALSE`)) {
-    fail(`${compilerPath} does not retain canonical is_deleted anchors`);
-  }
-}
 
 requireMarkers('crates/rustok-index/src/application/postgres_localized_query_result.rs', [
   'pub enum PostgresLocalizedQueryDecodeError',
@@ -60,14 +61,12 @@ requireMarkers('crates/rustok-index/src/application/postgres_localized_query_res
   'LocalizedCursorCodec::encode_for_query(&cursor, query, self)',
   'IndexQueryPage {',
 ]);
-
 requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
   'LinkedPathPending(FieldPath)',
   'LocalizedProjectionMany(FieldPath)',
   'LocalizedProjectionInOrdinaryFilter(FieldPath)',
   'LocalizedProjectionInOrder(FieldPath)',
 ]);
-
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'mod postgres_localized_query;',
   'mod postgres_localized_query_result;',
@@ -80,7 +79,6 @@ const ordinaryCompiler = read('crates/rustok-index/src/application/postgres_quer
 if (ordinaryCompiler.includes('localized_entity_fold_plan_v1')) {
   fail('ordinary exact-locale SQL compiler must not absorb localized fold semantics');
 }
-
 const port = read('crates/rustok-index/src/application/query_port.rs');
 if (port.includes('execute_localized_query')) {
   fail('compiler/decoder slice must not publish runtime localized execution yet');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -30,8 +30,7 @@ const ownerQuery = requireMarkers(ownerQueryPath, [
 ]);
 const titleSearchStart = ownerQuery.indexOf('fn product_title_search_condition(');
 if (titleSearchStart < 0) fail(`${ownerQueryPath} title-search helper is missing`);
-const titleSearch = ownerQuery.slice(titleSearchStart);
-if (titleSearch.includes('pt.locale')) {
+if (ownerQuery.slice(titleSearchStart).includes('pt.locale')) {
   fail(`${ownerQueryPath} title search became locale-scoped; revisit the localized identity architecture in the same PR`);
 }
 
@@ -39,7 +38,6 @@ requireMarkers('crates/rustok-product/src/services/catalog/commands.rs', [
   'if input.translations.is_empty()',
   'At least one translation is required',
 ]);
-
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
   'Lower keys are historical storage identities only.',
@@ -52,8 +50,6 @@ const productSource = requireMarkers(productSourcePath, [
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'derive_index_schema_source_event_id(',
   'many_field("attribute_terms", IndexValueType::String, false, true)?',
-  'name: link_name("variants")?',
-  'name: link_name("sales_channels")?',
 ]);
 if (productSource.includes('SchemaVersion::new(3)')) {
   fail(`${productSourcePath} must not restore historical Product routing key 3`);
@@ -61,37 +57,30 @@ if (productSource.includes('SchemaVersion::new(3)')) {
 
 const architecturePath = 'crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md';
 requireMarkers(architecturePath, [
-  'Status: `query_contract_source_complete_compiler_and_evidence_pending`',
-  'Keep the current owner Storefront behavior and keep exactly one current Product Index schema.',
-  '`(tenant_id, schema_ref, entity_id)`',
-  '`LocalizedEntityQuery` wraps an ordinary validated `IndexQuery`',
-  '`any_locale_filter` is a separate identity-level existential predicate',
-  '`SchemaRegistry::validate_localized_entity_query` permits the mode only for `LocaleMode::Required`',
-  '`LocalizedCursorCodec` and `LocalizedIndexCursor` provide a separate continuation identity',
-  'wire version `3`',
-  'ordinary exact-locale cursor wire version `2` remains unchanged',
-  'Any-locale title search is an identity predicate',
-  'the row that satisfied search does **not** become the result locale merely because it matched',
-  'Grouping happens **before** pagination and exact count.',
-  'exact count is the number of distinct admitted Product identities',
-  'a cursor from an ordinary exact-locale query must not be accepted by the folded query path',
-  'Existing schema readiness, Product entity freshness, and queried link-target availability remain',
-  'Compile `LocalizedEntityQuery` into one PostgreSQL identity-fold statement',
+  'Status: `compiler_decoder_source_complete_runtime_and_evidence_pending`',
+  '`localized_projection_fields`',
+  '`SchemaRegistry::compile_postgres_localized_page_query`',
+  '`t0` — deterministic admitted identity anchor',
+  '`t1` — requested-locale projection row',
+  '`t2` — fallback-locale projection row',
+  '`t3` — any-locale existential predicate row',
+  '`t4` — lower-locale anti-duplicate anchor candidate',
+  '`SchemaRegistry::decode_postgres_localized_query_page`',
+  '`LocalizedCursorCodec` uses scoped wire version `3`',
+  'The public query runtime still has no `execute_localized_query` method.',
+  'Wire `CompiledPostgresLocalizedPageQuery` into the PostgreSQL query port',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'm7-product-storefront-localized-query-architecture.md',
-  'A scalar substring/LIKE operator alone cannot close Storefront parity',
+  'Status: `localized_compiler_decoder_source_complete_runtime_and_evidence_pending`',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
-
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@0a8d09a84688e4c0f3d6007d9b90d7f41b2a53a3` (#3204)',
-  'one current Product schema on internal routing key `4`',
-  'Add explicit generic localized query shape/validation',
-  'Add dedicated localized cursor identity/version',
-  'compile `LocalizedEntityQuery` into one PostgreSQL identity-fold page/count',
+  'Status overlay rechecked from `main@678606a78916ed631669e40c617c60a031097138` (#3208)',
+  'Compile the root-only localized-entity fold to one PostgreSQL page/exact-count contract.',
+  'Add the localized page decoder with explicit requested/fallback-null semantics and dedicated cursor.',
+  'wire explicit localized execution into the PostgreSQL Index query port',
   'Do not add a runtime alias for key `3`',
 ]);
 
-console.log('[verify-index-product-storefront-localized-query-architecture] localized Product architecture plus query/cursor contract are locked; compiler and evidence remain pending');
+console.log('[verify-index-product-storefront-localized-query-architecture] localized Product compiler/decoder architecture is locked; runtime and evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -47,7 +47,6 @@ requireMarkers(typesPath, [
   'pub enum StorefrontProductSortBy',
   'PublishedAt',
   'CreatedAt',
-  'pub enum StorefrontProductSortDirection',
   'pub struct ProductAttributeFilter',
   'const MAX_ATTRIBUTE_FILTERS: usize = 8',
   'pub struct StorefrontProductListQuery',
@@ -67,83 +66,41 @@ const ownerQuery = requireMarkers(ownerQueryPath, [
   'Column::PrimaryCategoryId.eq(category_id)',
   'product_title_search_condition(',
   'attribute_filters::load_catalog_attribute_filter_conditions(',
-  'StorefrontProductSortBy::PublishedAt',
-  'StorefrontProductSortBy::CreatedAt',
-  '.order_by_asc(entities::product::Column::Id)',
-  '.order_by_desc(entities::product::Column::Id)',
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
-  'load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))',
   'fn product_title_search_condition(',
   'FROM product_translations pt',
   'pt.product_id = products.id',
   'pt.title LIKE $1',
 ]);
-const titleSearchStart = ownerQuery.indexOf('fn product_title_search_condition(');
-const titleSearch = ownerQuery.slice(titleSearchStart);
+const titleSearch = ownerQuery.slice(ownerQuery.indexOf('fn product_title_search_condition('));
 if (titleSearch.includes('pt.locale')) {
-  fail(`${ownerQueryPath} title search became locale-scoped; update the parity architecture and guard in the same PR`);
+  fail(`${ownerQueryPath} title search became locale-scoped; update parity architecture in the same PR`);
 }
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
-const productIndex = read(productIndexPath);
-const schemaStart = productIndex.indexOf('fn product_schema()');
-const schemaEnd = productIndex.indexOf('fn validated_schema(', schemaStart);
-if (schemaStart < 0 || schemaEnd < 0 || schemaEnd <= schemaStart) {
-  fail(`${productIndexPath} canonical Product schema block is missing`);
-}
-const productSchema = productIndex.slice(schemaStart, schemaEnd);
-for (const marker of [
-  'scalar_field("id"',
-  'scalar_field("status"',
-  'scalar_field("title"',
-  'scalar_field("handle"',
-  'scalar_field("description"',
-  'scalar_field("seller_id"',
-  'scalar_field("vendor"',
-  'scalar_field("product_type"',
-  '"primary_category_id"',
-  'many_field("tag_ids"',
-  'scalar_field("created_at"',
-  'scalar_field("published_at"',
-  'many_field("attribute_terms"',
-  'many_field("variant_ids"',
-  'many_field("sales_channel_ids"',
-  'name: link_name("variants")?',
-  'name: link_name("sales_channels")?',
-]) {
-  if (!productSchema.includes(marker)) fail(`${productIndexPath} schema is missing ${marker}`);
-}
-if (!productIndex.includes('assert_eq!(schema.fields.len(), 15);')) {
-  fail(`${productIndexPath} current single Product field-count assertion is not 15`);
-}
-requireMarkers(productIndexPath, [
+const productIndex = requireMarkers(productIndexPath, [
+  'assert_eq!(schema.fields.len(), 15);',
   'JOIN product_translations t',
   't.locale',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'derive_index_schema_source_event_id(',
-  "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
-  "COALESCE(attributes.attribute_terms, '[]'::jsonb) AS attribute_terms",
+  'many_field("attribute_terms", IndexValueType::String, false, true)?',
 ]);
 forbidMarkers(productIndexPath, productIndex, [
   'SchemaVersion::new(3)',
   'derive_index_source_event_id(',
-  'ProductSchemaVersion',
   'product_v1_schema',
   'product_v2_schema',
   'COALESCE(requested_translation',
-  'fallback_translation AS title',
 ]);
 
-const absencePath = 'crates/rustok-distribution/src/product_index/absence.rs';
-requireMarkers(absencePath, [
+requireMarkers('crates/rustok-distribution/src/product_index/absence.rs', [
   'translation.locale = $3',
   'return Ok(None);',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
-
-const schemaStorePath = 'crates/rustok-index/src/infrastructure/postgres/schema_registration.rs';
-requireMarkers(schemaStorePath, [
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/schema_registration.rs', [
   'VersionConflict { reference: SchemaRef }',
   'pub async fn register_current(',
   'retire_lower_active_schemas(',
@@ -151,23 +108,24 @@ requireMarkers(schemaStorePath, [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_query_contract_source_complete_compiler_and_evidence_pending`',
+  'Status: `localized_compiler_decoder_source_complete_runtime_and_evidence_pending`',
   'does **not** restrict that search row to the requested or fallback locale',
   'owner list can still return the Product using its fallback translation',
   'one Index entity for each physically stored `product_translations.locale`',
   'A scalar substring/LIKE operator alone cannot close Storefront parity',
   'localized-entity identity fold',
-  '`LocalizedEntityQuery` explicitly wraps the ordinary exact-locale query shape',
-  '`LocalizedCursorCodec` uses dedicated scoped wire version `3`',
+  '`localized_projection_fields`',
+  '`SchemaRegistry::compile_postgres_localized_page_query`',
+  '`SchemaRegistry::decode_postgres_localized_query_page`',
+  'The public query runtime still has no `execute_localized_query` method.',
   'm7-product-storefront-localized-query-architecture.md',
   'Do **not** add another Product routing key merely to patch this query semantic.',
   'actualize retained Product PostgreSQL packets',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
-
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
   'Status: `source_complete_materialized_rebuild_pending`',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains fail-closed while localized fold compiler/evidence are pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native while localized runtime/evidence are pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -82,6 +82,7 @@ const scripts = [
   'verify-index-product-storefront-parity-gate.mjs',
   'verify-index-product-storefront-localized-query-architecture.mjs',
   'verify-index-localized-query-contract.mjs',
+  'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- continue the explicit localized query contract merged in #3208 with a root-only PostgreSQL identity-fold compiler and decoder;
- add explicit `localized_projection_fields` so requested/fallback localized output cannot leak from an arbitrary third-locale identity anchor without changing the immutable schema fingerprint;
- keep localized projection fields selected/root/scalar-only and forbid them from ordinary identity filtering or ordering in this initial compiler;
- compile one de-duplicated Product identity per `(tenant, schema, entity)` using canonical physical roles: `t0` anchor, `t1` requested, `t2` fallback, `t3` any-locale predicate, and `t4` lower-locale anti-duplicate candidate;
- retain ordinary `is_deleted = FALSE` anchors on every physical role so existing generic `PostgresQueryEntityAdmission` can inject owner freshness into all participating locale rows;
- group/de-duplicate before ordering, lookahead, limit and exact count; requested/fallback projection uses row-presence `CASE`, while exact count does not depend on projection-row availability;
- add a localized plan fingerprint binding fallback, any-locale predicate and localized projection roles on top of the ordinary plan fingerprint;
- decode folded pages with strict column/count/lookahead contracts, allow SQL null beyond physical nullability only for explicit localized projection fields, and emit dedicated localized continuation cursors;
- keep the ordinary exact-locale compiler/cursor unchanged and keep linked folded paths rejected pending dedicated availability evidence;
- deliberately do not publish `execute_localized_query` yet: runtime readiness/admission/repeatable-read wiring is the next atomic slice.

## Main recheck

The branch started from `main@678606a78916ed631669e40c617c60a031097138` (#3208). Before PR creation, current `main@7cd2a144497c0cd2f45fd515b658463f1b9f4a25` had advanced through #3207 (Commerce Product effective-form owner-port cutover) and #3209 (Moderation rereview workflow). Those changes are disjoint from this `rustok-index`/Index-guard slice. Final compare contains only the expected Index domain/application/docs/verifier files.

## Boundary

This PR does not publish localized runtime execution, add scalar substring matching, change Product schema/routing key, add Product events, switch Storefront traffic, or claim PostgreSQL equivalence. Storefront remains owner-native and fail-closed.

The next source slice wires `CompiledPostgresLocalizedPageQuery` through the PostgreSQL query port with persisted readiness, generic owner entity admission, one read-only repeatable-read page/count snapshot, and decoding through `decode_postgres_localized_query_page`.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.