### PR TITLE
feat(index): add Product Storefront shadow adapter

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -11,6 +11,9 @@ pub(crate) use product::PRODUCT_INDEX_SOURCE;
 mod query_admission;
 pub(crate) mod relation_admission;
 mod storefront_shadow;
+pub(crate) use storefront_shadow::{
+    ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,
+};
 #[path = "../product_variant_index.rs"]
 mod variant;
 #[cfg(test)]

--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -10,6 +10,7 @@ mod product;
 pub(crate) use product::PRODUCT_INDEX_SOURCE;
 mod query_admission;
 pub(crate) mod relation_admission;
+mod storefront_shadow;
 #[path = "../product_variant_index.rs"]
 mod variant;
 #[cfg(test)]

--- a/crates/rustok-distribution/src/product_index/storefront_shadow.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow.rs
@@ -92,11 +92,14 @@ pub(crate) fn build_product_storefront_index_shadow_query(
 
     if owner.attribute_filters.len() > MAX_STOREFRONT_ATTRIBUTE_FILTERS
         || canonical_attribute_filters.len() != owner.attribute_filters.len()
-        || !canonical_attribute_filters
-            .iter()
-            .all(is_canonical_attribute_term_predicate)
     {
         return Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch);
+    }
+    if !canonical_attribute_filters
+        .iter()
+        .all(is_canonical_attribute_term_predicate)
+    {
+        return Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate);
     }
 
     let mut filters = vec![
@@ -111,9 +114,6 @@ pub(crate) fn build_product_storefront_index_shadow_query(
         ),
     ];
     if let Some(category_id) = owner.category_id {
-        if category_id.is_nil() {
-            return Err(ProductStorefrontIndexShadowError::InvalidSchemaContract);
-        }
         filters.push(FilterExpr::Eq(
             root_field("primary_category_id")?,
             IndexValue::Uuid(category_id),
@@ -249,7 +249,9 @@ mod tests {
     fn attribute_term() -> FilterExpr {
         FilterExpr::Contains(
             root_field("attribute_terms").unwrap(),
-            IndexValue::String("a:00000000-0000-0000-0000-000000000001:t:acme".to_owned()),
+            IndexValue::String(
+                "00000000-0000-0000-0000-000000000001|text||61636d65".to_owned(),
+            ),
         )
     }
 
@@ -306,6 +308,20 @@ mod tests {
                 Vec::new(),
             ),
             Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch)
+        );
+        assert_eq!(
+            build_product_storefront_index_shadow_query(
+                Uuid::new_v4(),
+                "fi",
+                "en",
+                Some(Uuid::new_v4()),
+                &owner,
+                vec![FilterExpr::Eq(
+                    root_field("attribute_terms").unwrap(),
+                    IndexValue::String("forbidden".to_owned()),
+                )],
+            ),
+            Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate)
         );
     }
 

