### PR TITLE
feat(index): add Product Storefront shadow executor

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -14,6 +14,11 @@ mod storefront_shadow;
 pub(crate) use storefront_shadow::{
     ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,
 };
+mod storefront_shadow_executor;
+pub(crate) use storefront_shadow_executor::{
+    ProductStorefrontIndexShadowComparison, ProductStorefrontIndexShadowExecution,
+    ProductStorefrontIndexShadowExecutor, ProductStorefrontIndexShadowProjectionError,
+};
 #[path = "../product_variant_index.rs"]
 mod variant;
 #[cfg(test)]

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -6,9 +6,9 @@ use rustok_index::{
     IndexQueryExecutionError, IndexQueryPage, IndexQueryPort, SharedIndexQueryRuntime,
 };
 use rustok_product::{
-    FilteredPublishedProductsRequest, ProductCatalogReadPort, ProductCatalogReadRuntime,
-    ProductCatalogSchemaReadPort, ProductStorefrontAttributeFilterResolutionRequest,
-    StorefrontProductList, StorefrontProductListQuery,
+    FilteredPublishedProductsRequest, ProductCatalogReadRuntime,
+    ProductStorefrontAttributeFilterResolutionRequest, StorefrontProductList,
+    StorefrontProductListQuery,
 };
 
 use super::{
@@ -45,7 +45,7 @@ pub(crate) enum ProductStorefrontIndexShadowProjectionError {
     SchemaReadPortUnavailable,
     #[error("Product Storefront shadow request tenant identity is invalid")]
     InvalidTenant,
-    #[error("Product Storefront shadow requires matching public channel slug and id")]
+    #[error("Product Storefront shadow requires a trusted public channel slug/id pair")]
     PublicChannelIdentityUnavailable,
     #[error("Product Storefront shadow attribute-filter owner resolution failed: {0}")]
     AttributeFilterResolution(PortError),
@@ -61,6 +61,10 @@ pub(crate) enum ProductStorefrontIndexShadowProjectionError {
 /// `CatalogService`, `ProductCatalogSchemaService`, a PostgreSQL Index port, or a database connection.
 /// The owner list result remains authoritative even when Product metadata resolution, shadow query build,
 /// Index readiness/admission, or Index execution fails.
+///
+/// `public_channel_slug` and `public_channel_id` must be a trusted pair supplied by the caller's current
+/// channel context. This executor only checks that both identities are present and non-empty/non-nil; it
+/// does not independently prove slug/UUID correspondence.
 #[derive(Clone)]
 pub(crate) struct ProductStorefrontIndexShadowExecutor {
     product: ProductCatalogReadRuntime,
@@ -164,7 +168,7 @@ impl ProductStorefrontIndexShadowExecutor {
         self.index
             .execute_localized_query(index_query)
             .await
-            .map_err(Into::into)
+            .map_err(ProductStorefrontIndexShadowProjectionError::Index)
     }
 }
 

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -1,0 +1,214 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+use rustok_api::{PortContext, PortError};
+use rustok_index::{
+    IndexQueryExecutionError, IndexQueryPage, IndexQueryPort, SharedIndexQueryRuntime,
+};
+use rustok_product::{
+    FilteredPublishedProductsRequest, ProductCatalogReadPort, ProductCatalogReadRuntime,
+    ProductCatalogSchemaReadPort, ProductStorefrontAttributeFilterResolutionRequest,
+    StorefrontProductList, StorefrontProductListQuery,
+};
+
+use super::{
+    ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,
+};
+
+/// Non-serving Product Storefront parity execution result.
+///
+/// The authoritative owner result is always produced first. Projected failures or mismatches are retained
+/// separately and never replace the owner result.
+#[derive(Debug)]
+pub(crate) struct ProductStorefrontIndexShadowExecution {
+    pub(crate) authoritative: StorefrontProductList,
+    pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>,
+    pub(crate) comparison: Option<ProductStorefrontIndexShadowComparison>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProductStorefrontIndexShadowComparison {
+    pub(crate) identities_match: bool,
+    pub(crate) exact_count_matches: bool,
+    pub(crate) has_more_matches: bool,
+}
+
+impl ProductStorefrontIndexShadowComparison {
+    pub(crate) fn is_match(self) -> bool {
+        self.identities_match && self.exact_count_matches && self.has_more_matches
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProductStorefrontIndexShadowProjectionError {
+    #[error("Product Storefront shadow schema-read capability is unavailable")]
+    SchemaReadPortUnavailable,
+    #[error("Product Storefront shadow request tenant identity is invalid")]
+    InvalidTenant,
+    #[error("Product Storefront shadow requires matching public channel slug and id")]
+    PublicChannelIdentityUnavailable,
+    #[error("Product Storefront shadow attribute-filter owner resolution failed: {0}")]
+    AttributeFilterResolution(PortError),
+    #[error(transparent)]
+    QueryBuild(#[from] ProductStorefrontIndexShadowError),
+    #[error(transparent)]
+    Index(#[from] IndexQueryExecutionError),
+}
+
+/// Owner-first, non-serving Product Storefront shadow executor.
+///
+/// This object composes only host-selected Product and Index capabilities. It never constructs
+/// `CatalogService`, `ProductCatalogSchemaService`, a PostgreSQL Index port, or a database connection.
+/// The owner list result remains authoritative even when Product metadata resolution, shadow query build,
+/// Index readiness/admission, or Index execution fails.
+#[derive(Clone)]
+pub(crate) struct ProductStorefrontIndexShadowExecutor {
+    product: ProductCatalogReadRuntime,
+    index: SharedIndexQueryRuntime,
+}
+
+impl ProductStorefrontIndexShadowExecutor {
+    pub(crate) fn new(
+        product: ProductCatalogReadRuntime,
+        index: SharedIndexQueryRuntime,
+    ) -> Self {
+        Self { product, index }
+    }
+
+    pub(crate) async fn execute(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        public_channel_slug: Option<String>,
+        public_channel_id: Option<Uuid>,
+        query: StorefrontProductListQuery,
+    ) -> Result<ProductStorefrontIndexShadowExecution, PortError> {
+        let authoritative = self
+            .product
+            .read_port()
+            .list_filtered_published_products(
+                context.clone(),
+                FilteredPublishedProductsRequest {
+                    locale: Some(context.locale.clone()),
+                    fallback_locale: Some(fallback_locale.clone()),
+                    public_channel_slug: public_channel_slug.clone(),
+                    query: query.clone(),
+                },
+            )
+            .await?;
+
+        let projected = self
+            .execute_projected(
+                context,
+                fallback_locale,
+                public_channel_slug,
+                public_channel_id,
+                query,
+            )
+            .await;
+        let comparison = projected
+            .as_ref()
+            .ok()
+            .map(|projected| compare_owner_and_index(&authoritative, projected));
+
+        Ok(ProductStorefrontIndexShadowExecution {
+            authoritative,
+            projected,
+            comparison,
+        })
+    }
+
+    async fn execute_projected(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        public_channel_slug: Option<String>,
+        public_channel_id: Option<Uuid>,
+        query: StorefrontProductListQuery,
+    ) -> Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError> {
+        let public_channel_id = match (
+            public_channel_slug.as_deref().map(str::trim),
+            public_channel_id,
+        ) {
+            (Some(slug), Some(channel_id)) if !slug.is_empty() && !channel_id.is_nil() => channel_id,
+            _ => {
+                return Err(
+                    ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable,
+                );
+            }
+        };
+        let tenant_id = Uuid::parse_str(context.tenant_id.as_str())
+            .map_err(|_| ProductStorefrontIndexShadowProjectionError::InvalidTenant)?;
+        let schema_read = self
+            .product
+            .schema_read_port()
+            .ok_or(ProductStorefrontIndexShadowProjectionError::SchemaReadPortUnavailable)?;
+        let resolved = schema_read
+            .resolve_storefront_attribute_filters(
+                context.clone(),
+                ProductStorefrontAttributeFilterResolutionRequest {
+                    fallback_locale: fallback_locale.clone(),
+                    filters: query.attribute_filters.clone(),
+                },
+            )
+            .await
+            .map_err(ProductStorefrontIndexShadowProjectionError::AttributeFilterResolution)?;
+        let index_query = build_product_storefront_index_shadow_query(
+            tenant_id,
+            context.locale.as_str(),
+            fallback_locale.as_str(),
+            Some(public_channel_id),
+            &query,
+            resolved,
+        )?;
+        self.index
+            .execute_localized_query(index_query)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+fn compare_owner_and_index(
+    authoritative: &StorefrontProductList,
+    projected: &IndexQueryPage,
+) -> ProductStorefrontIndexShadowComparison {
+    let authoritative_ids = authoritative
+        .items
+        .iter()
+        .map(|item| item.id)
+        .collect::<Vec<_>>();
+    let projected_ids = projected
+        .items
+        .iter()
+        .map(|item| item.entity_id)
+        .collect::<Vec<_>>();
+    ProductStorefrontIndexShadowComparison {
+        identities_match: authoritative_ids == projected_ids,
+        exact_count_matches: projected.exact_count == Some(authoritative.total),
+        has_more_matches: projected.has_more == authoritative.has_next,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comparison_requires_identity_order_count_and_page_boundary() {
+        let authoritative = StorefrontProductList {
+            items: Vec::new(),
+            total: 0,
+            page: 1,
+            per_page: 12,
+            has_next: false,
+        };
+        let projected = IndexQueryPage {
+            items: Vec::new(),
+            exact_count: Some(0),
+            has_more: false,
+            next_cursor: None,
+        };
+        let comparison = compare_owner_and_index(&authoritative, &projected);
+        assert!(comparison.is_match());
+    }
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product-owned Storefront filter resolution merge `215389fcac0e086d7015453d7712fc341d6b722f` and continued on
-`agent/index-storefront-owner-terms-20260808`.
+Status overlay rechecked after Product-owned term translation merge `9a684becf802904baec3e860eb2178c689a0253c` and continued on
+`agent/index-storefront-shadow-executor-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -25,12 +25,18 @@ Source-complete:
 - bounded generic String `TextLike` for all-translations title matching;
 - localized Product-ID tie-break direction matching owner Asc/Desc ordering;
 - Product-owned public Storefront attribute-filter -> neutral canonical term resolution;
-- pure crate-local Storefront shadow builder that consumes only `ProductResolvedAttributeFilter` and
-  translates `Term/And/Or/Not/Never` into Index root predicates.
+- pure Storefront shadow builder consuming only `ProductResolvedAttributeFilter`;
+- non-serving owner-first `ProductStorefrontIndexShadowExecutor` over host-selected Product and Index
+  runtimes.
 
-`Never` maps to a bind-free false predicate by negating the current Product schema's required/non-null `id`
-invariant. The builder validates owner/resolver filter count and code identity before translating terms, so
-arbitrary consumer-built `FilterExpr` values can no longer cross the Product ownership boundary.
+The shadow executor first calls the authoritative Product read port. Only after owner success does it resolve
+Product EAV metadata, build the localized Index query and call `execute_localized_query`. Projected failures
+remain data in the shadow result and cannot replace the successful owner result.
+
+For channel-scoped comparison the caller must supply a trusted current slug/UUID pair; the executor checks
+presence/non-empty/non-nil only and does not independently prove their correspondence. Built-in comparison
+covers ordered Product IDs, exact count and `has_more` only. Full field/search/tag equivalence is still
+retained PostgreSQL evidence debt.
 
 ## Remaining Storefront parity blockers
 
@@ -38,15 +44,26 @@ arbitrary consumer-built `FilterExpr` values can no longer cross the Product own
 - owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`;
 - channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
 - owner page depth exceeds Index bounded offset depth;
-- localized Taxonomy tag names must be hydrated after Product page identity/count is fixed.
+- localized Taxonomy tag names must be hydrated after Product page identity/count is fixed;
+- shadow execution has no serving latency/deadline policy and must remain non-serving.
 
 ## Retained Product evidence debt
 
 Historical PostgreSQL packets must be actualized to routing key `4` / current 15-field Product contract;
-never add a key-3 runtime alias. Localized Storefront retained equivalence must cover requested/fallback/
-third-locale projection and search, wildcard behavior, scalar and localized EAV terms, Select/Multiselect
-option code and UUID inputs, missing option `Never`, channel membership, equal timestamp Asc/Desc ties,
-pagination/count, stale locale exclusion, readiness/admission and restart.
+never add a key-3 runtime alias.
+
+The next localized Storefront PostgreSQL packet must run owner and shadow execution side-by-side and cover:
+
+- requested/fallback/neither localized projection;
+- third-locale/all-translations title search and wildcard semantics;
+- duplicate locale matches yielding one identity/count;
+- scalar and localized EAV terms;
+- Select/Multiselect option code, UUID and missing-option `Never` behavior;
+- trusted public-channel membership;
+- equal timestamp Asc/Desc Product-ID ties;
+- pagination and exact count;
+- stale locale exclusion, readiness/admission and replay/restart behavior;
+- explicit search-bound and collation evidence.
 
 ## M5 incremental ingestion
 
@@ -78,7 +95,7 @@ pagination/count, stale locale exclusion, readiness/admission and restart.
 - [x] Product Storefront Index shadow/evidence query builder.
 - [x] Product-owned Storefront attribute-filter resolution to neutral canonical term expressions.
 - [x] Wire Product term expressions into the shadow builder.
-- [ ] Compose non-serving Product-owner + Index shadow executor.
+- [x] Compose non-serving Product-owner + Index shadow executor.
 - [ ] Retain owner-vs-Index localized PostgreSQL equivalence packet.
 - [ ] Resolve/admit search-length and collation parity.
 - [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
@@ -88,14 +105,14 @@ pagination/count, stale locale exclusion, readiness/admission and restart.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
-- [ ] Move Storefront traffic only after every parity/readiness/freshness/restart gate passes.
+- [ ] Move Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes.
 
 ## Next source-code step
 
-Compose a non-serving **shadow executor/equivalence boundary**. It must retrieve the host-selected Product
-schema read port, call `resolve_storefront_attribute_filters`, feed those owner-owned results to the shadow
-builder, execute through `execute_localized_query`, and retain owner-vs-Index evidence without changing
-mounted Storefront behavior. Taxonomy hydration remains after Product page selection.
+Build the retained Product Storefront localized PostgreSQL **owner-vs-shadow equivalence packet/harness** on
+current routing key `4`. It must exercise the actual Product owner list and the non-serving shadow executor,
+record identity/order/count and projected field evidence, and keep unresolved search/channel/deep-page cases
+explicitly fail-closed. Taxonomy hydration remains a post-page evidence step.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,55 +1,63 @@
 # M7 Product Storefront Index parity gate
 
-Status: `shadow_query_and_product_owned_eav_resolution_source_complete_execution_evidence_pending`.
+Status: `shadow_executor_source_complete_postgres_equivalence_pending`.
 
 ## Current boundary
 
 Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
-The Index-side shadow query builder is source-complete, and Product now owns the missing public
-Storefront attribute-filter resolution capability. The next slice is shadow execution/equivalence, not
-consumer cutover.
+The Product-owned EAV resolver, pure localized shadow query builder and non-serving owner-first shadow
+executor are source-complete. Source completion is not PostgreSQL equivalence evidence and does not admit
+Index output for serving.
 
 ## Product-owned attribute-filter resolution — source complete
 
-`ProductCatalogSchemaReadPort` now exposes optional
-`resolve_storefront_attribute_filters`. Existing external adapters remain source-compatible because the
-default implementation fails closed with
-`product.storefront_attribute_filter_resolution_unavailable`.
+`ProductCatalogSchemaReadPort::resolve_storefront_attribute_filters` is the only Product metadata boundary
+used by shadow execution. Existing external adapters remain source-compatible through the fail-closed
+default implementation.
 
-The in-process Product implementation resolves each canonical `ProductAttributeFilter` using the same
-owner rules as the mounted SQL list path:
-
-- at most eight filters, case-insensitive duplicate-code rejection and existing code/value bounds;
-- definition eligibility is tenant-scoped, active, filterable and `product|both` scope;
-- attribute lookup is case-insensitive by code;
-- text is exact value matching;
-- integer/decimal/boolean/date/datetime parsing is shared with the owner SQL condition builder;
-- localized text is represented as `requested-value OR (NOT requested-present AND fallback-value)`;
-- Select/Multiselect accepts a UUID directly or resolves an exact active option code to its option UUID;
-- missing option code and nil UUID resolve to neutral `ProductAttributeTermExpr::Never`, preserving the
-  owner SQL empty-result behavior rather than inventing a validation error;
-- JSON remains unsupported exactly as on the owner list path.
-
-Product exports a neutral `ProductAttributeTermExpr` (`Term`, `And`, `Or`, `Not`, `Never`) and owns the
-canonical term grammar `attribute_uuid|kind|hex(locale)|hex(value)`. Product does not depend on
-`rustok-index`.
-
-`rustok-distribution` no longer owns a second Rust term encoder: its Product Index helpers delegate term
-identity to `rustok-product`. The PostgreSQL Product source CTE remains the materialization-side mirror of
-the same grammar.
+The owner resolver preserves mounted list semantics for definition eligibility, typed scalar parsing,
+localized requested/fallback text behavior and Select/Multiselect UUID/code resolution. It returns neutral
+`ProductAttributeTermExpr` values and Product owns the canonical term grammar. Distribution only translates
+those owner-owned expressions into `attribute_terms` Index predicates.
 
 ## Shadow query adapter — source complete
 
-`build_product_storefront_index_shadow_query` remains a pure crate-local translation into
-`LocalizedEntityQuery`. It maps Active/published-only, trusted public-channel membership, optional primary
-category, canonical `attribute_terms`, any-locale title `TextLike`, requested/fallback title+handle,
-paired timestamp order plus matching Product-ID tie-break, bounded offset pagination and exact count.
-It selects stable `tag_ids` for later Taxonomy hydration and uses only current Product routing key `4`.
+`build_product_storefront_index_shadow_query` accepts only `ProductResolvedAttributeFilter`, validates the
+resolved filter identities against the authoritative `StorefrontProductListQuery`, and translates
+`Term/And/Or/Not/Never` into root Index predicates. `Never` is represented by a bind-free false predicate
+using the current Product schema's required/non-null `id` invariant.
 
-The builder still does not execute Index queries, read Product EAV tables, hydrate Taxonomy names or mount
-Storefront traffic.
+The builder maps Active/published-only, trusted current public-channel membership, optional primary
+category, canonical EAV terms, any-locale title `TextLike`, requested/fallback title+handle, paired timestamp
+order plus matching Product-ID direction, bounded offset pagination and exact count. It remains pure: no DB,
+Product service construction or Index execution occurs inside it.
+
+## Non-serving shadow executor — source complete
+
+`ProductStorefrontIndexShadowExecutor` composes only host-selected `ProductCatalogReadRuntime` and
+`SharedIndexQueryRuntime`.
+
+Execution order is deliberately owner-first:
+
+1. `ProductCatalogReadPort::list_filtered_published_products` produces the authoritative result;
+2. only after owner success, the optional Product schema-read capability resolves EAV filters;
+3. the pure shadow builder creates `LocalizedEntityQuery`;
+4. `SharedIndexQueryRuntime::execute_localized_query` executes with the existing persisted-readiness,
+   owner-admission and one-snapshot localized runtime contract.
+
+If schema resolution, query build, readiness/admission or Index execution fails, that error is retained only
+inside `projected`; it cannot replace the successful owner result. The executor is not mounted into
+Storefront serving.
+
+For channel-scoped evidence the caller must provide a **trusted current** slug/UUID pair. The executor checks
+only that both identities are present and non-empty/non-nil; it does not independently prove slug↔UUID
+correspondence. Channel-less requests remain projected fail-closed.
+
+The built-in comparison is intentionally narrow: ordered Product identity list, exact count and page
+`has_more` boundary. It does **not** claim scalar/localized projection, tag hydration, search-collation or
+full semantic equivalence. Those belong to retained PostgreSQL evidence.
 
 ## Remaining fail-closed parity gates
 
@@ -60,31 +68,38 @@ Storefront traffic.
    distinguish unrestricted from restricted-to-all-current-channels.
 4. Owner page depth is wider than the Index 10,000 offset bound.
 5. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
+6. Shadow execution has no serving-latency/deadline policy and therefore must remain non-serving.
 
-## Next source slice
+## Next source slice: retained PostgreSQL equivalence
 
-Compose a **shadow executor/equivalence harness** that:
+Add a Product Storefront localized PostgreSQL packet/harness that exercises the actual owner path and the
+non-serving shadow executor side-by-side. It must cover at least:
 
-- obtains `ProductCatalogSchemaReadPort` from the host-selected Product read runtime;
-- resolves public EAV filters through `resolve_storefront_attribute_filters`;
-- translates neutral Product term expressions into canonical Index `attribute_terms` filters;
-- executes only through `execute_localized_query` with existing readiness/admission/snapshot semantics;
-- retains owner and Index results side-by-side without serving Index output to Storefront;
-- batch-hydrates Taxonomy tags only after the Product page is fixed;
-- records PostgreSQL equivalence across requested/fallback/third-locale search, EAV option code/UUID,
-  localized EAV fallback, channel membership, Asc/Desc equal timestamps, count, pagination, stale rows and
-  restart/readiness cases.
+- requested translation, fallback translation and neither requested nor fallback;
+- third-locale/all-translations title search plus `%`, `_` and backslash wildcard cases;
+- duplicate locale matches yielding one Product identity and exact count;
+- scalar and localized EAV terms;
+- Select/Multiselect option code, direct UUID and missing-option `Never` behavior;
+- trusted public-channel membership;
+- equal timestamps under both Asc and Desc Product-ID tie-breaks;
+- pagination and exact count;
+- stale locale exclusion, readiness/admission failure and replay/restart behavior;
+- explicit search-bound/collation evidence rather than silently declaring parity.
 
-Historical Product PostgreSQL packets still need routing key `4` / current 15-field actualization. Do not
-add a key-3 runtime compatibility path.
+Historical Product PostgreSQL packets still need routing key `4` / current 15-field actualization. Never add
+a key-3 runtime compatibility path.
+
+Taxonomy tag hydration must be retained only after the Product page is fixed and must not change Product
+identity/order/count.
 
 ## Source guards
 
-- `verify-product-storefront-attribute-filter-terms.mjs` locks Product ownership, shared typed parsing,
-  option resolution, neutral expression shape and distribution delegation;
-- `verify-index-product-storefront-shadow-adapter.mjs` locks the pure fail-closed shadow translation;
+- `verify-product-storefront-attribute-filter-terms.mjs` locks Product-owned EAV resolution;
+- `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term → localized query translation;
+- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution and forbids
+  direct DB/service/PostgreSQL-port construction;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native;
-- localized runtime/order/TextLike guards continue to lock the generic Index execution contract.
+- localized runtime/order/TextLike guards continue to lock generic Index semantics.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -54,6 +54,14 @@ requireMarkers('crates/rustok-product/src/services/catalog_attribute_terms.rs', 
   'pub struct ProductResolvedAttributeFilter',
   'product_attribute_localized_text_expr(',
 ]);
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs', [
+  'pub(crate) struct ProductStorefrontIndexShadowExecutor',
+  'list_filtered_published_products(',
+  '.resolve_storefront_attribute_filters(',
+  '.execute_localized_query(index_query)',
+  'pub(crate) authoritative: StorefrontProductList',
+  'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
+]);
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
@@ -65,17 +73,18 @@ const productIndex = requireMarkers(productIndexPath, [
 if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `shadow_query_and_product_owned_eav_resolution_source_complete_execution_evidence_pending`',
+  'Status: `shadow_executor_source_complete_postgres_equivalence_pending`',
   'Mounted Storefront remains owner-native',
-  'Product-owned attribute-filter resolution — source complete',
-  '`ProductAttributeTermExpr`',
-  '`ProductCatalogSchemaReadPort`',
-  'Channel-less owner requests',
-  'shadow executor/equivalence harness',
+  'Non-serving shadow executor — source complete',
+  'owner-first',
+  '`ProductCatalogReadRuntime`',
+  '`SharedIndexQueryRuntime`',
+  'trusted current',
+  'retained PostgreSQL equivalence',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
   'Status: `source_complete_materialized_rebuild_pending`',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; shadow query plus Product-owned EAV resolution are source-complete while execution/evidence gates remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; Product-owned EAV resolution, shadow translation and owner-first non-serving execution are source-complete while PostgreSQL equivalence remains pending');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-shadow-executor] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const source = requireMarkers(executorPath, [
+  'pub(crate) struct ProductStorefrontIndexShadowExecutor',
+  'product: ProductCatalogReadRuntime',
+  'index: SharedIndexQueryRuntime',
+  'pub(crate) struct ProductStorefrontIndexShadowExecution',
+  'pub(crate) authoritative: StorefrontProductList',
+  'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
+  'list_filtered_published_products(',
+  'let projected = self',
+  '.schema_read_port()',
+  '.resolve_storefront_attribute_filters(',
+  'build_product_storefront_index_shadow_query(',
+  '.execute_localized_query(index_query)',
+  'PublicChannelIdentityUnavailable',
+  'SchemaReadPortUnavailable',
+  'compare_owner_and_index(&authoritative, projected)',
+  'identities_match: authoritative_ids == projected_ids',
+  'projected.exact_count == Some(authoritative.total)',
+  'projected.has_more == authoritative.has_next',
+]);
+
+const ownerPosition = source.indexOf('list_filtered_published_products(');
+const projectedPosition = source.indexOf('let projected = self');
+if (ownerPosition < 0 || projectedPosition < 0 || ownerPosition > projectedPosition) {
+  fail('authoritative Product owner list must execute before any Index shadow work');
+}
+
+for (const forbidden of [
+  'DatabaseConnection',
+  'CatalogService::new',
+  'ProductCatalogSchemaService::new',
+  'PostgresIndexQueryPort',
+  'query_all(',
+  'query_one(',
+]) {
+  if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports only; found ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod storefront_shadow_executor;',
+  'ProductStorefrontIndexShadowExecutor',
+  'ProductStorefrontIndexShadowExecution',
+  'ProductStorefrontIndexShadowComparison',
+]);
+
+const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
+const mounted = requireMarkers(mountedPath, [
+  'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
+  '.list_published_products_with_query(',
+]);
+for (const forbidden of ['ProductStorefrontIndexShadowExecutor', 'execute_localized_query']) {
+  if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
+}
+
+console.log('[verify-index-product-storefront-shadow-executor] owner-first non-serving shadow execution is source-locked; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -83,6 +83,7 @@ const scripts = [
   'verify-index-product-storefront-parity-gate.mjs',
   'verify-index-product-storefront-localized-query-architecture.mjs',
   'verify-index-product-storefront-shadow-adapter.mjs',
+  'verify-index-product-storefront-shadow-executor.mjs',
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-localized-query-runtime.mjs',


### PR DESCRIPTION
## Summary

- add a non-serving owner-first `ProductStorefrontIndexShadowExecutor` in `rustok-distribution`;
- compose only host-selected `ProductCatalogReadRuntime` and `SharedIndexQueryRuntime`, with no direct DB, `CatalogService`, schema-service or PostgreSQL Index port construction;
- execute authoritative `list_filtered_published_products` first and return owner errors normally;
- only after owner success, obtain the optional Product schema-read capability, resolve Storefront EAV filters, build the localized shadow query and call `execute_localized_query`;
- retain Product metadata/query-build/readiness/admission/Index execution failures inside the projected shadow result so they cannot replace the successful authoritative Product result;
- require a trusted non-empty/non-nil public channel slug/UUID pair for channel-scoped projection; the executor deliberately does not claim to prove slug↔UUID correspondence;
- keep channel-less projection fail-closed;
- retain a deliberately narrow built-in comparison for ordered Product identities, exact count and `has_more`; full scalar/localized/tag/search equivalence remains PostgreSQL evidence debt;
- add source guards and advance the Storefront parity/current-plan cursor to retained owner-vs-shadow PostgreSQL equivalence.

## Main recheck

The branch started from Product-term translation merge `9a684becf802904baec3e860eb2178c689a0253c`. Before PR creation, current `main@8275c38a44974aa404d253fcbf76d372c5de4d69` advanced only through #3232 Forum moderation concurrency evidence. That commit is disjoint from this 7-file Product/Index shadow-executor slice.

## Boundary

This PR does not mount the executor into Storefront serving, add a serving latency/deadline policy, hydrate Taxonomy tags, resolve search-length/collation/channel-less/deep-page parity, run PostgreSQL equivalence, or change Product schema/routing key.

The next source slice is the retained Product Storefront localized PostgreSQL owner-vs-shadow packet on current routing key 4, covering localized projection/search, EAV option code/UUID/missing option behavior, channel membership, Asc/Desc ties, page/count and readiness/restart cases.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.