### PR TITLE
feat(index): add bounded text-like filters

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,6 +1,6 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@1ddbc6b5457d2f9263b842c6e5b1942598a26ff7` (#3215) and continued on
+Status overlay rechecked from `main@eab3b1b925e5cbfa65d2fe3f938b63be7a067846` (#3218) and continued on
 `agent/index-text-like-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
@@ -25,9 +25,11 @@ The Product/Index sequence relevant to this cursor includes:
 - #3212 wired localized execution through the canonical PostgreSQL query runtime with persisted readiness,
   generic admission and one read-only repeatable-read snapshot.
 
-Later #3213, #3214 and #3215 are respectively Moderation recovery evidence, Commerce Product
-attribute-values owner-port cutover, and Pages contribution generation. They do not change the Product
-Storefront list owner contract or the `rustok-index` localized query semantics in this slice.
+Later #3213/#3216/#3217 are Moderation evidence slices, #3214 cut Product attribute-values reads to the
+owner schema port, #3215 generated Pages contributions, and #3218 cut mounted Storefront search-option
+metadata to the Product schema read port. Rechecking current `main` after #3218 confirms those changes do
+not alter `StorefrontProductListQuery`, `CatalogService::list_published_products_with_query`, owner title
+`LIKE`, or the `rustok-index` localized query algebra in this slice.
 
 This branch closes the remaining generic scalar title-pattern capability with bounded `TextLike` while
 keeping Storefront traffic owner-native and all execution/equivalence gates unchanged.

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,52 +1,54 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@6044dbd5110a65e2ebeee0a6a3a0053d9971b250` (#3210) and continued on
-`agent/index-localized-query-runtime-20260808`.
+Status overlay rechecked from `main@1ddbc6b5457d2f9263b842c6e5b1942598a26ff7` (#3215) and continued on
+`agent/index-text-like-20260808`.
 
-`implementation-plan.md` remains historical architecture context. The 2026-08-07 overlay remains useful
-history for the linked-target/replay sequence, but this file is the current execution cursor.
+`implementation-plan.md` remains historical architecture context. This file is the current execution
+cursor.
 
 ## Recheck result
 
-The current Product/Index sequence now includes:
+The Product/Index sequence relevant to this cursor includes:
 
 - #3190 retained linked-target replay/redelivery source evidence;
 - #3192 added the fail-closed Product Storefront parity gate;
 - #3193 added staged single-current schema supersession;
-- #3194 added schema-scoped source delivery IDs for replacement rebuilds;
+- #3194 added schema-scoped source delivery IDs;
 - #3197 advanced the canonical Product owner clock for EAV writes;
 - #3198 defined canonical typed Product `attribute_terms`;
 - #3199 replaced Product runtime code with one current 15-field Product contract on internal routing key
   `4`, with lower keys historical only;
-- #3200 corrected Storefront parity after proving owner title search is all-translations and owner result
-  projection is requested-locale -> fallback-locale;
-- #3204 selected the generic localized-entity fold architecture;
-- #3208 added explicit localized query/validation and dedicated cursor identity;
-- #3210 added root-only PostgreSQL localized identity-fold page/count compilation and decoding.
+- #3200 proved owner title search is all-translations while result projection is requested -> fallback;
+- #3204 selected the generic localized-entity identity-fold architecture;
+- #3208 added explicit localized query validation and dedicated cursor identity;
+- #3210 added the root-only PostgreSQL localized page/count compiler and decoder;
+- #3212 wired localized execution through the canonical PostgreSQL query runtime with persisted readiness,
+  generic admission and one read-only repeatable-read snapshot.
 
-This source slice continues from #3210 and wires that compiler/decoder through the canonical query runtime
-without changing Product schema, Product traffic, ordinary exact-locale query semantics, or evidence
-status.
+Later #3213, #3214 and #3215 are respectively Moderation recovery evidence, Commerce Product
+attribute-values owner-port cutover, and Pages contribution generation. They do not change the Product
+Storefront list owner contract or the `rustok-index` localized query semantics in this slice.
+
+This branch closes the remaining generic scalar title-pattern capability with bounded `TextLike` while
+keeping Storefront traffic owner-native and all execution/equivalence gates unchanged.
 
 ## Old execution branch
 
-`agent/index-linked-target-replay-redelivery-evidence-20260807` is no longer a valid continuation base.
-Its source was already squash-merged through #3190. Do not reuse it.
-
-The old branch should be deleted when repository tooling permits it. Branch deletion is repository
-hygiene only; it is not part of Index correctness.
+`agent/index-linked-target-replay-redelivery-evidence-20260807` is not a valid continuation base; its source
+was already squash-merged through #3190. Do not reuse it. Branch deletion is repository hygiene only and
+remains dependent on repository tooling that exposes ref deletion.
 
 ## Current primary owner gate
 
 `M6 - execute and admit concrete repair PostgreSQL evidence`
 
-The concrete repair implementation, recovery policy, PostgreSQL harness, and retained-evidence admission
+The concrete repair implementation, recovery policy, PostgreSQL harness and retained-evidence admission
 source remain complete. Maintainer execution/admission is still required and is not claimed by source
 inspection.
 
 ## Current Product/Storefront source state
 
-The canonical Product graph keeps one current Product runtime contract and the existing ProductVariant and
+The canonical Product graph keeps one current Product runtime contract plus ProductVariant and
 SalesChannel target contracts.
 
 Current Product source/runtime facts:
@@ -55,64 +57,77 @@ Current Product source/runtime facts:
 - 15 fields: `id`, `status`, `title`, `handle`, `description`, `seller_id`, `vendor`, `product_type`,
   `primary_category_id`, `tag_ids`, `created_at`, `published_at`, `attribute_terms`, `variant_ids`, and
   `sales_channel_ids`;
-- `variants` and `sales_channels` links unchanged;
 - Product replay IDs are schema-scoped through `derive_index_schema_source_event_id`;
 - lower Product routing keys are historical persisted identities, not compatibility implementations;
 - EAV writes advance the same Product owner `index_revision` / graph `projection_epoch` clock;
-- dynamic Product EAV filters use stable UUID-keyed typed `attribute_terms`;
-- ProductVariant/SalesChannel recreate ordering still uses retained tombstone-backed `index_revision`;
+- dynamic EAV filters use stable UUID-keyed `attribute_terms`;
+- ProductVariant/SalesChannel recreate ordering remains tombstone-backed and monotonic;
 - Product root freshness and ordinary linked-target availability remain fail-closed.
 
 ## Localized Product query source state
 
-The Storefront owner contract still requires all-translations title admission plus requested -> fallback
-projection. Ordinary exact-locale `IndexQuery` cannot provide that identity contract by itself.
-
-The localized fold source is now complete through runtime execution:
+The localized fold is source-complete through runtime execution:
 
 - `LocalizedEntityQuery` keeps requested locale in `query.scope.locale`, canonical fallback separately,
-  and `any_locale_filter` as an identity-level existential predicate;
-- `localized_projection_fields` explicitly marks selected root scalar fields that project requested ->
-  fallback -> null and therefore cannot leak arbitrary third-locale content;
-- fold validation requires `LocaleMode::Required`, reuses ordinary field/operator/value rules, and keeps
-  the initial implementation root-only;
-- `LocalizedCursorCodec` has independent scoped wire version `3` and binds fallback/search/projection/order
-  semantics; ordinary cursor version `2` remains unchanged;
-- `compile_postgres_localized_page_query` emits page + exact count using `t0` anchor, `t1` requested,
-  `t2` fallback, `t3` any-locale predicate and `t4` lower-locale anti-duplicate candidate;
-- every physical row role retains canonical `is_deleted = FALSE` anchors for generic owner admission;
-- de-duplication occurs before ordering/lookahead/limit/exact count;
-- requested/fallback projection uses row-presence `CASE` rather than value-level `COALESCE`;
-- `decode_postgres_localized_query_page` validates ordinary/localized plan identities and emits only
-  localized continuation cursors;
-- `IndexQueryPort::execute_localized_query` is now an explicit capability with a fail-closed default for
-  adapters that do not implement it;
-- `SharedIndexQueryRuntime` forwards the capability;
-- `PostgresIndexQueryPort` compiles and applies availability/entity admission before beginning data
-  execution, then verifies persisted schema readiness and executes page/count inside one
-  `REPEATABLE READ, READ ONLY` transaction;
-- localized results are decoded only through the localized decoder and transaction success/failure uses
-  the same commit/rollback policy as ordinary queries.
+  `any_locale_filter` as an identity-level existential predicate, and explicit
+  `localized_projection_fields` for requested -> fallback -> null projection;
+- validation requires `LocaleMode::Required`, reuses ordinary field/operator/value rules and keeps this
+  implementation root-only;
+- `LocalizedCursorCodec` uses scoped wire version `3`; ordinary exact-locale cursor wire version `2`
+  remains unchanged;
+- page/count compilation uses `t0` admitted identity anchor, `t1` requested, `t2` fallback, `t3`
+  any-locale predicate and `t4` lower-locale anti-duplicate candidate;
+- physical row roles retain canonical `is_deleted = FALSE` anchors for generic owner admission;
+- identity de-duplication happens before ordering/lookahead/limit/exact count;
+- requested/fallback projection uses row-presence `CASE`;
+- localized decoding checks ordinary/localized plan identities and emits localized cursors only;
+- `IndexQueryPort::execute_localized_query` has a fail-closed default and is forwarded by
+  `SharedIndexQueryRuntime`;
+- `PostgresIndexQueryPort` applies availability/entity admission before storage execution, then verifies
+  persisted readiness and executes page/count inside one `REPEATABLE READ, READ ONLY` transaction.
 
-Storefront traffic is still owner-native. Source-complete runtime is not execution/equivalence evidence.
+## Generic scalar `TextLike` — source complete in this slice
 
-## Remaining localized Storefront query gap
+`FilterExpr::TextLike(FieldPath, String)` is appended after existing filter variants so previous postcard
+discriminants remain stable.
 
-The identity/fallback problem is now solved at the generic query/runtime layer, but owner title search uses
-`LIKE %search%` while the current generic Index scalar filter algebra has no bounded string text-pattern
-operator.
+Validation permits it only for a filterable scalar String field and enforces:
 
-The next source step is a generic scalar string text-pattern primitive that can be validated and compiled
-inside `LocalizedEntityQuery::any_locale_filter`. It must remain generic Index behavior and must not add a
-Product-specific SQL branch.
+- at most 1024 UTF-8 bytes;
+- no NUL;
+- no dangling trailing backslash escape.
 
-After that primitive exists, the Product Storefront adapter can map owner query inputs to the fold and
-retained owner-vs-Index PostgreSQL evidence can be added.
+Semantics match PostgreSQL `LIKE` with explicit backslash escape: `%` matches zero-or-more characters,
+`_` one character and `\` escapes the next wildcard/literal.
+
+The ordinary PostgreSQL compiler binds the pattern and supports linked/many paths through the existing
+correlated `compile_many_exists` machinery. The localized compiler uses the same bound pattern and SQL
+operator for root `any_locale_filter`. The in-memory reference engine and PostgreSQL equivalence reference
+fixture implement the same wildcard grammar.
+
+The current Product owner title helper is still `format!("%{search}%")` + `pt.title LIKE $1` over all
+translations, so the future Product adapter can express the same title predicate as folded
+`TextLike(title, pattern)` without Product-specific Index SQL.
+
+## Search parity caveats discovered during recheck
+
+`StorefrontProductListQuery` currently normalizes optional search text but imposes no explicit search
+length bound. Generic `TextLike` is intentionally bounded to 1024 UTF-8 bytes. Therefore the adapter must
+not claim full owner parity until one of these is proven in reviewed source/evidence:
+
+1. an authoritative upstream Storefront request bound <= 1024 bytes already exists; or
+2. the owner/API contract is explicitly bounded with matching validation and compatibility review.
+
+Silent truncation or rejection in an Index-only adapter is forbidden.
+
+The owner title `LIKE` uses database-default collation while Index String scalar SQL uses deterministic
+`COLLATE "C"`. Retained PostgreSQL equivalence must cover the admitted deployment/input contract before
+search parity can be promoted.
 
 ## Retained M7 PostgreSQL packets
 
-The six packets retained before the Product replacement remain valuable historical scenario definitions,
-but several fixtures still hardcode historical Product routing key `3` and pre-replacement assumptions:
+Several retained packets still encode historical Product routing key `3` / pre-replacement assumptions and
+must be actualized before they count as current replacement evidence:
 
 1. `product_materialized_query_freshness_postgres.rs`;
 2. `product_channel_convergence_postgres.rs`;
@@ -121,10 +136,8 @@ but several fixtures still hardcode historical Product routing key `3` and pre-r
 5. `product_linked_target_availability_equivalence_postgres.rs`;
 6. `product_linked_target_replay_redelivery_postgres.rs`.
 
-The Product locale-absence retained packet and related static guards also require recheck for historical key
-assumptions.
-
-Do not add a runtime alias for key `3`. Evidence must follow the one current Product contract.
+The Product locale-absence retained packet and related guards also require recheck. Do not add a runtime
+alias for key `3`; evidence must follow the one current Product contract.
 
 ## M5 incremental ingestion
 
@@ -135,17 +148,14 @@ Do not add a runtime alias for key `3`. Evidence must follow the one current Pro
 - [x] Product locale/ProductVariant refresh ledgers and durable relay step.
 - [ ] Execute canonical event-contract digest admission on current reviewed `main` and commit the
       generated canonical digest artifact through its own reviewed PR.
-- [ ] Add exactly one canonical Product Index typed event family and concrete routes/consumers only after
-      the digest gate is valid.
+- [ ] Add exactly one canonical Product Index typed event family only after the digest gate is valid.
 - [ ] Retain crash-between-commit-and-ack/redelivery evidence for the typed incremental route.
-
-The digest workflow remains a maintainer execution gate. Source inspection must not fabricate the digest.
 
 ## M6 replay, reconciliation, diagnosis, and repair
 
 - [x] Bounded scan/load and stable replay identities.
-- [x] Durable jobs, leases, checkpoints, multi-page replay, cancellation, and reconciliation.
-- [x] Source timeout, dry-run, cooperative interruption, retry and dead-letter recovery.
+- [x] Durable jobs, leases, checkpoints, multi-page replay, cancellation and reconciliation.
+- [x] Source timeout, dry-run, interruption, retry and dead-letter recovery.
 - [x] Drift discovery/confirmation/finding lifecycle and targeted repair.
 - [x] Concrete missing-entity/orphan-link repair and prepared-command recovery.
 - [x] Real-migration PostgreSQL repair harness and retained-evidence admission tooling.
@@ -155,32 +165,27 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 
 ## M7 Product/ProductVariant/SalesChannel production graph
 
-- [x] Canonical Product, ProductVariant, and SalesChannel bounded sources.
-- [x] Product `variants` and `sales_channels` links.
-- [x] Product/ProductVariant/SalesChannel retained delete identities.
-- [x] Product-to-SalesChannel relation membership ledger and bounded resolver.
-- [x] Canonical Product graph projection epoch and projection-aware Product absence.
-- [x] Product-to-SalesChannel freshness witness and Channel identity generation.
-- [x] Product visibility convergence requests and bounded automatic generic ModuleWork convergence.
-- [x] Rejected-Product poison isolation.
-- [x] Product materialized root freshness fence.
-- [x] Entity-level stale linked-target freshness fence for ProductVariant and SalesChannel.
-- [x] ProductVariant/SalesChannel recreate-safe monotonic `index_revision` via retained tombstones.
-- [x] Query-path-scoped fail-closed linked-target availability semantics for ordinary Product queries.
+- [x] Canonical Product, ProductVariant and SalesChannel bounded sources.
+- [x] Product `variants` and `sales_channels` links and retained delete identities.
+- [x] Product-to-SalesChannel relation membership ledger, resolver and freshness witness.
+- [x] Canonical Product graph projection epoch and projection-aware absence.
+- [x] Rejected-Product poison isolation and materialized root freshness fence.
+- [x] Entity-level stale linked-target freshness fence and recreate-safe target revisions.
+- [x] Query-path-scoped fail-closed linked-target availability for ordinary Product queries.
 - [x] One current 15-field Product Storefront-capable source contract.
 - [x] Schema-safe single-current replacement/promotion mechanism.
 - [x] Canonical typed EAV term representation and Product EAV owner clock.
 - [x] Recheck owner all-translations search + requested/fallback projection mismatch.
-- [x] Select one generic localized identity/fallback architecture without another Product routing key.
-- [x] Add explicit localized query shape/validation and dedicated cursor identity.
-- [x] Compile/decode the root-only localized identity fold page/count contract.
-- [x] Wire localized execution through the canonical PostgreSQL query runtime with persisted readiness,
-      generic admission and one read-only repeatable-read snapshot.
-- [ ] Add generic scalar string text-pattern matching inside folded `any_locale_filter`.
+- [x] Select generic localized identity/fallback architecture without another Product routing key.
+- [x] Add localized query shape/validation and dedicated cursor identity.
+- [x] Compile/decode root-only localized identity-fold page/count.
+- [x] Wire localized execution through canonical PostgreSQL runtime with readiness/admission/snapshot.
+- [x] Add generic scalar String `TextLike` usable inside folded `any_locale_filter`.
 - [ ] Implement the Product Storefront Index adapter and Taxonomy tag hydration boundary.
+- [ ] Resolve owner-search input bound and collation parity for authoritative adapter search.
+- [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` / 15-field source.
+- [ ] Retain source-ready owner-vs-Index localized PostgreSQL equivalence packets.
 - [ ] Extend folded execution to linked paths only with dedicated target-availability evidence.
