### PR TITLE
feat(index): execute localized fold runtime

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@678606a78916ed631669e40c617c60a031097138` (#3208) and continued on
-`agent/index-localized-query-postgres-fold-20260808`.
+Status overlay rechecked from `main@6044dbd5110a65e2ebeee0a6a3a0053d9971b250` (#3210) and continued on
+`agent/index-localized-query-runtime-20260808`.
 
 `implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
 history for the linked-target/replay sequence, but this file is the current execution cursor.
@@ -20,20 +20,18 @@ The current Product/Index sequence now includes:
   `4`, with lower keys historical only;
 - #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
   projection is requested-locale -> fallback-locale;
-- #3204 selected the one generic localized-entity fold architecture and kept Storefront cutover
-  fail-closed pending implementation/evidence;
-- #3208 added the explicit generic localized query shape, fail-closed validation, dedicated cursor wire
-  identity, and kept ordinary exact-locale `IndexQuery` unchanged.
+- #3204 selected the generic localized-entity fold architecture;
+- #3208 added explicit localized query/validation and dedicated cursor identity;
+- #3210 added root-only PostgreSQL localized identity-fold page/count compilation and decoding.
 
-This source slice continues directly from #3208. It makes the root-only PostgreSQL localized fold compiler
-and decoder source-complete without publishing a production execution method, changing Product traffic,
-changing Product schema, or bypassing retained evidence gates.
+This source slice continues from #3210 and wires that compiler/decoder through the canonical query runtime
+without changing Product schema, Product traffic, ordinary exact-locale query semantics, or evidence
+status.
 
 ## Old execution branch
 
 `agent/index-linked-target-replay-redelivery-evidence-20260807` is no longer a valid continuation base.
-It diverges from current `main` and contains source content already squash-merged through #3190. Do not
-cherry-pick or continue development from that branch.
+Its source was already squash-merged through #3190. Do not reuse it.
 
 The old branch should be deleted when repository tooling permits it. Branch deletion is repository
 hygiene only; it is not part of Index correctness.
@@ -63,77 +61,58 @@ Current Product source/runtime facts:
 - EAV writes advance the same Product owner `index_revision` / graph `projection_epoch` clock;
 - dynamic Product EAV filters use stable UUID-keyed typed `attribute_terms`;
 - ProductVariant/SalesChannel recreate ordering still uses retained tombstone-backed `index_revision`;
-- Product root freshness and linked-target availability remain fail-closed.
+- Product root freshness and ordinary linked-target availability remain fail-closed.
 
-## Corrected Storefront parity boundary
+## Localized Product query source state
 
-The 15-field replacement fixed the old missing-field/EAV gap, but #3200 proved a separate query identity
-mismatch:
+The Storefront owner contract still requires all-translations title admission plus requested -> fallback
+projection. Ordinary exact-locale `IndexQuery` cannot provide that identity contract by itself.
 
-1. owner title search can match any Product translation;
-2. owner result projection prefers requested translation, then fallback translation;
-3. Product Index physically stores one entity per actual translation locale;
-4. ordinary `IndexQuery` scopes one exact locale and therefore cannot by itself preserve owner search,
-   fallback, global pagination, de-duplication, and exact count.
+The localized fold source is now complete through runtime execution:
 
-A scalar substring/LIKE operator on the current exact-locale query remains insufficient.
+- `LocalizedEntityQuery` keeps requested locale in `query.scope.locale`, canonical fallback separately,
+  and `any_locale_filter` as an identity-level existential predicate;
+- `localized_projection_fields` explicitly marks selected root scalar fields that project requested ->
+  fallback -> null and therefore cannot leak arbitrary third-locale content;
+- fold validation requires `LocaleMode::Required`, reuses ordinary field/operator/value rules, and keeps
+  the initial implementation root-only;
+- `LocalizedCursorCodec` has independent scoped wire version `3` and binds fallback/search/projection/order
+  semantics; ordinary cursor version `2` remains unchanged;
+- `compile_postgres_localized_page_query` emits page + exact count using `t0` anchor, `t1` requested,
+  `t2` fallback, `t3` any-locale predicate and `t4` lower-locale anti-duplicate candidate;
+- every physical row role retains canonical `is_deleted = FALSE` anchors for generic owner admission;
+- de-duplication occurs before ordering/lookahead/limit/exact count;
+- requested/fallback projection uses row-presence `CASE` rather than value-level `COALESCE`;
+- `decode_postgres_localized_query_page` validates ordinary/localized plan identities and emits only
+  localized continuation cursors;
+- `IndexQueryPort::execute_localized_query` is now an explicit capability with a fail-closed default for
+  adapters that do not implement it;
+- `SharedIndexQueryRuntime` forwards the capability;
+- `PostgresIndexQueryPort` compiles and applies availability/entity admission before beginning data
+  execution, then verifies persisted schema readiness and executes page/count inside one
+  `REPEATABLE READ, READ ONLY` transaction;
+- localized results are decoded only through the localized decoder and transaction success/failure uses
+  the same commit/rollback policy as ordinary queries.
 
-## Localized Product query architecture, contract, compiler and decoder
+Storefront traffic is still owner-native. Source-complete runtime is not execution/equivalence evidence.
 
-Architecture decision: complete in
-`m7-product-storefront-localized-query-architecture.md`.
+## Remaining localized Storefront query gap
 
-Selected architecture remains:
+The identity/fallback problem is now solved at the generic query/runtime layer, but owner title search uses
+`LIKE %search%` while the current generic Index scalar filter algebra has no bounded string text-pattern
+operator.
 
-- preserve owner Storefront semantics;
-- keep exactly one current Product schema/routing key;
-- use a generic Index query-layer localized-entity fold whose logical page identity is
-  `(tenant_id, schema_ref, entity_id)` while physical storage remains locale-keyed;
-- evaluate any-locale title search as an identity predicate across current/admitted locale rows;
-- choose result localization independently: requested locale -> fallback locale -> no localized row;
-- apply exact count, sort, lookahead, and cursor semantics to Product identities before page truncation;
-- forbid client-side merging of independently paginated locale queries;
-- keep existing schema readiness and Product owner freshness admission mandatory.
+The next source step is a generic scalar string text-pattern primitive that can be validated and compiled
+inside `LocalizedEntityQuery::any_locale_filter`. It must remain generic Index behavior and must not add a
+Product-specific SQL branch.
 
-The query/cursor contract from #3208 remains source-complete and this slice closes the compiler/decoder
-source gap:
-
-- `LocalizedEntityQuery` stays explicit and ordinary `IndexQuery` remains exact-locale;
-- `localized_projection_fields` explicitly identifies selected root scalar fields that must be projected
-  requested -> fallback -> null instead of leaking a third-locale identity anchor;
-- localized projection fields cannot drive the ordinary identity filter or identity ordering;
-- the first compiler deliberately accepts root-only query paths; linked folded paths remain a later
-  capability/evidence step;
-- `SchemaRegistry::compile_postgres_localized_page_query` emits one page statement and matching exact
-  count using canonical physical aliases `t0` anchor, `t1` requested, `t2` fallback, `t3` any-locale
-  predicate and `t4` lower-locale anti-duplicate candidate;
-- all physical row roles retain the ordinary `is_deleted = FALSE` compiler anchor so generic
-  `PostgresQueryEntityAdmission` can inject owner freshness into every participating row;
-- one admitted identity anchor survives before ordering/lookahead/limit/count by excluding a lower-locale
-  admitted `t4` row;
-- requested/fallback projection uses row-presence `CASE`, so a present requested row with a nullable field
-  never incorrectly falls through to fallback;
-- exact count uses the same identity/admission boundary but does not depend on requested/fallback
-  projection-row availability;
-- `LocalizedQueryPlanFingerprint` separately binds canonical fallback, any-locale predicate and localized
-  projection roles on top of the ordinary query plan fingerprint;
-- `SchemaRegistry::decode_postgres_localized_query_page` checks both plan fingerprints, exact column/count
-  shape and lookahead bounds;
-- SQL null is accepted for a physically non-null field only when that field is explicitly listed as a
-  localized projection field, meaning no requested/fallback row was admitted;
-- lookahead emits only the dedicated `LocalizedCursorCodec` wire-version-3 continuation.
-
-No `execute_localized_query` runtime method exists yet. The compiler/decoder output is therefore not an
-authoritative production query path until the PostgreSQL port wires readiness, admission and one
-repeatable-read execution snapshot around it.
+After that primitive exists, the Product Storefront adapter can map owner query inputs to the fold and
+retained owner-vs-Index PostgreSQL evidence can be added.
 
 ## Retained M7 PostgreSQL packets
 
 The six packets retained before the Product replacement remain valuable historical scenario definitions,
