### PR TITLE
refactor(commerce): cut legacy admin Product reads to owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -245,11 +245,20 @@ These are source-contract defects, not verification-only tasks.
   trimmed locale, current-tenant scope, service actor, request channel, bounded deadline,
   exact category/attribute option projection semantics, and the shared stable Product
   GraphQL public error mapper.
-- [ ] Cut remaining Product schema writes, REST delete/publish/unpublish lifecycle
-  commands, and remaining GraphQL Product lifecycle operations over to host-composed
-  Product owner ports. Direct Product entities, `CatalogService`, and remaining
-  write-side `ProductCatalogSchemaService` usage remain explicit source debt; repeatable
-  lifecycle commands need an explicit caller idempotency contract before cutover.
+- [x] Publish optional fail-closed `ProductCatalogReadPort::list_legacy_admin_products`
+  and cut mounted legacy admin GraphQL `product` / `products` to the host-selected
+  Product read runtime, preserving current-tenant and Product permission admission,
+  the detail resolver's existing storefront-channel gate, authenticated actor, request
+  channel, requested/default locale fallback, bounded deadline, `NotFound -> null`,
+  status/vendor/search filters, created-at-desc ordering, clamped pagination,
+  `Untitled product`, normalized/default shipping-profile fallback, tags, telemetry,
+  response projection, and shared stable Product GraphQL public errors.
+- [ ] Cut legacy mounted storefront GraphQL `storefrontProduct` / `storefrontProducts`,
+  remaining Product schema writes, REST delete/publish/unpublish lifecycle commands,
+  and remaining GraphQL Product lifecycle operations over to host-composed Product owner
+  ports. Direct Product entities, `CatalogService`, and remaining write-side
+  `ProductCatalogSchemaService` usage remain explicit source debt; repeatable lifecycle
+  commands need an explicit caller idempotency contract before cutover.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -889,6 +898,11 @@ Source inspection is not execution evidence.
   owner capabilities while preserving storefront admission, current tenant, required
   locale, request channel/deadline context, exact option projection, and stable public
   owner errors without adding a redundant Product port method.
+- [x] Publish the optional legacy admin Product list compatibility capability and cut
+  mounted legacy admin GraphQL `product` / `products` to the host-selected Product read
+  runtime while preserving legacy detail/list admission, locale, filtering, ordering,
+  pagination, title/shipping fallback, tags, telemetry, projection, and stable errors;
+  legacy storefront Product reads remain separate source debt.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`, then continued the Product schema-read cutover from `aaa496887fd1492f3feca8ac52261458ce25705e` through the current `main` line.
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`, then continued the Product schema-read and legacy catalog-read cutover from `aaa496887fd1492f3feca8ac52261458ce25705e` through the current `main` line.
 
 The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
 
@@ -11,7 +11,8 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 1. `ProductCatalogSchemaReadPort` publishes the effective-form aggregate capability added by PR #3182, and mounted `productEffectiveForm` is now cut over to that host-selected owner capability.
 2. PR #3203 published `ProductCatalogSchemaReadPort::read_product_attribute_values`, and mounted `productAttributeValues` is now cut over to that owner capability.
 3. `storefrontCatalogSearchOptions` was the remaining mounted direct `ProductCatalogSchemaService` schema-read consumer. Its current projection needs only categories and filterable/sortable attributes, so the already-published `list_categories` and `list_attributes` owner capabilities preserve the existing data and ordering semantics without a new Product projection.
-4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths use `ProductCatalogReadRuntime`, while legacy mounted `product`/`products` roots in `query::CommerceQuery` still contain direct `CatalogService`/Product entity read paths. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path must remain open; source inspection does not justify a status promotion.
+4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths already use `ProductCatalogReadRuntime`; the mounted legacy admin `product`/`products` roots were still direct `CatalogService` / Product-entity consumers and are cut over in the continuation below.
+5. The legacy mounted `storefrontProduct` / `storefrontProducts` roots remain direct `CatalogService` / Product-entity consumers. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path remains open; source inspection does not justify a status promotion.
 
 ## PR #3203 source change
 