-- [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` and the 15-field source.
-- [ ] Retain source-ready folded-query owner-vs-Index PostgreSQL equivalence packets.
 - [ ] Execute/admit current replacement Product PostgreSQL packets.
 - [ ] Stage/rebuild/promote the current Product schema for a tenant.
 - [ ] Move Storefront traffic only after readiness/equivalence/freshness/availability/restart evidence
@@ -190,15 +195,17 @@ The digest workflow remains a maintainer execution gate. Source inspection must 
 
 Primary maintainer gate remains: **execute and admit the locked M6 repair PostgreSQL packet**.
 
-Next source-code step: **add one generic bounded scalar string text-pattern filter operator** to the Index
-query contract/validation/PostgreSQL compiler and allow it inside folded `any_locale_filter`. Preserve
-ordinary query compatibility and use explicit pattern semantics; do not add a Product-only SQL branch.
+Next source-code step: **implement the Product Storefront Index adapter plus retained localized-query
+PostgreSQL equivalence packet**, while leaving Storefront traffic owner-native. The adapter must map
+Active/published/category/channel/EAV/order/page/count, requested/fallback localized projection and
+`TextLike` all-translations title search, then batch-hydrate Taxonomy tag names after the Product page is
+fixed.
 
-After text-pattern support, implement the Product Storefront Index adapter and a retained localized-query
-PostgreSQL equivalence packet before any traffic switch.
+The same slice must make the search-bound/collation mismatch explicit and fail closed until an
+authoritative equivalent input contract is demonstrated. Do not silently truncate owner-valid search.
 
-In parallel, actualize retained Product PostgreSQL packets to routing key `4` / the 15-field current
-contract. No historical-key compatibility path is allowed.
+In parallel, actualize retained Product PostgreSQL packets to routing key `4` / current 15-field contract.
+No historical-key runtime compatibility path is allowed.
 
 Typed Product events remain separately blocked on maintainer event-digest admission.
 
@@ -207,6 +214,7 @@ Typed Product events remain separately blocked on maintainer event-digest admiss
 The implementation agent has not run these commands. Maintainer verification should include:
 
 ```bash
+node scripts/verify/verify-index-text-like-filter.mjs
 node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-localized-query-postgres-fold.mjs
 node scripts/verify/verify-index-localized-query-runtime.mjs

--- a/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
+++ b/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
@@ -1,29 +1,33 @@
 # M7 Product Storefront localized query architecture
 
-Status: `runtime_source_complete_text_pattern_and_evidence_pending`.
+Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`.
 
 ## Decision
 
-Keep the current owner Storefront behavior and exactly one current Product Index schema. Close the
-remaining locale/search mismatch in the **Index query layer** with a generic localized-entity identity
-fold over the existing physical locale rows.
+Keep the current owner Storefront behavior and exactly one current Product Index schema. Preserve the
+physical locale-keyed Index rows and close Storefront locale/search parity in the generic Index query layer
+with an explicit localized-entity identity fold.
 
-Do not narrow Product owner search/fallback semantics merely to fit `IndexQueryScope`, and do not add a
-Storefront-only Product routing key or compatibility source. Locale folding is a query-shape concern, not
-a new immutable Product schema version.
+Do not narrow owner search/fallback behavior merely to fit ordinary `IndexQueryScope`, and do not add a
+Storefront-only Product routing key or compatibility schema. Locale folding and text matching are query
+semantics, not immutable Product storage identities.
 
 ## Owner contract preserved
 
-`CatalogService::list_published_products_with_query` remains authoritative until cutover evidence passes.
-The replacement path must preserve:
+`CatalogService::list_published_products_with_query` remains authoritative until retained equivalence and
+cutover gates pass. Its relevant contract is:
 
 - one result identity per Product;
-- title search matching any Product translation;
+- title search may match any Product translation;
 - requested locale -> fallback locale result projection;
 - owner placeholder behavior when neither requested nor fallback translation exists;
-- Product status/publication/category/channel/EAV identity predicates;
-- timestamp ordering with stable Product identity tie-break;
-- pagination/exact count over Product identities, not physical translation rows.
+- Active/published/category/channel/EAV identity predicates;
+- exact count and stable timestamp + Product-ID ordering over Product identities;
+- page/per-page pagination after those identity predicates.
+
+The current Product title helper trims an empty search away, then constructs `format!("%{search}%")` and
+executes PostgreSQL `pt.title LIKE $1` in an `EXISTS` over all Product translations. It has no locale
+predicate and currently has no Product-level search-length limit.
 
 ## Generic identity model
 
@@ -32,46 +36,39 @@ The folded logical identity is `(tenant_id, schema_ref, entity_id)` while physic
 replay, absence and freshness remain locale-keyed.
 
 `LocalizedEntityQuery` keeps `query.scope.locale` as requested locale, stores canonical fallback separately,
-and exposes a separate root-only `any_locale_filter` for identity-level existential matching.
+and exposes root-only `any_locale_filter` for identity-level existential matching.
 
-Generic Index schemas intentionally do not label fields as owner-localized. The fold therefore has an
-explicit `localized_projection_fields` role set. A listed field is projected only from:
+Generic schemas intentionally do not claim that particular fields are owner-localized. The fold therefore
+uses explicit `localized_projection_fields`. A listed field is projected only from:
 
 1. an admitted requested-locale row;
 2. otherwise an admitted fallback-locale row;
 3. otherwise SQL null.
 
-Unlisted fields are read from a deterministic admitted identity anchor. This explicit classification
-prevents a third-locale anchor from leaking `title`, `handle` or other localized content when the
-requested/fallback rows are absent. It does not change the Product schema fingerprint.
+Unlisted fields are read from a deterministic admitted identity anchor. This prevents an arbitrary third
+locale from leaking title/handle content when requested/fallback rows are absent, without changing the
+Product schema fingerprint.
 
-The initial compiler/runtime is intentionally root-only. Linked query paths fail validation until linked
-fold semantics and their own availability evidence are added. This still covers the current Product
-Storefront list contract, which can express its identity predicates through root fields such as
-`sales_channel_ids` and `attribute_terms`.
+The current compiler/runtime remains root-only. Linked folded paths fail validation until linked semantics
+and target-availability evidence are introduced explicitly. The current Storefront list can express its
+root identity predicates through materialized fields such as `sales_channel_ids` and `attribute_terms`.
 
 ## Query validation and cursor identity
 
-`SchemaRegistry::validate_localized_entity_query`:
-
-- requires `LocaleMode::Required`;
-- reuses ordinary field/operator/value validation;
-- shares one bounded node budget between ordinary and any-locale filters;
-- rejects linked paths in this compiler/runtime slice;
-- requires every `localized_projection_fields` entry to be a selected root scalar field;
-- rejects localized projection fields from the ordinary identity filter and identity ordering.
+`SchemaRegistry::validate_localized_entity_query` requires `LocaleMode::Required`, reuses ordinary
+field/operator/value validation, shares one bounded filter-node budget across ordinary and any-locale
+filters, rejects linked paths, and requires every localized projection entry to be a selected root scalar.
+Localized projection fields cannot drive ordinary identity filtering or ordering.
 
 `LocalizedCursorCodec` uses scoped wire version `3`; ordinary exact-locale cursors remain on version `2`.
-Its fingerprint binds fold mode, tenant/schema, requested/fallback roles, ordinary filter,
-`any_locale_filter`, canonical localized projection roles and ordering. A token cannot cross fold modes or
-be reused after changing projection/search/fallback semantics.
+The localized query fingerprint binds fold mode, tenant/schema, requested/fallback roles, ordinary filter,
+`any_locale_filter`, canonical localized projection roles and ordering. A continuation cannot cross modes
+or survive a changed text pattern/search shape.
 
-## PostgreSQL fold compiler
+## PostgreSQL fold compiler and decoder
 
 `SchemaRegistry::compile_postgres_localized_page_query` compiles one page statement and optional exact
-count without modifying the ordinary PostgreSQL compiler.
-
-The page compiler uses canonical physical aliases:
+count. Canonical physical aliases are:
 
 - `t0` — deterministic admitted identity anchor;
 - `t1` — requested-locale projection row;
@@ -79,92 +76,99 @@ The page compiler uses canonical physical aliases:
 - `t3` — any-locale existential predicate row;
 - `t4` — lower-locale anti-duplicate anchor candidate.
 
-Every physical role is an `index_entities AS "tN"` relation with the ordinary
-`"tN".is_deleted = FALSE` anchor. The existing generic `PostgresQueryEntityAdmission` can therefore
-inject current owner freshness rules into every participating row role without a Product-specific compiler
-branch.
+Every role retains the ordinary `is_deleted = FALSE` anchor so generic `PostgresQueryEntityAdmission` can
+inject owner freshness without a Product-specific compiler branch. One identity survives before
+ordering/lookahead/limit/count by excluding an admitted lower-locale `t4` row.
 
-One Product identity survives page/count selection by choosing the lexicographically lowest **admitted**
-physical locale row as `t0`: an identity is rejected as a duplicate when an admitted same-identity `t4`
-with a lower locale key exists. De-duplication therefore happens before ordering, lookahead, limit and
-exact count.
+Ordinary identity filters and ordering are evaluated on `t0`; `any_locale_filter` is an `EXISTS` over
+`t3`. Requested/fallback projection uses row-presence `CASE`, not value-level `COALESCE`. Exact count uses
+the same identity/search boundary but intentionally omits requested/fallback projection rows.
 
-Ordinary identity filters and ordering are evaluated on `t0`. `any_locale_filter` is compiled into an
-`EXISTS` over `t3`. Localized projected fields use row-presence `CASE`, not value-level `COALESCE`, so a
-present requested row with a nullable field does not incorrectly fall through to fallback content.
-
-Exact count uses the same `t0`/`t3`/`t4` identity boundary but intentionally omits `t1`/`t2`: requested or
-fallback projection availability does not change owner Product identity count.
-
-The compiler emits a dedicated `LocalizedQueryPlanFingerprint` in addition to the ordinary plan
-fingerprint. It binds the canonical fallback, any-locale predicate and localized projection roles.
-
-## Decoder
-
-`SchemaRegistry::decode_postgres_localized_query_page` verifies both ordinary and localized plan
-fingerprints, exact column contracts, lookahead bounds and exact-count shape.
-
-For unlisted fields it preserves the ordinary schema nullability/type/cardinality contract. For an explicit
-localized projection field only, SQL null is additionally valid and means that neither requested nor
-fallback physical locale row was admitted. That null is an Index-level absence signal; the later Product
-Storefront adapter must apply the existing owner placeholder behavior instead of selecting an arbitrary
-third translation.
-
-Lookahead produces `LocalizedIndexCursor` through `LocalizedCursorCodec`; no ordinary exact-locale cursor
-is emitted or accepted by this path.
+`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary and localized plan fingerprints,
+column/count/lookahead contracts and emits only localized continuation cursors. SQL null beyond physical
+field nullability is accepted only for an explicit localized projection field and means no admitted
+requested/fallback row exists.
 
 ## Runtime execution — source complete
 
-`IndexQueryPort` now publishes an explicit `execute_localized_query` method. The trait default fails closed
-with a stable contract-preparation error, so existing non-PostgreSQL/custom adapters remain source
-compatible without silently claiming localized semantics.
+`IndexQueryPort` publishes `execute_localized_query`; its default implementation fails closed so custom or
+non-PostgreSQL adapters do not silently claim the capability. `SharedIndexQueryRuntime` forwards the
+capability.
 
-`SharedIndexQueryRuntime` forwards the localized capability to the host-selected query port.
+`PostgresIndexQueryPort::execute_localized_query`:
 
-`PostgresIndexQueryPort::execute_localized_query` implements the canonical execution boundary:
+1. requires PostgreSQL;
+2. derives persisted schema contracts from the embedded ordinary root query;
+3. compiles the localized page/count contract;
+4. applies query-path availability plus `PostgresQueryEntityAdmission` before storage execution;
+5. starts one `REPEATABLE READ, READ ONLY` transaction;
+6. verifies persisted tenant schema status/fingerprint/JSON in that snapshot;
+7. executes page and optional exact count in the same snapshot;
+8. decodes only through `decode_postgres_localized_query_page`;
+9. commits successful reads and rolls back failures.
 
-1. require PostgreSQL backend;
-2. derive the same persisted schema contracts from the embedded ordinary root query;
-3. compile `CompiledPostgresLocalizedPageQuery`;
-4. apply query-path availability plus `PostgresQueryEntityAdmission` to the compiled fold **before**
-   beginning storage execution;
-5. begin one transaction and configure it as `REPEATABLE READ, READ ONLY`;
-6. verify tenant-scoped persisted schema readiness/fingerprint/JSON/status inside that snapshot;
-7. execute page SQL and optional exact-count SQL in the same snapshot;
-8. decode only through `decode_postgres_localized_query_page`;
-9. commit successful read snapshots or roll back on any error.
+The path reuses ordinary bind mapping, row mapping, exact-count handling, readiness verification and
+transaction finalization.
 
-Admission preparation is deliberately outside storage execution. A malformed or incompatible trusted
-admission template fails closed before page/count statements run. Persisted readiness remains inside the
-same snapshot as data reads.
+## Generic `TextLike` — source complete
 
-The runtime reuses the ordinary page-row mapping, exact-count mapping, schema readiness verifier, bind
-mapping and transaction finalization rather than creating a second storage policy.
+`FilterExpr::TextLike(FieldPath, String)` is appended after all pre-existing filter variants so existing
+postcard enum discriminants remain stable. It is generic Index behavior, not Product-specific behavior.
 
-Because the current fold validator rejects linked paths, query-path link-target availability is a no-op for
-this initial localized runtime. The same admission helper is still called so future linked support cannot
-silently bypass the established execution boundary.
+Validation requires:
 
-## Remaining title-search primitive
+- a filterable scalar (`FieldCardinality::One`) String field;
+- pattern size at most 1024 UTF-8 bytes;
+- no NUL byte;
+- no trailing unpaired backslash escape.
 
-Any-locale title search remains an identity predicate. A matching physical locale row may admit an
-identity, but that row never becomes result localization merely because it matched.
+Pattern semantics are explicit PostgreSQL `LIKE` semantics:
 
-The current generic filter algebra still lacks a scalar string text-pattern/substring operator matching
-the Product owner `LIKE %search%` semantics. The next source slice must add one generic bounded scalar
-text-pattern primitive and compile it inside `any_locale_filter`; adding LIKE/substring only to ordinary
-exact-locale filtering remains insufficient.
+- `%` matches zero or more characters;
+- `_` matches one character;
+- `\` escapes the following wildcard or literal character.
+
+Both the ordinary PostgreSQL compiler and the localized alias compiler bind the pattern as
+`PostgresBindValue::Text` and compile `LIKE ... ESCAPE E'\\'`. Ordinary linked/many filtering reuses the
+existing correlated `compile_many_exists` path; the localized fold stays root-only and can use the same
+operator inside `any_locale_filter`.
+
+The in-memory reference engine and the PostgreSQL equivalence reference fixture implement the same
+wildcard/escape grammar over Unicode scalar values. Query/cursor fingerprints already serialize
+`FilterExpr`, so changing a `TextLike` pattern changes continuation identity without another cursor wire
+version.
+
+For the current Product owner search, the future adapter can build `%{trimmed_search}%` and place
+`TextLike(title, pattern)` inside `any_locale_filter`. A search match in `t3` admits the Product identity but
+does not choose the projected locale.
+
+## Remaining Product search-bound mismatch
+
+`TextLike` is deliberately bounded, while the current `StorefrontProductListQuery` has no explicit search
+length bound. Therefore source completion of `TextLike` does **not** by itself establish owner parity for
+arbitrarily long search input.
+
+Before Storefront cutover, the adapter/equivalence slice must resolve this explicitly. Acceptable outcomes
+are to establish an existing authoritative upstream bound that is <= 1024 bytes, or introduce one
+reviewed owner/API bound and retain matching validation evidence. The adapter must not silently truncate,
+reject, or reinterpret an input that the authoritative owner path still accepts.
+
+Retained PostgreSQL evidence must also cover the deployment collation used by owner title `LIKE` versus the
+Index String scalar's deterministic `COLLATE "C"`; no general collation-equivalence claim is made by source
+inspection.
 
 ## Storefront adapter boundary
 
-After scalar text-pattern support exists, the Product adapter must:
+The next Product adapter must:
 
 - map Active + published-only/category/channel visibility predicates;
-- resolve public Product attribute/option codes to canonical `attribute_terms`;
-- classify `title`/`handle` and other returned localized fields in `localized_projection_fields`;
-- use folded any-locale title search;
-- batch-hydrate localized Taxonomy tag names after the Product page is fixed;
-- preserve owner page/per-page, exact count, ordering and ID tie-break semantics.
+- resolve Product attribute/option codes to canonical `attribute_terms`;
+- classify returned localized fields such as `title`/`handle` in `localized_projection_fields`;
+- build folded any-locale title search with `TextLike`;
+- preserve requested/fallback/placeholder behavior;
+- preserve timestamp ordering, Product-ID tie-break, page/per-page and exact count;
+- batch-hydrate localized Taxonomy tag names only after the Product page is fixed;
+- fail closed on the unresolved owner-vs-Index search-bound/collation gates.
 
 Taxonomy localization stays Taxonomy-owned; Product Index stores stable tag UUIDs only.
 
@@ -175,16 +179,18 @@ Before Storefront traffic can move, PostgreSQL equivalence must cover at least:
 1. requested translation present;
 2. requested absent + fallback present;
 3. requested/fallback absent while another translation exists;
-4. search match only in requested locale;
-5. search match only in fallback locale;
-6. search match only in a third locale while projection still follows requested/fallback roles;
-7. duplicate matches in multiple locales yielding one Product identity/exact count;
-8. interleaved physical locale rows with stable global identity ordering/page boundaries;
-9. cursor continuation and exact-count parity;
-10. delayed/stale locale rows excluded by owner freshness;
-11. persisted schema readiness failure before authoritative query results;
-12. fresh runtime/recomposition/replay redelivery preserving the same grouped page;
-13. current Product routing-key rebuild/promotion rather than a historical lower key.
+4. title match only in requested locale;
+5. title match only in fallback locale;
+6. title match only in a third locale while projection still follows requested/fallback roles;
+7. `%`, `_` and escaped wildcard search behavior;
+8. duplicate matches in multiple locales yielding one Product identity/exact count;
+9. interleaved locale rows with stable global identity ordering/page boundaries;
+10. cursor continuation and exact-count parity;
+11. delayed/stale locale rows excluded by owner freshness;
+12. persisted schema readiness failure before authoritative results;
+13. restart/recomposition/replay redelivery preserving the grouped page;
+14. search-bound and database-collation parity for the admitted Storefront input contract;
+15. current Product routing-key rebuild/promotion rather than a historical lower key.
 
 Linked-target lag evidence remains required before adding linked paths to folded execution.
 
@@ -192,28 +198,31 @@ Linked-target lag evidence remains required before adding linked paths to folded
 
 This slice does not:
 
-- change ordinary `IndexQuery` or its compiler/cursor;
-- add scalar text-pattern matching;
 - implement the Product Storefront Index adapter;
-- actualize/execute retained Product PostgreSQL packets;
+- resolve the currently unbounded owner search-input contract;
+- claim owner/Index collation equivalence;
+- actualize or execute retained Product PostgreSQL packets;
 - add Product typed events or bypass event-digest admission;
 - rebuild/promote a tenant Product schema;
 - switch Storefront traffic.
 
 ## Next implementation slice
 
-Add a generic bounded scalar string text-pattern primitive to the Index filter contract and PostgreSQL
-compiler, then allow it inside `LocalizedEntityQuery::any_locale_filter`. Keep the operator generic and
-schema-validated; do not add a Product-specific SQL branch. After that, implement the Product Storefront
-adapter plus retained owner-vs-Index localized-query PostgreSQL evidence before any traffic cutover.
+Implement the Product Storefront Index adapter and a retained owner-vs-Index localized-query PostgreSQL
+packet, while keeping traffic owner-native. The adapter slice must explicitly resolve the search-input
+bound/collation gates before it can claim full search parity.
+
+In parallel, actualize historical Product PostgreSQL packets to routing key `4` and the current 15-field
+contract. Do not add a historical routing-key compatibility implementation.
 
 ## Source guards
 
 - `scripts/verify/verify-index-localized-query-contract.mjs` locks query/projection/cursor roles.
-- `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks the root-only page/count compiler,
-  physical alias/admission anchors and decoder.
-- `scripts/verify/verify-index-localized-query-runtime.mjs` locks fail-closed port publication, host
-  forwarding, readiness/admission-before-execution and one-snapshot page/count runtime semantics.
+- `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks fold compiler/decoder semantics.
+- `scripts/verify/verify-index-localized-query-runtime.mjs` locks fail-closed runtime readiness/admission
+  and one-snapshot page/count execution.
+- `scripts/verify/verify-index-text-like-filter.mjs` locks bounded scalar String validation, PostgreSQL
+  LIKE compilation, reference semantics and the current Product owner search shape.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,15 +1,15 @@
 # M7 Product Storefront Index parity gate
 
-Status: `localized_runtime_source_complete_text_pattern_adapter_and_evidence_pending`.
+Status: `localized_runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`.
 
 ## Purpose
 
-The Product Storefront catalog remains owner-native. The single current Product Index source materializes
-the Storefront scalar fields, stable tag identities, and typed EAV query state that were previously
-missing. The remaining localized Product identity mismatch now has a selected architecture, explicit
-query/cursor contract, PostgreSQL fold compiler/decoder, and fail-closed PostgreSQL runtime execution.
-Generic scalar text-pattern support, the Product Storefront adapter, and retained owner-vs-Index evidence
-are still pending.
+The Product Storefront catalog remains owner-native. The current Product Index source now has the
+Storefront scalar/EAV state, the localized identity fold, PostgreSQL compiler/decoder, fail-closed runtime,
+and a generic bounded scalar String `TextLike` operator usable inside folded `any_locale_filter`.
+
+The Product Storefront adapter and retained owner-vs-Index PostgreSQL evidence are still pending. Source
+completion is not traffic-cutover evidence.
 
 Storefront must continue to execute `CatalogService::list_published_products_with_query`.
 
@@ -27,94 +27,89 @@ Two translation details remain authoritative:
    the matching row to requested/fallback locale;
 2. result projection uses `pick_product_translation(items, requested, fallback)`.
 
+The title helper builds `format!("%{search}%")` and executes `pt.title LIKE $1`. Current Product list input
+normalizes whitespace but does not impose an explicit search-length bound.
+
 ## Single current Product Index coverage
 
-Current Product runtime code publishes one Product schema with 15 fields and two links. Product Index
-still emits one physical entity per stored translation locale. It does not fabricate requested/fallback
-rows. This physical model remains correct; Storefront equivalence is resolved by the query fold, not by
-another Product schema/routing key.
+Current Product runtime code publishes one Product schema with 15 fields and two links. Product Index emits
+one physical entity per stored translation locale and does not fabricate requested/fallback rows. The
+physical model remains correct; Storefront equivalence is handled by the query fold rather than another
+Product schema or routing key.
 
 Do **not** add another Product routing key merely to patch localized Storefront query semantics. The
 current Product contract remains the only runtime Product implementation.
 
 ## Localized identity fold — source complete
 
-The selected generic fold preserves logical result identity
-`(tenant_id, schema_ref, entity_id)` while physical storage remains locale-keyed.
+The generic fold preserves logical result identity `(tenant_id, schema_ref, entity_id)` while physical
+storage remains locale-keyed.
 
-`LocalizedEntityQuery` provides:
-
-- requested locale through `query.scope.locale`;
-- canonical fallback locale;
-- root-only `any_locale_filter` for identity-level existential matching;
-- explicit `localized_projection_fields` for requested -> fallback -> null output semantics.
-
-`LocalizedCursorCodec` uses dedicated scoped wire version `3`; ordinary exact-locale cursors remain on
-version `2` and cannot cross modes.
+`LocalizedEntityQuery` provides requested locale through `query.scope.locale`, canonical fallback,
+root-only `any_locale_filter`, and explicit `localized_projection_fields` for requested -> fallback -> null
+output semantics. `LocalizedCursorCodec` uses dedicated scoped wire version `3`; ordinary exact-locale
+cursors remain on version `2`.
 
 The initial fold deliberately rejects linked query paths. Current Product Storefront list identity
-predicates can still be expressed through root fields such as `sales_channel_ids` and `attribute_terms`.
-Linked folded paths remain separately evidence-gated.
+predicates can still use root materialized fields such as `sales_channel_ids` and `attribute_terms`.
 
 ## PostgreSQL compiler/decoder — source complete
 
-`SchemaRegistry::compile_postgres_localized_page_query` uses canonical physical aliases:
+`SchemaRegistry::compile_postgres_localized_page_query` uses canonical physical aliases `t0` anchor, `t1`
+requested row, `t2` fallback row, `t3` any-locale predicate row and `t4` lower-locale anti-duplicate
+candidate.
 
-- `t0` deterministic admitted identity anchor;
-- `t1` requested projection row;
-- `t2` fallback projection row;
-- `t3` any-locale predicate row;
-- `t4` lower-locale anti-duplicate candidate.
+All physical roles retain `is_deleted = FALSE` so generic `PostgresQueryEntityAdmission` can inject owner
+freshness. De-duplication happens before ordering/lookahead/limit/exact-count. Requested/fallback projection
+uses row-presence `CASE`; exact count is independent of requested/fallback projection availability.
 
-All physical roles retain the ordinary `is_deleted = FALSE` anchor so trusted generic
-`PostgresQueryEntityAdmission` can inject current owner freshness before execution. De-duplication occurs
-before ordering/lookahead/limit/exact-count. Requested/fallback projection uses row-presence `CASE`, and
-exact count is independent of projection-row availability.
-
-`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary plus localized plan identity,
-column/count/lookahead contracts, allows extra SQL-null only for explicit localized projection fields,
-and emits dedicated localized continuation cursors.
+`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary/localized plan identity,
+column/count/lookahead contracts, allows extra SQL-null only for explicit localized projection fields, and
+emits localized continuation cursors.
 
 ## PostgreSQL runtime — source complete
 
-`IndexQueryPort` now exposes explicit `execute_localized_query`. Its default implementation fails closed,
-keeping existing adapters source-compatible without claiming unsupported semantics.
+`IndexQueryPort` exposes explicit `execute_localized_query` with a fail-closed default.
+`SharedIndexQueryRuntime` forwards it. Canonical `PostgresIndexQueryPort` applies availability and generic
+owner admission before storage execution, then runs persisted schema readiness, page and optional exact
+count in one `REPEATABLE READ, READ ONLY` transaction and decodes only through the localized decoder.
 
-`SharedIndexQueryRuntime` forwards the capability to the host-selected port.
+## Generic `TextLike` — source complete
 
-The canonical `PostgresIndexQueryPort` execution path:
+`FilterExpr::TextLike(FieldPath, String)` is a generic Index filter variant appended after the existing
+filter variants to preserve prior postcard discriminants.
 
-1. requires PostgreSQL;
-2. compiles the localized page/count contract;
-3. applies query-path availability plus generic owner entity admission to all compiled physical aliases
-   before storage execution;
-4. begins one `REPEATABLE READ, READ ONLY` transaction;
-5. verifies tenant-scoped persisted schema status/fingerprint/JSON inside that snapshot;
-6. executes page and optional exact count in the same snapshot;
-7. decodes only through `decode_postgres_localized_query_page`;
-8. commits successful read snapshots and rolls back failures.
+Validation permits it only on a filterable scalar String field. The pattern is limited to 1024 UTF-8
+bytes, rejects NUL and a trailing unpaired backslash, and uses PostgreSQL-compatible wildcard rules:
+`%` for zero-or-more characters, `_` for one character, and `\` as the escape character.
 
-This reuses the ordinary readiness verifier, bind mapping, row mapping, exact-count mapping, and
-transaction finalization. No second storage policy is introduced.
+Both ordinary and localized PostgreSQL compilers bind the pattern and emit `LIKE ... ESCAPE E'\\'`.
+Ordinary linked/many filtering reuses the existing correlated filter machinery. The reference engine and
+PostgreSQL equivalence fixture implement the same wildcard grammar.
 
-## Remaining search gap
+The localized Product title predicate can therefore be represented as
+`any_locale_filter = TextLike(title, format!("%{trimmed_search}%"))` without a Product-specific SQL branch.
+A title match admits the Product identity but does not select the projected locale.
 
-A scalar substring/LIKE operator alone was previously insufficient because exact-locale querying could
-not preserve any-locale admission plus requested/fallback projection. The fold now solves that identity
-problem, but the generic filter algebra still lacks a scalar string text-pattern primitive matching the
-owner `LIKE %search%` behavior.
+## Remaining search parity gates
 
-The next source slice must add one generic bounded scalar string text-pattern operator and compile it in
-ordinary root SQL so it can be used safely inside `any_locale_filter`. It must not introduce a
-Product-specific SQL branch.
+The Product owner list currently has no explicit search-length bound, while generic `TextLike` is bounded
+to 1024 UTF-8 bytes. The Storefront adapter must not silently truncate or reject owner-valid input.
+Before cutover, the adapter/evidence slice must either prove an authoritative upstream <=1024-byte bound
+or introduce a reviewed owner/API bound with matching validation evidence.
+
+The owner title `LIKE` also uses the database default collation while Index String scalar SQL uses the
+engine's deterministic `COLLATE "C"`. Retained PostgreSQL equivalence must establish the admitted
+deployment/input contract before search parity can be promoted.
 
 ## Typed EAV and Taxonomy boundaries
 
 Dynamic Product EAV remains represented by canonical UUID-keyed `attribute_terms`. Public Product
 attribute/option codes must be resolved through Product owner metadata before building Index predicates.
+Localized text EAV retains the owner fallback predicate defined in `m7-product-attribute-term-contract.md`.
 
-Index stores stable Product tag UUIDs, not localized Taxonomy names. A future Storefront adapter must
-batch-hydrate requested/fallback tag names only after the Product page is fixed.
+Index stores stable Product tag UUIDs, not localized Taxonomy names. A future adapter must batch-hydrate
+requested/fallback tag names only after the Product page is fixed.
 
 ## Immutable replacement boundary
 
@@ -124,14 +119,14 @@ historical only. Promotion remains staged: register current key, rebuild/replay,
 
 ## Remaining work before Storefront cutover
 
-1. add generic scalar text-pattern matching usable in folded `any_locale_filter`;
-2. implement the Product Storefront Index adapter;
-3. map Active + published-only/category/channel/EAV/order/page/count semantics;
-4. resolve Product attribute/option codes to canonical terms;
-5. batch-hydrate localized Taxonomy tag names;
+1. implement the Product Storefront Index adapter over `execute_localized_query`;
+2. map Active + published-only/category/channel/EAV/order/page/count semantics;
+3. resolve Product attribute/option codes to canonical terms;
+4. use `TextLike` for all-translations title search and explicitly resolve the search-bound/collation gates;
+5. batch-hydrate localized Taxonomy tag names after page selection;
 6. actualize retained Product PostgreSQL packets to routing key `4` / current 15-field contract;
-7. retain and execute owner-vs-Index localized equivalence, including requested/fallback/third-locale
-   search, de-dup, ordering, pagination, exact count, stale locale materialization, readiness and restart;
+7. retain owner-vs-Index localized equivalence for requested/fallback/third-locale search, wildcard escape,
+   de-dup, ordering, pagination, exact count, stale locale materialization, readiness and restart;
 8. extend linked folded paths only with explicit target-lag availability evidence;
 9. stage/rebuild/promote the current Product key for a tenant;
 10. only then select Index traffic.
@@ -143,18 +138,20 @@ historical only. Promotion remains staged: register current key, rebuild/replay,
 - `verify-index-product-storefront-localized-query-architecture.mjs` locks the fold architecture;
 - `verify-index-localized-query-contract.mjs` locks query/projection/cursor roles;
 - `verify-index-localized-query-postgres-fold.mjs` locks compiler/decoder semantics;
-- `verify-index-localized-query-runtime.mjs` locks fail-closed port publication, readiness, admission and
-  one-snapshot execution.
+- `verify-index-localized-query-runtime.mjs` locks readiness/admission/one-snapshot execution;
+- `verify-index-text-like-filter.mjs` locks bounded String `TextLike`, PostgreSQL/reference semantics and
+  the current Product owner title-search shape.
 
 ## Deliberate limits
 
-This slice does not add scalar text-pattern matching, implement the Product Storefront adapter, execute or
-admit PostgreSQL evidence, rebuild/promote a tenant Product schema, add Product typed events, or switch
-Storefront traffic.
+This slice does not implement the Product Storefront adapter, resolve the owner search-length/collation
+parity gates, execute/admit PostgreSQL evidence, rebuild/promote a tenant Product schema, add Product typed
+events, or switch Storefront traffic.
 
 ## Maintainer verification
 
 ```bash
+node scripts/verify/verify-index-text-like-filter.mjs
 node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-localized-query-postgres-fold.mjs
 node scripts/verify/verify-index-localized-query-runtime.mjs

--- a/crates/rustok-index/src/application/postgres_localized_query.rs
+++ b/crates/rustok-index/src/application/postgres_localized_query.rs
@@ -429,6 +429,14 @@ fn compile_filter_for_alias(
                 Ok(format!("NOT ({})", sql.null_predicate))
             }
         }