--- a/crates/rustok-distribution/src/product_index/storefront_shadow.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow.rs
@@ -1,0 +1,328 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+use rustok_index::{
+    EntityName, FieldName, FieldPath, FilterExpr, IndexQuery, IndexQueryScope, IndexValue,
+    LocaleKey, LocalizedEntityQuery, ModuleName, OrderDirection, OrderExpr, Pagination, SchemaRef,
+    SchemaVersion,
+};
+use rustok_product::{
+    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
+    entities::product::ProductStatus,
+};
+
+use super::PRODUCT_SCHEMA_ROUTING_KEY;
+
+const MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024;
+const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;
+const MAX_STOREFRONT_ATTRIBUTE_FILTERS: usize = 8;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum ProductStorefrontIndexShadowError {
+    #[error("Product Storefront Index shadow query requires a non-nil tenant")]
+    NilTenant,
+    #[error("Product Storefront Index shadow query requires a current public channel id")]
+    PublicChannelRequired,
+    #[error("Product Storefront Index shadow query received a nil public channel id")]
+    NilPublicChannel,
+    #[error("Product Storefront Index shadow query locale contract is invalid")]
+    InvalidLocale,
+    #[error("Product Storefront Index shadow query schema contract is invalid")]
+    InvalidSchemaContract,
+    #[error("Product Storefront Index shadow query pagination is invalid")]
+    InvalidPagination,
+    #[error("Product Storefront Index shadow query offset exceeds the Index bounded offset depth")]
+    OffsetTooDeep,
+    #[error("Product Storefront Index shadow query title pattern exceeds the bounded TextLike contract")]
+    SearchPatternTooLong,
+    #[error("Product Storefront Index shadow query title pattern contains a NUL byte")]
+    SearchPatternContainsNul,
+    #[error("resolved Product attribute filter count does not match owner Storefront filter count")]
+    AttributeFilterResolutionMismatch,
+    #[error("resolved Product attribute filter is not a canonical attribute_terms predicate")]
+    InvalidAttributeTermPredicate,
+}
+
+/// Build the Product Storefront query used only for shadow/equivalence work.
+///
+/// The caller must resolve every public Product attribute filter through a Product-owned metadata
+/// capability before calling this function. `canonical_attribute_filters` are accepted only when every
+/// leaf is `Contains(attribute_terms, String(term))`; localized text fallback may compose those leaves
+/// with And/Or/Not. This keeps Product option/attribute ownership out of the generic Index engine.
+///
+/// A public channel ID is mandatory in this source slice. The owner channel-less contract means
+/// "metadata unrestricted only", while the current `sales_channel_ids` projection cannot distinguish
+/// unrestricted from a restricted Product that currently contains every channel. Authoritative
+/// channel-less execution therefore remains fail-closed.
+pub(crate) fn build_product_storefront_index_shadow_query(
+    tenant_id: Uuid,
+    requested_locale: &str,
+    fallback_locale: &str,
+    public_channel_id: Option<Uuid>,
+    owner: &StorefrontProductListQuery,
+    canonical_attribute_filters: Vec<FilterExpr>,
+) -> Result<LocalizedEntityQuery, ProductStorefrontIndexShadowError> {
+    if tenant_id.is_nil() {
+        return Err(ProductStorefrontIndexShadowError::NilTenant);
+    }
+    let public_channel_id = public_channel_id
+        .ok_or(ProductStorefrontIndexShadowError::PublicChannelRequired)?;
+    if public_channel_id.is_nil() {
+        return Err(ProductStorefrontIndexShadowError::NilPublicChannel);
+    }
+
+    let requested_locale =
+        LocaleKey::new(requested_locale).map_err(|_| ProductStorefrontIndexShadowError::InvalidLocale)?;
+    let fallback_locale =
+        LocaleKey::new(fallback_locale).map_err(|_| ProductStorefrontIndexShadowError::InvalidLocale)?;
+
+    if owner.page == 0 || owner.per_page == 0 || owner.per_page > 48 {
+        return Err(ProductStorefrontIndexShadowError::InvalidPagination);
+    }
+    let offset = owner
+        .page
+        .checked_sub(1)
+        .and_then(|page| page.checked_mul(owner.per_page))
+        .ok_or(ProductStorefrontIndexShadowError::InvalidPagination)?;
+    if offset > MAX_INDEX_OFFSET_DEPTH {
+        return Err(ProductStorefrontIndexShadowError::OffsetTooDeep);
+    }
+    let limit = u32::try_from(owner.per_page)
+        .map_err(|_| ProductStorefrontIndexShadowError::InvalidPagination)?;
+
+    if owner.attribute_filters.len() > MAX_STOREFRONT_ATTRIBUTE_FILTERS
+        || canonical_attribute_filters.len() != owner.attribute_filters.len()
+        || !canonical_attribute_filters
+            .iter()
+            .all(is_canonical_attribute_term_predicate)
+    {
+        return Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch);
+    }
+
+    let mut filters = vec![
+        FilterExpr::Eq(
+            root_field("status")?,
+            IndexValue::String(ProductStatus::Active.to_string()),
+        ),
+        FilterExpr::IsNull(root_field("published_at")?, false),
+        FilterExpr::Contains(
+            root_field("sales_channel_ids")?,
+            IndexValue::Uuid(public_channel_id),
+        ),
+    ];
+    if let Some(category_id) = owner.category_id {
+        if category_id.is_nil() {
+            return Err(ProductStorefrontIndexShadowError::InvalidSchemaContract);
+        }
+        filters.push(FilterExpr::Eq(
+            root_field("primary_category_id")?,
+            IndexValue::Uuid(category_id),
+        ));
+    }
+    filters.extend(canonical_attribute_filters);
+
+    let any_locale_filter = owner
+        .search
+        .as_deref()
+        .map(str::trim)
+        .filter(|search| !search.is_empty())
+        .map(|search| {
+            let pattern = format!("%{search}%");
+            if pattern.len() > MAX_TEXT_LIKE_PATTERN_BYTES {
+                return Err(ProductStorefrontIndexShadowError::SearchPatternTooLong);
+            }
+            if pattern.contains('\0') {
+                return Err(ProductStorefrontIndexShadowError::SearchPatternContainsNul);
+            }
+            Ok(FilterExpr::TextLike(root_field("title")?, pattern))
+        })
+        .transpose()?;
+
+    let direction = match owner.sort_direction {
+        StorefrontProductSortDirection::Asc => OrderDirection::Asc,
+        StorefrontProductSortDirection::Desc => OrderDirection::Desc,
+    };
+    let timestamp_fields = match owner.sort_by {
+        StorefrontProductSortBy::PublishedAt => ["published_at", "created_at"],
+        StorefrontProductSortBy::CreatedAt => ["created_at", "published_at"],
+    };
+    let order_by = timestamp_fields
+        .into_iter()
+        .map(|field| {
+            Ok(OrderExpr {
+                field: root_field(field)?,
+                direction,
+            })
+        })
+        .collect::<Result<Vec<_>, ProductStorefrontIndexShadowError>>()?;
+
+    let query = IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id,
+            locale: Some(requested_locale),
+        },
+        schema: product_schema_ref()?,
+        fields: [
+            "id",
+            "status",
+            "title",
+            "handle",
+            "seller_id",
+            "vendor",
+            "product_type",
+            "tag_ids",
+            "created_at",
+            "published_at",
+        ]
+        .into_iter()
+        .map(root_field)
+        .collect::<Result<Vec<_>, _>>()?,
+        filter: Some(FilterExpr::And(filters)),
+        order_by,
+        pagination: Pagination::Offset { limit, offset },
+        include_exact_count: true,
+    };
+
+    Ok(LocalizedEntityQuery::new(
+        query,
+        Some(fallback_locale),
+        any_locale_filter,
+    )
+    .with_localized_projection_fields([root_field("title")?, root_field("handle")?])
+    .with_identity_order_direction(direction))
+}
+
+fn product_schema_ref() -> Result<SchemaRef, ProductStorefrontIndexShadowError> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")
+            .map_err(|_| ProductStorefrontIndexShadowError::InvalidSchemaContract)?,
+        entity: EntityName::new("product")
+            .map_err(|_| ProductStorefrontIndexShadowError::InvalidSchemaContract)?,
+        version: SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY),
+    })
+}
+
+fn root_field(name: &str) -> Result<FieldPath, ProductStorefrontIndexShadowError> {
+    Ok(FieldPath::new(
+        FieldName::new(name).map_err(|_| ProductStorefrontIndexShadowError::InvalidSchemaContract)?,
+    ))
+}
+
+fn is_canonical_attribute_term_predicate(filter: &FilterExpr) -> bool {
+    match filter {
+        FilterExpr::Contains(path, IndexValue::String(term)) => {
+            path.links().is_empty()
+                && path.field().as_str() == "attribute_terms"
+                && !term.is_empty()
+        }
+        FilterExpr::And(children) | FilterExpr::Or(children) => {
+            !children.is_empty() && children.iter().all(is_canonical_attribute_term_predicate)
+        }
+        FilterExpr::Not(child) => is_canonical_attribute_term_predicate(child),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_product::ProductAttributeFilter;
+
+    fn owner_query(direction: StorefrontProductSortDirection) -> StorefrontProductListQuery {
+        StorefrontProductListQuery::try_from_transport_with_attribute_filters(
+            Some(" phone ".to_owned()),
+            Some(Uuid::new_v4()),
+            Some("published_at"),
+            Some(match direction {
+                StorefrontProductSortDirection::Asc => "asc",
+                StorefrontProductSortDirection::Desc => "desc",
+            }),
+            vec![ProductAttributeFilter {
+                code: "brand".to_owned(),
+                value: "acme".to_owned(),
+            }],
+        )
+        .unwrap()
+        .with_pagination(2, 12)
+    }
+
+    fn attribute_term() -> FilterExpr {
+        FilterExpr::Contains(
+            root_field("attribute_terms").unwrap(),
+            IndexValue::String("a:00000000-0000-0000-0000-000000000001:t:acme".to_owned()),
+        )
+    }
+
+    #[test]
+    fn maps_owner_filters_projection_order_and_page_to_localized_fold() {
+        let tenant = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        let owner = owner_query(StorefrontProductSortDirection::Desc);
+        let query = build_product_storefront_index_shadow_query(
+            tenant,
+            "fi",
+            "en",
+            Some(channel),
+            &owner,
+            vec![attribute_term()],
+        )
+        .unwrap();
+
+        assert_eq!(query.query.scope.tenant_id, tenant);
+        assert_eq!(query.identity_order_direction, OrderDirection::Desc);
+        assert_eq!(query.query.order_by.len(), 2);
+        assert!(query.query.order_by.iter().all(|order| order.direction == OrderDirection::Desc));
+        assert_eq!(query.query.order_by[0].field.field().as_str(), "published_at");
+        assert_eq!(query.query.order_by[1].field.field().as_str(), "created_at");
+        assert!(matches!(
+            query.query.pagination,
+            Pagination::Offset { limit: 12, offset: 12 }
+        ));
+        assert!(matches!(query.any_locale_filter, Some(FilterExpr::TextLike(_, _))));
+        assert_eq!(query.localized_projection_fields.len(), 2);
+    }
+
+    #[test]
+    fn fails_closed_without_public_channel_or_resolved_attribute_terms() {
+        let owner = owner_query(StorefrontProductSortDirection::Asc);
+        assert_eq!(
+            build_product_storefront_index_shadow_query(
+                Uuid::new_v4(),
+                "fi",
+                "en",
+                None,
+                &owner,
+                vec![attribute_term()],
+            ),
+            Err(ProductStorefrontIndexShadowError::PublicChannelRequired)
+        );
+        assert_eq!(
+            build_product_storefront_index_shadow_query(
+                Uuid::new_v4(),
+                "fi",
+                "en",
+                Some(Uuid::new_v4()),
+                &owner,
+                Vec::new(),
+            ),
+            Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch)
+        );
+    }
+
+    #[test]
+    fn fails_closed_when_owner_page_exceeds_bounded_index_offset() {
+        let mut owner = owner_query(StorefrontProductSortDirection::Asc);
+        owner.page = 1_000;
+        assert_eq!(
+            build_product_storefront_index_shadow_query(
+                Uuid::new_v4(),
+                "fi",
+                "en",
+                Some(Uuid::new_v4()),
+                &owner,
+                vec![attribute_term()],
+            ),
+            Err(ProductStorefrontIndexShadowError::OffsetTooDeep)
+        );
+    }
+}

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,164 +1,137 @@
 # M7 Product Storefront Index parity gate
 
