### PR TITLE
test(index): actualize Product PostgreSQL packets to key 4

### DIFF
--- a/crates/rustok-distribution/tests/product_channel_convergence_postgres.rs
+++ b/crates/rustok-distribution/tests/product_channel_convergence_postgres.rs
@@ -501,7 +501,7 @@ fn product_schema_ref() -> TestResult<SchemaRef> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product")?,
         entity: EntityName::new("product")?,
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(4),
     })
 }
 
@@ -686,7 +686,7 @@ FROM index_entities
 WHERE tenant_id = $1
   AND module_name = 'rustok-product'
   AND entity_name = 'product'
-  AND schema_version = 3
+  AND schema_version = 4
   AND entity_id = $2
   AND locale_key = 'en'
   AND is_deleted = FALSE

--- a/crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs
+++ b/crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs
@@ -431,7 +431,7 @@ fn product_schema_ref() -> TestResult<SchemaRef> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product")?,
         entity: EntityName::new("product")?,
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(4),
     })
 }
 
@@ -551,7 +551,7 @@ FROM index_entities
 WHERE tenant_id = $1
   AND module_name = 'rustok-product'
   AND entity_name = 'product'
-  AND schema_version = 3
+  AND schema_version = 4
   AND entity_id = $2
   AND locale_key = 'en'
   AND is_deleted = FALSE

--- a/crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs
@@ -442,7 +442,7 @@ fn product_schema_ref() -> TestResult<SchemaRef> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product")?,
         entity: EntityName::new("product")?,
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(4),
     })
 }
 

--- a/crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs
@@ -396,7 +396,7 @@ fn product_schema_ref() -> TestResult<SchemaRef> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product")?,
         entity: EntityName::new("product")?,
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(4),
     })
 }
 
@@ -730,7 +730,7 @@ async fn product_epoch(db: &DatabaseConnection, sql: &str, column: &str) -> Test
 }
 
 async fn materialized_product_version(db: &DatabaseConnection) -> TestResult<u64> {
-    materialized_target_version(db, "rustok-product", "product", 3, PRODUCT_ID).await
+    materialized_target_version(db, "rustok-product", "product", 4, PRODUCT_ID).await
 }
 
 async fn assert_materialized_target_version(

--- a/crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs
+++ b/crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs
@@ -473,7 +473,7 @@ fn product_schema_ref() -> TestResult<SchemaRef> {
     Ok(SchemaRef {
         module: ModuleName::new("rustok-product")?,
         entity: EntityName::new("product")?,
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(4),
     })
 }
 

--- a/crates/rustok-distribution/tests/product_locale_absence_postgres.rs
+++ b/crates/rustok-distribution/tests/product_locale_absence_postgres.rs
@@ -361,7 +361,7 @@ fn product_key(locale: &str) -> TestResult<EntityKey> {
             entity: EntityName::new("product")?,
             // Index core requires a numeric schema key; only this current Product contract is
             // registered by rustok-distribution.
-            version: SchemaVersion::new(3),
+            version: SchemaVersion::new(4),
         },
         entity_id: PRODUCT_ID,
         locale: Some(LocaleKey::new(locale)?),

--- a/crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs
+++ b/crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs
@@ -385,7 +385,7 @@ fn product_schema_ref() -> TestResult<SchemaRef> {
         entity: EntityName::new("product")?,
         // Index core still requires one positive numeric routing/storage key. Distribution registers
         // only this current Product contract.
-        version: SchemaVersion::new(3),
+        version: SchemaVersion::new(4),
     })
 }
 
@@ -456,7 +456,7 @@ FROM index_entities
 WHERE tenant_id = $1
   AND module_name = 'rustok-product'
   AND entity_name = 'product'