+        FilterExpr::TextLike(path, pattern) => {
+            let sql = field_sql_for_path(plan, path, alias, bindings)?;
+            let pattern = bindings.push(PostgresBindValue::Text(pattern.clone()));
+            Ok(format!(
+                "COALESCE({} LIKE {pattern} ESCAPE E'\\\\', FALSE)",
+                sql.scalar
+            ))
+        }
     }
 }
 
@@ -775,9 +783,9 @@ mod tests {
                 include_exact_count: true,
             },
             Some(LocaleKey::new("en").unwrap()),
-            Some(FilterExpr::Eq(
+            Some(FilterExpr::TextLike(
                 FieldPath::new(FieldName::new("title").unwrap()),
-                IndexValue::String("needle".to_owned()),
+                "%needle%".to_owned(),
             )),
         )
         .with_localized_projection_fields([FieldPath::new(FieldName::new("title").unwrap())])
@@ -801,11 +809,14 @@ mod tests {
         assert!(sql.contains("\"t4\".locale_key < \"t0\".locale_key"));
         assert!(sql.contains("CASE WHEN \"t1\".entity_id IS NOT NULL"));
         assert!(sql.contains("WHEN \"t2\".entity_id IS NOT NULL"));
+        assert!(sql.contains(" LIKE "));
+        assert!(sql.contains("ESCAPE E'\\\\'"));
         assert_eq!(compiled.requested_page_size(), 20);
         let count = compiled.compiled().exact_count.as_ref().unwrap();
         assert!(count.sql.contains("index_entities AS \"t0\""));
         assert!(count.sql.contains("index_entities AS \"t3\""));
         assert!(count.sql.contains("index_entities AS \"t4\""));
+        assert!(count.sql.contains(" LIKE "));
         assert!(!count.sql.contains("index_entities AS \"t1\""));
     }
 

--- a/crates/rustok-index/src/application/postgres_query_sql.rs
+++ b/crates/rustok-index/src/application/postgres_query_sql.rs
@@ -273,6 +273,7 @@ fn compile_filter(
         FilterExpr::IsNull(path, expected_null) => {
             compile_is_null(plan, path, *expected_null, bindings)
         }
+        FilterExpr::TextLike(path, pattern) => compile_text_like(plan, path, pattern, bindings),
     }
 }
 