-Status: `localized_runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`.
+Status: `shadow_query_adapter_source_complete_owner_resolution_and_evidence_pending`.
 
 ## Purpose
 
-The Product Storefront catalog remains owner-native. The current Product Index source now has the
-Storefront scalar/EAV state, the localized identity fold, PostgreSQL compiler/decoder, fail-closed runtime,
-and a generic bounded scalar String `TextLike` operator usable inside folded `any_locale_filter`.
+The mounted Product Storefront catalog remains owner-native and must continue to execute
+`CatalogService::list_published_products_with_query`.
 
-The Product Storefront adapter and retained owner-vs-Index PostgreSQL evidence are still pending. Source
-completion is not traffic-cutover evidence.
+The Index side is now source-complete through localized identity folding, bounded `TextLike`, explicit
+Asc/Desc Product-ID tie-break direction, PostgreSQL runtime execution, and a **pure shadow/evidence query
+builder** in `rustok-distribution`. That builder translates only owner inputs whose semantics are already
+representable. It is not wired to Storefront traffic and does not execute Index queries itself.
 
-Storefront must continue to execute `CatalogService::list_published_products_with_query`.
+## Owner contract still authoritative
 
-## Owner Storefront contract
+The owner list enforces tenant scope, Active status, non-null `published_at`, Product channel visibility,
+optional primary category, typed Product EAV filters, all-translations title `LIKE`, exact count,
+requested/fallback Product translation projection, localized Taxonomy tag names and stable ordering.
 