-  AND schema_version = 3
+  AND schema_version = 4
   AND entity_id = $2
   AND locale_key = $3
   AND is_deleted = FALSE

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after core Product Storefront PostgreSQL packet merge `6e635d890503443622b41ebfe203c5d5682e7333` and continued on
-`agent/index-storefront-eav-equivalence-postgres-20260808`.
+Status overlay rechecked after Product Storefront EAV PostgreSQL packet merge
+`2098ab10cbac4741d83a06f49bb4de21a605b909` and continued on
+`agent/index-product-postgres-key4-actualize-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -16,7 +17,7 @@ required and is not claimed by source inspection.
 
 Source-complete:
 
-- one current 15-field Product schema on routing key `4`; lower keys historical only;
+- one current 15-field Product schema on routing key `4`; lower keys are historical storage identities only;
 - schema-scoped Product replay IDs, Product owner clock and canonical typed `attribute_terms`;
 - Product channel relation/freshness materialization;
 - localized entity identity fold, scoped cursor v3 and requested -> fallback projection;
@@ -28,20 +29,27 @@ Source-complete:
 - pure Storefront shadow builder consuming only `ProductResolvedAttributeFilter`;
 - non-serving owner-first `ProductStorefrontIndexShadowExecutor`;
 - current-key core Product Storefront owner-vs-shadow PostgreSQL packet source;
-- separate current-key Product Storefront EAV owner-vs-shadow PostgreSQL packet source.
+- separate current-key Product Storefront EAV owner-vs-shadow PostgreSQL packet source;
+- historical retained Product PostgreSQL fixtures actualized to current Product routing key `4` without a
+  key-3 runtime alias.
 
 The core packet retains localized projection/search, identity de-duplication, equal-timestamp ordering,
 page/count and public-channel scenarios. The EAV packet isolates Product term resolution/materialization and
 retains integer, localized requested/fallback, Select/Multiselect option code, direct option UUID and
 missing/nil option `Never` scenarios. Both remain source-only until maintainer execution.
 
-The core packet also records a public projection gap: owner uses `Untitled product`/empty handle when no
-requested/fallback translation exists, while generic localized Index returns null. Final Storefront
+Historical Product freshness, locale-absence, Channel convergence/identity-transition and linked-target
+recreate/availability/replay packets now target the same current Product key `4`. Their scenario semantics are
+unchanged; ProductVariant remains key `2` and SalesChannel remains key `1`.
+
+The core Storefront packet also records a public projection gap: owner uses `Untitled product`/empty handle
+when no requested/fallback translation exists, while generic localized Index returns null. Final Storefront
 projection must apply public placeholders only after Product page identity/order/count are fixed.
 
 ## Remaining Storefront parity/evidence blockers
 
-- execute/review both current-key Storefront PostgreSQL packets; source presence is not evidence admission;
+- execute/review both current-key Storefront PostgreSQL packets and the actualized retained Product packets;
+  source presence is not evidence admission;
 - owner title search has no explicit length bound vs Index `TextLike` 1024-byte bound;
 - owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`;
 - channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
@@ -51,14 +59,21 @@ projection must apply public placeholders only after Product page identity/order
 - shadow execution has no serving latency/deadline policy and must remain non-serving;
 - stale locale/readiness/admission/restart evidence still requires maintainer execution/extension.
 
-## Retained Product evidence debt
+## Retained Product evidence state
 
-Historical PostgreSQL packets must still be mechanically actualized to routing key `4` / current 15-field
-Product contract; never add a key-3 runtime alias. Keep those large fixture rewrites separate from the new
-Storefront packets.
+The retained Product PostgreSQL fixture set is now source-aligned on routing key `4`:
 
-After the current packets are executed, use observed evidence to decide the next correction/admission slice:
-search collation/bounds, placeholder projection, channel-less visibility, deep-page policy or restart/readiness.
+- Product locale absence;
+- Product materialized query freshness;
+- Product/Channel convergence;
+- Channel identity transitions;
+- linked-target delete/recreate;
+- linked-target availability equivalence;
+- linked-target replay/redelivery.
+
+`verify-index-product-postgres-key4-fixtures.mjs` prevents these packets from restoring Product key `3` while
+also pinning the current 15-field Product bridge and unchanged ProductVariant/SalesChannel target keys.
+Execution and evidence admission remain separate maintainer gates.
 
 ## M5 incremental ingestion
 
@@ -93,14 +108,15 @@ search collation/bounds, placeholder projection, channel-less visibility, deep-p
 - [x] Compose non-serving Product-owner + Index shadow executor.
 - [x] Retain current-key core owner-vs-shadow localized PostgreSQL packet source.
 - [x] Retain Product EAV owner-vs-shadow PostgreSQL packet source.
