### PR TITLE
test(index): retain Product Storefront core PostgreSQL parity packet

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -19,6 +19,8 @@ pub(crate) use storefront_shadow_executor::{
     ProductStorefrontIndexShadowComparison, ProductStorefrontIndexShadowExecution,
     ProductStorefrontIndexShadowExecutor, ProductStorefrontIndexShadowProjectionError,
 };
+#[cfg(test)]
+mod storefront_shadow_postgres_tests;
 #[path = "../product_variant_index.rs"]
 mod variant;
 #[cfg(test)]

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs
@@ -1,0 +1,611 @@
+use std::{env, error::Error, sync::Arc, time::Duration};
+
+use rustok_api::{PortActor, PortContext};
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, EntityName, FieldName, FieldPath, IndexModule, IndexSourceLoadRequest, IndexValue,
+    LocaleKey, ModuleName, MutationApplyOutcome, MutationDelivery, PostgresMutationStore,
+    PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion, SharedIndexQueryRuntime,
+    SharedIndexSchemaRegistry, SharedIndexSourceRegistry, materialize_index_source_registry,
+    materialize_postgres_index_query_runtime, materialize_postgres_index_sources,
+};
+use rustok_outbox::{OutboxTransport, TransactionalEventBus};
+use rustok_product::{
+    ProductCatalogReadRuntime, StorefrontProductListQuery, StorefrontProductSortDirection,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
+use uuid::Uuid;
+
+use super::{
+    PRODUCT_SCHEMA_ROUTING_KEY, ProductStorefrontIndexShadowExecutor,
+    channel_relation_resolver::ProductSalesChannelRelationResolver,
+};
+
+const DATABASE_ENV: &str = "RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const TENANT_ID: Uuid = Uuid::from_u128(0x5100);
+const CHANNEL_ID: Uuid = Uuid::from_u128(0x5200);
+const PRODUCT_A: Uuid = Uuid::from_u128(0x5301);
+const PRODUCT_B: Uuid = Uuid::from_u128(0x5302);
+const PRODUCT_C: Uuid = Uuid::from_u128(0x5303);
+const FIXED_TIME: &str = "2026-08-08T06:00:00Z";
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct ProductMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for ProductMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_product::migrations::migrations()
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    owner: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Product Storefront localized equivalence packet"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_product_storefront_eq_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("product_storefront_eq_migration_{suffix}"),
+        )
+        .await?;
+        create_migration_prerequisites(&migration).await?;
+        ProductMigrator::up(&migration, None).await?;
+        let manager = SchemaManager::new(&migration);
+        for migration_step in IndexModule.migrations() {
+            migration_step.up(&manager).await?;
+        }
+        seed_products(&migration).await?;
+        let resolver = ProductSalesChannelRelationResolver::new(migration.clone());
+        for product_id in [PRODUCT_A, PRODUCT_B, PRODUCT_C] {
+            let receipt = resolver.reconcile_product(TENANT_ID, product_id).await?;
+            assert_eq!(receipt.channel_ids(), &[CHANNEL_ID]);
+        }
+        migration.close().await?;
+
+        Ok(Some(Self {
+            control,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("product_storefront_eq_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("product_storefront_eq_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("product_storefront_eq_query_{suffix}"),
+            )
+            .await?,
+            owner: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("product_storefront_eq_owner_{suffix}"),
+            )
+            .await?,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.owner.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct EvidenceRuntime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+}
+
+#[tokio::test]
+async fn product_storefront_localized_postgres_retains_owner_shadow_identity_and_projection_evidence(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let outcome = run_localized_projection_and_search_evidence(&database).await;
+    let cleanup = database.cleanup().await;
+    outcome?;
+    cleanup
+}
+
+#[tokio::test]
+async fn product_storefront_localized_postgres_retains_wildcard_and_equal_timestamp_paging_evidence(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+    let outcome = run_wildcard_and_paging_evidence(&database).await;
+    let cleanup = database.cleanup().await;
+    outcome?;
+    cleanup
+}
+
+async fn run_localized_projection_and_search_evidence(database: &TestDatabase) -> TestResult<()> {
+    let runtime = index_runtime(database).await?;
+    materialize_products(&runtime).await?;
+    let executor = shadow_executor(database, runtime.query.clone());
+
+    // `%` is intentionally owner-visible wildcard input. The resulting owner pattern `%Needle%%`
+    // matches a third-locale title on A, fallback-locale title on B, and unrelated third-locale title
+    // on C. Identity folding must still return one row per Product.
+    let query = storefront_query(Some("Needle%"), StorefrontProductSortDirection::Desc, 1, 12)?;
+    let execution = executor
+        .execute(
+            port_context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(CHANNEL_ID),
+            query,
+        )
+        .await?;
+    let projected = execution
+        .projected
+        .as_ref()
+        .map_err(|error| std::io::Error::other(format!("shadow projection failed: {error}")))?;
+    let comparison = execution
+        .comparison
+        .ok_or_else(|| std::io::Error::other("successful shadow projection must compare"))?;
+    assert!(comparison.is_match());
+    assert_eq!(execution.authoritative.total, 3);
+    assert_eq!(projected.exact_count, Some(3));
+    assert_eq!(
+        execution
+            .authoritative
+            .items
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>(),
+        vec![PRODUCT_C, PRODUCT_B, PRODUCT_A]
+    );
+
+    // Search matched A through `fr`, but projection still selects requested `fi`.
+    let owner_a = owner_item(&execution.authoritative, PRODUCT_A)?;
+    let index_a = index_item(projected, PRODUCT_A)?;
+    assert_eq!(owner_a.title, "Requested A");
+    assert_eq!(owner_a.handle, "requested-a");
+    assert_eq!(projected_string(index_a, "title")?, Some("Requested A"));
+    assert_eq!(projected_string(index_a, "handle")?, Some("requested-a"));
+
+    // B has no requested `fi`, so both owner and Index projection use fallback `en`.
+    let owner_b = owner_item(&execution.authoritative, PRODUCT_B)?;
+    let index_b = index_item(projected, PRODUCT_B)?;
+    assert_eq!(owner_b.title, "NeedleXFR");
+    assert_eq!(owner_b.handle, "fallback-b");
+    assert_eq!(projected_string(index_b, "title")?, Some("NeedleXFR"));
+    assert_eq!(projected_string(index_b, "handle")?, Some("fallback-b"));
+
+    // C has only `de`: owner applies its public placeholder while the generic localized fold exposes
+    // SQL null. This is retained evidence for the final Storefront projection adapter and must not be
+    // misreported as raw field equivalence.
+    let owner_c = owner_item(&execution.authoritative, PRODUCT_C)?;
+    let index_c = index_item(projected, PRODUCT_C)?;
+    assert_eq!(owner_c.title, "Untitled product");
+    assert_eq!(owner_c.handle, "");
+    assert_eq!(projected_string(index_c, "title")?, None);
+    assert_eq!(projected_string(index_c, "handle")?, None);
+
+    Ok(())
+}
+
+async fn run_wildcard_and_paging_evidence(database: &TestDatabase) -> TestResult<()> {
+    let runtime = index_runtime(database).await?;
+    materialize_products(&runtime).await?;
+    let executor = shadow_executor(database, runtime.query.clone());
+
+    // `_` remains a one-character wildcard on both owner and Index paths.
+    let wildcard = executor
+        .execute(
+            port_context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(CHANNEL_ID),
+            storefront_query(
+                Some("Needle_FR"),
+                StorefrontProductSortDirection::Asc,
+                1,
+                12,
+            )?,
+        )
+        .await?;
+    assert!(
+        wildcard
+            .comparison
+            .ok_or_else(|| std::io::Error::other("wildcard comparison missing"))?
+            .is_match()
+    );
+    assert_eq!(
+        wildcard
+            .authoritative
+            .items
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>(),
+        vec![PRODUCT_A, PRODUCT_B]
+    );
+
+    // Backslash escapes `_`, leaving only A's exact third-locale `Needle_FR` title.
+    let escaped = executor
+        .execute(
+            port_context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(CHANNEL_ID),
+            storefront_query(
+                Some(r"Needle\_FR"),
+                StorefrontProductSortDirection::Asc,
+                1,
+                12,
+            )?,
+        )
+        .await?;
+    assert!(
+        escaped
+            .comparison
+            .ok_or_else(|| std::io::Error::other("escaped comparison missing"))?
+            .is_match()
+    );
+    assert_eq!(escaped.authoritative.total, 1);
+    assert_eq!(escaped.authoritative.items[0].id, PRODUCT_A);
+
+    // All Products share both owner sort timestamps. DESC therefore proves the Product-ID DESC
+    // tie-break and offset/page boundary; ASC proves the opposite identity direction.
+    let desc_first = executor
+        .execute(
+            port_context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(CHANNEL_ID),
+            storefront_query(None, StorefrontProductSortDirection::Desc, 1, 2)?,
+        )
+        .await?;
+    assert!(
+        desc_first
+            .comparison
+            .ok_or_else(|| std::io::Error::other("DESC page comparison missing"))?
+            .is_match()
+    );
+    assert_eq!(desc_first.authoritative.total, 3);
+    assert!(desc_first.authoritative.has_next);
+    assert_eq!(
+        desc_first
+            .authoritative
+            .items
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>(),
+        vec![PRODUCT_C, PRODUCT_B]
+    );
+
+    let desc_second = executor
+        .execute(
+            port_context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(CHANNEL_ID),
+            storefront_query(None, StorefrontProductSortDirection::Desc, 2, 2)?,
+        )
+        .await?;
+    assert!(
+        desc_second
+            .comparison
+            .ok_or_else(|| std::io::Error::other("DESC second page comparison missing"))?
+            .is_match()
+    );
+    assert_eq!(desc_second.authoritative.total, 3);
+    assert!(!desc_second.authoritative.has_next);
+    assert_eq!(desc_second.authoritative.items[0].id, PRODUCT_A);
+
+    let asc_first = executor
+        .execute(
+            port_context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(CHANNEL_ID),
+            storefront_query(None, StorefrontProductSortDirection::Asc, 1, 2)?,
+        )
+        .await?;
+    assert!(
+        asc_first
+            .comparison
+            .ok_or_else(|| std::io::Error::other("ASC page comparison missing"))?
+            .is_match()
+    );
+    assert_eq!(
+        asc_first
+            .authoritative
+            .items
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>(),
+        vec![PRODUCT_A, PRODUCT_B]
+    );
+
+    Ok(())
+}
+
+async fn index_runtime(database: &TestDatabase) -> TestResult<EvidenceRuntime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = crate::build_runtime_extensions(&registry)?;
+
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product schema registry is missing"))?;
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    for registered in schemas.registry().iter() {
+        schema_store.register(TENANT_ID, &registered.schema).await?;
+    }
+
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Product source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Product query runtime is missing"))?;
+
+    Ok(EvidenceRuntime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+    })
+}
+
+async fn materialize_products(runtime: &EvidenceRuntime) -> TestResult<()> {
+    let request = IndexSourceLoadRequest::new(vec![
+        product_key(PRODUCT_A, "fi")?,
+        product_key(PRODUCT_A, "en")?,
+        product_key(PRODUCT_A, "fr")?,
+        product_key(PRODUCT_B, "en")?,
+        product_key(PRODUCT_C, "de")?,
+    ])?;
+    let mutations = runtime.sources.load(request).await?.into_mutations();
+    assert_eq!(mutations.len(), 5);
+    for mutation in mutations {
+        let expected_source_version = mutation.source_version();
+        let delivery = MutationDelivery::from_event(PRODUCT_SOURCE, mutation)?;
+        let outcome = runtime
+            .mutations
+            .apply(runtime.schemas.registry(), &delivery)
+            .await?;
+        assert!(matches!(
+            outcome,
+            MutationApplyOutcome::Applied { source_version }
+                if source_version == expected_source_version
+        ));
+    }
+    Ok(())
+}
+
+fn shadow_executor(
+    database: &TestDatabase,
+    index: SharedIndexQueryRuntime,
+) -> ProductStorefrontIndexShadowExecutor {
+    let transport = Arc::new(OutboxTransport::new(database.owner.clone()));
+    let event_bus = TransactionalEventBus::new(transport);
+    let product = ProductCatalogReadRuntime::in_process(database.owner.clone(), event_bus);
+    ProductStorefrontIndexShadowExecutor::new(product, index)
+}
+
+fn storefront_query(
+    search: Option<&str>,
+    direction: StorefrontProductSortDirection,
+    page: u64,
+    per_page: u64,
+) -> TestResult<StorefrontProductListQuery> {
+    Ok(StorefrontProductListQuery::try_new_with_attribute_filters(
+        search.map(ToOwned::to_owned),
+        None,
+        Some("published_at".to_owned()),
+        Some(match direction {
+            StorefrontProductSortDirection::Asc => "asc".to_owned(),
+            StorefrontProductSortDirection::Desc => "desc".to_owned(),
+        }),
+        Vec::new(),
+    )?
+    .with_pagination(page, per_page))
+}
+
+fn port_context() -> PortContext {
+    PortContext::new(
+        TENANT_ID.to_string(),
+        PortActor::service("product-storefront-postgres-evidence"),
+        "fi",
+        Uuid::new_v4().to_string(),
+    )
+    .with_channel("online")
+    .with_deadline(Duration::from_secs(5))
+}
+
+fn product_key(product_id: Uuid, locale: &str) -> TestResult<EntityKey> {
+    Ok(EntityKey {
+        tenant_id: TENANT_ID,
+        schema: product_schema_ref()?,
+        entity_id: product_id,
+        locale: Some(LocaleKey::new(locale)?),
+    })
+}
+
+fn product_schema_ref() -> TestResult<SchemaRef> {
+    Ok(SchemaRef {
+        module: ModuleName::new("rustok-product")?,
+        entity: EntityName::new("product")?,
+        version: SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY),
+    })
+}
+
+fn owner_item(
+    list: &rustok_product::StorefrontProductList,
+    product_id: Uuid,
+) -> TestResult<&rustok_product::StorefrontProductListItem> {
+    list.items
+        .iter()
+        .find(|item| item.id == product_id)
+        .ok_or_else(|| std::io::Error::other(format!("owner Product {product_id} missing")).into())
+}
+
+fn index_item(
+    page: &rustok_index::IndexQueryPage,
+    product_id: Uuid,
+) -> TestResult<&rustok_index::IndexQueryItem> {
+    page.items
+        .iter()
+        .find(|item| item.entity_id == product_id)
+        .ok_or_else(|| std::io::Error::other(format!("Index Product {product_id} missing")).into())
+}
+
+fn projected_string<'a>(
+    item: &'a rustok_index::IndexQueryItem,
+    field: &str,
+) -> TestResult<Option<&'a str>> {
+    let path = FieldPath::new(FieldName::new(field)?);
+    let projected = item
+        .fields
+        .iter()
+        .find(|projected| projected.path == path)
+        .ok_or_else(|| std::io::Error::other(format!("missing projected field {field}")))?;
+    match &projected.value {
+        IndexValue::String(value) => Ok(Some(value.as_str())),
+        IndexValue::Null => Ok(None),
+        other => Err(std::io::Error::other(format!(
+            "projected field {field} has unexpected value {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn create_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE channels (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    slug TEXT NOT NULL,
+    UNIQUE (tenant_id, id),
+    UNIQUE (tenant_id, slug)
+);
+CREATE TABLE channel_index_identity_generations (
+    tenant_id UUID PRIMARY KEY,
+    generation BIGINT NOT NULL CHECK (generation > 0)
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_products(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+INSERT INTO channels (id, tenant_id, slug) VALUES ('{CHANNEL_ID}', '{TENANT_ID}', 'online');
+
+INSERT INTO products (id, tenant_id) VALUES
+    ('{PRODUCT_A}', '{TENANT_ID}'),
+    ('{PRODUCT_B}', '{TENANT_ID}'),
+    ('{PRODUCT_C}', '{TENANT_ID}');
+
+UPDATE products
+SET status = 'active',
+    created_at = '{FIXED_TIME}'::timestamptz,
+    updated_at = '{FIXED_TIME}'::timestamptz,
+    published_at = '{FIXED_TIME}'::timestamptz,
+    metadata = '{{}}'::jsonb
+WHERE tenant_id = '{TENANT_ID}';
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('00000000-0000-0000-0000-000000005401', '{PRODUCT_A}', '{TENANT_ID}', 'fi', 'Requested A', 'requested-a'),
+    ('00000000-0000-0000-0000-000000005402', '{PRODUCT_A}', '{TENANT_ID}', 'en', 'Fallback A', 'fallback-a'),
+    ('00000000-0000-0000-0000-000000005403', '{PRODUCT_A}', '{TENANT_ID}', 'fr', 'Needle_FR', 'needle-a-fr'),
+    ('00000000-0000-0000-0000-000000005404', '{PRODUCT_B}', '{TENANT_ID}', 'en', 'NeedleXFR', 'fallback-b'),
+    ('00000000-0000-0000-0000-000000005405', '{PRODUCT_C}', '{TENANT_ID}', 'de', 'NeedleZZ', 'third-c');
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product-owned term translation merge `9a684becf802904baec3e860eb2178c689a0253c` and continued on
-`agent/index-storefront-shadow-executor-20260808`.
+Status overlay rechecked after Product Storefront shadow-executor merge `de32e18022e761e3fcc80d2e8becc625f567fc5e` and continued on
+`agent/index-storefront-equivalence-postgres-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -27,43 +27,46 @@ Source-complete:
 - Product-owned public Storefront attribute-filter -> neutral canonical term resolution;
 - pure Storefront shadow builder consuming only `ProductResolvedAttributeFilter`;
 - non-serving owner-first `ProductStorefrontIndexShadowExecutor` over host-selected Product and Index
-  runtimes.
+  runtimes;
+- first current-key Product Storefront owner-vs-shadow PostgreSQL packet source.
 
-The shadow executor first calls the authoritative Product read port. Only after owner success does it resolve
-Product EAV metadata, build the localized Index query and call `execute_localized_query`. Projected failures
-remain data in the shadow result and cannot replace the successful owner result.
+The core PostgreSQL packet is source-only until the maintainer runs it. It uses real Product/Index migrations,
+channel relation freshness, Product source/mutation/query runtimes and Product owner reads. It covers
+requested/fallback/neither localized projection, third-locale search, `%`/`_`/backslash wildcard behavior,
+identity de-duplication, equal-timestamp Asc/Desc Product-ID ordering, exact count and offset page boundaries.
 
-For channel-scoped comparison the caller must supply a trusted current slug/UUID pair; the executor checks
-presence/non-empty/non-nil only and does not independently prove their correspondence. Built-in comparison
-covers ordered Product IDs, exact count and `has_more` only. Full field/search/tag equivalence is still
-retained PostgreSQL evidence debt.
+The packet also retains an explicit raw projection gap: owner uses `Untitled product`/empty handle when no
+requested/fallback translation exists, while the generic localized Index layer returns null. Final Storefront
+projection must apply those public placeholders after Index page identity/order/count are fixed.
 
-## Remaining Storefront parity blockers
+## Remaining Storefront parity/evidence blockers
 
+- execute/review the new core PostgreSQL packet; source presence is not evidence admission;
+- add a separate EAV PostgreSQL packet for scalar/localized terms and Select/Multiselect code/UUID/`Never`;
 - owner title search has no explicit length bound vs Index `TextLike` 1024-byte bound;
 - owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`;
 - channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
 - owner page depth exceeds Index bounded offset depth;
+- final Storefront projection must map localized null title/handle to owner placeholders;
 - localized Taxonomy tag names must be hydrated after Product page identity/count is fixed;
 - shadow execution has no serving latency/deadline policy and must remain non-serving.
 
 ## Retained Product evidence debt
 
-Historical PostgreSQL packets must be actualized to routing key `4` / current 15-field Product contract;
-never add a key-3 runtime alias.
+Historical PostgreSQL packets must still be mechanically actualized to routing key `4` / current 15-field
+Product contract; never add a key-3 runtime alias. This is deliberately kept separate from the new current-key
+Storefront packet to avoid hiding large fixture rewrites inside parity work.
 
-The next localized Storefront PostgreSQL packet must run owner and shadow execution side-by-side and cover:
+The next EAV Storefront packet should run owner and shadow side-by-side for:
 
-- requested/fallback/neither localized projection;
-- third-locale/all-translations title search and wildcard semantics;
-- duplicate locale matches yielding one identity/count;
-- scalar and localized EAV terms;
-- Select/Multiselect option code, UUID and missing-option `Never` behavior;
-- trusted public-channel membership;
-- equal timestamp Asc/Desc Product-ID ties;
-- pagination and exact count;
-- stale locale exclusion, readiness/admission and replay/restart behavior;
-- explicit search-bound and collation evidence.
+- nonlocalized scalar terms;
+- localized requested value and requested-missing/fallback value;
+- Select/Multiselect exact option code;
+- direct option UUID;
+- missing option code and nil UUID `Never` behavior;
+- exact identity/count/page agreement under the existing Product admission/freshness runtime.
+
+Later execution/admission still needs stale locale/readiness/restart and explicit search-bound/collation review.
 
 ## M5 incremental ingestion
 
@@ -96,12 +99,16 @@ The next localized Storefront PostgreSQL packet must run owner and shadow execut
 - [x] Product-owned Storefront attribute-filter resolution to neutral canonical term expressions.
 - [x] Wire Product term expressions into the shadow builder.
 - [x] Compose non-serving Product-owner + Index shadow executor.
-- [ ] Retain owner-vs-Index localized PostgreSQL equivalence packet.
+- [x] Retain current-key core owner-vs-shadow localized PostgreSQL packet source.
+- [ ] Execute/review the core Storefront PostgreSQL packet.
+- [ ] Retain Product EAV owner-vs-shadow PostgreSQL packet source.
+- [ ] Execute/review the EAV Storefront PostgreSQL packet.
 - [ ] Resolve/admit search-length and collation parity.
 - [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
 - [ ] Decide authoritative deep-page policy.
+- [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
 - [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
-- [ ] Actualize retained Product PostgreSQL packets to routing key `4`.
+- [ ] Actualize historical retained Product PostgreSQL packets to routing key `4`.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
@@ -109,10 +116,9 @@ The next localized Storefront PostgreSQL packet must run owner and shadow execut
 
 ## Next source-code step
 
-Build the retained Product Storefront localized PostgreSQL **owner-vs-shadow equivalence packet/harness** on
-current routing key `4`. It must exercise the actual Product owner list and the non-serving shadow executor,
-record identity/order/count and projected field evidence, and keep unresolved search/channel/deep-page cases
-explicitly fail-closed. Taxonomy hydration remains a post-page evidence step.
+Build the separate Product Storefront EAV PostgreSQL packet on current routing key `4`. Keep it independent
+from the localized core packet so a failure identifies Product term resolution/materialization rather than
+locale folding or page ordering. Do not execute the packet in this implementation turn.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `shadow_executor_source_complete_postgres_equivalence_pending`.
+Status: `core_postgres_packet_source_complete_execution_and_eav_pending`.
 
 ## Current boundary
 
@@ -8,8 +8,8 @@ Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
 The Product-owned EAV resolver, pure localized shadow query builder and non-serving owner-first shadow
-executor are source-complete. Source completion is not PostgreSQL equivalence evidence and does not admit
-Index output for serving.
+executor are source-complete. A first current-key PostgreSQL owner-vs-shadow packet is now retained in
+source, but it has **not** been executed or admitted by the implementation agent.
 
 ## Product-owned attribute-filter resolution — source complete
 
@@ -22,82 +22,87 @@ localized requested/fallback text behavior and Select/Multiselect UUID/code reso
 `ProductAttributeTermExpr` values and Product owns the canonical term grammar. Distribution only translates
 those owner-owned expressions into `attribute_terms` Index predicates.
 
-## Shadow query adapter — source complete
+## Shadow query and executor — source complete
 
-`build_product_storefront_index_shadow_query` accepts only `ProductResolvedAttributeFilter`, validates the
-resolved filter identities against the authoritative `StorefrontProductListQuery`, and translates
-`Term/And/Or/Not/Never` into root Index predicates. `Never` is represented by a bind-free false predicate
-using the current Product schema's required/non-null `id` invariant.
-
-The builder maps Active/published-only, trusted current public-channel membership, optional primary
-category, canonical EAV terms, any-locale title `TextLike`, requested/fallback title+handle, paired timestamp
-order plus matching Product-ID direction, bounded offset pagination and exact count. It remains pure: no DB,
-Product service construction or Index execution occurs inside it.
-
-## Non-serving shadow executor — source complete
+`build_product_storefront_index_shadow_query` accepts only Product-owned resolved filters and maps
+Active/published-only, trusted current public-channel membership, optional category, canonical EAV terms,
+any-locale title `TextLike`, requested/fallback title+handle, paired timestamp order plus matching Product-ID
+direction, bounded offset pagination and exact count.
 
 `ProductStorefrontIndexShadowExecutor` composes only host-selected `ProductCatalogReadRuntime` and
-`SharedIndexQueryRuntime`.
+`SharedIndexQueryRuntime`. It executes the Product owner list first. Product schema resolution, localized
+query build and `execute_localized_query` happen only after owner success, and projected failures cannot
+replace the successful authoritative owner result.
 
-Execution order is deliberately owner-first:
+For channel-scoped evidence the caller must provide a trusted current slug/UUID pair. The executor checks
+presence only; it does not independently prove slug↔UUID correspondence. Channel-less requests remain
+projected fail-closed.
 
-1. `ProductCatalogReadPort::list_filtered_published_products` produces the authoritative result;
-2. only after owner success, the optional Product schema-read capability resolves EAV filters;
-3. the pure shadow builder creates `LocalizedEntityQuery`;
-4. `SharedIndexQueryRuntime::execute_localized_query` executes with the existing persisted-readiness,
-   owner-admission and one-snapshot localized runtime contract.
+## Core PostgreSQL owner-vs-shadow packet — source complete, execution pending
 
-If schema resolution, query build, readiness/admission or Index execution fails, that error is retained only
-inside `projected`; it cannot replace the successful owner result. The executor is not mounted into
-Storefront serving.
+`storefront_shadow_postgres_tests.rs` is a crate-internal opt-in PostgreSQL packet and does not publish a new
+production evidence API. It uses:
 
-For channel-scoped evidence the caller must provide a **trusted current** slug/UUID pair. The executor checks
-only that both identities are present and non-empty/non-nil; it does not independently prove slug↔UUID
-correspondence. Channel-less requests remain projected fail-closed.
+- current Product routing key `4` through `PRODUCT_SCHEMA_ROUTING_KEY`;
+- real Product and Index migrations;
+- a real Product channel-visibility relation resolver/freshness path;
+- real Product source registry + mutation store materialization;
+- persisted Index schema registration and canonical localized query runtime;
+- real `ProductCatalogReadRuntime` owner reads;
+- the non-serving `ProductStorefrontIndexShadowExecutor`.
 
-The built-in comparison is intentionally narrow: ordered Product identity list, exact count and page
-`has_more` boundary. It does **not** claim scalar/localized projection, tag hydration, search-collation or
-full semantic equivalence. Those belong to retained PostgreSQL evidence.
+The source packet retains these core scenarios:
 
-## Remaining fail-closed parity gates
+- requested-locale projection after a **third-locale** title match;
+- fallback-locale projection;
+- an identity having neither requested nor fallback locale;
+- `%` wildcard, `_` wildcard and backslash-escaped `_` behavior;
+- one logical Product identity despite multiple physical locale rows;
+- exact count;
+- equal owner timestamps with both Asc and Desc Product-ID tie-breaks;
+- first/second offset page boundaries and `has_next`/`has_more` agreement;
+- trusted public-channel membership.
 
-1. Owner title search has no explicit length bound while Index `TextLike` is bounded to 1024 UTF-8 bytes.
-2. Owner title `LIKE` uses deployment/default collation while Index String SQL uses deterministic
+The packet intentionally records one remaining projection adapter gap: when neither requested nor fallback
+translation exists, owner Storefront returns public placeholders (`"Untitled product"` and empty handle),
+while the generic localized Index projection correctly returns SQL/`IndexValue::Null`. A future serving
+adapter must map this null state to the owner placeholders **after** Index page identity/order/count are
+fixed. Raw null-vs-placeholder values must not be called field-equivalent.
+
+## Remaining fail-closed parity/evidence gates
+
+1. The new core PostgreSQL packet still needs maintainer execution and review; source presence is not
+   evidence admission.
+2. Scalar/localized EAV and Select/Multiselect option code/direct UUID/missing-option `Never` need a second
+   owner-vs-shadow PostgreSQL packet.
+3. Owner title search has no explicit length bound while Index `TextLike` is bounded to 1024 UTF-8 bytes.
+4. Owner title `LIKE` uses deployment/default collation while Index String SQL uses deterministic
    `COLLATE "C"`.
-3. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot
+5. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot
    distinguish unrestricted from restricted-to-all-current-channels.
-4. Owner page depth is wider than the Index 10,000 offset bound.
-5. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
-6. Shadow execution has no serving-latency/deadline policy and therefore must remain non-serving.
+6. Owner page depth is wider than the Index 10,000 offset bound.
+7. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
+8. Shadow execution has no serving-latency/deadline policy and therefore must remain non-serving.
+9. Historical Product PostgreSQL packets still need routing key `4` / current 15-field actualization; never
+   add a key-3 runtime compatibility path.
 
-## Next source slice: retained PostgreSQL equivalence
+## Next source slice
 
-Add a Product Storefront localized PostgreSQL packet/harness that exercises the actual owner path and the
-non-serving shadow executor side-by-side. It must cover at least:
+Add the second retained PostgreSQL packet for Product EAV parity. It should seed real filterable Product
+attributes/options and prove owner-vs-shadow behavior for scalar terms, localized requested/fallback text,
+Select/Multiselect option code, direct UUID and missing-option `Never`. Keep the core packet and EAV packet
+separate so failures identify the owner/query layer precisely.
 
-- requested translation, fallback translation and neither requested nor fallback;
-- third-locale/all-translations title search plus `%`, `_` and backslash wildcard cases;
-- duplicate locale matches yielding one Product identity and exact count;
-- scalar and localized EAV terms;
-- Select/Multiselect option code, direct UUID and missing-option `Never` behavior;
-- trusted public-channel membership;
-- equal timestamps under both Asc and Desc Product-ID tie-breaks;
-- pagination and exact count;
-- stale locale exclusion, readiness/admission failure and replay/restart behavior;
-- explicit search-bound/collation evidence rather than silently declaring parity.
-
-Historical Product PostgreSQL packets still need routing key `4` / current 15-field actualization. Never add
-a key-3 runtime compatibility path.
-
-Taxonomy tag hydration must be retained only after the Product page is fixed and must not change Product
-identity/order/count.
+After those source packets exist, maintainer execution can determine the next correction/admission step.
+Search-bound/collation and channel-less/deep-page policy remain explicit gates rather than silent narrowing.
 
 ## Source guards
 
 - `verify-product-storefront-attribute-filter-terms.mjs` locks Product-owned EAV resolution;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term → localized query translation;
-- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution and forbids
-  direct DB/service/PostgreSQL-port construction;
+- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution;
+- `verify-index-product-storefront-equivalence-postgres-packet.mjs` locks the current-key core PostgreSQL
+  packet and its null-vs-placeholder evidence;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native;
 - localized runtime/order/TextLike guards continue to lock generic Index semantics.
 

--- a/scripts/verify/verify-index-product-storefront-equivalence-postgres-packet.mjs
+++ b/scripts/verify/verify-index-product-storefront-equivalence-postgres-packet.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-equivalence-postgres-packet] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const packetPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs';
+const packet = requireMarkers(packetPath, [
+  'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
+  'ProductStorefrontIndexShadowExecutor',
+  'ProductSalesChannelRelationResolver',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'materialize_postgres_index_sources',
+  'materialize_postgres_index_query_runtime',
+  'PostgresSchemaRegistrationStore',
+  'MutationDelivery::from_event(PRODUCT_SOURCE, mutation)',
+  'ProductCatalogReadRuntime::in_process',
+  'Some("online".to_owned())',
+  'Some(CHANNEL_ID)',
+  'Some("Needle%")',
+  'Some("Needle_FR")',
+  'Some(r"Needle\\_FR")',
+  'StorefrontProductSortDirection::Desc',
+  'StorefrontProductSortDirection::Asc',
+  'vec![PRODUCT_C, PRODUCT_B, PRODUCT_A]',
+  'vec![PRODUCT_A, PRODUCT_B]',
+  'assert_eq!(execution.authoritative.total, 3);',
+  'assert_eq!(projected.exact_count, Some(3));',
+  'assert_eq!(owner_a.title, "Requested A");',
+  'assert_eq!(projected_string(index_a, "title")?, Some("Requested A"));',
+  'assert_eq!(owner_b.title, "NeedleXFR");',
+  'assert_eq!(projected_string(index_b, "title")?, Some("NeedleXFR"));',
+  'assert_eq!(owner_c.title, "Untitled product");',
+  'assert_eq!(projected_string(index_c, "title")?, None);',
+  'product_storefront_localized_postgres_retains_owner_shadow_identity_and_projection_evidence',
+  'product_storefront_localized_postgres_retains_wildcard_and_equal_timestamp_paging_evidence',
+]);
+
+if (packet.includes('SchemaVersion::new(3)')) {
+  fail(`${packetPath} must never use historical Product routing key 3`);
+}
+if (packet.includes('register_current') || packet.includes('Storefront traffic')) {
+  fail(`${packetPath} is evidence only and must not perform Product schema promotion or consumer cutover`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  '#[cfg(test)]',
+  'mod storefront_shadow_postgres_tests;',
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+]);
+
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
+  'placeholder',
+  'routing key `4`',
+]);
+
+console.log('[verify-index-product-storefront-equivalence-postgres-packet] current-key Product owner-vs-shadow core PostgreSQL packet is source-locked; execution and EAV evidence remain maintainer gates');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -62,6 +62,14 @@ requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_e
   'pub(crate) authoritative: StorefrontProductList',
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
 ]);
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
+  'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'ProductSalesChannelRelationResolver',
+  'ProductStorefrontIndexShadowExecutor',
+  'assert_eq!(owner_c.title, "Untitled product");',
+  'assert_eq!(projected_string(index_c, "title")?, None);',
+]);
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
@@ -73,18 +81,17 @@ const productIndex = requireMarkers(productIndexPath, [
 if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `shadow_executor_source_complete_postgres_equivalence_pending`',
+  'Status: `core_postgres_packet_source_complete_execution_and_eav_pending`',
   'Mounted Storefront remains owner-native',
-  'Non-serving shadow executor — source complete',
-  'owner-first',
-  '`ProductCatalogReadRuntime`',
-  '`SharedIndexQueryRuntime`',
-  'trusted current',
-  'retained PostgreSQL equivalence',
+  'Core PostgreSQL owner-vs-shadow packet — source complete, execution pending',
+  'routing key `4`',
+  'third-locale',
+  'placeholder',
+  'EAV parity',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
   'Status: `source_complete_materialized_rebuild_pending`',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; Product-owned EAV resolution, shadow translation and owner-first non-serving execution are source-complete while PostgreSQL equivalence remains pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; current-key core owner-vs-shadow PostgreSQL packet is retained in source while execution, EAV, placeholder and policy gates remain pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -84,6 +84,7 @@ const scripts = [
   'verify-index-product-storefront-localized-query-architecture.mjs',
   'verify-index-product-storefront-shadow-adapter.mjs',
   'verify-index-product-storefront-shadow-executor.mjs',
+  'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-localized-query-runtime.mjs',


### PR DESCRIPTION
## Summary

- retain a crate-internal opt-in PostgreSQL Product Storefront owner-vs-shadow packet built from scratch on the current Product routing key `4`;
- use real Product and Index migrations, real Product channel relation/freshness resolution, real Product source registry/mutation materialization, persisted schema registration and canonical localized Index query runtime;
- run the real Product owner read runtime and non-serving `ProductStorefrontIndexShadowExecutor` side-by-side in the retained packet;
- cover requested-locale projection after a third-locale title match, fallback projection, and the neither-requested-nor-fallback case;
- cover `%`, `_` and backslash-escaped `_` title LIKE behavior without adding Product-specific search SQL;
- retain one logical Product identity/exact count across multiple physical locale rows;
- prove source intent for equal timestamp Asc/Desc Product-ID tie-breaks, offset page boundaries and trusted public-channel membership;
- explicitly retain the remaining raw projection gap: owner Storefront maps no requested/fallback translation to `Untitled product`/empty handle while generic localized Index correctly returns null; this must be mapped only in a future serving projection adapter after page identity/order/count is fixed;
- keep EAV Select/Multiselect/scalar/localized evidence as a separate next packet so failures remain attributable;
- add source guards and advance the plan/parity gate without claiming execution or admission.

## Main recheck

The branch started from shadow-executor merge `de32e18022e761e3fcc80d2e8becc625f567fc5e`. Before PR creation current `main@74accbcd6e616fa6bd149e2b03132ced150a0fc3` advanced only through #3234/#3235 Forum moderation evidence. Those commits are disjoint from this 7-file Product/Index evidence slice.

## Boundary

This PR does not execute the PostgreSQL packet, admit its results, add EAV evidence, resolve search-length/collation/channel-less/deep-page policy, hydrate Taxonomy tags, map nulls to public placeholders in production, promote a Product schema, add a key-3 alias, or switch Storefront traffic.

Historical Product PostgreSQL fixtures that still mention key 3 remain separate mechanical debt and are not reused by this packet.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.