### PR TITLE
feat(index): align localized identity ordering

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,227 +1,170 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked from `main@eab3b1b925e5cbfa65d2fe3f938b63be7a067846` (#3218) and continued on
-`agent/index-text-like-20260808`.
+Status overlay continued from `main@500c6f647b5f09f617cb907a43093e4f954b3fed` (#3220) on
+`agent/index-localized-identity-order-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution
 cursor.
 
 ## Recheck result
 
-The Product/Index sequence relevant to this cursor includes:
+The Product/Index Storefront sequence now includes:
 
-- #3190 retained linked-target replay/redelivery source evidence;
-- #3192 added the fail-closed Product Storefront parity gate;
-- #3193 added staged single-current schema supersession;
-- #3194 added schema-scoped source delivery IDs;
-- #3197 advanced the canonical Product owner clock for EAV writes;
-- #3198 defined canonical typed Product `attribute_terms`;
-- #3199 replaced Product runtime code with one current 15-field Product contract on internal routing key
-  `4`, with lower keys historical only;
-- #3200 proved owner title search is all-translations while result projection is requested -> fallback;
-- #3204 selected the generic localized-entity identity-fold architecture;
-- #3208 added explicit localized query validation and dedicated cursor identity;
-- #3210 added the root-only PostgreSQL localized page/count compiler and decoder;
-- #3212 wired localized execution through the canonical PostgreSQL query runtime with persisted readiness,
-  generic admission and one read-only repeatable-read snapshot.
+- #3199: one current 15-field Product contract on internal routing key `4`;
+- #3200: owner all-translations title search and requested -> fallback projection mismatch documented;
+- #3204: generic localized-entity identity-fold architecture selected;
+- #3208: explicit localized query validation and dedicated cursor identity;
+- #3210: root-only PostgreSQL localized identity-fold page/count compiler and decoder;
+- #3212: canonical PostgreSQL localized runtime with persisted readiness, generic admission and one
+  read-only repeatable-read page/count snapshot;
+- #3220: generic bounded scalar String `TextLike` with PostgreSQL/reference wildcard semantics.
 
-Later #3213/#3216/#3217 are Moderation evidence slices, #3214 cut Product attribute-values reads to the
-owner schema port, #3215 generated Pages contributions, and #3218 cut mounted Storefront search-option
-metadata to the Product schema read port. Rechecking current `main` after #3218 confirms those changes do
-not alter `StorefrontProductListQuery`, `CatalogService::list_published_products_with_query`, owner title
-`LIKE`, or the `rustok-index` localized query algebra in this slice.
-
-This branch closes the remaining generic scalar title-pattern capability with bounded `TextLike` while
-keeping Storefront traffic owner-native and all execution/equivalence gates unchanged.
-
-## Old execution branch
-
-`agent/index-linked-target-replay-redelivery-evidence-20260807` is not a valid continuation base; its source
-was already squash-merged through #3190. Do not reuse it. Branch deletion is repository hygiene only and
-remains dependent on repository tooling that exposes ref deletion.
+The adapter recheck after #3220 found one additional query-order mismatch before Product translation can be
+claimed: owner descending Storefront order uses both timestamp DESC and Product ID DESC, while the
+localized compiler still used a fixed root entity-ID ASC tie-break. This slice closes that localized-only
+gap without changing ordinary exact-locale `IndexQuery` semantics.
 
 ## Current primary owner gate
 
 `M6 - execute and admit concrete repair PostgreSQL evidence`
 
-The concrete repair implementation, recovery policy, PostgreSQL harness and retained-evidence admission
-source remain complete. Maintainer execution/admission is still required and is not claimed by source
-inspection.
+The repair implementation/harness/admission source remains complete. Maintainer execution/admission is
+still required and is not claimed by source inspection.
 
 ## Current Product/Storefront source state
 
-The canonical Product graph keeps one current Product runtime contract plus ProductVariant and
-SalesChannel target contracts.
+Current Product facts remain:
 
-Current Product source/runtime facts:
-
-- one current Product schema on internal routing key `4`;
-- 15 fields: `id`, `status`, `title`, `handle`, `description`, `seller_id`, `vendor`, `product_type`,
-  `primary_category_id`, `tag_ids`, `created_at`, `published_at`, `attribute_terms`, `variant_ids`, and
+- one current Product schema, routing key `4`; lower keys are historical only;
+- 15 Product fields including Storefront scalars, `attribute_terms`, `variant_ids` and
   `sales_channel_ids`;
-- Product replay IDs are schema-scoped through `derive_index_schema_source_event_id`;
-- lower Product routing keys are historical persisted identities, not compatibility implementations;
-- EAV writes advance the same Product owner `index_revision` / graph `projection_epoch` clock;
-- dynamic EAV filters use stable UUID-keyed `attribute_terms`;
-- ProductVariant/SalesChannel recreate ordering remains tombstone-backed and monotonic;
-- Product root freshness and ordinary linked-target availability remain fail-closed.
+- Product replay IDs are schema-scoped;
+- EAV writes advance the canonical Product owner clock;
+- Product root freshness and ordinary linked-target availability remain fail-closed;
+- Product channel visibility convergence materializes resolved current channel UUID membership under a
+  freshness witness.
 
-## Localized Product query source state
+## Localized query/runtime state
 
-The localized fold is source-complete through runtime execution:
+Source-complete capabilities now include:
 
-- `LocalizedEntityQuery` keeps requested locale in `query.scope.locale`, canonical fallback separately,
-  `any_locale_filter` as an identity-level existential predicate, and explicit
-  `localized_projection_fields` for requested -> fallback -> null projection;
-- validation requires `LocaleMode::Required`, reuses ordinary field/operator/value rules and keeps this
-  implementation root-only;
-- `LocalizedCursorCodec` uses scoped wire version `3`; ordinary exact-locale cursor wire version `2`
-  remains unchanged;
-- page/count compilation uses `t0` admitted identity anchor, `t1` requested, `t2` fallback, `t3`
-  any-locale predicate and `t4` lower-locale anti-duplicate candidate;
-- physical row roles retain canonical `is_deleted = FALSE` anchors for generic owner admission;
-- identity de-duplication happens before ordering/lookahead/limit/exact count;
-- requested/fallback projection uses row-presence `CASE`;
-- localized decoding checks ordinary/localized plan identities and emits localized cursors only;
-- `IndexQueryPort::execute_localized_query` has a fail-closed default and is forwarded by
-  `SharedIndexQueryRuntime`;
-- `PostgresIndexQueryPort` applies availability/entity admission before storage execution, then verifies
-  persisted readiness and executes page/count inside one `REPEATABLE READ, READ ONLY` transaction.
+- `LocalizedEntityQuery` requested/fallback roles, `any_locale_filter` and
+  `localized_projection_fields`;
+- localized cursor wire version `3`, separate from ordinary wire version `2`;
+- root-only identity fold over physical locale rows;
+- requested -> fallback -> null projection;
+- group-before-order/page/count semantics;
+- generic owner admission on all participating physical row roles;
+- persisted schema readiness plus one `REPEATABLE READ, READ ONLY` page/count snapshot;
+- generic bounded scalar String `TextLike` for ordinary and folded filters;
+- explicit localized `identity_order_direction` for the final root entity-ID tie-break.
 
-## Generic scalar `TextLike` — source complete in this slice
+`identity_order_direction` defaults to `Asc`, validates only `Asc|Desc`, is bound into localized cursor and
+plan fingerprints, and changes only the localized final identity term:
 
-`FilterExpr::TextLike(FieldPath, String)` is appended after existing filter variants so previous postcard
-discriminants remain stable.
+- Asc: `entity_id ASC`, continuation `entity_id > cursor`;
+- Desc: `entity_id DESC`, continuation `entity_id < cursor`.
 
-Validation permits it only for a filterable scalar String field and enforces:
+Ordinary `IndexQuery` and its existing ascending entity-ID tie-break remain unchanged.
 
-- at most 1024 UTF-8 bytes;
-- no NUL;
-- no dangling trailing backslash escape.
+## Product adapter blockers discovered during source recheck
 
-Semantics match PostgreSQL `LIKE` with explicit backslash escape: `%` matches zero-or-more characters,
-`_` one character and `\` escapes the next wildcard/literal.
+The next Product Storefront adapter remains fail-closed on three explicit parity gaps:
 
-The ordinary PostgreSQL compiler binds the pattern and supports linked/many paths through the existing
-correlated `compile_many_exists` machinery. The localized compiler uses the same bound pattern and SQL
-operator for root `any_locale_filter`. The in-memory reference engine and PostgreSQL equivalence reference
-fixture implement the same wildcard grammar.
+1. **Search length** — owner search has no explicit length bound; `TextLike` is capped at 1024 UTF-8
+   bytes. The adapter must not silently truncate or reject owner-valid search without a reviewed owner/API
+   bound.
+2. **Search collation** — owner title `LIKE` uses deployment/default collation while Index String scalar
+   SQL uses deterministic `COLLATE "C"`; retained PostgreSQL evidence must establish the admitted contract.
+3. **Channel-less visibility** — owner list requests without a public channel admit only metadata-
+   unrestricted Products. Current `sales_channel_ids` represents unrestricted as membership in all current
+   channels and therefore cannot distinguish unrestricted from a restricted Product that currently
+   contains every channel. A channel-less authoritative adapter must fail closed until that distinction is
+   materialized or supplied by an owner capability.
 
-The current Product owner title helper is still `format!("%{search}%")` + `pt.title LIKE $1` over all
-translations, so the future Product adapter can express the same title predicate as folded
-`TextLike(title, pattern)` without Product-specific Index SQL.
+For a request carrying a trusted current public channel ID, `Contains(sales_channel_ids, channel_id)` is the
+intended root membership predicate under the existing channel resolver/freshness contract.
 
-## Search parity caveats discovered during recheck
+## Retained Product evidence debt
 
-`StorefrontProductListQuery` currently normalizes optional search text but imposes no explicit search
-length bound. Generic `TextLike` is intentionally bounded to 1024 UTF-8 bytes. Therefore the adapter must
-not claim full owner parity until one of these is proven in reviewed source/evidence:
+Historical PostgreSQL packets still need mechanical actualization to routing key `4` / the current
+15-field Product contract. Do not add a runtime alias for key `3`.
 
-1. an authoritative upstream Storefront request bound <= 1024 bytes already exists; or
-2. the owner/API contract is explicitly bounded with matching validation and compatibility review.
+The localized Storefront equivalence packet must additionally cover:
 
-Silent truncation or rejection in an Index-only adapter is forbidden.
-
-The owner title `LIKE` uses database-default collation while Index String scalar SQL uses deterministic
-`COLLATE "C"`. Retained PostgreSQL equivalence must cover the admitted deployment/input contract before
-search parity can be promoted.
-
-## Retained M7 PostgreSQL packets
-
-Several retained packets still encode historical Product routing key `3` / pre-replacement assumptions and
-must be actualized before they count as current replacement evidence:
-
-1. `product_materialized_query_freshness_postgres.rs`;
-2. `product_channel_convergence_postgres.rs`;
-3. `product_channel_identity_transitions_postgres.rs`;
-4. `product_linked_target_recreate_postgres.rs`;
-5. `product_linked_target_availability_equivalence_postgres.rs`;
-6. `product_linked_target_replay_redelivery_postgres.rs`.
-
-The Product locale-absence retained packet and related guards also require recheck. Do not add a runtime
-alias for key `3`; evidence must follow the one current Product contract.
+- requested present / fallback / neither requested nor fallback;
+- any-locale title matches, including third-locale matches;
+- `%`, `_` and escaped wildcard behavior;
+- duplicate locale matches yielding one Product identity and count;
+- equal-timestamp ordering under both ascending and descending Product-ID tie-breaks;
+- cursor continuation across those ties;
+- EAV terms, category and public channel visibility;
+- stale locale exclusion/readiness/admission/restart;
+- search-bound/collation behavior;
+- current Product routing key promotion.
 
 ## M5 incremental ingestion
 
-- [x] Source replay registry and bounded source failures.
+- [x] Source replay registry and bounded failures.
 - [x] Inbox deduplication and monotonic source versions.
-- [x] Mutation-event registry and commit-before-ack orchestration.
-- [x] Exact source-refresh worker with owner revision fence.
-- [x] Product locale/ProductVariant refresh ledgers and durable relay step.
-- [ ] Execute canonical event-contract digest admission on current reviewed `main` and commit the
-      generated canonical digest artifact through its own reviewed PR.
-- [ ] Add exactly one canonical Product Index typed event family only after the digest gate is valid.
-- [ ] Retain crash-between-commit-and-ack/redelivery evidence for the typed incremental route.
+- [x] Mutation event orchestration and exact source refresh.
+- [x] Product locale/ProductVariant refresh ledgers and durable relay.
+- [ ] Execute canonical event-contract digest admission on reviewed `main`.
+- [ ] Add canonical Product Index typed event family only after digest admission.
+- [ ] Retain commit/ack crash-redelivery evidence for that route.
 
-## M6 replay, reconciliation, diagnosis, and repair
+## M6 replay/reconciliation/repair
 
-- [x] Bounded scan/load and stable replay identities.
-- [x] Durable jobs, leases, checkpoints, multi-page replay, cancellation and reconciliation.
-- [x] Source timeout, dry-run, interruption, retry and dead-letter recovery.
-- [x] Drift discovery/confirmation/finding lifecycle and targeted repair.
-- [x] Concrete missing-entity/orphan-link repair and prepared-command recovery.
-- [x] Real-migration PostgreSQL repair harness and retained-evidence admission tooling.
+- [x] Bounded replay, durable jobs/leases/checkpoints and cancellation.
+- [x] Reconciliation, drift diagnosis and targeted repair source.
+- [x] Real-migration repair PostgreSQL harness and retained-evidence admission tooling.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
-- [ ] Retain remaining multi-host/restart/graceful-shutdown/command-transport evidence.
-- [ ] Add remaining locale/partition checkpoint dimensions and explicit rebuild modes.
+- [ ] Complete remaining multi-host/restart/shutdown/command-transport evidence.
 
-## M7 Product/ProductVariant/SalesChannel production graph
+## M7 Product Storefront graph
 
-- [x] Canonical Product, ProductVariant and SalesChannel bounded sources.
-- [x] Product `variants` and `sales_channels` links and retained delete identities.
-- [x] Product-to-SalesChannel relation membership ledger, resolver and freshness witness.
-- [x] Canonical Product graph projection epoch and projection-aware absence.
-- [x] Rejected-Product poison isolation and materialized root freshness fence.
-- [x] Entity-level stale linked-target freshness fence and recreate-safe target revisions.
-- [x] Query-path-scoped fail-closed linked-target availability for ordinary Product queries.
-- [x] One current 15-field Product Storefront-capable source contract.
-- [x] Schema-safe single-current replacement/promotion mechanism.
-- [x] Canonical typed EAV term representation and Product EAV owner clock.
-- [x] Recheck owner all-translations search + requested/fallback projection mismatch.
-- [x] Select generic localized identity/fallback architecture without another Product routing key.
-- [x] Add localized query shape/validation and dedicated cursor identity.
-- [x] Compile/decode root-only localized identity-fold page/count.
-- [x] Wire localized execution through canonical PostgreSQL runtime with readiness/admission/snapshot.
-- [x] Add generic scalar String `TextLike` usable inside folded `any_locale_filter`.
-- [ ] Implement the Product Storefront Index adapter and Taxonomy tag hydration boundary.
-- [ ] Resolve owner-search input bound and collation parity for authoritative adapter search.
-- [ ] Actualize retained Product PostgreSQL packets/guards to routing key `4` / 15-field source.
-- [ ] Retain source-ready owner-vs-Index localized PostgreSQL equivalence packets.
-- [ ] Extend folded execution to linked paths only with dedicated target-availability evidence.
-- [ ] Execute/admit current replacement Product PostgreSQL packets.
-- [ ] Stage/rebuild/promote the current Product schema for a tenant.
-- [ ] Move Storefront traffic only after readiness/equivalence/freshness/availability/restart evidence
-      passes.
+- [x] Current Product/ProductVariant/SalesChannel sources and graph freshness.
+- [x] One current 15-field Product contract and schema-safe replacement mechanism.
+- [x] Canonical typed EAV terms and Product owner clock.
+- [x] Localized identity/fallback architecture.
+- [x] Localized query/cursor contract.
+- [x] Localized PostgreSQL compiler/decoder.
+- [x] Localized production runtime with readiness/admission/snapshot semantics.
+- [x] Generic scalar String `TextLike`.
+- [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
+- [ ] Implement Product Storefront Index shadow/evidence adapter.
+- [ ] Resolve search-length/collation parity.
+- [ ] Resolve channel-less unrestricted visibility parity.
+- [ ] Resolve Product attribute option-code metadata through an owner capability and emit canonical
+  `attribute_terms`.
+- [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
+- [ ] Actualize retained Product PostgreSQL packets to routing key `4`.
+- [ ] Retain owner-vs-Index localized PostgreSQL equivalence packet.
+- [ ] Extend folded linked paths only with dedicated target-availability evidence.
+- [ ] Execute/admit current replacement Product PostgreSQL evidence.
+- [ ] Stage/rebuild/promote Product key `4` for a tenant.
+- [ ] Move Storefront traffic only after every parity/readiness/freshness/restart gate passes.
 
-## Next implementation step
+## Next source-code step
 
-Primary maintainer gate remains: **execute and admit the locked M6 repair PostgreSQL packet**.
+Build the Product Storefront **shadow/evidence adapter**, not a traffic switch. It should translate only
+inputs whose parity is already representable and fail closed for unresolved search/channel cases. The
+adapter must map owner sort direction to both timestamp ordering and localized identity tie-break direction,
+resolve Product EAV metadata through Product-owned capabilities, and leave Taxonomy hydration after page
+selection.
 
-Next source-code step: **implement the Product Storefront Index adapter plus retained localized-query
-PostgreSQL equivalence packet**, while leaving Storefront traffic owner-native. The adapter must map
-Active/published/category/channel/EAV/order/page/count, requested/fallback localized projection and
-`TextLike` all-translations title search, then batch-hydrate Taxonomy tag names after the Product page is
-fixed.
+In parallel, actualize historical Product PostgreSQL packets to routing key `4` / current 15-field source.
 
-The same slice must make the search-bound/collation mismatch explicit and fail closed until an
-authoritative equivalent input contract is demonstrated. Do not silently truncate owner-valid search.
-
-In parallel, actualize retained Product PostgreSQL packets to routing key `4` / current 15-field contract.
-No historical-key runtime compatibility path is allowed.
-
-Typed Product events remain separately blocked on maintainer event-digest admission.
-
-## Maintainer verification after this source slice
+## Maintainer verification after this slice
 
 The implementation agent has not run these commands. Maintainer verification should include:
 
 ```bash
-node scripts/verify/verify-index-text-like-filter.mjs
+node scripts/verify/verify-index-localized-identity-order.mjs
 node scripts/verify/verify-index-localized-query-contract.mjs
 node scripts/verify/verify-index-localized-query-postgres-fold.mjs
 node scripts/verify/verify-index-localized-query-runtime.mjs
-node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
-node scripts/verify/verify-index-product-storefront-parity-gate.mjs
+node scripts/verify/verify-index-text-like-filter.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
 git diff --check

--- a/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
+++ b/crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md
@@ -1,16 +1,16 @@
 # M7 Product Storefront localized query architecture
 
-Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`.
+Status: `runtime_text_pattern_identity_order_source_complete_adapter_and_evidence_pending`.
 
 ## Decision
 
-Keep the current owner Storefront behavior and exactly one current Product Index schema. Preserve the
-physical locale-keyed Index rows and close Storefront locale/search parity in the generic Index query layer
-with an explicit localized-entity identity fold.
+Keep the current owner Storefront behavior and exactly one current Product Index schema. Preserve physical
+locale-keyed Index rows and close Storefront locale/search parity in the generic Index query layer with an
+explicit localized-entity identity fold.
 
-Do not narrow owner search/fallback behavior merely to fit ordinary `IndexQueryScope`, and do not add a
-Storefront-only Product routing key or compatibility schema. Locale folding and text matching are query
-semantics, not immutable Product storage identities.
+Ordinary `IndexQuery` remains exact-locale and keeps its existing stable ascending entity-ID tie-break.
+Product-specific parity is expressed only through the explicit localized query contract; no second Product
+routing key or Product-only SQL compiler branch is introduced.
 
 ## Owner contract preserved
 
@@ -22,207 +22,124 @@ cutover gates pass. Its relevant contract is:
 - requested locale -> fallback locale result projection;
 - owner placeholder behavior when neither requested nor fallback translation exists;
 - Active/published/category/channel/EAV identity predicates;
-- exact count and stable timestamp + Product-ID ordering over Product identities;
+- exact count over Product identities;
+- ordering by the selected timestamp and Product ID in the **same** direction;
 - page/per-page pagination after those identity predicates.
 
-The current Product title helper trims an empty search away, then constructs `format!("%{search}%")` and
-executes PostgreSQL `pt.title LIKE $1` in an `EXISTS` over all Product translations. It has no locale
-predicate and currently has no Product-level search-length limit.
+The owner title helper builds `%{search}%` and executes `pt.title LIKE $1` across all translations. It has no
+locale predicate and `StorefrontProductListQuery` currently has no explicit search-length bound.
 
-## Generic identity model
+## Generic localized identity model
 
-The fold operates only for `LocaleMode::Required`. Ordinary `IndexQuery` stays exact-locale and unchanged.
-The folded logical identity is `(tenant_id, schema_ref, entity_id)` while physical storage, mutation,
-replay, absence and freshness remain locale-keyed.
+The fold operates only for `LocaleMode::Required`. Its logical result identity is
+`(tenant_id, schema_ref, entity_id)` while physical storage, mutation, replay, absence and freshness remain
+locale-keyed.
 
-`LocalizedEntityQuery` keeps `query.scope.locale` as requested locale, stores canonical fallback separately,
-and exposes root-only `any_locale_filter` for identity-level existential matching.
+`LocalizedEntityQuery` carries:
 
-Generic schemas intentionally do not claim that particular fields are owner-localized. The fold therefore
-uses explicit `localized_projection_fields`. A listed field is projected only from:
+- the ordinary exact-locale `IndexQuery` shape;
+- requested locale in `query.scope.locale`;
+- canonical fallback locale;
+- root-only `any_locale_filter`;
+- explicit `localized_projection_fields` for requested -> fallback -> null projection;
+- explicit `identity_order_direction` for the final root entity-ID tie-break.
 
-1. an admitted requested-locale row;
-2. otherwise an admitted fallback-locale row;
-3. otherwise SQL null.
+`identity_order_direction` defaults to `Asc` for compatibility with all localized queries created before
+this capability. Validation accepts only `Asc` or `Desc`; aggregate order variants are rejected.
 
-Unlisted fields are read from a deterministic admitted identity anchor. This prevents an arbitrary third
-locale from leaking title/handle content when requested/fallback rows are absent, without changing the
-Product schema fingerprint.
+## Cursor and plan identity
 
-The current compiler/runtime remains root-only. Linked folded paths fail validation until linked semantics
-and target-availability evidence are introduced explicitly. The current Storefront list can express its
-root identity predicates through materialized fields such as `sales_channel_ids` and `attribute_terms`.
+`LocalizedCursorCodec` remains on localized wire version `3`; ordinary exact-locale cursors remain on
+version `2`. The localized query fingerprint now also binds `identity_order_direction`, so a continuation
+created under ascending identity ordering cannot be accepted under descending identity ordering and vice
+versa. Existing localized v3 tokens from the earlier query-fingerprint shape fail closed by fingerprint
+mismatch.
 
-## Query validation and cursor identity
+`LocalizedQueryPlanFingerprint` likewise binds `identity_order_direction` in addition to ordinary plan
+fingerprint, fallback, any-locale predicate and localized projection roles.
 
-`SchemaRegistry::validate_localized_entity_query` requires `LocaleMode::Required`, reuses ordinary
-field/operator/value validation, shares one bounded filter-node budget across ordinary and any-locale
-filters, rejects linked paths, and requires every localized projection entry to be a selected root scalar.
-Localized projection fields cannot drive ordinary identity filtering or ordering.
+## PostgreSQL fold ordering
 
-`LocalizedCursorCodec` uses scoped wire version `3`; ordinary exact-locale cursors remain on version `2`.
-The localized query fingerprint binds fold mode, tenant/schema, requested/fallback roles, ordinary filter,
-`any_locale_filter`, canonical localized projection roles and ordering. A continuation cannot cross modes
-or survive a changed text pattern/search shape.
+The root-only localized compiler continues to use:
 
-## PostgreSQL fold compiler and decoder
+- `t0` deterministic admitted identity anchor;
+- `t1` requested projection row;
+- `t2` fallback projection row;
+- `t3` any-locale predicate row;
+- `t4` lower-locale anti-duplicate candidate.
 
-`SchemaRegistry::compile_postgres_localized_page_query` compiles one page statement and optional exact
-count. Canonical physical aliases are:
+Grouping/de-duplication occurs before ordering, lookahead, limit and exact count. Explicit `order_by` terms
+keep their own direction/null semantics. The final `t0.entity_id` tie-break uses
+`query.identity_order_direction`:
 
-- `t0` — deterministic admitted identity anchor;
-- `t1` — requested-locale projection row;
-- `t2` — fallback-locale projection row when distinct from requested;
-- `t3` — any-locale existential predicate row;
-- `t4` — lower-locale anti-duplicate anchor candidate.
+- `Asc` -> `ORDER BY ... entity_id ASC` and cursor continuation `entity_id > cursor.entity_id`;
+- `Desc` -> `ORDER BY ... entity_id DESC` and cursor continuation `entity_id < cursor.entity_id`.
 
-Every role retains the ordinary `is_deleted = FALSE` anchor so generic `PostgresQueryEntityAdmission` can
-inject owner freshness without a Product-specific compiler branch. One identity survives before
-ordering/lookahead/limit/count by excluding an admitted lower-locale `t4` row.
+This closes the Product owner mismatch for descending timestamp pages where multiple Products share the
+same timestamp. Ordinary exact-locale SQL compilation is deliberately unchanged.
 
-Ordinary identity filters and ordering are evaluated on `t0`; `any_locale_filter` is an `EXISTS` over
-`t3`. Requested/fallback projection uses row-presence `CASE`, not value-level `COALESCE`. Exact count uses
-the same identity/search boundary but intentionally omits requested/fallback projection rows.
+## Existing runtime and text-pattern contract
 
-`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary and localized plan fingerprints,
-column/count/lookahead contracts and emits only localized continuation cursors. SQL null beyond physical
-field nullability is accepted only for an explicit localized projection field and means no admitted
-requested/fallback row exists.
+The localized compiler/decoder/runtime remains source-complete:
 
-## Runtime execution — source complete
+- persisted schema readiness and generic entity admission are fail-closed;
+- page and exact count execute in one `REPEATABLE READ, READ ONLY` transaction;
+- localized results decode only through the localized decoder;
+- `FilterExpr::TextLike` is a generic bounded scalar String predicate usable inside `any_locale_filter`;
+- `%`, `_` and backslash escape use PostgreSQL `LIKE` semantics;
+- the reference engine mirrors those wildcard semantics.
 
-`IndexQueryPort` publishes `execute_localized_query`; its default implementation fails closed so custom or
-non-PostgreSQL adapters do not silently claim the capability. `SharedIndexQueryRuntime` forwards the
-capability.
+## Storefront adapter blockers discovered during recheck
 
-`PostgresIndexQueryPort::execute_localized_query`:
+Three explicit parity gates remain before an owner-facing adapter can claim completeness:
 
-1. requires PostgreSQL;
-2. derives persisted schema contracts from the embedded ordinary root query;
-3. compiles the localized page/count contract;
-4. applies query-path availability plus `PostgresQueryEntityAdmission` before storage execution;
-5. starts one `REPEATABLE READ, READ ONLY` transaction;
-6. verifies persisted tenant schema status/fingerprint/JSON in that snapshot;
-7. executes page and optional exact count in the same snapshot;
-8. decodes only through `decode_postgres_localized_query_page`;
-9. commits successful reads and rolls back failures.
+1. **Search bound:** Product owner search is not explicitly length-bounded, while generic `TextLike` is
+   capped at 1024 UTF-8 bytes. The adapter must not silently truncate/reject owner-valid input.
+2. **Search collation:** owner `LIKE` uses deployment/default collation while Index String scalar SQL uses
+   deterministic `COLLATE "C"`; retained PostgreSQL evidence must establish the admitted contract.
+3. **Channel-less visibility:** owner requests without a public channel admit only Products whose metadata
+   visibility is unrestricted. Current `sales_channel_ids` materializes unrestricted visibility as
+   membership in all current channels, so it cannot distinguish unrestricted from a restricted Product
+   that happens to contain every current channel. A channel-less authoritative adapter must therefore
+   fail closed until that distinction is materialized or otherwise proven by an owner capability.
 
-The path reuses ordinary bind mapping, row mapping, exact-count handling, readiness verification and
-transaction finalization.
+For a request with a trusted current public channel ID, `sales_channel_ids` membership remains the intended
+root predicate because the Product channel resolver maps unrestricted visibility to all current channels
+and restricted visibility to its resolved allowed channels, under the existing freshness witness.
 
-## Generic `TextLike` — source complete
+## Next adapter/evidence slice
 
-`FilterExpr::TextLike(FieldPath, String)` is appended after all pre-existing filter variants so existing
-postcard enum discriminants remain stable. It is generic Index behavior, not Product-specific behavior.
+The next source slice may build a shadow/evidence Product Storefront adapter only after preserving these
+rules:
 
-Validation requires:
+- requested/fallback Product fields are explicit localized projections;
+- `TextLike(title, "%...%")` remains an any-locale identity predicate;
+- ascending owner sort uses ascending identity tie-break;
+- descending owner sort uses descending identity tie-break;
+- Active, published-only, category, EAV, channel and exact-count semantics are root identity predicates;
+- Product attribute/option inputs resolve through Product-owned metadata before canonical
+  `attribute_terms` are emitted;
+- Taxonomy tag names are hydrated only after the Product page is fixed;
+- unresolved search-bound/collation/channel-less visibility cases fail closed;
+- Storefront traffic remains owner-native until retained PostgreSQL equivalence is executed and admitted.
 
-- a filterable scalar (`FieldCardinality::One`) String field;
-- pattern size at most 1024 UTF-8 bytes;
-- no NUL byte;
-- no trailing unpaired backslash escape.
+## Retained evidence required before cutover
 
-Pattern semantics are explicit PostgreSQL `LIKE` semantics:
+Evidence must cover requested/fallback/third-locale cases, cross-locale search, wildcard escaping,
+duplicate locale matches, exact count, repeated equal timestamps under both ascending and descending ID
+tie-breaks, cursor continuation, stale locale exclusion, readiness/admission failure, restart/replay,
+channel visibility, EAV predicates, search-bound/collation behavior and current Product routing key `4`.
 
-- `%` matches zero or more characters;
-- `_` matches one character;
-- `\` escapes the following wildcard or literal character.
-
-Both the ordinary PostgreSQL compiler and the localized alias compiler bind the pattern as
-`PostgresBindValue::Text` and compile `LIKE ... ESCAPE E'\\'`. Ordinary linked/many filtering reuses the
-existing correlated `compile_many_exists` path; the localized fold stays root-only and can use the same
-operator inside `any_locale_filter`.
-
-The in-memory reference engine and the PostgreSQL equivalence reference fixture implement the same
-wildcard/escape grammar over Unicode scalar values. Query/cursor fingerprints already serialize
-`FilterExpr`, so changing a `TextLike` pattern changes continuation identity without another cursor wire
-version.
-
-For the current Product owner search, the future adapter can build `%{trimmed_search}%` and place
-`TextLike(title, pattern)` inside `any_locale_filter`. A search match in `t3` admits the Product identity but
-does not choose the projected locale.
-
-## Remaining Product search-bound mismatch
-
-`TextLike` is deliberately bounded, while the current `StorefrontProductListQuery` has no explicit search
-length bound. Therefore source completion of `TextLike` does **not** by itself establish owner parity for
-arbitrarily long search input.
-
-Before Storefront cutover, the adapter/equivalence slice must resolve this explicitly. Acceptable outcomes
-are to establish an existing authoritative upstream bound that is <= 1024 bytes, or introduce one
-reviewed owner/API bound and retain matching validation evidence. The adapter must not silently truncate,
-reject, or reinterpret an input that the authoritative owner path still accepts.
-
-Retained PostgreSQL evidence must also cover the deployment collation used by owner title `LIKE` versus the
-Index String scalar's deterministic `COLLATE "C"`; no general collation-equivalence claim is made by source
-inspection.
-
-## Storefront adapter boundary
-
-The next Product adapter must:
-
-- map Active + published-only/category/channel visibility predicates;
-- resolve Product attribute/option codes to canonical `attribute_terms`;
-- classify returned localized fields such as `title`/`handle` in `localized_projection_fields`;
-- build folded any-locale title search with `TextLike`;
-- preserve requested/fallback/placeholder behavior;
-- preserve timestamp ordering, Product-ID tie-break, page/per-page and exact count;
-- batch-hydrate localized Taxonomy tag names only after the Product page is fixed;
-- fail closed on the unresolved owner-vs-Index search-bound/collation gates.
-
-Taxonomy localization stays Taxonomy-owned; Product Index stores stable tag UUIDs only.
-
-## Required retained evidence
-
-Before Storefront traffic can move, PostgreSQL equivalence must cover at least:
-
-1. requested translation present;
-2. requested absent + fallback present;
-3. requested/fallback absent while another translation exists;
-4. title match only in requested locale;
-5. title match only in fallback locale;
-6. title match only in a third locale while projection still follows requested/fallback roles;
-7. `%`, `_` and escaped wildcard search behavior;
-8. duplicate matches in multiple locales yielding one Product identity/exact count;
-9. interleaved locale rows with stable global identity ordering/page boundaries;
-10. cursor continuation and exact-count parity;
-11. delayed/stale locale rows excluded by owner freshness;
-12. persisted schema readiness failure before authoritative results;
-13. restart/recomposition/replay redelivery preserving the grouped page;
-14. search-bound and database-collation parity for the admitted Storefront input contract;
-15. current Product routing-key rebuild/promotion rather than a historical lower key.
-
-Linked-target lag evidence remains required before adding linked paths to folded execution.
-
-## Deliberate limits
-
-This slice does not:
-
-- implement the Product Storefront Index adapter;
-- resolve the currently unbounded owner search-input contract;
-- claim owner/Index collation equivalence;
-- actualize or execute retained Product PostgreSQL packets;
-- add Product typed events or bypass event-digest admission;
-- rebuild/promote a tenant Product schema;
-- switch Storefront traffic.
-
-## Next implementation slice
-
-Implement the Product Storefront Index adapter and a retained owner-vs-Index localized-query PostgreSQL
-packet, while keeping traffic owner-native. The adapter slice must explicitly resolve the search-input
-bound/collation gates before it can claim full search parity.
-
-In parallel, actualize historical Product PostgreSQL packets to routing key `4` and the current 15-field
-contract. Do not add a historical routing-key compatibility implementation.
+Linked folded paths remain separately blocked on explicit target-availability evidence.
 
 ## Source guards
 
-- `scripts/verify/verify-index-localized-query-contract.mjs` locks query/projection/cursor roles.
-- `scripts/verify/verify-index-localized-query-postgres-fold.mjs` locks fold compiler/decoder semantics.
-- `scripts/verify/verify-index-localized-query-runtime.mjs` locks fail-closed runtime readiness/admission
-  and one-snapshot page/count execution.
-- `scripts/verify/verify-index-text-like-filter.mjs` locks bounded scalar String validation, PostgreSQL
-  LIKE compilation, reference semantics and the current Product owner search shape.
+- `verify-index-localized-query-contract.mjs` locks query/projection/cursor roles;
+- `verify-index-localized-query-postgres-fold.mjs` locks fold compiler/decoder semantics;
+- `verify-index-localized-query-runtime.mjs` locks readiness/admission/snapshot execution;
+- `verify-index-text-like-filter.mjs` locks generic bounded LIKE semantics;
+- `verify-index-localized-identity-order.mjs` locks explicit localized entity-ID tie-break direction and
+  proves ordinary exact-locale ordering remains unchanged.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/application/localized_cursor.rs
+++ b/crates/rustok-index/src/application/localized_cursor.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::domain::{
-    FieldPath, FilterExpr, IndexValue, IndexValueType, LocaleKey, LocalizedEntityQuery, OrderExpr,
-    SchemaFingerprint, SchemaRef,
+    FieldPath, FilterExpr, IndexValue, IndexValueType, LocaleKey, LocalizedEntityQuery, OrderDirection,
+    OrderExpr, SchemaFingerprint, SchemaRef,
 };
 
 use super::{LocalizedEntityQueryValidationError, SchemaRegistry, SchemaRegistryError};
@@ -42,6 +42,7 @@ struct LocalizedCursorQueryIdentity<'a> {
     any_locale_filter: &'a Option<FilterExpr>,
     localized_projection_fields: Vec<&'a FieldPath>,
     order_by: &'a [OrderExpr],
+    identity_order_direction: OrderDirection,
 }
 
 #[derive(Debug, Error)]
@@ -178,6 +179,7 @@ fn query_fingerprint(
         any_locale_filter: &query.any_locale_filter,
         localized_projection_fields,
         order_by: &query.query.order_by,
+        identity_order_direction: query.identity_order_direction,
     };
     let bytes = postcard::to_stdvec(&identity)?;
     let mut hasher = Sha256::new();
@@ -276,7 +278,7 @@ mod tests {
     use super::*;
     use crate::domain::{
         EntityName, FieldCardinality, FieldName, IndexField, IndexQuery, IndexQueryScope, IndexSchema,
-        LocaleMode, ModuleName, OrderDirection, Pagination, SchemaVersion,
+        LocaleMode, ModuleName, Pagination, SchemaVersion,
     };
     use crate::{CursorCodec, IndexCursor};
 
@@ -341,21 +343,25 @@ mod tests {
         .with_localized_projection_fields([FieldPath::new(FieldName::new("title").unwrap())])
     }
 
+    fn cursor(query: &LocalizedEntityQuery, schema: &IndexSchema) -> LocalizedIndexCursor {
+        LocalizedIndexCursor {
+            tenant_id: query.query.scope.tenant_id,
+            schema: schema.reference.clone(),
+            schema_fingerprint: schema.fingerprint().unwrap(),
+            requested_locale: LocaleKey::new("en-US").unwrap(),
+            fallback_locale: query.canonical_fallback_locale().cloned(),
+            order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
+            entity_id: Uuid::new_v4(),
+        }
+    }
+
     #[test]
     fn localized_cursor_is_bound_to_fallback_and_has_separate_wire_version() {
         let schema = schema();
         let mut registry = SchemaRegistry::new();
         registry.register(schema.clone()).unwrap();
         let original = query(&schema, Some("en"));
-        let cursor = LocalizedIndexCursor {
-            tenant_id: original.query.scope.tenant_id,
-            schema: schema.reference.clone(),
-            schema_fingerprint: schema.fingerprint().unwrap(),
-            requested_locale: LocaleKey::new("en-US").unwrap(),
-            fallback_locale: Some(LocaleKey::new("en").unwrap()),
-            order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
-            entity_id: Uuid::new_v4(),
-        };
+        let cursor = cursor(&original, &schema);
         let encoded = LocalizedCursorCodec::encode_for_query(&cursor, &original, &registry).unwrap();
         assert_eq!(
             LocalizedCursorCodec::decode_scoped_for_query(&encoded, &original, &registry).unwrap(),
@@ -381,39 +387,35 @@ mod tests {
     }
 
     #[test]
-    fn localized_cursor_cannot_cross_fallback_or_projection_semantics() {
+    fn localized_cursor_cannot_cross_fallback_projection_or_identity_order_semantics() {
         let schema = schema();
         let mut registry = SchemaRegistry::new();
         registry.register(schema.clone()).unwrap();
         let original = query(&schema, Some("en"));
-        let cursor = LocalizedIndexCursor {
-            tenant_id: original.query.scope.tenant_id,
-            schema: schema.reference.clone(),
-            schema_fingerprint: schema.fingerprint().unwrap(),
-            requested_locale: LocaleKey::new("en-US").unwrap(),
-            fallback_locale: Some(LocaleKey::new("en").unwrap()),
-            order_values: vec![IndexValue::Uuid(Uuid::new_v4())],
-            entity_id: Uuid::new_v4(),
-        };
+        let cursor = cursor(&original, &schema);
         let encoded = LocalizedCursorCodec::encode_for_query(&cursor, &original, &registry).unwrap();
 
         let mut changed_fallback = original.clone();
         changed_fallback.fallback_locale = Some(LocaleKey::new("fr").unwrap());
         assert!(matches!(
-            LocalizedCursorCodec::decode_scoped_for_query(
-                &encoded,
-                &changed_fallback,
-                &registry
-            ),
+            LocalizedCursorCodec::decode_scoped_for_query(&encoded, &changed_fallback, &registry),
             Err(LocalizedCursorValidationError::QueryFingerprintMismatch)
         ));
 
         let mut changed_projection = original.clone();
         changed_projection.localized_projection_fields.clear();
         assert!(matches!(
+            LocalizedCursorCodec::decode_scoped_for_query(&encoded, &changed_projection, &registry),
+            Err(LocalizedCursorValidationError::QueryFingerprintMismatch)
+        ));
+
+        let changed_identity_order = original
+            .clone()
+            .with_identity_order_direction(OrderDirection::Desc);
+        assert!(matches!(
             LocalizedCursorCodec::decode_scoped_for_query(
                 &encoded,
-                &changed_projection,
+                &changed_identity_order,
                 &registry
             ),
             Err(LocalizedCursorValidationError::QueryFingerprintMismatch)

--- a/crates/rustok-index/src/application/localized_validation.rs
+++ b/crates/rustok-index/src/application/localized_validation.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use thiserror::Error;
 
 use crate::domain::{
-    FieldCardinality, FieldPath, LocalizedEntityQuery, LocaleMode, SchemaRef,
+    FieldCardinality, FieldPath, LocalizedEntityQuery, LocaleMode, OrderDirection, SchemaRef,
 };
 
 use super::{QueryValidationError, SchemaRegistry, SchemaRegistryError};
@@ -16,6 +16,8 @@ pub enum LocalizedEntityQueryValidationError {
     Registry(#[from] SchemaRegistryError),
     #[error("localized entity fold requires a locale-required root schema: {0}")]
     LocaleRequiredSchema(SchemaRef),
+    #[error("localized entity identity tie-break supports only asc or desc")]
+    InvalidIdentityOrderDirection,
     #[error("localized entity fold compiler currently accepts root-only query paths: {0:?}")]
     LinkedPathPending(FieldPath),
     #[error("any-locale identity predicate must reference root fields only: {0:?}")]
@@ -45,6 +47,13 @@ impl SchemaRegistry {
             .validate_shape()
             .map_err(QueryValidationError::from)?;
 
+        if !matches!(
+            query.identity_order_direction,
+            OrderDirection::Asc | OrderDirection::Desc
+        ) {
+            return Err(LocalizedEntityQueryValidationError::InvalidIdentityOrderDirection);
+        }
+
         let registered = self
             .get(&query.query.schema)
             .ok_or_else(|| SchemaRegistryError::SchemaNotFound(query.query.schema.clone()))?;
@@ -54,13 +63,8 @@ impl SchemaRegistry {
             ));
         }
 
-        // The embedded query remains a normal, fully validated exact-locale query shape. Fold mode is
-        // additive and cannot weaken selection/filter/order/pagination/schema checks.
         self.validate_query(&query.query)?;
 
-        // The first folded PostgreSQL compiler is intentionally root-only. This exactly covers the
-        // Product Storefront list contract while keeping linked traversal/availability semantics out of
-        // the slice until they can be introduced with dedicated retained evidence.
         if let Some(path) = query
             .query
             .referenced_paths()
@@ -82,9 +86,6 @@ impl SchemaRegistry {
             ));
         }
 
-        // Reuse the canonical filter validator by substituting only the existential root predicate.
-        // This keeps field existence/filterability/operator/value rules exactly aligned with ordinary
-        // Index queries while preserving the separate any-locale semantic role.
         if let Some(filter) = &query.any_locale_filter {
             let mut probe = query.query.clone();
             probe.filter = Some(filter.clone());
@@ -162,8 +163,8 @@ mod tests {
     use super::*;
     use crate::domain::{
         EntityName, FieldName, FieldPath, FilterExpr, IndexField, IndexQuery, IndexQueryScope,
-        IndexSchema, IndexValue, IndexValueType, LocaleKey, ModuleName, OrderDirection, OrderExpr,
-        Pagination, SchemaRef, SchemaVersion,
+        IndexSchema, IndexValue, IndexValueType, LocaleKey, ModuleName, OrderExpr, Pagination,
+        SchemaRef, SchemaVersion,
     };
 
     fn schema(locale_mode: LocaleMode) -> IndexSchema {
@@ -244,6 +245,19 @@ mod tests {
             registry.validate_localized_entity_query(&query),
             Err(LocalizedEntityQueryValidationError::LocaleRequiredSchema(_))
         ));
+    }
+
+    #[test]
+    fn rejects_aggregate_identity_tie_break_direction() {
+        let schema = schema(LocaleMode::Required);
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let query = localized_query(&schema)
+            .with_identity_order_direction(OrderDirection::MaxDesc);
+        assert_eq!(
+            registry.validate_localized_entity_query(&query),
+            Err(LocalizedEntityQueryValidationError::InvalidIdentityOrderDirection)
+        );
     }
 
     #[test]

--- a/crates/rustok-index/src/application/postgres_localized_query.rs
+++ b/crates/rustok-index/src/application/postgres_localized_query.rs
@@ -91,16 +91,10 @@ struct LocalizedPlanIdentity<'a> {
     fallback_locale: Option<&'a crate::domain::LocaleKey>,
     any_locale_filter: &'a Option<FilterExpr>,
     localized_projection_fields: Vec<&'a FieldPath>,
+    identity_order_direction: OrderDirection,
 }
 
 impl SchemaRegistry {
-    /// Compile one root-only localized-entity fold page and optional exact-count statement.
-    ///
-    /// The compiler deliberately emits only ordinary canonical `tN` materialized entity aliases and
-    /// an `is_deleted = FALSE` anchor for each physical row role. Existing trusted owner admission can
-    /// therefore be applied to anchor/requested/fallback/search/anti-duplicate rows without learning a
-    /// Product-specific query shape. Runtime execution is published only in a later slice after
-    /// admission composition is wired and retained PostgreSQL evidence exists.
     pub fn compile_postgres_localized_page_query(
         &self,
         query: &LocalizedEntityQuery,
@@ -194,10 +188,10 @@ fn compile_localized_page(
         )?);
     }
     if let Some(cursor) = cursor {
-        predicates.push(compile_keyset(plan, cursor, &mut bindings)?);
+        predicates.push(compile_keyset(query, plan, cursor, &mut bindings)?);
     }
 
-    let order = compile_order(plan, &mut bindings)?;
+    let order = compile_order(query, plan, &mut bindings)?;
     let pagination = compile_pagination_with_lookahead(&plan.pagination, &mut bindings)?;
     let sql = format!(
         "SELECT {} {} WHERE {} {order} {pagination}",
@@ -242,6 +236,7 @@ pub(super) fn localized_plan_fingerprint(
         fallback_locale: query.canonical_fallback_locale(),
         any_locale_filter: &query.any_locale_filter,
         localized_projection_fields,
+        identity_order_direction: query.identity_order_direction,
     };
     let bytes = postcard::to_stdvec(&identity)?;
     let mut hasher = Sha256::new();
@@ -483,6 +478,7 @@ fn field_sql_for_path(
 }
 
 fn compile_keyset(
+    query: &LocalizedEntityQuery,
     plan: &ExecutableQueryPlan,
     cursor: &LocalizedIndexCursor,
     bindings: &mut Bindings,
@@ -503,10 +499,17 @@ fn compile_keyset(
     }
 
     let entity_id = bindings.push(PostgresBindValue::Uuid(cursor.entity_id));
-    let root_after = format!(
-        "{}.entity_id > {entity_id}",
-        quote_identifier(ROOT_ALIAS)
-    );
+    let root_after = match query.identity_order_direction {
+        OrderDirection::Asc => format!(
+            "{}.entity_id > {entity_id}",
+            quote_identifier(ROOT_ALIAS)
+        ),
+        OrderDirection::Desc => format!(
+            "{}.entity_id < {entity_id}",
+            quote_identifier(ROOT_ALIAS)
+        ),
+        _ => unreachable!("validated localized identity order is asc or desc"),
+    };
     disjuncts.push(conjunction(&equalities, &root_after));
     Ok(format!("({})", disjuncts.join(" OR ")))
 }
@@ -550,6 +553,7 @@ fn conjunction(prefix: &[String], final_predicate: &str) -> String {
 }
 
 fn compile_order(
+    query: &LocalizedEntityQuery,
     plan: &ExecutableQueryPlan,
     bindings: &mut Bindings,
 ) -> Result<String, PostgresQueryCompileError> {
@@ -565,7 +569,15 @@ fn compile_order(
             })
         })
         .collect::<Result<Vec<_>, PostgresQueryCompileError>>()?;
-    terms.push(format!("{}.entity_id ASC", quote_identifier(ROOT_ALIAS)));
+    let identity_direction = match query.identity_order_direction {
+        OrderDirection::Asc => "ASC",
+        OrderDirection::Desc => "DESC",
+        _ => unreachable!("validated localized identity order is asc or desc"),
+    };
+    terms.push(format!(
+        "{}.entity_id {identity_direction}",
+        quote_identifier(ROOT_ALIAS)
+    ));
     Ok(format!("ORDER BY {}", terms.join(", ")))
 }
 
@@ -811,6 +823,7 @@ mod tests {
         assert!(sql.contains("WHEN \"t2\".entity_id IS NOT NULL"));
         assert!(sql.contains(" LIKE "));
         assert!(sql.contains("ESCAPE E'\\\\'"));
+        assert!(sql.contains("\"t0\".entity_id ASC"));
         assert_eq!(compiled.requested_page_size(), 20);
         let count = compiled.compiled().exact_count.as_ref().unwrap();
         assert!(count.sql.contains("index_entities AS \"t0\""));
@@ -818,6 +831,18 @@ mod tests {
         assert!(count.sql.contains("index_entities AS \"t4\""));
         assert!(count.sql.contains(" LIKE "));
         assert!(!count.sql.contains("index_entities AS \"t1\""));
+    }
+
+    #[test]
+    fn localized_identity_tie_break_can_follow_descending_owner_order() {
+        let schema = schema();
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema.clone()).unwrap();
+        let query = query(&schema).with_identity_order_direction(OrderDirection::Desc);
+        let compiled = registry
+            .compile_postgres_localized_page_query(&query)
+            .unwrap();
+        assert!(compiled.compiled().sql.contains("\"t0\".entity_id DESC"));
     }
 
     #[test]

--- a/crates/rustok-index/src/domain/localized_query.rs
+++ b/crates/rustok-index/src/domain/localized_query.rs
@@ -1,8 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use super::{DomainError, FieldPath, FilterExpr, IndexQuery, LocaleKey};
+use super::{DomainError, FieldPath, FilterExpr, IndexQuery, LocaleKey, OrderDirection};
 
 const MAX_LOCALIZED_FILTER_NODES: usize = 128;
+
+fn default_identity_order_direction() -> OrderDirection {
+    OrderDirection::Asc
+}
 
 /// Explicit localized-entity fold request layered on top of the ordinary exact-locale query shape.
 ///
@@ -17,6 +21,9 @@ const MAX_LOCALIZED_FILTER_NODES: usize = 128;
 /// requested row, then fallback row, then SQL null. Unlisted root fields are read from the deterministic
 /// admitted identity anchor. This prevents a third-locale anchor from becoming visible localized
 /// content when requested/fallback rows are absent without changing the immutable schema fingerprint.
+///
+/// `identity_order_direction` controls only the final root entity UUID tie-break after all explicit
+/// `query.order_by` terms. Ordinary `IndexQuery` keeps its existing always-ascending identity tie-break.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalizedEntityQuery {
     pub query: IndexQuery,
@@ -24,6 +31,8 @@ pub struct LocalizedEntityQuery {
     pub any_locale_filter: Option<FilterExpr>,
     #[serde(default)]
     pub localized_projection_fields: Vec<FieldPath>,
+    #[serde(default = "default_identity_order_direction")]
+    pub identity_order_direction: OrderDirection,
 }
 
 impl LocalizedEntityQuery {
@@ -37,6 +46,7 @@ impl LocalizedEntityQuery {
             fallback_locale,
             any_locale_filter,
             localized_projection_fields: Vec::new(),
+            identity_order_direction: OrderDirection::Asc,
         }
     }
 
@@ -48,14 +58,16 @@ impl LocalizedEntityQuery {
         self
     }
 
+    pub fn with_identity_order_direction(mut self, direction: OrderDirection) -> Self {
+        self.identity_order_direction = direction;
+        self
+    }
+
     pub fn requested_locale(&self) -> Option<&LocaleKey> {
         self.query.scope.locale.as_ref()
     }
 
     /// Return the canonical fallback role used by planning, cursor identity and execution.
-    ///
-    /// Equal requested/fallback locales collapse to one role instead of creating duplicate physical
-    /// locale work or a second cursor identity for equivalent semantics.
     pub fn canonical_fallback_locale(&self) -> Option<&LocaleKey> {
         self.fallback_locale
             .as_ref()
@@ -157,5 +169,17 @@ mod tests {
         assert!(!plain.is_localized_projection_path(&title));
         let localized = plain.with_localized_projection_fields([title.clone()]);
         assert!(localized.is_localized_projection_path(&title));
+    }
+
+    #[test]
+    fn identity_order_defaults_ascending_and_can_be_selected() {
+        let query = LocalizedEntityQuery::new(base_query("en-US"), None, None);
+        assert_eq!(query.identity_order_direction, OrderDirection::Asc);
+        assert_eq!(
+            query
+                .with_identity_order_direction(OrderDirection::Desc)
+                .identity_order_direction,
+            OrderDirection::Desc
+        );
     }
 }

--- a/scripts/verify/verify-index-localized-identity-order.mjs
+++ b/scripts/verify/verify-index-localized-identity-order.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-localized-identity-order] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+requireMarkers('crates/rustok-index/src/domain/localized_query.rs', [
+  'pub identity_order_direction: OrderDirection',
+  'default_identity_order_direction',
+  'identity_order_direction: OrderDirection::Asc',
+  'pub fn with_identity_order_direction(',
+]);
+requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
+  'InvalidIdentityOrderDirection',
+  'OrderDirection::Asc | OrderDirection::Desc',
+]);
+requireMarkers('crates/rustok-index/src/application/localized_cursor.rs', [
+  'identity_order_direction: OrderDirection',
+  'identity_order_direction: query.identity_order_direction',
+  'LOCALIZED_SCOPED_CURSOR_VERSION: u8 = 3',
+]);
+const compiler = requireMarkers('crates/rustok-index/src/application/postgres_localized_query.rs', [
+  'identity_order_direction: OrderDirection',
+  'compile_keyset(query, plan, cursor, &mut bindings)',
+  'compile_order(query, plan, &mut bindings)',
+  'OrderDirection::Asc => format!(',
+  'OrderDirection::Desc => format!(',
+  '.entity_id > {entity_id}',
+  '.entity_id < {entity_id}',
+  'identity_direction = match query.identity_order_direction',
+]);
+if (!compiler.includes('"{}.entity_id {identity_direction}"')) {
+  fail('localized ORDER BY must use the explicit identity tie-break direction');
+}
+
+const ordinary = read('crates/rustok-index/src/application/postgres_query_sql.rs');
+if (!ordinary.includes('entity_id ASC')) {
+  fail('ordinary exact-locale query identity tie-break must remain unchanged');
+}
+if (ordinary.includes('identity_order_direction')) {
+  fail('ordinary exact-locale compiler must not absorb localized identity ordering');
+}
+
+const owner = requireMarkers('crates/rustok-product/src/services/catalog/queries.rs', [
+  '.order_by_asc(entities::product::Column::Id)',
+  '.order_by_desc(entities::product::Column::Id)',
+]);
+if (!owner.includes('StorefrontProductSortDirection::Desc')) {
+  fail('owner Storefront descending ordering contract is missing');
+}
+
+console.log('[verify-index-localized-identity-order] localized root identity tie-break can mirror owner asc/desc without changing ordinary IndexQuery');

--- a/scripts/verify/verify-index-localized-query-contract.mjs
+++ b/scripts/verify/verify-index-localized-query-contract.mjs
@@ -24,61 +24,49 @@ requireMarkers('crates/rustok-index/src/domain/localized_query.rs', [
   'pub fallback_locale: Option<LocaleKey>',
   'pub any_locale_filter: Option<FilterExpr>',
   'pub localized_projection_fields: Vec<FieldPath>',
+  'pub identity_order_direction: OrderDirection',
   'pub fn with_localized_projection_fields(',
+  'pub fn with_identity_order_direction(',
   'pub fn canonical_fallback_locale(&self)',
-  'Some(*fallback) != self.requested_locale()',
-  'pub fn is_localized_projection_path(&self, path: &FieldPath)',
   'ordinary_nodes + any_locale_nodes > MAX_LOCALIZED_FILTER_NODES',
 ]);
 requireMarkers('crates/rustok-index/src/application/localized_validation.rs', [
-  'pub enum LocalizedEntityQueryValidationError',
   'LocaleRequiredSchema(SchemaRef)',
+  'InvalidIdentityOrderDirection',
+  'OrderDirection::Asc | OrderDirection::Desc',
   'LinkedPathPending(FieldPath)',
   'AnyLocaleLinkedPath(FieldPath)',
-  'DuplicateLocalizedProjection(FieldPath)',
   'LocalizedProjectionInOrdinaryFilter(FieldPath)',
   'LocalizedProjectionInOrder(FieldPath)',
-  'registered.schema.locale_mode != LocaleMode::Required',
   'self.validate_query(&query.query)?;',
-  'probe.filter = Some(filter.clone());',
-  'field.cardinality != FieldCardinality::One',
 ]);
 requireMarkers('crates/rustok-index/src/application/localized_cursor.rs', [
   'const LOCALIZED_SCOPED_CURSOR_VERSION: u8 = 3;',
-  'pub struct LocalizedIndexCursor',
-  'localized_projection_fields: Vec<&\'a FieldPath>',
+  'identity_order_direction: OrderDirection',
+  'identity_order_direction: query.identity_order_direction',
   'mode: "localized_entity_fold_v1"',
-  'fallback_locale: query.canonical_fallback_locale()',
-  'any_locale_filter: &query.any_locale_filter',
   'localized_projection_fields.sort();',
-  'b"rustok-index-localized-cursor-query-v1"',
-  'LocalizedCursorCodecError::UnsupportedVersion(2)',
 ]);
 
 const ordinaryCursor = requireMarkers('crates/rustok-index/src/application/cursor.rs', [
   'const SCOPED_CURSOR_VERSION: u8 = 2;',
   'b"rustok-index-cursor-query-v1"',
-  'pub struct IndexCursor',
 ]);
-if (ordinaryCursor.includes('localized_entity_fold_v1')) {
-  fail('ordinary cursor codec must not absorb localized fold identity');
+if (ordinaryCursor.includes('identity_order_direction')) {
+  fail('ordinary cursor codec must not absorb localized identity ordering');
 }
 
 requireMarkers('crates/rustok-index/src/application/query_port.rs', [
   'async fn execute_localized_query(',
   'localized Index query execution is unavailable for this adapter',
 ]);
-requireMarkers('crates/rustok-index/src/domain/query.rs', [
-  'TextLike(FieldPath, String)',
-]);
+requireMarkers('crates/rustok-index/src/domain/query.rs', ['TextLike(FieldPath, String)']);
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
-  'Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
+  'Status: `runtime_text_pattern_identity_order_source_complete_adapter_and_evidence_pending`',
   '`LocalizedEntityQuery`',
-  '`localized_projection_fields`',
-  '`LocalizedCursorCodec`',
-  'wire version `3`',
-  'ordinary exact-locale cursors remain on version `2`',
-  'Generic `TextLike` — source complete',
+  '`identity_order_direction`',
+  '`LocalizedCursorCodec` remains on localized wire version `3`',
+  'Generic `TextLike`',
 ]);
 
-console.log('[verify-index-localized-query-contract] localized query/projection/cursor contract remains source-locked with fail-closed runtime and generic text-pattern capability');
+console.log('[verify-index-localized-query-contract] localized query/projection/cursor/identity-order contract is source-locked');

--- a/scripts/verify/verify-index-localized-query-runtime.mjs
+++ b/scripts/verify/verify-index-localized-query-runtime.mjs
@@ -61,12 +61,11 @@ if (admissionPosition < 0 || beginPosition < 0 || admissionPosition > beginPosit
 }
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
-  'Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
+  'Status: `runtime_text_pattern_identity_order_source_complete_adapter_and_evidence_pending`',
   '`execute_localized_query`',
   '`REPEATABLE READ, READ ONLY`',
-  'persisted schema',
   '`PostgresQueryEntityAdmission`',
-  'Generic `TextLike` — source complete',
+  '`identity_order_direction`',
 ]);
 
-console.log('[verify-index-localized-query-runtime] localized fold runtime remains source-locked behind readiness/admission/snapshot semantics; Product adapter/evidence remain pending');
+console.log('[verify-index-localized-query-runtime] localized fold runtime remains source-locked behind readiness/admission/snapshot semantics with explicit identity ordering');

--- a/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+++ b/scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
@@ -21,18 +21,17 @@ const requireMarkers = (relative, markers) => {
 const ownerQueryPath = 'crates/rustok-product/src/services/catalog/queries.rs';
 const ownerQuery = requireMarkers(ownerQueryPath, [
   'pub async fn list_published_products_with_query(',
+  '.order_by_asc(entities::product::Column::Id)',
+  '.order_by_desc(entities::product::Column::Id)',
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
-  'fn product_title_search_condition(',
   'let pattern = format!("%{search}%");',
-  'FROM product_translations pt',
-  'pt.product_id = products.id',
   'pt.title LIKE $1',
 ]);
 const titleSearchStart = ownerQuery.indexOf('fn product_title_search_condition(');
 if (titleSearchStart < 0) fail(`${ownerQueryPath} title-search helper is missing`);
 if (ownerQuery.slice(titleSearchStart).includes('pt.locale')) {
-  fail(`${ownerQueryPath} title search became locale-scoped; revisit the localized identity architecture in the same PR`);
+  fail(`${ownerQueryPath} title search became locale-scoped`);
 }
 
 requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
@@ -40,54 +39,23 @@ requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
   'pub search: Option<String>',
   'search: normalize_optional_text(search)',
 ]);
-requireMarkers('crates/rustok-product/src/services/catalog/commands.rs', [
-  'if input.translations.is_empty()',
-  'At least one translation is required',
-]);
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
   'Lower keys are historical storage identities only.',
 ]);
-const productSourcePath = 'crates/rustok-distribution/src/product_index/product.rs';
-const productSource = requireMarkers(productSourcePath, [
-  'locale_mode: LocaleMode::Required',
-  'JOIN product_translations t',
-  't.locale',
-  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
-  'derive_index_schema_source_event_id(',
-  'many_field("attribute_terms", IndexValueType::String, false, true)?',
-]);
-if (productSource.includes('SchemaVersion::new(3)')) {
-  fail(`${productSourcePath} must not restore historical Product routing key 3`);
-}
 
-const architecturePath = 'crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md';
-requireMarkers(architecturePath, [
-  'Status: `runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
-  '`localized_projection_fields`',
-  '`SchemaRegistry::compile_postgres_localized_page_query`',
-  '`SchemaRegistry::decode_postgres_localized_query_page`',
-  '`IndexQueryPort` publishes `execute_localized_query`',
-  '`PostgresIndexQueryPort::execute_localized_query`',
-  '`REPEATABLE READ, READ ONLY`',
-  '`PostgresQueryEntityAdmission`',
-  'Generic `TextLike` — source complete',
-  '`FilterExpr::TextLike(FieldPath, String)`',
-  'pattern size at most 1024 UTF-8 bytes',
-  'Remaining Product search-bound mismatch',
-  'Implement the Product Storefront Index adapter',
-]);
-
-requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
-  'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-localized-query-architecture.md', [
+  'Status: `runtime_text_pattern_identity_order_source_complete_adapter_and_evidence_pending`',
+  '`identity_order_direction`',
+  'entity_id DESC',
+  'entity_id < cursor.entity_id',
+  'Channel-less visibility',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Status overlay rechecked from `main@eab3b1b925e5cbfa65d2fe3f938b63be7a067846` (#3218)',
-  'Wire localized execution through canonical PostgreSQL runtime with readiness/admission/snapshot.',
-  'Add generic scalar String `TextLike` usable inside folded `any_locale_filter`.',
-  'implement the Product Storefront Index adapter plus retained localized-query',
-  'No historical-key runtime compatibility path is allowed.',
+  'main@500c6f647b5f09f617cb907a43093e4f954b3fed` (#3220)',
+  'Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.',
+  'Channel-less visibility',
+  'Build the Product Storefront **shadow/evidence adapter**',
 ]);
 