-but they are **not yet current replacement evidence** because several fixtures still hardcode historical
-Product routing key `3` and pre-replacement assumptions.
-
-Packets requiring source actualization before execution/admission:
+but several fixtures still hardcode historical Product routing key `3` and pre-replacement assumptions:
 
 1. `product_materialized_query_freshness_postgres.rs`;
 2. `product_channel_convergence_postgres.rs`;
@@ -142,11 +121,10 @@ Packets requiring source actualization before execution/admission:
 5. `product_linked_target_availability_equivalence_postgres.rs`;
 6. `product_linked_target_replay_redelivery_postgres.rs`.
 
-The separate Product locale-absence retained packet and related static guards must also be rechecked for
-historical key assumptions.
+The Product locale-absence retained packet and related static guards also require recheck for historical key
+assumptions.
 
-Do not add a runtime alias for key `3` to make these tests pass. Evidence must follow the one current
-Product contract.
+Do not add a runtime alias for key `3`. Evidence must follow the one current Product contract.
 
 ## M5 incremental ingestion
 
@@ -188,23 +166,17 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 - [x] Product materialized root freshness fence.
 - [x] Entity-level stale linked-target freshness fence for ProductVariant and SalesChannel.
 - [x] ProductVariant/SalesChannel recreate-safe monotonic `index_revision` via retained tombstones.
-- [x] Query-path-scoped fail-closed linked-target availability semantics for ordinary Product graph
-      queries.
+- [x] Query-path-scoped fail-closed linked-target availability semantics for ordinary Product queries.
 - [x] One current 15-field Product Storefront-capable source contract.
 - [x] Schema-safe single-current replacement/promotion mechanism.
 - [x] Canonical typed EAV term representation and Product EAV owner clock.
