### PR TITLE
feat(parity): onboard Forum contribution discovery

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -5,7 +5,7 @@ language: en
 status: active
 owners:
   - rustok-forum
-last_reviewed: 2026-08-07
+last_reviewed: 2026-08-08
 ---
 
 # `rustok-forum` canonical implementation plan
@@ -100,6 +100,16 @@ revisions/tombstones, bounded reads, subscription levels, accepted solutions,
 tags, Forum statistics, transactional events, visibility-aware Search/SEO,
 shared rich text, module-owned admin/storefront packages and Page Builder
 contracts.
+
+Forum Page Builder contribution discovery metadata is now source-ready through
+the shared platform module-metadata boundary. `rustok-module.toml` declares the
+versioned owner-provider discovery entry `rustok.forum.widget-catalog`, requires
+`forum_topics:read`, points at the existing Forum-owned widget catalog/validation
+routes and corrects the topic-detail schema id to `forum.topic_detail.v1`.
+The Fly block/renderer/property-editor adapter remains open: the discovery entry
+has `blocks = []`, no renderers/property editors/storefront surface and explicit
+`adapter_state = "pending"`, so source metadata does not fabricate a runtime
+Forum/Fly capability before real component definitions and an adapter exist.
 
 Profiles, Media, Social Graph, Reactions, Moderation, Notifications,
 Translation, SEO, Search/Index, Outbox/Events, Taxonomy, Workflow, Comments,
@@ -208,7 +218,7 @@ remain pending.
 | `FORUM-29` | `planned` | Shared realtime transport with Forum cursors/revisions and canonical reload. |
 | `FORUM-30` | `planned` | Complete Forum admin by composing Forum and shared owners. |
 | `FORUM-31` | `planned` | Complete Forum storefront by composing Profiles, Media, Reactions, Notifications and Search. |
-| `FORUM-32` | `in_progress` | Widget contracts exist; richer widgets and observed Page Builder evidence remain. |
+| `FORUM-32` | `in_progress` | Shared Page Builder contribution discovery metadata is source-ready; real Fly block/renderer/property-editor adapter and observed Page Builder evidence remain. |
 | `FORUM-33` | `planned` | Forum metrics/reconciliation providers integrated with platform operations. |
 | `FORUM-34` | `planned` | Forum import/export adapter and NodeBB mapping over a shared runner. |
 | `NOTIFY-00` | `in_progress` | Neutral API/runtime composition and Forum providers exist; executable distribution evidence remains. |
@@ -524,6 +534,60 @@ fresh-producer-revision -> new case -> new immutable decision re-review flow. It
 must not move recovery state into Forum or bypass the existing shared-scheduler +
 one-attempt dispatch path.
 
+## `FORUM-32` — Page Builder and widget evolution
+
+**Status:** `in_progress`
+
+Forum Page Builder contribution discovery metadata: source-ready. The existing
+Forum-owned widget catalog (`forum.topic_list`, `forum.topic_detail`,
+`forum.reply_stream`) is now represented by one canonical versioned owner-provider
+contribution declaration in `rustok-module.toml`. Shared module tooling/publish
+validation owns provider/version/capability/permission normalization; Forum does
+not add a local TOML parser or generator.
+
+Authorization remains Forum-owned. The contribution requires
+`forum_topics:read`, matching the existing catalog/validate HTTP boundary, and the
+metadata points to those Forum endpoints rather than copying JSON schema bodies.
+The previous `topic_detail -> forum.topic_list.v1` manifest drift is corrected to
+`forum.topic_detail.v1`.
+
+Fly block/renderer/property-editor adapter remains open. Until actual Forum Fly
+component definitions, block templates and a `ContributionAdapter` exist, the
+canonical contribution stays discovery-only with `blocks = []`, no renderer or
+property-editor declarations, no storefront contribution and
+`adapter_state = "pending"`. Page Builder stays optional; forum routes must not
+depend on provider availability.
+
+Next source work is the real Forum Fly component/block/adapter boundary. It must
+preserve Forum persistence, visibility, authorization and widget validation as
+owner facts; Page Builder may compose/preview them but must not create a second
+Forum data authority.
+
+Replace the synthetic Wave packet with an observed tenant control-plane run only
+after the `pages` reference-consumer gate. The observed run must retain the
+existing all-on/publish-off/preview-off/builder-off profiles and correlate
+`builder_write -> forum_publish -> storefront_read`; source-ready discovery
+metadata is not observed rollout evidence.
+
+Verification cursors include:
+
+```bash
+node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
+npm run verify:page-builder:consumer:forum
+npm run verify:forum:wave-evidence-freshness
+cargo xtask module validate forum
+```
+
+These commands remain maintainer-run in this source slice.
+
+## `FORUM-33` — analytics, observability and reconciliation
+
+**Status:** `planned`
+
+Forum metrics/reconciliation providers remain planned platform-operations work.
+This Page Builder metadata slice does not change that ownership or claim runtime
+observability evidence.
+
 ### `FORUM-30`/`FORUM-31`: UI composition
 
 Forum packages own Forum workflows. Shared modules own reusable profile, media,
@@ -558,6 +622,13 @@ Hosts register/mount packages and do not absorb policy.
 2. Batched Profiles member composition.
 3. Topic kinds, drafts/bookmarks, read-state bulk completion and trust enforcement.
 4. Full admin/storefront assembly and release integrations.
