### PR TITLE
feat(index): consume Product-owned Storefront terms

### DIFF
--- a/crates/rustok-distribution/src/product_index/storefront_shadow.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow.rs
@@ -7,8 +7,8 @@ use rustok_index::{
     SchemaVersion,
 };
 use rustok_product::{
-    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
-    entities::product::ProductStatus,
+    ProductAttributeTermExpr, ProductResolvedAttributeFilter, StorefrontProductListQuery,
+    StorefrontProductSortBy, StorefrontProductSortDirection, entities::product::ProductStatus,
 };
 
 use super::PRODUCT_SCHEMA_ROUTING_KEY;
@@ -37,18 +37,17 @@ pub(crate) enum ProductStorefrontIndexShadowError {
     SearchPatternTooLong,
     #[error("Product Storefront Index shadow query title pattern contains a NUL byte")]
     SearchPatternContainsNul,
-    #[error("resolved Product attribute filter count does not match owner Storefront filter count")]
+    #[error("resolved Product attribute filters do not match the owner Storefront filter identities")]
     AttributeFilterResolutionMismatch,
-    #[error("resolved Product attribute filter is not a canonical attribute_terms predicate")]
+    #[error("resolved Product attribute term expression is invalid")]
     InvalidAttributeTermPredicate,
 }
 
 /// Build the Product Storefront query used only for shadow/equivalence work.
 ///
-/// The caller must resolve every public Product attribute filter through a Product-owned metadata
-/// capability before calling this function. `canonical_attribute_filters` are accepted only when every
-/// leaf is `Contains(attribute_terms, String(term))`; localized text fallback may compose those leaves
-/// with And/Or/Not. This keeps Product option/attribute ownership out of the generic Index engine.
+/// `resolved_attribute_filters` must come from the Product-owned Storefront filter resolution
+/// capability. Distribution translates the neutral Product expression shape into Index predicates but
+/// never resolves Product attribute codes, option codes or storage identities itself.
 ///
 /// A public channel ID is mandatory in this source slice. The owner channel-less contract means
 /// "metadata unrestricted only", while the current `sales_channel_ids` projection cannot distinguish
@@ -60,7 +59,7 @@ pub(crate) fn build_product_storefront_index_shadow_query(
     fallback_locale: &str,
     public_channel_id: Option<Uuid>,
     owner: &StorefrontProductListQuery,
-    canonical_attribute_filters: Vec<FilterExpr>,
+    resolved_attribute_filters: Vec<ProductResolvedAttributeFilter>,
 ) -> Result<LocalizedEntityQuery, ProductStorefrontIndexShadowError> {
     if tenant_id.is_nil() {
         return Err(ProductStorefrontIndexShadowError::NilTenant);
@@ -90,17 +89,7 @@ pub(crate) fn build_product_storefront_index_shadow_query(
     let limit = u32::try_from(owner.per_page)
         .map_err(|_| ProductStorefrontIndexShadowError::InvalidPagination)?;
 
-    if owner.attribute_filters.len() > MAX_STOREFRONT_ATTRIBUTE_FILTERS
-        || canonical_attribute_filters.len() != owner.attribute_filters.len()
-    {
-        return Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch);
-    }
-    if !canonical_attribute_filters
-        .iter()
-        .all(is_canonical_attribute_term_predicate)
-    {
-        return Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate);
-    }
+    let attribute_filters = resolved_attribute_filters_to_index(owner, resolved_attribute_filters)?;
 
     let mut filters = vec![
         FilterExpr::Eq(
@@ -119,7 +108,7 @@ pub(crate) fn build_product_storefront_index_shadow_query(
             IndexValue::Uuid(category_id),
         ));
     }
-    filters.extend(canonical_attribute_filters);
+    filters.extend(attribute_filters);
 
     let any_locale_filter = owner
         .search
@@ -192,6 +181,76 @@ pub(crate) fn build_product_storefront_index_shadow_query(
     .with_identity_order_direction(direction))
 }
 
