### PR TITLE
test(forum): prove moderation revision fencing under concurrent edits

### DIFF
--- a/crates/rustok-forum/docs/forum-moderation-revision-concurrency-contract.md
+++ b/crates/rustok-forum/docs/forum-moderation-revision-concurrency-contract.md
@@ -1,0 +1,77 @@
+# Forum moderation revision PostgreSQL concurrency contract
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+`crates/rustok-forum/tests/moderation_revision_concurrency_postgres.rs` retains real PostgreSQL concurrency evidence for the Forum-owned moderation subject revision fence.
+
+The test uses the production Forum migrations through the shared `PostgresForumTestDb` bootstrap and materializes the real `ForumModerationSubjectAdapterFactory` against independent database connections. No test double stands in for the producer adapter.
+
+This contract complements `forum-moderation-revision-migration-contract.md`: the migration contract proves clock initialization/backfill/trigger parity, while this target proves an edit that owns the clock concurrently cannot be silently moderated under an older reviewed revision.
+
+## Overlap construction
+
+Each scenario starts with a public subject whose current moderation revision is recorded as the reviewed revision. A separate PostgreSQL transaction then changes reviewed content:
+
+- topic scenario: update the topic translation title while a permanent-lock decision still references the old topic revision;
+- reply scenario: update the reply body while a hide decision still references the old reply revision.
+
+The content update fires the production Forum moderation-revision trigger inside the still-open edit transaction. The test verifies the transaction-local revision has advanced by exactly one before starting moderation application.
+
+The real Forum adapter is then invoked on another connection. Before allowing the edit to commit, the harness waits until the producer has created its real `forum/apply_moderation_decision` `owner_operation_receipts` row in `processing` state. This proves the moderation call has crossed the producer admission boundary while the edit still owns the revision-row lock; the concurrency assertion is not satisfied merely because Tokio delayed scheduling the application task.
+
+While that edit transaction remains open, the moderation application must not complete.
+
+## Safe PostgreSQL outcomes
+
+Forum application transactions use PostgreSQL `SERIALIZABLE` isolation and lock both the active subject and its dedicated moderation-revision row. When the edit transaction wins the revision lock, PostgreSQL may expose either of two fail-closed first-call outcomes after the edit commits:
+
+1. the adapter observes the newer revision and returns non-retryable `forum.moderation_subject_revision_conflict`; or
+2. PostgreSQL resolves the serializable overlap as a retryable storage/serialization failure, surfaced as `forum.moderation_database_unavailable`.
+
+Both are safe because neither outcome may apply the stale moderation effect.
+
+A second application with a fresh decision UUID but the **same stale reviewed revision** is then issued after the edit has committed. The fresh UUID deliberately separates the subject-revision assertion from the first call's owner-receipt lease state if PostgreSQL chose the retryable serialization outcome. This second call must deterministically return `forum.moderation_subject_revision_conflict`.
+
+Receipt lease/reclaim semantics for retryable producer failures are covered separately by the owner-operation receipt and lost-response evidence; this target is specifically about the subject clock fence.
+
+## Topic lock assertions
+
+For the topic race, after the concurrent translation edit wins:
+
+- title equals the edited value;
+- moderation revision equals `reviewed_revision + 1` exactly;
+- `is_locked` remains false after both the overlapping call and deterministic stale call;
+- no lock effect is allowed to retarget the edited topic silently.
+
+## Reply hide assertions
+
+For the reply race, after the concurrent body edit wins:
+
+- body equals the edited value;
+- moderation revision equals `reviewed_revision + 1` exactly;
+- reply remains `approved`;
+- topic/category public reply counters remain one;
+- no `forum.reply.status_changed` event is emitted by a rejected stale moderation application.
+
+The same invariants are rechecked after the deterministic stale call, proving the semantic conflict path is side-effect free.
+
+## Why this is a concurrency contract
+
+The edit transaction stays open while the real producer receipt already exists and the adapter task remains incomplete. The two operations therefore overlap on independent PostgreSQL connections and contend on the same owner revision clock. The test does not simulate concurrency by manually changing a revision after an application returns.
+
+The retained invariant is fail-closed: a decision reviewed against revision `N` can never mutate subject state that an overlapping edit has advanced to `N+1`.
+
+## Maintainer commands
+
+Intentionally not run while preparing this slice:
+
+```bash
+RUSTOK_FORUM_TEST_DATABASE_URL=postgres://... \
+  cargo test -p rustok-forum --test moderation_revision_concurrency_postgres -- --nocapture
+
+node scripts/verify/verify-forum-moderation-revision-concurrency-postgres.mjs
+```
+
+No tests, Cargo commands, Node verifiers, formatters, real PostgreSQL migrations, workflows or CI were executed while preparing this file.

