### PR TITLE
test(forum): retain moderation effect accounting and tombstone evidence

### DIFF
--- a/crates/rustok-forum/docs/forum-moderation-effect-postgres-contract.md
+++ b/crates/rustok-forum/docs/forum-moderation-effect-postgres-contract.md
@@ -1,0 +1,74 @@
+# Forum moderation effect PostgreSQL contract
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+`crates/rustok-forum/tests/moderation_effect_contract_postgres.rs` retains real PostgreSQL producer evidence for Forum reply moderation effects that were intentionally left distinct in FORUM-19:
+
+- `RejectPublication` accounting, audit, idempotent replay, and already-rejected no-op behavior;
+- `Remove + SetVisibility(Removed)` through the complete Forum reply-removal owner path, including accepted-solution cleanup and tombstone preservation;
+- valid neutral `Unpublish + SetVisibility(Unpublished)` failing closed because Forum has no faithful unpublished lifecycle state.
+
+The target uses the production Forum migrations through `PostgresForumTestDb` and materializes the real `ForumModerationSubjectAdapterFactory::reply()`. SQL is used only to seed truthful owner state and to observe the committed result; moderation mutations are performed only through the real adapter.
+
+## RejectPublication
+
+The fixture starts with one approved public reply and matching topic/category/author reply counters at one. Applying a real `RejectPublication` decision against the current Forum moderation revision must atomically:
+
+- change the reply from `approved` to `rejected` without soft-deleting it;
+- decrement topic, category and author public reply counters to zero exactly once;
+- emit exactly one `forum.reply.status_changed` outbox event;
+- advance the dedicated reply moderation revision;
+- complete exactly one Forum owner-operation receipt under the immutable decision UUID.
+
+Replaying the same decision UUID and request must return the stored application result without another state transition, event, counter adjustment or revision bump.
+
+A second, fresh decision evaluated against the already-rejected **current** revision exercises the owner no-op path. Since `apply_reply_non_public_status_effect_in_tx` returns `changed=false` when the reply already has the target status, this decision completes truthfully at the same applied revision and does not emit another event or adjust accounting again.
+
+## Removed accepted solution
+
+The removal fixture starts with an approved reply that is also the topic's accepted solution. Public reply counters and the author's solution counter all begin at one.
+
+`Remove + SetVisibility(Removed)` must route through `ReplyService::remove_in_tx`, the same owner path used for Forum reply deletion. A successful application must atomically leave:
+
+- the reply row preserved as a tombstone with `status=deleted` and non-null `deleted_at`;
+- the reply body preserved;
+- the accepted-solution relation removed;
+- topic/category/author reply counters at zero;
+- author `solution_count` at zero;
+- exactly one `forum.reply.status_changed` event to `deleted`;
+- one completed Forum owner-operation receipt.
+
+The same decision UUID is then replayed. The replay must return the exact stored `ModerationDecisionApplication` and leave the tombstone, counters, solution state, event count and moderation revision unchanged. This is a particularly strong receipt-first assertion: without completed receipt replay, normal active-subject lookup would reject the already soft-deleted reply.
+
+## Unpublished remains distinct
+
+The neutral Moderation API permits `ModerationDecisionKind::Unpublish` only with `SetVisibility(Unpublished)`, so the test supplies a structurally valid typed decision rather than a malformed command.
+
+Forum deliberately does not approximate `Unpublished` as `Hidden`, `Rejected` or `Removed`. The real adapter must return non-retryable validation code `forum.moderation_effect_unsupported` and persist a failed owner-operation receipt. The reply must remain approved, its moderation revision and public counters must remain unchanged, and no status-change event may be emitted.
+
+This keeps the shared semantic distinction intact: producers may support only the lifecycle states they can represent faithfully, and unsupported valid effects fail closed instead of being silently remapped.
+
+## Relationship to other evidence
+
+This target complements, rather than duplicates:
+
+- `soft_delete_revision_postgres.rs`, which proves the generic Forum tombstone/revision owner invariant;
+- `forum-lost-response-postgres-contract.md`, which proves lost-response replay across Moderation and Forum;
+- `forum-moderation-revision-concurrency-contract.md`, which proves stale moderation cannot cross a concurrent content-edit revision fence.
+
+Here the focus is the exact producer effect semantics and accounting/event/tombstone/solution consequences of successful or unsupported Forum moderation applications.
+
+## Maintainer commands
+
+Intentionally not run while preparing this slice:
+
+```bash
+RUSTOK_FORUM_TEST_DATABASE_URL=postgres://... \
+  cargo test -p rustok-forum --test moderation_effect_contract_postgres -- --nocapture
+
+node scripts/verify/verify-forum-moderation-effect-postgres-contract.mjs
+```
+
+No tests, Cargo commands, Node verifiers, formatters, real PostgreSQL migrations, workflows or CI were executed while preparing this file.