+fn resolved_attribute_filters_to_index(
+    owner: &StorefrontProductListQuery,
+    resolved: Vec<ProductResolvedAttributeFilter>,
+) -> Result<Vec<FilterExpr>, ProductStorefrontIndexShadowError> {
+    if owner.attribute_filters.len() > MAX_STOREFRONT_ATTRIBUTE_FILTERS
+        || resolved.len() != owner.attribute_filters.len()
+        || owner
+            .attribute_filters
+            .iter()
+            .zip(&resolved)
+            .any(|(owner, resolved)| !owner.code.eq_ignore_ascii_case(resolved.code.as_str()))
+    {
+        return Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch);
+    }
+
+    resolved
+        .into_iter()
+        .map(|resolved| product_term_expr_to_index(resolved.predicate))
+        .collect()
+}
+
+fn product_term_expr_to_index(
+    expression: ProductAttributeTermExpr,
+) -> Result<FilterExpr, ProductStorefrontIndexShadowError> {
+    match expression {
+        ProductAttributeTermExpr::Term(term) => {
+            if term.is_empty() {
+                return Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate);
+            }
+            Ok(FilterExpr::Contains(
+                root_field("attribute_terms")?,
+                IndexValue::String(term),
+            ))
+        }
+        ProductAttributeTermExpr::And(children) => {
+            if children.is_empty() {
+                return Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate);
+            }
+            Ok(FilterExpr::And(
+                children
+                    .into_iter()
+                    .map(product_term_expr_to_index)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        ProductAttributeTermExpr::Or(children) => {
+            if children.is_empty() {
+                return Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate);
+            }
+            Ok(FilterExpr::Or(
+                children
+                    .into_iter()
+                    .map(product_term_expr_to_index)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        ProductAttributeTermExpr::Not(child) => Ok(FilterExpr::Not(Box::new(
+            product_term_expr_to_index(*child)?,
+        ))),
+        ProductAttributeTermExpr::Never => {
+            // Product ids are required/non-null in the current schema. Negating that invariant is a
+            // generic, bind-free false predicate without inventing a Product-specific sentinel term.
+            Ok(FilterExpr::Not(Box::new(FilterExpr::IsNull(
+                root_field("id")?,
+                false,
+            ))))
+        }
+    }
+}
+
 fn product_schema_ref() -> Result<SchemaRef, ProductStorefrontIndexShadowError> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product")
@@ -208,25 +267,10 @@ fn root_field(name: &str) -> Result<FieldPath, ProductStorefrontIndexShadowError
     ))
 }
 
