### PR TITLE
refactor(commerce): cut legacy storefront Product reads to owner port

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `dfddce9f57916a712d531db38e75c87e7c45e8cf`, then continued the Product schema-read and legacy catalog-read cutover from `aaa496887fd1492f3feca8ac52261458ce25705e` through the current `main` line.
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `fe0bddc83c7f81431c731e823fe87ef9b558f807`, then continued the Product schema-read and legacy catalog-read cutover through the current implementation branch.
 
 The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
 
@@ -11,8 +11,9 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 1. `ProductCatalogSchemaReadPort` publishes the effective-form aggregate capability added by PR #3182, and mounted `productEffectiveForm` is now cut over to that host-selected owner capability.
 2. PR #3203 published `ProductCatalogSchemaReadPort::read_product_attribute_values`, and mounted `productAttributeValues` is now cut over to that owner capability.
 3. `storefrontCatalogSearchOptions` was the remaining mounted direct `ProductCatalogSchemaService` schema-read consumer. Its current projection needs only categories and filterable/sortable attributes, so the already-published `list_categories` and `list_attributes` owner capabilities preserve the existing data and ordering semantics without a new Product projection.
-4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths already use `ProductCatalogReadRuntime`; the mounted legacy admin `product`/`products` roots were still direct `CatalogService` / Product-entity consumers and are cut over in the continuation below.
-5. The legacy mounted `storefrontProduct` / `storefrontProducts` roots remain direct `CatalogService` / Product-entity consumers. Therefore the broad ecommerce invariant requiring typed owner boundaries on every production path remains open; source inspection does not justify a status promotion.
+4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths already use `ProductCatalogReadRuntime`, and the mounted legacy admin `product`/`products` roots are cut over to the Product owner read runtime.
+5. PR #3238 published optional fail-closed legacy storefront detail/list capabilities without changing mounted serving. The continuation below cuts mounted `storefrontProduct` / `storefrontProducts` to those capabilities, so these production reads no longer choose Product lifecycle/channel/inventory policy or query Product entities directly.
+6. The broad ecommerce owner-boundary invariant remains open because Product schema writes, REST delete/publish/unpublish lifecycle commands, and remaining GraphQL Product lifecycle operations still require owner-port cutover and explicit idempotency contracts. Source inspection does not justify a status promotion.
 
 ## PR #3203 source change
 
@@ -51,12 +52,21 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Cut mounted legacy admin GraphQL `products` to `list_legacy_admin_products`, preserving `PRODUCTS_LIST`, current tenant, authenticated actor, request channel/deadline, exact legacy filters/order/pagination/projection, telemetry path, and the shared stable Product GraphQL public error mapper.
 - Extend the Product admin GraphQL source guard so both modern and legacy admin read roots require the host-selected runtime/ports and direct Product service/entity access is forbidden inside the cut-over resolvers.
 
+## Legacy storefront Product read continuation
+
+- PR #3238 publishes optional fail-closed `ProductCatalogReadPort::read_storefront_product_projection` with typed Product-id/handle subjects and `list_legacy_storefront_products` with the exact compatibility projection needed by the mounted legacy list.
+- Cut mounted `storefrontProduct` to the host-selected Product read runtime while preserving Product-module and storefront-channel admission, current-tenant-only scope, requested/request/default locale resolution, id-over-handle precedence, trimmed non-empty handle validation, request public channel, `commerce-storefront-graphql` service actor, bounded two-second deadline, `None` for missing/invisible products, and the shared correlation-aware Product GraphQL public error mapper.
+- Product owner now applies active/published lifecycle admission, public-channel visibility, public-channel inventory enrichment, and requested/default locale narrowing for both Product-id and handle detail subjects instead of Commerce reconstructing those policies.
+- Cut mounted `storefrontProducts` to `list_legacy_storefront_products`, preserving current-tenant/storefront admission, vendor/product-type/raw-search filters, page defaults and exact `1..48` validation, public-channel visibility, requested/default locale, Product-owned published/created ordering, tags, `Untitled product`, normalized/default shipping-profile projection, totals/page metadata, RFC3339 response fields, and the existing `commerce.storefront_products` read-budget metric.
+- Extend `verify-commerce-product-storefront-graphql-read.mjs` so the mounted detail/list slices require the host-selected runtime and new owner capabilities and forbid the previous direct `CatalogService`, Product entity, visibility SQL, translation-search, and inventory-enrichment calls inside those serving resolver slices.
+- Keep the old private Commerce list helper as unmounted compatibility source in this source-only slice; its cleanup remains separate from the mounted serving cutover and should follow compile/evidence work.
+
 ## Remaining execution order
 