-`StorefrontProductListQuery` accepts optional title search/category, `published_at` or `created_at`
-sorting in either direction, up to eight typed Product EAV predicates, and page/per-page pagination.
-Owner execution additionally enforces tenant scope, Active status, non-null `published_at`, public
-SalesChannel visibility, exact count, stable timestamp+ID ordering, Product translation fallback, and
-localized tag projection.
+Owner ordering uses two timestamp terms plus Product ID in the same direction:
 
-Two translation details remain authoritative:
+- `published_at, created_at, id`; or
+- `created_at, published_at, id`.
 
-1. `product_title_search_condition` uses an `EXISTS` over `product_translations` and does **not** restrict
-   the matching row to requested/fallback locale;
-2. result projection uses `pick_product_translation(items, requested, fallback)`.
+The localized Index compiler now has an explicit `identity_order_direction`, so the shadow builder can map
+owner Asc/Desc to both timestamp terms and the final Product-ID tie-break.
 
-The title helper builds `format!("%{search}%")` and executes `pt.title LIKE $1`. Current Product list input
-normalizes whitespace but does not impose an explicit search-length bound.
+## Shadow query adapter — source complete
 
-## Single current Product Index coverage
+`crates/rustok-distribution/src/product_index/storefront_shadow.rs` owns
+`build_product_storefront_index_shadow_query`.
 