+
+### Track 4 — Forum Page Builder contribution continuation
+
+1. Keep canonical Forum contribution discovery metadata on the shared module-tooling boundary.
+2. Define real Fly component and block identities for Forum widgets without copying Forum data ownership.
+3. Implement the Forum adapter/preview path and only then populate contribution blocks/renderers/property editors.
+4. Retain source/runtime/browser evidence before replacing synthetic Wave evidence with an observed run.
 
 ## Compatibility and migration
 
@@ -671,10 +742,18 @@ Hosts register/mount packages and do not absorb policy.
   UUID; it is not a Forum route/revision/vote identity.
 - Reactions bounded reconciliation repairs aggregate projection only and cannot
   mutate Forum-owned subjects or reinterpret Forum votes.
+- Forum Page Builder contribution discovery is metadata-only until a real Fly
+  adapter/component registry exists. No source may populate Forum contribution
+  blocks/renderers/property editors or a storefront contribution merely from the
+  widget catalog declaration.
+- Forum widget persistence, visibility, props validation and authorization remain
+  Forum-owned even after Fly adapter work begins; Page Builder may compose those
+  facts but must not become a second Forum data authority.
 
 ## Required verification
 
 ```bash
+node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
 node scripts/verify/verify-forum-shared-capability-ownership.mjs
 node scripts/verify/verify-forum-moderation-subject-adapter.mjs
 node scripts/verify/verify-moderation-host-composition.mjs
@@ -721,6 +800,7 @@ cargo test -p rustok-server --no-default-features --features mod-moderation --te
 cargo test -p rustok-server --no-default-features --features "mod-forum mod-moderation" --test moderation_composition_profiles
 cargo run -p rustok-events --example event_contract_digests -- --write
 cargo xtask module validate forum
+npm run verify:page-builder:consumer:forum
 npm run verify:forum:admin-boundary
 npm run verify:forum:storefront-boundary
 git diff --check
@@ -728,8 +808,9 @@ git diff --check
 
 Tests, lockfile/event-digest generation and runtime evidence are maintainer-run.
 Source contracts, Moderation adapter/migration/materialization/application-operation/
-one-attempt-dispatch/shared-scheduler/application-audit/operator-recovery source
-and browser harness source do not promote runtime status.
+one-attempt-dispatch/shared-scheduler/application-audit/operator-recovery source,
+Forum Page Builder contribution discovery source and browser harness source do not
+promote runtime status.
 
 ## Release gates
 
@@ -749,6 +830,13 @@ runtime claims without retained executable evidence.
 7. Search, SEO, Translation, Outbox/Events and realtime remain shared.
 
 ## Immediate next action
+
+For FORUM-32, define real Fly component/block identities for the existing Forum
+widget catalog and a real adapter/preview path before making the canonical
+contribution declaration non-empty. Preserve Forum-owned persistence, visibility,
+props validation and `forum_topics:read` authorization. Do not claim renderer,
+property-editor, storefront or observed Wave capability from discovery metadata
+alone.
 
 Regenerate the event-contract digests and retain release verification for the
 current `Cargo.lock`, then retain SQLite and PostgreSQL evidence for changed/

--- a/crates/rustok-forum/rustok-module.toml
+++ b/crates/rustok-forum/rustok-module.toml
@@ -77,6 +77,39 @@ consumer_min_version = "1.0"
 catalog_version = "v1"
 capabilities = ["preview", "tree", "properties", "publish"]
 
+# Canonical contribution discovery for the Forum Page Builder consumer. This intentionally
+# advertises the existing Forum-owned widget catalog only. Real Fly block definitions,
+# renderers, and property editors remain absent until a Forum adapter/component-registry slice
+# exists, so contribution assembly cannot imply an authoring/runtime capability that Forum does
+# not yet implement.
+[fba.builder_consumer.contribution_manifest]
+owner_provider = "rustok.forum"
+target_providers = {}
+dependencies = []
+required_permissions = ["forum_topics:read"]
+
+[[fba.builder_consumer.contribution_manifest.admin]]
+role = "widget_catalog"
+id = "rustok.forum.widget-catalog"
+provider = "rustok.forum"
+required_capabilities = ["preview"]
+blocks = []
+
+[fba.builder_consumer.contribution_manifest.admin.messages]
+"forum.builder.contributions.widgetCatalog" = "Forum widget catalog"
+
+[fba.builder_consumer.contribution_manifest.admin.metadata]
+format = "forum_widget_catalog_v1"
+surface = "admin"
+catalog_version = "v1"
+contract_version = "1.0"
+catalog_endpoint = "/api/forum/widgets/catalog"
+validate_endpoint = "/api/forum/widgets/validate"
+catalog_source = "fba.builder_consumer.widgets"
+adapter_state = "pending"
+persistence_owner = "forum"
+authorization_owner = "forum"
+
 [fba.builder_consumer.error_mapping]
 validation = "forum.widget.validation"
 sanitize = "forum.widget.sanitize"
@@ -95,7 +128,7 @@ fallback_mode = "readonly"
 
 [fba.builder_consumer.widgets.topic_detail]
 data_contract_version = "1.0"
-props_schema = "forum.topic_list.v1"
+props_schema = "forum.topic_detail.v1"
 capability_requirements = ["preview", "moderation_view"]
 fallback_mode = "degraded"
 

--- a/docs/modules/forum-page-builder-contribution-metadata-actualization-2026-08-08.md
+++ b/docs/modules/forum-page-builder-contribution-metadata-actualization-2026-08-08.md
@@ -1,0 +1,59 @@
+# Forum / Page Builder contribution metadata actualization — 2026-08-08
+
+Status: `source-ready / adapter-open / execution-pending`
+
+## Scope
+
+This slice continues the shared contribution-tooling cursor after PR #3222. Forum is the repository's second production Page Builder FBA consumer: its module manifest already declares Page Builder capability/degraded/rollout policy and its backend already owns a versioned widget catalog for `forum.topic_list`, `forum.topic_detail` and `forum.reply_stream`.
+
+The missing boundary was canonical Fly contribution discovery metadata. Forum had no `fba.builder_consumer.contribution_manifest`, so the shared `rustok-build` normalizer and `xtask module validate forum` publish-readiness gate could not validate Forum contribution identity, provider version, permission admission or capability admission.
+
+## Source result
+
+`crates/rustok-forum/rustok-module.toml` now declares one owner-provider contribution discovery entry:
+
+- module/provider identity remains `forum` / `rustok.forum`;
+- owner version continues to derive from `[module].version` through the shared normalizer;
+- module-level contribution admission requires `forum_topics:read`, matching the existing widget catalog/validation HTTP authorization boundary;
+- the contribution requires only the already-declared `preview` Page Builder capability;
+- metadata points at the existing Forum-owned catalog and validation endpoints instead of copying widget schema bodies;
+- Forum remains the persistence and authorization owner.
+
+The contribution deliberately declares `blocks = []` and no renderer/property-editor/storefront entries. Forum does not yet register Fly `BlockDefinition`s or a `ContributionAdapter` for its widget types. Advertising those surfaces before they exist would create a false runtime capability. The manifest therefore records `adapter_state = "pending"` and stays discovery-only.
+
+## Widget schema drift correction
+
+The existing `topic_detail` manifest entry incorrectly reused `forum.topic_list.v1` even though `ForumWidgetContractService` validates a distinct topic-detail schema. The canonical metadata now uses `forum.topic_detail.v1`; topic-list and reply-stream retain their existing distinct ids.
+
+## Shared tooling boundary
+
+No Forum-local TOML parser or contribution generator is added. The declaration is consumed by the shared source introduced in PR #3222:
+
+- `crates/rustok-build/src/module_manifest_contribution.rs` validates module/provider/version, exact target provider versions, required permissions, capabilities and reserved identity metadata;
+- `xtask module validate forum` invokes the same normalizer as module publish readiness;
+- Forum admin receives no `fly-ui` or Page Builder UI dependency in this slice;
+- `Cargo.toml` dependency topology and `Cargo.lock` remain unchanged by this slice.
+
+## Ownership retained
+
+Forum continues to own category/topic/reply lifecycle, revisions, visibility, widget source facts, widget validation and authorization. Page Builder/Fly continues to own generic authoring/composition contracts. This slice does not move Forum persistence, moderation, publication, routing or widget runtime data into Page Builder.
+
+## Guardrail
+
+`scripts/verify/verify-forum-page-builder-contribution-metadata.mjs` source-checks:
+
+- exact Forum contribution discovery identity and `forum_topics:read` permission admission;
+- distinct topic-list/topic-detail/reply-stream schema ids;
+- shared normalizer markers;
+- existing Forum widget endpoint RBAC;
+- absence of Forum Fly renderer/property-editor/storefront claims while the adapter is pending;
+- absence of a new Forum-admin `fly-ui` / Page Builder UI dependency;
+- synchronized Forum and Page Builder plan markers.
+
+## Next source cursor
+
+Implement the first real Forum Fly adapter/component-registry slice before adding non-empty contribution blocks/renderers/property editors. That slice must define actual Fly component/block identities, adapter rendering/property behavior, preview data ownership and failure/degraded semantics against Forum-owned widget contracts. Only then should runtime contribution assembly claim those capabilities.
+
+Observed tenant Wave evidence remains separate and still requires maintainer execution after the Pages reference-consumer gate.
+
+No tests, Node verifiers, Cargo checks, formatting, builds, workflows, CI, browser or database evidence were run by the implementation agent.

--- a/docs/modules/page-builder-implementation-plan.md
+++ b/docs/modules/page-builder-implementation-plan.md
@@ -31,6 +31,8 @@ Current source markers for this slice:
 Provider status/degraded controls: source-ready
 Pages module-metadata contribution generation: source-ready
 Shared module contribution tooling: source-ready
+Forum second-consumer contribution discovery: source-ready
+Forum Fly adapter/component registry: open
 ```
 
 Observed provider-health evidence remains an execution/composition cursor; an
