### PR TITLE
test(moderation): add PostgreSQL recovery contract evidence

### DIFF
--- a/crates/rustok-moderation/docs/postgres-recovery-contract.md
+++ b/crates/rustok-moderation/docs/postgres-recovery-contract.md
@@ -1,0 +1,55 @@
+# Moderation PostgreSQL recovery contract evidence
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+`crates/rustok-moderation/tests/postgres_recovery_contract.rs` is an opt-in PostgreSQL integration target for the operator-recovery and legacy-terminal reconciliation invariants in the Moderation plan.
+
+It uses the same isolated-schema pattern as the owner-contract PostgreSQL target and covers four database-backed scenarios:
+
+1. a real pending application is claimed, rejected, explicitly requeued by a human operator, replayed through the same Moderation command receipt, rejects a changed request under that same receipt key, and becomes claimable again with `attempt_count = 2`;
+2. a real applied application closes its case and remains impossible to requeue;
+3. a truthful legacy pre-audit `rejected` application row with a still-`decided` case reconciles to `escalated`, then a new reconciliation request with the current case revision is a no-op;
+4. a truthful legacy pre-audit `applied` row with stored applied revision/time reconciles to `closed`, sets present-time `closed_at`, and releases `active_deduplication_key`.
+
+The harness runs the four production Moderation migrations in a unique temporary PostgreSQL schema. No Forum/domain table or adapter is present, so legacy reconciliation cannot accidentally depend on or invoke domain enforcement.
+
+## Legacy fixture boundary
+
+Normal pending/rejected/applied states in the first two scenarios are created only through public Moderation services (`claim_application_operation`, `mark_application_rejected`, and `mark_application_applied`).
+
+The two legacy scenarios deliberately mutate only `moderation_application_operations` with SQL while leaving the freshly decided case unchanged. This recreates the exact upgrade condition that cannot be reached through the current atomic finalizers: a terminal application row whose case still reflects pre-audit lifecycle state. Reconciliation itself always runs through `operator_reconcile_legacy_application_replay_safe`.
+
+The seeded legacy shapes remain constrained by the production table contract:
+
+- terminal rows have no lease tuple;
+- rejected rows have no applied evidence;
+- applied rows have `applied_revision >= subject_revision` and a non-null `applied_at`.
+
+## Maintainer commands
+
+Intentionally not run while preparing this slice:
+
+```bash
+RUSTOK_MODERATION_TEST_DATABASE_URL=postgres://... \
+  cargo test -p rustok-moderation --test postgres_recovery_contract -- --nocapture
+
+node scripts/verify/verify-moderation-postgres-recovery-contract.mjs
+```
+
+## What success proves
+
+A passing PostgreSQL run demonstrates that the recovery source works against the production PostgreSQL constraints and transactional lifecycle rather than only against SQLite/source inspection:
+
+- rejected/operator intervention can move the same immutable decision back to `retryable` without changing domain idempotency identity;
+- the command receipt replays identical operator input and conflicts on changed input;
+- the next owner claim advances only the application attempt count and does not duplicate the case revision already advanced by requeue;
+- `applied` remains terminal and cannot re-enter the scheduler;
+- legacy rejected/applied rows align only the Moderation case according to persisted terminal operation truth;
+- already-aligned legacy reconciliation is a no-op;
+- applied legacy reconciliation closes at reconciliation time and releases active-case deduplication identity.
+
+This target does not claim adapter invocation, scheduler stop behavior, multi-host dispatcher convergence, or UI evidence; those remain separate retained-evidence slices.
+
+No tests, Cargo commands, Node verifiers, formatting, migrations against a real database, workflows or CI were executed while preparing this file.