-Current Product runtime code publishes one Product schema with 15 fields and two links. Product Index emits
-one physical entity per stored translation locale and does not fabricate requested/fallback rows. The
-physical model remains correct; Storefront equivalence is handled by the query fold rather than another
-Product schema or routing key.
+For currently representable requests it maps:
 
-Do **not** add another Product routing key merely to patch localized Storefront query semantics. The
-current Product contract remains the only runtime Product implementation.
+- Product status -> `Eq(status, "active")`;
+- published-only -> `IsNull(published_at, false)`;
+- a trusted current public channel UUID -> `Contains(sales_channel_ids, channel_id)`;
+- optional primary category -> `Eq(primary_category_id, category_id)`;
+- Product-owned resolved EAV predicates -> canonical `attribute_terms` predicates only;
+- title search -> folded `TextLike(title, "%...%")` in `any_locale_filter`;
+- localized output -> requested/fallback `title` and `handle`;
+- owner public fields -> Product root projection including `tag_ids` for later Taxonomy hydration;
+- owner timestamp order -> the same two timestamp fields/direction;
+- owner Product-ID tie-break -> the same localized identity direction;
+- owner page/per-page -> bounded Index offset pagination;
+- exact count -> enabled.
 
-## Localized identity fold — source complete
+The builder points only at the current Product routing key `4`. It is crate-visible for retained evidence
+harnesses, not public API.
 
-The generic fold preserves logical result identity `(tenant_id, schema_ref, entity_id)` while physical
-storage remains locale-keyed.
+## Pure boundary: no owner bypass
 
-`LocalizedEntityQuery` provides requested locale through `query.scope.locale`, canonical fallback,
-root-only `any_locale_filter`, and explicit `localized_projection_fields` for requested -> fallback -> null
-output semantics. `LocalizedCursorCodec` uses dedicated scoped wire version `3`; ordinary exact-locale
-cursors remain on version `2`.
+The shadow builder does not import or construct `DatabaseConnection`, `CatalogService`,
+`ProductCatalogSchemaService`, Product EAV tables, or the Index execution runtime. It only converts an
+already validated owner query plus Product-owned resolved canonical EAV predicates into
+`LocalizedEntityQuery`.
 
-The initial fold deliberately rejects linked query paths. Current Product Storefront list identity
-predicates can still use root materialized fields such as `sales_channel_ids` and `attribute_terms`.
+This is intentional. Product attribute definitions can already be read through
+`ProductCatalogSchemaReadPort`, but current owner read capabilities do not expose the option-code/option-ID
+resolution required to reproduce Select/Multiselect filters without direct Product table access.
 
-## PostgreSQL compiler/decoder — source complete
+The next Product-owned capability must resolve each public `ProductAttributeFilter` into the same canonical
+Index term predicate used by the Product source. Only then may the shadow executor compose metadata
+resolution with this query builder.
 
-`SchemaRegistry::compile_postgres_localized_page_query` uses canonical physical aliases `t0` anchor, `t1`
-requested row, `t2` fallback row, `t3` any-locale predicate row and `t4` lower-locale anti-duplicate
-candidate.
+## Explicit fail-closed parity gaps
 
-All physical roles retain `is_deleted = FALSE` so generic `PostgresQueryEntityAdmission` can inject owner
-freshness. De-duplication happens before ordering/lookahead/limit/exact-count. Requested/fallback projection
-uses row-presence `CASE`; exact count is independent of requested/fallback projection availability.
+The builder refuses to pretend parity where the owner contract is wider than the current Index query
+contract:
 
-`SchemaRegistry::decode_postgres_localized_query_page` verifies ordinary/localized plan identity,
-column/count/lookahead contracts, allows extra SQL-null only for explicit localized projection fields, and
-emits localized continuation cursors.
+1. **Channel-less visibility** — owner `None` channel means metadata-unrestricted only. Current
+   `sales_channel_ids` materializes unrestricted as membership in all current channels, so it cannot
+   distinguish unrestricted from a restricted Product that currently contains every channel. A public
+   channel UUID is therefore mandatory for the shadow builder.
+2. **Deep page offsets** — owner page is not upper-bounded, while Index offset depth is capped at 10,000.
+   The builder returns `OffsetTooDeep` instead of silently changing the page.
+3. **Search length** — owner search has no explicit length bound; `TextLike` is capped at 1024 UTF-8 bytes.
+   The builder rejects an over-bound pattern rather than truncating it.
+4. **Search collation** — owner title `LIKE` uses deployment/default collation while Index String SQL uses
+   deterministic `COLLATE "C"`. Source inspection does not claim equivalence.
+5. **Public EAV option resolution** — Select/Multiselect public option codes still require a Product-owned
+   code-to-ID resolver before canonical `attribute_terms` can be built.
 
