### PR TITLE
refactor(commerce): cut storefront search options to Product schema port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -239,11 +239,17 @@ These are source-contract defects, not verification-only tasks.
   and `PRODUCTS_READ` admission, authenticated actor, trimmed locale, request channel,
   bounded deadline, the existing GraphQL projection, and the shared stable Product
   GraphQL public error mapper.
-- [ ] Cut remaining mounted Product schema read `storefrontCatalogSearchOptions`, schema
-  writes, REST delete/publish/unpublish lifecycle commands, and remaining GraphQL Product
-  lifecycle operations over to host-composed Product owner ports. Direct Product entities,
-  `CatalogService`, and `ProductCatalogSchemaService` remain explicit source debt;
-  repeatable lifecycle commands need an explicit caller idempotency contract before cutover.
+- [x] Cut mounted GraphQL `storefrontCatalogSearchOptions` to the host-selected
+  `ProductCatalogSchemaReadPort` using its existing `list_categories` and
+  `list_attributes` capabilities, preserving storefront-channel admission, required
+  trimmed locale, current-tenant scope, service actor, request channel, bounded deadline,
+  exact category/attribute option projection semantics, and the shared stable Product
+  GraphQL public error mapper.
+- [ ] Cut remaining Product schema writes, REST delete/publish/unpublish lifecycle
+  commands, and remaining GraphQL Product lifecycle operations over to host-composed
+  Product owner ports. Direct Product entities, `CatalogService`, and remaining
+  write-side `ProductCatalogSchemaService` usage remain explicit source debt; repeatable
+  lifecycle commands need an explicit caller idempotency contract before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -872,13 +878,17 @@ Source inspection is not execution evidence.
 - [x] Publish the optional Product schema-directory read capability on the host-selected
   Product read runtime and cut `productAttributes`, `catalogCategories`, and
   `productAttributeSchemas` away from direct `ProductCatalogSchemaService` construction;
-  search-option schema reads and Product writes remain open.
+  Product schema writes and lifecycle operations remain open.
 - [x] Cut mounted `productEffectiveForm` to the host-selected Product schema read port,
   preserving tenant/permission/actor/channel/locale/deadline context and moving aggregate
   reconstruction plus invariant handling back behind the Product owner boundary.
 - [x] Cut mounted `productAttributeValues` to the host-selected Product schema read port,
   preserving tenant/permission/actor/channel/locale/deadline context, the existing GraphQL
   projection, and shared stable Product public error mapping.
+- [x] Cut mounted `storefrontCatalogSearchOptions` to existing Product schema-directory
+  owner capabilities while preserving storefront admission, current tenant, required
+  locale, request channel/deadline context, exact option projection, and stable public
+  owner errors without adding a redundant Product port method.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -9,8 +9,8 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 ## Recheck findings
 
 1. `ProductCatalogSchemaReadPort` publishes the effective-form aggregate capability added by PR #3182, and mounted `productEffectiveForm` is now cut over to that host-selected owner capability.
-2. PR #3203 published `ProductCatalogSchemaReadPort::read_product_attribute_values`; the mounted `productAttributeValues` resolver was still constructing `ProductCatalogSchemaService` directly and is cut over in the continuation slice below.
-3. `storefrontCatalogSearchOptions` remains a direct `ProductCatalogSchemaService` consumer and still needs an owner projection/cutover.
+2. PR #3203 published `ProductCatalogSchemaReadPort::read_product_attribute_values`, and mounted `productAttributeValues` is now cut over to that owner capability.
+3. `storefrontCatalogSearchOptions` was the remaining mounted direct `ProductCatalogSchemaService` schema-read consumer. Its current projection needs only categories and filterable/sortable attributes, so the already-published `list_categories` and `list_attributes` owner capabilities preserve the existing data and ordering semantics without a new Product projection.
 4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths use `ProductCatalogReadRuntime`, while legacy mounted `product`/`products` roots in `query::CommerceQuery` still contain direct `CatalogService`/Product entity read paths. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path must remain open; source inspection does not justify a status promotion.
 
 ## PR #3203 source change
@@ -35,12 +35,18 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Preserve the existing GraphQL response shape by mapping the Product-owned `ProductAttributeValueRecord` projection through the existing `GqlProductAttributeValue` conversion.
 - Extend the schema-read source guard to require `ProductAttributeValuesRequest`, the mounted owner-port call, and no direct `ProductCatalogSchemaService` construction in this resolver.
 
+## Storefront search-options continuation
+
+- Cut mounted `storefrontCatalogSearchOptions` to the host-selected `ProductCatalogSchemaReadPort` using its existing `list_categories` and `list_attributes` capabilities; no new Product port method is required.
+- Preserve storefront-channel admission, the required non-empty trimmed locale, current-tenant scope, the `commerce-storefront-graphql` service actor, request channel, bounded deadline, and the shared correlation-aware Product GraphQL public error mapper.
+- Preserve the exact GraphQL projection: category values remain category ids with path/name/code fallback labels; attribute options remain limited to filterable or sortable attributes and keep the existing `label (code)` formatting.
+- Extend the schema-read source guard to require both owner calls and the existing option-projection semantics while forbidding direct `ProductCatalogSchemaService` construction in this resolver.
+
 ## Remaining execution order
 