@@ -433,6 +434,31 @@ fn compile_is_null(
         } else {
             Ok(format!("NOT ({})", sql.null_predicate))
         }
+    }
+}
+
+fn compile_text_like(
+    plan: &ExecutableQueryPlan,
+    path: &FieldPath,
+    pattern: &str,
+    bindings: &mut Bindings,
+) -> Result<String, PostgresQueryCompileError> {
+    let field = planned_field(plan, path)?;
+    if field.traverses_many {
+        compile_many_exists(plan, field, bindings, |sql, bindings| {
+            let pattern = bindings.push(PostgresBindValue::Text(pattern.to_owned()));
+            Ok(format!(
+                "COALESCE({} LIKE {pattern} ESCAPE E'\\\\', FALSE)",
+                sql.scalar
+            ))
+        })
+    } else {
+        let sql = field_sql(field, bindings);
+        let pattern = bindings.push(PostgresBindValue::Text(pattern.to_owned()));
+        Ok(format!(
+            "COALESCE({} LIKE {pattern} ESCAPE E'\\\\', FALSE)",
+            sql.scalar
+        ))
     }
 }
 

--- a/crates/rustok-index/src/application/reference.rs
+++ b/crates/rustok-index/src/application/reference.rs
@@ -263,6 +263,13 @@ impl<'a> ReferenceIndex<'a> {
                         .all(|value| matches!(value, IndexValue::Null));
                 is_null == *expected_null
             }