@@ -44,9 +46,15 @@ only Pages-specific role/constant assertions. `xtask module validate` consumes t
 same normalizer for publish readiness. Admin/WASM runtime still does not parse TOML
 and no handwritten Pages `ContributionDescriptor` tree remains.
 
-The next contribution source cursor is a second production consumer, selected only
-after its persistence, authorization and preview ownership are explicit. Live SLO
-health remains a separate open cursor.
+Forum is now the second production consumer selected for the shared metadata
+boundary. Its canonical `rustok-module.toml` declares a versioned owner-provider
+`rustok.forum.widget-catalog` discovery contribution guarded by `forum_topics:read`
+and `preview`, while preserving Forum as widget persistence/authorization owner.
+The entry deliberately has no Fly blocks, renderers, property editors or storefront
+surface: Forum does not yet have a real Fly component registry/adapter, so the
+metadata records that adapter state as pending instead of fabricating runtime
+capability. The next source cursor is that real Forum adapter/component-registry
+slice. Live SLO health remains a separate open cursor.
 
 ## Current-only policy
 
@@ -208,6 +216,21 @@ persistence. Rich text remains an external dedicated capability.
 - [ ] Accepted evidence must correlate outbox delivery, repair/rollback receipts,
   generation rotation, cache miss/refill, browser authoring and provider status.
 