--- a/crates/rustok-forum/tests/moderation_effect_contract_postgres.rs
+++ b/crates/rustok-forum/tests/moderation_effect_contract_postgres.rs
@@ -5,10 +5,10 @@ use std::{sync::Arc, time::Duration};
 use rustok_api::{HostRuntimeContext, PortActor, PortContext, PortErrorKind};
 use rustok_forum::ForumModerationSubjectAdapterFactory;
 use rustok_moderation_api::{
-    ApplyModerationDecisionCommand, ModerationDecisionApplication, ModerationDecisionEffect,
-    ModerationDecisionEffectAction, ModerationDecisionKind, ModerationReasonCode,
-    ModerationSubjectAdapterFactory, ModerationSubjectCommandPort, ModerationSubjectKind,
-    ModerationSubjectRef, ModerationVisibilityState,
+    ApplyModerationDecisionCommand, ModerationDecisionEffect, ModerationDecisionEffectAction,
+    ModerationDecisionKind, ModerationReasonCode, ModerationSubjectAdapterFactory,
+    ModerationSubjectCommandPort, ModerationSubjectKind, ModerationSubjectRef,
+    ModerationVisibilityState,
 };
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
 use uuid::Uuid;
@@ -80,8 +80,6 @@ async fn reject_publication_accounts_once_and_replays(db: &DatabaseConnection) -
     assert_eq!(status_event_count(db, seed.tenant_id).await?, 1);
     assert_receipt(db, seed.tenant_id, decision_id, "completed").await?;
 
-    // A new decision evaluated against the already-rejected current revision is an owner no-op:
-    // it completes truthfully without another counter adjustment, event, or revision bump.
     let no_op_id = Uuid::new_v4();
     let no_op = reject_command(seed, revision_after_first, no_op_id)?;
     let no_op_application = adapter
@@ -170,11 +168,7 @@ fn reply_adapter(db: DatabaseConnection) -> TestResult<Arc<dyn ModerationSubject
     Ok(ForumModerationSubjectAdapterFactory::reply().build(&HostRuntimeContext::new(db))?)
 }
 