+            FilterExpr::TextLike(path, pattern) => self
+                .values_for_path(record, path)
+                .into_iter()
+                .any(|value| match value {
+                    IndexValue::String(value) => text_like_matches(value, pattern),
+                    _ => false,
+                }),
         }
     }
 
@@ -316,6 +323,60 @@ impl<'a> ReferenceIndex<'a> {
             .filter_map(|record| record.fields.get(path.field()))
             .collect()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextLikeToken {
+    AnyMany,
+    AnyOne,
+    Literal(char),
+}
+
+fn text_like_matches(value: &str, pattern: &str) -> bool {
+    let mut tokens = Vec::new();
+    let mut characters = pattern.chars();
+    while let Some(character) = characters.next() {
+        match character {
+            '%' => tokens.push(TextLikeToken::AnyMany),
+            '_' => tokens.push(TextLikeToken::AnyOne),
+            '\\' => {
+                let Some(literal) = characters.next() else {
+                    return false;
+                };
+                tokens.push(TextLikeToken::Literal(literal));
+            }
+            literal => tokens.push(TextLikeToken::Literal(literal)),
+        }
+    }
+
+    let value = value.chars().collect::<Vec<_>>();
+    let mut previous = vec![false; value.len() + 1];
+    previous[0] = true;
+
+    for token in tokens {
+        let mut current = vec![false; value.len() + 1];
+        match token {
+            TextLikeToken::AnyMany => {
+                current[0] = previous[0];
+                for index in 1..=value.len() {
+                    current[index] = previous[index] || current[index - 1];
+                }
+            }
+            TextLikeToken::AnyOne => {
+                for index in 1..=value.len() {
+                    current[index] = previous[index - 1];
+                }
+            }
+            TextLikeToken::Literal(expected) => {
+                for index in 1..=value.len() {
+                    current[index] = previous[index - 1] && value[index - 1] == expected;
+                }
+            }
+        }
+        previous = current;
+    }
+
+    previous[value.len()]
 }
 
 fn apply_direction(ordering: Ordering, direction: OrderDirection) -> Ordering {
@@ -563,5 +624,14 @@ mod tests {
             second_page[0].fields[&FieldName::new("value").unwrap()],
             IndexValue::Integer(3)
         );
+    }
+
+    #[test]
+    fn text_like_matches_postgres_wildcards_and_escape() {
+        assert!(text_like_matches("Phone_Pro", "%Phone\\_Pro%"));
+        assert!(text_like_matches("PhoneXPro", "%Phone_Pro%"));
+        assert!(!text_like_matches("PhoneXXPro", "%Phone_Pro%"));
+        assert!(text_like_matches("anything", "%"));
+        assert!(text_like_matches("Привет", "Пр_вет"));
     }
 }