+### Forum second contribution consumer
+
+- [x] Forum already owns versioned `topic_list`, `topic_detail` and `reply_stream`
+  widget contracts plus catalog/validation HTTP routes guarded by
+  `forum_topics:read`.
+- [x] Canonical `rustok-module.toml` now declares the Forum owner-provider
+  contribution discovery entry through the shared module metadata boundary.
+- [x] The topic-detail manifest schema id is distinct (`forum.topic_detail.v1`)
+  instead of incorrectly reusing the topic-list schema id.
+- [x] Contribution discovery remains fail-closed with `blocks = []`, no renderers,
+  no property editors and no storefront claim while the adapter is pending.
+- [ ] Define actual Forum Fly component/block identities and a real adapter before
+  exposing authoring or rendering contributions.
+- [ ] Retain Forum Page Builder runtime/browser and observed Wave evidence.
+
 ## Target architecture
 
 ```text
@@ -246,6 +269,12 @@ persistence. Rich text remains an external dedicated capability.
     -> module-owned route/page/artifact generation rotation
     -> generation-aware storefront/artifact cache reads
 
+  consumer domain (Forum)
+    -> topic/reply lifecycle, revisions and visibility remain Forum-owned
+    -> versioned widget catalog and props validation remain Forum-owned
+    -> canonical contribution discovery metadata is shared-tooling validated
+    -> Fly component/block/adapter runtime remains pending
+
   rustok-page-builder
     -> capability policy / health / rollout
     -> provider adapter seams
@@ -254,7 +283,7 @@ persistence. Rich text remains an external dedicated capability.
 ```
 
 Hosts are composition roots only. They supply route, locale, auth, tenant context
-and neutral shared capabilities; they do not own Fly state, Pages policy,
+and neutral shared capabilities; they do not own Fly state, Pages/Forum policy,
 persistence or cache-key semantics.
 
 ## Dependency rules
@@ -361,10 +390,12 @@ Rules:
   remain retryable. A retry may safely advance a generation more than once.
 - Provider rollout flags and observed health are separate evidence. Lack of an
   observed SLO snapshot is never converted to a healthy claim.
-- Consumer contribution metadata is build-generated from canonical module
-  metadata; runtime source must not retain a parallel handwritten descriptor tree.
+- Consumer contribution metadata is canonical module metadata; runtime source must
+  not retain a parallel handwritten descriptor tree.
 - Shared contribution parsing/normalization is platform build tooling and publish
   validation only; it must not become runtime registry, tenant or persistence policy.
+- A discovery contribution with no real adapter must not claim blocks, renderers,
+  property editors or storefront runtime surfaces.
 
 ## Implementation phases
 
@@ -488,20 +519,25 @@ of the verification programme.
 - [x] Duplicate, cycle, version and missing-provider diagnostics.
 - [x] Generalize canonical contribution metadata parsing/normalization into shared
   platform build tooling and `xtask` module publish validation.
+- [x] Onboard Forum as the second production consumer to canonical contribution
+  discovery metadata without a consumer-local parser or schema authority.
+- [ ] Connect Forum to runtime Fly component/block/adapter contribution assembly.
 
 ### Phase 10 — rollout
 
 - [ ] Internal tenant Wave 0 with observed evidence.
 - [ ] Pages Wave 1 after accepted publication/cache/rollback/repair/browser gates.
+- [x] Forum canonical contribution discovery metadata through shared tooling.
+- [ ] Forum Fly adapter/component registry and runtime contribution assembly.
 - [ ] Media/Pages reusable sections.
-- [ ] Blog, Forum, Product, Pricing, Taxonomy and SEO contributions.
+- [ ] Blog, Product, Pricing, Taxonomy and SEO contributions.
 - [ ] Additional modules only after renderer/property/cache ownership is proven.
 
 ## Immediate implementation order
 
-1. Select a second production contribution consumer only after its tenant-scoped
-   persistence, authorization and preview ownership are explicit, then adopt the
-   shared canonical metadata/tooling boundary without a local schema/parser.
+1. Define the real Forum Fly component/block identities and adapter behavior against
+   the existing Forum-owned widget catalog; only then make Forum contribution
+   blocks/renderers/property editors non-empty and mount runtime assembly.
 2. Connect a real provider-health observation source to the admin status seam and
    retain observed provider-health evidence for degraded/unavailable behavior.
 3. Retain accepted Pages execution evidence for reviewed publish, rollback/repair,