-fn reject_command(
-    seed: ReplySeed,
-    revision: i64,
-    decision_id: Uuid,
-) -> TestResult<ApplyModerationDecisionCommand> {
+fn reject_command(seed: ReplySeed, revision: i64, decision_id: Uuid) -> TestResult<ApplyModerationDecisionCommand> {
     command(
         seed,
         revision,
@@ -185,11 +179,7 @@ fn reject_command(
     )
 }
 
-fn removed_command(
-    seed: ReplySeed,
-    revision: i64,
-    decision_id: Uuid,
-) -> TestResult<ApplyModerationDecisionCommand> {
+fn removed_command(seed: ReplySeed, revision: i64, decision_id: Uuid) -> TestResult<ApplyModerationDecisionCommand> {
     command(
         seed,
         revision,
@@ -202,11 +192,7 @@ fn removed_command(
     )
 }
 
-fn unpublished_command(
-    seed: ReplySeed,
-    revision: i64,
-    decision_id: Uuid,
-) -> TestResult<ApplyModerationDecisionCommand> {
+fn unpublished_command(seed: ReplySeed, revision: i64, decision_id: Uuid) -> TestResult<ApplyModerationDecisionCommand> {
     command(
         seed,
         revision,
@@ -340,25 +326,16 @@ VALUES
     Ok(seed)
 }
 
-async fn assert_approved_state(
-    db: &DatabaseConnection,
-    seed: ReplySeed,
-    accepted_solution: bool,
-) -> TestResult<()> {
+async fn assert_approved_state(db: &DatabaseConnection, seed: ReplySeed, accepted_solution: bool) -> TestResult<()> {
     let row = reply_state_row(db, seed).await?;
+    let expected_solution_count = if accepted_solution { 1 } else { 0 };
     assert_eq!(row.try_get::<String>("", "status")?, "approved");
     assert!(!row.try_get::<bool>("", "is_deleted")?);
     assert_eq!(row.try_get::<i64>("", "topic_reply_count")?, 1);
     assert_eq!(row.try_get::<i64>("", "category_reply_count")?, 1);
     assert_eq!(row.try_get::<i64>("", "user_reply_count")?, 1);
-    assert_eq!(
-        row.try_get::<i64>("", "solution_rows")?,
-        i64::from(accepted_solution)
-    );
-    assert_eq!(
-        row.try_get::<i64>("", "user_solution_count")?,
-        i64::from(accepted_solution)
-    );
+    assert_eq!(row.try_get::<i64>("", "solution_rows")?, expected_solution_count);
+    assert_eq!(row.try_get::<i64>("", "user_solution_count")?, expected_solution_count);
     Ok(())
 }
 
@@ -374,17 +351,11 @@ async fn assert_rejected_state(db: &DatabaseConnection, seed: ReplySeed) -> Test
     Ok(())
 }
 
-async fn assert_removed_solution_tombstone(
-    db: &DatabaseConnection,
-    seed: ReplySeed,
-) -> TestResult<()> {
+async fn assert_removed_solution_tombstone(db: &DatabaseConnection, seed: ReplySeed) -> TestResult<()> {
     let row = reply_state_row(db, seed).await?;
     assert_eq!(row.try_get::<String>("", "status")?, "deleted");
     assert!(row.try_get::<bool>("", "is_deleted")?);
-    assert_eq!(
-        row.try_get::<String>("", "body")?,
-        "Moderation effect fixture"
-    );
+    assert_eq!(row.try_get::<String>("", "body")?, "Moderation effect fixture");
     for field in [
         "topic_reply_count",
         "category_reply_count",
@@ -397,10 +368,7 @@ async fn assert_removed_solution_tombstone(
     Ok(())
 }
 
-async fn reply_state_row(
-    db: &DatabaseConnection,
-    seed: ReplySeed,
-) -> TestResult<sea_orm::QueryResult> {
+async fn reply_state_row(db: &DatabaseConnection, seed: ReplySeed) -> TestResult<sea_orm::QueryResult> {
     db.query_one(Statement::from_string(
         DatabaseBackend::Postgres,
         format!(

--- a/crates/rustok-forum/tests/moderation_effect_contract_postgres.rs
+++ b/crates/rustok-forum/tests/moderation_effect_contract_postgres.rs
@@ -1,0 +1,492 @@
+mod support;
+
+use std::{sync::Arc, time::Duration};
+
+use rustok_api::{HostRuntimeContext, PortActor, PortContext, PortErrorKind};
+use rustok_forum::ForumModerationSubjectAdapterFactory;
+use rustok_moderation_api::{
+    ApplyModerationDecisionCommand, ModerationDecisionApplication, ModerationDecisionEffect,
+    ModerationDecisionEffectAction, ModerationDecisionKind, ModerationReasonCode,
+    ModerationSubjectAdapterFactory, ModerationSubjectCommandPort, ModerationSubjectKind,
+    ModerationSubjectRef, ModerationVisibilityState,
+};
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
+use uuid::Uuid;
+
+use support::postgres::{PostgresForumTestDb, execute};
+use support::{TestResult, test_error};
+
+const MODERATION_ACTOR: &str = "rustok-moderation";
+const APPLY_OPERATION: &str = "apply_moderation_decision";
+const UNSUPPORTED_EFFECT: &str = "forum.moderation_effect_unsupported";
+
+#[derive(Clone, Copy)]
+struct ReplySeed {
+    tenant_id: Uuid,
+    category_id: Uuid,
+    topic_id: Uuid,
+    reply_id: Uuid,
+    author_id: Uuid,
+}
+
+#[tokio::test]
+async fn postgres_moderation_effects_preserve_accounting_tombstones_and_unpublished_boundary(
+) -> TestResult<()> {
+    let Some(database) = PostgresForumTestDb::setup("moderation_effect_contract").await? else {
+        return Ok(());
+    };
+
+    let outcome = async {
+        reject_publication_accounts_once_and_replays(&database.db).await?;
+        removed_solution_reply_tombstones_once_and_replays(&database.db).await?;
+        unpublished_visibility_fails_closed_without_forum_mutation(&database.db).await?;
+        Ok(())
+    }
+    .await;
+
+    database.cleanup().await?;
+    outcome
+}
+
+async fn reject_publication_accounts_once_and_replays(db: &DatabaseConnection) -> TestResult<()> {
+    let seed = seed_approved_reply(db, "reject-publication", false).await?;
+    let reviewed_revision = reply_revision(db, seed).await?;
+    let adapter = reply_adapter(db.clone())?;
+    let decision_id = Uuid::new_v4();
+    let command = reject_command(seed, reviewed_revision, decision_id)?;
+
+    let first = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, decision_id, "reject-first"),
+            command.clone(),
+        )
+        .await?;
+    assert_eq!(first.decision_id, decision_id);
+    assert!(first.applied_revision > reviewed_revision);
+    assert_rejected_state(db, seed).await?;
+    assert_eq!(status_event_count(db, seed.tenant_id).await?, 1);
+    assert_receipt(db, seed.tenant_id, decision_id, "completed").await?;
+
+    let revision_after_first = reply_revision(db, seed).await?;
+    let replay = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, decision_id, "reject-replay"),
+            command,
+        )
+        .await?;
+    assert_eq!(replay, first);
+    assert_eq!(reply_revision(db, seed).await?, revision_after_first);
+    assert_rejected_state(db, seed).await?;
+    assert_eq!(status_event_count(db, seed.tenant_id).await?, 1);
+    assert_receipt(db, seed.tenant_id, decision_id, "completed").await?;
+
+    // A new decision evaluated against the already-rejected current revision is an owner no-op:
+    // it completes truthfully without another counter adjustment, event, or revision bump.
+    let no_op_id = Uuid::new_v4();
+    let no_op = reject_command(seed, revision_after_first, no_op_id)?;
+    let no_op_application = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, no_op_id, "reject-no-op"),
+            no_op,
+        )
+        .await?;
+    assert_eq!(no_op_application.applied_revision, revision_after_first);
+    assert_eq!(reply_revision(db, seed).await?, revision_after_first);
+    assert_rejected_state(db, seed).await?;
+    assert_eq!(status_event_count(db, seed.tenant_id).await?, 1);
+    assert_receipt(db, seed.tenant_id, no_op_id, "completed").await?;
+    Ok(())
+}
+
+async fn removed_solution_reply_tombstones_once_and_replays(
+    db: &DatabaseConnection,
+) -> TestResult<()> {
+    let seed = seed_approved_reply(db, "removed-solution", true).await?;
+    let reviewed_revision = reply_revision(db, seed).await?;
+    let adapter = reply_adapter(db.clone())?;
+    let decision_id = Uuid::new_v4();
+    let command = removed_command(seed, reviewed_revision, decision_id)?;
+
+    let first = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, decision_id, "remove-first"),
+            command.clone(),
+        )
+        .await?;
+    assert_eq!(first.decision_id, decision_id);
+    assert!(first.applied_revision > reviewed_revision);
+    assert_removed_solution_tombstone(db, seed).await?;
+    assert_eq!(status_event_count(db, seed.tenant_id).await?, 1);
+    assert_receipt(db, seed.tenant_id, decision_id, "completed").await?;
+
+    let revision_after_first = reply_revision(db, seed).await?;
+    let replay = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, decision_id, "remove-replay"),
+            command,
+        )
+        .await?;
+    assert_eq!(replay, first);
+    assert_eq!(reply_revision(db, seed).await?, revision_after_first);
+    assert_removed_solution_tombstone(db, seed).await?;
+    assert_eq!(status_event_count(db, seed.tenant_id).await?, 1);
+    assert_receipt(db, seed.tenant_id, decision_id, "completed").await?;
+    Ok(())
+}
+
+async fn unpublished_visibility_fails_closed_without_forum_mutation(
+    db: &DatabaseConnection,
+) -> TestResult<()> {
+    let seed = seed_approved_reply(db, "unpublished-fail-closed", false).await?;
+    let reviewed_revision = reply_revision(db, seed).await?;
+    let adapter = reply_adapter(db.clone())?;
+    let decision_id = Uuid::new_v4();
+    let command = unpublished_command(seed, reviewed_revision, decision_id)?;
+
+    let error = adapter
+        .apply_moderation_decision(
+            application_context(seed.tenant_id, decision_id, "unpublished"),
+            command,
+        )
+        .await
+        .expect_err("Forum must not approximate Unpublished as hidden or rejected");
+    if error.kind != PortErrorKind::Validation
+        || error.retryable
+        || error.code != UNSUPPORTED_EFFECT
+    {
+        return Err(test_error(format!(
+            "expected fail-closed unsupported Forum visibility effect, got {error}"
+        )));
+    }
+
+    assert_eq!(reply_revision(db, seed).await?, reviewed_revision);
+    assert_approved_state(db, seed, false).await?;
+    assert_eq!(status_event_count(db, seed.tenant_id).await?, 0);
+    assert_receipt(db, seed.tenant_id, decision_id, "failed").await?;
+    Ok(())
+}
+
+fn reply_adapter(db: DatabaseConnection) -> TestResult<Arc<dyn ModerationSubjectCommandPort>> {
+    Ok(ForumModerationSubjectAdapterFactory::reply().build(&HostRuntimeContext::new(db))?)
+}
+
+fn reject_command(
+    seed: ReplySeed,
+    revision: i64,
+    decision_id: Uuid,
+) -> TestResult<ApplyModerationDecisionCommand> {
+    command(
+        seed,
+        revision,
+        decision_id,
+        ModerationDecisionKind::RejectPublication,
+        ModerationDecisionEffectAction::RejectPublication,
+        'a',
+    )
+}
+
+fn removed_command(
+    seed: ReplySeed,
+    revision: i64,
+    decision_id: Uuid,
+) -> TestResult<ApplyModerationDecisionCommand> {
+    command(
+        seed,
+        revision,
+        decision_id,
+        ModerationDecisionKind::Remove,
+        ModerationDecisionEffectAction::SetVisibility {
+            state: ModerationVisibilityState::Removed,
+        },
+        'b',
+    )
+}
+
+fn unpublished_command(
+    seed: ReplySeed,
+    revision: i64,
+    decision_id: Uuid,
+) -> TestResult<ApplyModerationDecisionCommand> {
+    command(
+        seed,
+        revision,
+        decision_id,
+        ModerationDecisionKind::Unpublish,
+        ModerationDecisionEffectAction::SetVisibility {
+            state: ModerationVisibilityState::Unpublished,
+        },
+        'c',
+    )
+}
+
+fn command(
+    seed: ReplySeed,
+    revision: i64,
+    decision_id: Uuid,
+    decision_kind: ModerationDecisionKind,
+    action: ModerationDecisionEffectAction,
+    hash_char: char,
+) -> TestResult<ApplyModerationDecisionCommand> {
+    Ok(ApplyModerationDecisionCommand {
+        decision_id,
+        subject: ModerationSubjectRef {
+            module: "forum".to_string(),
+            kind: ModerationSubjectKind::ForumPost,
+            id: seed.reply_id,
+            revision,
+        },
+        decision_kind,
+        reason_code: ModerationReasonCode::Other,
+        effect: ModerationDecisionEffect::v1(action)?,
+        decision_hash: std::iter::repeat(hash_char).take(64).collect(),
+    })
+}
+
+fn application_context(tenant_id: Uuid, decision_id: Uuid, correlation: &str) -> PortContext {
+    let decision = decision_id.to_string();
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service(MODERATION_ACTOR),
+        "und",
+        correlation,
+    )
+    .with_causation_id(decision.clone())
+    .with_idempotency_key(decision)
+    .with_deadline(Duration::from_secs(5))
+}
+
+async fn seed_approved_reply(
+    db: &DatabaseConnection,
+    label: &str,
+    accepted_solution: bool,
+) -> TestResult<ReplySeed> {
+    let seed = ReplySeed {
+        tenant_id: Uuid::new_v4(),
+        category_id: Uuid::new_v4(),
+        topic_id: Uuid::new_v4(),
+        reply_id: Uuid::new_v4(),
+        author_id: Uuid::new_v4(),
+    };
+    let solution_count = if accepted_solution { 1 } else { 0 };
+    execute(
+        db,
+        format!(
+            r#"
+INSERT INTO forum_categories
+    (id, tenant_id, position, moderated, topic_count, reply_count)
+VALUES
+    ('{}', '{}', 0, FALSE, 1, 1);
+
+INSERT INTO forum_topics
+    (id, tenant_id, category_id, status, metadata, is_pinned, is_locked, reply_count)
+VALUES
+    ('{}', '{}', '{}', 'open', '{{"fixture":"{}"}}', FALSE, FALSE, 1);
+
+INSERT INTO forum_replies
+    (id, tenant_id, topic_id, author_id, status, position)
+VALUES
+    ('{}', '{}', '{}', '{}', 'approved', 1);
+
+INSERT INTO forum_reply_bodies
+    (id, tenant_id, reply_id, locale, body)
+VALUES
+    ('{}', '{}', '{}', 'en', 'Moderation effect fixture');
+
+INSERT INTO forum_user_stats
+    (tenant_id, user_id, topic_count, reply_count, solution_count)
+VALUES
+    ('{}', '{}', 0, 1, {});
+"#,
+            seed.category_id,
+            seed.tenant_id,
+            seed.topic_id,
+            seed.tenant_id,
+            seed.category_id,
+            label,
+            seed.reply_id,
+            seed.tenant_id,
+            seed.topic_id,
+            seed.author_id,
+            Uuid::new_v4(),
+            seed.tenant_id,
+            seed.reply_id,
+            seed.tenant_id,
+            seed.author_id,
+            solution_count,
+        ),
+    )
+    .await?;
+
+    if accepted_solution {
+        execute(
+            db,
+            format!(
+                r#"
+INSERT INTO forum_solutions
+    (tenant_id, topic_id, reply_id, marked_by_user_id)
+VALUES
+    ('{}', '{}', '{}', '{}')
+"#,
+                seed.tenant_id,
+                seed.topic_id,
+                seed.reply_id,
+                Uuid::new_v4(),
+            ),
+        )
+        .await?;
+    }
+
+    assert_approved_state(db, seed, accepted_solution).await?;
+    Ok(seed)
+}
+
+async fn assert_approved_state(
+    db: &DatabaseConnection,
+    seed: ReplySeed,
+    accepted_solution: bool,
+) -> TestResult<()> {
+    let row = reply_state_row(db, seed).await?;
+    assert_eq!(row.try_get::<String>("", "status")?, "approved");
+    assert!(!row.try_get::<bool>("", "is_deleted")?);
+    assert_eq!(row.try_get::<i64>("", "topic_reply_count")?, 1);
+    assert_eq!(row.try_get::<i64>("", "category_reply_count")?, 1);
+    assert_eq!(row.try_get::<i64>("", "user_reply_count")?, 1);
+    assert_eq!(
+        row.try_get::<i64>("", "solution_rows")?,
+        i64::from(accepted_solution)
+    );
+    assert_eq!(
+        row.try_get::<i64>("", "user_solution_count")?,
+        i64::from(accepted_solution)
+    );
+    Ok(())
+}
+
+async fn assert_rejected_state(db: &DatabaseConnection, seed: ReplySeed) -> TestResult<()> {
+    let row = reply_state_row(db, seed).await?;
+    assert_eq!(row.try_get::<String>("", "status")?, "rejected");
+    assert!(!row.try_get::<bool>("", "is_deleted")?);
+    assert_eq!(row.try_get::<i64>("", "topic_reply_count")?, 0);
+    assert_eq!(row.try_get::<i64>("", "category_reply_count")?, 0);
+    assert_eq!(row.try_get::<i64>("", "user_reply_count")?, 0);
+    assert_eq!(row.try_get::<i64>("", "solution_rows")?, 0);
+    assert_eq!(row.try_get::<i64>("", "user_solution_count")?, 0);
+    Ok(())
+}
+
+async fn assert_removed_solution_tombstone(
+    db: &DatabaseConnection,
+    seed: ReplySeed,
+) -> TestResult<()> {
+    let row = reply_state_row(db, seed).await?;
+    assert_eq!(row.try_get::<String>("", "status")?, "deleted");
+    assert!(row.try_get::<bool>("", "is_deleted")?);
+    assert_eq!(
+        row.try_get::<String>("", "body")?,
+        "Moderation effect fixture"
+    );
+    for field in [
+        "topic_reply_count",
+        "category_reply_count",
+        "user_reply_count",
+        "solution_rows",
+        "user_solution_count",
+    ] {
+        assert_eq!(row.try_get::<i64>("", field)?, 0, "field `{field}`");
+    }
+    Ok(())
+}
+
+async fn reply_state_row(
+    db: &DatabaseConnection,
+    seed: ReplySeed,
+) -> TestResult<sea_orm::QueryResult> {
+    db.query_one(Statement::from_string(
+        DatabaseBackend::Postgres,
+        format!(
+            r#"
+SELECT
+    reply.status::text AS status,
+    reply.deleted_at IS NOT NULL AS is_deleted,
+    body.body,
+    topic.reply_count::bigint AS topic_reply_count,
+    category.reply_count::bigint AS category_reply_count,
+    stats.reply_count::bigint AS user_reply_count,
+    stats.solution_count::bigint AS user_solution_count,
+    (SELECT COUNT(*)::bigint FROM forum_solutions solution
+      WHERE solution.tenant_id = reply.tenant_id
+        AND solution.reply_id = reply.id) AS solution_rows
+FROM forum_replies reply
+JOIN forum_reply_bodies body
+  ON body.tenant_id = reply.tenant_id
+ AND body.reply_id = reply.id
+JOIN forum_topics topic
+  ON topic.tenant_id = reply.tenant_id
+ AND topic.id = reply.topic_id
+JOIN forum_categories category
+  ON category.tenant_id = topic.tenant_id
+ AND category.id = topic.category_id
+JOIN forum_user_stats stats
+  ON stats.tenant_id = reply.tenant_id
+ AND stats.user_id = reply.author_id
+WHERE reply.tenant_id = '{}' AND reply.id = '{}'
+"#,
+            seed.tenant_id, seed.reply_id
+        ),
+    ))
+    .await?
+    .ok_or_else(|| test_error("Forum moderation reply fixture disappeared"))
+}
+
+async fn reply_revision(db: &DatabaseConnection, seed: ReplySeed) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        format!(
+            "SELECT revision::bigint AS value FROM forum_reply_moderation_subject_revisions WHERE tenant_id = '{}' AND reply_id = '{}'",
+            seed.tenant_id, seed.reply_id
+        ),
+    )
+    .await
+}
+
+async fn status_event_count(db: &DatabaseConnection, tenant_id: Uuid) -> TestResult<i64> {
+    scalar_i64(
+        db,
+        format!(
+            "SELECT COUNT(*)::bigint AS value FROM sys_events WHERE event_type = 'forum.reply.status_changed' AND payload->>'tenant_id' = '{}'",
+            tenant_id
+        ),
+    )
+    .await
+}
+
+async fn assert_receipt(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    decision_id: Uuid,
+    expected_status: &str,
+) -> TestResult<()> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "SELECT status, COUNT(*) OVER ()::bigint AS receipt_count FROM owner_operation_receipts WHERE tenant_id = $1 AND owner_slug = 'forum' AND idempotency_key = $2 AND operation = $3",
+            vec![
+                tenant_id.into(),
+                decision_id.to_string().into(),
+                APPLY_OPERATION.to_string().into(),
+            ],
+        ))
+        .await?
+        .ok_or_else(|| test_error("Forum moderation owner receipt is missing"))?;
+    assert_eq!(row.try_get::<String>("", "status")?, expected_status);
+    assert_eq!(row.try_get::<i64>("", "receipt_count")?, 1);
+    Ok(())
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: String) -> TestResult<i64> {
+    let row = db
+        .query_one(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await?
+        .ok_or_else(|| test_error("scalar PostgreSQL query returned no row"))?;
+    Ok(row.try_get("", "value")?)
+}

--- a/scripts/verify/verify-forum-moderation-effect-postgres-contract.mjs
+++ b/scripts/verify/verify-forum-moderation-effect-postgres-contract.mjs
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+
+const test = fs.readFileSync(
+  "crates/rustok-forum/tests/moderation_effect_contract_postgres.rs",
+  "utf8",
+);
+const docs = fs.readFileSync(
+  "crates/rustok-forum/docs/forum-moderation-effect-postgres-contract.md",
+  "utf8",
+);
+const adapter = fs.readFileSync(
+  "crates/rustok-forum/src/moderation_subject.rs",
+  "utf8",
+);
+const replyOwner = fs.readFileSync(
+  "crates/rustok-forum/src/services/reply_owner.rs",
+  "utf8",
+);
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  "postgres_moderation_effects_preserve_accounting_tombstones_and_unpublished_boundary",
+  "reject_publication_accounts_once_and_replays",
+  "removed_solution_reply_tombstones_once_and_replays",
+  "unpublished_visibility_fails_closed_without_forum_mutation",
+  "ForumModerationSubjectAdapterFactory::reply()",
+  "ModerationDecisionKind::RejectPublication",
+  "ModerationDecisionEffectAction::RejectPublication",
+  "ModerationDecisionKind::Remove",
+  "ModerationVisibilityState::Removed",
+  "ModerationDecisionKind::Unpublish",
+  "ModerationVisibilityState::Unpublished",
+  "forum.moderation_effect_unsupported",
+  "assert_rejected_state",
+  "assert_removed_solution_tombstone",
+  "status_event_count",
+  "owner_operation_receipts",
+  "expected_solution_count",
+]) {
+  requireText(test, marker, `Forum moderation effect contract is missing ${marker}`);
+}
+
+for (const marker of [
+  "apply_reply_rejected_effect_in_tx",
+  "apply_reply_removed_effect_in_tx",
+  "apply_reply_non_public_status_effect_in_tx",
+  "if reply.status == target",
+  "return Ok(false)",
+  "forum.moderation_effect_unsupported",
+  "idempotency::admit",
+  "APPLY_MODERATION_DECISION_OPERATION",
+]) {
+  requireText(adapter, marker, `Forum moderation adapter invariant is missing ${marker}`);
+}
+
+for (const marker of [
+  "pub(crate) async fn remove_in_tx",
+  "forum_solution::Entity::delete_many()",
+  "mark_reply_deleted_in_tx",
+  "adjust_reply_count_in_tx",
+  "adjust_solution_count_in_tx",
+  "status = 'deleted'",
+]) {
+  requireText(replyOwner, marker, `Forum reply-removal owner invariant is missing ${marker}`);
+}
+
+for (const marker of [
+  "RejectPublication",
+  "Removed accepted solution",
+  "Unpublished remains distinct",
+  "status=deleted",
+  "failed owner-operation receipt",
+  "fail closed instead of being silently remapped",
+  "cargo test -p rustok-forum --test moderation_effect_contract_postgres",
+]) {
+  requireText(docs, marker, `Forum moderation effect handoff is missing ${marker}`);
+}
+
+console.log("Forum moderation effect PostgreSQL source guard passed");