-## PostgreSQL runtime — source complete
+These are evidence/capability gates, not reasons to weaken the owner contract.
 
-`IndexQueryPort` exposes explicit `execute_localized_query` with a fail-closed default.
-`SharedIndexQueryRuntime` forwards it. Canonical `PostgresIndexQueryPort` applies availability and generic
-owner admission before storage execution, then runs persisted schema readiness, page and optional exact
-count in one `REPEATABLE READ, READ ONLY` transaction and decodes only through the localized decoder.
+## Taxonomy boundary
 
-## Generic `TextLike` — source complete
+Product Index stores stable `tag_ids`, not localized Taxonomy names. The shadow query selects those IDs,
+but localized Taxonomy hydration remains a separate post-page owner boundary. Product page selection must
+be fixed before tag-name hydration so Taxonomy work cannot change Product pagination or exact count.
 
-`FilterExpr::TextLike(FieldPath, String)` is a generic Index filter variant appended after the existing
-filter variants to preserve prior postcard discriminants.
+## Current routing/replacement boundary
 
-Validation permits it only on a filterable scalar String field. The pattern is limited to 1024 UTF-8
-bytes, rejects NUL and a trailing unpaired backslash, and uses PostgreSQL-compatible wildcard rules:
-`%` for zero-or-more characters, `_` for one character, and `\` as the escape character.
+Product runtime still publishes exactly one current 15-field Product schema on internal routing key `4`.
+Lower persisted Product keys remain historical only. Do not add a key-3 compatibility implementation to
+make retained evidence pass.
 
-Both ordinary and localized PostgreSQL compilers bind the pattern and emit `LIKE ... ESCAPE E'\\'`.
-Ordinary linked/many filtering reuses the existing correlated filter machinery. The reference engine and
-PostgreSQL equivalence fixture implement the same wildcard grammar.
+## Remaining work before traffic cutover
 
-The localized Product title predicate can therefore be represented as
-`any_locale_filter = TextLike(title, format!("%{trimmed_search}%"))` without a Product-specific SQL branch.
-A title match admits the Product identity but does not select the projected locale.
-
-## Remaining search parity gates
-
-The Product owner list currently has no explicit search-length bound, while generic `TextLike` is bounded
-to 1024 UTF-8 bytes. The Storefront adapter must not silently truncate or reject owner-valid input.
-Before cutover, the adapter/evidence slice must either prove an authoritative upstream <=1024-byte bound
-or introduce a reviewed owner/API bound with matching validation evidence.
-
-The owner title `LIKE` also uses the database default collation while Index String scalar SQL uses the
-engine's deterministic `COLLATE "C"`. Retained PostgreSQL equivalence must establish the admitted
-deployment/input contract before search parity can be promoted.
-
-## Typed EAV and Taxonomy boundaries
-
-Dynamic Product EAV remains represented by canonical UUID-keyed `attribute_terms`. Public Product
-attribute/option codes must be resolved through Product owner metadata before building Index predicates.
-Localized text EAV retains the owner fallback predicate defined in `m7-product-attribute-term-contract.md`.
-
-Index stores stable Product tag UUIDs, not localized Taxonomy names. A future adapter must batch-hydrate
-requested/fallback tag names only after the Product page is fixed.
-
-## Immutable replacement boundary
-
-The current Product routing key remains internal storage/replay identity. Lower persisted keys are
-historical only. Promotion remains staged: register current key, rebuild/replay, prove readiness/parity,
-`register_current` to retire lower active keys, then consumer cutover.
-
-## Remaining work before Storefront cutover
-
-1. implement the Product Storefront Index adapter over `execute_localized_query`;
-2. map Active + published-only/category/channel/EAV/order/page/count semantics;
-3. resolve Product attribute/option codes to canonical terms;
-4. use `TextLike` for all-translations title search and explicitly resolve the search-bound/collation gates;
-5. batch-hydrate localized Taxonomy tag names after page selection;
-6. actualize retained Product PostgreSQL packets to routing key `4` / current 15-field contract;
-7. retain owner-vs-Index localized equivalence for requested/fallback/third-locale search, wildcard escape,
-   de-dup, ordering, pagination, exact count, stale locale materialization, readiness and restart;
-8. extend linked folded paths only with explicit target-lag availability evidence;
-9. stage/rebuild/promote the current Product key for a tenant;
-10. only then select Index traffic.
+1. add Product-owned canonical Storefront attribute-filter resolution, including option-code -> option-ID;
+2. compose a shadow executor over that resolver + `execute_localized_query` without mounting it in
+   Storefront traffic;
+3. add retained owner-vs-Index PostgreSQL equivalence for requested/fallback/third-locale projection,
+   title wildcard behavior, category, EAV, channel membership, Asc/Desc equal-timestamp ties, pagination,
+   exact count, stale locale exclusion, readiness and restart;
+4. resolve/admit search-length and collation parity;
+5. resolve channel-less unrestricted visibility or keep that request shape owner-native;
+6. decide the authoritative policy for owner pages beyond the Index offset bound;
+7. batch-hydrate localized Taxonomy tags after the shadow Product page;
+8. actualize historical Product PostgreSQL packets to routing key `4` / current 15-field contract;
+9. execute/admit current replacement evidence and stage/rebuild/promote Product key `4`;
+10. only then consider Storefront traffic selection.
 
 ## Source guards
 
-- `verify-index-product-storefront-parity-gate.mjs` keeps Storefront owner-native and locks the physical
-  source boundary;
-- `verify-index-product-storefront-localized-query-architecture.mjs` locks the fold architecture;
-- `verify-index-localized-query-contract.mjs` locks query/projection/cursor roles;
-- `verify-index-localized-query-postgres-fold.mjs` locks compiler/decoder semantics;
+- `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native;
+- `verify-index-product-storefront-localized-query-architecture.mjs` locks fold/search/order semantics;
+- `verify-index-product-storefront-shadow-adapter.mjs` locks the pure fail-closed shadow translation;
 - `verify-index-localized-query-runtime.mjs` locks readiness/admission/one-snapshot execution;