--- a/crates/rustok-forum/tests/moderation_revision_concurrency_postgres.rs
+++ b/crates/rustok-forum/tests/moderation_revision_concurrency_postgres.rs
@@ -1,0 +1,508 @@
+mod support;
+
+use std::{sync::Arc, time::Duration};
+
+use rustok_api::{HostRuntimeContext, PortActor, PortContext, PortError, PortErrorKind};
+use rustok_forum::ForumModerationSubjectAdapterFactory;
+use rustok_moderation_api::{
+    ApplyModerationDecisionCommand, ModerationDecisionEffect, ModerationDecisionEffectAction,
+    ModerationDecisionKind, ModerationReasonCode, ModerationSubjectAdapterFactory,
+    ModerationSubjectCommandPort, ModerationSubjectKind, ModerationSubjectRef,
+    ModerationVisibilityState,
+};
+use sea_orm::{
+    ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction, Statement,
+    TransactionTrait,
+};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+use support::postgres::{PostgresForumTestDb, execute};
+use support::{TestResult, test_error};
+
+const REVISION_CONFLICT: &str = "forum.moderation_subject_revision_conflict";
+const DATABASE_UNAVAILABLE: &str = "forum.moderation_database_unavailable";
+const MODERATION_ACTOR: &str = "rustok-moderation";
+
+#[derive(Clone, Copy)]
+struct RaceSeed {
+    tenant_id: Uuid,
+    category_id: Uuid,
+    topic_id: Uuid,
+    topic_translation_id: Uuid,
+    reply_id: Uuid,
+    reply_body_id: Uuid,
+}
+
+#[tokio::test]
+async fn postgres_concurrent_content_edits_fence_topic_lock_and_reply_hide() -> TestResult<()> {
+    let Some(database) = PostgresForumTestDb::setup("moderation_revision_concurrency").await? else {
+        return Ok(());
+    };
+
+    let outcome = async {
+        topic_translation_edit_fences_permanent_lock(&database).await?;
+        reply_body_edit_fences_hide_application(&database).await?;
+        Ok(())
+    }
+    .await;
+
+    database.cleanup().await?;
+    outcome
+}
+
+async fn topic_translation_edit_fences_permanent_lock(
+    database: &PostgresForumTestDb,
+) -> TestResult<()> {
+    let seed = seed_public_subjects(&database.db).await?;
+    let reviewed_revision = topic_revision(&database.db, seed).await?;
+
+    let edit_db = database.peer().await?;
+    let edit = edit_db.begin().await?;
+    edit.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "UPDATE forum_topic_translations SET title = $1 WHERE tenant_id = $2 AND id = $3",
+        vec![
+            "Concurrent topic edit".to_string().into(),
+            seed.tenant_id.into(),
+            seed.topic_translation_id.into(),
+        ],
+    ))
+    .await?;
+    assert_eq!(topic_revision_in(&edit, seed).await?, reviewed_revision + 1);
+
+    let adapter = topic_adapter(database.peer().await?)?;
+    let command = topic_lock_command(seed, reviewed_revision, Uuid::new_v4())?;
+    let mut application = spawn_application(adapter.clone(), seed.tenant_id, command);
+
+    assert_application_waits_while_edit_owns_revision(&mut application, "topic").await?;
+    edit.commit().await?;
+
+    let first_error = application
+        .await?
+        .expect_err("overlapping topic edit must prevent lock application against the old revision");
+    assert_overlap_error_is_fail_closed(&first_error)?;
+
+    assert_eq!(topic_revision(&database.db, seed).await?, reviewed_revision + 1);
+    assert_eq!(topic_locked(&database.db, seed).await?, false);
+    assert_eq!(
+        topic_title(&database.db, seed).await?,
+        "Concurrent topic edit"
+    );
+
+    // A new delivery attempt against the same stale reviewed revision must deterministically
+    // resolve to the semantic revision conflict once the concurrent edit has committed.
+    let stale = topic_lock_command(seed, reviewed_revision, Uuid::new_v4())?;
+    let stale_error = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, stale.decision_id, "topic-stale-retry"),
+            stale,
+        )
+        .await
+        .expect_err("stale topic decision must not lock edited content");
+    assert_revision_conflict(&stale_error)?;
+    assert_eq!(topic_locked(&database.db, seed).await?, false);
+    assert_eq!(topic_revision(&database.db, seed).await?, reviewed_revision + 1);
+    Ok(())
+}
+
+async fn reply_body_edit_fences_hide_application(
+    database: &PostgresForumTestDb,
+) -> TestResult<()> {
+    let seed = seed_public_subjects(&database.db).await?;
+    let reviewed_revision = reply_revision(&database.db, seed).await?;
+
+    let edit_db = database.peer().await?;
+    let edit = edit_db.begin().await?;
+    edit.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "UPDATE forum_reply_bodies SET body = $1 WHERE tenant_id = $2 AND id = $3",
+        vec![
+            "Concurrent reply edit".to_string().into(),
+            seed.tenant_id.into(),
+            seed.reply_body_id.into(),
+        ],
+    ))
+    .await?;
+    assert_eq!(reply_revision_in(&edit, seed).await?, reviewed_revision + 1);
+
+    let adapter = reply_adapter(database.peer().await?)?;
+    let command = reply_hide_command(seed, reviewed_revision, Uuid::new_v4())?;
+    let mut application = spawn_application(adapter.clone(), seed.tenant_id, command);
+
+    assert_application_waits_while_edit_owns_revision(&mut application, "reply").await?;
+    edit.commit().await?;
+
+    let first_error = application
+        .await?
+        .expect_err("overlapping reply edit must prevent hide application against the old revision");
+    assert_overlap_error_is_fail_closed(&first_error)?;
+
+    assert_eq!(reply_revision(&database.db, seed).await?, reviewed_revision + 1);
+    assert_eq!(reply_status(&database.db, seed).await?, "approved");
+    assert_eq!(reply_body(&database.db, seed).await?, "Concurrent reply edit");
+    assert_public_reply_accounting(&database.db, seed).await?;
+    assert_eq!(count_reply_status_events(&database.db, seed).await?, 0);
+
+    let stale = reply_hide_command(seed, reviewed_revision, Uuid::new_v4())?;
+    let stale_error = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, stale.decision_id, "reply-stale-retry"),
+            stale,
+        )
+        .await
+        .expect_err("stale reply decision must not hide edited content");
+    assert_revision_conflict(&stale_error)?;
+    assert_eq!(reply_status(&database.db, seed).await?, "approved");
+    assert_eq!(reply_revision(&database.db, seed).await?, reviewed_revision + 1);
+    assert_public_reply_accounting(&database.db, seed).await?;
+    assert_eq!(count_reply_status_events(&database.db, seed).await?, 0);
+    Ok(())
+}
+
+fn spawn_application(
+    adapter: Arc<dyn ModerationSubjectCommandPort>,
+    tenant_id: Uuid,
+    command: ApplyModerationDecisionCommand,
+) -> tokio::task::JoinHandle<Result<rustok_moderation_api::ModerationDecisionApplication, PortError>> {
+    tokio::spawn(async move {
+        adapter
+            .apply_moderation_decision(
+                application_context(tenant_id, command.decision_id, "overlapping-application"),
+                command,
+            )
+            .await
+    })
+}
+
+async fn assert_application_waits_while_edit_owns_revision(
+    application: &mut tokio::task::JoinHandle<
+        Result<rustok_moderation_api::ModerationDecisionApplication, PortError>,
+    >,
+    label: &str,
+) -> TestResult<()> {
+    tokio::task::yield_now().await;
+    if let Ok(result) = timeout(Duration::from_millis(50), application).await {
+        let completed = result?;
+        return Err(test_error(format!(
+            "{label} moderation application completed while the concurrent edit still held the subject revision lock: {completed:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn assert_overlap_error_is_fail_closed(error: &PortError) -> TestResult<()> {
+    match error.code.as_str() {
+        REVISION_CONFLICT => assert_revision_conflict(error),
+        DATABASE_UNAVAILABLE => {
+            if error.kind != PortErrorKind::Unavailable || !error.retryable {
+                return Err(test_error(format!(
+                    "serialization/storage overlap must remain retryable unavailable, got {error}"
+                )));
+            }
+            Ok(())
+        }
+        other => Err(test_error(format!(
+            "concurrent Forum moderation application returned unexpected error code `{other}`: {error}"
+        ))),
+    }
+}
+
+fn assert_revision_conflict(error: &PortError) -> TestResult<()> {
+    if error.kind != PortErrorKind::Conflict
+        || error.retryable
+        || error.code != REVISION_CONFLICT
+    {
+        return Err(test_error(format!(
+            "expected non-retryable Forum moderation revision conflict, got {error}"
+        )));
+    }
+    Ok(())
+}
+
+fn topic_adapter(
+    db: DatabaseConnection,
+) -> TestResult<Arc<dyn ModerationSubjectCommandPort>> {
+    Ok(ForumModerationSubjectAdapterFactory::topic().build(&HostRuntimeContext::new(db))?)
+}
+
+fn reply_adapter(
+    db: DatabaseConnection,
+) -> TestResult<Arc<dyn ModerationSubjectCommandPort>> {
+    Ok(ForumModerationSubjectAdapterFactory::reply().build(&HostRuntimeContext::new(db))?)
+}
+
+fn topic_lock_command(
+    seed: RaceSeed,
+    reviewed_revision: i64,
+    decision_id: Uuid,
+) -> TestResult<ApplyModerationDecisionCommand> {
+    Ok(ApplyModerationDecisionCommand {
+        decision_id,
+        subject: ModerationSubjectRef {
+            module: "forum".to_string(),
+            kind: ModerationSubjectKind::ForumTopic,
+            id: seed.topic_id,
+            revision: reviewed_revision,
+        },
+        decision_kind: ModerationDecisionKind::Lock,
+        reason_code: ModerationReasonCode::Other,
+        effect: ModerationDecisionEffect::v1(ModerationDecisionEffectAction::Lock {
+            effective_until: None,
+        })?,
+        decision_hash: "a".repeat(64),
+    })
+}
+
+fn reply_hide_command(
+    seed: RaceSeed,
+    reviewed_revision: i64,
+    decision_id: Uuid,
+) -> TestResult<ApplyModerationDecisionCommand> {
+    Ok(ApplyModerationDecisionCommand {
+        decision_id,
+        subject: ModerationSubjectRef {
+            module: "forum".to_string(),
+            kind: ModerationSubjectKind::ForumPost,
+            id: seed.reply_id,
+            revision: reviewed_revision,
+        },
+        decision_kind: ModerationDecisionKind::Hide,
+        reason_code: ModerationReasonCode::Other,
+        effect: ModerationDecisionEffect::v1(
+            ModerationDecisionEffectAction::SetVisibility {
+                state: ModerationVisibilityState::Hidden,
+            },
+        )?,
+        decision_hash: "b".repeat(64),
+    })
+}
+
+fn application_context(tenant_id: Uuid, decision_id: Uuid, correlation: &str) -> PortContext {
+    let decision = decision_id.to_string();
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service(MODERATION_ACTOR),
+        "und",
+        correlation,
+    )
+    .with_causation_id(decision.clone())
+    .with_idempotency_key(decision)
+    .with_deadline(Duration::from_secs(5))
+}
+
+async fn seed_public_subjects(db: &DatabaseConnection) -> TestResult<RaceSeed> {
+    let seed = RaceSeed {
+        tenant_id: Uuid::new_v4(),
+        category_id: Uuid::new_v4(),
+        topic_id: Uuid::new_v4(),
+        topic_translation_id: Uuid::new_v4(),
+        reply_id: Uuid::new_v4(),
+        reply_body_id: Uuid::new_v4(),
+    };
+    execute(
+        db,
+        format!(
+            r#"
+            INSERT INTO forum_categories
+                (id, tenant_id, position, moderated, topic_count, reply_count)
+            VALUES
+                ('{}', '{}', 0, FALSE, 1, 1);
+            INSERT INTO forum_topics
+                (id, tenant_id, category_id, status, metadata, is_pinned, is_locked, reply_count)
+            VALUES
+                ('{}', '{}', '{}', 'open', '{{}}', FALSE, FALSE, 1);
+            INSERT INTO forum_topic_translations
+                (id, tenant_id, topic_id, locale, title, slug, body)
+            VALUES
+                ('{}', '{}', '{}', 'en', 'Reviewed topic', 'reviewed-topic', 'Reviewed topic body');
+            INSERT INTO forum_replies
+                (id, tenant_id, topic_id, status, position)
+            VALUES
+                ('{}', '{}', '{}', 'approved', 1);
+            INSERT INTO forum_reply_bodies
+                (id, tenant_id, reply_id, locale, body)
+            VALUES
+                ('{}', '{}', '{}', 'en', 'Reviewed reply body');
+            "#,
+            seed.category_id,
+            seed.tenant_id,
+            seed.topic_id,
+            seed.tenant_id,
+            seed.category_id,
+            seed.topic_translation_id,
+            seed.tenant_id,
+            seed.topic_id,
+            seed.reply_id,
+            seed.tenant_id,
+            seed.topic_id,
+            seed.reply_body_id,
+            seed.tenant_id,
+            seed.reply_id,
+        ),
+    )
+    .await?;
+    Ok(seed)
+}
+
+async fn topic_revision(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        format!(
+            "SELECT revision::bigint AS value FROM forum_topic_moderation_subject_revisions WHERE tenant_id = '{}' AND topic_id = '{}'",
+            seed.tenant_id, seed.topic_id
+        ),
+    )
+    .await
+}
+
+async fn topic_revision_in(
+    db: &DatabaseTransaction,
+    seed: RaceSeed,
+) -> TestResult<i64> {
+    scalar_i64_on(
+        db,
+        format!(
+            "SELECT revision::bigint AS value FROM forum_topic_moderation_subject_revisions WHERE tenant_id = '{}' AND topic_id = '{}'",
+            seed.tenant_id, seed.topic_id
+        ),
+    )
+    .await
+}
+
+async fn reply_revision(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        format!(
+            "SELECT revision::bigint AS value FROM forum_reply_moderation_subject_revisions WHERE tenant_id = '{}' AND reply_id = '{}'",
+            seed.tenant_id, seed.reply_id
+        ),
+    )
+    .await
+}
+
+async fn reply_revision_in(
+    db: &DatabaseTransaction,
+    seed: RaceSeed,
+) -> TestResult<i64> {
+    scalar_i64_on(
+        db,
+        format!(
+            "SELECT revision::bigint AS value FROM forum_reply_moderation_subject_revisions WHERE tenant_id = '{}' AND reply_id = '{}'",
+            seed.tenant_id, seed.reply_id
+        ),
+    )
+    .await
+}
+
+async fn topic_locked(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<bool> {
+    scalar_bool(
+        db,
+        format!(
+            "SELECT is_locked AS value FROM forum_topics WHERE tenant_id = '{}' AND id = '{}'",
+            seed.tenant_id, seed.topic_id
+        ),
+    )
+    .await
+}
+
+async fn topic_title(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<String> {
+    scalar_string(
+        db,
+        format!(
+            "SELECT title AS value FROM forum_topic_translations WHERE tenant_id = '{}' AND id = '{}'",
+            seed.tenant_id, seed.topic_translation_id
+        ),
+    )
+    .await
+}
+
+async fn reply_status(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<String> {
+    scalar_string(
+        db,
+        format!(
+            "SELECT status AS value FROM forum_replies WHERE tenant_id = '{}' AND id = '{}'",
+            seed.tenant_id, seed.reply_id
+        ),
+    )
+    .await
+}
+
+async fn reply_body(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<String> {
+    scalar_string(
+        db,
+        format!(
+            "SELECT body AS value FROM forum_reply_bodies WHERE tenant_id = '{}' AND id = '{}'",
+            seed.tenant_id, seed.reply_body_id
+        ),
+    )
+    .await
+}
+
+async fn assert_public_reply_accounting(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<()> {
+    assert_eq!(
+        scalar_i64(
+            db,
+            format!(
+                "SELECT reply_count::bigint AS value FROM forum_topics WHERE tenant_id = '{}' AND id = '{}'",
+                seed.tenant_id, seed.topic_id
+            ),
+        )
+        .await?,
+        1
+    );
+    assert_eq!(
+        scalar_i64(
+            db,
+            format!(
+                "SELECT reply_count::bigint AS value FROM forum_categories WHERE tenant_id = '{}' AND id = '{}'",
+                seed.tenant_id, seed.category_id
+            ),
+        )
+        .await?,
+        1
+    );
+    Ok(())
+}
+
+async fn count_reply_status_events(db: &DatabaseConnection, seed: RaceSeed) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        format!(
+            "SELECT COUNT(*)::bigint AS value FROM sys_events WHERE event_type = 'forum.reply.status_changed' AND payload->>'tenant_id' = '{}'",
+            seed.tenant_id
+        ),
+    )
+    .await
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: String) -> TestResult<i64> {
+    scalar_i64_on(db, sql).await
+}
+
+async fn scalar_i64_on<C>(db: &C, sql: String) -> TestResult<i64>
+where
+    C: ConnectionTrait,
+{
+    let row = db
+        .query_one(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await?
+        .ok_or_else(|| test_error("scalar PostgreSQL query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+async fn scalar_bool(db: &DatabaseConnection, sql: String) -> TestResult<bool> {
+    let row = db
+        .query_one(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await?
+        .ok_or_else(|| test_error("boolean PostgreSQL query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}
+
+async fn scalar_string(db: &DatabaseConnection, sql: String) -> TestResult<String> {
+    let row = db
+        .query_one(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await?
+        .ok_or_else(|| test_error("string PostgreSQL query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}

--- a/crates/rustok-forum/tests/moderation_revision_concurrency_postgres.rs
+++ b/crates/rustok-forum/tests/moderation_revision_concurrency_postgres.rs
@@ -14,7 +14,7 @@ use sea_orm::{
     ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction, Statement,
     TransactionTrait,
 };
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 use uuid::Uuid;
 
 use support::postgres::{PostgresForumTestDb, execute};
@@ -23,6 +23,7 @@ use support::{TestResult, test_error};
 const REVISION_CONFLICT: &str = "forum.moderation_subject_revision_conflict";
 const DATABASE_UNAVAILABLE: &str = "forum.moderation_database_unavailable";
 const MODERATION_ACTOR: &str = "rustok-moderation";
+const APPLY_OPERATION: &str = "apply_moderation_decision";
 
 #[derive(Clone, Copy)]
 struct RaceSeed {
@@ -73,8 +74,10 @@ async fn topic_translation_edit_fences_permanent_lock(
 
     let adapter = topic_adapter(database.peer().await?)?;
     let command = topic_lock_command(seed, reviewed_revision, Uuid::new_v4())?;
+    let decision_id = command.decision_id;
     let mut application = spawn_application(adapter.clone(), seed.tenant_id, command);
 
+    wait_for_processing_receipt(&database.db, seed.tenant_id, decision_id).await?;
     assert_application_waits_while_edit_owns_revision(&mut application, "topic").await?;
     edit.commit().await?;
 
@@ -90,8 +93,10 @@ async fn topic_translation_edit_fences_permanent_lock(
         "Concurrent topic edit"
     );
 
-    // A new delivery attempt against the same stale reviewed revision must deterministically
-    // resolve to the semantic revision conflict once the concurrent edit has committed.
+    // A new delivery against the same stale reviewed revision must deterministically resolve to
+    // the semantic revision conflict once the concurrent edit has committed. A fresh decision UUID
+    // avoids confusing the subject fence with the first call's owner-receipt state after a possible
+    // PostgreSQL serialization retry.
     let stale = topic_lock_command(seed, reviewed_revision, Uuid::new_v4())?;
     let stale_error = adapter
         .apply_moderation_decision(
@@ -128,8 +133,10 @@ async fn reply_body_edit_fences_hide_application(
 
     let adapter = reply_adapter(database.peer().await?)?;
     let command = reply_hide_command(seed, reviewed_revision, Uuid::new_v4())?;
+    let decision_id = command.decision_id;
     let mut application = spawn_application(adapter.clone(), seed.tenant_id, command);
 
+    wait_for_processing_receipt(&database.db, seed.tenant_id, decision_id).await?;
     assert_application_waits_while_edit_owns_revision(&mut application, "reply").await?;
     edit.commit().await?;
 
@@ -175,13 +182,45 @@ fn spawn_application(
     })
 }
 
+async fn wait_for_processing_receipt(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    decision_id: Uuid,
+) -> TestResult<()> {
+    for _ in 0..100 {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT status FROM owner_operation_receipts WHERE tenant_id = $1 AND owner_slug = 'forum' AND idempotency_key = $2 AND operation = $3",
+                vec![
+                    tenant_id.into(),
+                    decision_id.to_string().into(),
+                    APPLY_OPERATION.to_string().into(),
+                ],
+            ))
+            .await?;
+        if let Some(row) = row {
+            let status: String = row.try_get("", "status")?;
+            if status == "processing" {
+                return Ok(());
+            }
+            return Err(test_error(format!(
+                "Forum moderation receipt reached unexpected `{status}` state before concurrent edit commit"
+            )));
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    Err(test_error(
+        "Forum moderation application did not reach the owner receipt boundary while edit transaction was open",
+    ))
+}
+
 async fn assert_application_waits_while_edit_owns_revision(
     application: &mut tokio::task::JoinHandle<
         Result<rustok_moderation_api::ModerationDecisionApplication, PortError>,
     >,
     label: &str,
 ) -> TestResult<()> {
-    tokio::task::yield_now().await;
     if let Ok(result) = timeout(Duration::from_millis(50), application).await {
         let completed = result?;
         return Err(test_error(format!(

--- a/scripts/verify/verify-forum-moderation-revision-concurrency-postgres.mjs
+++ b/scripts/verify/verify-forum-moderation-revision-concurrency-postgres.mjs
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+
+const test = fs.readFileSync(
+  "crates/rustok-forum/tests/moderation_revision_concurrency_postgres.rs",
+  "utf8",
+);
+const docs = fs.readFileSync(
+  "crates/rustok-forum/docs/forum-moderation-revision-concurrency-contract.md",
+  "utf8",
+);
+const adapter = fs.readFileSync(
+  "crates/rustok-forum/src/moderation_subject.rs",
+  "utf8",
+);
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  "postgres_concurrent_content_edits_fence_topic_lock_and_reply_hide",
+  "topic_translation_edit_fences_permanent_lock",
+  "reply_body_edit_fences_hide_application",
+  "PostgresForumTestDb::setup",
+  "ForumModerationSubjectAdapterFactory::topic()",
+  "ForumModerationSubjectAdapterFactory::reply()",
+  "UPDATE forum_topic_translations SET title",
+  "UPDATE forum_reply_bodies SET body",
+  "wait_for_processing_receipt",
+  "owner_operation_receipts",
+  "status == \"processing\"",
+  "assert_application_waits_while_edit_owns_revision",
+  "forum.moderation_subject_revision_conflict",
+  "forum.moderation_database_unavailable",
+  "ModerationDecisionEffectAction::Lock",
+  "ModerationVisibilityState::Hidden",
+  "reviewed_revision + 1",
+  "assert_public_reply_accounting",
+  "count_reply_status_events",
+]) {
+  requireText(test, marker, `Forum moderation concurrency contract is missing ${marker}`);
+}
+
+for (const marker of [
+  "IsolationLevel::Serializable",
+  "FOR UPDATE",
+  "forum.moderation_subject_revision_conflict",
+  "reviewed_revision != command.subject.revision",
+  "idempotency::admit",
+  "APPLY_MODERATION_DECISION_OPERATION",
+]) {
+  requireText(adapter, marker, `Forum moderation adapter concurrency invariant is missing ${marker}`);
+}
+
+for (const marker of [
+  "Overlap construction",
+  "Safe PostgreSQL outcomes",
+  "owner_operation_receipts",
+  "same stale reviewed revision",
+  "Topic lock assertions",
+  "Reply hide assertions",
+  "fail-closed",
+  "cargo test -p rustok-forum --test moderation_revision_concurrency_postgres",
+]) {
+  requireText(docs, marker, `Forum moderation concurrency handoff is missing ${marker}`);
+}
+
+console.log("Forum moderation revision PostgreSQL concurrency source guard passed");


### PR DESCRIPTION
## Summary
- add real PostgreSQL concurrency evidence for Forum moderation subject revision fencing
- use production Forum migrations and the real `ForumModerationSubjectAdapterFactory` on independent PostgreSQL connections
- hold a topic translation edit open after its production revision trigger advances the clock, then start a permanent-lock application against the old reviewed revision
- hold a reply body edit open after its revision trigger advances the clock, then start a hide application against the old reviewed revision
- wait for the real `forum/apply_moderation_decision` owner receipt to reach `processing` before releasing the edit lock, proving the calls overlap beyond the producer admission boundary
- accept only fail-closed first-call outcomes allowed by PostgreSQL SERIALIZABLE overlap: semantic revision conflict or retryable database/serialization unavailability
- after commit, issue a fresh decision against the same stale reviewed revision and require deterministic `forum.moderation_subject_revision_conflict`
- prove stale topic lock never sets `is_locked`
- prove stale reply hide never changes status, counters or status-change audit and the edited body remains intact
- add focused docs and a static source guard

## Plan context
This closes the concurrent producer-edit versus moderation-application evidence portion of Forum/Moderation priority 6. Migration/backfill/trigger parity is covered separately by #3230.

A fresh decision UUID is used only for the deterministic post-overlap stale assertion so the subject fence is not confused with a first call that PostgreSQL may leave behind a retryable processing owner-receipt lease. Receipt reclaim/lost-response semantics are covered by the separate receipt evidence.

## Verification
Static source review only. PostgreSQL tests, Cargo commands, Node source guards, formatters, real database migrations, workflows and CI were intentionally not run per maintainer request.