--- a/crates/rustok-moderation/tests/postgres_recovery_contract.rs
+++ b/crates/rustok-moderation/tests/postgres_recovery_contract.rs
@@ -1,0 +1,483 @@
+use std::{env, error::Error, time::Duration};
+
+use chrono::Utc;
+use rustok_api::{PortActor, PortContext};
+use rustok_moderation::{
+    AssignModerationCaseCommand, DecideModerationCaseCommand, ModerationApplicationOperationStatus,
+    ModerationCasePriority, ModerationCaseRecord, ModerationCaseStatus, ModerationDecisionApplication,
+    ModerationDecisionEffect, ModerationDecisionEffectAction, ModerationDecisionKind,
+    ModerationDecisionRecord, ModerationError, ModerationReasonCode, ModerationReporterKind,
+    ModerationScopeRef, ModerationService, ModerationSubjectKind, ModerationSubjectRef,
+    OpenModerationCaseCommand, ReconcileLegacyModerationApplicationCommand,
+    RequeueModerationApplicationCommand, SubmitModerationReportCommand,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::{MigrationTrait, MigratorTrait};
+use serde_json::json;
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_MODERATION_TEST_DATABASE_URL";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct TestMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for TestMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_moderation::migrations::migrations()
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Moderation PostgreSQL recovery contract"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url, "moderation_recovery_control").await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_moderation_recovery_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("moderation_recovery_migration_{suffix}"),
+        )
+        .await?;
+        TestMigrator::up(&migration, None).await?;
+        migration.close().await?;
+
+        Ok(Some(Self {
+            control,
+            database_url,
+            schema_name,
+        }))
+    }
+
+    async fn connection(&self, name: &str) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name, name).await
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn postgres_recovery_contract_preserves_requeue_denial_and_legacy_reconciliation(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+
+    let outcome = run_recovery_contract(&database).await;
+    let cleanup = database.cleanup().await;
+    outcome?;
+    cleanup
+}
+
+async fn run_recovery_contract(database: &TestDatabase) -> TestResult<()> {
+    rejected_application_requeues_replay_safely_and_claims_again(database).await?;
+    applied_application_cannot_be_requeued(database).await?;
+    legacy_rejected_application_reconciles_to_escalated(database).await?;
+    legacy_applied_application_reconciles_to_closed(database).await?;
+    Ok(())
+}
+
+async fn rejected_application_requeues_replay_safely_and_claims_again(
+    database: &TestDatabase,
+) -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let service = ModerationService::new(database.connection("recovery_requeue_owner").await?);
+    let (case, decision) = seed_decided_case(&service, tenant_id, actor_id, 21, "requeue").await?;
+
+    let claimed = service
+        .claim_application_operation(tenant_id, decision.id, "postgres-requeue-first", 60)
+        .await?
+        .ok_or_else(|| std::io::Error::other("pending application was not claimable"))?;
+    let lease_token = claimed
+        .lease_token
+        .ok_or_else(|| std::io::Error::other("claimed application has no lease token"))?;
+    assert_eq!(claimed.status, ModerationApplicationOperationStatus::Applying);
+    assert_eq!(claimed.attempt_count, 1);
+
+    let rejected = service
+        .mark_application_rejected(
+            tenant_id,
+            decision.id,
+            lease_token,
+            "postgres_rejected",
+            "postgres recovery contract rejection",
+        )
+        .await?;
+    assert_eq!(rejected.status, ModerationApplicationOperationStatus::Rejected);
+    let escalated = service
+        .get_case(tenant_id, case.id)
+        .await?
+        .ok_or_else(|| std::io::Error::other("rejected application case is missing"))?;
+    assert_eq!(escalated.status, ModerationCaseStatus::Escalated);
+
+    let command = RequeueModerationApplicationCommand {
+        decision_id: decision.id,
+        expected_case_revision: escalated.revision,
+        reason: "operator confirmed same immutable decision should retry".to_string(),
+    };
+    let context = write_context(tenant_id, actor_id, "pg-recovery-requeue");
+    let requeued = service
+        .operator_requeue_application_replay_safe(context.clone(), command.clone())
+        .await?;
+    assert!(requeued.changed);
+    assert_eq!(
+        requeued.operation_status,
+        ModerationApplicationOperationStatus::Retryable
+    );
+    assert_eq!(requeued.case_status, ModerationCaseStatus::ApplyingDecision);
+
+    let replay = service
+        .operator_requeue_application_replay_safe(context.clone(), command.clone())
+        .await?;
+    assert_eq!(replay, requeued);
+    let changed_request = service
+        .operator_requeue_application_replay_safe(
+            context,
+            RequeueModerationApplicationCommand {
+                reason: "changed request under the same receipt key".to_string(),
+                ..command
+            },
+        )
+        .await;
+    assert!(matches!(changed_request, Err(ModerationError::IdempotencyConflict)));
+
+    let second_claim = service
+        .claim_application_operation(tenant_id, decision.id, "postgres-requeue-second", 60)
+        .await?
+        .ok_or_else(|| std::io::Error::other("requeued application was not claimable"))?;
+    assert_eq!(second_claim.status, ModerationApplicationOperationStatus::Applying);
+    assert_eq!(second_claim.attempt_count, 2);
+    let applying_case = service
+        .get_case(tenant_id, case.id)
+        .await?
+        .ok_or_else(|| std::io::Error::other("requeued application case is missing"))?;
+    assert_eq!(applying_case.status, ModerationCaseStatus::ApplyingDecision);
+    assert_eq!(applying_case.revision, requeued.case_revision);
+    Ok(())
+}
+
+async fn applied_application_cannot_be_requeued(database: &TestDatabase) -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let service = ModerationService::new(database.connection("recovery_applied_owner").await?);
+    let (case, decision) = seed_decided_case(&service, tenant_id, actor_id, 31, "applied").await?;
+
+    let claimed = service
+        .claim_application_operation(tenant_id, decision.id, "postgres-applied", 60)
+        .await?
+        .ok_or_else(|| std::io::Error::other("application was not claimable"))?;
+    let lease_token = claimed
+        .lease_token
+        .ok_or_else(|| std::io::Error::other("claimed application has no lease token"))?;
+    let applied = service
+        .mark_application_applied(
+            tenant_id,
+            decision.id,
+            lease_token,
+            ModerationDecisionApplication {
+                decision_id: decision.id,
+                subject: case.subject.clone(),
+                applied_revision: case.subject.revision,
+                applied_at: Utc::now(),
+            },
+        )
+        .await?;
+    assert_eq!(applied.status, ModerationApplicationOperationStatus::Applied);
+    let closed = service
+        .get_case(tenant_id, case.id)
+        .await?
+        .ok_or_else(|| std::io::Error::other("applied application case is missing"))?;
+    assert_eq!(closed.status, ModerationCaseStatus::Closed);
+
+    let result = service
+        .operator_requeue_application_replay_safe(
+            write_context(tenant_id, actor_id, "pg-recovery-applied-denial"),
+            RequeueModerationApplicationCommand {
+                decision_id: decision.id,
+                expected_case_revision: closed.revision,
+                reason: "must remain applied".to_string(),
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(ModerationError::Validation(message)) if message.contains("applied decisions must never be requeued")
+    ));
+    assert_eq!(
+        service
+            .get_application_operation(tenant_id, decision.id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("applied operation disappeared"))?
+            .status,
+        ModerationApplicationOperationStatus::Applied
+    );
+    assert_eq!(
+        service
+            .get_case(tenant_id, case.id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("closed case disappeared"))?
+            .status,
+        ModerationCaseStatus::Closed
+    );
+    Ok(())
+}
+
+async fn legacy_rejected_application_reconciles_to_escalated(
+    database: &TestDatabase,
+) -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let service = ModerationService::new(database.connection("legacy_rejected_owner").await?);
+    let (case, decision) = seed_decided_case(&service, tenant_id, actor_id, 41, "legacy-rejected").await?;
+    let storage = database.connection("legacy_rejected_storage").await?;
+    storage
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE moderation_application_operations SET status = 'rejected', last_error_code = 'legacy_rejected', last_error_message = 'legacy terminal row', updated_at = NOW() WHERE tenant_id = $1 AND decision_id = $2",
+            vec![tenant_id.into(), decision.id.into()],
+        ))
+        .await?;
+
+    let reconciled = service
+        .operator_reconcile_legacy_application_replay_safe(
+            write_context(tenant_id, actor_id, "pg-reconcile-legacy-rejected"),
+            ReconcileLegacyModerationApplicationCommand {
+                decision_id: decision.id,
+                expected_case_revision: case.revision,
+                reason: "align legacy rejected terminal row".to_string(),
+            },
+        )
+        .await?;
+    assert!(reconciled.changed);
+    assert_eq!(
+        reconciled.operation_status,
+        ModerationApplicationOperationStatus::Rejected
+    );
+    assert_eq!(reconciled.case_status, ModerationCaseStatus::Escalated);
+
+    let no_op = service
+        .operator_reconcile_legacy_application_replay_safe(
+            write_context(tenant_id, actor_id, "pg-reconcile-legacy-rejected-noop"),
+            ReconcileLegacyModerationApplicationCommand {
+                decision_id: decision.id,
+                expected_case_revision: reconciled.case_revision,
+                reason: "confirm already reconciled rejected row".to_string(),
+            },
+        )
+        .await?;
+    assert!(!no_op.changed);
+    assert_eq!(no_op.case_revision, reconciled.case_revision);
+    Ok(())
+}
+
+async fn legacy_applied_application_reconciles_to_closed(
+    database: &TestDatabase,
+) -> TestResult<()> {
+    let tenant_id = Uuid::new_v4();
+    let actor_id = Uuid::new_v4();
+    let service = ModerationService::new(database.connection("legacy_applied_owner").await?);
+    let (case, decision) = seed_decided_case(&service, tenant_id, actor_id, 51, "legacy-applied").await?;
+    let storage = database.connection("legacy_applied_storage").await?;
+    storage
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "UPDATE moderation_application_operations SET status = 'applied', applied_revision = subject_revision, applied_at = NOW(), updated_at = NOW() WHERE tenant_id = $1 AND decision_id = $2",
+            vec![tenant_id.into(), decision.id.into()],
+        ))
+        .await?;
+
+    let reconciled = service
+        .operator_reconcile_legacy_application_replay_safe(
+            write_context(tenant_id, actor_id, "pg-reconcile-legacy-applied"),
+            ReconcileLegacyModerationApplicationCommand {
+                decision_id: decision.id,
+                expected_case_revision: case.revision,
+                reason: "align legacy applied terminal row".to_string(),
+            },
+        )
+        .await?;
+    assert!(reconciled.changed);
+    assert_eq!(
+        reconciled.operation_status,
+        ModerationApplicationOperationStatus::Applied
+    );
+    assert_eq!(reconciled.case_status, ModerationCaseStatus::Closed);
+
+    let row = storage
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT closed_at IS NOT NULL AS has_closed_at, active_deduplication_key IS NULL AS released_active_key FROM moderation_cases WHERE tenant_id = $1 AND id = $2",
+            vec![tenant_id.into(), case.id.into()],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("reconciled legacy applied case is missing"))?;
+    assert!(row.try_get::<bool>("", "has_closed_at")?);
+    assert!(row.try_get::<bool>("", "released_active_key")?);
+    Ok(())
+}
+
+async fn seed_decided_case(
+    service: &ModerationService,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    subject_revision: i64,
+    key_prefix: &str,
+) -> TestResult<(ModerationCaseRecord, ModerationDecisionRecord)> {
+    let subject_id = Uuid::new_v4();
+    let report = service
+        .submit_report_replay_safe(
+            write_context(tenant_id, actor_id, &format!("{key_prefix}-report")),
+            report_command(actor_id, subject_id, subject_revision),
+        )
+        .await?;
+    let case = service
+        .open_case_replay_safe(
+            write_context(tenant_id, actor_id, &format!("{key_prefix}-case")),
+            case_command(subject_id, subject_revision, vec![report.id]),
+        )
+        .await?;
+    let assigned = service
+        .assign_case_replay_safe(
+            write_context(tenant_id, actor_id, &format!("{key_prefix}-assign")),
+            AssignModerationCaseCommand {
+                case_id: case.id,
+                expected_revision: case.revision,
+                moderator_id: actor_id,
+            },
+        )
+        .await?;
+    let decision = service
+        .decide_case_replay_safe(
+            write_context(tenant_id, actor_id, &format!("{key_prefix}-decide")),
+            DecideModerationCaseCommand {
+                case_id: assigned.id,
+                expected_revision: assigned.revision,
+                decision_kind: ModerationDecisionKind::Warning,
+                reason_code: ModerationReasonCode::Other,
+                effect: ModerationDecisionEffect::v1(
+                    ModerationDecisionEffectAction::NoDomainMutation,
+                )?,
+                policy_snapshot: json!({"policy": "postgres-recovery-contract", "version": 1}),
+            },
+        )
+        .await?;
+    let decided = service
+        .get_case(tenant_id, case.id)
+        .await?
+        .ok_or_else(|| std::io::Error::other("decided case is missing"))?;
+    assert_eq!(decided.status, ModerationCaseStatus::Decided);
+    Ok((decided, decision))
+}
+
+fn write_context(tenant_id: Uuid, actor_id: Uuid, key: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("postgres-moderation-recovery-{key}"),
+    )
+    .with_idempotency_key(key)
+    .with_deadline(Duration::from_secs(5))
+}
+
+fn report_command(
+    actor_id: Uuid,
+    subject_id: Uuid,
+    revision: i64,
+) -> SubmitModerationReportCommand {
+    SubmitModerationReportCommand {
+        scope: ModerationScopeRef::platform(),
+        subject: ModerationSubjectRef {
+            module: "forum".to_string(),
+            kind: ModerationSubjectKind::ForumPost,
+            id: subject_id,
+            revision,
+        },
+        reporter_kind: ModerationReporterKind::User,
+        reporter_id: Some(actor_id),
+        reason_code: ModerationReasonCode::Spam,
+        description_reference: None,
+        metadata: json!({"source": "postgres-recovery-contract"}),
+    }
+}
+
+fn case_command(
+    subject_id: Uuid,
+    revision: i64,
+    report_ids: Vec<Uuid>,
+) -> OpenModerationCaseCommand {
+    OpenModerationCaseCommand {
+        scope: ModerationScopeRef::platform(),
+        subject: ModerationSubjectRef {
+            module: "forum".to_string(),
+            kind: ModerationSubjectKind::ForumPost,
+            id: subject_id,
+            revision,
+        },
+        queue_key: "content".to_string(),
+        priority: ModerationCasePriority::Normal,
+        policy_id: None,
+        policy_version: 1,
+        report_ids,
+        metadata: json!({"source": "postgres-recovery-contract"}),
+    }
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str, application_name: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options).await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url, application_name).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}

