### PR TITLE
test(moderation): retain executable host composition failures

### DIFF
--- a/apps/server/tests/moderation_factory_failure_composition.rs
+++ b/apps/server/tests/moderation_factory_failure_composition.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "mod-moderation")]
+
+use std::sync::Arc;
+
+use rustok_auth::AuthConfig;
+use rustok_core::{MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule};
+use rustok_index::IndexModule;
+use rustok_moderation::{
+    ModerationModule, ModerationSubjectAdapterBuildError, ModerationSubjectAdapterFactory,
+    ModerationSubjectAdapterKey, ModerationSubjectCommandPort, ModerationSubjectKind,
+    register_moderation_subject_adapter_factory,
+};
+use rustok_server::common::settings::RustokSettings;
+use rustok_server::error::{Error, Result};
+use rustok_server::services::module_event_dispatcher::build_shared_runtime_extensions_with_host_providers;
+use rustok_server::services::server_runtime_context::ServerRuntimeContext;
+use sea_orm::Database;
+use sea_orm_migration::MigrationTrait;
+
+const TEST_AUTH_SECRET: &str = "test-secret-key-for-unit-tests-only-32bytes!";
+const FAILING_MODULE: &str = "broken_moderation_producer";
+
+struct FailingModerationFactory;
+
+impl ModerationSubjectAdapterFactory for FailingModerationFactory {
+    fn key(&self) -> ModerationSubjectAdapterKey {
+        ModerationSubjectAdapterKey::new(FAILING_MODULE, ModerationSubjectKind::ForumPost)
+            .expect("test factory key must be valid")
+    }
+
+    fn build(
+        &self,
+        _host: &rustok_api::HostRuntimeContext,
+    ) -> std::result::Result<
+        Arc<dyn ModerationSubjectCommandPort>,
+        ModerationSubjectAdapterBuildError,
+    > {
+        Err(ModerationSubjectAdapterBuildError::InvalidConfiguration)
+    }
+}
+
+struct FailingModerationProducerModule;
+
+impl MigrationSource for FailingModerationProducerModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        Vec::new()
+    }
+}
+
+impl RusToKModule for FailingModerationProducerModule {
+    fn slug(&self) -> &'static str {
+        FAILING_MODULE
+    }
+
+    fn name(&self) -> &'static str {
+        "Broken Moderation Producer Test Module"
+    }
+
+    fn description(&self) -> &'static str {
+        "Test-only module that publishes a moderation adapter factory which cannot initialize"
+    }
+
+    fn version(&self) -> &'static str {
+        "0.0.0-test"
+    }
+
+    fn register_runtime_extensions(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+    ) -> rustok_core::Result<()> {
+        register_moderation_subject_adapter_factory(extensions, FailingModerationFactory)
+            .map_err(|error| rustok_core::Error::Validation(error.to_string()))
+    }
+}
+
+async fn compose(registry: &ModuleRegistry) -> Result<Arc<ModuleRuntimeExtensions>> {
+    let settings = RustokSettings::default();
+    let database = Database::connect("sqlite::memory:").await?;
+    let runtime = ServerRuntimeContext::new(database, settings.clone());
+
+    build_shared_runtime_extensions_with_host_providers(
+        registry,
+        &settings,
+        runtime,
+        AuthConfig::new(TEST_AUTH_SECRET.to_string()),
+    )
+}
+
+#[tokio::test]
+async fn selected_moderation_host_fails_closed_when_subject_factory_build_fails() {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(ModerationModule)
+        .register(FailingModerationProducerModule);
+
+    let error = match compose(&registry).await {
+        Ok(_) => panic!("host composition must reject a producer factory that cannot initialize"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(&error, Error::Message(_)));
+    let message = error.to_string();
+    assert!(message.contains("moderation subject adapter materialization failed"));
+    assert!(message.contains("broken_moderation_producer/forum_post"));
+    assert!(message.contains("moderation subject adapter configuration is invalid"));
+}

--- a/crates/rustok-moderation/docs/host-composition-executable-contract.md
+++ b/crates/rustok-moderation/docs/host-composition-executable-contract.md
@@ -1,0 +1,60 @@
+# Moderation executable host-composition contract
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+The server-owned executable composition evidence is split across:
+
+- `apps/server/tests/moderation_composition_profiles.rs` for the supported feature/module matrix;
+- `apps/server/tests/moderation_factory_failure_composition.rs` for fail-closed producer-factory initialization.
+
+Both targets exercise `build_shared_runtime_extensions_with_host_providers`, the same server composition seam that transfers module runtime extensions into `HostRuntimeContext` and materializes the Moderation subject-adapter registry.
+
+## Retained composition matrix
+
+With the corresponding Cargo features selected, the existing profile target retains these deployment contracts:
+
+- Forum without Moderation remains a valid host composition and does not require the Moderation owner registry;
+- Moderation without Forum materializes a valid, empty `ModerationSubjectAdapterRegistry`;
+- Forum plus Moderation materializes exactly the Forum topic and reply adapters under the exact `forum/forum_topic` and `forum/forum_post` keys;
+- selecting `mod-moderation` while omitting `ModerationModule` from `ModuleRegistry` fails composition with the explicit owner-missing error instead of silently starting without the owner.
+
+These are executable server composition tests, not source-only assertions over feature declarations.
+
+## Producer factory failure
+
+`moderation_factory_failure_composition.rs` adds a test-only producer module through the ordinary `RusToKModule::register_runtime_extensions` hook. Its factory declares a valid `broken_moderation_producer/forum_post` key but returns `ModerationSubjectAdapterBuildError::InvalidConfiguration` when the host asks it to build an adapter.
+
+The server must reject the whole composition. The retained assertions require the error to preserve all three layers of context:
+
+- server materialization boundary: `moderation subject adapter materialization failed`;
+- exact producer key: `broken_moderation_producer/forum_post`;
+- neutral typed build failure: `moderation subject adapter configuration is invalid`.
+
+No fallback adapter is installed and no partially usable Moderation registry is returned to the caller. Factory build failure therefore remains a startup failure, as required by the neutral registry contract.
+
+## Dependency boundary
+
+The failure fixture uses only dependencies already owned directly by `rustok-server`: `rustok-core`, `rustok-api`, optional `rustok-moderation`, SeaORM and `sea-orm-migration`. It does not add a test helper crate, workspace member or Cargo lockfile change.
+
+The producer is test-only and owns no migrations. It exists solely to exercise host materialization failure through the same typed extension path used by real modules.
+
+## Maintainer commands
+
+Intentionally not run while preparing this slice:
+
+```bash
+cargo test -p rustok-server \
+  --no-default-features --features mod-moderation \
+  --test moderation_composition_profiles \
+  --test moderation_factory_failure_composition -- --nocapture
+
+cargo test -p rustok-server \
+  --no-default-features --features mod-moderation,mod-forum \
+  --test moderation_composition_profiles -- --nocapture
+
+node scripts/verify/verify-moderation-host-executable-contract.mjs
+```
+
+No tests, Cargo commands, Node verifiers, formatters, workflows or CI were executed while preparing this file.

--- a/scripts/verify/verify-moderation-host-executable-contract.mjs
+++ b/scripts/verify/verify-moderation-host-executable-contract.mjs
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+
+const profiles = fs.readFileSync(
+  "apps/server/tests/moderation_composition_profiles.rs",
+  "utf8",
+);
+const failure = fs.readFileSync(
+  "apps/server/tests/moderation_factory_failure_composition.rs",
+  "utf8",
+);
+const host = fs.readFileSync(
+  "apps/server/src/services/module_event_dispatcher.rs",
+  "utf8",
+);
+const docs = fs.readFileSync(
+  "crates/rustok-moderation/docs/host-composition-executable-contract.md",
+  "utf8",
+);
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  "moderation_without_forum_materializes_an_empty_subject_registry",
+  "assert!(subjects.is_empty())",
+  "forum_with_moderation_materializes_topic_and_reply_adapters",
+  "assert_eq!(subjects.len(), 2)",
+  'subjects.contains("forum", rustok_moderation::ModerationSubjectKind::ForumTopic)',
+  'subjects.contains("forum", rustok_moderation::ModerationSubjectKind::ForumPost)',
+  "selected_moderation_feature_fails_when_owner_module_is_missing",
+  "Moderation feature is selected but ModerationModule is missing from ModuleRegistry",
+  "build_shared_runtime_extensions_with_host_providers",
+]) {
+  requireText(profiles, marker, `Moderation composition profile evidence is missing ${marker}`);
+}
+
+for (const marker of [
+  "FailingModerationFactory",
+  "FailingModerationProducerModule",
+  "register_moderation_subject_adapter_factory",
+  "ModerationSubjectAdapterBuildError::InvalidConfiguration",
+  "selected_moderation_host_fails_closed_when_subject_factory_build_fails",
+  "build_shared_runtime_extensions_with_host_providers",
+  "moderation subject adapter materialization failed",
+  "broken_moderation_producer/forum_post",
+  "moderation subject adapter configuration is invalid",
+]) {
+  requireText(failure, marker, `Moderation factory-failure evidence is missing ${marker}`);
+}
+
+for (const marker of [
+  "Moderation feature is selected but ModerationModule is missing from ModuleRegistry",
+  "materialize_moderation_subject_adapter_registry",
+  "moderation subject adapter materialization failed",
+]) {
+  requireText(host, marker, `Server Moderation composition boundary is missing ${marker}`);
+}
+
+for (const marker of [
+  "Retained composition matrix",
+  "Producer factory failure",
+  "broken_moderation_producer/forum_post",
+  "Factory build failure therefore remains a startup failure",
+  "--no-default-features --features mod-moderation",
+]) {
+  requireText(docs, marker, `Moderation executable composition handoff is missing ${marker}`);
+}
+
+console.log("Moderation executable host-composition source guard passed");


### PR DESCRIPTION
## Summary
- retain the existing executable server composition matrix for Moderation-only, Forum+Moderation and selected-owner/missing-owner profiles
- add a test-only producer module that registers a valid Moderation subject factory which fails to initialize with `InvalidConfiguration`
- drive the failure through `build_shared_runtime_extensions_with_host_providers`, the ordinary server runtime-extension/materialization boundary
- prove host composition fails closed and preserves the server boundary, exact producer key and typed neutral build-error context
- avoid any fallback/partial registry behavior
- add focused handoff docs and a static source guard

## Plan context
This closes the remaining executable host-composition evidence item in Moderation priority 4. The existing profile test already covers empty Moderation-only materialization, Forum topic/reply materialization and selected-feature/missing-owner failure; this slice adds the missing factory-build-failure startup proof without duplicating those profiles.

The test-only producer has no migrations and uses only dependencies already present in `rustok-server`; Cargo.toml and Cargo.lock are unchanged.

## Verification
Static source review only. Tests, Cargo commands, Node source guards, formatters, workflows and CI were intentionally not run per maintainer request.