-console.log('[verify-index-product-storefront-localized-query-architecture] localized Product runtime plus generic TextLike are locked; adapter/search-bound/evidence remain pending');
+console.log('[verify-index-product-storefront-localized-query-architecture] localized runtime/text-pattern/identity-order are locked; adapter and evidence remain pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -84,6 +84,7 @@ const scripts = [
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-localized-query-runtime.mjs',
+  'verify-index-localized-identity-order.mjs',
   'verify-index-text-like-filter.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- close the Product Storefront descending-order parity gap discovered while starting the shadow adapter;
- add explicit `LocalizedEntityQuery::identity_order_direction`, defaulting to `Asc`, while leaving ordinary exact-locale `IndexQuery` unchanged;
- validate localized identity direction as plain `Asc` or `Desc` only;
- bind the direction into localized cursor and localized plan fingerprints so continuations cannot cross identity-order semantics;
- keep localized cursor wire version 3: earlier v3 tokens using the previous fingerprint shape fail closed by query-fingerprint mismatch;
- compile the final folded root identity term as `entity_id ASC`/`DESC` and keyset continuation as `>`/`<` respectively;
- preserve all explicit field-order null semantics and group-before-page/count behavior;
- add source tests/guard markers for descending identity order while requiring the ordinary compiler to retain its existing ascending identity tie-break;
- actualize the current plan and localized architecture with adapter blockers discovered during recheck: search-length bound, search collation, and channel-less unrestricted visibility.

## Why this precedes the Product adapter

The owner Storefront query orders the selected timestamp and Product ID in the same direction. Before this slice the localized compiler always appended root entity ID ASC and used `entity_id > cursor`, so equal-timestamp DESC pages could disagree with owner pagination. Publishing an adapter on top of that mismatch would create false parity.

The channel visibility recheck also found that a channel-less owner request means unrestricted metadata only, while current `sales_channel_ids` cannot distinguish unrestricted from a restricted Product that happens to include every current channel. The future shadow adapter will therefore fail closed for channel-less requests until that distinction is representable.

## Main recheck

The branch started from `main@500c6f647b5f09f617cb907a43093e4f954b3fed` (#3220). Before PR creation, current `main@e6a99ef0df2ad0954f42c8552f3a25bd525ceee0` advanced through #3221 Moderation scheduler evidence and #3222 shared module-contribution tooling. Both are disjoint from this `rustok-index` localized-query slice. Final compare contains only the expected Index domain/application/docs/verifier files.

## Boundary

This PR does not implement the Product Storefront adapter, switch Storefront traffic, change ordinary `IndexQuery`, change Product schema/routing key, resolve search-bound/collation/channel-less visibility, execute PostgreSQL evidence, or add Product events.

The next source slice is a fail-closed Product Storefront shadow/evidence adapter that maps only already-representable inputs and preserves the owner sort direction in both timestamp and localized identity tie-break.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.