-- `verify-index-text-like-filter.mjs` locks bounded String `TextLike`, PostgreSQL/reference semantics and
-  the current Product owner title-search shape.
-
-## Deliberate limits
-
-This slice does not implement the Product Storefront adapter, resolve the owner search-length/collation
-parity gates, execute/admit PostgreSQL evidence, rebuild/promote a tenant Product schema, add Product typed
-events, or switch Storefront traffic.
+- `verify-index-localized-identity-order.mjs` locks owner-compatible Product-ID tie-break direction;
+- `verify-index-text-like-filter.mjs` locks generic bounded LIKE semantics.
 
 ## Maintainer verification
 
 ```bash
-node scripts/verify/verify-index-text-like-filter.mjs
-node scripts/verify/verify-index-localized-query-contract.mjs
-node scripts/verify/verify-index-localized-query-postgres-fold.mjs
-node scripts/verify/verify-index-localized-query-runtime.mjs
-node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+node scripts/verify/verify-index-product-storefront-shadow-adapter.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
+node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
+node scripts/verify/verify-index-localized-query-runtime.mjs
+node scripts/verify/verify-index-localized-identity-order.mjs
+node scripts/verify/verify-index-text-like-filter.mjs
 node scripts/verify/verify-index-query-contract.mjs
-cargo check -p rustok-index --all-targets
+cargo check -p rustok-distribution --features mod-product --all-targets
 git diff --check
 ```
 