+- [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
 - [ ] Execute/review the core Storefront PostgreSQL packet.
 - [ ] Execute/review the EAV Storefront PostgreSQL packet.
+- [ ] Execute/review the actualized retained Product PostgreSQL packets.
 - [ ] Resolve/admit search-length and collation parity.
 - [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
 - [ ] Decide authoritative deep-page policy.
 - [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
 - [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
-- [ ] Actualize historical retained Product PostgreSQL packets to routing key `4`.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
@@ -108,9 +124,10 @@ search collation/bounds, placeholder projection, channel-less visibility, deep-p
 
 ## Next source-code step
 
-Mechanically actualize historical retained Product PostgreSQL packets to current routing key `4` / 15-field
-fixtures without adding runtime compatibility. Keep that mechanical debt separate from Storefront parity.
-Do not execute tests or PostgreSQL packets in this implementation turn.
+Keep serving owner-native and resolve the next source-level parity mismatch: establish an authoritative Product
+Storefront title-search length contract compatible with bounded Index `TextLike`, then retain explicit
+PostgreSQL collation evidence. Do not silently truncate owner-valid input or weaken deterministic Index
+collation.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `core_and_eav_postgres_packets_source_complete_execution_pending`.
+Status: `core_eav_and_retained_key4_packets_source_complete_execution_pending`.
 
 ## Current boundary
 
@@ -8,9 +8,10 @@ Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
 The Product-owned EAV resolver, pure localized shadow builder and non-serving owner-first shadow executor are
-source-complete. Two current-key PostgreSQL owner-vs-shadow packets are now retained in source: the localized
-core packet and a separate EAV packet. Neither packet has been executed or admitted by the implementation
-agent.
+source-complete. Two current-key PostgreSQL owner-vs-shadow Storefront packets are retained in source: the
+localized core packet and a separate EAV packet. Historical retained Product PostgreSQL packets are also
+source-actualized to Product routing key `4`. None of those packets has been executed or admitted by the
+implementation agent.
 
 ## Product-owned EAV resolution and shadow execution
 
@@ -62,10 +63,30 @@ The EAV fixture deliberately does not call `save_product_attribute_values`: Prod
 semantics already have a separate retained gate. This packet isolates query resolution/materialization parity
 from command-publication evidence.
 
+## Historical retained Product packets — key 4 source actualized
+
+The following retained PostgreSQL fixtures now use the current Product routing key `4` while preserving their
+existing scenario semantics:
+
+- `product_locale_absence_postgres.rs`;
+- `product_materialized_query_freshness_postgres.rs`;
+- `product_channel_convergence_postgres.rs`;
+- `product_channel_identity_transitions_postgres.rs`;
+- `product_linked_target_recreate_postgres.rs`;
+- `product_linked_target_availability_equivalence_postgres.rs`;
+- `product_linked_target_replay_redelivery_postgres.rs`.
+
+They continue to build the real distribution schema/source registries, so current Product materialization is
+against the 15-field key-4 contract rather than a test-only compatibility schema. ProductVariant stays on key
+`2`, SalesChannel stays on key `1`, and no Product key-3 runtime alias exists.
+
+`verify-index-product-postgres-key4-fixtures.mjs` locks that boundary. Actualization is source maintenance,
+not proof that the packets pass; execution/review remains a maintainer gate.
+
 ## Remaining fail-closed parity/evidence gates
 
-1. Maintainer execution/review of both current-key Storefront PostgreSQL packets; source presence is not
-   evidence admission.
+1. Maintainer execution/review of the Storefront core/EAV packets and actualized retained Product packets;
+   source presence is not evidence admission.
 2. Search-length mismatch: owner search is not explicitly bounded while Index `TextLike` is capped at 1024
    UTF-8 bytes.
 3. Owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`.
@@ -75,26 +96,22 @@ from command-publication evidence.
 6. Final Storefront projection must map no-localized-row null title/handle to owner placeholders.
 7. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
 8. Shadow execution has no serving latency/deadline policy and remains non-serving.
-9. Historical Product PostgreSQL packets still need routing key `4` / current 15-field actualization; never
-   add a key-3 compatibility alias.
-10. Stale locale/readiness/admission/restart cases still need maintainer-executed retained Storefront evidence.
+9. Stale locale/readiness/admission/restart cases still need maintainer-executed retained Storefront evidence.
 
 ## Next source slice
 
-Mechanically actualize historical retained Product PostgreSQL packets from routing key `3` fixtures to the
-current key `4` / 15-field contract, without adding runtime compatibility. Keep those rewrites separate from
-Storefront parity packets.
-
-After packet execution, use observed results to decide whether the next source correction is search
-collation/bounds, public placeholder projection, channel-less policy, or readiness/restart evidence.
+Establish an authoritative Product Storefront title-search length contract compatible with bounded Index
+`TextLike`. Do not silently truncate owner-valid input. After that contract is source-aligned, retain explicit
+PostgreSQL evidence for owner/default title `LIKE` collation versus deterministic Index `COLLATE "C"`.
 
 ## Source guards
 
 - `verify-product-storefront-attribute-filter-terms.mjs` locks Product-owned EAV resolution;
-- `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term → localized query translation;
+- `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;
 - `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution;
 - `verify-index-product-storefront-equivalence-postgres-packet.mjs` locks the core current-key packet;
 - `verify-index-product-storefront-eav-equivalence-postgres-packet.mjs` locks the EAV current-key packet;
+- `verify-index-product-postgres-key4-fixtures.mjs` locks all actualized retained Product packets on key `4`;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or

--- a/scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
+++ b/scripts/verify/verify-index-linked-target-recreate-postgres-harness.mjs
@@ -43,6 +43,9 @@ const harness = requireMarkers(harnessPath, [
   'PRODUCT_SOURCE: &str = "product-postgres-primary"',
   'PRODUCT_VARIANT_SOURCE: &str = "product-variant-postgres-primary"',
   'SALES_CHANNEL_SOURCE: &str = "sales-channel-postgres-primary"',
+  'SchemaVersion::new(4)',
+  'SchemaVersion::new(2)',
+  'SchemaVersion::INITIAL',
   'FieldPath::linked(',
   'LinkName::new("variants")',
   'LinkName::new("sales_channels")',
@@ -53,24 +56,26 @@ const harness = requireMarkers(harnessPath, [
   'variant_tombstone_version(&database.writer).await?.is_none()',
   'assert_materialized_target_version(',
   '"product_variant"',
-  'assert_graph_payloads(&runtime.query, &[], &[OLD_CHANNEL_NAME])',
+  'old_variant_version',
+  'assert_scalar_product_visible(&runtime.query, true)',
+  'assert_graph_query_visible(&runtime.query, false)',
+  '&[NEW_VARIANT_SKU]',
+  '&[OLD_CHANNEL_NAME]',
   'delete_channel(&database.writer).await?',
   'channel_tombstone_version(&database.writer)',
   'recreate_channel(&database.writer).await?',
   'recreated_channel_version > channel_tombstone',
   'channel_tombstone_version(&database.writer).await?.is_none()',
-  'assert_product_root_visible(&runtime.query, false)',
+  'generation_after_channel_recreate',
   'run_scheduler_until_idle(&runtime.scheduler, 20)',
   'latest_relation_epoch(&database.writer)',
   'latest_projection_epoch(&database.writer)',
   'latest_freshness_generation(&database.writer)',
-  '"sales_channel"',
-  'assert_graph_payloads(&runtime.query, &[NEW_VARIANT_SKU], &[])',
-  'assert_graph_payloads(',
-  '&[NEW_VARIANT_SKU]',
+  'old_channel_version',
   '&[NEW_CHANNEL_NAME]',
 ]);
 forbidMarkers(harnessPath, harness, [
+  'SchemaVersion::new(3)',
   'tokio::spawn',
   'loop {',
   'CREATE TABLE product_variant_index_tombstones',
@@ -111,4 +116,4 @@ requireMarkers('crates/rustok-index/docs/m7-linked-target-recreate-postgres-harn
   'does not claim execution success',
 ]);
 
-console.log('[verify-index-linked-target-recreate-postgres-harness] source-ready packet verified');
+console.log('[verify-index-linked-target-recreate-postgres-harness] current-key source-ready packet verified');

--- a/scripts/verify/verify-index-product-absence-postgres-harness.mjs
+++ b/scripts/verify/verify-index-product-absence-postgres-harness.mjs
@@ -57,7 +57,7 @@ requireMarkers("test", [
   "product.index_revision",
   "'all'",
   "'[]'::jsonb",
-  "SchemaVersion::new(3)",
+  "SchemaVersion::new(4)",
   "translation insertion between observations must reject the snapshot pair",
   "IndexDriftDependencyFailureKind::Retryable",
   '"index_drift_source_changed_during_capture"',
@@ -66,6 +66,7 @@ requireMarkers("test", [
 
 for (const forbidden of [
   "SchemaVersion::INITIAL",
+  "SchemaVersion::new(3)",
   "SequencedSource",
   "FixedProvider",
   "register_index_source_absence_provider",
@@ -73,7 +74,7 @@ for (const forbidden of [
   "tokio::time::timeout(Duration::from_secs(0)",
 ]) {
   if (content.test.includes(forbidden)) {
-    throw new Error(`Product absence PostgreSQL harness contains forbidden shortcut or legacy key: ${forbidden}`);
+    throw new Error(`Product absence PostgreSQL harness contains forbidden shortcut or historical key: ${forbidden}`);
   }
 }
 

--- a/scripts/verify/verify-index-product-postgres-key4-fixtures.mjs
+++ b/scripts/verify/verify-index-product-postgres-key4-fixtures.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-postgres-key4-fixtures] ${message}`);
+  process.exit(1);
+};
+
+const productFixtures = [
+  'crates/rustok-distribution/tests/product_locale_absence_postgres.rs',
+  'crates/rustok-distribution/tests/product_materialized_query_freshness_postgres.rs',
+  'crates/rustok-distribution/tests/product_channel_convergence_postgres.rs',
+  'crates/rustok-distribution/tests/product_channel_identity_transitions_postgres.rs',
+  'crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs',
+  'crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs',
+  'crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs',
+];
+
+for (const relative of productFixtures) {
+  const source = read(relative);
+  if (!source.includes('SchemaVersion::new(4)')) {
+    fail(`${relative} does not target current Product routing key 4`);
+  }
+  if (source.includes('SchemaVersion::new(3)')) {
+    fail(`${relative} restored historical Product routing key 3`);
+  }
+  if (/entity_name\s*=\s*'product'[\s\S]{0,160}schema_version\s*=\s*3/.test(source)) {
+    fail(`${relative} contains a direct historical Product schema_version = 3 assertion`);
+  }
+}
+
+const productSource = read('crates/rustok-distribution/src/product_index/mod.rs');
+if (!productSource.includes('PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4')) {
+  fail('current Product routing key is not 4');
+}
+const productBridge = read('crates/rustok-distribution/src/product_index/product.rs');
+for (const marker of [
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'assert_eq!(schema.fields.len(), 15);',
+  'many_field("attribute_terms", IndexValueType::String, false, true)',
+  'many_field("variant_ids", IndexValueType::Uuid, true, true)',
+  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
+]) {
+  if (!productBridge.includes(marker)) fail(`current Product bridge is missing ${marker}`);
+}
+if (productBridge.includes('SchemaVersion::new(3)')) {
+  fail('current Product bridge restored a historical key-3 compatibility path');
+}
+
+for (const relative of [
+  'crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs',
+  'crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs',
+  'crates/rustok-distribution/tests/product_linked_target_replay_redelivery_postgres.rs',
+]) {
+  const source = read(relative);
+  if (!source.includes('SchemaVersion::new(2)')) {
+    fail(`${relative} changed the ProductVariant routing key unexpectedly`);
+  }
+}
+
+for (const relative of [
+  'crates/rustok-distribution/tests/product_linked_target_recreate_postgres.rs',
+  'crates/rustok-distribution/tests/product_linked_target_availability_equivalence_postgres.rs',
+]) {
+  const source = read(relative);
+  if (!source.includes('SchemaVersion::INITIAL')) {
+    fail(`${relative} changed the SalesChannel routing key unexpectedly`);
+  }
+}
+
+console.log('[verify-index-product-postgres-key4-fixtures] retained Product PostgreSQL fixtures target current key 4 without a key-3 compatibility path');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -87,19 +87,37 @@ const productIndex = requireMarkers(productIndexPath, [
 ]);
 if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
 
+requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
+  'product_locale_absence_postgres.rs',
+  'product_materialized_query_freshness_postgres.rs',
+  'product_channel_convergence_postgres.rs',
+  'product_channel_identity_transitions_postgres.rs',
+  'product_linked_target_recreate_postgres.rs',
+  'product_linked_target_availability_equivalence_postgres.rs',
+  'product_linked_target_replay_redelivery_postgres.rs',
+  "source.includes('SchemaVersion::new(3)')",
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+]);
+
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `core_and_eav_postgres_packets_source_complete_execution_pending`',
+  'Status: `core_eav_and_retained_key4_packets_source_complete_execution_pending`',
   'Mounted Storefront remains owner-native',
   'Core PostgreSQL packet — source complete, execution pending',
   'EAV PostgreSQL packet — source complete, execution pending',
+  'Historical retained Product packets — key 4 source actualized',
   'routing key `4`',
   'missing option code',
   'nil option UUID',
   'placeholder',
+  'ProductVariant stays on key',
+  'SalesChannel stays on key',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
   'Status: `source_complete_materialized_rebuild_pending`',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-product-postgres-key4-fixtures.mjs'",
+]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; current-key core and EAV owner-vs-shadow PostgreSQL packets are retained in source while execution/admission and policy gates remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; Storefront core/EAV and retained Product PostgreSQL packets are source-aligned on key 4 while execution/admission and policy gates remain pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -91,6 +91,7 @@ const scripts = [
   'verify-index-localized-query-runtime.mjs',
   'verify-index-localized-identity-order.mjs',
   'verify-index-text-like-filter.mjs',
+  'verify-index-product-postgres-key4-fixtures.mjs',
   'verify-index-product-materialized-query-freshness-postgres-harness.mjs',
   'verify-index-product-channel-convergence-postgres-harness.mjs',
   'verify-index-product-channel-identity-transitions-postgres-harness.mjs',


### PR DESCRIPTION
## Summary

- actualize seven retained Product PostgreSQL fixtures from historical Product routing key `3` to the current key `4` while preserving their existing scenarios;
- update local Product `SchemaRef` construction and direct `index_entities.schema_version` assertions only; the packets already compose the real current distribution schema/source registry, so no test-only 15-field schema or compatibility alias is introduced;
- keep ProductVariant routing key `2` and SalesChannel routing key `1` unchanged in linked-target packets;
- cover the retained Product locale-absence, materialized-freshness, Product/Channel convergence, Channel identity-transition, linked-target recreate, linked-target availability and replay/redelivery packets;
- add `verify-index-product-postgres-key4-fixtures.mjs` to forbid historical Product key `3` across that packet set and pin the current 15-field Product bridge;
- actualize the Product locale-absence source guard to key `4`;
- repair a pre-existing stale linked-target recreate guard so its markers match the packet's current fail-closed target-availability scenario rather than an older empty-link expectation;
- advance the M7 plan/parity docs from key-4 fixture debt to source-actualized / execution-pending state.

## Main recheck

The implementation branch started from `main@fe0bddc83c7f81431c731e823fe87ef9b558f807`. Current `main@08ddd0b99fe71b28c2d15d6fe3b4f75f7c1bcbc8` advanced through #3240 only in Commerce legacy Storefront GraphQL files and its guard; that three-file slice is disjoint from this Product/Index evidence actualization.

The final compare shows each Rust PostgreSQL fixture changed by only one or two Product key/version lines. No scenario, seed, admission/freshness behavior, ProductVariant key, or SalesChannel key was changed.

## Boundary

This PR does not execute PostgreSQL packets, admit evidence, add a Product key-3 runtime alias, change Storefront serving, resolve search-length/collation/channel-less/deep-page parity, hydrate Taxonomy tags, promote Product key `4`, or claim production evidence completion.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.