### PR DESCRIPTION
## Summary
- add real PostgreSQL producer evidence for Forum `RejectPublication`, `Removed`, and valid-but-unsupported `Unpublished` moderation effects
- drive all moderation mutations through the real `ForumModerationSubjectAdapterFactory::reply()` and production Forum migrations
- prove `RejectPublication` decrements topic/category/author public reply accounting exactly once, emits exactly one status event, advances the moderation revision, and replays from one completed owner receipt
- prove a fresh `RejectPublication` decision against an already-rejected current revision is a truthful no-op with no second event/accounting/revision change
- prove `Removed` on an accepted-solution reply routes through the full Forum removal owner path: soft-delete tombstone, body preservation, solution cleanup, public/author reply counters and solution count all updated atomically
- prove replay of the same remove decision returns the stored application result even though active-subject lookup would now reject the soft-deleted reply, without duplicating accounting or events
- prove valid neutral `Unpublish + SetVisibility(Unpublished)` remains distinct and fails closed with `forum.moderation_effect_unsupported`, no Forum mutation, and one failed owner receipt
- add focused handoff docs and a static source guard

## Plan context
This closes the FORUM-19 retained producer-effect evidence gap for accounting/event/tombstone/solution behavior and the explicit `Unpublished` semantic boundary. It complements the existing generic soft-delete owner test, lost-response receipt evidence, and concurrent revision-fence evidence rather than duplicating them.

SQL is used only for truthful fixture setup and committed-state observation; moderation mutations under test are performed only by the real Forum adapter. Production Forum source is unchanged.

## Verification
Static source review only. PostgreSQL tests, Cargo commands, Node source guards, formatters, real database migrations, workflows and CI were intentionally not run per maintainer request.