-fn is_canonical_attribute_term_predicate(filter: &FilterExpr) -> bool {
-    match filter {
-        FilterExpr::Contains(path, IndexValue::String(term)) => {
-            path.links().is_empty()
-                && path.field().as_str() == "attribute_terms"
-                && !term.is_empty()
-        }
-        FilterExpr::And(children) | FilterExpr::Or(children) => {
-            !children.is_empty() && children.iter().all(is_canonical_attribute_term_predicate)
-        }
-        FilterExpr::Not(child) => is_canonical_attribute_term_predicate(child),
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustok_product::ProductAttributeFilter;
+    use rustok_product::{ProductAttributeFilter, ProductResolvedAttributeFilter};
 
     fn owner_query(direction: StorefrontProductSortDirection) -> StorefrontProductListQuery {
         StorefrontProductListQuery::try_from_transport_with_attribute_filters(
@@ -237,26 +281,23 @@ mod tests {
                 StorefrontProductSortDirection::Asc => "asc",
                 StorefrontProductSortDirection::Desc => "desc",
             }),
-            vec![ProductAttributeFilter {
-                code: "brand".to_owned(),
-                value: "acme".to_owned(),
-            }],
+            vec!["brand=acme".to_owned()],
         )
         .unwrap()
         .with_pagination(2, 12)
     }
 
-    fn attribute_term() -> FilterExpr {
-        FilterExpr::Contains(
-            root_field("attribute_terms").unwrap(),
-            IndexValue::String(
+    fn attribute_term() -> ProductResolvedAttributeFilter {
+        ProductResolvedAttributeFilter {
+            code: "brand".to_owned(),
+            predicate: ProductAttributeTermExpr::Term(
                 "00000000-0000-0000-0000-000000000001|text||61636d65".to_owned(),
             ),
-        )
+        }
     }
 
     #[test]
-    fn maps_owner_filters_projection_order_and_page_to_localized_fold() {
+    fn maps_product_owned_terms_projection_order_and_page_to_localized_fold() {
         let tenant = Uuid::new_v4();
         let channel = Uuid::new_v4();
         let owner = owner_query(StorefrontProductSortDirection::Desc);
@@ -285,7 +326,29 @@ mod tests {
     }
 
     #[test]
-    fn fails_closed_without_public_channel_or_resolved_attribute_terms() {
+    fn product_never_expression_becomes_false_root_predicate() {
+        let owner = owner_query(StorefrontProductSortDirection::Asc);
+        let resolved = ProductResolvedAttributeFilter {
+            code: "brand".to_owned(),
+            predicate: ProductAttributeTermExpr::Never,
+        };
+        let query = build_product_storefront_index_shadow_query(
+            Uuid::new_v4(),
+            "fi",
+            "en",
+            Some(Uuid::new_v4()),
+            &owner,
+            vec![resolved],
+        )
+        .unwrap();
+        let Some(FilterExpr::And(filters)) = query.query.filter else {
+            panic!("shadow query root filter must be AND");
+        };
+        assert!(filters.iter().any(|filter| matches!(filter, FilterExpr::Not(_))));
+    }
+
+    #[test]
+    fn fails_closed_without_public_channel_or_matching_owner_resolution() {
         let owner = owner_query(StorefrontProductSortDirection::Asc);
         assert_eq!(
             build_product_storefront_index_shadow_query(
@@ -309,6 +372,10 @@ mod tests {
             ),
             Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch)
         );
+        let wrong = ProductResolvedAttributeFilter {
+            code: "other".to_owned(),
+            predicate: ProductAttributeTermExpr::Term("term".to_owned()),
+        };
         assert_eq!(
             build_product_storefront_index_shadow_query(
                 Uuid::new_v4(),
@@ -316,10 +383,27 @@ mod tests {
                 "en",
                 Some(Uuid::new_v4()),
                 &owner,
-                vec![FilterExpr::Eq(
-                    root_field("attribute_terms").unwrap(),
-                    IndexValue::String("forbidden".to_owned()),
-                )],
+                vec![wrong],
+            ),
+            Err(ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch)
+        );
+    }
+
+    #[test]
+    fn rejects_empty_product_term_expression() {
+        let owner = owner_query(StorefrontProductSortDirection::Asc);
+        let invalid = ProductResolvedAttributeFilter {
+            code: "brand".to_owned(),
+            predicate: ProductAttributeTermExpr::Or(Vec::new()),
+        };
+        assert_eq!(
+            build_product_storefront_index_shadow_query(
+                Uuid::new_v4(),
+                "fi",
+                "en",
+                Some(Uuid::new_v4()),
+                &owner,
+                vec![invalid],
             ),
             Err(ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate)
         );

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product Storefront shadow adapter merge `4e9e032e11848db91ad4f837937c0de8ca3a7eaf` and continued on
-`agent/product-storefront-filter-terms-20260808`.
+Status overlay rechecked after Product-owned Storefront filter resolution merge `215389fcac0e086d7015453d7712fc341d6b722f` and continued on
+`agent/index-storefront-owner-terms-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -24,14 +24,13 @@ Source-complete:
   `REPEATABLE READ, READ ONLY` page/count snapshot;
 - bounded generic String `TextLike` for all-translations title matching;
 - localized Product-ID tie-break direction matching owner Asc/Desc ordering;
-- pure crate-local Product Storefront shadow query builder;
-- Product-owned public Storefront attribute-filter -> canonical term resolution capability.
+- Product-owned public Storefront attribute-filter -> neutral canonical term resolution;
+- pure crate-local Storefront shadow builder that consumes only `ProductResolvedAttributeFilter` and
+  translates `Term/And/Or/Not/Never` into Index root predicates.
 
-The Product-owned resolver now centralizes typed filter parsing used by the owner SQL path and exposes
-neutral `ProductAttributeTermExpr` values through optional `ProductCatalogSchemaReadPort` capability.
-Select/Multiselect option codes resolve to current active Product option UUIDs; UUID inputs keep owner
-identity semantics; missing option code/nil UUID becomes `Never` and therefore preserves owner empty-result
-behavior. Distribution Rust term helpers delegate canonical term identity to Product.
+`Never` maps to a bind-free false predicate by negating the current Product schema's required/non-null `id`
+invariant. The builder validates owner/resolver filter count and code identity before translating terms, so
+arbitrary consumer-built `FilterExpr` values can no longer cross the Product ownership boundary.
 
 ## Remaining Storefront parity blockers
 
@@ -46,7 +45,7 @@ behavior. Distribution Rust term helpers delegate canonical term identity to Pro
 Historical PostgreSQL packets must be actualized to routing key `4` / current 15-field Product contract;
 never add a key-3 runtime alias. Localized Storefront retained equivalence must cover requested/fallback/
 third-locale projection and search, wildcard behavior, scalar and localized EAV terms, Select/Multiselect
-option code and UUID inputs, missing option behavior, channel membership, equal timestamp Asc/Desc ties,
+option code and UUID inputs, missing option `Never`, channel membership, equal timestamp Asc/Desc ties,
 pagination/count, stale locale exclusion, readiness/admission and restart.
 
 ## M5 incremental ingestion
@@ -78,7 +77,8 @@ pagination/count, stale locale exclusion, readiness/admission and restart.
 - [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
 - [x] Product Storefront Index shadow/evidence query builder.
 - [x] Product-owned Storefront attribute-filter resolution to neutral canonical term expressions.
-- [ ] Wire Product term expressions into the shadow builder/executor.
+- [x] Wire Product term expressions into the shadow builder.
+- [ ] Compose non-serving Product-owner + Index shadow executor.
 - [ ] Retain owner-vs-Index localized PostgreSQL equivalence packet.
 - [ ] Resolve/admit search-length and collation parity.
 - [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
@@ -92,10 +92,10 @@ pagination/count, stale locale exclusion, readiness/admission and restart.
 
 ## Next source-code step
 
-Build a non-serving **shadow executor/equivalence boundary**. It should retrieve the host-selected Product
-schema read port, resolve owner EAV inputs there, translate `ProductAttributeTermExpr` into Index root
-predicates, execute through `execute_localized_query`, and retain owner-vs-Index evidence without changing
-mounted Storefront behavior. Taxonomy hydration stays after Product page selection.
+Compose a non-serving **shadow executor/equivalence boundary**. It must retrieve the host-selected Product
+schema read port, call `resolve_storefront_attribute_filters`, feed those owner-owned results to the shadow
+builder, execute through `execute_localized_query`, and retain owner-vs-Index evidence without changing
+mounted Storefront behavior. Taxonomy hydration remains after Product page selection.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-storefront-shadow-adapter.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-adapter.mjs
@@ -21,16 +21,25 @@ const requireMarkers = (relative, markers) => {
 const shadowPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
 const shadow = requireMarkers(shadowPath, [
   'pub(crate) fn build_product_storefront_index_shadow_query(',
+  'resolved_attribute_filters: Vec<ProductResolvedAttributeFilter>',
+  'resolved_attribute_filters_to_index(owner, resolved_attribute_filters)?',
+  'owner.code.eq_ignore_ascii_case(resolved.code.as_str())',
+  'fn product_term_expr_to_index(',
+  'ProductAttributeTermExpr::Term(term)',
+  'ProductAttributeTermExpr::And(children)',
+  'ProductAttributeTermExpr::Or(children)',
+  'ProductAttributeTermExpr::Not(child)',
+  'ProductAttributeTermExpr::Never',
+  'FilterExpr::Contains(',
+  'root_field("attribute_terms")?',
+  'FilterExpr::Not(Box::new(FilterExpr::IsNull(',
+  'root_field("id")?',
   'ProductStorefrontIndexShadowError::PublicChannelRequired',
   'ProductStorefrontIndexShadowError::OffsetTooDeep',
   'ProductStorefrontIndexShadowError::SearchPatternTooLong',
   'ProductStorefrontIndexShadowError::AttributeFilterResolutionMismatch',
   'ProductStorefrontIndexShadowError::InvalidAttributeTermPredicate',
   'ProductStatus::Active.to_string()',
-  'FilterExpr::IsNull(root_field("published_at")?, false)',
-  'root_field("sales_channel_ids")?',
-  'root_field("primary_category_id")?',
-  'root_field("attribute_terms")',
   'FilterExpr::TextLike(root_field("title")?, pattern)',
   'StorefrontProductSortBy::PublishedAt => ["published_at", "created_at"]',
   'StorefrontProductSortBy::CreatedAt => ["created_at", "published_at"]',
@@ -51,25 +60,15 @@ for (const forbidden of [
   if (shadow.includes(forbidden)) fail(`${shadowPath} must remain a pure shadow query builder; found ${forbidden}`);
 }
 
+requireMarkers('crates/rustok-product/src/catalog_schema_read_port.rs', [
+  'async fn resolve_storefront_attribute_filters(',
+  'ProductResolvedAttributeFilter',
+]);
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'mod storefront_shadow;',
   'build_product_storefront_index_shadow_query',
   'ProductStorefrontIndexShadowError',
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
-]);
-
-const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
-const owner = requireMarkers(ownerPath, [
-  'ProductStatus::Active',
-  'Column::PublishedAt.is_not_null()',
-  'product_channel_visibility_condition(',
-  'Column::PrimaryCategoryId.eq(category_id)',
-  'attribute_filters::load_catalog_attribute_filter_conditions(',
-  'let pattern = format!("%{search}%");',
-  'pt.title LIKE $1',
-  '.order_by_asc(entities::product::Column::Id)',
-  '.order_by_desc(entities::product::Column::Id)',
-  'let total = query.clone().count(&self.db).await?',
 ]);
 
 const storefrontPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -81,10 +80,4 @@ for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'execute_loc
   if (storefront.includes(forbidden)) fail(`${storefrontPath} must remain owner-native; found ${forbidden}`);
 }
 
-requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_resolver.rs', [
-  'if visibility.is_unrestricted',
-  'list_sales_channel_ids(',
-  'visibility.allowed_slugs',
-]);
-
-console.log('[verify-index-product-storefront-shadow-adapter] Product Storefront shadow builder is source-locked; traffic and unresolved owner metadata/search/channel gates remain fail-closed');
+console.log('[verify-index-product-storefront-shadow-adapter] shadow builder consumes only Product-owned resolved terms and remains non-serving/fail-closed');


### PR DESCRIPTION
## Summary

- tighten the Product Storefront shadow builder boundary so it accepts only `Vec<ProductResolvedAttributeFilter>` from the Product-owned resolver, not arbitrary consumer-built Index `FilterExpr` values;
- verify resolved filter count and case-insensitive code identity against the authoritative `StorefrontProductListQuery` before translation;
- translate neutral Product `Term`, `And`, `Or`, `Not` expressions recursively into root `attribute_terms` Index predicates;
- translate Product `Never` into a bind-free false predicate by negating the current Product schema's required/non-null `id` invariant, without inventing a sentinel term;
- reject empty term strings and empty logical expressions fail-closed;
- preserve the existing pure shadow boundary: no Product DB reads, no owner service construction, no `execute_localized_query`, no Storefront traffic switch;
- actualize the shadow source guard and current Index execution cursor to shadow-executor/equivalence as the next step.

## Main recheck

The branch started from Product-owned filter-resolution merge `215389fcac0e086d7015453d7712fc341d6b722f`. Current `main` subsequently advanced through #3228 legacy admin Product owner-port consumer cutover and #3227/#3230 Forum/Page Builder evidence. Those commits are disjoint from this distribution shadow-builder/Index-plan slice.

## Boundary

This PR does not execute the shadow query, retrieve Product schema-read runtime, hydrate Taxonomy tags, alter Storefront serving, resolve search-length/collation/channel-less/deep-page parity, or run owner-vs-Index PostgreSQL evidence.

Next is a non-serving shadow executor/equivalence boundary that obtains the host-selected Product schema read port, calls `resolve_storefront_attribute_filters`, feeds its result to this builder, and executes only through localized Index runtime while retaining owner output as the served result.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.