### PR TITLE
refactor(commerce): cut Product attribute-values read to owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -234,12 +234,16 @@ These are source-contract defects, not verification-only tasks.
   `PRODUCTS_READ` admission, authenticated actor, trimmed locale, request channel,
   bounded deadline, existing product/category input precedence, and the shared stable
   Product GraphQL public error mapper.
-- [ ] Cut remaining mounted Product schema reads (`productAttributeValues` and
-  `storefrontCatalogSearchOptions`), schema writes, REST delete/publish/unpublish
-  lifecycle commands, and remaining GraphQL Product lifecycle operations over to
-  host-composed Product owner ports. Direct Product entities, `CatalogService`, and
-  `ProductCatalogSchemaService` remain explicit source debt; repeatable lifecycle
-  commands need an explicit caller idempotency contract before cutover.
+- [x] Cut mounted GraphQL `productAttributeValues` to the host-selected
+  `ProductCatalogSchemaReadPort::read_product_attribute_values`, preserving current-tenant
+  and `PRODUCTS_READ` admission, authenticated actor, trimmed locale, request channel,
+  bounded deadline, the existing GraphQL projection, and the shared stable Product
+  GraphQL public error mapper.
+- [ ] Cut remaining mounted Product schema read `storefrontCatalogSearchOptions`, schema
+  writes, REST delete/publish/unpublish lifecycle commands, and remaining GraphQL Product
+  lifecycle operations over to host-composed Product owner ports. Direct Product entities,
+  `CatalogService`, and `ProductCatalogSchemaService` remain explicit source debt;
+  repeatable lifecycle commands need an explicit caller idempotency contract before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -868,10 +872,13 @@ Source inspection is not execution evidence.
 - [x] Publish the optional Product schema-directory read capability on the host-selected
   Product read runtime and cut `productAttributes`, `catalogCategories`, and
   `productAttributeSchemas` away from direct `ProductCatalogSchemaService` construction;
-  value/search-option schema reads and Product writes remain open.
+  search-option schema reads and Product writes remain open.
 - [x] Cut mounted `productEffectiveForm` to the host-selected Product schema read port,
   preserving tenant/permission/actor/channel/locale/deadline context and moving aggregate
   reconstruction plus invariant handling back behind the Product owner boundary.
+- [x] Cut mounted `productAttributeValues` to the host-selected Product schema read port,
+  preserving tenant/permission/actor/channel/locale/deadline context, the existing GraphQL
+  projection, and shared stable Product public error mapping.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -2,14 +2,14 @@
 
 ## Scope
 
-Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`, then continued the Product schema-read cutover from `aaa496887fd1492f3feca8ac52261458ce25705e`.
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`, then continued the Product schema-read cutover from `aaa496887fd1492f3feca8ac52261458ce25705e` through the current `main` line.
 
 The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
 
 ## Recheck findings
 
-1. `ProductCatalogSchemaReadPort` publishes the effective-form aggregate capability added by PR #3182. The mounted `productEffectiveForm` resolver was still constructing `ProductCatalogSchemaService` directly and is cut over in the continuation slice below.
-2. The mounted `productAttributeValues` resolver still constructs `ProductCatalogSchemaService` directly. PR #3203 published the transport-neutral owner capability needed for its next consumer cutover.
+1. `ProductCatalogSchemaReadPort` publishes the effective-form aggregate capability added by PR #3182, and mounted `productEffectiveForm` is now cut over to that host-selected owner capability.
+2. PR #3203 published `ProductCatalogSchemaReadPort::read_product_attribute_values`; the mounted `productAttributeValues` resolver was still constructing `ProductCatalogSchemaService` directly and is cut over in the continuation slice below.
 3. `storefrontCatalogSearchOptions` remains a direct `ProductCatalogSchemaService` consumer and still needs an owner projection/cutover.
 4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths use `ProductCatalogReadRuntime`, while legacy mounted `product`/`products` roots in `query::CommerceQuery` still contain direct `CatalogService`/Product entity read paths. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path must remain open; source inspection does not justify a status promotion.
 
@@ -18,7 +18,7 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Published `ProductAttributeValuesRequest` and optional `ProductCatalogSchemaReadPort::read_product_attribute_values`.
 - Kept existing adapters source-compatible with a stable fail-closed `product.attribute_values_unavailable` default.
 - Implemented the in-process Product owner capability through `ProductCatalogSchemaService::load_product_attribute_values`, preserving canonical `PortContext` policy, tenant, locale, deadline, correlation, and stable public `PortError` mapping.
-- Extended `verify-product-catalog-schema-read-port.mjs` so the owner capability is locked in source while the mounted `productAttributeValues` consumer remains explicit follow-up debt.
+- Extended `verify-product-catalog-schema-read-port.mjs` so the owner capability is locked in source while the mounted consumer remained explicit follow-up debt.
 
 ## Effective-form continuation
 