@@ -526,10 +562,12 @@ cargo test -p rustok-pages-admin
 cargo test -p rustok-pages-storefront
 cargo xtask module validate page_builder
 cargo xtask module validate pages
+cargo xtask module validate forum
 node scripts/verify/verify-pages-ui-boundary.mjs
 node --test scripts/verify/verify-pages-ui-boundary.test.mjs
 node scripts/verify/verify-fly-admin-browser-runtime.mjs
 node scripts/verify/verify-fly-ui-contributions.mjs
+node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-static-publish-resource-limits.mjs
@@ -540,6 +578,7 @@ node crates/rustok-page-builder/scripts/verify/verify-page-builder-publish-runti
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-publish-transport-cutover.mjs
 npm run verify:page-builder:fba:baseline
 npm run verify:page-builder:consumer:pages
+npm run verify:page-builder:consumer:forum
 npm run verify:i18n:ui
 npm run verify:i18n:contract
 cargo deny check
@@ -555,7 +594,8 @@ authoritative sanitization/resource budgets, deterministic artifact and receipt
 integrity, preview/static materialization parity, idempotent replay, repair/
 rollback continuity, event-driven cache generation rotation and public miss/
 refill, anonymous authoring exclusion, provider degradation, generated module
-metadata authority, shared publish validation and observed tenant rollout.
+metadata authority, shared publish validation, Forum discovery-to-real-adapter
+continuity and observed tenant rollout.
 
 ## Update rules
 

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-08  
-Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / contribution-module-metadata-generation-source-ready / shared-contribution-tooling-source-ready / observed-health-open / second-contribution-consumer-open / execution-browser-rollout-pending
+Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / contribution-module-metadata-generation-source-ready / shared-contribution-tooling-source-ready / forum-second-consumer-discovery-source-ready / forum-fly-adapter-open / observed-health-open / execution-browser-rollout-pending
 Scope: `rustok-pages` admin/storefront FFA and `rustok-page-builder` document, publication, artifact, routing, cache, authenticated inline-authoring and deterministic deployment boundaries
 
 ## Source-of-truth policy
@@ -15,9 +15,10 @@ Pages and Page Builder remain one vertical pipeline with explicit owners:
 - Pages owns persistence, lifecycle, immutable bindings, localized route identity, cache policy, public reads, authenticated inline grants/save transport and the module-owned authoring asset HTTP contract.
 - Pages admin owns the optional same-origin authoring launch control and consumes build-generated contribution metadata.
 - Platform build tooling owns the reusable parsing/normalization contract for canonical module contribution metadata; it does not own runtime registry policy.
+- Forum owns Forum category/topic/reply lifecycle, visibility, widget contracts, widget validation and widget authorization even when its Page Builder contribution metadata is discovered through shared tooling.
 - Page Builder/Fly owns the reviewed document, sanitizer, runtime materialization, renderer, artifact producer contracts and reusable real-DOM inline adapter/session.
 - Navigation and SEO own their resolved payloads.
-- Hosts own route admission, CSP and HTTP composition, not Pages document, route, asset or launch policy.
+- Hosts own route admission, CSP and HTTP composition, not Pages/Forum domain persistence, route policy, asset policy or launch policy.
 - Release engineering owns deterministic composition and durable evidence, not runtime authorization or persistence.
 
 Optional external event and delivery infrastructure remain outside the active Pages cursor.
@@ -32,17 +33,19 @@ The recheck includes all relevant merged source after the former PR #3063 cursor
 - PR #3196 — Page Builder admin provider rollout/degraded controls are connected through the Pages consumer; absent live SLO evidence remains explicitly `unobserved` and no health state is fabricated;
 - the existing `fly-ui` contribution path already has separate admin/storefront factories, tenant/permission/capability/provider-policy/provider-health filtering, and duplicate/missing-provider/missing-dependency/cycle diagnostics;
 - PR #3205 restored exact owner/target provider versions and fail-closed manifest-routed provider-version admission;
-- PR #3215 moved the Pages reference-consumer declaration into canonical `rustok-module.toml` and generated the version-pinned runtime manifest at build time.
+- PR #3215 moved the Pages reference-consumer declaration into canonical `rustok-module.toml` and generated the version-pinned runtime manifest at build time;
+- PR #3222 moved generic contribution parsing/normalization into platform `rustok-build` tooling and reused it from Pages generation plus module publish readiness.
 
-The current source slice closes the remaining shared-tooling gap without changing Pages persistence, publication or runtime registry ownership:
+The current source slice advances the shared-tooling cursor to the second production consumer without changing Pages persistence, publication or runtime registry ownership:
 