--- a/crates/rustok-index/src/application/validation.rs
+++ b/crates/rustok-index/src/application/validation.rs
@@ -10,6 +10,8 @@ use crate::domain::{
 
 use super::{SchemaRegistry, SchemaRegistryError};
 
+const MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024;
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RecordValidationError {
     #[error("schema is not registered: {0}")]
@@ -88,6 +90,12 @@ pub enum QueryValidationError {
     },
     #[error("filter value does not match field {field} on schema {schema}")]
     InvalidFilterValue { schema: SchemaRef, field: FieldName },
+    #[error("text-like filter pattern exceeds {maximum} UTF-8 bytes: {actual}")]
+    TextLikePatternTooLong { maximum: usize, actual: usize },
+    #[error("text-like filter pattern contains a NUL byte")]
+    TextLikePatternContainsNul,
+    #[error("text-like filter pattern ends with an unpaired escape character")]
+    TextLikePatternDanglingEscape,
     #[error("logical filter {operator} must contain at least one child")]
     EmptyLogicalFilter { operator: &'static str },
     #[error("IN filter must contain at least one value")]
@@ -152,15 +160,7 @@ impl SchemaRegistry {
             }
         }
 
-        let mut link_names = BTreeSet::new();
         for link_value in &record.links {
-            if !link_names.insert(link_value.name.clone()) {
-                return Err(RecordValidationError::DuplicateLink {
-                    schema: schema.reference.clone(),
-                    link: link_value.name.clone(),
-                });
-            }
-
             let definition = schema
                 .links
                 .iter()
@@ -344,6 +344,19 @@ impl SchemaRegistry {
                     });
                 }
             }
+            FilterExpr::TextLike(path, pattern) => {
+                let resolved = self.resolve_filterable_field(root, path)?;
+                if resolved.field.cardinality != FieldCardinality::One
+                    || resolved.field.value_type != IndexValueType::String
+                {
+                    return Err(QueryValidationError::InvalidOperator {
+                        schema: resolved.schema.clone(),
+                        field: resolved.field.name.clone(),
+                        operator: "text_like",
+                    });
+                }
+                validate_text_like_pattern(pattern)?;
+            }
         }
         Ok(())
     }
@@ -439,6 +452,32 @@ impl SchemaRegistry {
             traverses_many,
         })
     }