@@ -28,13 +28,19 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Consume the Product-owned aggregate projection directly, so Commerce no longer reconstructs group labels, definitions, options, and missing-definition invariants for this resolver.
 - Extend the schema-read source guard to require the mounted effective-form owner-port path and forbid direct `ProductCatalogSchemaService` construction in it.
 
+## Attribute-values continuation
+
+- Cut mounted `productAttributeValues` to the host-selected `ProductCatalogSchemaReadPort::read_product_attribute_values` capability published in PR #3203.
+- Preserve current-tenant admission, `PRODUCTS_READ`, authenticated actor, trimmed locale, request channel, bounded deadline, and the shared correlation-aware Product GraphQL public error mapper.
+- Preserve the existing GraphQL response shape by mapping the Product-owned `ProductAttributeValueRecord` projection through the existing `GqlProductAttributeValue` conversion.
+- Extend the schema-read source guard to require `ProductAttributeValuesRequest`, the mounted owner-port call, and no direct `ProductCatalogSchemaService` construction in this resolver.
+
 ## Remaining execution order
 
-1. Cut mounted `productAttributeValues` to `ProductCatalogSchemaReadPort::read_product_attribute_values`.
-2. Publish/cut the owner projection needed by `storefrontCatalogSearchOptions`.
-3. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
-4. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
-5. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
+1. Publish/cut the owner projection needed by `storefrontCatalogSearchOptions`.
+2. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
+3. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
+4. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 
 ## Verification state
 

--- a/crates/rustok-commerce/src/graphql/query.rs
+++ b/crates/rustok-commerce/src/graphql/query.rs
@@ -1834,7 +1834,7 @@ impl CommerceQuery {
     ) -> Result<Vec<GqlProductAttributeValue>> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_READ],
             "Permission denied: products:read required",
@@ -1842,10 +1842,33 @@ impl CommerceQuery {
 
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
-        ProductCatalogSchemaService::new(db.clone(), event_bus.clone())
-            .load_product_attribute_values(tenant_id, product_id, locale.trim())
+        let locale = locale.trim();
+        let port_context = product_schema_read_port_context(
+            ctx,
+            tenant_id,
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale,
+            "product_attribute_values",
+        );
+        let schema_read_port = product_schema_read_port(
+            db,
+            event_bus,
+            &port_context,
+            "product_attribute_values",
+        )?;
+        schema_read_port
+            .read_product_attribute_values(
+                port_context.clone(),
+                rustok_product::ProductAttributeValuesRequest { product_id },
+            )
             .await
-            .map_err(|error| map_product_service_error(error, "product_query"))
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "product_attribute_values",
+                ))
+            })
             .map(|items| items.into_iter().map(Into::into).collect())
     }
 

--- a/scripts/verify/verify-product-catalog-schema-read-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-read-port.mjs
@@ -117,6 +117,7 @@ const resolvers = [
   ["catalog_categories", "product_attribute_schemas", ".list_categories("],
   ["product_attribute_schemas", "product_effective_form", ".list_schemas("],
   ["product_effective_form", "product_attribute_values", ".read_effective_form("],
+  ["product_attribute_values", "storefront_catalog_search_options", ".read_product_attribute_values("],
 ];
 for (const [name, nextName, ownerCall] of resolvers) {
   const resolver = resolverSlice(commerceQuery, name, nextName);
@@ -162,13 +163,8 @@ const attributeValues = resolverSlice(
 );
 requireText(
   attributeValues,
-  "ProductCatalogSchemaService::new",
-  "productAttributeValues consumer cutover must remain explicit follow-up debt in this slice",
-);
-forbidText(
-  attributeValues,
-  ".read_product_attribute_values(",
-  "productAttributeValues must not be marked cut over before its consumer slice",
+  "rustok_product::ProductAttributeValuesRequest",
+  "productAttributeValues owner-port cutover must construct ProductAttributeValuesRequest",
 );
 
 if (!process.exitCode) {


### PR DESCRIPTION
## Summary

- cut mounted GraphQL `productAttributeValues` from direct `ProductCatalogSchemaService` construction to the host-selected `ProductCatalogSchemaReadPort::read_product_attribute_values`
- preserve current-tenant admission, `PRODUCTS_READ`, authenticated user actor, trimmed locale, request channel, bounded deadline, and the existing GraphQL response projection
- use the shared correlation-aware Product GraphQL public error mapper
- extend the Product schema-read source guard and actualize the canonical ecommerce plan/recheck packet
- keep `storefrontCatalogSearchOptions`, legacy mounted `product`/`products`, Product schema writes, and lifecycle command cutovers explicitly open

## Verification

Not run per maintainer instruction. No tests, checks, formatter, FBA/FFA promotion, or runtime verification status is claimed by this PR.