### PR TITLE
feat(product): publish legacy storefront read projections

### DIFF
--- a/crates/rustok-product/src/ports.rs
+++ b/crates/rustok-product/src/ports.rs
@@ -15,8 +15,10 @@ const MAX_PUBLISHED_PRODUCTS_PER_PAGE: u64 = 48;
 const MAX_ADMIN_PRODUCTS_PER_PAGE: u64 = 100;
 const READ_PRODUCT_PROJECTION_OPERATION: &str = "read_product_projection";
 const READ_VARIANT_PRODUCT_PROJECTION_OPERATION: &str = "read_variant_product_projection";
+const READ_STOREFRONT_PRODUCT_PROJECTION_OPERATION: &str = "read_storefront_product_projection";
 const LIST_PUBLISHED_PRODUCTS_OPERATION: &str = "list_published_products";
 const LIST_FILTERED_PUBLISHED_PRODUCTS_OPERATION: &str = "list_filtered_published_products";
+const LIST_LEGACY_STOREFRONT_PRODUCTS_OPERATION: &str = "list_legacy_storefront_products";
 const LIST_ADMIN_PRODUCTS_OPERATION: &str = "list_admin_products";
 const LIST_LEGACY_ADMIN_PRODUCTS_OPERATION: &str = "list_legacy_admin_products";
 
@@ -56,6 +58,33 @@ pub trait ProductCatalogReadPort: Send + Sync {
         Err(PortError::unavailable(
             "product.filtered_published_list_unavailable",
             "filtered product listing is unavailable",
+        ))
+    }
+
+    /// Optional published storefront detail projection for legacy consumers that need the
+    /// owner to apply lifecycle/channel visibility, locale narrowing, and public inventory.
+    async fn read_storefront_product_projection(
+        &self,
+        _context: PortContext,
+        _request: StorefrontProductProjectionRequest,
+    ) -> Result<Option<ProductResponse>, PortError> {
+        Err(PortError::unavailable(
+            "product.storefront_detail_unavailable",
+            "storefront product detail is unavailable",
+        ))
+    }
+
+    /// Optional compatibility projection for the mounted legacy storefront GraphQL list.
+    /// Existing adapters remain source-compatible and fail closed until they explicitly
+    /// implement vendor/product-type/raw-search plus shipping-profile projection semantics.
+    async fn list_legacy_storefront_products(
+        &self,
+        _context: PortContext,
+        _request: LegacyStorefrontProductsRequest,
+    ) -> Result<LegacyStorefrontProductList, PortError> {
+        Err(PortError::unavailable(
+            "product.legacy_storefront_list_unavailable",
+            "legacy storefront product listing is unavailable",
         ))
     }
 