@@ -42,9 +43,17 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Preserve the exact GraphQL projection: category values remain category ids with path/name/code fallback labels; attribute options remain limited to filterable or sortable attributes and keep the existing `label (code)` formatting.
 - Extend the schema-read source guard to require both owner calls and the existing option-projection semantics while forbidding direct `ProductCatalogSchemaService` construction in this resolver.
 
+## Legacy admin Product read continuation
+
+- Publish optional fail-closed `ProductCatalogReadPort::list_legacy_admin_products` / `LegacyAdminProductsRequest` so existing remote/test adapters remain source-compatible until they explicitly implement the exact legacy list projection.
+- Implement the in-process compatibility capability through Product's existing owner query path, preserving status/vendor/search filtering, created-at-desc ordering, page default/clamp semantics, requested/default locale fallback, `Untitled product`, normalized metadata-aware shipping-profile fallback, tags, and the existing list projection.
+- Cut mounted legacy admin GraphQL `product` to host-selected `ProductCatalogReadPort::read_product_projection`, preserving current-tenant and `PRODUCTS_READ` admission, the pre-existing storefront-channel admission, authenticated actor, requested/default locale fallback, request channel, bounded deadline, detail projection, and `NotFound -> null` behavior.
+- Cut mounted legacy admin GraphQL `products` to `list_legacy_admin_products`, preserving `PRODUCTS_LIST`, current tenant, authenticated actor, request channel/deadline, exact legacy filters/order/pagination/projection, telemetry path, and the shared stable Product GraphQL public error mapper.
+- Extend the Product admin GraphQL source guard so both modern and legacy admin read roots require the host-selected runtime/ports and direct Product service/entity access is forbidden inside the cut-over resolvers.
+
 ## Remaining execution order
 
-1. Reconcile or retire the legacy mounted `product`/`products` GraphQL roots so direct Product service/entity reads no longer violate the every-production-path FBA invariant.
+1. Cut legacy mounted `storefrontProduct` / `storefrontProducts` away from direct Product service/entity reads while preserving published/channel visibility, id-or-handle detail semantics, vendor/product-type/search filtering, inventory enrichment, ordering, pagination, locale fallback, and response projection.
 2. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
 3. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 

--- a/crates/rustok-commerce/src/graphql/query.rs
+++ b/crates/rustok-commerce/src/graphql/query.rs
@@ -1473,7 +1473,7 @@ impl CommerceQuery {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
         super::require_storefront_channel_enabled(ctx).await?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_READ],
             "Permission denied: products:read required",