-- `crates/rustok-build/src/module_manifest_contribution.rs` is the reusable metadata-only parser/normalizer for `[fba.builder_consumer.contribution_manifest]`;
-- it normalizes module/provider/version identity, exact target providers, dependencies, permissions and separate admin/storefront contributions;
-- contribution capabilities must remain inside `[fba.builder_consumer].capabilities`, nested renderer/property-editor providers must match their contribution provider, and reserved `ownerProvider`/`providerVersion` identity is injected only from canonical metadata;
-- `crates/rustok-pages/admin/build.rs` is now a thin Pages-specific adapter over that shared source and retains only Pages role/constant assertions;
-- `xtask module validate <slug>` consumes the same normalizer and rejects invalid contribution metadata during module publish readiness, including admin/storefront contributions without their corresponding declared UI surface;
-- the shared normalizer remains build/tooling code only and does not depend on `fly-ui`, Leptos, Page Builder runtime packages or tenant/provider-health state;
-- the Fly and Pages metadata source guards now require this shared boundary and reject reintroduction of a Pages-local parser/normalizer.
+- Forum is selected because its persistence, authorization and preview/widget ownership are already explicit: Forum owns topic/reply lifecycle and visibility plus `ForumWidgetContractService`, while Page Builder remains optional composition/authoring infrastructure;
+- `crates/rustok-forum/rustok-module.toml` now declares one canonical owner-provider discovery contribution, `rustok.forum.widget-catalog`, through the same `[fba.builder_consumer.contribution_manifest]` shape used by shared tooling;
+- the Forum discovery contribution is permission-gated by `forum_topics:read`, capability-gated by `preview`, points at the existing Forum-owned catalog/validation endpoints and derives exact owner version from `[module].version` through the shared normalizer;
+- the previous `topic_detail` schema-id drift is corrected from `forum.topic_list.v1` to the distinct `forum.topic_detail.v1` identity;
+- the contribution is deliberately discovery-only: `blocks = []`, no renderers, no property editors, no storefront contribution and `adapter_state = "pending"` because Forum has no real Fly component registry or `ContributionAdapter` yet;
+- `xtask module validate forum` therefore exercises the shared module-metadata/publish-readiness boundary without a Forum-local parser or generator;
+- Forum admin receives no new `fly-ui` or Page Builder UI dependency and this slice introduces no Cargo dependency/lockfile change;
+- source guards require the discovery-only boundary and reject premature renderer/property-editor/storefront claims.
 
 Rechecked Page Builder Phase 9 source state:
 
@@ -51,14 +54,17 @@ Rechecked Page Builder Phase 9 source state:
 - [x] Filter by tenant, permission, capability, provider policy and health.
 - [x] Duplicate, missing-provider, missing-dependency, cycle and provider-version diagnostics.
 - [x] Generalize canonical contribution metadata parsing/normalization into platform build tooling and module publish validation.
+- [x] Onboard Forum as the second production consumer to canonical shared contribution discovery metadata.
+- [ ] Define and connect the real Forum Fly component/block/adapter runtime before advertising non-empty Forum blocks/renderers/property editors.
 
-The next contribution source cursor is onboarding a second production consumer through this shared metadata boundary, but only after that consumer's persistence, authorization and preview ownership are explicit. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
+The next contribution source cursor is the real Forum Fly adapter/component-registry slice. It must preserve Forum-owned persistence, visibility, widget validation and authorization rather than creating a second domain authority. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
 
 Detailed evidence for the 2026-08-08 contribution slices is retained in:
 
 - `docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md`;
 - `docs/modules/pages-page-builder-module-metadata-contribution-generation-2026-08-08.md`;
-- `docs/modules/pages-page-builder-shared-contribution-tooling-2026-08-08.md`.
+- `docs/modules/pages-page-builder-shared-contribution-tooling-2026-08-08.md`;
+- `docs/modules/forum-page-builder-contribution-metadata-actualization-2026-08-08.md`.
 
 ## Rechecked merged cursor
 
@@ -112,6 +118,7 @@ No build, workflow, Docker, HTTP or browser execution is claimed.
 - `contribution-registry-version-parity-source-ready` — contribution owner/target provider versions are pinned and fail closed on missing/mismatched versions.
 - `contribution-module-metadata-generation-source-ready` — Pages contribution declarations and property schema are generated from canonical module metadata at build time.
 - `shared-contribution-tooling-source-ready` — canonical contribution parsing/normalization is shared by platform build tooling, Pages generation and module publish readiness.
+- `forum-second-consumer-discovery-source-ready` — Forum uses the same canonical contribution metadata/publish-validation boundary while truthfully keeping its Fly adapter pending.
 
 ## Current parity state
 
@@ -129,7 +136,9 @@ Execution evidence remains pending.
 
 Pages owns one canonical contribution declaration in `rustok-module.toml`. Its build script materializes the version-pinned Fly manifest and metadata property schema into `OUT_DIR`; runtime consumes only generated Rust/JSON and retains no TOML dependency or handwritten descriptor tree.
 
-Generic parsing, provider/version injection, capability admission and nested provider validation now live once in `rustok-build` tooling and are reused by Pages build generation and `xtask` publish readiness. A second production consumer has not yet been selected or onboarded.
+Generic parsing, provider/version injection, capability admission and nested provider validation live once in `rustok-build` tooling and are reused by Pages build generation and `xtask` publish readiness. Forum is now the second production consumer of that canonical metadata boundary: its owner-provider widget-catalog discovery entry is normalized/publish-validated without a Forum-local parser or new runtime dependency.
+
+Forum runtime contribution assembly remains intentionally open. The source does not yet contain Forum Fly component/block definitions or an adapter, so the Forum manifest advertises no blocks/renderers/property editors/storefront contribution.
 
 ### Public locale, route and cache authority: source-ready
 