+}
+
+fn validate_text_like_pattern(pattern: &str) -> Result<(), QueryValidationError> {
+    let actual = pattern.len();
+    if actual > MAX_TEXT_LIKE_PATTERN_BYTES {
+        return Err(QueryValidationError::TextLikePatternTooLong {
+            maximum: MAX_TEXT_LIKE_PATTERN_BYTES,
+            actual,
+        });
+    }
+    if pattern.contains('\0') {
+        return Err(QueryValidationError::TextLikePatternContainsNul);
+    }
+
+    let mut escaped = false;
+    for character in pattern.chars() {
+        if escaped {
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        }
+    }
+    if escaped {
+        return Err(QueryValidationError::TextLikePatternDanglingEscape);
+    }
+    Ok(())
 }
 
 fn validate_entity_key(
@@ -568,6 +607,7 @@ mod tests {
             locale_mode: LocaleMode::Required,
             fields: vec![
                 field("id", IndexValueType::Uuid),
+                field("title", IndexValueType::String),
                 field("sales_channel_id", IndexValueType::Uuid),
             ],
             links: vec![IndexLink {
@@ -607,6 +647,10 @@ mod tests {
                 (
                     FieldName::new("id").unwrap(),
                     IndexValue::Uuid(Uuid::new_v4()),
+                ),
+                (
+                    FieldName::new("title").unwrap(),
+                    IndexValue::String("Example".to_owned()),
                 ),
                 (
                     FieldName::new("sales_channel_id").unwrap(),
@@ -673,6 +717,48 @@ mod tests {
         };
 
         assert!(registry.validate_query(&query).is_ok());
+    }
+
+    #[test]
+    fn validates_bounded_text_like_only_for_scalar_strings() {
+        let registry = registry();
+        let mut query = IndexQuery {
+            scope: query_scope(),
+            schema: reference("product"),
+            fields: vec![FieldPath::new(FieldName::new("id").unwrap())],
+            filter: Some(FilterExpr::TextLike(
+                FieldPath::new(FieldName::new("title").unwrap()),
+                "%phone\\_%".to_owned(),
+            )),
+            order_by: Vec::new(),
+            pagination: Pagination::Cursor {
+                first: 20,
+                after: None,
+            },
+            include_exact_count: false,
+        };
+        assert!(registry.validate_query(&query).is_ok());
+
+        query.filter = Some(FilterExpr::TextLike(
+            FieldPath::new(FieldName::new("id").unwrap()),
+            "%id%".to_owned(),
+        ));
+        assert!(matches!(
+            registry.validate_query(&query),
+            Err(QueryValidationError::InvalidOperator {
+                operator: "text_like",
+                ..
+            })
+        ));
+
+        query.filter = Some(FilterExpr::TextLike(
+            FieldPath::new(FieldName::new("title").unwrap()),
+            "dangling\\".to_owned(),
+        ));
+        assert_eq!(
+            registry.validate_query(&query),
+            Err(QueryValidationError::TextLikePatternDanglingEscape)
+        );
     }
 
     #[test]

--- a/crates/rustok-index/src/application/validation.rs
+++ b/crates/rustok-index/src/application/validation.rs
@@ -160,7 +160,15 @@ impl SchemaRegistry {
             }
         }
 
+        let mut link_names = BTreeSet::new();
         for link_value in &record.links {
+            if !link_names.insert(link_value.name.clone()) {
+                return Err(RecordValidationError::DuplicateLink {
+                    schema: schema.reference.clone(),
+                    link: link_value.name.clone(),
+                });
+            }
+
             let definition = schema
                 .links
                 .iter()

--- a/crates/rustok-index/src/domain/query.rs
+++ b/crates/rustok-index/src/domain/query.rs
@@ -26,6 +26,7 @@ pub enum FilterExpr {
     Lte(FieldPath, IndexValue),
     Contains(FieldPath, IndexValue),
     IsNull(FieldPath, bool),
+    TextLike(FieldPath, String),
 }
 
 impl FilterExpr {
@@ -45,7 +46,8 @@ impl FilterExpr {
             | Self::Lt(path, _)
             | Self::Lte(path, _)
             | Self::Contains(path, _)
-            | Self::IsNull(path, _) => output.push(path),
+            | Self::IsNull(path, _)
+            | Self::TextLike(path, _) => output.push(path),
         }
     }
 

--- a/crates/rustok-index/src/infrastructure/postgres/postgres_reference_equivalence_tests/reference_fixture.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/postgres_reference_equivalence_tests/reference_fixture.rs
@@ -286,6 +286,13 @@ impl<'a> ReferenceFixture<'a> {
                         .all(|value| matches!(value, IndexValue::Null));
                 is_null == *expected_null
             }
+            FilterExpr::TextLike(path, pattern) => self
+                .values_for_path(record, path)
+                .into_iter()
+                .any(|value| match value {
+                    IndexValue::String(value) => text_like_matches(value, pattern),
+                    _ => false,
+                }),
         }
     }
 
@@ -362,6 +369,58 @@ impl<'a> ReferenceFixture<'a> {
             entity_id: record.key.entity_id,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextLikeToken {
+    AnyMany,
+    AnyOne,
+    Literal(char),
+}
+
+fn text_like_matches(value: &str, pattern: &str) -> bool {
+    let mut tokens = Vec::new();
+    let mut characters = pattern.chars();
+    while let Some(character) = characters.next() {
+        match character {
+            '%' => tokens.push(TextLikeToken::AnyMany),
+            '_' => tokens.push(TextLikeToken::AnyOne),
+            '\\' => {
+                let Some(literal) = characters.next() else {
+                    return false;
+                };
+                tokens.push(TextLikeToken::Literal(literal));
+            }
+            literal => tokens.push(TextLikeToken::Literal(literal)),
+        }
+    }
+
+    let value = value.chars().collect::<Vec<_>>();
+    let mut previous = vec![false; value.len() + 1];
+    previous[0] = true;
+    for token in tokens {
+        let mut current = vec![false; value.len() + 1];
+        match token {
+            TextLikeToken::AnyMany => {
+                current[0] = previous[0];
+                for index in 1..=value.len() {
+                    current[index] = previous[index] || current[index - 1];
+                }
+            }
+            TextLikeToken::AnyOne => {
+                for index in 1..=value.len() {
+                    current[index] = previous[index - 1];
+                }
+            }
+            TextLikeToken::Literal(expected) => {
+                for index in 1..=value.len() {
+                    current[index] = previous[index - 1] && value[index - 1] == expected;
+                }
+            }
+        }
+        previous = current;
+    }
+    previous[value.len()]
 }
 
 fn apply_direction(ordering: Ordering, direction: OrderDirection) -> Ordering {

--- a/scripts/verify/verify-index-localized-query-contract.mjs
+++ b/scripts/verify/verify-index-localized-query-contract.mjs
@@ -68,13 +68,17 @@ requireMarkers('crates/rustok-index/src/application/query_port.rs', [
   'async fn execute_localized_query(',
   'localized Index query execution is unavailable for this adapter',
 ]);
+requireMarkers('crates/rustok-index/src/domain/query.rs', [
+  'TextLike(FieldPath, String)',
+]);
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
-  'Status: `runtime_source_complete_text_pattern_and_evidence_pending`',
+  'Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
   '`LocalizedEntityQuery`',
   '`localized_projection_fields`',
   '`LocalizedCursorCodec`',
   'wire version `3`',
   'ordinary exact-locale cursors remain on version `2`',
+  'Generic `TextLike` — source complete',
 ]);
 
-console.log('[verify-index-localized-query-contract] localized query/projection/cursor contract remains source-locked with fail-closed runtime capability');
+console.log('[verify-index-localized-query-contract] localized query/projection/cursor contract remains source-locked with fail-closed runtime and generic text-pattern capability');

--- a/scripts/verify/verify-index-localized-query-runtime.mjs
+++ b/scripts/verify/verify-index-localized-query-runtime.mjs
@@ -61,11 +61,12 @@ if (admissionPosition < 0 || beginPosition < 0 || admissionPosition > beginPosit
 }
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
-  'Status: `runtime_source_complete_text_pattern_and_evidence_pending`',
+  'Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
   '`execute_localized_query`',
-  'read-only repeatable-read',
-  'persisted schema readiness',
+  '`REPEATABLE READ, READ ONLY`',
+  'persisted schema',
   '`PostgresQueryEntityAdmission`',
+  'Generic `TextLike` — source complete',
 ]);
 
-console.log('[verify-index-localized-query-runtime] localized fold runtime is source-locked behind readiness/admission/snapshot semantics; Product adapter/evidence remain pending');
+console.log('[verify-index-localized-query-runtime] localized fold runtime remains source-locked behind readiness/admission/snapshot semantics; Product adapter/evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -24,6 +24,7 @@ const ownerQuery = requireMarkers(ownerQueryPath, [
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
   'fn product_title_search_condition(',
+  'let pattern = format!("%{search}%");',
   'FROM product_translations pt',
   'pt.product_id = products.id',
   'pt.title LIKE $1',
@@ -34,6 +35,11 @@ if (ownerQuery.slice(titleSearchStart).includes('pt.locale')) {
   fail(`${ownerQueryPath} title search became locale-scoped; revisit the localized identity architecture in the same PR`);
 }
 
+requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
+  'pub struct StorefrontProductListQuery',
+  'pub search: Option<String>',
+  'search: normalize_optional_text(search)',
+]);
 requireMarkers('crates/rustok-product/src/services/catalog/commands.rs', [
   'if input.translations.is_empty()',
   'At least one translation is required',
@@ -57,27 +63,32 @@ if (productSource.includes('SchemaVersion::new(3)')) {
 
 const architecturePath = 'crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md';
 requireMarkers(architecturePath, [
-  'Status: `runtime_source_complete_text_pattern_and_evidence_pending`',
+  'Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
   '`localized_projection_fields`',
   '`SchemaRegistry::compile_postgres_localized_page_query`',
   '`SchemaRegistry::decode_postgres_localized_query_page`',
-  '`IndexQueryPort` now publishes an explicit `execute_localized_query` method.',
-  '`SharedIndexQueryRuntime` forwards the localized capability',
-  '`PostgresIndexQueryPort::execute_localized_query` implements the canonical execution boundary',
+  '`IndexQueryPort` publishes `execute_localized_query`',
+  '`SharedIndexQueryRuntime` forwards the',
+  '`PostgresIndexQueryPort::execute_localized_query`',
   '`REPEATABLE READ, READ ONLY`',
   '`PostgresQueryEntityAdmission`',
-  'The next source slice must add one generic bounded scalar string text-pattern primitive',
+  'Generic `TextLike` — source complete',
+  '`FilterExpr::TextLike(FieldPath, String)`',
+  'pattern size at most 1024 UTF-8 bytes',
+  'Remaining Product search-bound mismatch',
+  'Implement the Product Storefront Index adapter',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_runtime_source_complete_text_pattern_adapter_and_evidence_pending`',
+  'Status: `localized_runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@6044dbd5110a65e2ebeee0a6a3a0053d9971b250` (#3210)',
-  'Wire localized execution through the canonical PostgreSQL query runtime with persisted readiness,',
-  'Add generic scalar string text-pattern matching inside folded `any_locale_filter`.',
-  'Do not add a runtime alias for key `3`',
+  'Status overlay rechecked from `main@1ddbc6b5457d2f9263b842c6e5b1942598a26ff7` (#3215)',
+  'Wire localized execution through canonical PostgreSQL runtime with readiness/admission/snapshot.',
+  'Add generic scalar String `TextLike` usable inside folded `any_locale_filter`.',
+  'implement the Product Storefront Index adapter plus retained localized-query',
+  'Do not add a runtime',
 ]);
 
-console.log('[verify-index-product-storefront-localized-query-architecture] localized Product runtime architecture is locked; text pattern, adapter and evidence remain pending');
+console.log('[verify-index-product-storefront-localized-query-architecture] localized Product runtime plus generic TextLike are locked; adapter/search-bound/evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -68,7 +68,6 @@ requireMarkers(architecturePath, [
   '`SchemaRegistry::compile_postgres_localized_page_query`',
   '`SchemaRegistry::decode_postgres_localized_query_page`',
   '`IndexQueryPort` publishes `execute_localized_query`',
-  '`SharedIndexQueryRuntime` forwards the',
   '`PostgresIndexQueryPort::execute_localized_query`',
   '`REPEATABLE READ, READ ONLY`',
   '`PostgresQueryEntityAdmission`',
@@ -84,11 +83,11 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', 
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@1ddbc6b5457d2f9263b842c6e5b1942598a26ff7` (#3215)',
+  'Status overlay rechecked from `main@eab3b1b925e5cbfa65d2fe3f938b63be7a067846` (#3218)',
   'Wire localized execution through canonical PostgreSQL runtime with readiness/admission/snapshot.',
   'Add generic scalar String `TextLike` usable inside folded `any_locale_filter`.',
   'implement the Product Storefront Index adapter plus retained localized-query',
-  'Do not add a runtime',
+  'No historical-key runtime compatibility path is allowed.',
 ]);
 
 console.log('[verify-index-product-storefront-localized-query-architecture] localized Product runtime plus generic TextLike are locked; adapter/search-bound/evidence remain pending');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -17,92 +17,52 @@ const requireMarkers = (relative, markers) => {
   }
   return source;
 };
-const forbidMarkers = (relative, source, markers) => {
-  for (const marker of markers) {
-    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
-  }
-};
 
 const storefrontPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
 const storefront = requireMarkers(storefrontPath, [
-  'StorefrontProductListQuery::try_from_transport_with_attribute_filters(',
-  '.with_pagination(1, 12)',
   'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
   '.list_published_products_with_query(',
-  'public_channel_slug.as_deref()',
-  'seller_id: item.seller_id',
-  'tags: item.tags',
-  'created_at: item.created_at.to_rfc3339()',
-  'published_at: item.published_at.map(|value| value.to_rfc3339())',
 ]);
-forbidMarkers(storefrontPath, storefront, [
-  'rustok_index',
-  'SharedIndexQueryRuntime',
-  'IndexQuery',
-  'materialize_postgres_index_query_runtime',
-]);
+for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'IndexQuery']) {
+  if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
+}
 
-const ownerQueryPath = 'crates/rustok-product/src/services/catalog/queries.rs';
-const ownerQuery = requireMarkers(ownerQueryPath, [
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const owner = requireMarkers(ownerPath, [
   'ProductStatus::Active',
   'Column::PublishedAt.is_not_null()',
   'product_channel_visibility_condition(',
-  'Column::PrimaryCategoryId.eq(category_id)',
   'product_title_search_condition(',
-  'attribute_filters::load_catalog_attribute_filter_conditions(',
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
-  'fn product_title_search_condition(',
+  'let pattern = format!("%{search}%");',
   'FROM product_translations pt',
   'pt.product_id = products.id',
   'pt.title LIKE $1',
 ]);
-const titleSearch = ownerQuery.slice(ownerQuery.indexOf('fn product_title_search_condition('));
-if (titleSearch.includes('pt.locale')) {
-  fail(`${ownerQueryPath} title search became locale-scoped; update parity architecture in the same PR`);
-}
+const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
+if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
+
+requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
+  'pub struct StorefrontProductListQuery',
+  'pub search: Option<String>',
+  'search: normalize_optional_text(search)',
+]);
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
   'assert_eq!(schema.fields.len(), 15);',
   'JOIN product_translations t',
-  't.locale',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'derive_index_schema_source_event_id(',
-  'many_field("attribute_terms", IndexValueType::String, false, true)?',
 ]);