@@ -116,6 +145,56 @@ pub struct FilteredPublishedProductsRequest {
     pub fallback_locale: Option<String>,
     pub public_channel_slug: Option<String>,
     pub query: StorefrontProductListQuery,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorefrontProductProjectionSubject {
+    ProductId { product_id: Uuid },
+    Handle { handle: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorefrontProductProjectionRequest {
+    pub subject: StorefrontProductProjectionSubject,
+    pub locale: Option<String>,
+    pub fallback_locale: Option<String>,
+    pub public_channel_slug: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyStorefrontProductsRequest {
+    pub locale: Option<String>,
+    pub fallback_locale: Option<String>,
+    pub public_channel_slug: Option<String>,
+    pub vendor: Option<String>,
+    pub product_type: Option<String>,
+    pub search: Option<String>,
+    pub page: u64,
+    pub per_page: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LegacyStorefrontProductList {
+    pub items: Vec<LegacyStorefrontProductListItem>,
+    pub total: u64,
+    pub page: u64,
+    pub per_page: u64,
+    pub has_next: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LegacyStorefrontProductListItem {
+    pub id: Uuid,
+    pub status: crate::entities::product::ProductStatus,
+    pub title: String,
+    pub handle: String,
+    pub seller_id: Option<String>,
+    pub vendor: Option<String>,
+    pub product_type: Option<String>,
+    pub shipping_profile_slug: String,
+    pub tags: Vec<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub published_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -246,6 +325,85 @@ impl ProductCatalogReadPort for crate::CatalogService {
         .map_err(|error| product_error_to_port_error(&context, owner_operation, error))
     }
 
+    async fn read_storefront_product_projection(
+        &self,
+        context: PortContext,
+        request: StorefrontProductProjectionRequest,
+    ) -> Result<Option<ProductResponse>, PortError> {
+        let owner_operation = READ_STOREFRONT_PRODUCT_PROJECTION_OPERATION;
+        context
+            .require_policy(PortCallPolicy::read())
+            .map_err(|error| product_context_error(&context, owner_operation, error))?;
+        let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
+        let StorefrontProductProjectionRequest {
+            subject,
+            locale,
+            fallback_locale,
+            public_channel_slug,
+        } = request;
+        let locale = locale.as_deref().unwrap_or(context.locale.as_str());
+        let result = match subject {
+            StorefrontProductProjectionSubject::ProductId { product_id } => {
+                self.get_published_product_by_id_with_locale_fallback(
+                    tenant_id,
+                    product_id,
+                    locale,
+                    fallback_locale.as_deref(),
+                    public_channel_slug.as_deref(),
+                )
+                .await
+            }
+            StorefrontProductProjectionSubject::Handle { handle } => {
+                self.get_published_product_by_handle_with_locale_fallback(
+                    tenant_id,
+                    handle.as_str(),
+                    locale,
+                    fallback_locale.as_deref(),
+                    public_channel_slug.as_deref(),
+                )
+                .await
+            }
+        };
+        result.map_err(|error| product_error_to_port_error(&context, owner_operation, error))
+    }
+
+    async fn list_legacy_storefront_products(
+        &self,
+        context: PortContext,
+        request: LegacyStorefrontProductsRequest,
+    ) -> Result<LegacyStorefrontProductList, PortError> {
+        let owner_operation = LIST_LEGACY_STOREFRONT_PRODUCTS_OPERATION;
+        context
+            .require_policy(PortCallPolicy::read())
+            .map_err(|error| product_context_error(&context, owner_operation, error))?;
+        validate_legacy_storefront_products_request(&context, owner_operation, &request)?;
+        let tenant_id = parse_port_tenant_id(&context, owner_operation)?;
+        let LegacyStorefrontProductsRequest {
+            locale,
+            fallback_locale,
+            public_channel_slug,
+            vendor,
+            product_type,
+            search,
+            page,
+            per_page,
+        } = request;
+        let locale = locale.as_deref().unwrap_or(context.locale.as_str());
+        self.list_legacy_storefront_products_with_locale_fallback(
+            tenant_id,
+            locale,
+            fallback_locale.as_deref(),
+            public_channel_slug.as_deref(),
+            vendor.as_deref(),
+            product_type.as_deref(),
+            search.as_deref(),
+            page,
+            per_page,
+        )
+        .await
+        .map_err(|error| product_error_to_port_error(&context, owner_operation, error))
+    }
+
     async fn list_admin_products(
         &self,
         context: PortContext,
@@ -364,6 +522,45 @@ fn validate_published_products_request(
             operation = owner_operation,
             code = "product.per_page_invalid",
             "published product page-size validation failed"
+        );
+        return Err(PortError::validation(
+            "product.per_page_invalid",
+            "published products page size is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_legacy_storefront_products_request(
+    context: &PortContext,
+    owner_operation: &'static str,
+    request: &LegacyStorefrontProductsRequest,
+) -> Result<(), PortError> {
+    if request.page == 0 {
+        tracing::warn!(
+            page = request.page,
+            per_page = request.per_page,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation = owner_operation,
+            code = "product.page_invalid",
+            "legacy storefront product page validation failed"
+        );
+        return Err(PortError::validation(
+            "product.page_invalid",
+            "published products page is invalid",
+        ));
+    }
+    if !(1..=MAX_PUBLISHED_PRODUCTS_PER_PAGE).contains(&request.per_page) {
+        tracing::warn!(
+            page = request.page,
+            per_page = request.per_page,
+            max_per_page = MAX_PUBLISHED_PRODUCTS_PER_PAGE,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation = owner_operation,
+            code = "product.per_page_invalid",
+            "legacy storefront product page-size validation failed"
         );
         return Err(PortError::validation(
             "product.per_page_invalid",

--- a/crates/rustok-product/src/services/catalog/queries.rs
+++ b/crates/rustok-product/src/services/catalog/queries.rs
@@ -153,28 +153,130 @@ impl CatalogService {
     }
 
     #[instrument(skip(self))]
-    pub async fn get_published_product_by_handle_with_locale_fallback(
+    pub(crate) async fn list_legacy_storefront_products_with_locale_fallback(
         &self,
         tenant_id: Uuid,
-        handle: &str,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        public_channel_slug: Option<&str>,
+        vendor: Option<&str>,
+        product_type: Option<&str>,
+        search: Option<&str>,
+        page: u64,
+        per_page: u64,
+    ) -> CommerceResult<crate::LegacyStorefrontProductList> {
+        let fallback_locale = fallback_locale.unwrap_or(PLATFORM_FALLBACK_LOCALE);
+        if page == 0 || per_page == 0 || per_page > 48 {
+            return Err(CommerceError::Validation(
+                "page must be at least 1 and per_page must be between 1 and 48".to_owned(),
+            ));
+        }
+        let offset = (page.saturating_sub(1)) * per_page;
+
+        let mut query = entities::product::Entity::find()
+            .filter(entities::product::Column::TenantId.eq(tenant_id))
+            .filter(entities::product::Column::Status.eq(entities::product::ProductStatus::Active))
+            .filter(entities::product::Column::PublishedAt.is_not_null())
+            .filter(product_channel_visibility_condition(
+                self.db.get_database_backend(),
+                public_channel_slug,
+            ));
+        if let Some(vendor) = vendor {
+            query = query.filter(entities::product::Column::Vendor.eq(vendor));
+        }
+        if let Some(product_type) = product_type {
+            query = query.filter(entities::product::Column::ProductType.eq(product_type));
+        }
+        if let Some(search) = search {
+            query = query.filter(product_title_search_condition(
+                self.db.get_database_backend(),
+                search,
+            ));
+        }
+
+        let total = query.clone().count(&self.db).await?;
+        let products = query
+            .order_by_desc(entities::product::Column::PublishedAt)
+            .order_by_desc(entities::product::Column::CreatedAt)
+            .offset(offset)
+            .limit(per_page)
+            .all(&self.db)
+            .await?;
+        let product_ids = products
+            .iter()
+            .map(|product| product.id)
+            .collect::<Vec<_>>();
+        let translations = if product_ids.is_empty() {
+            Vec::new()
+        } else {
+            entities::product_translation::Entity::find()
+                .filter(entities::product_translation::Column::ProductId.is_in(product_ids))
+                .all(&self.db)
+                .await?
+        };
+        let mut translations_by_product: HashMap<Uuid, Vec<entities::product_translation::Model>> =
+            HashMap::new();
+        for translation in translations {
+            translations_by_product
+                .entry(translation.product_id)
+                .or_default()
+                .push(translation);
+        }
+        let product_tags = self
+            .load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))
+            .await?;
+
+        let items = products
+            .into_iter()
+            .map(|product| {
+                let translation = translations_by_product.get(&product.id).and_then(|items| {
+                    pick_product_translation(items.as_slice(), locale, fallback_locale)
+                });
+                let shipping_profile_slug = product
+                    .shipping_profile_slug
+                    .as_deref()
+                    .and_then(normalize_shipping_profile_slug)
+                    .or_else(|| extract_shipping_profile_slug(&product.metadata))
+                    .unwrap_or_else(|| "default".to_string());
+                crate::LegacyStorefrontProductListItem {
+                    id: product.id,
+                    status: product.status,
+                    title: translation
+                        .map(|value| value.title.clone())
+                        .unwrap_or_else(|| "Untitled product".to_string()),
+                    handle: translation
+                        .map(|value| value.handle.clone())
+                        .unwrap_or_default(),
+                    seller_id: product.seller_id,
+                    vendor: product.vendor,
+                    product_type: product.product_type,
+                    shipping_profile_slug,
+                    tags: product_tags.get(&product.id).cloned().unwrap_or_default(),
+                    created_at: product.created_at.into(),
+                    published_at: product.published_at.map(Into::into),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Ok(crate::LegacyStorefrontProductList {
+            items,
+            total,
+            page,
+            per_page,
+            has_next: page * per_page < total,
+        })
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_published_product_by_id_with_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        product_id: Uuid,
         locale: &str,
         fallback_locale: Option<&str>,
         public_channel_slug: Option<&str>,
     ) -> CommerceResult<Option<ProductResponse>> {
         let fallback_locale = fallback_locale.unwrap_or(PLATFORM_FALLBACK_LOCALE);
-        let Some(product_id) = find_published_product_id_by_handle(
-            &self.db,
-            tenant_id,
-            handle,
-            locale,
-            fallback_locale,
-            public_channel_slug,
-        )
-        .await?
-        else {
-            return Ok(None);
-        };
-
         let mut product = match self
             .get_product_with_locale_fallback(tenant_id, product_id, locale, Some(fallback_locale))
             .await
@@ -204,6 +306,39 @@ impl CatalogService {
             locale,
             fallback_locale,
         )))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_published_product_by_handle_with_locale_fallback(
+        &self,
+        tenant_id: Uuid,
+        handle: &str,
+        locale: &str,
+        fallback_locale: Option<&str>,
+        public_channel_slug: Option<&str>,
+    ) -> CommerceResult<Option<ProductResponse>> {
+        let fallback_locale = fallback_locale.unwrap_or(PLATFORM_FALLBACK_LOCALE);
+        let Some(product_id) = find_published_product_id_by_handle(
+            &self.db,
+            tenant_id,
+            handle,
+            locale,
+            fallback_locale,
+            public_channel_slug,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+
+        self.get_published_product_by_id_with_locale_fallback(
+            tenant_id,
+            product_id,
+            locale,
+            Some(fallback_locale),
+            public_channel_slug,
+        )
+        .await
     }
 }
 

--- a/scripts/verify/verify-commerce-product-storefront-graphql-read.mjs
+++ b/scripts/verify/verify-commerce-product-storefront-graphql-read.mjs
@@ -43,8 +43,20 @@ for (const required of [
   "filtered product listing is unavailable",
   "LIST_FILTERED_PUBLISHED_PRODUCTS_OPERATION",
   "CatalogService::list_published_products_with_query(",
+  "async fn read_storefront_product_projection(",
+  "pub enum StorefrontProductProjectionSubject",
+  "pub struct StorefrontProductProjectionRequest",
+  "product.storefront_detail_unavailable",
+  "READ_STOREFRONT_PRODUCT_PROJECTION_OPERATION",
+  "async fn list_legacy_storefront_products(",
+  "pub struct LegacyStorefrontProductsRequest",
+  "pub struct LegacyStorefrontProductList",
+  "pub struct LegacyStorefrontProductListItem",
+  "product.legacy_storefront_list_unavailable",
+  "LIST_LEGACY_STOREFRONT_PRODUCTS_OPERATION",
+  "list_legacy_storefront_products_with_locale_fallback(",
 ]) {
-  requireText(ports, required, `filtered Product read capability must contain ${required}`);
+  requireText(ports, required, `Product storefront read capability must contain ${required}`);
 }
 
 const publishedStart = ports.indexOf("pub struct PublishedProductsRequest");
@@ -56,6 +68,28 @@ for (const forbidden of ["search", "category_id", "sort_by", "attribute_filters"
     forbidden,
     `existing PublishedProductsRequest public shape must not gain filtered field ${forbidden}`,
   );
+}
+
+const ownerQueries = read("crates/rustok-product/src/services/catalog/queries.rs");
+for (const required of [
+  "list_legacy_storefront_products_with_locale_fallback(",
+  "Column::Status.eq(entities::product::ProductStatus::Active)",
+  "Column::PublishedAt.is_not_null()",
+  "product_channel_visibility_condition(",
+  "Column::Vendor.eq(vendor)",
+  "Column::ProductType.eq(product_type)",
+  "if let Some(search) = search",
+  "product_title_search_condition(",
+  "order_by_desc(entities::product::Column::PublishedAt)",
+  "order_by_desc(entities::product::Column::CreatedAt)",
+  ".and_then(normalize_shipping_profile_slug)",
+  "extract_shipping_profile_slug(&product.metadata)",
+  "unwrap_or_else(|| \"default\".to_string())",
+  "get_published_product_by_id_with_locale_fallback(",
+  "apply_public_channel_inventory_to_product(",
+  "localize_product_response(",
+]) {
+  requireText(ownerQueries, required, `Product owner storefront compatibility source must contain ${required}`);
 }
 
 const source = read("crates/rustok-commerce/src/graphql/product_catalog.rs");
@@ -96,6 +130,34 @@ for (const required of [
   requireText(admin, required, `admin Product catalog cutover must remain intact: ${required}`);
 }
 forbidText(source, "CatalogService::new", "Product GraphQL catalog module must not construct CatalogService");
+
+const legacySource = read("crates/rustok-commerce/src/graphql/query.rs");
+const legacyDetail = resolverSlice(legacySource, "storefront_product", "storefront_products");
+const legacyList = resolverSlice(legacySource, "storefront_products", null);
+for (const required of [
+  "CatalogService::new",
+  ".get_published_product_by_handle_with_locale_fallback(",
+  ".get_product_with_locale_fallback(",
+  "apply_public_channel_inventory_to_product(",
+]) {
+  requireText(
+    legacyDetail,
+    required,
+    `legacy storefront Product detail must remain explicit consumer cutover debt: ${required}`,
+  );
+}
+for (const required of [
+  "product::Entity::find()",
+  "product_channel_visibility_condition(",
+  "product_translation_title_search_condition(",
+  "load_product_list_items(",
+]) {
+  requireText(
+    legacyList,
+    required,
+    `legacy storefront Product list must remain explicit consumer cutover debt: ${required}`,
+  );
+}
 
 for (const required of [
   '"PRODUCT_VALIDATION"',


### PR DESCRIPTION
## Summary

- publish optional fail-closed `ProductCatalogReadPort::read_storefront_product_projection` for legacy storefront detail consumers, with typed id/handle subjects
- keep Product ownership of active/published/channel visibility, requested/default locale narrowing, and public-channel inventory enrichment for detail reads
- publish optional fail-closed `list_legacy_storefront_products` compatibility projection for the mounted legacy GraphQL list without widening the modern `StorefrontProductListQuery`
- preserve legacy vendor/product-type/raw-search filtering, `PublishedAt DESC` then `CreatedAt DESC`, bounded 1..48 pagination, `Untitled product`, metadata-aware/default shipping-profile projection, tags, totals and page metadata inside Product owner source
- refactor the existing handle lookup to reuse the new owner published-id detail path
- extend the storefront source guard to lock the new owner capabilities while explicitly keeping mounted `storefrontProduct` / `storefrontProducts` direct reads as follow-up consumer debt
- do not change mounted Storefront serving or the non-serving Index shadow path; the canonical ecommerce task remains open until the consumer cutover lands

## Verification

Not run per maintainer instruction. No tests, checks, formatter, workflow, runtime verification, or FBA/FFA status promotion was performed. Source and GitHub diff inspection only.