### PR TITLE
feat(product): resolve Storefront filters to canonical terms

### DIFF
--- a/crates/rustok-distribution/src/product_index/attribute_terms.rs
+++ b/crates/rustok-distribution/src/product_index/attribute_terms.rs
@@ -1,13 +1,14 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use rustok_index::{FieldName, FieldPath, FilterExpr, IndexValue, LocaleKey};
-use thiserror::Error;
 use uuid::Uuid;
+
+pub(crate) use rustok_product::ProductAttributeTermError;
 
 pub(crate) const PRODUCT_ATTRIBUTE_TERMS_FIELD: &str = "attribute_terms";
 
 /// PostgreSQL CTE fragment used by the replacement Product source to materialize every active,
-/// Product-scoped, filterable EAV value into the same canonical term grammar produced below in Rust.
+/// Product-scoped, filterable EAV value into the Product-owned canonical term grammar.
 ///
 /// The fragment is tenant-scoped by `$1` and intentionally aggregates terms by Product rather than by
 /// Product translation locale. Localized text terms carry their own canonical locale identity, so one
@@ -156,19 +157,11 @@ product_attribute_terms AS (
 )
 "#;
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub(crate) enum ProductAttributeTermError {
-    #[error("Product attribute term attribute id must not be nil")]
-    NilAttributeId,
-    #[error("Product attribute term option id must not be nil")]
-    NilOptionId,
-}
-
 pub(crate) fn text_term(
     attribute_id: Uuid,
     value: &str,
 ) -> Result<String, ProductAttributeTermError> {
-    term(attribute_id, "text", None, value)
+    rustok_product::product_attribute_text_term(attribute_id, value)
 }
 
 pub(crate) fn localized_text_term(
@@ -176,79 +169,56 @@ pub(crate) fn localized_text_term(
     locale: &LocaleKey,
     value: &str,
 ) -> Result<String, ProductAttributeTermError> {
-    term(attribute_id, "localized_text", Some(locale), value)
+    rustok_product::product_attribute_localized_text_term(attribute_id, locale.as_str(), value)
 }
 
 pub(crate) fn localized_presence_term(
     attribute_id: Uuid,
     locale: &LocaleKey,
 ) -> Result<String, ProductAttributeTermError> {
-    term(attribute_id, "localized_present", Some(locale), "")
+    rustok_product::product_attribute_localized_presence_term(attribute_id, locale.as_str())
 }
 
 pub(crate) fn integer_term(
     attribute_id: Uuid,
     value: i64,
 ) -> Result<String, ProductAttributeTermError> {
-    term(attribute_id, "integer", None, value.to_string().as_str())
+    rustok_product::product_attribute_integer_term(attribute_id, value)
 }
 
 pub(crate) fn decimal_term(
     attribute_id: Uuid,
     value: Decimal,
 ) -> Result<String, ProductAttributeTermError> {
-    term(
-        attribute_id,
-        "decimal",
-        None,
-        value.normalize().to_string().as_str(),
-    )
+    rustok_product::product_attribute_decimal_term(attribute_id, value)
 }
 
 pub(crate) fn boolean_term(
     attribute_id: Uuid,
     value: bool,
 ) -> Result<String, ProductAttributeTermError> {
-    term(
-        attribute_id,
-        "boolean",
-        None,
-        if value { "true" } else { "false" },
-    )
+    rustok_product::product_attribute_boolean_term(attribute_id, value)
 }
 
 pub(crate) fn date_term(
     attribute_id: Uuid,
     value: NaiveDate,
 ) -> Result<String, ProductAttributeTermError> {
-    term(
-        attribute_id,
-        "date",
-        None,
-        value.format("%Y-%m-%d").to_string().as_str(),
-    )
+    rustok_product::product_attribute_date_term(attribute_id, value)
 }
 
 pub(crate) fn datetime_term(
     attribute_id: Uuid,
     value: DateTime<Utc>,
 ) -> Result<String, ProductAttributeTermError> {
-    term(
-        attribute_id,
-        "datetime",
-        None,
-        value.timestamp_micros().to_string().as_str(),
-    )
+    rustok_product::product_attribute_datetime_term(attribute_id, value)
 }
 
 pub(crate) fn option_term(
     attribute_id: Uuid,
     option_id: Uuid,
 ) -> Result<String, ProductAttributeTermError> {
-    if option_id.is_nil() {
-        return Err(ProductAttributeTermError::NilOptionId);
-    }
-    term(attribute_id, "option", None, option_id.to_string().as_str())
+    rustok_product::product_attribute_option_term(attribute_id, option_id)
 }
 
 pub(crate) fn contains_term_filter(term: String) -> FilterExpr {
@@ -256,7 +226,6 @@ pub(crate) fn contains_term_filter(term: String) -> FilterExpr {
 }
 
 /// Reproduces the owner localized-text predicate exactly:
-///
 /// requested-value OR (requested-locale-absent AND fallback-value).
 pub(crate) fn localized_text_filter(
     attribute_id: Uuid,
@@ -295,33 +264,12 @@ fn attribute_terms_path() -> FieldPath {
     )
 }
 
-fn term(
-    attribute_id: Uuid,
-    kind: &str,
-    locale: Option<&LocaleKey>,
-    value: &str,
-) -> Result<String, ProductAttributeTermError> {
-    if attribute_id.is_nil() {
-        return Err(ProductAttributeTermError::NilAttributeId);
-    }
-    let locale = locale
-        .map(|locale| hex::encode(locale.as_str().as_bytes()))
-        .unwrap_or_default();
-    Ok(format!(
-        "{}|{}|{}|{}",
-        attribute_id,
-        kind,
-        locale,
-        hex::encode(value.as_bytes())
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn scalar_terms_are_collision_safe_and_normalized() {
+    fn scalar_terms_are_product_owned_and_materialization_compatible() {
         let attribute_id = Uuid::from_u128(1);
         assert_eq!(
             text_term(attribute_id, "A|b").unwrap(),

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,107 +1,53 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay continued from `main@500c6f647b5f09f617cb907a43093e4f954b3fed` (#3220) on
-`agent/index-localized-identity-order-20260808`.
+Status overlay rechecked after Product Storefront shadow adapter merge `4e9e032e11848db91ad4f837937c0de8ca3a7eaf` and continued on
+`agent/product-storefront-filter-terms-20260808`.
 
-`implementation-plan.md` remains historical architecture context. This file is the current execution
-cursor.
-
-## Recheck result
-
-The Product/Index Storefront sequence now includes:
-
-- #3199: one current 15-field Product contract on internal routing key `4`;
-- #3200: owner all-translations title search and requested -> fallback projection mismatch documented;
-- #3204: generic localized-entity identity-fold architecture selected;
-- #3208: explicit localized query validation and dedicated cursor identity;
-- #3210: root-only PostgreSQL localized identity-fold page/count compiler and decoder;
-- #3212: canonical PostgreSQL localized runtime with persisted readiness, generic admission and one
-  read-only repeatable-read page/count snapshot;
-- #3220: generic bounded scalar String `TextLike` with PostgreSQL/reference wildcard semantics.
-
-The adapter recheck after #3220 found one additional query-order mismatch before Product translation can be
-claimed: owner descending Storefront order uses both timestamp DESC and Product ID DESC, while the
-localized compiler still used a fixed root entity-ID ASC tie-break. This slice closes that localized-only
-gap without changing ordinary exact-locale `IndexQuery` semantics.
+`implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
 ## Current primary owner gate
 
 `M6 - execute and admit concrete repair PostgreSQL evidence`
 
-The repair implementation/harness/admission source remains complete. Maintainer execution/admission is
-still required and is not claimed by source inspection.
+Repair implementation/harness/admission source remains complete. Maintainer execution/admission is still
+required and is not claimed by source inspection.
 
-## Current Product/Storefront source state
+## M7 Product Storefront source state
 
-Current Product facts remain:
+Source-complete:
 
-- one current Product schema, routing key `4`; lower keys are historical only;
-- 15 Product fields including Storefront scalars, `attribute_terms`, `variant_ids` and
-  `sales_channel_ids`;
-- Product replay IDs are schema-scoped;
-- EAV writes advance the canonical Product owner clock;
-- Product root freshness and ordinary linked-target availability remain fail-closed;
-- Product channel visibility convergence materializes resolved current channel UUID membership under a
-  freshness witness.
+- one current 15-field Product schema on routing key `4`; lower keys historical only;
+- schema-scoped Product replay IDs, Product owner clock and canonical typed `attribute_terms`;
+- Product channel relation/freshness materialization;
+- localized entity identity fold, scoped cursor v3 and requested -> fallback projection;
+- localized PostgreSQL compiler/decoder/runtime with persisted readiness, generic admission and one
+  `REPEATABLE READ, READ ONLY` page/count snapshot;
+- bounded generic String `TextLike` for all-translations title matching;
+- localized Product-ID tie-break direction matching owner Asc/Desc ordering;
+- pure crate-local Product Storefront shadow query builder;
+- Product-owned public Storefront attribute-filter -> canonical term resolution capability.
 
-## Localized query/runtime state
+The Product-owned resolver now centralizes typed filter parsing used by the owner SQL path and exposes
+neutral `ProductAttributeTermExpr` values through optional `ProductCatalogSchemaReadPort` capability.
+Select/Multiselect option codes resolve to current active Product option UUIDs; UUID inputs keep owner
+identity semantics; missing option code/nil UUID becomes `Never` and therefore preserves owner empty-result
+behavior. Distribution Rust term helpers delegate canonical term identity to Product.
 
-Source-complete capabilities now include:
+## Remaining Storefront parity blockers
 
-- `LocalizedEntityQuery` requested/fallback roles, `any_locale_filter` and
-  `localized_projection_fields`;
-- localized cursor wire version `3`, separate from ordinary wire version `2`;
-- root-only identity fold over physical locale rows;
-- requested -> fallback -> null projection;
-- group-before-order/page/count semantics;
-- generic owner admission on all participating physical row roles;
-- persisted schema readiness plus one `REPEATABLE READ, READ ONLY` page/count snapshot;
-- generic bounded scalar String `TextLike` for ordinary and folded filters;
-- explicit localized `identity_order_direction` for the final root entity-ID tie-break.
-
-`identity_order_direction` defaults to `Asc`, validates only `Asc|Desc`, is bound into localized cursor and
-plan fingerprints, and changes only the localized final identity term:
-
-- Asc: `entity_id ASC`, continuation `entity_id > cursor`;
-- Desc: `entity_id DESC`, continuation `entity_id < cursor`.
-
-Ordinary `IndexQuery` and its existing ascending entity-ID tie-break remain unchanged.
-
-## Product adapter blockers discovered during source recheck
-
-The next Product Storefront adapter remains fail-closed on three explicit parity gaps:
-
-1. **Search length** — owner search has no explicit length bound; `TextLike` is capped at 1024 UTF-8
-   bytes. The adapter must not silently truncate or reject owner-valid search without a reviewed owner/API
-   bound.
-2. **Search collation** — owner title `LIKE` uses deployment/default collation while Index String scalar
-   SQL uses deterministic `COLLATE "C"`; retained PostgreSQL evidence must establish the admitted contract.
-3. **Channel-less visibility** — owner list requests without a public channel admit only metadata-
-   unrestricted Products. Current `sales_channel_ids` represents unrestricted as membership in all current
-   channels and therefore cannot distinguish unrestricted from a restricted Product that currently
-   contains every channel. A channel-less authoritative adapter must fail closed until that distinction is
-   materialized or supplied by an owner capability.
-
-For a request carrying a trusted current public channel ID, `Contains(sales_channel_ids, channel_id)` is the
-intended root membership predicate under the existing channel resolver/freshness contract.
+- owner title search has no explicit length bound vs Index `TextLike` 1024-byte bound;
+- owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`;
+- channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
+- owner page depth exceeds Index bounded offset depth;
+- localized Taxonomy tag names must be hydrated after Product page identity/count is fixed.
 
 ## Retained Product evidence debt
 
-Historical PostgreSQL packets still need mechanical actualization to routing key `4` / the current
-15-field Product contract. Do not add a runtime alias for key `3`.
-
-The localized Storefront equivalence packet must additionally cover:
-
-- requested present / fallback / neither requested nor fallback;
-- any-locale title matches, including third-locale matches;
-- `%`, `_` and escaped wildcard behavior;
-- duplicate locale matches yielding one Product identity and count;
-- equal-timestamp ordering under both ascending and descending Product-ID tie-breaks;
-- cursor continuation across those ties;
-- EAV terms, category and public channel visibility;
-- stale locale exclusion/readiness/admission/restart;
-- search-bound/collation behavior;
-- current Product routing key promotion.
+Historical PostgreSQL packets must be actualized to routing key `4` / current 15-field Product contract;
+never add a key-3 runtime alias. Localized Storefront retained equivalence must cover requested/fallback/
+third-locale projection and search, wildcard behavior, scalar and localized EAV terms, Select/Multiselect
+option code and UUID inputs, missing option behavior, channel membership, equal timestamp Asc/Desc ties,
+pagination/count, stale locale exclusion, readiness/admission and restart.
 
 ## M5 incremental ingestion
 
@@ -126,20 +72,19 @@ The localized Storefront equivalence packet must additionally cover:
 - [x] Current Product/ProductVariant/SalesChannel sources and graph freshness.
 - [x] One current 15-field Product contract and schema-safe replacement mechanism.
 - [x] Canonical typed EAV terms and Product owner clock.
-- [x] Localized identity/fallback architecture.
-- [x] Localized query/cursor contract.
-- [x] Localized PostgreSQL compiler/decoder.
-- [x] Localized production runtime with readiness/admission/snapshot semantics.
+- [x] Localized identity/fallback architecture and query/cursor contract.
+- [x] Localized PostgreSQL compiler/decoder/runtime.
 - [x] Generic scalar String `TextLike`.
 - [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
-- [ ] Implement Product Storefront Index shadow/evidence adapter.
-- [ ] Resolve search-length/collation parity.
-- [ ] Resolve channel-less unrestricted visibility parity.
-- [ ] Resolve Product attribute option-code metadata through an owner capability and emit canonical
-  `attribute_terms`.
+- [x] Product Storefront Index shadow/evidence query builder.
+- [x] Product-owned Storefront attribute-filter resolution to neutral canonical term expressions.
+- [ ] Wire Product term expressions into the shadow builder/executor.
+- [ ] Retain owner-vs-Index localized PostgreSQL equivalence packet.
+- [ ] Resolve/admit search-length and collation parity.
+- [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
+- [ ] Decide authoritative deep-page policy.
 - [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
 - [ ] Actualize retained Product PostgreSQL packets to routing key `4`.
-- [ ] Retain owner-vs-Index localized PostgreSQL equivalence packet.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
@@ -147,28 +92,10 @@ The localized Storefront equivalence packet must additionally cover:
 
 ## Next source-code step
 
-Build the Product Storefront **shadow/evidence adapter**, not a traffic switch. It should translate only
-inputs whose parity is already representable and fail closed for unresolved search/channel cases. The
-adapter must map owner sort direction to both timestamp ordering and localized identity tie-break direction,
-resolve Product EAV metadata through Product-owned capabilities, and leave Taxonomy hydration after page
-selection.
-
-In parallel, actualize historical Product PostgreSQL packets to routing key `4` / current 15-field source.
-
-## Maintainer verification after this slice
-
-The implementation agent has not run these commands. Maintainer verification should include:
-
-```bash
-node scripts/verify/verify-index-localized-identity-order.mjs
-node scripts/verify/verify-index-localized-query-contract.mjs
-node scripts/verify/verify-index-localized-query-postgres-fold.mjs
-node scripts/verify/verify-index-localized-query-runtime.mjs
-node scripts/verify/verify-index-text-like-filter.mjs
-node scripts/verify/verify-index-query-contract.mjs
-cargo check -p rustok-index --all-targets
-git diff --check
-```
+Build a non-serving **shadow executor/equivalence boundary**. It should retrieve the host-selected Product
+schema read port, resolve owner EAV inputs there, translate `ProductAttributeTermExpr` into Index root
+predicates, execute through `execute_localized_query`, and retain owner-vs-Index evidence without changing
+mounted Storefront behavior. Taxonomy hydration stays after Product page selection.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,139 +1,90 @@
 # M7 Product Storefront Index parity gate
 
-Status: `shadow_query_adapter_source_complete_owner_resolution_and_evidence_pending`.
+Status: `shadow_query_and_product_owned_eav_resolution_source_complete_execution_evidence_pending`.
 
-## Purpose
+## Current boundary
 
-The mounted Product Storefront catalog remains owner-native and must continue to execute
-`CatalogService::list_published_products_with_query`.
+Mounted Storefront remains owner-native and continues to execute
+`CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
-The Index side is now source-complete through localized identity folding, bounded `TextLike`, explicit
-Asc/Desc Product-ID tie-break direction, PostgreSQL runtime execution, and a **pure shadow/evidence query
-builder** in `rustok-distribution`. That builder translates only owner inputs whose semantics are already
-representable. It is not wired to Storefront traffic and does not execute Index queries itself.
+The Index-side shadow query builder is source-complete, and Product now owns the missing public
+Storefront attribute-filter resolution capability. The next slice is shadow execution/equivalence, not
+consumer cutover.
 
-## Owner contract still authoritative
+## Product-owned attribute-filter resolution — source complete
 
-The owner list enforces tenant scope, Active status, non-null `published_at`, Product channel visibility,
-optional primary category, typed Product EAV filters, all-translations title `LIKE`, exact count,
-requested/fallback Product translation projection, localized Taxonomy tag names and stable ordering.
+`ProductCatalogSchemaReadPort` now exposes optional
+`resolve_storefront_attribute_filters`. Existing external adapters remain source-compatible because the
+default implementation fails closed with
+`product.storefront_attribute_filter_resolution_unavailable`.
 
-Owner ordering uses two timestamp terms plus Product ID in the same direction:
+The in-process Product implementation resolves each canonical `ProductAttributeFilter` using the same
+owner rules as the mounted SQL list path:
 
-- `published_at, created_at, id`; or
-- `created_at, published_at, id`.
+- at most eight filters, case-insensitive duplicate-code rejection and existing code/value bounds;
+- definition eligibility is tenant-scoped, active, filterable and `product|both` scope;
+- attribute lookup is case-insensitive by code;
+- text is exact value matching;
+- integer/decimal/boolean/date/datetime parsing is shared with the owner SQL condition builder;
+- localized text is represented as `requested-value OR (NOT requested-present AND fallback-value)`;
+- Select/Multiselect accepts a UUID directly or resolves an exact active option code to its option UUID;
+- missing option code and nil UUID resolve to neutral `ProductAttributeTermExpr::Never`, preserving the
+  owner SQL empty-result behavior rather than inventing a validation error;
+- JSON remains unsupported exactly as on the owner list path.
 
-The localized Index compiler now has an explicit `identity_order_direction`, so the shadow builder can map
-owner Asc/Desc to both timestamp terms and the final Product-ID tie-break.
+Product exports a neutral `ProductAttributeTermExpr` (`Term`, `And`, `Or`, `Not`, `Never`) and owns the
+canonical term grammar `attribute_uuid|kind|hex(locale)|hex(value)`. Product does not depend on
+`rustok-index`.
+
+`rustok-distribution` no longer owns a second Rust term encoder: its Product Index helpers delegate term
+identity to `rustok-product`. The PostgreSQL Product source CTE remains the materialization-side mirror of
+the same grammar.
 
 ## Shadow query adapter — source complete
 
-`crates/rustok-distribution/src/product_index/storefront_shadow.rs` owns
-`build_product_storefront_index_shadow_query`.
+`build_product_storefront_index_shadow_query` remains a pure crate-local translation into
+`LocalizedEntityQuery`. It maps Active/published-only, trusted public-channel membership, optional primary
+category, canonical `attribute_terms`, any-locale title `TextLike`, requested/fallback title+handle,
+paired timestamp order plus matching Product-ID tie-break, bounded offset pagination and exact count.
+It selects stable `tag_ids` for later Taxonomy hydration and uses only current Product routing key `4`.
 
-For currently representable requests it maps:
+The builder still does not execute Index queries, read Product EAV tables, hydrate Taxonomy names or mount
+Storefront traffic.
 
-- Product status -> `Eq(status, "active")`;
-- published-only -> `IsNull(published_at, false)`;
-- a trusted current public channel UUID -> `Contains(sales_channel_ids, channel_id)`;
-- optional primary category -> `Eq(primary_category_id, category_id)`;
-- Product-owned resolved EAV predicates -> canonical `attribute_terms` predicates only;
-- title search -> folded `TextLike(title, "%...%")` in `any_locale_filter`;
-- localized output -> requested/fallback `title` and `handle`;
-- owner public fields -> Product root projection including `tag_ids` for later Taxonomy hydration;
-- owner timestamp order -> the same two timestamp fields/direction;
-- owner Product-ID tie-break -> the same localized identity direction;
-- owner page/per-page -> bounded Index offset pagination;
-- exact count -> enabled.
+## Remaining fail-closed parity gates
 
-The builder points only at the current Product routing key `4`. It is crate-visible for retained evidence
-harnesses, not public API.
+1. Owner title search has no explicit length bound while Index `TextLike` is bounded to 1024 UTF-8 bytes.
+2. Owner title `LIKE` uses deployment/default collation while Index String SQL uses deterministic
+   `COLLATE "C"`.
+3. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot
+   distinguish unrestricted from restricted-to-all-current-channels.
+4. Owner page depth is wider than the Index 10,000 offset bound.
+5. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
 
-## Pure boundary: no owner bypass
+## Next source slice
 
-The shadow builder does not import or construct `DatabaseConnection`, `CatalogService`,
-`ProductCatalogSchemaService`, Product EAV tables, or the Index execution runtime. It only converts an
-already validated owner query plus Product-owned resolved canonical EAV predicates into
-`LocalizedEntityQuery`.
+Compose a **shadow executor/equivalence harness** that:
 
-This is intentional. Product attribute definitions can already be read through
-`ProductCatalogSchemaReadPort`, but current owner read capabilities do not expose the option-code/option-ID
-resolution required to reproduce Select/Multiselect filters without direct Product table access.
+- obtains `ProductCatalogSchemaReadPort` from the host-selected Product read runtime;
+- resolves public EAV filters through `resolve_storefront_attribute_filters`;
+- translates neutral Product term expressions into canonical Index `attribute_terms` filters;
+- executes only through `execute_localized_query` with existing readiness/admission/snapshot semantics;
+- retains owner and Index results side-by-side without serving Index output to Storefront;
+- batch-hydrates Taxonomy tags only after the Product page is fixed;
+- records PostgreSQL equivalence across requested/fallback/third-locale search, EAV option code/UUID,
+  localized EAV fallback, channel membership, Asc/Desc equal timestamps, count, pagination, stale rows and
+  restart/readiness cases.
 
-The next Product-owned capability must resolve each public `ProductAttributeFilter` into the same canonical
-Index term predicate used by the Product source. Only then may the shadow executor compose metadata
-resolution with this query builder.
-
-## Explicit fail-closed parity gaps
-
-The builder refuses to pretend parity where the owner contract is wider than the current Index query
-contract:
-
-1. **Channel-less visibility** — owner `None` channel means metadata-unrestricted only. Current
-   `sales_channel_ids` materializes unrestricted as membership in all current channels, so it cannot
-   distinguish unrestricted from a restricted Product that currently contains every channel. A public
-   channel UUID is therefore mandatory for the shadow builder.
-2. **Deep page offsets** — owner page is not upper-bounded, while Index offset depth is capped at 10,000.
-   The builder returns `OffsetTooDeep` instead of silently changing the page.
-3. **Search length** — owner search has no explicit length bound; `TextLike` is capped at 1024 UTF-8 bytes.
-   The builder rejects an over-bound pattern rather than truncating it.
-4. **Search collation** — owner title `LIKE` uses deployment/default collation while Index String SQL uses
-   deterministic `COLLATE "C"`. Source inspection does not claim equivalence.
-5. **Public EAV option resolution** — Select/Multiselect public option codes still require a Product-owned
-   code-to-ID resolver before canonical `attribute_terms` can be built.
-
-These are evidence/capability gates, not reasons to weaken the owner contract.
-
-## Taxonomy boundary
-
-Product Index stores stable `tag_ids`, not localized Taxonomy names. The shadow query selects those IDs,
-but localized Taxonomy hydration remains a separate post-page owner boundary. Product page selection must
-be fixed before tag-name hydration so Taxonomy work cannot change Product pagination or exact count.
-
-## Current routing/replacement boundary
-
-Product runtime still publishes exactly one current 15-field Product schema on internal routing key `4`.
-Lower persisted Product keys remain historical only. Do not add a key-3 compatibility implementation to
-make retained evidence pass.
-
-## Remaining work before traffic cutover
-
-1. add Product-owned canonical Storefront attribute-filter resolution, including option-code -> option-ID;
-2. compose a shadow executor over that resolver + `execute_localized_query` without mounting it in
-   Storefront traffic;
-3. add retained owner-vs-Index PostgreSQL equivalence for requested/fallback/third-locale projection,
-   title wildcard behavior, category, EAV, channel membership, Asc/Desc equal-timestamp ties, pagination,
-   exact count, stale locale exclusion, readiness and restart;
-4. resolve/admit search-length and collation parity;
-5. resolve channel-less unrestricted visibility or keep that request shape owner-native;
-6. decide the authoritative policy for owner pages beyond the Index offset bound;
-7. batch-hydrate localized Taxonomy tags after the shadow Product page;
-8. actualize historical Product PostgreSQL packets to routing key `4` / current 15-field contract;
-9. execute/admit current replacement evidence and stage/rebuild/promote Product key `4`;
-10. only then consider Storefront traffic selection.
+Historical Product PostgreSQL packets still need routing key `4` / current 15-field actualization. Do not
+add a key-3 runtime compatibility path.
 
 ## Source guards
 
-- `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native;
-- `verify-index-product-storefront-localized-query-architecture.mjs` locks fold/search/order semantics;
+- `verify-product-storefront-attribute-filter-terms.mjs` locks Product ownership, shared typed parsing,
+  option resolution, neutral expression shape and distribution delegation;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks the pure fail-closed shadow translation;
-- `verify-index-localized-query-runtime.mjs` locks readiness/admission/one-snapshot execution;
-- `verify-index-localized-identity-order.mjs` locks owner-compatible Product-ID tie-break direction;
-- `verify-index-text-like-filter.mjs` locks generic bounded LIKE semantics.
-
-## Maintainer verification
-
-```bash
-node scripts/verify/verify-index-product-storefront-shadow-adapter.mjs
-node scripts/verify/verify-index-product-storefront-parity-gate.mjs
-node scripts/verify/verify-index-product-storefront-localized-query-architecture.mjs
-node scripts/verify/verify-index-localized-query-runtime.mjs
-node scripts/verify/verify-index-localized-identity-order.mjs
-node scripts/verify/verify-index-text-like-filter.mjs
-node scripts/verify/verify-index-query-contract.mjs
-cargo check -p rustok-distribution --features mod-product --all-targets
-git diff --check
-```
+- `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native;
+- localized runtime/order/TextLike guards continue to lock the generic Index execution contract.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-product/src/catalog_schema_read_port.rs
+++ b/crates/rustok-product/src/catalog_schema_read_port.rs
@@ -5,9 +5,9 @@ use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
 use uuid::Uuid;
 
 use crate::services::{
-    AttributeValueType, CatalogCategoryListRecord, EffectiveAttributeSource,
+    AttributeValueType, CatalogCategoryListRecord, EffectiveAttributeSource, ProductAttributeFilter,
     ProductAttributeListRecord, ProductAttributeOptionListRecord, ProductAttributeSchemaListRecord,
-    ProductAttributeValueRecord, ProductCatalogSchemaService,
+    ProductAttributeValueRecord, ProductCatalogSchemaService, ProductResolvedAttributeFilter,
 };
 
 const LIST_ATTRIBUTES_OPERATION: &str = "list_catalog_attributes";
@@ -15,6 +15,8 @@ const LIST_CATEGORIES_OPERATION: &str = "list_catalog_categories";
 const LIST_SCHEMAS_OPERATION: &str = "list_attribute_schemas";
 const READ_EFFECTIVE_FORM_OPERATION: &str = "read_effective_product_form";
 const READ_PRODUCT_ATTRIBUTE_VALUES_OPERATION: &str = "read_product_attribute_values";
+const RESOLVE_STOREFRONT_ATTRIBUTE_FILTERS_OPERATION: &str =
+    "resolve_storefront_attribute_filters";
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -56,8 +58,14 @@ pub struct ProductAttributeValuesRequest {
     pub product_id: Uuid,
 }
 
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProductStorefrontAttributeFilterResolutionRequest {
+    pub fallback_locale: String,
+    pub filters: Vec<ProductAttributeFilter>,
+}
+
 /// Optional Product-owned read boundary for catalog schema directory, effective-form,
-/// and product attribute-value projections.
+/// product attribute-value projections, and Storefront attribute-filter resolution.
 #[async_trait]
 pub trait ProductCatalogSchemaReadPort: Send + Sync {
     async fn list_attributes(
@@ -98,6 +106,19 @@ pub trait ProductCatalogSchemaReadPort: Send + Sync {
         Err(PortError::unavailable(
             "product.attribute_values_unavailable",
             "product attribute values are unavailable",
+        ))
+    }
+
+    /// Optional Product-owned Storefront filter resolver. Consumers receive canonical Product term
+    /// expressions and never resolve attribute/option storage identities themselves.
+    async fn resolve_storefront_attribute_filters(
+        &self,
+        _context: PortContext,
+        _request: ProductStorefrontAttributeFilterResolutionRequest,
+    ) -> Result<Vec<ProductResolvedAttributeFilter>, PortError> {
+        Err(PortError::unavailable(
+            "product.storefront_attribute_filter_resolution_unavailable",
+            "product storefront attribute filter resolution is unavailable",
         ))
     }
 }
@@ -269,6 +290,25 @@ impl ProductCatalogSchemaReadPort for ProductCatalogSchemaService {
             tenant_id,
             request.product_id,
             context.locale.as_str(),
+        )
+        .await
+        .map_err(|error| schema_error_to_port_error(&context, owner_operation, error))
+    }
+
+    async fn resolve_storefront_attribute_filters(
+        &self,
+        context: PortContext,
+        request: ProductStorefrontAttributeFilterResolutionRequest,
+    ) -> Result<Vec<ProductResolvedAttributeFilter>, PortError> {
+        let owner_operation = RESOLVE_STOREFRONT_ATTRIBUTE_FILTERS_OPERATION;
+        require_schema_read_context(&context, owner_operation)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        ProductCatalogSchemaService::resolve_storefront_attribute_filter_terms(
+            self,
+            tenant_id,
+            context.locale.as_str(),
+            request.fallback_locale.as_str(),
+            request.filters.as_slice(),
         )
         .await
         .map_err(|error| schema_error_to_port_error(&context, owner_operation, error))

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -31,6 +31,7 @@ pub use catalog_schema_read_port::{
     ProductAttributeValuesRequest, ProductCatalogSchemaReadPort,
     ProductEffectiveFormAttributeProjection, ProductEffectiveFormProjection,
     ProductEffectiveFormRequest, ProductEffectiveFormSubject,
+    ProductStorefrontAttributeFilterResolutionRequest,
 };
 pub use error::{CommerceError, CommerceResult};
 pub use ports::*;
@@ -45,13 +46,14 @@ pub use services::{
     MAX_PRODUCT_SALES_CHANNEL_CONVERGENCE_ERROR_BYTES,
     MAX_PRODUCT_SALES_CHANNEL_RELATION_CHANNELS, MAX_PRODUCT_SALES_CHANNEL_RELATION_PAGE,
     MAX_PRODUCT_SALES_CHANNEL_RELATION_TARGETS, MAX_PRODUCT_SALES_CHANNEL_VISIBILITY_KEY_BYTES,
-    ProductAttributeFilter, ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord,
-    ProductIndexLocaleRefreshSource, ProductIndexRefreshCanonicalWriter, ProductIndexRefreshContract,
+    ProductAttributeFilter, ProductAttributeTermError, ProductAttributeTermExpr,
+    ProductCatalogSchemaService, ProductIndexLocaleRefreshRecord, ProductIndexLocaleRefreshSource,
+    ProductIndexRefreshCanonicalWriter, ProductIndexRefreshContract,
     ProductIndexRefreshContractTarget, ProductIndexRefreshEventFactory,
     ProductIndexRefreshPublicationError, ProductIndexRefreshRelayError,
     ProductIndexRefreshRelayStep, ProductIndexRefreshRelayStepOutcome,
     ProductIndexVariantRefreshRecord, ProductIndexVariantRefreshSource,
-    ProductSalesChannelIndexRelationConvergenceClaim,
+    ProductResolvedAttributeFilter, ProductSalesChannelIndexRelationConvergenceClaim,
     ProductSalesChannelIndexRelationConvergenceClaimOutcome,
     ProductSalesChannelIndexRelationConvergenceError,
     ProductSalesChannelIndexRelationConvergenceStore,
@@ -61,7 +63,11 @@ pub use services::{
     ProductSalesChannelIndexRelationFreshnessWriteOutcome, ProductSalesChannelIndexRelationRecord,
     ProductSalesChannelIndexRelationStore, ProductSalesChannelIndexRelationWriteOutcome,
     StorefrontProductList, StorefrontProductListItem, StorefrontProductListQuery,
-    StorefrontProductSortBy, StorefrontProductSortDirection,
+    StorefrontProductSortBy, StorefrontProductSortDirection, product_attribute_boolean_term,
+    product_attribute_date_term, product_attribute_datetime_term, product_attribute_decimal_term,
+    product_attribute_integer_term, product_attribute_localized_presence_term,
+    product_attribute_localized_text_expr, product_attribute_localized_text_term,
+    product_attribute_option_term, product_attribute_text_term,
 };
 
 /// Typed marker proving that `ProductModule` participated in runtime extension registration.

--- a/crates/rustok-product/src/services/catalog/attribute_filters.rs
+++ b/crates/rustok-product/src/services/catalog/attribute_filters.rs
@@ -1,5 +1,3 @@
-use chrono::{DateTime, NaiveDate, Utc};
-use rust_decimal::Decimal;
 use sea_orm::{
     Condition, ConnectionTrait, DatabaseConnection, DbBackend, FromQueryResult, Statement,
     sea_query::Expr,
@@ -8,9 +6,13 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::error::{CommerceError, CommerceResult};
+use crate::services::catalog_attribute_terms::{
+    ProductAttributeFilterValue, parse_product_attribute_filter_value,
+};
 use crate::services::catalog_schema::AttributeValueType;
 
 use super::ProductAttributeFilter;
+use super::types::validate_product_attribute_filters;
 
 #[derive(Debug, FromQueryResult)]
 struct CatalogAttributeFilterDefinitionRow {
@@ -27,6 +29,7 @@ pub(super) async fn load_catalog_attribute_filter_conditions(
     fallback_locale: &str,
     filters: &[ProductAttributeFilter],
 ) -> CommerceResult<Vec<Condition>> {
+    validate_product_attribute_filters(filters)?;
     if filters.is_empty() {
         return Ok(Vec::new());
     }
@@ -104,23 +107,25 @@ fn build_attribute_filter_condition(
     locale: &str,
     fallback_locale: &str,
 ) -> CommerceResult<Condition> {
-    let condition = match value_type {
-        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext
-            if definition.is_localized =>
-        {
+    let value = parse_product_attribute_filter_value(
+        definition.code.as_str(),
+        value_type,
+        raw_value,
+    )?;
+    let condition = match value {
+        ProductAttributeFilterValue::Text(value) if definition.is_localized => {
             localized_text_condition(
                 backend,
                 tenant_id,
                 definition.id,
                 locale.trim(),
                 fallback_locale.trim(),
-                raw_value,
+                value.as_str(),
             )
         }
-        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext => {
-            custom_condition(
-                backend,
-                r#"
+        ProductAttributeFilterValue::Text(value) => custom_condition(
+            backend,
+            r#"
             EXISTS (
                 SELECT 1
                 FROM product_attribute_values pav
@@ -131,87 +136,45 @@ fn build_attribute_filter_condition(
                   AND pav.value_text = {p3}
             )
             "#,
-                vec![tenant_id.into(), definition.id.into(), raw_value.into()],
-            )
-        }
-        AttributeValueType::Integer => {
-            let value = raw_value
-                .parse::<i64>()
-                .map_err(|_| invalid_typed_value(definition.code.as_str(), "integer", raw_value))?;
-            scalar_condition(
-                backend,
-                tenant_id,
-                definition.id,
-                "value_integer",
-                value.into(),
-            )
-        }
-        AttributeValueType::Decimal => {
-            let value = raw_value
-                .parse::<Decimal>()
-                .map_err(|_| invalid_typed_value(definition.code.as_str(), "decimal", raw_value))?;
-            scalar_condition(
-                backend,
-                tenant_id,
-                definition.id,
-                "value_decimal",
-                value.into(),
-            )
-        }
-        AttributeValueType::Boolean => {
-            let value = match raw_value.to_ascii_lowercase().as_str() {
-                "true" | "1" => true,
-                "false" | "0" => false,
-                _ => {
-                    return Err(invalid_typed_value(
-                        definition.code.as_str(),
-                        "boolean",
-                        raw_value,
-                    ));
-                }
-            };
-            scalar_condition(
-                backend,
-                tenant_id,
-                definition.id,
-                "value_boolean",
-                value.into(),
-            )
-        }
-        AttributeValueType::Date => {
-            let value = NaiveDate::parse_from_str(raw_value, "%Y-%m-%d").map_err(|_| {
-                invalid_typed_value(definition.code.as_str(), "date (YYYY-MM-DD)", raw_value)
-            })?;
-            scalar_condition(
-                backend,
-                tenant_id,
-                definition.id,
-                "value_date",
-                value.into(),
-            )
-        }
-        AttributeValueType::Datetime => {
-            let value = DateTime::parse_from_rfc3339(raw_value)
-                .map(|value| value.with_timezone(&Utc))
-                .map_err(|_| {
-                    invalid_typed_value(definition.code.as_str(), "RFC3339 datetime", raw_value)
-                })?;
-            scalar_condition(
-                backend,
-                tenant_id,
-                definition.id,
-                "value_datetime",
-                value.into(),
-            )
-        }
-        AttributeValueType::Select | AttributeValueType::Multiselect => {
-            option_condition(backend, tenant_id, definition.id, raw_value)
-        }
-        AttributeValueType::Json => {
-            return Err(CommerceError::Validation(format!(
-                "attribute {} uses json and cannot be used in attribute_filters",
-                definition.code
-            )));
+            vec![tenant_id.into(), definition.id.into(), value.into()],
+        ),
+        ProductAttributeFilterValue::Integer(value) => scalar_condition(
+            backend,
+            tenant_id,
+            definition.id,
+            "value_integer",
+            value.into(),
+        ),
+        ProductAttributeFilterValue::Decimal(value) => scalar_condition(
+            backend,
+            tenant_id,
+            definition.id,
+            "value_decimal",
+            value.into(),
+        ),
+        ProductAttributeFilterValue::Boolean(value) => scalar_condition(
+            backend,
+            tenant_id,
+            definition.id,
+            "value_boolean",
+            value.into(),
+        ),
+        ProductAttributeFilterValue::Date(value) => scalar_condition(
+            backend,
+            tenant_id,
+            definition.id,
+            "value_date",
+            value.into(),
+        ),
+        ProductAttributeFilterValue::Datetime(value) => scalar_condition(
+            backend,
+            tenant_id,
+            definition.id,
+            "value_datetime",
+            value.into(),
+        ),
+        ProductAttributeFilterValue::Option(value) => {
+            option_condition(backend, tenant_id, definition.id, value.as_str())
         }
     };
     Ok(condition)
@@ -392,10 +355,4 @@ fn sql_placeholder(backend: DbBackend, index: usize) -> String {
         DbBackend::Sqlite => "?".to_string(),
         _ => format!("${index}"),
     }
-}
-
-fn invalid_typed_value(code: &str, expected: &str, value: &str) -> CommerceError {
-    CommerceError::Validation(format!(
-        "attribute filter {code} expects {expected}, received `{value}`"
-    ))
 }

--- a/crates/rustok-product/src/services/catalog/types.rs
+++ b/crates/rustok-product/src/services/catalog/types.rs
@@ -54,7 +54,7 @@ impl StorefrontProductSortDirection {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProductAttributeFilter {
     pub code: String,
     pub value: String,
@@ -65,49 +65,63 @@ impl ProductAttributeFilter {
         let (code, raw_value) = value.split_once('=').ok_or_else(|| {
             CommerceError::Validation("attribute_filters entries must use `code=value`".to_string())
         })?;
-        let code = code.trim();
-        let raw_value = raw_value.trim();
-        if code.is_empty()
-            || code.len() > MAX_ATTRIBUTE_FILTER_CODE_LENGTH
-            || !code.chars().all(|character| {
-                character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
-            })
-        {
-            return Err(CommerceError::Validation(
-                "attribute filter code must contain 1..128 ASCII letters, digits, `_`, or `-`"
-                    .to_string(),
-            ));
-        }
-        if raw_value.is_empty() || raw_value.len() > MAX_ATTRIBUTE_FILTER_VALUE_LENGTH {
-            return Err(CommerceError::Validation(
-                "attribute filter value must contain 1..512 characters".to_string(),
-            ));
-        }
-        Ok(Self {
-            code: code.to_string(),
-            value: raw_value.to_string(),
-        })
+        let filter = Self {
+            code: code.trim().to_string(),
+            value: raw_value.trim().to_string(),
+        };
+        validate_attribute_filter(&filter)?;
+        Ok(filter)
     }
 }
 
-fn parse_attribute_filters(values: Vec<String>) -> CommerceResult<Vec<ProductAttributeFilter>> {
-    if values.len() > MAX_ATTRIBUTE_FILTERS {
+fn validate_attribute_filter(filter: &ProductAttributeFilter) -> CommerceResult<()> {
+    let code = filter.code.as_str();
+    if code.is_empty()
+        || code.len() > MAX_ATTRIBUTE_FILTER_CODE_LENGTH
+        || !code.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+        })
+    {
+        return Err(CommerceError::Validation(
+            "attribute filter code must contain 1..128 ASCII letters, digits, `_`, or `-`"
+                .to_string(),
+        ));
+    }
+    if filter.value.is_empty() || filter.value.len() > MAX_ATTRIBUTE_FILTER_VALUE_LENGTH {
+        return Err(CommerceError::Validation(
+            "attribute filter value must contain 1..512 characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_product_attribute_filters(
+    filters: &[ProductAttributeFilter],
+) -> CommerceResult<()> {
+    if filters.len() > MAX_ATTRIBUTE_FILTERS {
         return Err(CommerceError::Validation(format!(
             "attribute_filters supports at most {MAX_ATTRIBUTE_FILTERS} entries"
         )));
     }
     let mut seen = HashSet::new();
-    let mut filters = Vec::with_capacity(values.len());
-    for value in values {
-        let filter = ProductAttributeFilter::parse(value)?;
+    for filter in filters {
+        validate_attribute_filter(filter)?;
         if !seen.insert(filter.code.to_ascii_lowercase()) {
             return Err(CommerceError::Validation(format!(
                 "attribute filter {} occurs more than once",
                 filter.code
             )));
         }
-        filters.push(filter);
     }
+    Ok(())
+}
+
+fn parse_attribute_filters(values: Vec<String>) -> CommerceResult<Vec<ProductAttributeFilter>> {
+    let filters = values
+        .into_iter()
+        .map(ProductAttributeFilter::parse)
+        .collect::<CommerceResult<Vec<_>>>()?;
+    validate_product_attribute_filters(&filters)?;
     Ok(filters)
 }
 

--- a/crates/rustok-product/src/services/catalog_attribute_terms.rs
+++ b/crates/rustok-product/src/services/catalog_attribute_terms.rs
@@ -1,0 +1,246 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use rustok_api::normalize_locale_tag;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProductAttributeTermExpr {
+    Term(String),
+    And(Vec<ProductAttributeTermExpr>),
+    Or(Vec<ProductAttributeTermExpr>),
+    Not(Box<ProductAttributeTermExpr>),
+    Never,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProductResolvedAttributeFilter {
+    pub code: String,
+    pub predicate: ProductAttributeTermExpr,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum ProductAttributeTermError {
+    #[error("Product attribute term attribute id must not be nil")]
+    NilAttributeId,
+    #[error("Product attribute term option id must not be nil")]
+    NilOptionId,
+    #[error("Product attribute term locale must be canonical")]
+    InvalidLocale,
+}
+
+pub fn product_attribute_text_term(
+    attribute_id: Uuid,
+    value: &str,
+) -> Result<String, ProductAttributeTermError> {
+    product_attribute_term(attribute_id, "text", None, value)
+}
+
+pub fn product_attribute_localized_text_term(
+    attribute_id: Uuid,
+    locale: &str,
+    value: &str,
+) -> Result<String, ProductAttributeTermError> {
+    let locale = canonical_locale(locale)?;
+    product_attribute_term(attribute_id, "localized_text", Some(locale.as_str()), value)
+}
+
+pub fn product_attribute_localized_presence_term(
+    attribute_id: Uuid,
+    locale: &str,
+) -> Result<String, ProductAttributeTermError> {
+    let locale = canonical_locale(locale)?;
+    product_attribute_term(attribute_id, "localized_present", Some(locale.as_str()), "")
+}
+
+pub fn product_attribute_integer_term(
+    attribute_id: Uuid,
+    value: i64,
+) -> Result<String, ProductAttributeTermError> {
+    product_attribute_term(attribute_id, "integer", None, value.to_string().as_str())
+}
+
+pub fn product_attribute_decimal_term(
+    attribute_id: Uuid,
+    value: Decimal,
+) -> Result<String, ProductAttributeTermError> {
+    product_attribute_term(
+        attribute_id,
+        "decimal",
+        None,
+        value.normalize().to_string().as_str(),
+    )
+}
+
+pub fn product_attribute_boolean_term(
+    attribute_id: Uuid,
+    value: bool,
+) -> Result<String, ProductAttributeTermError> {
+    product_attribute_term(
+        attribute_id,
+        "boolean",
+        None,
+        if value { "true" } else { "false" },
+    )
+}
+
+pub fn product_attribute_date_term(
+    attribute_id: Uuid,
+    value: NaiveDate,
+) -> Result<String, ProductAttributeTermError> {
+    product_attribute_term(
+        attribute_id,
+        "date",
+        None,
+        value.format("%Y-%m-%d").to_string().as_str(),
+    )
+}
+
+pub fn product_attribute_datetime_term(
+    attribute_id: Uuid,
+    value: DateTime<Utc>,
+) -> Result<String, ProductAttributeTermError> {
+    product_attribute_term(
+        attribute_id,
+        "datetime",
+        None,
+        value.timestamp_micros().to_string().as_str(),
+    )
+}
+
+pub fn product_attribute_option_term(
+    attribute_id: Uuid,
+    option_id: Uuid,
+) -> Result<String, ProductAttributeTermError> {
+    if option_id.is_nil() {
+        return Err(ProductAttributeTermError::NilOptionId);
+    }
+    product_attribute_term(attribute_id, "option", None, option_id.to_string().as_str())
+}
+
+/// Canonical term expression for owner localized-text semantics:
+/// requested-value OR (requested-locale-absent AND fallback-value).
+pub fn product_attribute_localized_text_expr(
+    attribute_id: Uuid,
+    requested_locale: &str,
+    fallback_locale: &str,
+    value: &str,
+) -> Result<ProductAttributeTermExpr, ProductAttributeTermError> {
+    let requested_locale = canonical_locale(requested_locale)?;
+    let fallback_locale = canonical_locale(fallback_locale)?;
+    let requested = ProductAttributeTermExpr::Term(product_attribute_localized_text_term(
+        attribute_id,
+        requested_locale.as_str(),
+        value,
+    )?);
+    if requested_locale == fallback_locale {
+        return Ok(requested);
+    }
+
+    let requested_present = ProductAttributeTermExpr::Term(
+        product_attribute_localized_presence_term(attribute_id, requested_locale.as_str())?,
+    );
+    let fallback = ProductAttributeTermExpr::Term(product_attribute_localized_text_term(
+        attribute_id,
+        fallback_locale.as_str(),
+        value,
+    )?);
+    Ok(ProductAttributeTermExpr::Or(vec![
+        requested,
+        ProductAttributeTermExpr::And(vec![
+            ProductAttributeTermExpr::Not(Box::new(requested_present)),
+            fallback,
+        ]),
+    ]))
+}
+
+fn canonical_locale(locale: &str) -> Result<String, ProductAttributeTermError> {
+    let trimmed = locale.trim();
+    let normalized = normalize_locale_tag(trimmed).ok_or(ProductAttributeTermError::InvalidLocale)?;
+    if normalized != trimmed {
+        return Err(ProductAttributeTermError::InvalidLocale);
+    }
+    Ok(normalized)
+}
+
+fn product_attribute_term(
+    attribute_id: Uuid,
+    kind: &str,
+    locale: Option<&str>,
+    value: &str,
+) -> Result<String, ProductAttributeTermError> {
+    if attribute_id.is_nil() {
+        return Err(ProductAttributeTermError::NilAttributeId);
+    }
+    let locale = locale.map(hex_encode).unwrap_or_default();
+    Ok(format!(
+        "{}|{}|{}|{}",
+        attribute_id,
+        kind,
+        locale,
+        hex_encode(value)
+    ))
+}
+
+fn hex_encode(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let bytes = value.as_bytes();
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_scalar_terms_match_materialized_grammar() {
+        let attribute_id = Uuid::from_u128(1);
+        assert_eq!(
+            product_attribute_text_term(attribute_id, "A|b").unwrap(),
+            "00000000-0000-0000-0000-000000000001|text||417c62"
+        );
+        assert_eq!(
+            product_attribute_decimal_term(attribute_id, Decimal::new(12_300, 3)).unwrap(),
+            "00000000-0000-0000-0000-000000000001|decimal||31322e33"
+        );
+        assert_eq!(
+            product_attribute_boolean_term(attribute_id, true).unwrap(),
+            "00000000-0000-0000-0000-000000000001|boolean||74727565"
+        );
+    }
+
+    #[test]
+    fn localized_expression_preserves_requested_presence_fallback() {
+        let expr = product_attribute_localized_text_expr(
+            Uuid::from_u128(1),
+            "de-DE",
+            "en-US",
+            "Red",
+        )
+        .unwrap();
+        let ProductAttributeTermExpr::Or(branches) = expr else {
+            panic!("localized fallback must be an OR expression");
+        };
+        assert_eq!(branches.len(), 2);
+        let ProductAttributeTermExpr::And(fallback) = &branches[1] else {
+            panic!("fallback branch must be an AND expression");
+        };
+        assert!(matches!(fallback[0], ProductAttributeTermExpr::Not(_)));
+        assert!(matches!(fallback[1], ProductAttributeTermExpr::Term(_)));
+    }
+
+    #[test]
+    fn noncanonical_locale_fails_closed() {
+        assert_eq!(
+            product_attribute_localized_text_term(Uuid::from_u128(1), "de_de", "x"),
+            Err(ProductAttributeTermError::InvalidLocale)
+        );
+    }
+}

--- a/crates/rustok-product/src/services/catalog_attribute_terms.rs
+++ b/crates/rustok-product/src/services/catalog_attribute_terms.rs
@@ -5,6 +5,57 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
+use super::catalog_schema::AttributeValueType;
+use crate::error::{CommerceError, CommerceResult};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ProductAttributeFilterValue {
+    Text(String),
+    Integer(i64),
+    Decimal(Decimal),
+    Boolean(bool),
+    Date(NaiveDate),
+    Datetime(DateTime<Utc>),
+    Option(String),
+}
+
+pub(crate) fn parse_product_attribute_filter_value(
+    code: &str,
+    value_type: AttributeValueType,
+    raw_value: &str,
+) -> CommerceResult<ProductAttributeFilterValue> {
+    match value_type {
+        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext => {
+            Ok(ProductAttributeFilterValue::Text(raw_value.to_string()))
+        }
+        AttributeValueType::Integer => raw_value
+            .parse::<i64>()
+            .map(ProductAttributeFilterValue::Integer)
+            .map_err(|_| invalid_typed_value(code, "integer", raw_value)),
+        AttributeValueType::Decimal => raw_value
+            .parse::<Decimal>()
+            .map(ProductAttributeFilterValue::Decimal)
+            .map_err(|_| invalid_typed_value(code, "decimal", raw_value)),
+        AttributeValueType::Boolean => match raw_value.to_ascii_lowercase().as_str() {
+            "true" | "1" => Ok(ProductAttributeFilterValue::Boolean(true)),
+            "false" | "0" => Ok(ProductAttributeFilterValue::Boolean(false)),
+            _ => Err(invalid_typed_value(code, "boolean", raw_value)),
+        },
+        AttributeValueType::Date => NaiveDate::parse_from_str(raw_value, "%Y-%m-%d")
+            .map(ProductAttributeFilterValue::Date)
+            .map_err(|_| invalid_typed_value(code, "date (YYYY-MM-DD)", raw_value)),
+        AttributeValueType::Datetime => DateTime::parse_from_rfc3339(raw_value)
+            .map(|value| ProductAttributeFilterValue::Datetime(value.with_timezone(&Utc)))
+            .map_err(|_| invalid_typed_value(code, "RFC3339 datetime", raw_value)),
+        AttributeValueType::Select | AttributeValueType::Multiselect => {
+            Ok(ProductAttributeFilterValue::Option(raw_value.to_string()))
+        }
+        AttributeValueType::Json => Err(CommerceError::Validation(format!(
+            "attribute {code} uses json and cannot be used in attribute_filters"
+        ))),
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProductAttributeTermExpr {
@@ -195,6 +246,12 @@ fn hex_encode(value: &str) -> String {
     encoded
 }
 
+fn invalid_typed_value(code: &str, expected: &str, value: &str) -> CommerceError {
+    CommerceError::Validation(format!(
+        "attribute filter {code} expects {expected}, received `{value}`"
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,6 +271,23 @@ mod tests {
             product_attribute_boolean_term(attribute_id, true).unwrap(),
             "00000000-0000-0000-0000-000000000001|boolean||74727565"
         );
+    }
+
+    #[test]
+    fn shared_value_parser_keeps_owner_boolean_and_datetime_rules() {
+        assert_eq!(
+            parse_product_attribute_filter_value("flag", AttributeValueType::Boolean, "1").unwrap(),
+            ProductAttributeFilterValue::Boolean(true)
+        );
+        assert!(matches!(
+            parse_product_attribute_filter_value(
+                "released",
+                AttributeValueType::Datetime,
+                "2026-08-08T06:00:00+03:00"
+            )
+            .unwrap(),
+            ProductAttributeFilterValue::Datetime(_)
+        ));
     }
 
     #[test]

--- a/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
@@ -5,14 +5,15 @@ use super::{
     ProductCatalogSchemaService, load_attribute_write_definition, map_schema_resolution_error,
     uuid_filter_values, validate_locale,
 };
-use chrono::{DateTime, NaiveDate, Utc};
-use rust_decimal::Decimal;
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, FromQueryResult, Statement};
 use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::error::{CommerceError, CommerceResult};
 use crate::services::catalog::types::validate_product_attribute_filters;
+use crate::services::catalog_attribute_terms::{
+    ProductAttributeFilterValue, parse_product_attribute_filter_value,
+};
 use crate::services::{
     ProductAttributeFilter, ProductAttributeTermError, ProductAttributeTermExpr,
     ProductResolvedAttributeFilter, product_attribute_boolean_term, product_attribute_date_term,
@@ -324,7 +325,8 @@ async fn load_storefront_filter_definitions(
     filters: &[ProductAttributeFilter],
 ) -> CommerceResult<HashMap<String, StorefrontAttributeFilterDefinitionRow>> {
     let backend = db.get_database_backend();
-    let mut values = vec![tenant_id.into()];
+    let mut values = Vec::<sea_orm::Value>::with_capacity(filters.len() + 1);
+    values.push(tenant_id.into());
     let placeholders = filters
         .iter()
         .enumerate()
@@ -369,63 +371,41 @@ async fn resolve_storefront_filter_predicate(
     requested_locale: &str,
     fallback_locale: &str,
 ) -> CommerceResult<ProductAttributeTermExpr> {
-    let term = match value_type {
-        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext
-            if definition.is_localized =>
-        {
+    let value = parse_product_attribute_filter_value(
+        definition.code.as_str(),
+        value_type,
+        raw_value,
+    )?;
+    let term = match value {
+        ProductAttributeFilterValue::Text(value) if definition.is_localized => {
             return product_attribute_localized_text_expr(
                 definition.id,
                 requested_locale,
                 fallback_locale,
-                raw_value,
+                value.as_str(),
             )
             .map_err(|error| map_term_error(definition.code.as_str(), error));
         }
-        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext => {
-            product_attribute_text_term(definition.id, raw_value)
+        ProductAttributeFilterValue::Text(value) => {
+            product_attribute_text_term(definition.id, value.as_str())
         }
-        AttributeValueType::Integer => {
-            let value = raw_value
-                .parse::<i64>()
-                .map_err(|_| invalid_typed_value(definition.code.as_str(), "integer", raw_value))?;
+        ProductAttributeFilterValue::Integer(value) => {
             product_attribute_integer_term(definition.id, value)
         }
-        AttributeValueType::Decimal => {
-            let value = raw_value
-                .parse::<Decimal>()
-                .map_err(|_| invalid_typed_value(definition.code.as_str(), "decimal", raw_value))?;
+        ProductAttributeFilterValue::Decimal(value) => {
             product_attribute_decimal_term(definition.id, value)
         }
-        AttributeValueType::Boolean => {
-            let value = match raw_value.to_ascii_lowercase().as_str() {
-                "true" | "1" => true,
-                "false" | "0" => false,
-                _ => {
-                    return Err(invalid_typed_value(
-                        definition.code.as_str(),
-                        "boolean",
-                        raw_value,
-                    ));
-                }
-            };
+        ProductAttributeFilterValue::Boolean(value) => {
             product_attribute_boolean_term(definition.id, value)
         }
-        AttributeValueType::Date => {
-            let value = NaiveDate::parse_from_str(raw_value, "%Y-%m-%d").map_err(|_| {
-                invalid_typed_value(definition.code.as_str(), "date (YYYY-MM-DD)", raw_value)
-            })?;
+        ProductAttributeFilterValue::Date(value) => {
             product_attribute_date_term(definition.id, value)
         }
-        AttributeValueType::Datetime => {
-            let value = DateTime::parse_from_rfc3339(raw_value)
-                .map(|value| value.with_timezone(&Utc))
-                .map_err(|_| {
-                    invalid_typed_value(definition.code.as_str(), "RFC3339 datetime", raw_value)
-                })?;
+        ProductAttributeFilterValue::Datetime(value) => {
             product_attribute_datetime_term(definition.id, value)
         }
-        AttributeValueType::Select | AttributeValueType::Multiselect => {
-            let option_id = match Uuid::parse_str(raw_value) {
+        ProductAttributeFilterValue::Option(raw_value) => {
+            let option_id = match Uuid::parse_str(raw_value.as_str()) {
                 Ok(option_id) if option_id.is_nil() => return Ok(ProductAttributeTermExpr::Never),
                 Ok(option_id) => option_id,
                 Err(_) => {
@@ -433,7 +413,7 @@ async fn resolve_storefront_filter_predicate(
                         db,
                         tenant_id,
                         definition.id,
-                        raw_value,
+                        raw_value.as_str(),
                     )
                     .await?
                     else {
@@ -443,12 +423,6 @@ async fn resolve_storefront_filter_predicate(
                 }
             };
             product_attribute_option_term(definition.id, option_id)
-        }
-        AttributeValueType::Json => {
-            return Err(CommerceError::Validation(format!(
-                "attribute {} uses json and cannot be used in attribute_filters",
-                definition.code
-            )));
         }
     }
     .map_err(|error| map_term_error(definition.code.as_str(), error))?;
@@ -462,17 +436,23 @@ async fn load_active_option_id(
     attribute_id: Uuid,
     code: &str,
 ) -> CommerceResult<Option<Uuid>> {
+    let backend = db.get_database_backend();
+    let tenant = storefront_sql_placeholder(backend, 1);
+    let attribute = storefront_sql_placeholder(backend, 2);
+    let code_placeholder = storefront_sql_placeholder(backend, 3);
     let row = StorefrontAttributeFilterOptionRow::find_by_statement(Statement::from_sql_and_values(
-        db.get_database_backend(),
-        r#"
-        SELECT id
-        FROM product_attribute_options
-        WHERE tenant_id = $1
-          AND attribute_id = $2
-          AND archived_at IS NULL
-          AND code = $3
-        LIMIT 1
-        "#,
+        backend,
+        format!(
+            r#"
+            SELECT id
+            FROM product_attribute_options
+            WHERE tenant_id = {tenant}
+              AND attribute_id = {attribute}
+              AND archived_at IS NULL
+              AND code = {code_placeholder}
+            LIMIT 1
+            "#
+        ),
         vec![tenant_id.into(), attribute_id.into(), code.to_string().into()],
     ))
     .one(db)
@@ -485,12 +465,6 @@ fn storefront_sql_placeholder(backend: DbBackend, index: usize) -> String {
         DbBackend::Sqlite => "?".to_string(),
         _ => format!("${index}"),
     }
-}
-
-fn invalid_typed_value(code: &str, expected: &str, value: &str) -> CommerceError {
-    CommerceError::Validation(format!(
-        "attribute filter {code} expects {expected}, received `{value}`"
-    ))
 }
 
 fn map_term_error(code: &str, error: ProductAttributeTermError) -> CommerceError {

--- a/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
@@ -5,10 +5,21 @@ use super::{
     ProductCatalogSchemaService, load_attribute_write_definition, map_schema_resolution_error,
     uuid_filter_values, validate_locale,
 };
-use sea_orm::{ConnectionTrait, FromQueryResult, Statement};
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, FromQueryResult, Statement};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::error::{CommerceError, CommerceResult};
+use crate::services::catalog::types::validate_product_attribute_filters;
+use crate::services::{
+    ProductAttributeFilter, ProductAttributeTermError, ProductAttributeTermExpr,
+    ProductResolvedAttributeFilter, product_attribute_boolean_term, product_attribute_date_term,
+    product_attribute_datetime_term, product_attribute_decimal_term,
+    product_attribute_integer_term, product_attribute_localized_text_expr,
+    product_attribute_option_term, product_attribute_text_term,
+};
 use crate::services::write_transaction::ProductWriteTransaction;
 use rustok_core::generate_id;
 use rustok_events::DomainEvent;
@@ -239,4 +250,251 @@ impl ProductCatalogSchemaService {
         .map(|rows| rows.into_iter().map(Into::into).collect())
         .map_err(Into::into)
     }
+
+    /// Resolve public Storefront attribute filters into the canonical Product-owned term grammar.
+    ///
+    /// This is an owner capability: consumers do not read Product attribute/option tables directly.
+    /// Missing option codes resolve to `Never`, matching the existing owner SQL's empty-result behavior.
+    pub async fn resolve_storefront_attribute_filter_terms(
+        &self,
+        tenant_id: Uuid,
+        requested_locale: &str,
+        fallback_locale: &str,
+        filters: &[ProductAttributeFilter],
+    ) -> CommerceResult<Vec<ProductResolvedAttributeFilter>> {
+        validate_product_attribute_filters(filters)?;
+        if filters.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let definitions =
+            load_storefront_filter_definitions(&self.db, tenant_id, filters).await?;
+        let mut resolved = Vec::with_capacity(filters.len());
+        for filter in filters {
+            let definition = definitions
+                .get(&filter.code.to_ascii_lowercase())
+                .ok_or_else(|| {
+                    CommerceError::Validation(format!(
+                        "attribute {} is not available as a product filter",
+                        filter.code
+                    ))
+                })?;
+            let value_type = AttributeValueType::from_storage(definition.value_type.as_str())
+                .map_err(|_| {
+                    CommerceError::Validation(format!(
+                        "attribute {} has an unsupported stored value type",
+                        definition.code
+                    ))
+                })?;
+            let predicate = resolve_storefront_filter_predicate(
+                &self.db,
+                tenant_id,
+                definition,
+                value_type,
+                filter.value.as_str(),
+                requested_locale,
+                fallback_locale,
+            )
+            .await?;
+            resolved.push(ProductResolvedAttributeFilter {
+                code: filter.code.clone(),
+                predicate,
+            });
+        }
+        Ok(resolved)
+    }
+}
+
+#[derive(Debug, FromQueryResult)]
+struct StorefrontAttributeFilterDefinitionRow {
+    id: Uuid,
+    code: String,
+    value_type: String,
+    is_localized: bool,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct StorefrontAttributeFilterOptionRow {
+    id: Uuid,
+}
+
+async fn load_storefront_filter_definitions(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    filters: &[ProductAttributeFilter],
+) -> CommerceResult<HashMap<String, StorefrontAttributeFilterDefinitionRow>> {
+    let backend = db.get_database_backend();
+    let mut values = vec![tenant_id.into()];
+    let placeholders = filters
+        .iter()
+        .enumerate()
+        .map(|(index, filter)| {
+            values.push(filter.code.to_ascii_lowercase().into());
+            storefront_sql_placeholder(backend, index + 2)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let tenant_placeholder = storefront_sql_placeholder(backend, 1);
+    StorefrontAttributeFilterDefinitionRow::find_by_statement(Statement::from_sql_and_values(
+        backend,
+        format!(
+            r#"
+            SELECT id, code, value_type, is_localized
+            FROM product_attributes
+            WHERE tenant_id = {tenant_placeholder}
+              AND archived_at IS NULL
+              AND is_filterable = TRUE
+              AND scope IN ('product', 'both')
+              AND LOWER(code) IN ({placeholders})
+            "#
+        ),
+        values,
+    ))
+    .all(db)
+    .await
+    .map(|rows| {
+        rows.into_iter()
+            .map(|definition| (definition.code.to_ascii_lowercase(), definition))
+            .collect()
+    })
+    .map_err(Into::into)
+}
+
+async fn resolve_storefront_filter_predicate(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    definition: &StorefrontAttributeFilterDefinitionRow,
+    value_type: AttributeValueType,
+    raw_value: &str,
+    requested_locale: &str,
+    fallback_locale: &str,
+) -> CommerceResult<ProductAttributeTermExpr> {
+    let term = match value_type {
+        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext
+            if definition.is_localized =>
+        {
+            return product_attribute_localized_text_expr(
+                definition.id,
+                requested_locale,
+                fallback_locale,
+                raw_value,
+            )
+            .map_err(|error| map_term_error(definition.code.as_str(), error));
+        }
+        AttributeValueType::Text | AttributeValueType::Textarea | AttributeValueType::Richtext => {
+            product_attribute_text_term(definition.id, raw_value)
+        }
+        AttributeValueType::Integer => {
+            let value = raw_value
+                .parse::<i64>()
+                .map_err(|_| invalid_typed_value(definition.code.as_str(), "integer", raw_value))?;
+            product_attribute_integer_term(definition.id, value)
+        }
+        AttributeValueType::Decimal => {
+            let value = raw_value
+                .parse::<Decimal>()
+                .map_err(|_| invalid_typed_value(definition.code.as_str(), "decimal", raw_value))?;
+            product_attribute_decimal_term(definition.id, value)
+        }
+        AttributeValueType::Boolean => {
+            let value = match raw_value.to_ascii_lowercase().as_str() {
+                "true" | "1" => true,
+                "false" | "0" => false,
+                _ => {
+                    return Err(invalid_typed_value(
+                        definition.code.as_str(),
+                        "boolean",
+                        raw_value,
+                    ));
+                }
+            };
+            product_attribute_boolean_term(definition.id, value)
+        }
+        AttributeValueType::Date => {
+            let value = NaiveDate::parse_from_str(raw_value, "%Y-%m-%d").map_err(|_| {
+                invalid_typed_value(definition.code.as_str(), "date (YYYY-MM-DD)", raw_value)
+            })?;
+            product_attribute_date_term(definition.id, value)
+        }
+        AttributeValueType::Datetime => {
+            let value = DateTime::parse_from_rfc3339(raw_value)
+                .map(|value| value.with_timezone(&Utc))
+                .map_err(|_| {
+                    invalid_typed_value(definition.code.as_str(), "RFC3339 datetime", raw_value)
+                })?;
+            product_attribute_datetime_term(definition.id, value)
+        }
+        AttributeValueType::Select | AttributeValueType::Multiselect => {
+            let option_id = match Uuid::parse_str(raw_value) {
+                Ok(option_id) if option_id.is_nil() => return Ok(ProductAttributeTermExpr::Never),
+                Ok(option_id) => option_id,
+                Err(_) => {
+                    let Some(option_id) = load_active_option_id(
+                        db,
+                        tenant_id,
+                        definition.id,
+                        raw_value,
+                    )
+                    .await?
+                    else {
+                        return Ok(ProductAttributeTermExpr::Never);
+                    };
+                    option_id
+                }
+            };
+            product_attribute_option_term(definition.id, option_id)
+        }
+        AttributeValueType::Json => {
+            return Err(CommerceError::Validation(format!(
+                "attribute {} uses json and cannot be used in attribute_filters",
+                definition.code
+            )));
+        }
+    }
+    .map_err(|error| map_term_error(definition.code.as_str(), error))?;
+
+    Ok(ProductAttributeTermExpr::Term(term))
+}
+
+async fn load_active_option_id(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    attribute_id: Uuid,
+    code: &str,
+) -> CommerceResult<Option<Uuid>> {
+    let row = StorefrontAttributeFilterOptionRow::find_by_statement(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+        SELECT id
+        FROM product_attribute_options
+        WHERE tenant_id = $1
+          AND attribute_id = $2
+          AND archived_at IS NULL
+          AND code = $3
+        LIMIT 1
+        "#,
+        vec![tenant_id.into(), attribute_id.into(), code.to_string().into()],
+    ))
+    .one(db)
+    .await?;
+    Ok(row.map(|row| row.id))
+}
+
+fn storefront_sql_placeholder(backend: DbBackend, index: usize) -> String {
+    match backend {
+        DbBackend::Sqlite => "?".to_string(),
+        _ => format!("${index}"),
+    }
+}
+
+fn invalid_typed_value(code: &str, expected: &str, value: &str) -> CommerceError {
+    CommerceError::Validation(format!(
+        "attribute filter {code} expects {expected}, received `{value}`"
+    ))
+}
+
+fn map_term_error(code: &str, error: ProductAttributeTermError) -> CommerceError {
+    CommerceError::Validation(format!(
+        "attribute filter {code} cannot be represented as a canonical term: {error}"
+    ))
 }

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod catalog_schema;
 pub mod catalog_schema_service;
+mod catalog_attribute_terms;
 mod index_channel_relation;
 mod index_channel_relation_convergence;
 mod index_channel_relation_freshness;
@@ -13,6 +14,14 @@ pub use catalog::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
     ProductAttributeFilter, StorefrontProductList, StorefrontProductListItem,
     StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
+};
+pub use catalog_attribute_terms::{
+    ProductAttributeTermError, ProductAttributeTermExpr, ProductResolvedAttributeFilter,
+    product_attribute_boolean_term, product_attribute_date_term, product_attribute_datetime_term,
+    product_attribute_decimal_term, product_attribute_integer_term,
+    product_attribute_localized_presence_term, product_attribute_localized_text_expr,
+    product_attribute_localized_text_term, product_attribute_option_term,
+    product_attribute_text_term,
 };
 pub use catalog_schema::*;
 pub use catalog_schema_service::*;

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -23,7 +23,7 @@ const storefront = requireMarkers(storefrontPath, [
   'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
   '.list_published_products_with_query(',
 ]);
-for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'IndexQuery']) {
+for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'execute_localized_query']) {
   if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
 }
 
@@ -32,21 +32,27 @@ const owner = requireMarkers(ownerPath, [
   'ProductStatus::Active',
   'Column::PublishedAt.is_not_null()',
   'product_channel_visibility_condition(',
+  'attribute_filters::load_catalog_attribute_filter_conditions(',
   'product_title_search_condition(',
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
   'let pattern = format!("%{search}%");',
-  'FROM product_translations pt',
-  'pt.product_id = products.id',
   'pt.title LIKE $1',
+  '.order_by_asc(entities::product::Column::Id)',
+  '.order_by_desc(entities::product::Column::Id)',
 ]);
 const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
 if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
 
-requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
-  'pub struct StorefrontProductListQuery',
-  'pub search: Option<String>',
-  'search: normalize_optional_text(search)',
+requireMarkers('crates/rustok-product/src/catalog_schema_read_port.rs', [
+  'ProductStorefrontAttributeFilterResolutionRequest',
+  'async fn resolve_storefront_attribute_filters(',
+  '"product.storefront_attribute_filter_resolution_unavailable"',
+]);
+requireMarkers('crates/rustok-product/src/services/catalog_attribute_terms.rs', [
+  'pub enum ProductAttributeTermExpr',
+  'pub struct ProductResolvedAttributeFilter',
+  'product_attribute_localized_text_expr(',
 ]);
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
@@ -59,15 +65,17 @@ const productIndex = requireMarkers(productIndexPath, [
 if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `localized_runtime_and_text_pattern_source_complete_adapter_and_evidence_pending`',
-  'Generic `TextLike` — source complete',
-  '`FilterExpr::TextLike(FieldPath, String)`',
-  'no explicit search-length bound',
-  'Storefront must continue to execute `CatalogService::list_published_products_with_query`',
+  'Status: `shadow_query_and_product_owned_eav_resolution_source_complete_execution_evidence_pending`',
+  'Mounted Storefront remains owner-native',
+  'Product-owned attribute-filter resolution — source complete',
+  '`ProductAttributeTermExpr`',
+  '`ProductCatalogSchemaReadPort`',
+  'Channel-less owner requests',
+  'shadow executor/equivalence harness',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
   'Status: `source_complete_materialized_rebuild_pending`',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native while adapter/search-bound/collation/evidence gates are pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; shadow query plus Product-owned EAV resolution are source-complete while execution/evidence gates remain pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -65,6 +65,7 @@ const scripts = [
   'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-eav-owner-clock.mjs',
   'verify-index-product-attribute-term-contract.mjs',
+  'verify-product-storefront-attribute-filter-terms.mjs',
   'verify-index-product-variant-refresh-ledger.mjs',
   'verify-index-product-refresh-canonical-writer.mjs',
   'verify-index-product-refresh-relay-step.mjs',

--- a/scripts/verify/verify-product-storefront-attribute-filter-terms.mjs
+++ b/scripts/verify/verify-product-storefront-attribute-filter-terms.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-product-storefront-attribute-filter-terms] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const terms = requireMarkers('crates/rustok-product/src/services/catalog_attribute_terms.rs', [
+  'pub enum ProductAttributeTermExpr',
+  'Term(String)',
+  'And(Vec<ProductAttributeTermExpr>)',
+  'Or(Vec<ProductAttributeTermExpr>)',
+  'Not(Box<ProductAttributeTermExpr>)',
+  'Never',
+  'pub struct ProductResolvedAttributeFilter',
+  'pub(crate) fn parse_product_attribute_filter_value(',
+  '"true" | "1"',
+  '"false" | "0"',
+  'NaiveDate::parse_from_str(raw_value, "%Y-%m-%d")',
+  'DateTime::parse_from_rfc3339(raw_value)',
+  'value.normalize().to_string()',
+  'value.timestamp_micros().to_string()',
+  'product_attribute_localized_text_expr(',
+  'ProductAttributeTermExpr::Not(Box::new(requested_present))',
+  'normalize_locale_tag(trimmed)',
+]);
+if (terms.includes('rustok_index')) {
+  fail('Product-owned canonical term contract must not depend on rustok-index');
+}
+
+requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
+  'pub struct ProductAttributeFilter',
+  'pub(crate) fn validate_product_attribute_filters(',
+  'MAX_ATTRIBUTE_FILTERS',
+  'MAX_ATTRIBUTE_FILTER_CODE_LENGTH',
+  'MAX_ATTRIBUTE_FILTER_VALUE_LENGTH',
+  'filter.code.to_ascii_lowercase()',
+]);
+
+requireMarkers('crates/rustok-product/src/services/catalog_schema_service/attributes.rs', [
+  'pub async fn resolve_storefront_attribute_filter_terms(',
+  'validate_product_attribute_filters(filters)?;',
+  'archived_at IS NULL',
+  'is_filterable = TRUE',
+  "scope IN ('product', 'both')",
+  'LOWER(code) IN',
+  'parse_product_attribute_filter_value(',
+  'product_attribute_localized_text_expr(',
+  'Uuid::parse_str(raw_value.as_str())',
+  'Ok(option_id) if option_id.is_nil() => return Ok(ProductAttributeTermExpr::Never)',
+  'AND archived_at IS NULL',
+  'AND code = {code_placeholder}',
+  'return Ok(ProductAttributeTermExpr::Never);',
+]);
+
+requireMarkers('crates/rustok-product/src/services/catalog/attribute_filters.rs', [
+  'validate_product_attribute_filters(filters)?;',
+  'parse_product_attribute_filter_value(',
+  'ProductAttributeFilterValue::Boolean(value)',
+  'ProductAttributeFilterValue::Option(value)',
+]);
+
+requireMarkers('crates/rustok-product/src/catalog_schema_read_port.rs', [
+  'pub struct ProductStorefrontAttributeFilterResolutionRequest',
+  'async fn resolve_storefront_attribute_filters(',
+  '"product.storefront_attribute_filter_resolution_unavailable"',
+  'ProductCatalogSchemaService::resolve_storefront_attribute_filter_terms(',
+  'context.locale.as_str()',
+  'request.fallback_locale.as_str()',
+]);
+
+const distribution = requireMarkers('crates/rustok-distribution/src/product_index/attribute_terms.rs', [
+  'pub(crate) use rustok_product::ProductAttributeTermError;',
+  'rustok_product::product_attribute_text_term(',
+  'rustok_product::product_attribute_localized_text_term(',
+  'rustok_product::product_attribute_option_term(',
+  'PRODUCT_ATTRIBUTE_TERMS_CTE',
+  "value.attribute_id::text || '|localized_text|'",
+  "value.attribute_id::text || '|option||'",
+]);
+if (distribution.includes('fn product_attribute_term(')) {
+  fail('distribution must not own a second Rust canonical Product term encoder');
+}
+
+console.log('[verify-product-storefront-attribute-filter-terms] Product owns Storefront filter parsing/term identity; port remains optional and distribution delegates Rust term grammar');


### PR DESCRIPTION
## Summary

- add a Product-owned neutral `ProductAttributeTermExpr` contract (`Term`, `And`, `Or`, `Not`, `Never`) plus canonical Product attribute-term encoders;
- centralize Storefront attribute-filter typed parsing so mounted owner SQL and canonical-term resolution share integer/decimal/boolean/date/datetime/text/option rules;
- keep the existing public filter bounds and case-insensitive duplicate-code semantics reusable for direct port requests;
- add `ProductCatalogSchemaService::resolve_storefront_attribute_filter_terms` using the same tenant/active/filterable/product-scope definition eligibility as owner list SQL;
- preserve localized text semantics as requested-value OR (requested-locale-absent AND fallback-value);
- preserve Select/Multiselect owner behavior: UUID inputs retain direct option identity semantics, exact active option codes resolve to UUID, missing codes/nil UUID produce `Never` rather than a new validation error;
- expose the capability as an optional `ProductCatalogSchemaReadPort::resolve_storefront_attribute_filters` method with a fail-closed default so external adapters remain source-compatible;
- move Rust-side canonical term ownership out of distribution: Product Index helpers now delegate term identity to `rustok-product`, while the source SQL CTE remains the materialization-side mirror;
- add/actualize static guards and advance the Storefront parity/current-plan cursor to shadow execution/equivalence.

## Main recheck

The branch started from the actual Product Storefront shadow-adapter merge `4e9e032e11848db91ad4f837937c0de8ca3a7eaf`. Before PR creation current `main@da8da0e1e62f26e7cbc3282cae669b53f8bcbfd9` advanced only through #3225/#3226 Moderation migration/host-composition evidence. Those commits are disjoint from this Product/Index slice.

## Boundary

This PR does not mount Index Storefront traffic, call `execute_localized_query`, add a shadow executor, hydrate Taxonomy names, resolve search-length/collation/channel-less/deep-page parity, change Product routing key, run PostgreSQL equivalence, or add a key-3 compatibility path.

The next source slice is a non-serving shadow executor/equivalence boundary: obtain the host-selected Product schema read port, resolve public EAV filters there, translate neutral Product term expressions into Index `attribute_terms` predicates, execute through localized Index runtime, and retain owner-vs-Index evidence without serving Index output.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.