-1. Cut legacy mounted `storefrontProduct` / `storefrontProducts` away from direct Product service/entity reads while preserving published/channel visibility, id-or-handle detail semantics, vendor/product-type/search filtering, inventory enrichment, ordering, pagination, locale fallback, and response projection.
-2. Continue remaining Product schema writes and lifecycle command cutovers from the canonical ecommerce plan.
+1. Continue remaining Product schema writes and Product lifecycle command cutovers from the canonical ecommerce plan, including REST delete/publish/unpublish and remaining GraphQL lifecycle operations. Repeatable commands require explicit caller idempotency semantics before cutover.
+2. Remove superseded private Product read compatibility helpers only after compile/source evidence confirms there are no remaining consumers.
 3. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 
 ## Verification state
 
-No tests, checks, formatters, or runtime verification were executed in these slices per maintainer instruction. All execution/promotion gates remain unchanged.
+No tests, checks, formatters, workflows, or runtime verification were executed in these slices per maintainer instruction. All execution/promotion gates remain unchanged.

--- a/crates/rustok-commerce/src/graphql/query.rs
+++ b/crates/rustok-commerce/src/graphql/query.rs
@@ -2019,23 +2019,15 @@ impl CommerceQuery {
         let tenant_id = tenant.id;
         let locale =
             resolve_commerce_graphql_locale(ctx, locale.as_deref(), tenant.default_locale.as_str());
-
         let public_channel_slug = request_public_channel_slug(ctx);
-        let service = CatalogService::new(db.clone(), event_bus.clone());
-        let product_id = match (id, handle.as_deref().map(str::trim)) {
-            (Some(id), _) => id,
+        let subject = match (id, handle.as_deref().map(str::trim)) {
+            (Some(product_id), _) => {
+                rustok_product::StorefrontProductProjectionSubject::ProductId { product_id }
+            }
             (None, Some(handle)) if !handle.is_empty() => {
-                return service
-                    .get_published_product_by_handle_with_locale_fallback(
-                        tenant_id,
-                        handle,
-                        &locale,
-                        Some(tenant.default_locale.as_str()),
-                        public_channel_slug.as_deref(),
-                    )
-                    .await
-                    .map_err(|error| map_product_service_error(error, "storefront_product"))
-                    .map(|product| product.map(Into::into));
+                rustok_product::StorefrontProductProjectionSubject::Handle {
+                    handle: handle.to_string(),
+                }
             }
             _ => {
                 return Err(async_graphql::Error::new(
@@ -2043,43 +2035,43 @@ impl CommerceQuery {
                 ));
             }
         };
-
-        let mut product = match service
-            .get_product_with_locale_fallback(
-                tenant_id,
-                product_id,
-                &locale,
-                Some(tenant.default_locale.as_str()),
+        let port_context = rustok_api::PortContext::new(
+            tenant_id.to_string(),
+            rustok_api::PortActor::service("commerce-storefront-graphql"),
+            locale.as_str(),
+            format!("commerce-graphql-product:legacy-storefront-product:{tenant_id}"),
+        )
+        .with_deadline(std::time::Duration::from_secs(2));
+        let port_context = public_channel_slug
+            .as_deref()
+            .map(|channel| port_context.clone().with_channel(channel))
+            .unwrap_or(port_context);
+        let product_read_runtime =
+            crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+                db.clone(),
+                event_bus.clone(),
+            );
+        let product = product_read_runtime
+            .read_port()
+            .read_storefront_product_projection(
+                port_context.clone(),
+                rustok_product::StorefrontProductProjectionRequest {
+                    subject,
+                    locale: Some(locale),
+                    fallback_locale: Some(tenant.default_locale.clone()),
+                    public_channel_slug,
+                },
             )
             .await
-        {
-            Ok(product) => product,
-            Err(rustok_product::CommerceError::ProductNotFound(_)) => return Ok(None),
-            Err(err) => return Err(map_product_service_error(err, "product_query")),
-        };
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "legacy_storefront_product",
+                ))
+            })?;
 
-        if product.status != rustok_product::entities::product::ProductStatus::Active
-            || product.published_at.is_none()
-            || !is_metadata_visible_for_public_channel(
-                &product.metadata,
-                public_channel_slug.as_deref(),
-            )
-        {
-            return Ok(None);
-        }
-
-        apply_public_channel_inventory_to_product(
-            db,
-            tenant_id,
-            &mut product,
-            public_channel_slug.as_deref(),
-        )
-        .await
-        .map_err(|error| map_product_service_error(error.into(), "storefront_product_inventory"))?;
-
-        Ok(Some(
-            localized_product_response(product, &locale, tenant.default_locale.as_str()).into(),
-        ))
+        Ok(product.map(Into::into))
     }
 
     async fn storefront_products(
@@ -2118,57 +2110,64 @@ impl CommerceQuery {
                 "page must be at least 1 and per_page must be between 1 and 48",
             ));
         }
