### PR TITLE
feat(parity): generate Pages contributions from module metadata

### DIFF
--- a/crates/rustok-pages/admin/Cargo.toml
+++ b/crates/rustok-pages/admin/Cargo.toml
@@ -42,5 +42,10 @@ thiserror.workspace = true
 url = { version = "2.5", optional = true }
 uuid = { workspace = true, optional = true }
 
+[build-dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml.workspace = true
+
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/rustok-pages/admin/build.rs
+++ b/crates/rustok-pages/admin/build.rs
@@ -1,0 +1,421 @@
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+const MODULE_MANIFEST_RELATIVE_PATH: &str = "../rustok-module.toml";
+const GENERATED_FILE: &str = "pages_contribution_manifest.rs";
+const OWNER_PROVIDER_METADATA_KEY: &str = "ownerProvider";
+const PROVIDER_VERSION_METADATA_KEY: &str = "providerVersion";
+
+#[derive(Debug, Deserialize)]
+struct ModuleManifestRoot {
+    module: ModuleMetadata,
+    fba: FbaMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModuleMetadata {
+    slug: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FbaMetadata {
+    builder_consumer: BuilderConsumerMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct BuilderConsumerMetadata {
+    capabilities: Vec<String>,
+    contribution_manifest: ContributionManifestSource,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContributionManifestSource {
+    owner_provider: String,
+    #[serde(default)]
+    target_providers: BTreeMap<String, String>,
+    #[serde(default)]
+    dependencies: BTreeSet<String>,
+    #[serde(default)]
+    required_permissions: BTreeSet<String>,
+    #[serde(default)]
+    admin: Vec<toml::Value>,
+    #[serde(default)]
+    storefront: Vec<toml::Value>,
+}
+
+#[derive(Debug, Clone)]
+struct ContributionExport {
+    id: String,
+    provider: String,
+    required_capabilities: Vec<String>,
+    blocks: Vec<String>,
+    property_editor_id: Option<String>,
+    property_editor_component_type: Option<String>,
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed={MODULE_MANIFEST_RELATIVE_PATH}");
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let manifest_path = manifest_dir.join(MODULE_MANIFEST_RELATIVE_PATH);
+    let source = fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", manifest_path.display()));
+    let root: ModuleManifestRoot = toml::from_str(&source)
+        .unwrap_or_else(|error| panic!("invalid {}: {error}", manifest_path.display()));
+
+    let module_id = required(&root.module.slug, "module.slug");
+    if module_id != "pages" {
+        panic!("Pages admin contribution generator requires module.slug='pages', got '{module_id}'");
+    }
+    let owner_version = required(&root.module.version, "module.version");
+    let cargo_version = env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION");
+    if owner_version != cargo_version {
+        panic!(
+            "Pages module.version '{owner_version}' must match rustok-pages-admin package version '{cargo_version}'"
+        );
+    }
+
+    let builder_capabilities = normalize_strings(
+        root.fba.builder_consumer.capabilities,
+        "fba.builder_consumer.capabilities",
+    );
+    if builder_capabilities.is_empty() {
+        panic!("fba.builder_consumer.capabilities must not be empty");
+    }
+
+    let ContributionManifestSource {
+        owner_provider,
+        target_providers,
+        dependencies,
+        required_permissions,
+        admin,
+        storefront,
+    } = root.fba.builder_consumer.contribution_manifest;
+    let owner_provider = required(&owner_provider, "contribution_manifest.owner_provider");
+    let target_providers = normalize_targets(target_providers, &owner_provider, &owner_version);
+
+    let mut exports = BTreeMap::new();
+    let admin = normalize_contributions(
+        admin,
+        "admin",
+        &owner_provider,
+        &owner_version,
+        &target_providers,
+        &mut exports,
+    );
+    let storefront = normalize_contributions(
+        storefront,
+        "storefront",
+        &owner_provider,
+        &owner_version,
+        &target_providers,
+        &mut exports,
+    );
+
+    let landing = exports
+        .get("landing_blocks")
+        .unwrap_or_else(|| panic!("contribution_manifest.admin must declare role='landing_blocks'"));
+    let metadata = exports
+        .get("metadata")
+        .unwrap_or_else(|| panic!("contribution_manifest.admin must declare role='metadata'"));
+    if landing.provider == owner_provider {
+        panic!("landing_blocks contribution must target a declared external provider");
+    }
+    if metadata.provider != owner_provider {
+        panic!("metadata contribution must target owner provider '{owner_provider}'");
+    }
+    let fly_builtin_version = target_providers
+        .get(&landing.provider)
+        .unwrap_or_else(|| panic!("landing_blocks provider '{}' is not version-pinned", landing.provider));
+    let metadata_property_editor_id = metadata
+        .property_editor_id
+        .as_deref()
+        .unwrap_or_else(|| panic!("metadata contribution must declare exactly one property editor"));
+    let metadata_component_type = metadata
+        .property_editor_component_type
+        .as_deref()
+        .unwrap_or_else(|| panic!("metadata property editor must declare component_type"));
+
+    let manifest_json = json!({
+        "module_id": module_id,
+        "owner_provider": owner_provider,
+        "owner_version": owner_version,
+        "target_providers": target_providers,
+        "dependencies": dependencies,
+        "required_permissions": required_permissions,
+        "admin": admin,
+        "storefront": storefront,
+    });
+    let manifest_json = serde_json::to_string(&manifest_json)
+        .expect("generated Pages contribution manifest must serialize");
+
+    let mut generated = String::from(
+        "// @generated by rustok-pages-admin/build.rs from ../rustok-module.toml.\n// Do not edit by hand.\n\n",
+    );
+    push_str_const(&mut generated, "PAGES_MODULE_ID", &module_id);
+    push_str_const(&mut generated, "PAGES_OWNER_PROVIDER", &owner_provider);
+    push_str_const(
+        &mut generated,
+        "PAGES_OWNER_PROVIDER_VERSION",
+        &owner_version,
+    );
+    push_str_const(&mut generated, "FLY_BUILTIN_PROVIDER", &landing.provider);
+    push_str_const(
+        &mut generated,
+        "FLY_BUILTIN_PROVIDER_VERSION",
+        fly_builtin_version,
+    );
+    push_str_const(
+        &mut generated,
+        "PAGES_LANDING_BLOCKS_CONTRIBUTION_ID",
+        &landing.id,
+    );
+    push_str_const(
+        &mut generated,
+        "PAGES_METADATA_CONTRIBUTION_ID",
+        &metadata.id,
+    );
+    push_str_const(
+        &mut generated,
+        "PAGES_METADATA_PROPERTY_EDITOR_ID",
+        metadata_property_editor_id,
+    );
+    push_str_const(
+        &mut generated,
+        "PAGES_METADATA_COMPONENT_TYPE",
+        metadata_component_type,
+    );
+    push_str_slice_const(
+        &mut generated,
+        "PAGES_BUILDER_CAPABILITIES",
+        &builder_capabilities,
+    );
+    push_str_slice_const(
+        &mut generated,
+        "PAGES_LANDING_BLOCK_CAPABILITIES",
+        &landing.required_capabilities,
+    );
+    push_str_slice_const(
+        &mut generated,
+        "PAGES_METADATA_CAPABILITIES",
+        &metadata.required_capabilities,
+    );
+    push_str_slice_const(
+        &mut generated,
+        "PAGES_LANDING_BLOCK_IDS",
+        &landing.blocks,
+    );
+    generated.push_str(&format!(
+        "pub const GENERATED_PAGES_CONTRIBUTION_MANIFEST_JSON: &str = {manifest_json:?};\n"
+    ));
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+    fs::write(out_dir.join(GENERATED_FILE), generated)
+        .expect("write generated Pages contribution manifest");
+}
+
+fn normalize_targets(
+    targets: BTreeMap<String, String>,
+    owner_provider: &str,
+    owner_version: &str,
+) -> BTreeMap<String, String> {
+    let mut normalized = BTreeMap::new();
+    for (provider, version) in targets {
+        let provider = required(&provider, "target provider");
+        let version = required(&version, "target provider version");
+        if provider == owner_provider {
+            if version != owner_version {
+                panic!(
+                    "target provider '{provider}@{version}' conflicts with owner version '{owner_version}'"
+                );
+            }
+            continue;
+        }
+        if normalized.insert(provider.clone(), version).is_some() {
+            panic!("target provider '{provider}' is duplicated after normalization");
+        }
+    }
+    normalized
+}
+
+fn normalize_contributions(
+    values: Vec<toml::Value>,
+    surface: &str,
+    owner_provider: &str,
+    owner_version: &str,
+    target_providers: &BTreeMap<String, String>,
+    exports: &mut BTreeMap<String, ContributionExport>,
+) -> Vec<serde_json::Value> {
+    values
+        .into_iter()
+        .map(|mut value| {
+            let table = value
+                .as_table_mut()
+                .unwrap_or_else(|| panic!("{surface} contribution must be a TOML table"));
+            let role = take_required_string(table, "role", surface);
+            let id = table_required_string(table, "id", surface);
+            let provider = table_required_string(table, "provider", &id);
+            let expected_version = if provider == owner_provider {
+                owner_version
+            } else {
+                target_providers.get(&provider).map(String::as_str).unwrap_or_else(|| {
+                    panic!(
+                        "contribution '{id}' targets undeclared provider '{provider}'; declare an exact target_providers version"
+                    )
+                })
+            };
+
+            let metadata = table
+                .entry("metadata".to_string())
+                .or_insert_with(|| toml::Value::Table(Default::default()));
+            let metadata = metadata
+                .as_table_mut()
+                .unwrap_or_else(|| panic!("contribution '{id}' metadata must be a TOML table"));
+            if metadata.contains_key(OWNER_PROVIDER_METADATA_KEY)
+                || metadata.contains_key(PROVIDER_VERSION_METADATA_KEY)
+            {
+                panic!(
+                    "contribution '{id}' must not hand-author ownerProvider/providerVersion; build generation owns those fields"
+                );
+            }
+            metadata.insert(
+                OWNER_PROVIDER_METADATA_KEY.to_string(),
+                toml::Value::String(owner_provider.to_string()),
+            );
+            metadata.insert(
+                PROVIDER_VERSION_METADATA_KEY.to_string(),
+                toml::Value::String(expected_version.to_string()),
+            );
+
+            let required_capabilities = table_string_array(table, "required_capabilities", &id);
+            let blocks = table_string_array(table, "blocks", &id);
+            let (property_editor_id, property_editor_component_type) =
+                property_editor_export(table, &role, &id);
+
+            let export = ContributionExport {
+                id: id.clone(),
+                provider,
+                required_capabilities,
+                blocks,
+                property_editor_id,
+                property_editor_component_type,
+            };
+            if exports.insert(role.clone(), export).is_some() {
+                panic!("contribution role '{role}' is duplicated");
+            }
+
+            serde_json::to_value(value)
+                .unwrap_or_else(|error| panic!("contribution '{id}' cannot serialize: {error}"))
+        })
+        .collect()
+}
+
+fn property_editor_export(
+    table: &toml::Table,
+    role: &str,
+    contribution_id: &str,
+) -> (Option<String>, Option<String>) {
+    let editors = table
+        .get("property_editors")
+        .and_then(toml::Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    if role != "metadata" {
+        return (None, None);
+    }
+    if editors.len() != 1 {
+        panic!("metadata contribution '{contribution_id}' must declare exactly one property editor");
+    }
+    let editor = editors[0]
+        .as_table()
+        .unwrap_or_else(|| panic!("metadata property editor must be a TOML table"));
+    (
+        Some(table_required_string(editor, "id", "metadata property editor")),
+        Some(table_required_string(
+            editor,
+            "component_type",
+            "metadata property editor",
+        )),
+    )
+}
+
+fn table_string_array(table: &toml::Table, key: &str, label: &str) -> Vec<String> {
+    let Some(value) = table.get(key) else {
+        return Vec::new();
+    };
+    let values = value
+        .as_array()
+        .unwrap_or_else(|| panic!("{label}.{key} must be an array"));
+    normalize_strings(
+        values
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .unwrap_or_else(|| panic!("{label}.{key} entries must be strings"))
+                    .to_string()
+            })
+            .collect(),
+        &format!("{label}.{key}"),
+    )
+}
+
+fn normalize_strings(values: Vec<String>, label: &str) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(values.len());
+    for value in values {
+        let value = required(&value, label);
+        if !seen.insert(value.clone()) {
+            panic!("{label} contains duplicate '{value}'");
+        }
+        normalized.push(value);
+    }
+    normalized
+}
+
+fn take_required_string(table: &mut toml::Table, key: &str, label: &str) -> String {
+    let value = table
+        .remove(key)
+        .unwrap_or_else(|| panic!("{label} contribution is missing '{key}'"));
+    required(
+        value
+            .as_str()
+            .unwrap_or_else(|| panic!("{label} contribution '{key}' must be a string")),
+        &format!("{label}.{key}"),
+    )
+}
+
+fn table_required_string(table: &toml::Table, key: &str, label: &str) -> String {
+    required(
+        table
+            .get(key)
+            .and_then(toml::Value::as_str)
+            .unwrap_or_else(|| panic!("{label} is missing string '{key}'")),
+        &format!("{label}.{key}"),
+    )
+}
+
+fn required(value: &str, label: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        panic!("{label} must not be empty");
+    }
+    value.to_string()
+}
+
+fn push_str_const(output: &mut String, name: &str, value: &str) {
+    output.push_str(&format!("pub const {name}: &str = {value:?};\n"));
+}
+
+fn push_str_slice_const(output: &mut String, name: &str, values: &[String]) {
+    output.push_str(&format!("pub const {name}: &[&str] = &["));
+    for value in values {
+        output.push_str(&format!("{value:?},"));
+    }
+    output.push_str("];\n");
+}

--- a/crates/rustok-pages/admin/src/contributions.rs
+++ b/crates/rustok-pages/admin/src/contributions.rs
@@ -1,207 +1,54 @@
 use fly_ui::{
-    AccessibilityMetadata, ContributionAssemblyPolicy, ContributionAssemblyResult,
-    ContributionDescriptor, ModuleContributionManifest, PropertyEditorDescriptor,
-    build_admin_contribution_registry_from_manifests,
+    ContributionAssemblyPolicy, ContributionAssemblyResult, ContributionDescriptor,
+    ModuleContributionManifest, build_admin_contribution_registry_from_manifests,
 };
 use rustok_page_builder_admin::{
-    ConsumerPropertyEditorSchema, ConsumerPropertyFieldDescriptor, ConsumerPropertyFieldKind,
-    PAGE_BUILDER_CONSUMER_PROPERTIES_FORMAT,
+    ConsumerPropertyEditorSchema, PAGE_BUILDER_CONSUMER_PROPERTIES_FORMAT,
 };
-use serde_json::{Map, Value};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
 
-pub const PAGES_MODULE_ID: &str = "pages";
-pub const PAGES_OWNER_PROVIDER: &str = "rustok.pages";
-pub const PAGES_OWNER_PROVIDER_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const FLY_BUILTIN_PROVIDER: &str = "fly.builtin";
-pub const FLY_BUILTIN_PROVIDER_VERSION: &str = "1";
-pub const PAGES_LANDING_BLOCKS_CONTRIBUTION_ID: &str = "rustok.pages.landing-blocks";
-pub const PAGES_METADATA_CONTRIBUTION_ID: &str = "rustok.pages.metadata";
-pub const PAGES_METADATA_PROPERTY_EDITOR_ID: &str = "rustok.pages.metadata.editor";
-pub const PAGES_METADATA_COMPONENT_TYPE: &str = "rustok-pages-metadata";
+include!(concat!(env!("OUT_DIR"), "/pages_contribution_manifest.rs"));
 
-pub const PAGES_BUILDER_CAPABILITIES: &[&str] = &["preview", "tree", "properties", "publish"];
-pub const PAGES_LANDING_BLOCK_CAPABILITIES: &[&str] = &["tree", "properties"];
-pub const PAGES_METADATA_CAPABILITIES: &[&str] = &["properties"];
+static GENERATED_PAGES_CONTRIBUTION_MANIFEST: LazyLock<ModuleContributionManifest> =
+    LazyLock::new(|| {
+        serde_json::from_str(GENERATED_PAGES_CONTRIBUTION_MANIFEST_JSON)
+            .expect("build-generated Pages contribution manifest must deserialize")
+    });
 
-pub const PAGES_LANDING_BLOCK_IDS: &[&str] = &[
-    "fly.hero",
-    "fly.two_columns",
-    "fly.feature_grid",
-    "fly.cta",
-    "fly.contact_form",
-];
-
-/// Module-owned metadata used by the generated Fly admin contribution registry.
+/// Build-generated module contribution metadata sourced only from `../rustok-module.toml`.
 ///
-/// Pages owns document lifecycle and metadata persistence. Landing blocks explicitly target
-/// `fly.builtin@1`, while the executable metadata editor remains under the version-pinned
-/// `rustok.pages` owner provider and calls the consumer facade rather than mutating the Fly document.
+/// The build script injects owner/provider versions from canonical module metadata. Pages runtime
+/// never parses TOML and this module does not retain a handwritten contribution descriptor tree.
 pub fn pages_contribution_manifest() -> ModuleContributionManifest {
-    ModuleContributionManifest {
-        module_id: PAGES_MODULE_ID.to_string(),
-        owner_provider: PAGES_OWNER_PROVIDER.to_string(),
-        owner_version: PAGES_OWNER_PROVIDER_VERSION.to_string(),
-        target_providers: BTreeMap::from([(
-            FLY_BUILTIN_PROVIDER.to_string(),
-            FLY_BUILTIN_PROVIDER_VERSION.to_string(),
-        )]),
-        dependencies: BTreeSet::new(),
-        required_permissions: BTreeSet::new(),
-        admin: vec![
-            pages_landing_blocks_contribution(),
-            pages_metadata_contribution(),
-        ],
-        storefront: Vec::new(),
-    }
+    GENERATED_PAGES_CONTRIBUTION_MANIFEST.clone()
 }
 
 pub fn pages_landing_blocks_contribution() -> ContributionDescriptor {
-    ContributionDescriptor {
-        id: PAGES_LANDING_BLOCKS_CONTRIBUTION_ID.to_string(),
-        provider: FLY_BUILTIN_PROVIDER.to_string(),
-        required_capabilities: capability_set(PAGES_LANDING_BLOCK_CAPABILITIES),
-        blocks: PAGES_LANDING_BLOCK_IDS
-            .iter()
-            .map(|id| (*id).to_string())
-            .collect(),
-        renderers: Vec::new(),
-        property_editors: Vec::new(),
-        messages: BTreeMap::from([(
-            "pages.builder.contributions.landingBlocks".to_string(),
-            "Pages landing blocks".to_string(),
-        )]),
-        metadata: Map::from_iter([
-            (
-                "ownerProvider".to_string(),
-                Value::String(PAGES_OWNER_PROVIDER.to_string()),
-            ),
-            (
-                "providerVersion".to_string(),
-                Value::String(FLY_BUILTIN_PROVIDER_VERSION.to_string()),
-            ),
-            ("format".to_string(), Value::String("grapesjs".to_string())),
-            ("surface".to_string(), Value::String("admin".to_string())),
-        ]),
-    }
-}
-
-pub fn pages_metadata_property_schema() -> ConsumerPropertyEditorSchema {
-    ConsumerPropertyEditorSchema {
-        format: PAGE_BUILDER_CONSUMER_PROPERTIES_FORMAT.to_string(),
-        id: "rustok.pages.metadata.schema".to_string(),
-        title: "Page metadata".to_string(),
-        description: Some(
-            "Versioned Pages metadata. Saving these properties never writes the Fly document."
-                .to_string(),
-        ),
-        fields: vec![
-            property_field(
-                "title",
-                "Title",
-                ConsumerPropertyFieldKind::Text,
-                true,
-                512,
-                None,
-                None,
-            ),
-            property_field(
-                "slug",
-                "Slug",
-                ConsumerPropertyFieldKind::Text,
-                true,
-                512,
-                None,
-                None,
-            ),
-            property_field(
-                "meta_title",
-                "SEO title",
-                ConsumerPropertyFieldKind::Text,
-                false,
-                512,
-                None,
-                None,
-            ),
-            property_field(
-                "meta_description",
-                "SEO description",
-                ConsumerPropertyFieldKind::TextArea,
-                false,
-                4_096,
-                None,
-                None,
-            ),
-            property_field(
-                "template",
-                "Template",
-                ConsumerPropertyFieldKind::Text,
-                false,
-                256,
-                None,
-                None,
-            ),
-            property_field(
-                "channel_slugs",
-                "Channels",
-                ConsumerPropertyFieldKind::StringList,
-                false,
-                4_096,
-                Some("Comma-separated channel slugs. Leave empty for every channel."),
-                Some("web, mobile"),
-            ),
-        ],
-    }
+    generated_admin_contribution(PAGES_LANDING_BLOCKS_CONTRIBUTION_ID)
 }
 
 pub fn pages_metadata_contribution() -> ContributionDescriptor {
-    let schema = pages_metadata_property_schema();
-    ContributionDescriptor {
-        id: PAGES_METADATA_CONTRIBUTION_ID.to_string(),
-        provider: PAGES_OWNER_PROVIDER.to_string(),
-        required_capabilities: capability_set(PAGES_METADATA_CAPABILITIES),
-        blocks: Vec::new(),
-        renderers: Vec::new(),
-        property_editors: vec![PropertyEditorDescriptor {
-            id: PAGES_METADATA_PROPERTY_EDITOR_ID.to_string(),
-            component_type: PAGES_METADATA_COMPONENT_TYPE.to_string(),
-            provider: PAGES_OWNER_PROVIDER.to_string(),
-            property_schema: serde_json::to_value(schema)
-                .expect("Pages metadata property schema must be serializable"),
-            accessibility: AccessibilityMetadata {
-                label_message_id: "pages.builder.contributions.metadata.label".to_string(),
-                description_message_id: Some(
-                    "pages.builder.contributions.metadata.description".to_string(),
-                ),
-                keyboard_hint_message_id: None,
-            },
-        }],
-        messages: BTreeMap::from([
-            (
-                "pages.builder.contributions.metadata.label".to_string(),
-                "Page metadata".to_string(),
-            ),
-            (
-                "pages.builder.contributions.metadata.description".to_string(),
-                "Edit versioned Pages metadata without modifying the Fly document.".to_string(),
-            ),
-        ]),
-        metadata: Map::from_iter([
-            (
-                "ownerProvider".to_string(),
-                Value::String(PAGES_OWNER_PROVIDER.to_string()),
-            ),
-            (
-                "providerVersion".to_string(),
-                Value::String(PAGES_OWNER_PROVIDER_VERSION.to_string()),
-            ),
-            (
-                "persistence".to_string(),
-                Value::String("consumer_facade".to_string()),
-            ),
-            ("surface".to_string(), Value::String("admin".to_string())),
-        ]),
-    }
+    generated_admin_contribution(PAGES_METADATA_CONTRIBUTION_ID)
+}
+
+pub fn pages_metadata_property_schema() -> ConsumerPropertyEditorSchema {
+    let contribution = pages_metadata_contribution();
+    let editor = contribution
+        .property_editors
+        .iter()
+        .find(|editor| editor.id == PAGES_METADATA_PROPERTY_EDITOR_ID)
+        .unwrap_or_else(|| {
+            panic!(
+                "generated Pages metadata contribution is missing property editor `{PAGES_METADATA_PROPERTY_EDITOR_ID}`"
+            )
+        });
+    let schema = serde_json::from_value::<ConsumerPropertyEditorSchema>(editor.property_schema.clone())
+        .expect("generated Pages metadata property schema must deserialize");
+    schema
+        .validate()
+        .expect("generated Pages metadata property schema must satisfy Page Builder contract");
+    schema
 }
 
 pub fn pages_admin_contribution_policy() -> ContributionAssemblyPolicy {
@@ -222,24 +69,13 @@ pub fn build_pages_admin_contribution_registry(
     build_admin_contribution_registry_from_manifests([pages_contribution_manifest()], policy)
 }
 
-fn property_field(
-    id: &str,
-    label: &str,
-    kind: ConsumerPropertyFieldKind,
-    required: bool,
-    max_bytes: usize,
-    help: Option<&str>,
-    placeholder: Option<&str>,
-) -> ConsumerPropertyFieldDescriptor {
-    ConsumerPropertyFieldDescriptor {
-        id: id.to_string(),
-        label: label.to_string(),
-        help: help.map(ToString::to_string),
-        kind,
-        required,
-        max_bytes,
-        placeholder: placeholder.map(ToString::to_string),
-    }
+fn generated_admin_contribution(id: &str) -> ContributionDescriptor {
+    GENERATED_PAGES_CONTRIBUTION_MANIFEST
+        .admin
+        .iter()
+        .find(|contribution| contribution.id == id)
+        .cloned()
+        .unwrap_or_else(|| panic!("generated Pages admin contribution `{id}` is missing"))
 }
 
 fn capability_set(capabilities: &[&str]) -> BTreeSet<String> {
@@ -317,14 +153,18 @@ mod tests {
     }
 
     #[test]
-    fn capability_constants_match_the_module_manifest() {
+    fn generated_constants_match_canonical_module_metadata() {
         let module_manifest = include_str!("../../rustok-module.toml");
+        assert!(module_manifest.contains("[fba.builder_consumer.contribution_manifest]"));
+        assert!(module_manifest.contains("role = \"landing_blocks\""));
+        assert!(module_manifest.contains("role = \"metadata\""));
         for capability in PAGES_BUILDER_CAPABILITIES {
-            assert!(
-                module_manifest.contains(&format!("\"{capability}\"")),
-                "Pages module manifest is missing builder capability `{capability}`"
-            );
+            assert!(module_manifest.contains(&format!("\"{capability}\"")));
         }
+        for block_id in PAGES_LANDING_BLOCK_IDS {
+            assert!(module_manifest.contains(&format!("\"{block_id}\"")));
+        }
+        assert_eq!(pages_metadata_property_schema().format, PAGE_BUILDER_CONSUMER_PROPERTIES_FORMAT);
     }
 
     #[test]

--- a/crates/rustok-pages/docs/implementation-plan.md
+++ b/crates/rustok-pages/docs/implementation-plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan for `rustok-pages`
 
-Date: 2026-08-07  
-Status: `in_progress / authenticated-authoring-route-source-ready / inline-edit-asset-delivery-source-ready / admin-launch-source-ready / release-composition-source-ready / artifact-repair-multilocale-recovery-source-ready / rollback-activated-artifact-loss-recovery-source-ready / rollback-activated-repair-rollback-continuity-source-ready / repeated-artifact-loss-recovery-source-ready / execution-rollout-pending`
+Date: 2026-08-08  
+Status: `in_progress / contribution-manifest-generation-source-ready / authenticated-authoring-route-source-ready / inline-edit-asset-delivery-source-ready / admin-launch-source-ready / release-composition-source-ready / artifact-repair-multilocale-recovery-source-ready / rollback-activated-artifact-loss-recovery-source-ready / rollback-activated-repair-rollback-continuity-source-ready / repeated-artifact-loss-recovery-source-ready / execution-rollout-pending`
 
 ## Policy: current code only
 
@@ -22,7 +22,8 @@ Forbidden:
 - enabling the same-origin admin launch in standalone/token-based admin builds;
 - mutable current draft content as immutable artifact repair authority;
 - automatic audit -> rebuild -> activation -> rollback chaining;
-- provenance-only rollback targets without live immutable artifacts and their required historical manifest.
+- provenance-only rollback targets without live immutable artifacts and their required historical manifest;
+- a handwritten Pages Fly contribution descriptor tree beside canonical module metadata.
 
 Fly remains the only visual document and command authority. Pages owns page identity, localization, document revisions, lifecycle, route history, immutable published bindings, artifact audit/rebuild/activation/rollback, caches, authenticated inline grants/save transport and the module-owned inline asset HTTP contract. Pages admin owns the optional same-origin launch control. Release engineering owns deterministic composition and evidence, not Pages document policy.
 
@@ -39,6 +40,18 @@ Fly remains the only visual document and command authority. Pages owns page iden
 - Reviewed Page Builder materialization remains the required publish path.
 - Rollback selects a prior immutable manifest without compiling the current draft.
 - Public/admin publication and rollback transports remain delegated to Pages owner services.
+
+### Canonical Page Builder contribution metadata: source-ready
+
+`rustok-module.toml` is now the single Pages source for the Page Builder contribution declaration. It owns the owner/target provider identity, contribution ids, capabilities, Fly landing block ids, messages, metadata property editor identity/accessibility and the full `page_builder_consumer_properties_v1` schema.
+
+`admin/build.rs` validates and normalizes that metadata at build time. Owner version is derived from `[module].version`; exact target-provider versions are retained from the module manifest; `ownerProvider` and `providerVersion` are injected by generation and may not be hand-authored in contribution metadata.
+
+The generator emits stable Rust constants plus the normalized `ModuleContributionManifest` JSON into `OUT_DIR`. `admin/src/contributions.rs` includes that generated source, lazily deserializes it and preserves the existing public helper API. The runtime has no TOML parser dependency and no handwritten `ModuleContributionManifest`, `ContributionDescriptor`, `PropertyEditorDescriptor` or consumer field tree.
+
+This changes metadata authority only. Pages persistence, lifecycle, reviewed publication, rollback, recovery and cache ownership are unchanged.
+
+The shared Page Builder plan tracks generalization of this Pages-specific build generator into reusable module tooling before a second production contribution consumer is connected.
 
 ### Immutable artifact integrity, rebuild, activation and rollback continuity
 
@@ -276,6 +289,11 @@ Dependency graph and built-artifact execution evidence remain pending.
 
 ## Source evidence
 
+- `rustok-module.toml`
+- `admin/build.rs`
+- `admin/src/contributions.rs`
+- `scripts/verify/verify-pages-metadata-properties.mjs`
+- `../../scripts/verify/verify-fly-ui-contributions.mjs`
 - `src/services/page/inline_edit.rs`
 - `src/services/page/inline_edit_feature.rs`
 - `src/services/page/inline_edit_runtime.rs`
@@ -320,7 +338,9 @@ These exact phrases remain only for retained static guard compatibility and desc
 - `Admin-owned inline edit launch: source-ready`.
 - `release-composition-source-ready`.
 
-## Remaining work: execution evidence only
+## Remaining Pages work: execution evidence only
+
+Shared cross-module contribution-generator generalization is tracked in the central Page Builder plan; the Pages reference consumer source boundary is complete in this plan.
 
 ### P0 — artifact repair and rollback evidence
 
@@ -342,6 +362,7 @@ These exact phrases remain only for retained static guard compatibility and desc
 
 - [ ] Apply and review the required `release-infra-approved` label for the protected workflow/build changes.
 - [ ] Review the exact action pins, occurrence counts and base-owned approval behavior.
+- [ ] Run Fly/Page Builder contribution metadata guards.
 - [ ] Run Pages inline consumer, route, asset, launch and release-composition static guards.
 - [ ] Run release infrastructure, supply-chain and readiness guards.
 - [ ] Run focused Cargo checks/tests for Pages admin/storefront/server profiles.
@@ -379,6 +400,8 @@ No tests, static verifiers, formatting, Cargo checks, npm installs, Trunk builds
 Suggested commands, intentionally not run:
 
 ```bash
+node scripts/verify/verify-fly-ui-contributions.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-explicit-artifact-binding-replacement.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-artifact-loss-activation-recovery-postgres.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-artifact-loss-multilocale-activation-recovery-postgres.mjs

--- a/crates/rustok-pages/rustok-module.toml
+++ b/crates/rustok-pages/rustok-module.toml
@@ -60,7 +60,6 @@ slot = "home_before_footer"
 route_segment = "pages"
 page_title = "Pages"
 
-
 [provides.storefront_ui.i18n]
 default_locale = "en"
 supported_locales = ["en", "ru"]
@@ -73,6 +72,108 @@ contract_version = "1.1"
 builder_contract_version = "1.1"
 consumer_min_version = "1.0"
 capabilities = ["preview", "tree", "properties", "publish"]
+
+# Canonical Fly contribution source for the Pages admin consumer. The admin build script derives
+# owner version from [module].version and injects ownerProvider/providerVersion into generated
+# descriptors, so those identity fields cannot drift in a parallel handwritten Rust manifest.
+[fba.builder_consumer.contribution_manifest]
+owner_provider = "rustok.pages"
+target_providers = { "fly.builtin" = "1" }
+
+[[fba.builder_consumer.contribution_manifest.admin]]
+role = "landing_blocks"
+id = "rustok.pages.landing-blocks"
+provider = "fly.builtin"
+required_capabilities = ["tree", "properties"]
+blocks = [
+  "fly.hero",
+  "fly.two_columns",
+  "fly.feature_grid",
+  "fly.cta",
+  "fly.contact_form",
+]
+
+[fba.builder_consumer.contribution_manifest.admin.messages]
+"pages.builder.contributions.landingBlocks" = "Pages landing blocks"
+
+[fba.builder_consumer.contribution_manifest.admin.metadata]
+format = "grapesjs"
+surface = "admin"
+
+[[fba.builder_consumer.contribution_manifest.admin]]
+role = "metadata"
+id = "rustok.pages.metadata"
+provider = "rustok.pages"
+required_capabilities = ["properties"]
+blocks = []
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors]]
+id = "rustok.pages.metadata.editor"
+component_type = "rustok-pages-metadata"
+provider = "rustok.pages"
+
+[fba.builder_consumer.contribution_manifest.admin.property_editors.accessibility]
+label_message_id = "pages.builder.contributions.metadata.label"
+description_message_id = "pages.builder.contributions.metadata.description"
+keyboard_hint_message_id = ""
+
+[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema]
+format = "page_builder_consumer_properties_v1"
+id = "rustok.pages.metadata.schema"
+title = "Page metadata"
+description = "Versioned Pages metadata. Saving these properties never writes the Fly document."
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema.fields]]
+id = "title"
+label = "Title"
+kind = "text"
+required = true
+max_bytes = 512
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema.fields]]
+id = "slug"
+label = "Slug"
+kind = "text"
+required = true
+max_bytes = 512
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema.fields]]
+id = "meta_title"
+label = "SEO title"
+kind = "text"
+required = false
+max_bytes = 512
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema.fields]]
+id = "meta_description"
+label = "SEO description"
+kind = "text_area"
+required = false
+max_bytes = 4096
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema.fields]]
+id = "template"
+label = "Template"
+kind = "text"
+required = false
+max_bytes = 256
+
+[[fba.builder_consumer.contribution_manifest.admin.property_editors.property_schema.fields]]
+id = "channel_slugs"
+label = "Channels"
+kind = "string_list"
+required = false
+max_bytes = 4096
+help = "Comma-separated channel slugs. Leave empty for every channel."
+placeholder = "web, mobile"
+
+[fba.builder_consumer.contribution_manifest.admin.messages]
+"pages.builder.contributions.metadata.label" = "Page metadata"
+"pages.builder.contributions.metadata.description" = "Edit versioned Pages metadata without modifying the Fly document."
+
+[fba.builder_consumer.contribution_manifest.admin.metadata]
+persistence = "consumer_facade"
+surface = "admin"
 
 [fba.builder_consumer.degraded_modes]
 builder_disabled = "admin_builder_readonly_fallback"

--- a/crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
@@ -18,6 +18,8 @@ const providerModuleExport = read(contract.provider.module_export_source);
 const providerPanelExport = read(contract.provider.panel_export_source);
 const providerCanvas = read(contract.provider.composition_source);
 const pagesContributions = read(contract.pages_consumer.contribution_source);
+const pagesContributionBuild = read("crates/rustok-pages/admin/build.rs");
+const pagesModuleManifest = read("crates/rustok-pages/rustok-module.toml");
 const pagesOwnerPort = read(contract.pages_consumer.owner_port_source);
 const pagesOwnerPortProduction = pagesOwnerPort.split("#[cfg(test)]")[0];
 const pagesBoundary = read(contract.pages_consumer.composition_source);
@@ -205,26 +207,61 @@ for (const marker of [
 }
 
 for (const marker of [
-  `PAGES_METADATA_CONTRIBUTION_ID: &str = "${contract.pages_consumer.contribution_id}"`,
-  `PAGES_METADATA_PROPERTY_EDITOR_ID: &str = "${contract.pages_consumer.property_editor_id}"`,
-  `PAGES_OWNER_PROVIDER: &str = "${contract.pages_consumer.provider}"`,
-  `PAGES_METADATA_COMPONENT_TYPE: &str = "${contract.pages_consumer.component_type}"`,
+  'include!(concat!(env!("OUT_DIR"), "/pages_contribution_manifest.rs"));',
+  "GENERATED_PAGES_CONTRIBUTION_MANIFEST_JSON",
   "pub fn pages_metadata_property_schema()",
-  "PAGE_BUILDER_CONSUMER_PROPERTIES_FORMAT",
   "pub fn pages_metadata_contribution()",
-  "PropertyEditorDescriptor",
-  "property_schema: serde_json::to_value(schema)",
-  "pages_metadata_contribution(),",
+  "generated_admin_contribution(PAGES_METADATA_CONTRIBUTION_ID)",
+  "serde_json::from_value::<ConsumerPropertyEditorSchema>",
+  "schema.validate()",
   "registered_schema.validate()",
 ]) {
-  requireMarker(pagesContributions, marker, "Pages metadata contribution");
+  requireMarker(pagesContributions, marker, "Pages generated metadata contribution runtime");
+}
+for (const forbidden of [
+  "PropertyEditorDescriptor {",
+  "ConsumerPropertyFieldDescriptor {",
+  "ContributionDescriptor {",
+  "ModuleContributionManifest {",
+]) {
+  forbidMarker(
+    pagesContributions,
+    forbidden,
+    "Pages generated metadata contribution runtime",
+  );
+}
+
+for (const marker of [
+  `id = "${contract.pages_consumer.contribution_id}"`,
+  `id = "${contract.pages_consumer.property_editor_id}"`,
+  `owner_provider = "${contract.pages_consumer.provider}"`,
+  `provider = "${contract.pages_consumer.provider}"`,
+  `component_type = "${contract.pages_consumer.component_type}"`,
+  `format = "${contract.format}"`,
+  'role = "metadata"',
+  'persistence = "consumer_facade"',
+]) {
+  requireMarker(pagesModuleManifest, marker, "Pages canonical metadata contribution source");
 }
 for (const field of contract.pages_consumer.fields) {
   requireMarker(
-    pagesContributions,
-    `"${field}"`,
-    "Pages metadata contribution fields",
+    pagesModuleManifest,
+    `id = "${field}"`,
+    "Pages canonical metadata contribution fields",
   );
+}
+for (const marker of [
+  "contribution_manifest: ContributionManifestSource",
+  "OWNER_PROVIDER_METADATA_KEY",
+  "PROVIDER_VERSION_METADATA_KEY",
+  "must not hand-author ownerProvider/providerVersion",
+  "metadata contribution must declare exactly one property editor",
+  "GENERATED_PAGES_CONTRIBUTION_MANIFEST_JSON",
+  "PAGES_METADATA_CONTRIBUTION_ID",
+  "PAGES_METADATA_PROPERTY_EDITOR_ID",
+  "PAGES_METADATA_COMPONENT_TYPE",
+]) {
+  requireMarker(pagesContributionBuild, marker, "Pages contribution build generator");
 }
 
 for (const marker of [
@@ -352,5 +389,5 @@ for (const marker of [
 }
 
 console.log(
-  "[verify-pages-metadata-properties] PASS metadata_surface_cutover_complete=true metadata_revision_isolation_source_ready=true published_metadata_surface_source_ready=true execution_evidence=pending",
+  "[verify-pages-metadata-properties] PASS metadata_surface_cutover_complete=true metadata_revision_isolation_source_ready=true published_metadata_surface_source_ready=true generated_manifest_authority=true execution_evidence=pending",
 );

--- a/docs/modules/page-builder-implementation-plan.md
+++ b/docs/modules/page-builder-implementation-plan.md
@@ -16,21 +16,30 @@ status: active
 
 ## Current-source actualization
 
-This central plan is reconciled to current `main` as of 2026-08-07. The detailed
+This central plan is reconciled to current `main` as of 2026-08-08. The detailed
 source overlays under `docs/modules/page-builder-*-actualization-2026-08-07.md`
-remain authoritative where they are more specific. In particular, older open
-checkboxes for Pages metadata contributions, immutable rollback, artifact audit/
-repair, reviewed static resource limits, authenticated real-DOM authoring and
-anonymous authoring exclusion were stale and are corrected below.
+and the 2026-08-08 Pages/Page Builder parity packets remain authoritative where
+they are more specific. Older open checkboxes for Pages metadata contributions,
+immutable rollback, artifact audit/repair, reviewed static resource limits,
+authenticated real-DOM authoring, anonymous authoring exclusion and generated
+contribution-registry foundations were stale and are corrected below.
 
-Current source marker for this slice:
+Current source markers for this slice:
 
 ```text
 Provider status/degraded controls: source-ready
+Pages module-metadata contribution generation: source-ready
 ```
 
 Observed provider-health evidence remains an execution/composition cursor; an
-absent live health snapshot is now represented as `unobserved`, not healthy.
+absent live health snapshot is represented as `unobserved`, not healthy.
+
+The Pages reference consumer now keeps its complete Fly contribution declaration
+in canonical `rustok-module.toml`. `rustok-pages-admin/build.rs` validates that
+metadata and emits the normalized version-pinned manifest/constants into
+`OUT_DIR`; the admin/WASM runtime does not parse TOML and no handwritten Pages
+`ContributionDescriptor` tree remains. Shared module-tooling generalization is
+the next source cursor before a second production contribution consumer is added.
 
 ## Current-only policy
 
@@ -136,6 +145,9 @@ persistence. Rich text remains an external dedicated capability.
 - [x] Metadata-only patch and document-only save commands are separate.
 - [x] Consumer metadata editing uses registered typed property contributions; the
   bespoke metadata editor/direct workspace metadata write are removed.
+- [x] Pages contribution identities, version-pinned providers, capabilities,
+  blocks, messages and the full metadata property schema are canonical module
+  metadata and are build-generated into the admin crate without runtime TOML.
 - [x] The obsolete parallel JSON/CRUD UI and PageBlock persistence/fallback paths
   are deleted.
 - [x] Pages provides one builder-first workspace with list/create/select,
@@ -337,6 +349,8 @@ Rules:
   remain retryable. A retry may safely advance a generation more than once.
 - Provider rollout flags and observed health are separate evidence. Lack of an
   observed SLO snapshot is never converted to a healthy claim.
+- Consumer contribution metadata is build-generated from canonical module
+  metadata; runtime source must not retain a parallel handwritten descriptor tree.
 
 ## Implementation phases
 
@@ -453,10 +467,13 @@ of the verification programme.
 
 ### Phase 9 — generated contribution registries
 
-- [ ] Separate admin/storefront factories.
-- [ ] Generate from module metadata.
-- [ ] Filter by tenant, permission, capability, policy and health.
-- [ ] Duplicate, cycle, version and missing-provider diagnostics.
+- [x] Separate admin/storefront factories.
+- [x] Generate the Pages reference-consumer contribution manifest from canonical
+  module metadata at build time, including version targets and property schema.
+- [x] Filter by tenant, permission, capability, policy and health.
+- [x] Duplicate, cycle, version and missing-provider diagnostics.
+- [ ] Generalize the canonical contribution metadata schema/generator into shared
+  module tooling before connecting a second production contribution consumer.
 
 ### Phase 10 — rollout
 
@@ -468,18 +485,18 @@ of the verification programme.
 
 ## Immediate implementation order
 
-1. Retain accepted Pages execution evidence for reviewed publish, rollback/repair,
+1. Generalize the Pages canonical contribution metadata/generation boundary into
+   shared module tooling and publish validation before onboarding a second consumer.
+2. Connect a real provider-health observation source to the admin status seam and
+   retain observed provider-health evidence for degraded/unavailable behavior.
+3. Retain accepted Pages execution evidence for reviewed publish, rollback/repair,
    cache rotation/miss-refill, metadata isolation and authenticated/anonymous
    authoring boundaries.
-2. Connect a real provider-health observation source to the new admin status seam
-   and retain observed provider-health evidence for degraded/unavailable behavior.
-3. Complete remaining generic Page Builder asset/accessibility controls and their
+4. Complete remaining generic Page Builder asset/accessibility controls and their
    executable browser evidence.
-4. Build generated contribution registries with tenant/permission/capability/
-   policy/health filtering and diagnostics.
 5. Connect the next production consumer to the canonical composition root only
-   after its tenant-scoped persistence, authorization and preview ownership are
-   explicitly defined.
+   after its tenant-scoped persistence, authorization, preview ownership and
+   contribution metadata authority are explicitly defined.
 
 ## Verification programme
 
@@ -498,6 +515,8 @@ cargo xtask module validate pages
 node scripts/verify/verify-pages-ui-boundary.mjs
 node --test scripts/verify/verify-pages-ui-boundary.test.mjs
 node scripts/verify/verify-fly-admin-browser-runtime.mjs
+node scripts/verify/verify-fly-ui-contributions.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-static-publish-resource-limits.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-scenario-baseline.mjs
@@ -521,8 +540,8 @@ cleanup, DnD/keyboard/accessibility, metadata/body revision conflicts,
 authoritative sanitization/resource budgets, deterministic artifact and receipt
 integrity, preview/static materialization parity, idempotent replay, repair/
 rollback continuity, event-driven cache generation rotation and public miss/
-refill, anonymous authoring exclusion, provider degradation and observed tenant
-rollout.
+refill, anonymous authoring exclusion, provider degradation, generated module
+metadata authority and observed tenant rollout.
 
 ## Update rules
 

--- a/docs/modules/pages-page-builder-module-metadata-contribution-generation-2026-08-08.md
+++ b/docs/modules/pages-page-builder-module-metadata-contribution-generation-2026-08-08.md
@@ -1,0 +1,76 @@
+# Pages / Page Builder Module-Metadata Contribution Generation — 2026-08-08
+
+Status: source-ready / Pages-reference-consumer-complete / shared-tooling-generalization-open / execution-pending
+
+## Rechecked gap
+
+The 2026-08-08 parity reconciliation established that Fly already had separate admin/storefront factories, tenant/permission/capability/policy/health filtering and structural/version diagnostics. The remaining Phase 9 source gap was the Pages reference consumer: `rustok-pages-admin` still hand-authored the same contribution identities, provider targets, capabilities, block ids, messages and metadata that belong in canonical module metadata.
+
+That duplicate declaration is removed in this slice.
+
+## Canonical authority
+
+`crates/rustok-pages/rustok-module.toml` now owns the Pages Page Builder contribution declaration under:
+
+```text
+[fba.builder_consumer.contribution_manifest]
+[[fba.builder_consumer.contribution_manifest.admin]]
+```
+
+The module manifest owns:
+
+- owner provider identity;
+- exact target-provider versions;
+- contribution roles, ids and providers;
+- required Page Builder capabilities;
+- contributed Fly block ids;
+- messages and contribution metadata;
+- the Pages metadata property-editor id/component type/accessibility contract;
+- the complete `page_builder_consumer_properties_v1` property schema and field limits.
+
+Owner version is derived from `[module].version`; it is not repeated in contribution metadata.
+
+## Build-time generation boundary
+
+`crates/rustok-pages/admin/build.rs` parses the canonical module manifest at build time and fails closed when:
+
+- module slug/version do not match the Pages admin package;
+- builder capability metadata is empty or duplicated;
+- a contribution role is missing or duplicated;
+- a contribution targets a provider without an exact declared version;
+- landing blocks do not target an external version-pinned provider;
+- metadata does not target the Pages owner provider;
+- the metadata contribution does not expose exactly one property editor;
+- contribution metadata tries to hand-author `ownerProvider` or `providerVersion`.
+
+The generator injects `ownerProvider` and exact `providerVersion`, serializes the normalized `ModuleContributionManifest`, and emits stable Rust constants plus one compact JSON manifest into `OUT_DIR`.
+
+`toml` is a build dependency only. Pages admin/WASM runtime does not parse `rustok-module.toml`.
+
+## Runtime boundary
+
+`crates/rustok-pages/admin/src/contributions.rs` now:
+
+- includes the generated Rust source from `OUT_DIR`;
+- lazily deserializes the generated normalized manifest;
+- retains the existing public contribution/policy helper API;
+- derives the metadata property schema from the generated property editor and reuses Page Builder validation;
+- contains no handwritten `ModuleContributionManifest`, `ContributionDescriptor`, `PropertyEditorDescriptor` or consumer property-field tree.
+
+Pages remains persistence/lifecycle/publication owner. This slice changes contribution metadata authority only.
+
+## Guard reconciliation
+
+The Fly contribution source guard and Pages metadata-property guard now inspect the canonical module metadata plus build generator instead of requiring duplicated literals in `contributions.rs`. They also reject reintroduction of handwritten descriptor authority in the Pages runtime source.
+
+## Phase 9 state after this slice
+
+- [x] Separate admin/storefront factories.
+- [x] Pages reference consumer generates its complete contribution manifest from canonical module metadata at build time.
+- [x] Tenant, permission, capability, provider policy and provider-health filtering.
+- [x] Duplicate, missing-provider, missing-dependency, cycle and provider-version diagnostics.
+- [ ] Generalize the Pages build-time metadata schema/generator into shared module tooling before onboarding the second production contribution consumer.
+
+## Validation boundary
+
+Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, TOML parser execution, WASM/native builds, workflows or CI were run by this slice. Source-ready does not claim executed evidence.

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-08  
-Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / observed-health-open / module-metadata-generation-open / execution-browser-rollout-pending
+Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / contribution-module-metadata-generation-source-ready / observed-health-open / shared-contribution-tooling-open / execution-browser-rollout-pending
 Scope: `rustok-pages` admin/storefront FFA and `rustok-page-builder` document, publication, artifact, routing, cache, authenticated inline-authoring and deterministic deployment boundaries
 
 ## Source-of-truth policy
@@ -13,7 +13,7 @@ This is the canonical shared continuation cursor. Historical dated packets remai
 Pages and Page Builder remain one vertical pipeline with explicit owners:
 
 - Pages owns persistence, lifecycle, immutable bindings, localized route identity, cache policy, public reads, authenticated inline grants/save transport and the module-owned authoring asset HTTP contract.
-- Pages admin owns the optional same-origin authoring launch control.
+- Pages admin owns the optional same-origin authoring launch control and consumes build-generated contribution metadata.
 - Page Builder/Fly owns the reviewed document, sanitizer, runtime materialization, renderer, artifact producer contracts and reusable real-DOM inline adapter/session.
 - Navigation and SEO own their resolved payloads.
 - Hosts own route admission, CSP and HTTP composition, not Pages document, route, asset or launch policy.
@@ -30,26 +30,30 @@ The recheck includes all relevant merged source after the former PR #3063 cursor
 - PR #3191 — repeated physical loss of rebuilt immutable Pages artifacts can recover again from the latest accepted repair state per locale while preserving bounded repair/rollback lineage; execution remains open;
 - PR #3196 — Page Builder admin provider rollout/degraded controls are connected through the Pages consumer; absent live SLO evidence remains explicitly `unobserved` and no health state is fabricated;
 - the existing `fly-ui` contribution path already has separate admin/storefront factories, tenant/permission/capability/provider-policy/provider-health filtering, and duplicate/missing-provider/missing-dependency/cycle diagnostics;
-- the contribution static guard still required owner/target version parity while the live Rust manifest model had regressed to an unversioned provider set.
+- PR #3205 restored exact owner/target provider versions and fail-closed manifest-routed provider-version admission.
 
-The current source slice restores that version boundary without changing Pages persistence or publication ownership:
+The present source slice closes the remaining Pages reference-consumer metadata-generation gap without changing Pages persistence or publication ownership:
 
-- `ModuleContributionManifest` carries an exact `owner_version` and exact target-provider version map;
-- manifest-routed contributions must declare `metadata.providerVersion`;
-- missing/invalid provider versions fail closed;
-- allowed provider names with the wrong version fail with `contribution_target_provider_version_mismatch`;
-- Pages pins `rustok.pages@<crate version>` and `fly.builtin@1` while retaining its existing landing-block and executable metadata-property contributions.
+- `crates/rustok-pages/rustok-module.toml` is the canonical source for contribution ids, providers, target versions, capabilities, Fly block ids, messages, metadata-property editor identity/accessibility and the complete consumer property schema;
+- `crates/rustok-pages/admin/build.rs` parses and validates that source at build time, derives owner version from `[module].version`, injects `ownerProvider` and exact `providerVersion`, and emits stable Rust constants plus a normalized `ModuleContributionManifest` JSON into `OUT_DIR`;
+- `rustok-pages-admin` keeps `toml` as a build dependency only; admin/WASM runtime never parses module TOML;
+- `admin/src/contributions.rs` consumes the generated manifest and retains the existing public helper API without a handwritten `ModuleContributionManifest`, `ContributionDescriptor`, `PropertyEditorDescriptor` or consumer property-field authority;
+- the existing Fly and Pages metadata source guards now verify canonical module metadata + generation and reject reintroduction of the parallel handwritten descriptor tree.
 
 Rechecked Page Builder Phase 9 source state:
 
 - [x] Separate admin/storefront factories.
-- [ ] Generate complete contribution manifests directly from canonical module metadata; Pages still builds its contribution manifest in module-owned Rust and only cross-checks selected capability metadata against `rustok-module.toml`.
+- [x] Generate the complete Pages reference-consumer contribution manifest from canonical module metadata at build time.
 - [x] Filter by tenant, permission, capability, provider policy and health.
 - [x] Duplicate, missing-provider, missing-dependency, cycle and provider-version diagnostics.
+- [ ] Generalize the canonical contribution metadata schema/generator into shared module tooling before onboarding a second production contribution consumer.
 
-The next source cursor is therefore module-metadata generation for contribution manifests. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
+The next source cursor is shared module-tooling generalization for contribution metadata and publish validation. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
 
-Detailed evidence for this reconciliation is retained in `docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md`.
+Detailed evidence for the two 2026-08-08 contribution slices is retained in:
+
+- `docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md`;
+- `docs/modules/pages-page-builder-module-metadata-contribution-generation-2026-08-08.md`.
 
 ## Rechecked merged cursor
 
@@ -71,7 +75,7 @@ Current `main` through PR #3063 contains the retained Pages/Page Builder sequenc
 - #3060 — Pages-owned binary-embedded authoring assets and exact-lock client/server builder source;
 - #3063 — Pages admin-owned same-origin launch source.
 
-The present source slice adds one deterministic deployment composition owner and connects it to release build, release reproducibility and the production server Docker builder. It also aligns action pins with the existing allow-list, protects all inline-edit build owners behind `release-infra-approved`, and updates release readiness evidence requirements.
+The historical release-composition source slice adds one deterministic deployment composition owner and connects it to release build, release reproducibility and the production server Docker builder. It also aligns action pins with the existing allow-list, protects all inline-edit build owners behind `release-infra-approved`, and updates release readiness evidence requirements.
 
 No build, workflow, Docker, HTTP or browser execution is claimed.
 
@@ -101,6 +105,7 @@ No build, workflow, Docker, HTTP or browser execution is claimed.
 - `pages-repeated-artifact-loss-recovery-source-ready` — repeated physical loss of a rebuilt immutable artifact can recover from the latest accepted repair lineage.
 - `provider-degraded-controls-source-ready` — rollout/degraded provider controls are connected without fabricating observed health.
 - `contribution-registry-version-parity-source-ready` — contribution owner/target provider versions are pinned and fail closed on missing/mismatched versions.
+- `contribution-module-metadata-generation-source-ready` — Pages contribution declarations and property schema are generated from canonical module metadata at build time.
 
 ## Current parity state
 
@@ -110,9 +115,15 @@ Draft workspaces and published Pages metadata share the registered consumer-prop
 
 Pages remains the sole document persistence owner. Reviewed Page Builder materialization remains required for publish. Rollback selects a prior immutable manifest without compiling the current draft.
 
-Database, GraphQL, REST, publish, rollback and event schemas are unchanged by the authenticated inline-authoring sequence.
+Database, GraphQL, REST, publish, rollback and event schemas are unchanged by the contribution-generation slice.
 
 Execution evidence remains pending.
+
+### Canonical contribution metadata generation: source-ready / shared-tooling-open
+
+Pages now owns one canonical contribution declaration in `rustok-module.toml`. Its build script validates and materializes the version-pinned Fly manifest and metadata property schema into `OUT_DIR`; runtime consumes only generated Rust/JSON and retains no TOML dependency or handwritten descriptor tree.
+
+The Pages reference consumer therefore completes the Phase 9 generation proof. Shared cross-module tooling and publish-time validation of this contribution metadata shape remain open before the same pattern is extended to another production consumer.
 
 ### Public locale, route and cache authority: source-ready
 
@@ -245,9 +256,9 @@ Pages keeps repair identity and latest accepted repair state per locale bounded.
 
 Page Builder provider flags can only narrow an already authorized capability set. Invalid/disabled builder state is unavailable, partial rollout or degraded health suppresses publish, and Pages exposes the same flags used by server composition. No live SLO source exists yet, so Pages health remains explicitly `unobserved`.
 
-### Contribution registry version parity: source-ready / metadata-generation-open
+### Contribution registry version parity: source-ready
 
-Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Complete generation from canonical module metadata remains open; handwritten module-owned contribution manifests are not treated as generated authority.
+Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Pages now supplies those identities from canonical module metadata generation rather than a handwritten runtime manifest.
 
 ## Parity matrix
 
@@ -256,6 +267,7 @@ Admin/storefront assembly, policy filters and structural diagnostics are source-
 | Registered metadata and owner port | Complete | Browser/conflict execution pending |
 | Reviewed publish and immutable rollback | Complete | DB/runtime execution pending |
 | Repeated immutable-artifact loss recovery | Source-ready | Repair/rollback execution pending |
+| Canonical contribution metadata generation | Source-ready (Pages) | Shared tooling / execution pending |
 | Public locale fallback | Source-ready | Native/GraphQL execution pending |
 | Published aliases, tombstones and history import | Source-ready | SQLite/PostgreSQL/host execution pending |
 | Host canonical/redirect/gone response | Source-ready | HTTP/SSR execution pending |
@@ -273,7 +285,7 @@ Admin/storefront assembly, policy filters and structural diagnostics are source-
 | Anonymous dependency graph | Source-ready | `cargo metadata` execution pending |
 | Anonymous SSR built artifact | Inspector source-ready | Build/inspection pending |
 | Provider degraded controls | Source-ready | Live observed-health evidence pending |
-| Version-pinned contribution registry | Source-ready | Metadata generation / execution pending |
+| Version-pinned contribution registry | Source-ready | Shared tooling / execution pending |
 | Tenant rollout and FFA/FBA | Open | Not promoted |
 
 ## Historical compatibility markers
@@ -294,7 +306,7 @@ These exact phrases are retained only because earlier static guards consume the 
 
 ## Boundaries
 
-The historical deployment slice below remains unchanged; the 2026-08-08 reconciliation additionally restores contribution version parity and updates the source cursor.
+The historical deployment slice below remains unchanged; the 2026-08-08 reconciliation additionally restores contribution version parity, moves Pages contribution authority to canonical module metadata and updates the source cursor.
 
 It does not:
 
@@ -305,6 +317,7 @@ It does not:
 - change database, GraphQL, REST, event, publish, rollback, artifact or cache schemas;
 - enable same-origin launch in standalone admin builds;
 - add runtime build tooling to `apps/server/Dockerfile.release`;
+- add a TOML parser to Pages admin/WASM runtime;
 - claim verifier, Cargo, npm, Trunk, WASM, server, Docker, workflow, HTTP, browser or rollout execution;
 - fabricate Page Builder provider-health observations;
 - promote FFA or FBA.
@@ -313,11 +326,11 @@ It does not:
 
 Source continuation:
 
-1. Generate complete Fly contribution manifests from canonical module metadata instead of maintaining a parallel handwritten declaration.
-2. Keep current Pages repair/recovery and Page Builder degraded-control source boundaries unchanged while that registry authority is centralized.
+1. Generalize the Pages canonical contribution metadata schema/generator into shared module tooling and publish validation before onboarding a second production contribution consumer.
+2. Keep current Pages repair/recovery and Page Builder degraded-control source boundaries unchanged while that shared authority is extracted.
 3. Connect real provider-health observation only after an authoritative Page Builder SLO source exists.
 
-Maintainer-owned execution evidence remains pending for the earlier release, browser, database and recovery slices.
+Maintainer-owned execution evidence remains pending for the contribution-generation, release, browser, database and recovery slices.
 
 ## Maintainer validation
 
@@ -325,6 +338,7 @@ Suggested commands, intentionally not run in this slice:
 
 ```bash
 node scripts/verify/verify-fly-ui-contributions.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-release-composition.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-admin-launch.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-asset-delivery.mjs

--- a/scripts/verify/verify-fly-ui-contributions.mjs
+++ b/scripts/verify/verify-fly-ui-contributions.mjs
@@ -18,6 +18,9 @@ const paths = {
   pageBuilderPalette: 'crates/rustok-page-builder/admin/src/editor/palette_layers.rs',
   pageBuilderPaletteAccess: 'crates/rustok-page-builder/admin/src/palette_access.rs',
   pageBuilderContextContract: 'crates/rustok-page-builder/admin/src/context_contract.rs',
+  pagesCargo: 'crates/rustok-pages/admin/Cargo.toml',
+  pagesBuild: 'crates/rustok-pages/admin/build.rs',
+  pagesModuleManifest: 'crates/rustok-pages/rustok-module.toml',
   pagesLib: 'crates/rustok-pages/admin/src/lib.rs',
   pagesContributions: 'crates/rustok-pages/admin/src/contributions.rs',
   pagesContributionBrowser: 'crates/rustok-pages/admin/src/contribution_browser_intent.rs',
@@ -217,18 +220,42 @@ requireMarker(
   'assert_send_sync::<Arc<ContributionAssemblyResult>>()',
   'contribution assembly must remain safe for Leptos owner context',
 );
-requireMarkers('pagesContributions', [
-  'pub const PAGES_BUILDER_CAPABILITIES',
-  'pub const PAGES_LANDING_BLOCK_CAPABILITIES',
-  'pub fn pages_contribution_manifest()',
-  'pub fn pages_landing_blocks_contribution()',
-  'pub fn pages_admin_contribution_policy()',
-  'pub fn build_pages_admin_contribution_registry(',
-  'FLY_BUILTIN_PROVIDER',
-  'FLY_BUILTIN_PROVIDER_VERSION',
+
+requireMarkers('pagesCargo', [
+  '[build-dependencies]',
+  'serde = { workspace = true, features = ["derive"] }',
+  'serde_json.workspace = true',
+  'toml.workspace = true',
+], 'Pages build-time contribution metadata dependencies');
+requireMarkers('pagesBuild', [
+  'MODULE_MANIFEST_RELATIVE_PATH',
+  'cargo:rerun-if-changed=',
+  'contribution_manifest: ContributionManifestSource',
+  'owner_provider: String',
+  'target_providers: BTreeMap<String, String>',
+  'role=\'landing_blocks\'',
+  'role=\'metadata\'',
+  'OWNER_PROVIDER_METADATA_KEY',
+  'PROVIDER_VERSION_METADATA_KEY',
+  'must not hand-author ownerProvider/providerVersion',
+  'GENERATED_PAGES_CONTRIBUTION_MANIFEST_JSON',
+  'PAGES_BUILDER_CAPABILITIES',
   'PAGES_LANDING_BLOCK_IDS',
-  'PAGES_OWNER_PROVIDER.to_string(),',
-  'FLY_BUILTIN_PROVIDER.to_string(),',
+  'module.version',
+  'CARGO_PKG_VERSION',
+], 'Pages canonical contribution build generator');
+requireMarkers('pagesModuleManifest', [
+  '[fba.builder_consumer.contribution_manifest]',
+  'owner_provider = "rustok.pages"',
+  'target_providers = { "fly.builtin" = "1" }',
+  'role = "landing_blocks"',
+  'id = "rustok.pages.landing-blocks"',
+  'provider = "fly.builtin"',
+  'role = "metadata"',
+  'id = "rustok.pages.metadata"',
+  'id = "rustok.pages.metadata.editor"',
+  'component_type = "rustok-pages-metadata"',
+  'format = "page_builder_consumer_properties_v1"',
   '"preview"',
   '"tree"',
   '"properties"',
@@ -238,13 +265,36 @@ requireMarkers('pagesContributions', [
   '"fly.feature_grid"',
   '"fly.cta"',
   '"fly.contact_form"',
-  'renderers: Vec::new()',
-  'property_editors: Vec::new()',
-  'contributed_block_ids_exist_in_the_fly_registry',
+], 'Pages canonical module contribution metadata');
+requireMarkers('pagesContributions', [
+  'include!(concat!(env!("OUT_DIR"), "/pages_contribution_manifest.rs"));',
+  'GENERATED_PAGES_CONTRIBUTION_MANIFEST',
+  'GENERATED_PAGES_CONTRIBUTION_MANIFEST_JSON',
+  'serde_json::from_str(',
+  'pub fn pages_contribution_manifest()',
+  'pub fn pages_landing_blocks_contribution()',
+  'pub fn pages_metadata_contribution()',
+  'pub fn pages_metadata_property_schema()',
+  'pub fn pages_admin_contribution_policy()',
+  'pub fn build_pages_admin_contribution_registry(',
+  'fn generated_admin_contribution(',
+  'generated_constants_match_canonical_module_metadata',
   'contribution_policy_enables_owner_and_target_providers',
-  'capability_constants_match_the_module_manifest',
   'storefront_surface_stays_empty_until_a_real_adapter_exists',
-], 'Pages Fly contribution manifest and policy');
+], 'Pages generated Fly contribution manifest and policy');
+for (const forbidden of [
+  'ModuleContributionManifest {',
+  'ContributionDescriptor {',
+  'PropertyEditorDescriptor {',
+  'ConsumerPropertyFieldDescriptor {',
+]) {
+  rejectMarker(
+    'pagesContributions',
+    forbidden,
+    `Pages contribution runtime must not retain handwritten descriptor authority: ${forbidden}`,
+  );
+}
+
 requireMarkers('pagesContributionBrowser', [
   'pub fn pages_palette_block_access()',
   'pub async fn dispatch_pages_browser_intent(',


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder parity cursor after #3205.

- move the Pages Fly contribution declaration into canonical `crates/rustok-pages/rustok-module.toml`;
- add a build-time `rustok-pages-admin` generator that validates module/provider/version/role identity, injects `ownerProvider` / exact `providerVersion`, and emits stable constants plus a normalized `ModuleContributionManifest` into `OUT_DIR`;
- keep TOML parsing out of Pages admin/WASM runtime and remove the parallel handwritten contribution/property-schema descriptor tree from `admin/src/contributions.rs`;
- preserve the existing Pages contribution helper API and Pages persistence/publication ownership;
- update the Fly contribution and Pages metadata guards to verify canonical metadata + generation and reject reintroduction of handwritten descriptor authority;
- actualize the Pages, Page Builder and shared parity plans: Phase 9 is source-ready for the Pages reference consumer, with shared module-tooling generalization as the next source cursor;
- keep observed provider health separate and explicitly open until a real Page Builder SLO source exists.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, TOML parser execution, WASM/native builds, workflows, CI, or `git diff --check` were run in this slice.