-1. Publish/cut the owner projection needed by `storefrontCatalogSearchOptions`.
-2. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
-3. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
-4. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
+1. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
+2. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
+3. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 
 ## Verification state
 

--- a/crates/rustok-commerce/src/graphql/query.rs
+++ b/crates/rustok-commerce/src/graphql/query.rs
@@ -17,7 +17,7 @@ use rustok_pricing::{
     in_process_pricing_read_port,
 };
 use rustok_product::services::catalog::helpers::product_channel_visibility_condition;
-use rustok_product::{CatalogService, ProductCatalogSchemaService};
+use rustok_product::CatalogService;
 use rustok_region::{RegionListRequest, RegionReadPort, RegionService};
 use rustok_telemetry::metrics;
 use sea_orm::{
@@ -1877,30 +1877,55 @@ impl CommerceQuery {
         ctx: &Context<'_>,
         locale: String,
     ) -> Result<GqlProductCatalogSearchOptions> {
-        require_module_enabled(ctx, "product").await?;
+        require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         super::require_storefront_channel_enabled(ctx).await?;
-        if locale.trim().is_empty() {
+        let locale = locale.trim();
+        if locale.is_empty() {
             return Err(async_graphql::Error::new("locale is required"));
         }
 
         let db = ctx.data::<DatabaseConnection>()?;
         let event_bus = ctx.data::<TransactionalEventBus>()?;
         let tenant = ctx.data::<TenantContext>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        let category_options = service
-            .list_categories(tenant.id, locale.trim())
+        let port_context = product_schema_read_port_context(
+            ctx,
+            tenant.id,
+            rustok_api::PortActor::service("commerce-storefront-graphql"),
+            locale,
+            "storefront_catalog_search_options",
+        );
+        let schema_read_port = product_schema_read_port(
+            db,
+            event_bus,
+            &port_context,
+            "storefront_catalog_search_options",
+        )?;
+        let category_options = schema_read_port
+            .list_categories(port_context.clone())
             .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "storefront_catalog_search_options",
+                ))
+            })?
             .into_iter()
             .map(|category| GqlProductCatalogSearchOption {
                 value: category.id.to_string(),
                 label: first_non_empty([category.path, category.name, category.code]),
             })
             .collect();
-        let attribute_options = service
-            .list_attributes(tenant.id, locale.trim())
+        let attribute_options = schema_read_port
+            .list_attributes(port_context.clone())
             .await
-            .map_err(|error| map_product_service_error(error, "product_query"))?
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "storefront_catalog_search_options",
+                ))
+            })?
             .into_iter()
             .filter(|attribute| attribute.is_filterable || attribute.is_sortable)
             .map(|attribute| {

--- a/scripts/verify/verify-product-catalog-schema-read-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-read-port.mjs
@@ -167,6 +167,39 @@ requireText(
   "productAttributeValues owner-port cutover must construct ProductAttributeValuesRequest",
 );
 
+const storefrontSearchOptions = resolverSlice(
+  commerceQuery,
+  "storefront_catalog_search_options",
+  "storefront_product",
+);
+for (const required of [
+  "require_module_enabled(ctx, PRODUCT_MODULE_SLUG)",
+  "super::require_storefront_channel_enabled(ctx)",
+  "let locale = locale.trim();",
+  "if locale.is_empty()",
+  "ctx.data::<TenantContext>()",
+  'rustok_api::PortActor::service("commerce-storefront-graphql")',
+  "product_schema_read_port_context(",
+  "product_schema_read_port(",
+  ".list_categories(port_context.clone())",
+  ".list_attributes(port_context.clone())",
+  "product_catalog_port_error(",
+  "first_non_empty([category.path, category.name, category.code])",
+  "attribute.is_filterable || attribute.is_sortable",
+  'format!("{label} ({})", attribute.code)',
+]) {
+  requireText(
+    storefrontSearchOptions,
+    required,
+    `storefrontCatalogSearchOptions owner-port cutover must contain ${required}`,
+  );
+}
+forbidText(
+  storefrontSearchOptions,
+  "ProductCatalogSchemaService::new",
+  "storefrontCatalogSearchOptions must not construct ProductCatalogSchemaService",
+);
+
 if (!process.exitCode) {
   console.log("Product catalog schema read-port guard: source contract OK");
 }


### PR DESCRIPTION
## Summary

- cut mounted GraphQL `storefrontCatalogSearchOptions` from direct `ProductCatalogSchemaService` construction to the host-selected `ProductCatalogSchemaReadPort`
- reuse the existing `list_categories` and `list_attributes` owner capabilities instead of adding a redundant Product projection/API
- preserve storefront-channel admission, required non-empty trimmed locale, current-tenant scope, `commerce-storefront-graphql` service actor, request channel, bounded deadline, and the exact existing category/attribute option filtering and label projection
- route owner errors through the shared correlation-aware Product GraphQL public error mapper
- extend the Product schema-read source guard and actualize the canonical ecommerce plan/recheck packet
- keep legacy mounted `product`/`products`, Product schema writes, and lifecycle command cutovers explicitly open; no FBA/FFA status promotion is claimed

## Verification

Not run per maintainer instruction. No tests, checks, formatter, runtime verification, or FBA/FFA promotion was performed in this PR.