-        let offset = (page.saturating_sub(1)) * per_page;
         let public_channel_slug = request_public_channel_slug(ctx);
-
-        let mut query = product::Entity::find()
-            .filter(product::Column::TenantId.eq(tenant_id))
-            .filter(
-                product::Column::Status
-                    .eq(rustok_product::entities::product::ProductStatus::Active),
-            )
-            .filter(product::Column::PublishedAt.is_not_null())
-            .filter(product_channel_visibility_condition(
-                db.get_database_backend(),
-                public_channel_slug.as_deref(),
-            ));
-
-        if let Some(vendor) = &filter.vendor {
-            query = query.filter(product::Column::Vendor.eq(vendor));
-        }
-        if let Some(product_type) = &filter.product_type {
-            query = query.filter(product::Column::ProductType.eq(product_type));
-        }
-        if let Some(search) = &filter.search {
-            query = query.filter(product_translation_title_search_condition(
-                db.get_database_backend(),
-                &locale,
-                search,
-            ));
-        }
-
-        let total = query.clone().count(db).await.map_err(|error| {
-            map_product_service_error(error.into(), "storefront_products_count")
-        })?;
-        let products = query
-            .order_by_desc(product::Column::PublishedAt)
-            .order_by_desc(product::Column::CreatedAt)
-            .offset(offset)
-            .limit(per_page)
-            .all(db)
-            .await
-            .map_err(|error| map_product_service_error(error.into(), "storefront_products_page"))?;
-
-        let items = load_product_list_items(
-            db,
-            event_bus,
-            tenant_id,
-            products,
-            &locale,
-            tenant.default_locale.as_str(),
-            product_list_path("commerce.storefront_products"),
+        let port_context = rustok_api::PortContext::new(
+            tenant_id.to_string(),
+            rustok_api::PortActor::service("commerce-storefront-graphql"),
+            locale.as_str(),
+            format!("commerce-graphql-product:legacy-storefront-products:{page}:{per_page}"),
         )
-        .await?;
+        .with_deadline(std::time::Duration::from_secs(2));
+        let port_context = public_channel_slug
+            .as_deref()
+            .map(|channel| port_context.clone().with_channel(channel))
+            .unwrap_or(port_context);
+        let product_read_runtime =
+            crate::graphql_runtime::product_catalog_read_runtime_for_current_graphql_scope(
+                db.clone(),
+                event_bus.clone(),
+            );
+        let products = product_read_runtime
+            .read_port()
+            .list_legacy_storefront_products(
+                port_context.clone(),
+                rustok_product::LegacyStorefrontProductsRequest {
+                    locale: Some(locale),
+                    fallback_locale: Some(tenant.default_locale.clone()),
+                    public_channel_slug,
+                    vendor: filter.vendor,
+                    product_type: filter.product_type,
+                    search: filter.search,
+                    page,
+                    per_page,
+                },
+            )
+            .await
+            .map_err(|error| {
+                FieldError::from(crate::graphql::product_catalog::product_catalog_port_error(
+                    &port_context,
+                    error,
+                    "legacy_storefront_products",
+                ))
+            })?;
+        let total = products.total;
+        let items = products
+            .items
+            .into_iter()
+            .map(|item| GqlProductListItem {
+                id: item.id,
+                status: item.status.into(),
+                title: item.title,
+                handle: item.handle,
+                seller_id: item.seller_id,
+                vendor: item.vendor,
+                product_type: item.product_type,
+                shipping_profile_slug: Some(item.shipping_profile_slug),
+                tags: item.tags,
+                created_at: item.created_at.to_rfc3339(),
+                published_at: item.published_at.map(|value| value.to_rfc3339()),
+            })
+            .collect::<Vec<_>>();
 
         metrics::record_read_path_budget(
             "graphql",

--- a/scripts/verify/verify-commerce-product-storefront-graphql-read.mjs
+++ b/scripts/verify/verify-commerce-product-storefront-graphql-read.mjs
@@ -133,29 +133,90 @@ forbidText(source, "CatalogService::new", "Product GraphQL catalog module must n
 
 const legacySource = read("crates/rustok-commerce/src/graphql/query.rs");
 const legacyDetail = resolverSlice(legacySource, "storefront_product", "storefront_products");
-const legacyList = resolverSlice(legacySource, "storefront_products", null);
+const legacyList = resolverSlice(
+  legacySource,
+  "storefront_products",
+  "load_storefront_customer_order",
+);
+
 for (const required of [
-  "CatalogService::new",
-  ".get_published_product_by_handle_with_locale_fallback(",
-  ".get_product_with_locale_fallback(",
-  "apply_public_channel_inventory_to_product(",
+  "super::require_storefront_channel_enabled(ctx)",
+  "Storefront catalog reads must use the current tenant",
+  "resolve_commerce_graphql_locale(",
+  "request_public_channel_slug(ctx)",
+  "StorefrontProductProjectionSubject::ProductId",
+  "StorefrontProductProjectionSubject::Handle",
+  "PortActor::service(\"commerce-storefront-graphql\")",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".read_port()",
+  ".read_storefront_product_projection(",
+  "rustok_product::StorefrontProductProjectionRequest",
+  "fallback_locale: Some(tenant.default_locale.clone())",
+  "public_channel_slug,",
+  "product_catalog_port_error(",
+  "legacy_storefront_product",
+  "Either `id` or non-empty `handle` is required",
 ]) {
   requireText(
     legacyDetail,
     required,
-    `legacy storefront Product detail must remain explicit consumer cutover debt: ${required}`,
+    `legacy storefront Product detail owner cutover must contain ${required}`,
   );
 }
+for (const forbidden of [
+  "CatalogService::new",
+  ".get_published_product_by_handle_with_locale_fallback(",
+  ".get_product_with_locale_fallback(",
+  "apply_public_channel_inventory_to_product(",
+  "product::Entity::find",
+]) {
+  forbidText(
+    legacyDetail,
+    forbidden,
+    `legacy storefront Product detail owner cutover must not contain ${forbidden}`,
+  );
+}
+
 for (const required of [
-  "product::Entity::find()",
-  "product_channel_visibility_condition(",
-  "product_translation_title_search_condition(",
-  "load_product_list_items(",
+  "super::require_storefront_channel_enabled(ctx)",
+  "Storefront catalog reads must use the current tenant",
+  "resolve_commerce_graphql_locale(",
+  "page must be at least 1 and per_page must be between 1 and 48",
+  "request_public_channel_slug(ctx)",
+  "PortActor::service(\"commerce-storefront-graphql\")",
+  ".with_deadline(std::time::Duration::from_secs(2))",
+  "product_catalog_read_runtime_for_current_graphql_scope(",
+  ".read_port()",
+  ".list_legacy_storefront_products(",
+  "rustok_product::LegacyStorefrontProductsRequest",
+  "fallback_locale: Some(tenant.default_locale.clone())",
+  "public_channel_slug,",
+  "vendor: filter.vendor",
+  "product_type: filter.product_type",
+  "search: filter.search",
+  "product_catalog_port_error(",
+  "legacy_storefront_products",
+  "shipping_profile_slug: Some(item.shipping_profile_slug)",
+  "commerce.storefront_products",
 ]) {
   requireText(
     legacyList,
     required,
-    `legacy storefront Product list must remain explicit consumer cutover debt: ${required}`,
+    `legacy storefront Product list owner cutover must contain ${required}`,
+  );
+}
+for (const forbidden of [
+  "product::Entity::find()",
+  "product_channel_visibility_condition(",
+  "product_translation_title_search_condition(",
+  "load_product_list_items(",
+  "CatalogService::new",
+]) {
+  forbidText(
+    legacyList,
+    forbidden,
+    `legacy storefront Product list owner cutover must not contain ${forbidden}`,
   );
 }
 


### PR DESCRIPTION
## Summary

- cut mounted legacy GraphQL `storefrontProduct` to the host-selected `ProductCatalogReadPort::read_storefront_product_projection` capability published in #3238
- preserve Product-module/storefront-channel admission, current-tenant-only scope, requested/request/default locale resolution, id-over-handle precedence, trimmed handle validation, public channel, the `commerce-storefront-graphql` service actor, a two-second deadline, nullable missing/invisible detail semantics, and the shared safe Product GraphQL error mapper
- move active/published lifecycle admission, public-channel visibility, public-channel inventory enrichment, and detail locale narrowing fully behind the Product owner boundary for this mounted path
- cut mounted legacy GraphQL `storefrontProducts` to `list_legacy_storefront_products`, preserving vendor/product-type/raw-search filters, page defaults and exact 1..48 validation, public-channel visibility, locale fallback, owner ordering, tags, shipping-profile fallback, totals/page metadata, RFC3339 projection, and the existing read-budget metric
- update the storefront source guard so the two mounted resolver slices require the owner runtime/capabilities and forbid their former direct `CatalogService`, Product entity, visibility SQL, translation-search, list-helper, and inventory-enrichment calls
- update the ecommerce Product recheck packet; the broad canonical item remains open for Product schema writes and REST/GraphQL lifecycle command cutovers, so no FBA/FFA or verification status is promoted
- keep the old private Commerce list helper as unmounted compatibility source for a later cleanup after compile/evidence work

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, runtime verification, or FBA/FFA status promotion were run per maintainer instruction.