@@ -264,7 +273,7 @@ Page Builder provider flags can only narrow an already authorized capability set
 
 ### Contribution registry version parity: source-ready
 
-Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Pages supplies those identities through canonical metadata and the shared build normalizer rather than a handwritten runtime manifest.
+Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Pages supplies those identities through canonical metadata and the shared build normalizer rather than a handwritten runtime manifest. Forum now supplies canonical owner-provider discovery metadata through the same normalizer but does not yet claim runtime adapter surfaces.
 
 ## Parity matrix
 
@@ -274,6 +283,7 @@ Admin/storefront assembly, policy filters and structural diagnostics are source-
 | Reviewed publish and immutable rollback | Complete | DB/runtime execution pending |
 | Repeated immutable-artifact loss recovery | Source-ready | Repair/rollback execution pending |
 | Canonical contribution metadata generation | Source-ready (Pages + shared tooling) | Execution pending |
+| Forum second-consumer contribution discovery | Source-ready | Fly adapter/runtime/browser pending |
 | Public locale fallback | Source-ready | Native/GraphQL execution pending |
 | Published aliases, tombstones and history import | Source-ready | SQLite/PostgreSQL/host execution pending |
 | Host canonical/redirect/gone response | Source-ready | HTTP/SSR execution pending |
@@ -312,19 +322,20 @@ These exact phrases are retained only because earlier static guards consume the 
 
 ## Boundaries
 
-The historical deployment slice remains unchanged; the 2026-08-08 reconciliation additionally restores contribution version parity, moves Pages contribution authority to canonical module metadata and centralizes metadata normalization in platform build tooling.
+The historical deployment slice remains unchanged; the 2026-08-08 reconciliation additionally restores contribution version parity, moves Pages contribution authority to canonical module metadata, centralizes metadata normalization in platform build tooling and onboards Forum to discovery-only shared metadata.
 
 It does not:
 
 - change anonymous public Pages rendering;
 - accept delegated or service principals;
-- create another document persistence path;
-- edit immutable published documents;
+- create another Pages or Forum persistence path;
+- edit immutable published Pages documents;
 - change database, GraphQL, REST, event, publish, rollback, artifact or cache schemas;
 - enable same-origin launch in standalone admin builds;
 - add runtime build tooling to `apps/server/Dockerfile.release`;
-- add a TOML parser to Pages admin/WASM runtime;
+- add a TOML parser to Pages or Forum admin/WASM runtime;
 - make platform build tooling a runtime contribution registry or tenant policy owner;
+- claim a Forum Fly block, renderer, property editor, storefront adapter or observed Wave before such runtime source exists;
 - claim verifier, Cargo, npm, Trunk, WASM, server, Docker, workflow, HTTP, browser or rollout execution;
 - fabricate Page Builder provider-health observations;
 - promote FFA or FBA.
@@ -333,11 +344,11 @@ It does not:
 
 Source continuation:
 
-1. Select the second production contribution consumer only after its persistence, authorization and preview ownership are explicit, then adopt the shared canonical module metadata/tooling boundary without a consumer-local parser or manifest schema.
-2. Keep current Pages repair/recovery and Page Builder degraded-control source boundaries unchanged during that onboarding.
+1. Define real Forum Fly component/block identities and adapter behavior against the existing Forum-owned widget catalog, then connect runtime contribution assembly without moving Forum persistence/authorization into Page Builder.
+2. Keep current Pages repair/recovery and Page Builder degraded-control source boundaries unchanged while Forum adapter work proceeds.
 3. Connect real provider-health observation only after an authoritative Page Builder SLO source exists.
 
-Maintainer-owned execution evidence remains pending for the contribution-generation/tooling, release, browser, database and recovery slices.
+Maintainer-owned execution evidence remains pending for the contribution-generation/tooling, Forum adapter/rollout, release, browser, database and recovery slices.
 
 ## Maintainer validation
 