-- [x] Recheck and document owner all-translations search + requested/fallback projection mismatch.
-- [x] Choose one generic localized Product query identity/fallback architecture without another Product
-      routing key.
-- [x] Add explicit generic localized query shape/validation while keeping ordinary exact-locale
-      `IndexQuery` unchanged.
-- [x] Add dedicated localized cursor identity/version bound to requested/fallback/filter/projection/order
-      semantics.
-- [x] Compile the root-only localized-entity fold to one PostgreSQL page/exact-count contract.
-- [x] Add the localized page decoder with explicit requested/fallback-null semantics and dedicated cursor.
-- [ ] Wire localized execution through the PostgreSQL query port using persisted readiness, generic
-      entity admission and one read-only repeatable-read snapshot.
-- [ ] Add generic scalar text-pattern matching inside the folded any-locale identity predicate.
+- [x] Recheck owner all-translations search + requested/fallback projection mismatch.
+- [x] Select one generic localized identity/fallback architecture without another Product routing key.
+- [x] Add explicit localized query shape/validation and dedicated cursor identity.
+- [x] Compile/decode the root-only localized identity fold page/count contract.
+- [x] Wire localized execution through the canonical PostgreSQL query runtime with persisted readiness,
+      generic admission and one read-only repeatable-read snapshot.
+- [ ] Add generic scalar string text-pattern matching inside folded `any_locale_filter`.
 - [ ] Implement the Product Storefront Index adapter and Taxonomy tag hydration boundary.
 - [ ] Extend folded execution to linked paths only with dedicated target-availability evidence.
 - [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` and the 15-field source.
@@ -218,19 +190,15 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 
 Primary maintainer gate remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-Next source-code step: **wire explicit localized execution into the PostgreSQL Index query port**. Reuse
-the current persisted-schema readiness verifier, `PostgresQueryEntityAdmission`, page/exact-count statement
-mapping and one read-only repeatable-read transaction. Admission/preparation failures must fail closed
-before page/count storage execution, and results must be decoded only through
-`decode_postgres_localized_query_page`.
+Next source-code step: **add one generic bounded scalar string text-pattern filter operator** to the Index
+query contract/validation/PostgreSQL compiler and allow it inside folded `any_locale_filter`. Preserve
+ordinary query compatibility and use explicit pattern semantics; do not add a Product-only SQL branch.
 
-Do not publish Product Storefront traffic in that runtime slice. After the runtime boundary exists, add the
-generic scalar text-pattern primitive inside `any_locale_filter`, then implement the Product Storefront
-adapter and retained equivalence packet.
+After text-pattern support, implement the Product Storefront Index adapter and a retained localized-query
+PostgreSQL equivalence packet before any traffic switch.
 
-In parallel, the retained Product PostgreSQL packets need a mechanical source actualization to routing key
-`4`/15-field Product contract before they can be treated as current evidence. No historical-key runtime
-compatibility path is allowed.
+In parallel, actualize retained Product PostgreSQL packets to routing key `4` / the 15-field current
+contract. No historical-key compatibility path is allowed.
 
 Typed Product events remain separately blocked on maintainer event-digest admission.
 
@@ -241,6 +209,7 @@ The implementation agent has not run these commands. Maintainer verification sho
 ```bash
 node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-localized-query-postgres-fold.mjs
+node scripts/verify/verify-index-localized-query-runtime.mjs
 node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-query-contract.mjs

--- a/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
+++ b/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront localized query architecture
 
-Status: `compiler_decoder_source_complete_runtime_and_evidence_pending`.
+Status: `runtime_source_complete_text_pattern_and_evidence_pending`.
 
 ## Decision
 
@@ -41,14 +41,14 @@ explicit `localized_projection_fields` role set. A listed field is projected onl
 2. otherwise an admitted fallback-locale row;
 3. otherwise SQL null.
 
-Unlisted fields are read from a deterministic admitted identity anchor. This explicit classification is
-required so a third-locale anchor can never leak `title`, `handle` or other localized content when the
+Unlisted fields are read from a deterministic admitted identity anchor. This explicit classification
+prevents a third-locale anchor from leaking `title`, `handle` or other localized content when the
 requested/fallback rows are absent. It does not change the Product schema fingerprint.
 
-The initial compiler is intentionally root-only. Linked query paths fail validation until linked fold
-semantics and their own evidence are added. This still covers the current Product Storefront list contract,
-which can express its identity predicates through root fields such as `sales_channel_ids` and
-`attribute_terms`.
+The initial compiler/runtime is intentionally root-only. Linked query paths fail validation until linked
+fold semantics and their own availability evidence are added. This still covers the current Product
+Storefront list contract, which can express its identity predicates through root fields such as
+`sales_channel_ids` and `attribute_terms`.
 
 ## Query validation and cursor identity
 
@@ -57,7 +57,7 @@ which can express its identity predicates through root fields such as `sales_cha
 - requires `LocaleMode::Required`;
 - reuses ordinary field/operator/value validation;
 - shares one bounded node budget between ordinary and any-locale filters;
-- rejects linked paths in this compiler slice;
+- rejects linked paths in this compiler/runtime slice;
 - requires every `localized_projection_fields` entry to be a selected root scalar field;
 - rejects localized projection fields from the ordinary identity filter and identity ordering.
 
@@ -66,7 +66,7 @@ Its fingerprint binds fold mode, tenant/schema, requested/fallback roles, ordina
 `any_locale_filter`, canonical localized projection roles and ordering. A token cannot cross fold modes or
 be reused after changing projection/search/fallback semantics.
 
-## PostgreSQL fold compiler — source complete
+## PostgreSQL fold compiler
 
 `SchemaRegistry::compile_postgres_localized_page_query` compiles one page statement and optional exact
 count without modifying the ordinary PostgreSQL compiler.
@@ -80,14 +80,14 @@ The page compiler uses canonical physical aliases:
 - `t4` — lower-locale anti-duplicate anchor candidate.
 
 Every physical role is an `index_entities AS "tN"` relation with the ordinary
-`"tN".is_deleted = FALSE` anchor. This is deliberate: the existing generic
-`PostgresQueryEntityAdmission` can inject current owner freshness rules into every participating row role
-without a Product-specific compiler branch.
+`"tN".is_deleted = FALSE` anchor. The existing generic `PostgresQueryEntityAdmission` can therefore
+inject current owner freshness rules into every participating row role without a Product-specific compiler
+branch.
 
 One Product identity survives page/count selection by choosing the lexicographically lowest **admitted**
 physical locale row as `t0`: an identity is rejected as a duplicate when an admitted same-identity `t4`
-with a lower locale key exists. Grouping/de-duplication therefore happens before ordering, lookahead,
-limit and exact count.
+with a lower locale key exists. De-duplication therefore happens before ordering, lookahead, limit and
+exact count.
 
 Ordinary identity filters and ordering are evaluated on `t0`. `any_locale_filter` is compiled into an
 `EXISTS` over `t3`. Localized projected fields use row-presence `CASE`, not value-level `COALESCE`, so a
@@ -99,43 +99,65 @@ fallback projection availability does not change owner Product identity count.
 The compiler emits a dedicated `LocalizedQueryPlanFingerprint` in addition to the ordinary plan
 fingerprint. It binds the canonical fallback, any-locale predicate and localized projection roles.
 
-## Decoder — source complete
+## Decoder
 
 `SchemaRegistry::decode_postgres_localized_query_page` verifies both ordinary and localized plan
 fingerprints, exact column contracts, lookahead bounds and exact-count shape.
 
 For unlisted fields it preserves the ordinary schema nullability/type/cardinality contract. For an explicit
 localized projection field only, SQL null is additionally valid and means that neither requested nor
-fallback physical row was admitted. That null is an Index-level absence signal; the later Product
+fallback physical locale row was admitted. That null is an Index-level absence signal; the later Product
 Storefront adapter must apply the existing owner placeholder behavior instead of selecting an arbitrary
 third translation.
 
 Lookahead produces `LocalizedIndexCursor` through `LocalizedCursorCodec`; no ordinary exact-locale cursor
 is emitted or accepted by this path.
 
-## Admission and runtime boundary
+## Runtime execution — source complete
 
-The compiler/decoder are not yet published through `IndexQueryPort` or `SharedIndexQueryRuntime`.
-`execute_localized_query` intentionally does not exist yet.
+`IndexQueryPort` now publishes an explicit `execute_localized_query` method. The trait default fails closed
+with a stable contract-preparation error, so existing non-PostgreSQL/custom adapters remain source
+compatible without silently claiming localized semantics.
 
-The next runtime slice must execute page + exact count in the same read-only repeatable-read snapshot as
-ordinary Index queries, verify persisted schema readiness, and apply the existing entity admission to the
-compiled `t0`/`t1`/`t2`/`t3`/`t4` relations **before execution**. Until that wiring exists, compiled fold
-SQL is not an authoritative production query path.
+`SharedIndexQueryRuntime` forwards the localized capability to the host-selected query port.
 
-Because the current fold rejects linked paths, generic link-target availability injection is not needed
-for this source slice. Linked folded queries remain a later capability/evidence step.
+`PostgresIndexQueryPort::execute_localized_query` implements the canonical execution boundary:
 
-## Search semantics
+1. require PostgreSQL backend;
+2. derive the same persisted schema contracts from the embedded ordinary root query;
+3. compile `CompiledPostgresLocalizedPageQuery`;
+4. apply query-path availability plus `PostgresQueryEntityAdmission` to the compiled fold **before**
+   beginning storage execution;
+5. begin one transaction and configure it as `REPEATABLE READ, READ ONLY`;
+6. verify tenant-scoped persisted schema readiness/fingerprint/JSON/status inside that snapshot;
+7. execute page SQL and optional exact-count SQL in the same snapshot;
+8. decode only through `decode_postgres_localized_query_page`;
+9. commit successful read snapshots or roll back on any error.
+
+Admission preparation is deliberately outside storage execution. A malformed or incompatible trusted
+admission template fails closed before page/count statements run. Persisted readiness remains inside the
+same snapshot as data reads.
+
+The runtime reuses the ordinary page-row mapping, exact-count mapping, schema readiness verifier, bind
+mapping and transaction finalization rather than creating a second storage policy.
+
+Because the current fold validator rejects linked paths, query-path link-target availability is a no-op for
+this initial localized runtime. The same admission helper is still called so future linked support cannot
+silently bypass the established execution boundary.
+
+## Remaining title-search primitive
 
 Any-locale title search remains an identity predicate. A matching physical locale row may admit an
-identity, but that row never becomes result localization merely because it matched. The future scalar
-text-pattern primitive must be compiled inside `any_locale_filter`; adding LIKE/substring to ordinary
-exact-locale filtering alone remains insufficient.
+identity, but that row never becomes result localization merely because it matched.
+
+The current generic filter algebra still lacks a scalar string text-pattern/substring operator matching
+the Product owner `LIKE %search%` semantics. The next source slice must add one generic bounded scalar
+text-pattern primitive and compile it inside `any_locale_filter`; adding LIKE/substring only to ordinary
+exact-locale filtering remains insufficient.
 
 ## Storefront adapter boundary
 
-After runtime execution and text-pattern support exist, the Product adapter must:
+After scalar text-pattern support exists, the Product adapter must:
 
 - map Active + published-only/category/channel visibility predicates;
 - resolve public Product attribute/option codes to canonical `attribute_terms`;
@@ -160,8 +182,9 @@ Before Storefront traffic can move, PostgreSQL equivalence must cover at least:
 8. interleaved physical locale rows with stable global identity ordering/page boundaries;
 9. cursor continuation and exact-count parity;
 10. delayed/stale locale rows excluded by owner freshness;
-11. restart/recomposition/replay redelivery preserving the same grouped page;
-12. current Product routing-key rebuild/promotion rather than a historical lower key.
+11. persisted schema readiness failure before authoritative query results;
+12. fresh runtime/recomposition/replay redelivery preserving the same grouped page;
+13. current Product routing-key rebuild/promotion rather than a historical lower key.
 
 Linked-target lag evidence remains required before adding linked paths to folded execution.
 
@@ -170,9 +193,8 @@ Linked-target lag evidence remains required before adding linked paths to folded
 This slice does not:
 
 - change ordinary `IndexQuery` or its compiler/cursor;
-- publish localized runtime execution;
 - add scalar text-pattern matching;
-- implement the Storefront Index adapter;
+- implement the Product Storefront Index adapter;
 - actualize/execute retained Product PostgreSQL packets;
 - add Product typed events or bypass event-digest admission;
 - rebuild/promote a tenant Product schema;
@@ -180,17 +202,18 @@ This slice does not:
 
 ## Next implementation slice
 
-Wire `CompiledPostgresLocalizedPageQuery` into the PostgreSQL query port behind a separate explicit
-localized execution method. Reuse persisted readiness, read-only repeatable-read execution and
-`PostgresQueryEntityAdmission`, fail closed before storage execution on admission/preparation errors, and
-decode with `decode_postgres_localized_query_page`. Only after that runtime boundary is complete should
-generic scalar text-pattern matching be added to `any_locale_filter`.
+Add a generic bounded scalar string text-pattern primitive to the Index filter contract and PostgreSQL
+compiler, then allow it inside `LocalizedEntityQuery::any_locale_filter`. Keep the operator generic and
+schema-validated; do not add a Product-specific SQL branch. After that, implement the Product Storefront
+adapter plus retained owner-vs-Index localized-query PostgreSQL evidence before any traffic cutover.
 
 ## Source guards
 
 - `scripts/verify/verify-index-localized-query-contract.mjs` locks query/projection/cursor roles.
 - `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks the root-only page/count compiler,
-  physical alias/admission anchors and decoder while forbidding premature runtime publication.
+  physical alias/admission anchors and decoder.
+- `scripts/verify/verify-index-localized-query-runtime.mjs` locks fail-closed port publication, host
+  forwarding, readiness/admission-before-execution and one-snapshot page/count runtime semantics.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,14 +1,15 @@
 # M7 Product Storefront Index parity gate
 
-Status: `localized_compiler_decoder_source_complete_runtime_and_evidence_pending`.
+Status: `localized_runtime_source_complete_text_pattern_adapter_and_evidence_pending`.
 
 ## Purpose
 
 The Product Storefront catalog remains owner-native. The single current Product Index source materializes
 the Storefront scalar fields, stable tag identities, and typed EAV query state that were previously
 missing. The remaining localized Product identity mismatch now has a selected architecture, explicit
-query/cursor contract, and root-only PostgreSQL fold compiler/decoder. Production runtime execution and
-retained owner-vs-Index equivalence evidence are still pending.
+query/cursor contract, PostgreSQL fold compiler/decoder, and fail-closed PostgreSQL runtime execution.
+Generic scalar text-pattern support, the Product Storefront adapter, and retained owner-vs-Index evidence
+are still pending.
 
 Storefront must continue to execute `CatalogService::list_published_products_with_query`.
 
@@ -16,204 +17,151 @@ Storefront must continue to execute `CatalogService::list_published_products_wit
 
 `StorefrontProductListQuery` accepts optional title search/category, `published_at` or `created_at`
 sorting in either direction, up to eight typed Product EAV predicates, and page/per-page pagination.
-
 Owner execution additionally enforces tenant scope, Active status, non-null `published_at`, public
 SalesChannel visibility, exact count, stable timestamp+ID ordering, Product translation fallback, and
 localized tag projection.
 
-Two translation details are authoritative today:
+Two translation details remain authoritative:
 
-1. `product_title_search_condition` uses an `EXISTS` over `product_translations` for the Product and does
-   **not** restrict that search row to the requested or fallback locale. A title match in any Product
-   translation can therefore admit the Product.
-2. Result projection calls `pick_product_translation(items, requested, fallback)`. If the requested
-   translation is absent, the owner list can still return the Product using its fallback translation.
-
-The public item then returns `id`, `status`, effective `title`, effective `handle`, `seller_id`, `vendor`,
-`product_type`, localized tag names, `created_at`, and `published_at`.
+1. `product_title_search_condition` uses an `EXISTS` over `product_translations` and does **not** restrict
+   the matching row to requested/fallback locale;
+2. result projection uses `pick_product_translation(items, requested, fallback)`.
 
 ## Single current Product Index coverage
 
-Current Product runtime code publishes one Product schema with 15 fields and two links:
+Current Product runtime code publishes one Product schema with 15 fields and two links. Product Index
+still emits one physical entity per stored translation locale. It does not fabricate requested/fallback
+rows. This physical model remains correct; Storefront equivalence is resolved by the query fold, not by
+another Product schema/routing key.
 
-- identity/content: `id`, `status`, `title`, `handle`, `description`;
-- Storefront owner scalars: `seller_id`, `vendor`, `product_type`, `primary_category_id`, `created_at`,
-  `published_at`;
-- stable Taxonomy identities: `tag_ids`;
-- typed EAV query machinery: `attribute_terms`;
-- graph membership: `variant_ids`, `sales_channel_ids`;
-- links `variants` and `sales_channels`.
+Do **not** add another Product routing key merely to patch localized Storefront query semantics. The
+current Product contract remains the only runtime Product implementation.
 
-The source emits **one Index entity for each physically stored `product_translations.locale`**. It does
-not fabricate a requested-locale row when that translation is absent. The Product absence provider
-correctly reports that exact locale identity as absent; it is not a Storefront fallback synthesizer.
+## Localized identity fold — source complete
 
-This physical storage model remains correct. Storefront equivalence is resolved at query composition,
-not by introducing another Product schema or fabricating locale rows during replay.
+The selected generic fold preserves logical result identity
+`(tenant_id, schema_ref, entity_id)` while physical storage remains locale-keyed.
 
-## Selected locale/search architecture
+`LocalizedEntityQuery` provides:
 
-A scalar substring/LIKE operator alone cannot close Storefront parity:
+- requested locale through `query.scope.locale`;
+- canonical fallback locale;
+- root-only `any_locale_filter` for identity-level existential matching;
+- explicit `localized_projection_fields` for requested -> fallback -> null output semantics.
 
-- searching only the current Index entity's `title` would miss owner matches that exist in another
-  translation;
-- querying only the requested locale would omit Products for which the owner list returns a fallback
-  translation;
-- issuing an independent fallback query after the requested query would not automatically preserve one
-  owner-equivalent global sort, page boundary, exact count, and de-duplication contract.
+`LocalizedCursorCodec` uses dedicated scoped wire version `3`; ordinary exact-locale cursors remain on
+version `2` and cannot cross modes.
 
-The selected design is a generic **localized-entity identity fold** in the Index query layer. Physical
-Index rows remain locale-keyed, while the folded page is de-duplicated by Product entity identity before
-exact count and pagination. Any admitted locale row may satisfy title search; result localization is
-selected independently as requested locale, then fallback locale, then no localized row.
+The initial fold deliberately rejects linked query paths. Current Product Storefront list identity
+predicates can still be expressed through root fields such as `sales_channel_ids` and `attribute_terms`.
+Linked folded paths remain separately evidence-gated.
 
-Ordinary exact-locale `IndexQuery` remains unchanged. A consumer must not approximate the folded contract
-by independently paging multiple locales and merging them afterward.
+## PostgreSQL compiler/decoder — source complete
 
-See `m7-product-storefront-localized-query-architecture.md` for the identity, search, projection,
-ordering, cursor, freshness, compiler/decoder, and retained-evidence contracts.
-
-Do **not** add another Product routing key merely to patch this query semantic. The current Product
-contract remains the only runtime Product implementation.
-
-## Generic query/cursor contract — source complete
-
-`rustok-index` now exposes:
-
-- `LocalizedEntityQuery`, keeping requested locale in `query.scope.locale` and fallback as a separate
-  canonical role;
-- `any_locale_filter` as a separate root-only identity predicate;
-- `localized_projection_fields` as an explicit selected root-scalar role set for requested -> fallback ->
-  null projection, preventing arbitrary third-locale content leakage without changing schema fingerprint;
-- `SchemaRegistry::validate_localized_entity_query`, reusing ordinary field/operator/type validation and
-  requiring a locale-required schema;
-- `LocalizedCursorCodec` with dedicated scoped wire version `3`; ordinary exact-locale cursors remain on
-  version `2`;
-- continuation fingerprint binding requested/fallback, ordinary filter, any-locale filter, localized
-  projection roles, order and schema identity.
-
-The initial fold is deliberately root-only. Linked folded paths remain a later capability/evidence step.
-
-## PostgreSQL fold compiler/decoder — source complete
-
-`SchemaRegistry::compile_postgres_localized_page_query` emits one root identity-fold page statement and
-matching exact-count statement. It uses canonical physical aliases:
+`SchemaRegistry::compile_postgres_localized_page_query` uses canonical physical aliases:
 
 - `t0` deterministic admitted identity anchor;
 - `t1` requested projection row;
 - `t2` fallback projection row;
-- `t3` any-locale existential predicate row;
-- `t4` lower-locale anti-duplicate anchor candidate.
+- `t3` any-locale predicate row;
+- `t4` lower-locale anti-duplicate candidate.
 
-Each physical role keeps the ordinary `is_deleted = FALSE` compiler anchor, allowing the existing generic
-`PostgresQueryEntityAdmission` to apply owner freshness to every row role. One identity survives before
-order/lookahead/limit/count by excluding an admitted lower-locale `t4` row.
+All physical roles retain the ordinary `is_deleted = FALSE` anchor so trusted generic
+`PostgresQueryEntityAdmission` can inject current owner freshness before execution. De-duplication occurs
+before ordering/lookahead/limit/exact-count. Requested/fallback projection uses row-presence `CASE`, and
+exact count is independent of projection-row availability.
 
-Localized output uses row-presence `CASE`: an admitted requested row wins even when a selected field itself
-is nullable; fallback is used only when the requested physical row is absent. Exact count uses the same
-identity/search boundary but does not depend on requested/fallback projection availability.
+`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary plus localized plan identity,
+column/count/lookahead contracts, allows extra SQL-null only for explicit localized projection fields,
+and emits dedicated localized continuation cursors.
 
-`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary plus localized plan fingerprints,
-column/count contracts and lookahead. SQL null is additionally accepted only for fields explicitly listed
-in `localized_projection_fields`, representing absence of both admitted requested and fallback rows.
-Lookahead emits only `LocalizedCursorCodec` continuation tokens.
+## PostgreSQL runtime — source complete
 
-## Runtime remains fail-closed
+`IndexQueryPort` now exposes explicit `execute_localized_query`. Its default implementation fails closed,
+keeping existing adapters source-compatible without claiming unsupported semantics.
 
-The public query runtime still has no `execute_localized_query` method. The compiler/decoder are not yet
-an authoritative production execution path.
+`SharedIndexQueryRuntime` forwards the capability to the host-selected port.
 
-The next slice must wire them into the PostgreSQL query port with:
+The canonical `PostgresIndexQueryPort` execution path:
 
-- persisted schema readiness verification;
-- generic entity admission applied before storage execution;
-- one read-only repeatable-read transaction for page + exact count;
-- result decoding only through `decode_postgres_localized_query_page`;
-- fail-closed preparation/admission/readiness errors.
+1. requires PostgreSQL;
+2. compiles the localized page/count contract;
+3. applies query-path availability plus generic owner entity admission to all compiled physical aliases
+   before storage execution;
+4. begins one `REPEATABLE READ, READ ONLY` transaction;
+5. verifies tenant-scoped persisted schema status/fingerprint/JSON inside that snapshot;
+6. executes page and optional exact count in the same snapshot;
+7. decodes only through `decode_postgres_localized_query_page`;
+8. commits successful read snapshots and rolls back failures.
 
-Because the current compiler rejects linked paths, link-target availability is not widened silently in
-this slice.
+This reuses the ordinary readiness verifier, bind mapping, row mapping, exact-count mapping, and
+transaction finalization. No second storage policy is introduced.
 
-## Typed EAV representation
+## Remaining search gap
 
-Dynamic EAV attributes do not create dynamic Index fields. Public Product attribute/option codes are
-resolved through Product owner metadata to stable UUIDs; the adapter then builds
-`Contains(attribute_terms, term)` predicates.
+A scalar substring/LIKE operator alone was previously insufficient because exact-locale querying could
+not preserve any-locale admission plus requested/fallback projection. The fold now solves that identity
+problem, but the generic filter algebra still lacks a scalar string text-pattern primitive matching the
+owner `LIKE %search%` behavior.
 
-Localized text EAV uses the exact owner predicate:
+The next source slice must add one generic bounded scalar string text-pattern operator and compile it in
+ordinary root SQL so it can be used safely inside `any_locale_filter`. It must not introduce a
+Product-specific SQL branch.
 
-`requested-value OR (NOT requested-present AND fallback-value)`
+## Typed EAV and Taxonomy boundaries
 
-See `m7-product-attribute-term-contract.md`.
+Dynamic Product EAV remains represented by canonical UUID-keyed `attribute_terms`. Public Product
+attribute/option codes must be resolved through Product owner metadata before building Index predicates.
 
-## Tags remain Taxonomy-owned
-
-Index stores stable `product_tags.term_id` UUIDs, not localized Taxonomy names. A future Storefront Index
-adapter must batch-hydrate requested/fallback tag names from Taxonomy after Product page selection. That
-boundary remains evidence-gated and does not require Product to own Taxonomy translation freshness.
+Index stores stable Product tag UUIDs, not localized Taxonomy names. A future Storefront adapter must
+batch-hydrate requested/fallback tag names only after the Product page is fixed.
 
 ## Immutable replacement boundary
 
-The previous Product fingerprint was not modified in place. Current runtime code publishes one higher
-internal routing key, derives replay IDs with `derive_index_schema_source_event_id`, and publishes no
-lower Product compatibility implementation.
-
-Lower persisted Product keys are historical storage identities only. Promotion remains staged:
-
-1. ordinary-register the current key;
-2. rebuild/replay it completely;
-3. prove exact readiness, freshness, inbox isolation, and query parity;
-4. call `PostgresSchemaRegistrationStore::register_current` to retire lower active persisted keys;
-5. only then allow an authoritative consumer cutover.
+The current Product routing key remains internal storage/replay identity. Lower persisted keys are
+historical only. Promotion remains staged: register current key, rebuild/replay, prove readiness/parity,
+`register_current` to retire lower active keys, then consumer cutover.
 
 ## Remaining work before Storefront cutover
 
-Storefront traffic stays blocked until all of these are complete:
-
-1. wire localized compiler/decoder through the production PostgreSQL query runtime with readiness and
-   owner admission;
-2. add the required generic scalar text-pattern primitive inside the folded any-locale identity
-   predicate;
-3. translate Active + published-only, category, visibility, EAV, timestamp ordering, ID tie-break,
-   pagination, and exact count to Index;
-4. resolve Product attribute/option codes to canonical EAV terms;
+1. add generic scalar text-pattern matching usable in folded `any_locale_filter`;
+2. implement the Product Storefront Index adapter;
+3. map Active + published-only/category/channel/EAV/order/page/count semantics;
+4. resolve Product attribute/option codes to canonical terms;
 5. batch-hydrate localized Taxonomy tag names;
-6. actualize retained Product PostgreSQL packets to the current Product routing key/source contract;
-7. retain and execute full owner-vs-Index equivalence for requested locale present/absent, fallback,
-   cross-locale title matches, EAV, visibility, ordering, pagination, exact count and restart;
-8. extend folded linked paths only with explicit target-lag availability evidence;
-9. stage/rebuild/promote the current Product key for the tenant;
+6. actualize retained Product PostgreSQL packets to routing key `4` / current 15-field contract;
+7. retain and execute owner-vs-Index localized equivalence, including requested/fallback/third-locale
+   search, de-dup, ordering, pagination, exact count, stale locale materialization, readiness and restart;
+8. extend linked folded paths only with explicit target-lag availability evidence;
+9. stage/rebuild/promote the current Product key for a tenant;
 10. only then select Index traffic.
 
 ## Source guards
 
-- `scripts/verify/verify-index-product-storefront-parity-gate.mjs` keeps Storefront owner-native and locks
-  the physical/source boundary.
-- `scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs` locks the selected
-  identity-fold architecture plus source-complete query/compiler/decoder contracts.
-- `scripts/verify/verify-index-localized-query-contract.mjs` locks query/projection/cursor roles.
-- `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks the page/count compiler and
-  decoder while forbidding premature runtime publication.
+- `verify-index-product-storefront-parity-gate.mjs` keeps Storefront owner-native and locks the physical
+  source boundary;
+- `verify-index-product-storefront-localized-query-architecture.mjs` locks the fold architecture;
+- `verify-index-localized-query-contract.mjs` locks query/projection/cursor roles;
+- `verify-index-localized-query-postgres-fold.mjs` locks compiler/decoder semantics;
+- `verify-index-localized-query-runtime.mjs` locks fail-closed port publication, readiness, admission and
+  one-snapshot execution.
 
 ## Deliberate limits
 
-This slice does not publish localized runtime execution, change owner Storefront semantics, add another
-Product routing key, implement the Storefront Index adapter, execute tenant rebuild, add public typed
-Product events, or switch traffic.
+This slice does not add scalar text-pattern matching, implement the Product Storefront adapter, execute or
+admit PostgreSQL evidence, rebuild/promote a tenant Product schema, add Product typed events, or switch
+Storefront traffic.
 
 ## Maintainer verification
 
 ```bash
 node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-localized-query-postgres-fold.mjs
+node scripts/verify/verify-index-localized-query-runtime.mjs
 node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
-node scripts/verify/verify-index-product-source.mjs
-node scripts/verify/verify-index-product-attribute-term-contract.mjs
 node scripts/verify/verify-index-query-contract.mjs
-node scripts/verify/verify-product-storefront-boundary.mjs
 cargo check -p rustok-index --all-targets
-cargo check -p rustok-distribution --features mod-product --all-targets
 git diff --check
 ```
 

--- a/crates/rustok-index/src/application/query_port.rs
+++ b/crates/rustok-index/src/application/query_port.rs
@@ -3,10 +3,11 @@ use std::fmt;
 use async_trait::async_trait;
 use thiserror::Error;
 
-use crate::domain::{IndexQuery, SchemaRef};
+use crate::domain::{IndexQuery, LocalizedEntityQuery, SchemaRef};
 
 use super::{
-    IndexQueryPage, PostgresQueryDecodeError, PostgresQueryPageBuildError, QueryPlanError,
+    IndexQueryPage, PostgresLocalizedQueryBuildError, PostgresLocalizedQueryDecodeError,
+    PostgresQueryDecodeError, PostgresQueryPageBuildError, QueryPlanError,
 };
 
 /// Persisted schema state that prevents a compiled query from executing safely.
@@ -37,7 +38,11 @@ pub enum IndexQueryExecutionError {
     #[error(transparent)]
     Build(#[from] PostgresQueryPageBuildError),
     #[error(transparent)]
+    LocalizedBuild(#[from] PostgresLocalizedQueryBuildError),
+    #[error(transparent)]
     Decode(#[from] PostgresQueryDecodeError),
+    #[error(transparent)]
+    LocalizedDecode(#[from] PostgresLocalizedQueryDecodeError),
     #[error("Index query execution requires a PostgreSQL connection")]
     UnsupportedBackend,
     #[error("persisted Index schema is not query-ready: {reference} ({reason})")]
@@ -106,4 +111,20 @@ pub trait IndexQueryPort: Send + Sync {
         &self,
         query: IndexQuery,
     ) -> Result<IndexQueryPage, IndexQueryExecutionError>;
+
+    /// Explicit localized identity-fold capability.
+    ///
+    /// Existing adapters remain source-compatible and fail closed until they implement the localized
+    /// execution contract. The canonical PostgreSQL adapter overrides this method only after fold SQL,
+    /// persisted readiness, trusted owner admission, one-snapshot page/count execution, and decoder
+    /// semantics are available together.
+    async fn execute_localized_query(
+        &self,
+        query: LocalizedEntityQuery,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        Err(IndexQueryExecutionError::contract_preparation(
+            query.query.schema.clone(),
+            "localized Index query execution is unavailable for this adapter",
+        ))
+    }
 }

--- a/crates/rustok-index/src/application/query_runtime.rs
+++ b/crates/rustok-index/src/application/query_runtime.rs
@@ -2,7 +2,7 @@ use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 
-use crate::domain::IndexQuery;
+use crate::domain::{IndexQuery, LocalizedEntityQuery};
 
 use super::{IndexQueryExecutionError, IndexQueryPage, IndexQueryPort};
 
@@ -41,5 +41,12 @@ impl IndexQueryPort for SharedIndexQueryRuntime {
         query: IndexQuery,
     ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
         self.port.execute_query(query).await
+    }
+
+    async fn execute_localized_query(
+        &self,
+        query: LocalizedEntityQuery,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        self.port.execute_localized_query(query).await
     }
 }

--- a/crates/rustok-index/src/infrastructure/postgres/query_port.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/query_port.rs
@@ -10,12 +10,12 @@ use uuid::Uuid;
 
 use crate::{
     application::{
-        CompiledPostgresCell, CompiledPostgresCount, CompiledPostgresPageQuery,
-        CompiledPostgresQuery, CompiledPostgresRow, CompiledQueryColumn,
-        IndexQueryExecutionError, IndexQueryPage, IndexQueryPort,
-        PersistedSchemaReadinessFailure, PostgresBindValue, SchemaRegistry,
+        CompiledPostgresCell, CompiledPostgresCount, CompiledPostgresLocalizedPageQuery,
+        CompiledPostgresPageQuery, CompiledPostgresQuery, CompiledPostgresRow, CompiledQueryColumn,
+        IndexQueryExecutionError, IndexQueryPage, IndexQueryPort, PersistedSchemaReadinessFailure,
+        PostgresBindValue, SchemaRegistry,
     },
-    domain::{IndexQuery, SchemaRef},
+    domain::{IndexQuery, LocalizedEntityQuery, SchemaRef},
 };
 
 use super::PostgresIndexQueryAdmissionCatalog;
@@ -81,20 +81,49 @@ impl PostgresIndexQueryPort {
         page_query: &CompiledPostgresPageQuery,
     ) -> Result<CompiledPostgresQuery, IndexQueryExecutionError> {
         let mut compiled = page_query.compiled().clone();
+        self.apply_admissions(query, &mut compiled)?;
+        Ok(compiled)
+    }
+
+    fn admitted_localized_page_query(
+        &self,
+        query: &LocalizedEntityQuery,
+        mut page_query: CompiledPostgresLocalizedPageQuery,
+    ) -> Result<CompiledPostgresLocalizedPageQuery, IndexQueryExecutionError> {
+        self.apply_admissions(&query.query, page_query.compiled_mut())?;
+        Ok(page_query)
+    }
+
+    fn apply_admissions(
+        &self,
+        query: &IndexQuery,
+        compiled: &mut CompiledPostgresQuery,
+    ) -> Result<(), IndexQueryExecutionError> {
         self.admissions
-            .apply_link_target_availability(query, &mut compiled)
+            .apply_link_target_availability(query, compiled)
             .map_err(|error| {
                 IndexQueryExecutionError::contract_preparation(query.schema.clone(), error)
             })?;
         if let Some(descriptor) = self.admissions.get(&query.schema) {
-            descriptor
-                .admission()
-                .apply(&mut compiled)
-                .map_err(|error| {
-                    IndexQueryExecutionError::contract_preparation(query.schema.clone(), error)
-                })?;
+            descriptor.admission().apply(compiled).map_err(|error| {
+                IndexQueryExecutionError::contract_preparation(query.schema.clone(), error)
+            })?;
         }
-        Ok(compiled)
+        Ok(())
+    }
+
+    async fn configure_snapshot_and_verify(
+        transaction: &DatabaseTransaction,
+        query: &IndexQuery,
+        required_schemas: &[RequiredSchemaContract],
+    ) -> Result<(), IndexQueryExecutionError> {
+        transaction
+            .execute_unprepared(READ_ONLY_SNAPSHOT_SQL)
+            .await
+            .map_err(|error| {
+                IndexQueryExecutionError::storage("configure read-only snapshot", error)
+            })?;
+        verify_persisted_schemas(transaction, query, required_schemas).await
     }
 
     async fn execute_in_transaction(
@@ -105,23 +134,9 @@ impl PostgresIndexQueryPort {
         compiled: &CompiledPostgresQuery,
         required_schemas: &[RequiredSchemaContract],
     ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
-        transaction
-            .execute_unprepared(READ_ONLY_SNAPSHOT_SQL)
-            .await
-            .map_err(|error| {
-                IndexQueryExecutionError::storage("configure read-only snapshot", error)
-            })?;
+        Self::configure_snapshot_and_verify(transaction, query, required_schemas).await?;
 
-        verify_persisted_schemas(transaction, query, required_schemas).await?;
-
-        let page_rows = transaction
-            .query_all(compiled_statement(compiled))
-            .await
-            .map_err(|error| IndexQueryExecutionError::storage("execute page statement", error))?
-            .into_iter()
-            .map(|row| map_page_row(row, compiled))
-            .collect::<Result<Vec<_>, _>>()?;
-
+        let page_rows = execute_page_rows(transaction, compiled).await?;
         let exact_count_row = match compiled.exact_count.as_ref() {
             Some(count) => Some(execute_exact_count(transaction, count).await?),
             None => None,
@@ -130,6 +145,47 @@ impl PostgresIndexQueryPort {
         self.registry
             .decode_postgres_query_page(query, page_query, page_rows, exact_count_row)
             .map_err(IndexQueryExecutionError::from)
+    }
+
+    async fn execute_localized_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        query: &LocalizedEntityQuery,
+        page_query: &CompiledPostgresLocalizedPageQuery,
+        required_schemas: &[RequiredSchemaContract],
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        Self::configure_snapshot_and_verify(transaction, &query.query, required_schemas).await?;
+
+        let compiled = page_query.compiled();
+        let page_rows = execute_page_rows(transaction, compiled).await?;
+        let exact_count_row = match compiled.exact_count.as_ref() {
+            Some(count) => Some(execute_exact_count(transaction, count).await?),
+            None => None,
+        };
+
+        self.registry
+            .decode_postgres_localized_query_page(query, page_query, page_rows, exact_count_row)
+            .map_err(IndexQueryExecutionError::from)
+    }
+
+    async fn finish_transaction(
+        transaction: DatabaseTransaction,
+        result: Result<IndexQueryPage, IndexQueryExecutionError>,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        match result {
+            Ok(page) => {
+                transaction.commit().await.map_err(|error| {
+                    IndexQueryExecutionError::storage("commit query snapshot", error)
+                })?;
+                Ok(page)
+            }
+            Err(error) => {
+                transaction.rollback().await.map_err(|rollback_error| {
+                    IndexQueryExecutionError::storage("rollback query snapshot", rollback_error)
+                })?;
+                Err(error)
+            }
+        }
     }
 }
 
@@ -160,21 +216,36 @@ impl IndexQueryPort for PostgresIndexQueryPort {
                 &required_schemas,
             )
             .await;
+        Self::finish_transaction(transaction, result).await
+    }
 
-        match result {
-            Ok(page) => {
-                transaction.commit().await.map_err(|error| {
-                    IndexQueryExecutionError::storage("commit query snapshot", error)
-                })?;
-                Ok(page)
-            }
-            Err(error) => {
-                transaction.rollback().await.map_err(|rollback_error| {
-                    IndexQueryExecutionError::storage("rollback query snapshot", rollback_error)
-                })?;
-                Err(error)
-            }
+    async fn execute_localized_query(
+        &self,
+        query: LocalizedEntityQuery,
+    ) -> Result<IndexQueryPage, IndexQueryExecutionError> {
+        if self.db.get_database_backend() != DbBackend::Postgres {
+            return Err(IndexQueryExecutionError::UnsupportedBackend);
         }
+
+        let required_schemas = required_schema_contracts(&self.registry, &query.query)?;
+        let page_query = self.registry.compile_postgres_localized_page_query(&query)?;
+        // Trusted owner/link admission is applied to every physical fold alias before the read-only
+        // transaction begins. A malformed admission contract therefore cannot execute page/count SQL.
+        let page_query = self.admitted_localized_page_query(&query, page_query)?;
+        let transaction = self
+            .db
+            .begin()
+            .await
+            .map_err(|error| IndexQueryExecutionError::storage("begin localized query snapshot", error))?;
+        let result = self
+            .execute_localized_in_transaction(
+                &transaction,
+                &query,
+                &page_query,
+                &required_schemas,
+            )
+            .await;
+        Self::finish_transaction(transaction, result).await
     }
 }
 
@@ -267,6 +338,19 @@ async fn verify_persisted_schemas(
         }
     }
     Ok(())
+}
+
+async fn execute_page_rows(
+    transaction: &DatabaseTransaction,
+    compiled: &CompiledPostgresQuery,
+) -> Result<Vec<CompiledPostgresRow>, IndexQueryExecutionError> {
+    transaction
+        .query_all(compiled_statement(compiled))
+        .await
+        .map_err(|error| IndexQueryExecutionError::storage("execute page statement", error))?
+        .into_iter()
+        .map(|row| map_page_row(row, compiled))
+        .collect::<Result<Vec<_>, _>>()
 }
 
 fn compiled_statement(compiled: &CompiledPostgresQuery) -> Statement {

--- a/scripts/verify/verify-index-localized-query-contract.mjs
+++ b/scripts/verify/verify-index-localized-query-contract.mjs
@@ -30,7 +30,6 @@ requireMarkers('crates/rustok-index/src/domain/localized_query.rs', [
   'pub fn is_localized_projection_path(&self, path: &FieldPath)',
   'ordinary_nodes + any_locale_nodes > MAX_LOCALIZED_FILTER_NODES',
 ]);
-
 requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
   'pub enum LocalizedEntityQueryValidationError',
   'LocaleRequiredSchema(SchemaRef)',
@@ -44,7 +43,6 @@ requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
   'probe.filter = Some(filter.clone());',
   'field.cardinality != FieldCardinality::One',
 ]);
-
 requireMarkers('crates/rustok-index/src/application/localized_cursor.rs', [
   'const LOCALIZED_SCOPED_CURSOR_VERSION: u8 = 3;',
   'pub struct LocalizedIndexCursor',
@@ -66,24 +64,17 @@ if (ordinaryCursor.includes('localized_entity_fold_v1')) {
   fail('ordinary cursor codec must not absorb localized fold identity');
 }
 
-requireMarkers('crates/rustok-index/src/application/mod.rs', [
-  'mod localized_cursor;',
-  'mod localized_validation;',
-  'pub use localized_validation::LocalizedEntityQueryValidationError;',
+requireMarkers('crates/rustok-index/src/application/query_port.rs', [
+  'async fn execute_localized_query(',
+  'localized Index query execution is unavailable for this adapter',
 ]);
-
-const port = read('crates/rustok-index/src/application/query_port.rs');
-if (port.includes('execute_localized_query')) {
-  fail('localized execution must remain unpublished until runtime admission/readiness wiring is complete');
-}
-
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
-  'Status: `compiler_decoder_source_complete_runtime_and_evidence_pending`',
+  'Status: `runtime_source_complete_text_pattern_and_evidence_pending`',
   '`LocalizedEntityQuery`',
   '`localized_projection_fields`',
   '`LocalizedCursorCodec`',
   'wire version `3`',
-  'ordinary exact-locale cursor wire version `2` remains unchanged',
+  'ordinary exact-locale cursors remain on version `2`',
 ]);
 
-console.log('[verify-index-localized-query-contract] localized query/projection/cursor contract is source-locked; runtime publication remains pending');
+console.log('[verify-index-localized-query-contract] localized query/projection/cursor contract remains source-locked with fail-closed runtime capability');

--- a/scripts/verify/verify-index-localized-query-postgres-fold.mjs
+++ b/scripts/verify/verify-index-localized-query-postgres-fold.mjs
@@ -48,7 +48,6 @@ requireMarkers(compilerPath, [
   '__exact_count',
   'compiled_mut(&mut self) -> &mut CompiledPostgresQuery',
 ]);
-
 requireMarkers('crates/rustok-index/src/application/postgres_localized_query_result.rs', [
   'pub enum PostgresLocalizedQueryDecodeError',
   'pub fn decode_postgres_localized_query_page(',
@@ -79,9 +78,5 @@ const ordinaryCompiler = read('crates/rustok-index/src/application/postgres_quer
 if (ordinaryCompiler.includes('localized_entity_fold_plan_v1')) {
   fail('ordinary exact-locale SQL compiler must not absorb localized fold semantics');
 }
-const port = read('crates/rustok-index/src/application/query_port.rs');
-if (port.includes('execute_localized_query')) {
-  fail('compiler/decoder slice must not publish runtime localized execution yet');
-}
 
-console.log('[verify-index-localized-query-postgres-fold] localized root identity fold page/count compiler and decoder are source-locked; runtime admission remains pending');
+console.log('[verify-index-localized-query-postgres-fold] localized root identity fold page/count compiler and decoder remain source-locked');

--- a/scripts/verify/verify-index-localized-query-runtime.mjs
+++ b/scripts/verify/verify-index-localized-query-runtime.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-localized-query-runtime] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-index/src/application/query_port.rs', [
+  'LocalizedBuild(#[from] PostgresLocalizedQueryBuildError)',
+  'LocalizedDecode(#[from] PostgresLocalizedQueryDecodeError)',
+  'async fn execute_localized_query(',
+  'query: LocalizedEntityQuery',
+  'localized Index query execution is unavailable for this adapter',
+]);
+requireMarkers('crates/rustok-index/src/application/query_runtime.rs', [
+  'use crate::domain::{IndexQuery, LocalizedEntityQuery};',
+  'async fn execute_localized_query(',
+  'self.port.execute_localized_query(query).await',
+]);
+
+const postgres = requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_port.rs', [
+  'CompiledPostgresLocalizedPageQuery',
+  'domain::{IndexQuery, LocalizedEntityQuery, SchemaRef}',
+  'fn admitted_localized_page_query(',
+  'self.apply_admissions(&query.query, page_query.compiled_mut())?;',
+  'fn apply_admissions(',
+  '.apply_link_target_availability(query, compiled)',
+  'descriptor.admission().apply(compiled)',
+  'async fn configure_snapshot_and_verify(',
+  'READ_ONLY_SNAPSHOT_SQL',
+  'verify_persisted_schemas(transaction, query, required_schemas).await',
+  'async fn execute_localized_in_transaction(',
+  'Self::configure_snapshot_and_verify(transaction, &query.query, required_schemas).await?;',
+  'let page_rows = execute_page_rows(transaction, compiled).await?;',
+  'execute_exact_count(transaction, count).await?',
+  '.decode_postgres_localized_query_page(query, page_query, page_rows, exact_count_row)',
+  'async fn execute_localized_query(',
+  'let required_schemas = required_schema_contracts(&self.registry, &query.query)?;',
+  'let page_query = self.registry.compile_postgres_localized_page_query(&query)?;',
+  'let page_query = self.admitted_localized_page_query(&query, page_query)?;',
+  'begin localized query snapshot',
+  'Self::finish_transaction(transaction, result).await',
+]);
+const admissionPosition = postgres.indexOf('let page_query = self.admitted_localized_page_query(&query, page_query)?;');
+const beginPosition = postgres.indexOf('begin localized query snapshot');
+if (admissionPosition < 0 || beginPosition < 0 || admissionPosition > beginPosition) {
+  fail('localized owner admission must be prepared before the storage transaction begins');
+}
+
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
+  'Status: `runtime_source_complete_text_pattern_and_evidence_pending`',
+  '`execute_localized_query`',
+  'read-only repeatable-read',
+  'persisted schema readiness',
+  '`PostgresQueryEntityAdmission`',
+]);
+
+console.log('[verify-index-localized-query-runtime] localized fold runtime is source-locked behind readiness/admission/snapshot semantics; Product adapter/evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -57,30 +57,27 @@ if (productSource.includes('SchemaVersion::new(3)')) {
 
 const architecturePath = 'crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md';
 requireMarkers(architecturePath, [
-  'Status: `compiler_decoder_source_complete_runtime_and_evidence_pending`',
+  'Status: `runtime_source_complete_text_pattern_and_evidence_pending`',
   '`localized_projection_fields`',
   '`SchemaRegistry::compile_postgres_localized_page_query`',
-  '`t0` — deterministic admitted identity anchor',
-  '`t1` — requested-locale projection row',
-  '`t2` — fallback-locale projection row',
-  '`t3` — any-locale existential predicate row',
-  '`t4` — lower-locale anti-duplicate anchor candidate',
   '`SchemaRegistry::decode_postgres_localized_query_page`',
-  '`LocalizedCursorCodec` uses scoped wire version `3`',
-  'The public query runtime still has no `execute_localized_query` method.',
-  'Wire `CompiledPostgresLocalizedPageQuery` into the PostgreSQL query port',
+  '`IndexQueryPort` now publishes an explicit `execute_localized_query` method.',
+  '`SharedIndexQueryRuntime` forwards the localized capability',
+  '`PostgresIndexQueryPort::execute_localized_query` implements the canonical execution boundary',
+  '`REPEATABLE READ, READ ONLY`',
+  '`PostgresQueryEntityAdmission`',
+  'The next source slice must add one generic bounded scalar string text-pattern primitive',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_compiler_decoder_source_complete_runtime_and_evidence_pending`',
+  'Status: `localized_runtime_source_complete_text_pattern_adapter_and_evidence_pending`',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@678606a78916ed631669e40c617c60a031097138` (#3208)',
-  'Compile the root-only localized-entity fold to one PostgreSQL page/exact-count contract.',
-  'Add the localized page decoder with explicit requested/fallback-null semantics and dedicated cursor.',
-  'wire explicit localized execution into the PostgreSQL Index query port',
+  'Status overlay rechecked from `main@6044dbd5110a65e2ebeee0a6a3a0053d9971b250` (#3210)',
+  'Wire localized execution through the canonical PostgreSQL query runtime with persisted readiness,',
+  'Add generic scalar string text-pattern matching inside folded `any_locale_filter`.',
   'Do not add a runtime alias for key `3`',
 ]);
 
-console.log('[verify-index-product-storefront-localized-query-architecture] localized Product compiler/decoder architecture is locked; runtime and evidence remain pending');
+console.log('[verify-index-product-storefront-localized-query-architecture] localized Product runtime architecture is locked; text pattern, adapter and evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -42,22 +42,6 @@ forbidMarkers(storefrontPath, storefront, [
   'materialize_postgres_index_query_runtime',
 ]);
 
-const typesPath = 'crates/rustok-product/src/services/catalog/types.rs';
-requireMarkers(typesPath, [
-  'pub enum StorefrontProductSortBy',
-  'PublishedAt',
-  'CreatedAt',
-  'pub struct ProductAttributeFilter',
-  'const MAX_ATTRIBUTE_FILTERS: usize = 8',
-  'pub struct StorefrontProductListQuery',
-  'pub attribute_filters: Vec<ProductAttributeFilter>',
-  'pub struct StorefrontProductListItem',
-  'pub seller_id: Option<String>',
-  'pub tags: Vec<String>',
-  'pub created_at: chrono::DateTime<chrono::Utc>',
-  'pub published_at: Option<chrono::DateTime<chrono::Utc>>',
-]);
-
 const ownerQueryPath = 'crates/rustok-product/src/services/catalog/queries.rs';
 const ownerQuery = requireMarkers(ownerQueryPath, [
   'ProductStatus::Active',
@@ -108,19 +92,17 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/schema_registrat
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_compiler_decoder_source_complete_runtime_and_evidence_pending`',
-  'does **not** restrict that search row to the requested or fallback locale',
-  'owner list can still return the Product using its fallback translation',
-  'one Index entity for each physically stored `product_translations.locale`',
-  'A scalar substring/LIKE operator alone cannot close Storefront parity',
+  'Status: `localized_runtime_source_complete_text_pattern_adapter_and_evidence_pending`',
+  'does **not** restrict',
+  'one physical entity per stored translation locale',
   'localized-entity identity fold',
   '`localized_projection_fields`',
   '`SchemaRegistry::compile_postgres_localized_page_query`',
   '`SchemaRegistry::decode_postgres_localized_query_page`',
-  'The public query runtime still has no `execute_localized_query` method.',
-  'm7-product-storefront-localized-query-architecture.md',
-  'Do **not** add another Product routing key merely to patch this query semantic.',
-  'actualize retained Product PostgreSQL packets',
+  '`IndexQueryPort` now exposes explicit `execute_localized_query`',
+  '`REPEATABLE READ, READ ONLY`',
+  'generic scalar string text-pattern',
+  'Do **not** add another Product routing key',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
@@ -128,4 +110,4 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native while localized runtime/evidence are pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native while text-pattern/adapter/evidence gates are pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -83,6 +83,7 @@ const scripts = [
   'verify-index-product-storefront-localized-query-architecture.mjs',
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
+  'verify-index-localized-query-runtime.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- continue the localized fold compiler/decoder merged in #3210 by publishing an explicit fail-closed localized query runtime capability;
- add `IndexQueryPort::execute_localized_query` with a default contract-preparation failure so existing adapters remain source-compatible without claiming unsupported localized semantics;
- forward the capability through `SharedIndexQueryRuntime`;
- extend `IndexQueryExecutionError` with typed localized build/decode failures;
- wire `PostgresIndexQueryPort::execute_localized_query` through the existing persisted-schema readiness, trusted admission, row mapping, exact-count mapping, and transaction finalization machinery;
- apply query-path availability plus generic `PostgresQueryEntityAdmission` to the compiled fold before any page/count storage execution;
- execute persisted readiness, page SQL and optional exact-count SQL in one `REPEATABLE READ, READ ONLY` transaction and decode only through `decode_postgres_localized_query_page`;
- preserve ordinary `execute_query` semantics while factoring common admission/snapshot/page/transaction helpers;
- keep the localized runtime root-only because the fold validator still rejects linked paths; linked folded availability remains a later evidence-gated capability;
- advance Storefront parity/docs/guards to generic scalar text-pattern support as the next source gap.

## Main recheck

The branch started from `main@6044dbd5110a65e2ebeee0a6a3a0053d9971b250` (#3210). Before PR creation, current `main@8aa2887c6933fcacb4c5104ab1e357777c0402fb` had advanced only through #3211 Moderation PostgreSQL owner evidence. That work is disjoint from this `rustok-index` runtime/docs/guard slice. Final compare contains only the expected Index files.

## Boundary

This PR does not add scalar substring/text-pattern matching, implement the Product Storefront adapter, change Product schema/routing key, add Product events, execute/admit localized PostgreSQL equivalence, or switch Storefront traffic. Storefront remains owner-native and fail-closed.

The next source slice is a generic bounded scalar string text-pattern filter operator usable inside localized `any_locale_filter`, with no Product-specific compiler branch.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.