@@ -1484,20 +1484,46 @@ impl CommerceQuery {
         let tenant = ctx.data::<TenantContext>()?;
         let locale =
             resolve_commerce_graphql_locale(ctx, locale.as_deref(), tenant.default_locale.as_str());
-
-        let service = CatalogService::new(db.clone(), event_bus.clone());
-        let product = match service
-            .get_product_with_locale_fallback(
-                tenant_id,
-                id,
-                &locale,
-                Some(tenant.default_locale.as_str()),
+        let request_context = ctx.data_opt::<RequestContext>();
+        let port_context = rustok_api::PortContext::new(
+            tenant_id.to_string(),
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale.as_str(),
+            format!("commerce-graphql-product:legacy-product:{id}"),
+        )
+        .with_deadline(std::time::Duration::from_secs(2));
+        let port_context = match request_context.and_then(|context| context.channel_slug.as_deref()) {
+            Some(channel) => port_context.with_channel(channel),
+            None => port_context,
+        };
+        let product_read_runtime =
+            crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+                db.clone(),
+                event_bus.clone(),
+            );
+        let product = match product_read_runtime
+            .read_port()
+            .read_product_projection(
+                port_context.clone(),
+                rustok_product::ProductProjectionRequest {
+                    product_id: id,
+                    locale: Some(locale.clone()),
+                    fallback_locale: Some(tenant.default_locale.clone()),
+                },
             )
             .await
         {
             Ok(product) => product,
-            Err(rustok_product::CommerceError::ProductNotFound(_)) => return Ok(None),
-            Err(err) => return Err(map_product_service_error(err, "product_query")),
+            Err(error) if error.kind == rustok_api::PortErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(FieldError::from(
+                    crate::graphql::product_catalog::product_catalog_port_error(
+                        &port_context,
+                        error,
+                        "legacy_product",
+                    ),
+                ));
+            }
         };
 
         Ok(Some(
@@ -1514,7 +1540,7 @@ impl CommerceQuery {
     ) -> Result<GqlProductList> {
         require_module_enabled(ctx, PRODUCT_MODULE_SLUG).await?;
         let tenant_id = product_query_tenant(ctx, tenant_id)?;
-        require_commerce_permission(
+        let auth = require_commerce_permission(
             ctx,
             &[Permission::PRODUCTS_LIST],
             "Permission denied: products:list required",
@@ -1535,43 +1561,67 @@ impl CommerceQuery {
         let requested_limit = filter.per_page;
         let page = filter.page.unwrap_or(1).max(1);
         let per_page = filter.per_page.unwrap_or(20).clamp(1, 100);
-        let offset = (page.saturating_sub(1)) * per_page;
-
-        let mut query = product::Entity::find().filter(product::Column::TenantId.eq(tenant_id));
-
-        if let Some(status) = &filter.status {
-            let status: rustok_product::entities::product::ProductStatus = (*status).into();
-            query = query.filter(product::Column::Status.eq(status));
-        }
-        if let Some(vendor) = &filter.vendor {
-            query = query.filter(product::Column::Vendor.eq(vendor));
-        }
-        if let Some(search) = &filter.search {
-            query = query.filter(product_translation_title_search_condition(
-                db.get_database_backend(),
-                &locale,
-                search,
-            ));
-        }
-
-        let total = query.clone().count(db).await?;
-        let products = query
-            .order_by_desc(product::Column::CreatedAt)
-            .offset(offset)
-            .limit(per_page)
-            .all(db)
-            .await?;
-
-        let items = load_product_list_items(
-            db,
-            event_bus,
-            tenant_id,
-            products,
-            &locale,
-            tenant.default_locale.as_str(),
-            product_list_path("commerce.products"),
+        let request_context = ctx.data_opt::<RequestContext>();
+        let port_context = rustok_api::PortContext::new(
+            tenant_id.to_string(),
+            rustok_api::PortActor::user(auth.user_id.to_string()),
+            locale.as_str(),
+            format!("commerce-graphql-product:legacy-products:{page}:{per_page}"),
         )
-        .await?;
+        .with_deadline(std::time::Duration::from_secs(2));
+        let port_context = match request_context.and_then(|context| context.channel_slug.as_deref()) {
+            Some(channel) => port_context.with_channel(channel),
+            None => port_context,
+        };
+        let product_read_runtime =
+            crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+                db.clone(),
+                event_bus.clone(),
+            );
+        let products = product_read_runtime
+            .read_port()
+            .list_legacy_admin_products(
+                port_context.clone(),
+                rustok_product::LegacyAdminProductsRequest {
+                    locale: Some(locale),
+                    fallback_locale: Some(tenant.default_locale.clone()),
+                    search: filter.search,
+                    status: filter.status.map(Into::into),
+                    vendor: filter.vendor,
+                    page,
+                    per_page,
+                },
+            )
+            .await
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "legacy_products",
+                ))
+            })?;
+        let items = products
+            .items
+            .into_iter()
+            .map(|item| GqlProductListItem {
+                id: item.id,
+                status: item.status.into(),
+                title: item.title,
+                handle: item.handle,
+                seller_id: item.seller_id,
+                vendor: item.vendor,
+                product_type: item.product_type,
+                shipping_profile_slug: Some(
+                    item.shipping_profile_slug
+                        .as_deref()
+                        .and_then(crate::storefront_shipping::normalize_shipping_profile_slug)
+                        .unwrap_or_else(|| "default".to_string()),
+                ),
+                tags: item.tags,
+                created_at: item.created_at.to_rfc3339(),
+                published_at: item.published_at.map(|value| value.to_rfc3339()),
+            })
+            .collect::<Vec<_>>();
 
         metrics::record_read_path_budget(
             "graphql",
@@ -1583,10 +1633,10 @@ impl CommerceQuery {
 
         Ok(GqlProductList {
             items,
-            total,
+            total: products.total,
             page,
             per_page,
-            has_next: page * per_page < total,
+            has_next: page * per_page < products.total,
         })
     }
 

--- a/crates/rustok-product/src/ports.rs
+++ b/crates/rustok-product/src/ports.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     AdminProductList, AdminProductListQuery, StorefrontProductList, StorefrontProductListQuery,
+    StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 use crate::dto::ProductResponse;
 use crate::entities::product_variant;
@@ -17,6 +18,7 @@ const READ_VARIANT_PRODUCT_PROJECTION_OPERATION: &str = "read_variant_product_pr
 const LIST_PUBLISHED_PRODUCTS_OPERATION: &str = "list_published_products";
 const LIST_FILTERED_PUBLISHED_PRODUCTS_OPERATION: &str = "list_filtered_published_products";
 const LIST_ADMIN_PRODUCTS_OPERATION: &str = "list_admin_products";
+const LIST_LEGACY_ADMIN_PRODUCTS_OPERATION: &str = "list_legacy_admin_products";
 
 /// Transport-neutral owner boundary for product catalog read projections.
 #[async_trait]
@@ -69,6 +71,20 @@ pub trait ProductCatalogReadPort: Send + Sync {
             "product admin listing is unavailable",
         ))
     }
+
+    /// Optional compatibility projection for the mounted legacy admin GraphQL list.
+    /// Existing adapters remain source-compatible and fail closed until they explicitly
+    /// implement the exact legacy list semantics.
+    async fn list_legacy_admin_products(
+        &self,
+        _context: PortContext,
+        _request: LegacyAdminProductsRequest,
+    ) -> Result<AdminProductList, PortError> {
+        Err(PortError::unavailable(
+            "product.legacy_admin_list_unavailable",
+            "legacy product admin listing is unavailable",
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -115,6 +131,17 @@ pub struct AdminProductsRequest {
     /// Preserve the mounted legacy REST projection: empty missing titles and normalized
     /// shipping-profile metadata fallback. Owner-native callers leave this disabled.
     pub empty_missing_title: bool,
+    pub page: u64,
+    pub per_page: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyAdminProductsRequest {
+    pub locale: Option<String>,
+    pub fallback_locale: Option<String>,
+    pub search: Option<String>,
+    pub status: Option<crate::entities::product::ProductStatus>,
+    pub vendor: Option<String>,
     pub page: u64,
     pub per_page: u64,
 }
@@ -259,6 +286,52 @@ impl ProductCatalogReadPort for crate::CatalogService {
         .await
         .map_err(|error| product_error_to_port_error(&context, owner_operation, error))
     }
+
+    async fn list_legacy_admin_products(
+        &self,
+        context: PortContext,
+        request: LegacyAdminProductsRequest,
+    ) -> Result<AdminProductList, PortError> {
+        let owner_operation = LIST_LEGACY_ADMIN_PRODUCTS_OPERATION;
+        context
+            .require_policy(PortCallPolicy::read())
+            .map_err(|error| product_context_error(&context, owner_operation, error))?;
+        validate_legacy_admin_products_request(&context, owner_operation, &request)?;
+        let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
+        let LegacyAdminProductsRequest {
+            locale,
+            fallback_locale,
+            search,
+            status,
+            vendor,
+            page,
+            per_page,
+        } = request;
+        let locale = locale.as_deref().unwrap_or(context.locale.as_str());
+        let page = page.max(1);
+        self.list_admin_products_with_compatibility_query(
+            tenant_id,
+            locale,
+            fallback_locale.as_deref(),
+            AdminProductListQuery {
+                search,
+                status,
+                category_id: None,
+                sort_by: StorefrontProductSortBy::CreatedAt,
+                sort_direction: StorefrontProductSortDirection::Desc,
+                attribute_filters: Vec::new(),
+            },
+            page,
+            per_page,
+            None,
+            vendor.as_deref(),
+            None,
+            false,
+            true,
+        )
+        .await
+        .map_err(|error| product_error_to_port_error(&context, owner_operation, error))
+    }
 }
 
 fn validate_published_products_request(
@@ -315,6 +388,30 @@ fn validate_admin_products_request(
             operation = owner_operation,
             code = "product.per_page_invalid",
             "admin product page-size validation failed"
+        );
+        return Err(PortError::validation(
+            "product.per_page_invalid",
+            "admin products page size is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_legacy_admin_products_request(
+    context: &PortContext,
+    owner_operation: &'static str,
+    request: &LegacyAdminProductsRequest,
+) -> Result<(), PortError> {
+    if !(1..=MAX_ADMIN_PRODUCTS_PER_PAGE).contains(&request.per_page) {
+        tracing::warn!(
+            page = request.page,
+            per_page = request.per_page,
+            max_per_page = MAX_ADMIN_PRODUCTS_PER_PAGE,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation = owner_operation,
+            code = "product.per_page_invalid",
+            "legacy admin product page-size validation failed"
         );
         return Err(PortError::validation(
             "product.per_page_invalid",

--- a/scripts/verify/verify-commerce-product-admin-graphql-read.mjs
+++ b/scripts/verify/verify-commerce-product-admin-graphql-read.mjs
@@ -34,9 +34,13 @@ function resolverSlice(source, name, nextName) {
   return source.slice(start, end < 0 ? source.length : end);
 }
 
-const source = read("crates/rustok-commerce/src/graphql/product_catalog.rs");
-const admin = resolverSlice(source, "admin_product_catalog", null);
-const storefront = resolverSlice(source, "storefront_product_catalog", "admin_product_catalog");
+const catalogSource = read("crates/rustok-commerce/src/graphql/product_catalog.rs");
+const admin = resolverSlice(catalogSource, "admin_product_catalog", null);
+const storefront = resolverSlice(
+  catalogSource,
+  "storefront_product_catalog",
+  "admin_product_catalog",
+);
 
 for (const required of [
   "let auth = require_commerce_permission(",
@@ -54,11 +58,10 @@ for (const required of [
   "vendor: None",
   "product_type: None",
   "empty_missing_title: false",
-  "admin_product_catalog_port_error(&port_context, error)",
+  "product_catalog_port_error(&port_context, error, \"admin_product_catalog\")",
 ]) {
   requireText(admin, required, `admin Product catalog resolver must contain ${required}`);
 }
-
 for (const forbidden of [
   "CatalogService::new",
   ".list_admin_products_with_query(",
@@ -69,26 +72,103 @@ for (const forbidden of [
 }
 
 for (const required of [
+  "require_storefront_channel_enabled(ctx)",
+  "PortActor::service(\"commerce-storefront-graphql\")",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".list_filtered_published_products(",
+  "rustok_product::FilteredPublishedProductsRequest",
+  "product_catalog_port_error(&port_context, error, \"storefront_product_catalog\")",
+]) {
+  requireText(storefront, required, `storefront Product catalog resolver must contain ${required}`);
+}
+for (const forbidden of ["CatalogService::new", "product::Entity::find"]) {
+  forbidText(
+    storefront,
+    forbidden,
+    `storefront Product catalog resolver must not contain ${forbidden}`,
+  );
+}
+
+for (const required of [
   '"PRODUCT_VALIDATION"',
   '"PRODUCT_NOT_FOUND"',
   '"PRODUCT_TEMPORARILY_UNAVAILABLE"',
   '"PRODUCT_OPERATION_FAILED"',
   'extensions.set("correlation_id", context.correlation_id.to_string())',
 ]) {
-  requireText(source, required, `Product GraphQL PortError mapper must contain ${required}`);
+  requireText(catalogSource, required, `Product GraphQL PortError mapper must contain ${required}`);
 }
 for (const forbidden of [
   "Error::new(error.message)",
   'extensions.set("message", error.message)',
 ]) {
-  forbidText(source, forbidden, `Product GraphQL owner errors must not expose ${forbidden}`);
+  forbidText(catalogSource, forbidden, `Product GraphQL owner errors must not expose ${forbidden}`);
 }
 
-requireText(
-  storefront,
+const legacySource = read("crates/rustok-commerce/src/graphql/query.rs");
+const legacyProduct = resolverSlice(legacySource, "product", "products");
+for (const required of [
+  "let auth = require_commerce_permission(",
+  "product_query_tenant(ctx, tenant_id)",
+  "super::require_storefront_channel_enabled(ctx)",
+  "rustok_api::PortActor::user(auth.user_id.to_string())",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".read_port()",
+  ".read_product_projection(",
+  "rustok_product::ProductProjectionRequest",
+  "PortErrorKind::NotFound",
+  "product_catalog_port_error(",
+  "localized_product_response(",
+]) {
+  requireText(legacyProduct, required, `legacy product resolver must contain ${required}`);
+}
+for (const forbidden of ["CatalogService::new", ".get_product_with_locale_fallback("]) {
+  forbidText(legacyProduct, forbidden, `legacy product resolver must not contain ${forbidden}`);
+}
+
+const legacyProducts = resolverSlice(legacySource, "products", "product_attributes");
+for (const required of [
+  "let auth = require_commerce_permission(",
+  "product_query_tenant(ctx, tenant_id)",
+  "rustok_api::PortActor::user(auth.user_id.to_string())",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".list_legacy_admin_products(",
+  "rustok_product::LegacyAdminProductsRequest",
+  "status: filter.status.map(Into::into)",
+  "vendor: filter.vendor",
+  "product_catalog_port_error(",
+  "normalize_shipping_profile_slug",
+  'unwrap_or_else(|| "default".to_string())',
+  'metrics::record_read_path_budget(\n            "graphql",\n            "commerce.products"',
+]) {
+  requireText(legacyProducts, required, `legacy products resolver must contain ${required}`);
+}
+for (const forbidden of [
+  "product::Entity::find",
+  "product_translation_title_search_condition(",
+  "load_product_list_items(",
   "CatalogService::new",
-  "storefront Product catalog must remain explicit follow-up debt in this slice",
-);
+]) {
+  forbidText(legacyProducts, forbidden, `legacy products resolver must not contain ${forbidden}`);
+}
+
+const ports = read("crates/rustok-product/src/ports.rs");
+for (const required of [
+  "async fn list_legacy_admin_products(",
+  "pub struct LegacyAdminProductsRequest",
+  '"product.legacy_admin_list_unavailable"',
+  "LIST_LEGACY_ADMIN_PRODUCTS_OPERATION",
+  "validate_legacy_admin_products_request(",
+  "StorefrontProductSortBy::CreatedAt",
+  "StorefrontProductSortDirection::Desc",
+  "vendor.as_deref()",
+  "false,\n            true,",
+]) {
+  requireText(ports, required, `Product legacy admin read contract must contain ${required}`);
+}
 
 const runtime = read("crates/rustok-commerce/src/graphql_runtime.rs");
 for (const required of [


### PR DESCRIPTION
## Summary

- publish optional fail-closed `ProductCatalogReadPort::list_legacy_admin_products` / `LegacyAdminProductsRequest` so existing remote/test adapters remain source-compatible
- implement the in-process compatibility projection through Product's existing owner admin query path with exact legacy GraphQL status/vendor/search filtering, `CreatedAt DESC`, clamped pagination, `Untitled product`, metadata-aware shipping-profile fallback, tags, and projection semantics
- cut mounted legacy admin GraphQL `product` to host-selected `ProductCatalogReadPort::read_product_projection`, preserving tenant/permission/storefront-channel admission, authenticated actor, locale fallback, request channel/deadline, stable errors, and `NotFound -> null`
- cut mounted legacy admin GraphQL `products` to the new optional owner capability while preserving telemetry and response shape
- actualize the Product admin GraphQL source guard, canonical ecommerce plan, and Product recheck packet
- keep legacy `storefrontProduct` / `storefrontProducts`, Product writes, and lifecycle operations explicitly open; no FBA/FFA status promotion is claimed

## Verification

Not run per maintainer instruction. No tests, checks, formatter, runtime verification, or FBA/FFA promotion was performed in this PR. Source/diff inspection only.