--- a/scripts/verify/verify-moderation-postgres-recovery-contract.mjs
+++ b/scripts/verify/verify-moderation-postgres-recovery-contract.mjs
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+
+const test = fs.readFileSync(
+  "crates/rustok-moderation/tests/postgres_recovery_contract.rs",
+  "utf8",
+);
+const docs = fs.readFileSync(
+  "crates/rustok-moderation/docs/postgres-recovery-contract.md",
+  "utf8",
+);
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  'RUSTOK_MODERATION_TEST_DATABASE_URL',
+  'rustok_moderation_recovery_',
+  'TestMigrator::up(&migration, None).await?',
+  'claim_application_operation',
+  'mark_application_rejected',
+  'operator_requeue_application_replay_safe',
+  'ModerationError::IdempotencyConflict',
+  'attempt_count, 2',
+  'mark_application_applied',
+  'applied decisions must never be requeued',
+  'operator_reconcile_legacy_application_replay_safe',
+  "SET status = 'rejected'",
+  "SET status = 'applied'",
+  'applied_revision = subject_revision',
+  'ModerationCaseStatus::Escalated',
+  'ModerationCaseStatus::Closed',
+  'active_deduplication_key IS NULL',
+]) {
+  requireText(test, marker, `Moderation PostgreSQL recovery contract is missing ${marker}`);
+}
+
+for (const marker of [
+  'receipt replays identical operator input',
+  '`applied` remains terminal',
+  'legacy rejected/applied rows',
+  'cargo test -p rustok-moderation --test postgres_recovery_contract',
+]) {
+  requireText(docs, marker, `Moderation PostgreSQL recovery handoff is missing ${marker}`);
+}
+
+console.log("Moderation PostgreSQL recovery contract source guard passed");


### PR DESCRIPTION
## Summary
- add an opt-in PostgreSQL recovery integration target in an isolated temporary schema
- exercise real `claim -> rejected -> operator requeue -> receipt replay/conflict -> next claim` lifecycle and assert attempt-count/case-revision behavior
- prove a real applied application closes its case and can never be requeued
- recreate truthful legacy pre-audit rejected/applied terminal rows and reconcile them through the replay-safe owner command
- prove rejected legacy reconciliation escalates and then no-ops when already aligned
- prove applied legacy reconciliation closes at present time and releases active-case deduplication identity
- add focused maintainer handoff and a static source guard

## Plan context
This advances retained operator-recovery/database evidence after #3211. Normal terminal states are produced through public Moderation owner methods. Direct SQL is used only to create the legacy condition that current atomic finalizers intentionally cannot produce: a terminal application row whose case still has pre-audit `decided` state.

No domain adapter or Forum table exists in the isolated test schema, so legacy reconciliation remains owner-only by construction.

## Verification
Static source review only. PostgreSQL tests, Cargo commands, Node source guard, formatters, real database migrations, workflows and CI were intentionally not run per request.