@@ -345,8 +356,10 @@ Suggested commands, intentionally not run in this slice:
 
 ```bash
 node scripts/verify/verify-fly-ui-contributions.mjs
+node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs
 cargo xtask module validate pages
+cargo xtask module validate forum
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-release-composition.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-admin-launch.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-inline-edit-asset-delivery.mjs

--- a/scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
+++ b/scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
@@ -85,7 +85,11 @@ for (const marker of [
   requireMarker(sharedTooling, marker, "shared contribution metadata tooling");
 }
 
-for (const forbidden of ["fly-ui", "rustok-page-builder-admin", "rustok-page-builder ="] ) {
+for (const forbidden of [
+  "fly-ui",
+  "rustok-page-builder-admin",
+  "rustok-page-builder =",
+]) {
   forbidMarker(adminCargo, forbidden, "Forum admin adapter-pending dependency boundary");
 }
 

--- a/scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
+++ b/scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const moduleManifest = read("crates/rustok-forum/rustok-module.toml");
+const widgetContract = read("crates/rustok-forum/src/services/widget_contract.rs");
+const widgetController = read("crates/rustok-forum/src/controllers/widgets.rs");
+const adminCargo = read("crates/rustok-forum/admin/Cargo.toml");
+const sharedTooling = read("crates/rustok-build/src/module_manifest_contribution.rs");
+const forumPlan = read("crates/rustok-forum/docs/implementation-plan.md");
+const pageBuilderPlan = read("docs/modules/page-builder-implementation-plan.md");
+
+const failures = [];
+const requireMarker = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label} is missing ${marker}`);
+};
+const forbidMarker = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label} still contains ${marker}`);
+};
+
+for (const marker of [
+  "[fba.builder_consumer.contribution_manifest]",
+  'owner_provider = "rustok.forum"',
+  'required_permissions = ["forum_topics:read"]',
+  'role = "widget_catalog"',
+  'id = "rustok.forum.widget-catalog"',
+  'provider = "rustok.forum"',
+  'required_capabilities = ["preview"]',
+  "blocks = []",
+  'format = "forum_widget_catalog_v1"',
+  'catalog_version = "v1"',
+  'catalog_endpoint = "/api/forum/widgets/catalog"',
+  'validate_endpoint = "/api/forum/widgets/validate"',
+  'catalog_source = "fba.builder_consumer.widgets"',
+  'adapter_state = "pending"',
+  'persistence_owner = "forum"',
+  'authorization_owner = "forum"',
+  'props_schema = "forum.topic_list.v1"',
+  'props_schema = "forum.topic_detail.v1"',
+  'props_schema = "forum.reply_stream.v1"',
+]) {
+  requireMarker(moduleManifest, marker, "Forum canonical Page Builder metadata");
+}
+
+for (const forbidden of [
+  "[[fba.builder_consumer.contribution_manifest.admin.renderers]]",
+  "[[fba.builder_consumer.contribution_manifest.admin.property_editors]]",
+  "[[fba.builder_consumer.contribution_manifest.storefront]]",
+]) {
+  forbidMarker(moduleManifest, forbidden, "Forum adapter-pending contribution metadata");
+}
+
+for (const marker of [
+  'FORUM_WIDGET_TYPE_TOPIC_LIST: &str = "forum.topic_list"',
+  'FORUM_WIDGET_TYPE_TOPIC_DETAIL: &str = "forum.topic_detail"',
+  'FORUM_WIDGET_TYPE_REPLY_STREAM: &str = "forum.reply_stream"',
+  "fn topic_list_catalog_item()",
+  "fn topic_detail_catalog_item()",
+  "fn reply_stream_catalog_item()",
+]) {
+  requireMarker(widgetContract, marker, "Forum owner widget contract");
+}
+
+for (const marker of [
+  'path = "/api/forum/widgets/catalog"',
+  'path = "/api/forum/widgets/validate"',
+  "Permission::FORUM_TOPICS_READ",
+  '"Permission denied: forum_topics:read required"',
+]) {
+  requireMarker(widgetController, marker, "Forum widget authorization boundary");
+}
+
+for (const marker of [
+  "pub fn normalize_module_contribution_manifest(",
+  "required_permissions",
+  "OWNER_PROVIDER_METADATA_KEY",
+  "PROVIDER_VERSION_METADATA_KEY",
+  "outside fba.builder_consumer.capabilities",
+]) {
+  requireMarker(sharedTooling, marker, "shared contribution metadata tooling");
+}
+
+for (const forbidden of ["fly-ui", "rustok-page-builder-admin", "rustok-page-builder ="] ) {
+  forbidMarker(adminCargo, forbidden, "Forum admin adapter-pending dependency boundary");
+}
+
+for (const marker of [
+  "Forum Page Builder contribution discovery metadata: source-ready",
+  "Fly block/renderer/property-editor adapter remains open",
+]) {
+  requireMarker(forumPlan, marker, "Forum canonical implementation plan");
+}
+for (const marker of [
+  "Forum second-consumer contribution discovery: source-ready",
+  "Forum Fly adapter/component registry: open",
+]) {
+  requireMarker(pageBuilderPlan, marker, "Page Builder canonical implementation plan");
+}
+
+if (failures.length > 0) {
+  console.error("forum Page Builder contribution metadata verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "forum Page Builder contribution metadata verification passed: shared_metadata=true adapter_state=pending runtime_claim=false",
+);


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder parity cursor after #3222 by selecting Forum as the second production consumer of the shared contribution metadata boundary.

- declare canonical `rustok.forum.widget-catalog` discovery metadata in `rustok-forum/rustok-module.toml` using the shared module contribution schema;
- gate discovery with existing `forum_topics:read` authorization and `preview` capability while keeping Forum persistence, visibility, widget validation and authorization owner-local;
- correct the `topic_detail` props-schema identity from the reused `forum.topic_list.v1` value to `forum.topic_detail.v1`;
- remain fail-closed while the real Fly adapter is absent: `blocks = []`, no renderers/property editors/storefront contribution, `adapter_state = "pending"`;
- add a retained source guard for shared-tooling adoption and no premature runtime claims;
- restore/actualize the canonical FORUM-32 task card and update the central Page Builder plus shared Pages/Page Builder cursors to the next real source gap: Forum Fly component/block/adapter runtime;
- keep observed provider-health and Forum tenant Wave evidence separate and pending.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo checks, formatting, builds, workflows, CI, browser/database evidence, or `git diff --check` were run in this slice.