--- a/scripts/verify/verify-index-product-storefront-shadow-adapter.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-adapter.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-shadow-adapter] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const shadowPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
+const shadow = requireMarkers(shadowPath, [
+  'pub(crate) fn build_product_storefront_index_shadow_query(',
+  'ProductStorefrontIndexShadowError::PublicChannelRequired',
+  'ProductStorefrontIndexShadowError::OffsetTooDeep',
+  'ProductStorefrontIndexShadowError::SearchPatternTooLong',
+  'ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch',
+  'ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate',
+  'ProductStatus::Active.to_string()',
+  'FilterExpr::IsNull(root_field("published_at")?, false)',
+  'root_field("sales_channel_ids")?',
+  'root_field("primary_category_id")?',
+  'root_field("attribute_terms")',
+  'FilterExpr::TextLike(root_field("title")?, pattern)',
+  'StorefrontProductSortBy::PublishedAt => ["published_at", "created_at"]',
+  'StorefrontProductSortBy::CreatedAt => ["created_at", "published_at"]',
+  'Pagination::Offset { limit, offset }',
+  'include_exact_count: true',
+  '.with_localized_projection_fields([root_field("title")?, root_field("handle")?])',
+  '.with_identity_order_direction(direction)',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'CatalogService::new',
+  'ProductCatalogSchemaService',
+  'product_attribute_options::Entity',
+  'product_attribute_values::Entity',
+  'execute_localized_query(',
+]) {
+  if (shadow.includes(forbidden)) fail(`${shadowPath} must remain a pure shadow query builder; found ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod storefront_shadow;',
+  'build_product_storefront_index_shadow_query',
+  'ProductStorefrontIndexShadowError',
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+]);
+
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const owner = requireMarkers(ownerPath, [
+  'ProductStatus::Active',
+  'Column::PublishedAt.is_not_null()',
+  'product_channel_visibility_condition(',
+  'Column::PrimaryCategoryId.eq(category_id)',
+  'attribute_filters::load_catalog_attribute_filter_conditions(',
+  'let pattern = format!("%{search}%");',
+  'pt.title LIKE $1',
+  '.order_by_asc(entities::product::Column::Id)',
+  '.order_by_desc(entities::product::Column::Id)',
+  'let total = query.clone().count(&self.db).await?',
+]);
+
+const storefrontPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
+const storefront = requireMarkers(storefrontPath, [
+  'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
+  '.list_published_products_with_query(',
+]);
+for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'execute_localized_query']) {
+  if (storefront.includes(forbidden)) fail(`${storefrontPath} must remain owner-native; found ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_resolver.rs', [
+  'if visibility.is_unrestricted',
+  'list_sales_channel_ids(',
+  'visibility.allowed_slugs',
+]);
+
+console.log('[verify-index-product-storefront-shadow-adapter] Product Storefront shadow builder is source-locked; traffic and unresolved owner metadata/search/channel gates remain fail-closed');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -81,6 +81,7 @@ const scripts = [
   'verify-index-linked-target-replay-redelivery-postgres-harness.mjs',
   'verify-index-product-storefront-parity-gate.mjs',
   'verify-index-product-storefront-localized-query-architecture.mjs',
+  'verify-index-product-storefront-shadow-adapter.mjs',
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-localized-query-runtime.mjs',


### PR DESCRIPTION
## Summary

- add a crate-local Product Storefront shadow/evidence query builder in `rustok-distribution` without mounting Index traffic;
- translate representable `StorefrontProductListQuery` semantics into `LocalizedEntityQuery`: Active status, published-only, trusted public-channel membership, optional category, canonical Product-owned `attribute_terms`, all-translations `TextLike`, requested/fallback title+handle projection, owner public scalar/tag IDs, paired timestamp ordering, matching Product-ID tie-break, bounded offset pagination and exact count;
- require Product EAV filters to arrive already resolved through a Product-owned capability as canonical `attribute_terms` predicates; the builder does not read Product metadata/tables directly;
- fail closed for channel-less requests because current `sales_channel_ids` cannot distinguish unrestricted from restricted-to-all-current-channels;
- fail closed when owner page offset exceeds the Index 10,000 offset bound, when the bounded TextLike pattern is exceeded, or when EAV resolution count/shape is invalid;
- keep the current Product routing key `4` only;
- select stable `tag_ids` for later Taxonomy hydration without allowing Taxonomy work to change Product pagination/count;
- add a static source guard and advance Storefront parity/current-plan docs to Product-owned attribute-filter resolution as the next capability gap.

## Main recheck

The branch started from `main@424eb444af213acd4645aaf4781d429a268084cd` (#3223). Before PR creation, current `main@a5f90a9fcfe84214b8b6785d26290ff8dd21bd6b` advanced only through #3224 Moderation host-scheduler evidence, which is disjoint from this Product/Index shadow-adapter slice. Final compare contains only the expected 9 distribution/docs/verifier files.

## Boundary

This PR does not call `execute_localized_query`, construct `CatalogService`/`ProductCatalogSchemaService`, read Product EAV tables, add an owner option-code resolver, hydrate Taxonomy names, execute/admit PostgreSQL equivalence, change Product schema/routing key, or switch Storefront traffic.

The next source slice is a Product-owned public attribute-filter -> canonical `attribute_terms` resolution capability, especially Select/Multiselect option-code -> option-ID, followed by a retained shadow executor/equivalence harness.

Explicit parity blockers remain: owner search length vs bounded TextLike, owner/default collation vs Index `COLLATE "C"`, channel-less unrestricted visibility, and owner pages deeper than the Index offset bound.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.