-forbidMarkers(productIndexPath, productIndex, [
-  'SchemaVersion::new(3)',
-  'derive_index_source_event_id(',
-  'product_v1_schema',
-  'product_v2_schema',
-  'COALESCE(requested_translation',
-]);
-
-requireMarkers('crates/rustok-distribution/src/product_index/absence.rs', [
-  'translation.locale = $3',
-  'return Ok(None);',
-  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
-]);
-requireMarkers('crates/rustok-index/src/infrastructure/postgres/schema_registration.rs', [
-  'VersionConflict { reference: SchemaRef }',
-  'pub async fn register_current(',
-  'retire_lower_active_schemas(',
-  "status = 'retired'",
-]);
+if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_runtime_source_complete_text_pattern_adapter_and_evidence_pending`',
-  'does **not** restrict',
-  'one physical entity per stored translation locale',
-  'localized-entity identity fold',
-  '`localized_projection_fields`',
-  '`SchemaRegistry::compile_postgres_localized_page_query`',
-  '`SchemaRegistry::decode_postgres_localized_query_page`',
-  '`IndexQueryPort` now exposes explicit `execute_localized_query`',
-  '`REPEATABLE READ, READ ONLY`',
-  'generic scalar string text-pattern',
-  'Do **not** add another Product routing key',
+  'Status: `localized_runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
+  'Generic `TextLike` — source complete',
+  '`FilterExpr::TextLike(FieldPath, String)`',
+  'no explicit search-length bound',
   'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
@@ -110,4 +70,4 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native while text-pattern/adapter/evidence gates are pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native while adapter/search-bound/collation/evidence gates are pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -84,6 +84,7 @@ const scripts = [
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-localized-query-runtime.mjs',
+  'verify-index-text-like-filter.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',

--- a/scripts/verify/verify-index-text-like-filter.mjs
+++ b/scripts/verify/verify-index-text-like-filter.mjs
@@ -47,7 +47,7 @@ const ordinary = requireMarkers('crates/rustok-index/src/application/postgres_qu
   'fn compile_text_like(',
   'compile_many_exists(plan, field, bindings, |sql, bindings|',
   'PostgresBindValue::Text(pattern.to_owned())',
-  " LIKE {pattern} ESCAPE E'\\\\\\\\'",
+  ' LIKE {pattern} ESCAPE E\'',
 ]);
 if (ordinary.includes('rustok-product')) {
   fail('ordinary TextLike compiler must remain Product-agnostic');
@@ -56,8 +56,7 @@ if (ordinary.includes('rustok-product')) {
 const localized = requireMarkers('crates/rustok-index/src/application/postgres_localized_query.rs', [
   'FilterExpr::TextLike(path, pattern)',
   'PostgresBindValue::Text(pattern.clone())',
-  " LIKE {pattern} ESCAPE E'\\\\\\\\'",
-  'FilterExpr::TextLike(',
+  ' LIKE {pattern} ESCAPE E\'',
   '"%needle%".to_owned()',
 ]);
 if (localized.includes('product_title_search_condition')) {
@@ -89,4 +88,10 @@ if (owner.slice(searchStart).includes('pt.locale')) {
   fail(`${ownerPath} title search became locale-scoped; revisit localized Storefront parity in the same PR`);
 }
 
-console.log('[verify-index-text-like-filter] bounded generic PostgreSQL LIKE semantics are source-locked for ordinary and folded filters');
+requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
+  'pub struct StorefrontProductListQuery',
+  'pub search: Option<String>',
+  'search: normalize_optional_text(search)',
+]);
+
+console.log('[verify-index-text-like-filter] bounded generic PostgreSQL LIKE semantics are source-locked for ordinary and folded filters; Storefront input-bound parity remains explicit');

--- a/scripts/verify/verify-index-text-like-filter.mjs
+++ b/scripts/verify/verify-index-text-like-filter.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-text-like-filter] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const queryPath = 'crates/rustok-index/src/domain/query.rs';
+const query = requireMarkers(queryPath, [
+  'IsNull(FieldPath, bool)',
+  'TextLike(FieldPath, String)',
+  'Self::TextLike(path, _) => output.push(path)',
+]);
+if (query.indexOf('TextLike(FieldPath, String)') < query.indexOf('IsNull(FieldPath, bool)')) {
+  fail(`${queryPath} must append TextLike after existing filter variants to preserve postcard discriminants`);
+}
+
+requireMarkers('crates/rustok-index/src/application/validation.rs', [
+  'const MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024;',
+  'TextLikePatternTooLong { maximum: usize, actual: usize }',
+  'TextLikePatternContainsNul',
+  'TextLikePatternDanglingEscape',
+  'FilterExpr::TextLike(path, pattern)',
+  'resolved.field.cardinality != FieldCardinality::One',
+  'resolved.field.value_type != IndexValueType::String',
+  'operator: "text_like"',
+  'validate_text_like_pattern(pattern)?;',
+  "pattern.contains('\\0')",
+  "character == '\\\\'",
+]);
+
+const ordinary = requireMarkers('crates/rustok-index/src/application/postgres_query_sql.rs', [
+  'FilterExpr::TextLike(path, pattern) => compile_text_like(plan, path, pattern, bindings)',
+  'fn compile_text_like(',
+  'compile_many_exists(plan, field, bindings, |sql, bindings|',
+  'PostgresBindValue::Text(pattern.to_owned())',
+  " LIKE {pattern} ESCAPE E'\\\\\\\\'",
+]);
+if (ordinary.includes('rustok-product')) {
+  fail('ordinary TextLike compiler must remain Product-agnostic');
+}
+
+const localized = requireMarkers('crates/rustok-index/src/application/postgres_localized_query.rs', [
+  'FilterExpr::TextLike(path, pattern)',
+  'PostgresBindValue::Text(pattern.clone())',
+  " LIKE {pattern} ESCAPE E'\\\\\\\\'",
+  'FilterExpr::TextLike(',
+  '"%needle%".to_owned()',
+]);
+if (localized.includes('product_title_search_condition')) {
+  fail('localized TextLike compiler must not depend on Product owner code');
+}
+
+requireMarkers('crates/rustok-index/src/application/reference.rs', [
+  'FilterExpr::TextLike(path, pattern)',
+  'fn text_like_matches(value: &str, pattern: &str) -> bool',
+  "'%' => tokens.push(TextLikeToken::AnyMany)",
+  "'_' => tokens.push(TextLikeToken::AnyOne)",
+  'text_like_matches_postgres_wildcards_and_escape',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/postgres_reference_equivalence_tests/reference_fixture.rs', [
+  'FilterExpr::TextLike(path, pattern)',
+  'fn text_like_matches(value: &str, pattern: &str) -> bool',
+]);
+
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const owner = requireMarkers(ownerPath, [
+  'let pattern = format!("%{search}%");',
+  'FROM product_translations pt',
+  'pt.product_id = products.id',
+  'pt.title LIKE $1',
+]);
+const searchStart = owner.indexOf('fn product_title_search_condition(');
+if (searchStart < 0) fail(`${ownerPath} title-search helper is missing`);
+if (owner.slice(searchStart).includes('pt.locale')) {
+  fail(`${ownerPath} title search became locale-scoped; revisit localized Storefront parity in the same PR`);
+}
+
+console.log('[verify-index-text-like-filter] bounded generic PostgreSQL LIKE semantics are source-locked for ordinary and folded filters');


### PR DESCRIPTION
## Summary

- continue the localized Storefront query sequence after #3212 with one generic bounded scalar String `TextLike` filter operator;
- append `FilterExpr::TextLike(FieldPath, String)` after all existing filter variants so prior postcard enum discriminants remain stable;
- validate `TextLike` only for filterable scalar String fields, cap patterns at 1024 UTF-8 bytes, reject NUL, and reject a dangling trailing backslash escape;
- define explicit PostgreSQL `LIKE` semantics: `%` matches zero-or-more characters, `_` one character, and backslash escapes the next wildcard/literal;
- compile the operator with a bound `PostgresBindValue::Text` in both the ordinary PostgreSQL compiler and the localized fold compiler, with no Product-specific SQL branch;
- preserve ordinary many-link behavior by reusing the existing correlated `compile_many_exists` path;
- add matching Unicode-aware wildcard semantics to the in-memory reference engine and the PostgreSQL equivalence reference fixture;
- use `TextLike` in the localized compiler source test so folded `any_locale_filter` exercises the new operator shape;
- actualize Storefront architecture/parity docs and guards, keeping Storefront owner-native;
- record two remaining search parity gates discovered during recheck: Product owner search currently has no explicit length bound while `TextLike` is bounded, and owner/default collation vs Index `COLLATE "C"` still needs retained PostgreSQL equivalence.

## Main recheck

The branch was created from `main@1ddbc6b5457d2f9263b842c6e5b1942598a26ff7` (#3215). Before PR creation, current main advanced through #3216/#3217/#3219 Moderation evidence and #3218 Commerce `storefrontCatalogSearchOptions` owner-port cutover. Current `main` Product owner files were re-read after #3218: `StorefrontProductListQuery` still normalizes search without an explicit length bound, and `CatalogService::list_published_products_with_query` still builds `%{search}%` and executes all-translations `pt.title LIKE $1`. Those later main changes are disjoint from this Index query-algebra slice.

## Boundary

This PR does not implement the Product Storefront Index adapter, change Storefront traffic, change Product schema/routing key, resolve the owner-search input-bound or collation parity gates, execute/admit PostgreSQL equivalence, add Product events, or rebuild/promote a tenant Product schema.

The next source slice is the Product Storefront Index adapter plus retained localized-query owner-vs-Index PostgreSQL equivalence. That slice must fail closed on the explicit search-bound/collation gates rather than silently truncate or reject owner-valid search.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.