### PR TITLE
feat(groups): add direct membership enforcement owner command

### DIFF
--- a/crates/rustok-groups/README.md
+++ b/crates/rustok-groups/README.md
@@ -22,22 +22,28 @@ Source now exists for:
 - monotonic `group_memberships.revision`;
 - bounded current `group_membership_enforcements` projection;
 - owner-clock effective-state resolution with expired/revoked fallback;
+- direct `GroupMembershipEnforcementCommandPort` suspend/revoke with expected-revision CAS,
+  receipt-first replay, local hierarchy, owner protection, group-version advance, audit/events and
+  shared owner mutation functions reserved for the later neutral Moderation adapter;
+- stored lifecycle active `groups.member_count` semantics: temporary enforcement never changes the
+  counter, so owner-clock expiry cannot leave a cleanup-dependent count split;
+- append-only membership suspension/revocation semantic events beside targeted invitation events;
 - crate-root effective `GroupsService` for core access, join/rejoin, private redaction, membership
   listing, enabled features, and feature settings;
 - effective invitation, targeted-invitation, and membership-application public services;
 - transaction-aware invitation/application writes using one owner transaction for receipt replay,
   locking, effective authorization, mutation, audit, and receipt.
 
-Invitation/application writes use the lock order:
+Invitation/application and direct enforcement writes preserve the lock family:
 
 ```text
 Group -> GroupMembership -> GroupMembershipEnforcement
 ```
 
 PostgreSQL and MySQL use row locks. SQLite acquires writer serialization with a no-op group write
-before reading membership/enforcement state. The effective check therefore occurs after receipt
-replay and owner locking, but before the first domain mutation. Public facades no longer perform a
-separate write precheck that can race the owner transaction.
+before reading membership/enforcement state. Effective checks therefore occur after receipt replay
+and owner locking, but before the first domain mutation. Direct enforcement additionally locks
+actor/target memberships and enforcement rows in deterministic UUID order.
 
 The status-only implementations remain crate-private compatibility delegates. Public module paths
 remain stable:
@@ -48,9 +54,9 @@ rustok_groups::targeted_invitations::*
 rustok_groups::applications::*
 ```
 
-Direct suspend/revoke commands, localization/governance conversion, provider ACL integration,
-member-count suspension/restoration semantics, the moderation adapter/application orchestration,
-and runtime evidence remain open. `GROUPS-07` remains `in_progress`.
+Localization/governance transaction-aware conversion, provider ACL integration, the neutral
+moderation adapter/application orchestration, native/GraphQL direct-enforcement transport, and
+runtime evidence remain open. `GROUPS-07` remains `in_progress`.
 
 ## Responsibilities
 
@@ -82,7 +88,16 @@ and runtime evidence remain open. `GROUPS-07` remains `in_progress`.
 - Never copy moderation reports, case notes, queue state, policy snapshots, or appeals into Groups.
 - Evaluate expiry with the Groups UTC clock; cleanup is optional normalization, not access logic.
 - Resolve effective states `missing`, `active`, `inactive`, `suspended`, and `legacy_banned`.
-- Publish `GroupMembershipEnforcementReadPort`; no public enforcement command port exists yet.
+- Publish `GroupMembershipEnforcementReadPort` for owner-clock effective state.
+- Publish `GroupMembershipEnforcementCommandPort` for direct single-membership suspend/revoke.
+- Require a user actor, bounded idempotency key, exact expected membership revision, hierarchy and
+  owner protection for direct enforcement.
+- Keep `groups.member_count` as the stored lifecycle-active count; suspension/revocation never
+  adjusts it, while every actual enforcement mutation still bumps `groups.version`.
+- Allow direct revoke only for active `direct_local` enforcement. Local moderation cannot erase a
+  `moderation_decision` row.
+- Preserve original suspension provenance on revoke and record revoker identity in immutable
+  audit/event facts.
 
 ### Effective core access
 
@@ -130,6 +145,7 @@ Core owner/runtime:
 - `GroupsModule`
 - `rustok_groups::GroupsService`
 - `GroupMembershipEnforcementService`
+- `GroupMembershipEnforcementCommandService`
 - `GroupLocalizationService`
 - `GroupInvitationService`
 - `GroupTargetedInvitationService`
@@ -142,6 +158,7 @@ Primary ports:
 - `GroupSummaryReadPort`
 - `GroupMembershipReadPort`
 - `GroupMembershipEnforcementReadPort`
+- `GroupMembershipEnforcementCommandPort`
 - `GroupAccessReadPort`
 - `GroupLocalizationReadPort`
 - `GroupInvitationReadPort`
@@ -169,8 +186,8 @@ Primary ports:
   consume Groups access ports.
 - Notifications may consume committed targeted-invitation events asynchronously.
 - Moderation owns reports, cases, decisions, retries, appeals, and application orchestration.
-  A future neutral adapter will call a shared Groups enforcement command; moderation never writes
-  Groups tables directly.
+  The neutral adapter will call the shared Groups enforcement owner mutation after producer receipt,
+  scope, subject revision and effect validation; moderation never writes Groups tables directly.
 
 ## Readiness
 
@@ -178,13 +195,14 @@ Source presence does not prove compilation, migration behavior, PostgreSQL/SQLit
 concurrency, replay, CAS, transport parity, security, accessibility, retry, or recovery.
 
 FFA, FBA, `GROUPS-06`, `GROUPS-07`, and `GROUPS-19` remain `in_progress`. Transaction-aware
-invitation/application authorization is source-complete, but runtime evidence and the remaining
-owner paths are open.
+invitation/application authorization and the direct enforcement command are source-complete, but
+runtime evidence and the remaining owner/adapter paths are open.
 
 ## Documentation
 
 - [Live module contract](docs/README.md)
 - [Canonical implementation plan](docs/implementation-plan.md)
+- [Membership enforcement command contract](docs/membership-enforcement-command-contract.md)
 - [Bulk review contract](docs/bulk-review-contract.md)
 - [FBA registry](contracts/groups-fba-registry.json)
 - [Effective membership access contract](contracts/groups-effective-membership-access.json)
@@ -192,5 +210,6 @@ owner paths are open.
 - [Application no-bypass guard](../../scripts/verify/verify-groups-application-native-no-bypass.mjs)
 - [Bulk review guard](../../scripts/verify/verify-groups-application-bulk-review.mjs)
 - [Membership enforcement read guard](../../scripts/verify/verify-groups-membership-enforcement-read-path.mjs)
+- [Membership enforcement command guard](../../scripts/verify/verify-groups-membership-enforcement-command.mjs)
 - [Effective membership access guard](../../scripts/verify/verify-groups-effective-membership-access.mjs)
 - [Effective invitation/application guard](../../scripts/verify/verify-groups-effective-membership-invitations-applications.mjs)

--- a/crates/rustok-groups/contracts/groups-fba-registry.json
+++ b/crates/rustok-groups/contracts/groups-fba-registry.json
@@ -41,7 +41,34 @@
         "stored_status": "compatibility_only",
         "legacy_banned_behavior": "deny_reentry",
         "expired_or_revoked_behavior": "fall_back_to_stored_membership_state",
-        "command_port": "not_published_in_this_slice"
+        "command_port": "GroupMembershipEnforcementCommandPort"
+      },
+      {
+        "name": "GroupMembershipEnforcementCommandPort",
+        "operations": [
+          "suspend_membership",
+          "revoke_membership_suspension"
+        ],
+        "policy": "write",
+        "deadline_required": true,
+        "idempotency_key_required": true,
+        "actor": "user",
+        "authorization": "local_owner_admin_moderator_hierarchy_or_platform_groups_moderate_manage",
+        "self_target": "deny",
+        "owner_target": "deny_transfer_ownership_first",
+        "expected_revision": "group_memberships.revision",
+        "receipt_replay_order": "after_group_serialization_before_current_effective_authorization_and_revision_cas",
+        "receipt_identity": "tenant_group_actor_command_request_hash",
+        "lock_order": "group_then_memberships_uuid_order_then_enforcements_membership_id_order",
+        "direct_suspend_source_kind": "direct_local",
+        "direct_revoke_source": "active_direct_local_only",
+        "member_count_semantics": "stored_lifecycle_active_unchanged_by_enforcement",
+        "transactional_group_version": true,
+        "transactional_membership_revision": "database_enforcement_trigger",
+        "transactional_receipt": true,
+        "transactional_audit": true,
+        "transactional_semantic_event": true,
+        "transport_status": "rust_source_only"
       },
       {
         "name": "GroupAccessReadPort",
@@ -350,9 +377,18 @@
     "effective_clock": "groups_owner_utc_clock",
     "expiry_cleanup_dependency": false,
     "legacy_banned_behavior": "deny_reentry",
-    "access_path_integration": "open",
-    "invitation_application_provider_acl_integration": "open",
-    "direct_command_port": "not_published_in_this_slice",
+    "access_path_integration": "implemented_source",
+    "invitation_application_effective_integration": "implemented_source",
+    "provider_acl_integration": "open",
+    "direct_command_port": "implemented_source",
+    "direct_command_owner_mutation": "shared_with_future_moderation_adapter",
+    "member_count_semantics": "stored_lifecycle_active_unchanged_by_temporary_enforcement",
+    "group_version_on_enforcement_change": "increment_same_transaction",
+    "semantic_event_table": "group_domain_events",
+    "semantic_event_types": [
+      "groups.membership.suspended",
+      "groups.membership.suspension_revoked"
+    ],
     "moderation_adapter": "not_published_in_this_slice"
   },
   "localization": {
@@ -516,6 +552,16 @@
       "implicit_fallback": false
     },
     {
+      "name": "embedded_membership_enforcement_command_native",
+      "provider": "GroupMembershipEnforcementCommandService",
+      "status": "implemented_source",
+      "surfaces": [
+        "rust_command_port",
+        "shared_owner_mutation"
+      ],
+      "implicit_fallback": false
+    },
+    {
       "name": "embedded_localization_native",
       "provider": "GroupLocalizationService",
       "status": "implemented",
@@ -626,6 +672,7 @@
     "membership_application_native_no_bypass_static_boundary": "scripts/verify/verify-groups-application-native-no-bypass.mjs",
     "membership_application_bulk_review_static_boundary": "scripts/verify/verify-groups-application-bulk-review.mjs",
     "membership_enforcement_read_static_boundary": "scripts/verify/verify-groups-membership-enforcement-read-path.mjs",
+    "membership_enforcement_command_static_boundary": "scripts/verify/verify-groups-membership-enforcement-command.mjs",
     "runtime_provider_consumer": null,
     "runtime_fallback": null,
     "runtime_retry_recovery": null,
@@ -644,6 +691,9 @@
     "membership_application_bulk_review": null,
     "membership_enforcement_migration": null,
     "membership_enforcement_revision_runtime": null,
+    "membership_enforcement_command_runtime": null,
+    "membership_enforcement_command_concurrency": null,
+    "membership_enforcement_command_transport_parity": null,
     "membership_enforcement_access_path_integration": null,
     "governance_transport_parity": null,
     "governance_concurrency": null

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -6,7 +6,7 @@ status: active
 owners:
   - rustok-groups
   - platform-community
-last_reviewed: 2026-07-23
+last_reviewed: 2026-08-08
 ---
 
 # `rustok-groups` canonical implementation plan
@@ -69,6 +69,9 @@ subject revision must conflict and must never be retargeted.
   application, management, governance, or provider ACL decisions.
 - Expiry is evaluated with the Groups owner clock and never depends on cleanup.
 - Corrupt or unsupported enforcement state fails closed.
+- `groups.member_count` is a stored lifecycle active count, not an owner-clock effective-enforcement
+  count. Temporary suspension/revocation never changes it; join/leave and other stored lifecycle
+  transitions remain its mutation owners.
 
 ### Commands, replay, and locking
 
@@ -80,7 +83,7 @@ After those required pre-replay locks, an identical receipt is returned before c
 authorization, CAS, lifecycle validation, or domain mutation. A changed request using the same key
 conflicts. Replay is never denied because membership authority changed after the original commit.
 
-For invitation/application effective authorization, the canonical membership lock sequence is:
+The canonical membership lock sequence is:
 
 ```text
 Group -> GroupMembership -> GroupMembershipEnforcement
@@ -88,12 +91,14 @@ Group -> GroupMembership -> GroupMembershipEnforcement
 
 PostgreSQL/MySQL use row locks. SQLite obtains writer serialization through a no-op update of the
 already resolved group before membership/enforcement reads. Authorization runs after receipt replay
-and owner locking but before the first domain mutation.
+and owner locking but before the first domain mutation. Direct enforcement commands lock actor and
+target memberships in deterministic UUID order and their enforcement rows in deterministic
+membership-ID order.
 
 Application CAS preserves existing application-before-group ordering where an application row
-already exists. Invitation/application identity locks do not create a cycle with the future
-enforcement command because that command will not lock invitation or application rows. Bulk review
-remains one transaction, audit, receipt, and result per item.
+already exists. Invitation/application identity locks do not create a cycle with enforcement because
+the enforcement command never locks invitation or application rows. Bulk review remains one
+transaction, audit, receipt, and result per item.
 
 ## Current implementation state
 
@@ -109,6 +114,12 @@ Source exists for:
   lifecycle, focused review, and bounded partial-result bulk review;
 - monotonic membership revision and bounded current enforcement projection;
 - owner-clock effective resolver and `GroupMembershipEnforcementReadPort`;
+- direct `GroupMembershipEnforcementCommandPort` suspend/revoke with expected-revision CAS,
+  receipt-first replay, hierarchy/owner protection, shared owner mutation, audit/events and bounded
+  direct-local provenance;
+- stored lifecycle active member-count semantics that remain independent from temporary owner-clock
+  suspension/expiry/revocation while every enforcement mutation still advances group version;
+- append-only membership suspend/revoke semantic events beside targeted invitation events;
 - effective core `GroupsService` for access, redaction, join/rejoin, membership listing, enabled
   features, and feature settings;
 - sealed effective public invitation/application services with compatibility module paths;
@@ -120,15 +131,15 @@ Source exists for:
 Evidence still open:
 
 - compilation and executed unit/integration tests;
-- PostgreSQL and SQLite migration/runtime evidence;
+- PostgreSQL and SQLite migration/runtime evidence, including the expanded append-only event ledger;
 - lock behavior and concurrent enforcement-change tests;
-- native/GraphQL parity, replay, CAS, lifecycle, bulk-review, retry, recovery, security, and
-  accessibility evidence;
+- direct enforcement replay, expected-revision contention, hierarchy, owner-protection, expiry,
+  revoke, lifecycle-count invariance, audit/event atomicity, security and transport parity evidence;
+- native/GraphQL parity, CAS, lifecycle, bulk-review, retry, recovery, security, and accessibility
+  evidence for the broader module;
 - localization and governance effective authorization;
 - provider ACL integration and remote/degraded profiles;
-- leave/member-count suspension/restoration semantics;
-- direct suspend/revoke command, shared owner mutation path, moderation adapter, and durable
-  moderation application orchestration.
+- neutral moderation adapter and durable moderation application orchestration.
 
 ## Program ledger
 
@@ -137,11 +148,11 @@ Evidence still open:
 | GROUPS-00 | in_progress | ADR, ownership map, phpFox parity, FFA/FBA contracts | executable architecture review |
 | GROUPS-01 | in_progress | module skeleton, manifest, RBAC, migrations, host composition | build/module validation |
 | GROUPS-02 | in_progress | identity, localization, visibility, join policy, features, audit/events | lifecycle/runtime/concurrency |
-| GROUPS-03 | in_progress | memberships, join/leave, roles, ownership transfer | remaining enforcement integration |
-| GROUPS-04 | in_progress | typed summary/membership/access/localization/invitation/application/governance ports | consumer/fallback runtime matrix |
+| GROUPS-03 | in_progress | memberships, join/leave, roles, ownership transfer, direct enforcement | remaining enforcement integration |
+| GROUPS-04 | in_progress | typed summary/membership/access/localization/invitation/application/governance/enforcement ports | consumer/fallback runtime matrix |
 | GROUPS-05 | in_progress | GraphQL/native transports, invitation acceptance/delivery | parity and Notifications evidence |
 | GROUPS-06 | in_progress | localized policy, CAS, lifecycle, focused/bulk review, FFA UX | profiles/events/parity/concurrency/accessibility |
-| GROUPS-07 | in_progress | revision, enforcement read model, effective core access, transactional invitation/application authorization | remaining owner paths, direct command, adapter, runtime/concurrency evidence |
+| GROUPS-07 | in_progress | revision, enforcement read/direct command, effective core access, transactional invitation/application authorization | moderation adapter, transport/runtime/concurrency evidence |
 | GROUPS-08 | planned | dynamic feature-provider registry and navigation | registry/degradation evidence |
 | GROUPS-09 | planned | Forum group spaces and ACL inheritance | Forum integration evidence |
 | GROUPS-10 | planned | Blog and Pages/Wiki group contexts | owner/privacy evidence |
@@ -183,10 +194,14 @@ management UX, legacy API deprecation, and executed parity/replay/race/security/
 - `group_membership_enforcements` stores one bounded current row per membership.
 - Effective state distinguishes missing, active, inactive, suspended, and legacy banned.
 - Future, expired, or revoked enforcement falls back to stored lifecycle immediately.
+- `groups.member_count` counts stored lifecycle-active memberships. Enforcement never changes the
+  stored status, so temporary suspend/revoke leaves the count unchanged and avoids requiring cleanup
+  to restore a time-driven counter at expiry.
 - No Groups dependency on moderation owner persistence exists.
 
-The database trigger bridge remains transitional. The final write architecture requires an explicit
-shared Groups enforcement command used by direct actions and the neutral moderation adapter.
+The database trigger bridge remains transitional for revision maintenance, but the owner write
+architecture now has an explicit shared Groups enforcement mutation used by the direct command and
+reserved for the neutral moderation adapter.
 
 ### Transactional invitation/application cutover
 
@@ -229,18 +244,40 @@ Transactional effective authorization preserves:
 - `groups.membership_already_active`;
 - `groups.application_policy_changed` for CAS mismatch.
 
-### Planned owner enforcement command
+Direct enforcement additionally exposes stable fail-closed errors:
 
-The next command slice adds `GroupMembershipEnforcementCommandPort` for one direct suspend/revoke
-operation with:
+- `groups.membership_enforcement_revision_conflict`;
+- `groups.membership_enforcement_owner_protected`;
+- `groups.membership_enforcement_self_target`;
+- `groups.membership_enforcement_already_suspended`;
+- `groups.membership_enforcement_not_active`;
+- `groups.membership_enforcement_source_conflict`.
 
+### Source-complete direct enforcement command
+
+`GroupMembershipEnforcementCommandPort` now owns one direct suspend/revoke operation with:
+
+- a real user actor and bounded idempotency key;
 - expected membership revision CAS;
-- owner/admin/moderator hierarchy and owner protection;
-- receipt-first replay and changed-hash conflict;
-- the same group/membership/enforcement lock order;
-- explicit restoration lifecycle state;
-- atomic membership revision, enforcement row, member count/group version, audit, event, and receipt;
-- a shared owner method callable by the later moderation adapter.
+- owner/admin/moderator hierarchy plus platform moderate/manage authority and hard owner protection;
+- receipt-first replay after the required group serialization lock, with actor/group/request binding;
+- deterministic membership/enforcement lock ordering;
+- canonical reason codes and optional owner-clock expiry;
+- stored lifecycle status preserved as restoration state;
+- direct-local provenance with no Moderation decision identity;
+- shared crate-private suspension/revocation owner mutations for the later neutral adapter;
+- trigger-owned membership revision advance plus explicit group-version advance;
+- unchanged stored lifecycle member count on temporary suspend/revoke;
+- atomic audit, exact append-only membership semantic event and command receipt;
+- direct revoke restricted to active direct-local suspension, so local moderation cannot erase a
+  moderation-decision enforcement row;
+- original suspension actor/source preserved when revoked; revoker identity is immutable audit/event
+  provenance.
+
+Migration `m20260808_000009_extend_group_domain_events_for_membership_enforcement` widens the
+append-only event ledger to exact invitation/membership event pairs on PostgreSQL and SQLite. SQLite
+rebuild preserves historical sequence/event IDs and reinstalls targeted-invitation plus immutability
+triggers. Downgrade fails while membership events exist instead of deleting append-only history.
 
 No bulk enforcement command is introduced before single-command runtime evidence.
 
@@ -248,19 +285,26 @@ No bulk enforcement command is introduced before single-command runtime evidence
 
 Initial mapping remains:
 
-- `GroupMembership` plus `SuspendSubject { effective_until }` maps to the shared Groups command;
-- identical decision ID/hash replays; changed hash conflicts;
-- subject revision, tenant, scope, effect version, hierarchy, and owner invariants are validated in
-  the Groups transaction;
+- `GroupMembership` plus `SuspendSubject { effective_until }` maps to the shared Groups owner
+  suspension mutation;
+- identical decision ID/hash replays before current subject reads; changed hash conflicts;
+- subject revision, tenant, group scope, effect version, hierarchy, owner invariants and immutable
+  decision provenance are validated in the Groups transaction;
+- the adapter uses `source_kind=moderation_decision` and stores only bounded decision UUID/hash plus
+  trusted actor provenance, never case/report/queue/policy data;
 - unsupported effects and account sanctions are rejected without mutation;
 - moderation records applied evidence only after a matching adapter result.
+
+The adapter is the next moderation-specific source slice and requires the neutral
+`rustok-moderation-api` dependency plus producer receipt integration. It must reuse the owner mutation
+above rather than introduce a second Groups enforcement state path.
 
 ### GROUPS-07 definition of done
 
 - no ownership leakage between Groups and moderation;
 - monotonic membership identity/revision evidence;
 - permanent, expiring, revoked, and restored enforcement across every owner path;
-- hierarchy, owner protection, tenant isolation, replay, stale revision, member count, and
+- hierarchy, owner protection, tenant isolation, replay, stale revision, lifecycle member-count, and
   concurrency evidence;
 - native/GraphQL parity for state and direct actions;
 - missing/timeout/retry/lost-response adapter behavior;
@@ -271,18 +315,18 @@ Initial mapping remains:
 
 1. Convert localization management authorization to the transaction-aware resolver.
 2. Convert governance role/ownership commands with owner protection and the same lock protocol.
-3. Define leave and member-count suspension/restoration semantics.
-4. Add one direct suspend/revoke command and shared owner mutation path.
-5. Add the neutral moderation subject adapter.
-6. Convert provider ACL consumers and remote/degraded profiles.
-7. Produce runtime, parity, concurrency, security, and accessibility evidence.
+3. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
+4. Convert provider ACL consumers and remote/degraded profiles.
+5. Produce direct-enforcement and adapter runtime, parity, concurrency, security, migration and
+   accessibility evidence.
 
 ## Degraded modes
 
 - Groups access unavailable: deny private content.
 - Corrupt enforcement row: invariant failure; never infer active.
 - Expired/revoked enforcement: owner-clock fallback without cleanup.
-- Active suspension: remove membership authority without hiding public content.
+- Active suspension: remove membership authority without hiding public content or changing the
+  stored lifecycle member count.
 - Legacy banned membership: deny re-entry.
 - Exact-locale policy unavailable: form unavailable; never choose another locale.
 - Policy CAS conflict: write no owner state and require reload.
@@ -309,6 +353,7 @@ node scripts/verify/verify-groups-application-policy-cas.mjs
 node scripts/verify/verify-groups-application-lifecycle.mjs
 node scripts/verify/verify-groups-application-bulk-review.mjs
 node scripts/verify/verify-groups-membership-enforcement-read-path.mjs
+node scripts/verify/verify-groups-membership-enforcement-command.mjs
 node scripts/verify/verify-groups-effective-membership-access.mjs
 node scripts/verify/verify-groups-effective-membership-invitations-applications.mjs
 npm run verify:i18n:ui

--- a/crates/rustok-groups/docs/membership-enforcement-command-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-command-contract.md
@@ -1,0 +1,118 @@
+# Groups membership enforcement command contract
+
+Status: **source-ready / maintainer execution pending**
+
+## Scope
+
+`GroupMembershipEnforcementCommandPort` is the first Groups-owned write boundary for bounded membership enforcement. It exposes two single-membership direct actions:
+
+- `suspend_membership`;
+- `revoke_membership_suspension`.
+
+Both commands are user-actor operations. The later neutral Moderation adapter does **not** impersonate this port. It will perform trusted producer receipt/subject/scope validation and then reuse the same crate-private Groups owner mutation functions.
+
+## Lock and replay order
+
+The direct command uses one owner transaction and preserves the GROUPS-07 lock protocol:
+
+1. lock/reserve the group row;
+2. replay an identical `group_command_receipts` result, or reject a changed request/actor/group using the same idempotency key;
+3. lock actor/target memberships in deterministic UUID order when local authority is required;
+4. lock their enforcement rows in deterministic membership-ID order;
+5. evaluate effective actor authority with the Groups owner clock;
+6. compare the exact expected target membership revision;
+7. mutate the Groups enforcement projection;
+8. bump group version, append audit + semantic event, store the command receipt, and commit together.
+
+SQLite obtains writer serialization through the no-op group update already used by the effective Groups lock protocol. PostgreSQL/MySQL use row locks. The source does not introduce invitation/application locks and therefore does not invert their established ordering.
+
+## Hierarchy and owner protection
+
+A direct command requires a real user actor. Platform `groups:moderate`/`groups:manage` authority may operate without local membership; otherwise the actor must be an effective active local member.
+
+Local hierarchy is fixed:
+
+- owner -> admin/moderator/member;
+- admin -> moderator/member;
+- moderator -> member;
+- member -> none.
+
+The group owner cannot be suspended or revoked through this command, even through the platform-moderate bypass. Ownership must be transferred first. A user cannot directly target their own membership.
+
+Legacy `status=banned` remains fail-closed and is not rewritten as suspension.
+
+## Revision and idempotency
+
+Every request carries `expected_membership_revision >= 1`. The exact locked `group_memberships.revision` must match before mutation; stale requests return `groups.membership_enforcement_revision_conflict`.
+
+Direct command receipts bind tenant, group, actor, command type, request hash and idempotency key. Exact replay returns the stored result with `replayed=true` before current effective authorization. Reusing a key for another actor, group, command or request conflicts.
+
+The enforcement migration trigger remains the canonical revision bridge: every material enforcement insert/update increments the membership subject revision. The command reads the post-mutation owner state and returns that revision.
+
+## Suspension state
+
+A suspension preserves the membership's stored lifecycle status and writes/refreshes the bounded current `group_membership_enforcements` row with:
+
+- `state=suspended`;
+- canonical bounded reason code;
+- `source_kind=direct_local` for this port;
+- owner-clock `effective_from` and optional future `effective_until`;
+- the stored lifecycle status as `restore_status`;
+- direct actor provenance;
+- no Moderation decision identity.
+
+A currently effective suspension is not silently replaced by a fresh direct command; receipt replay is the idempotent path. An expired or revoked row may be reused by a later suspension and its revisions advance normally.
+
+Direct revoke may only revoke an effective `direct_local` suspension. It cannot remove an active `moderation_decision` enforcement row. Revoke sets `revoked_at` while preserving the original suspension source/actor provenance; the revoking actor is retained in immutable audit/event facts.
+
+## Member-count semantics
+
+`groups.member_count` is explicitly a **stored lifecycle active count**, not an owner-clock effective-enforcement count.
+
+Temporary suspension therefore does not decrement `member_count`, and revoke does not increment it. This avoids a time-driven counter split: an expiring suspension becomes ineffective immediately at `effective_until` without requiring cleanup, so a counter that had been decremented at suspension time could not be restored atomically at expiry.
+
+Every actual enforcement mutation still increments `groups.version`. Consumers that need current authority must use the effective membership resolver; `member_count` is not an authorization signal.
+
+Leave/join continue to own lifecycle-count changes because they mutate stored membership lifecycle.
+
+## Atomic audit and semantic events
+
+Successful suspend/revoke commits the following in one Groups transaction:
+
+- enforcement row mutation;
+- trigger-owned membership revision advance;
+- group-version advance with unchanged lifecycle member count;
+- `group_audit_entries` fact;
+- append-only `group_domain_events` membership event;
+- direct command receipt.
+
+Migration `m20260808_000009_extend_group_domain_events_for_membership_enforcement` expands the existing event ledger from targeted-invitation-only to the exact valid pairs:
+
+- `invitation / groups.invitation.targeted_created`;
+- `membership / groups.membership.suspended`;
+- `membership / groups.membership.suspension_revoked`.
+
+The SQLite migration rebuild preserves existing sequence/event IDs and reinstalls invitation plus immutability triggers. Downgrade fails closed while append-only membership events exist instead of deleting history to make an older CHECK constraint fit.
+
+## Moderation adapter seam
+
+The owner mutations retain bounded provenance fields for the later neutral adapter:
+
+- `source_kind=moderation_decision`;
+- immutable Moderation decision UUID/hash;
+- trusted service/system actor identity;
+- no copied Moderation report/case/queue/policy data.
+
+The adapter remains a separate next slice because it requires `rustok-moderation-api` plus producer receipt integration. This command PR creates the owner seam first, as required by the canonical Groups plan.
+
+## Verification
+
+Intentionally not run while preparing this source slice:
+
+```bash
+cargo check -p rustok-groups
+cargo test -p rustok-groups
+node scripts/verify/verify-groups-membership-enforcement-command.mjs
+```
+
+No Cargo command, unit/integration test, database migration, Node verifier, formatter, workflow or CI job was executed. PostgreSQL/SQLite runtime, contention, replay, security and transport evidence remains open.

--- a/crates/rustok-groups/src/error.rs
+++ b/crates/rustok-groups/src/error.rs
@@ -19,6 +19,18 @@ pub enum GroupsError {
     ManagerRequired(String),
     #[error("the user is already an active group member")]
     MembershipAlreadyActive,
+    #[error("group membership enforcement expected revision is stale")]
+    MembershipEnforcementRevisionConflict,
+    #[error("the group owner cannot be suspended; transfer ownership first")]
+    MembershipEnforcementOwnerProtected,
+    #[error("a direct membership enforcement command cannot target its own actor")]
+    MembershipEnforcementSelfTarget,
+    #[error("the group membership already has an effective suspension")]
+    MembershipEnforcementAlreadySuspended,
+    #[error("the group membership does not have an effective suspension to revoke")]
+    MembershipEnforcementNotActive,
+    #[error("direct local enforcement cannot revoke moderation-decision enforcement")]
+    MembershipEnforcementSourceConflict,
     #[error("group state conflict: {0}")]
     Conflict(String),
     #[error("group persistence failed: {0}")]
@@ -59,6 +71,30 @@ impl From<GroupsError> for PortError {
             GroupsError::MembershipAlreadyActive => PortError::conflict(
                 "groups.membership_already_active",
                 "user is already an active group member",
+            ),
+            GroupsError::MembershipEnforcementRevisionConflict => PortError::conflict(
+                "groups.membership_enforcement_revision_conflict",
+                "group membership changed after the enforcement command was prepared",
+            ),
+            GroupsError::MembershipEnforcementOwnerProtected => PortError::forbidden(
+                "groups.membership_enforcement_owner_protected",
+                "group owner must transfer ownership before membership enforcement",
+            ),
+            GroupsError::MembershipEnforcementSelfTarget => PortError::forbidden(
+                "groups.membership_enforcement_self_target",
+                "direct membership enforcement cannot target the acting user",
+            ),
+            GroupsError::MembershipEnforcementAlreadySuspended => PortError::conflict(
+                "groups.membership_enforcement_already_suspended",
+                "group membership already has an effective suspension",
+            ),
+            GroupsError::MembershipEnforcementNotActive => PortError::conflict(
+                "groups.membership_enforcement_not_active",
+                "group membership does not have an effective suspension to revoke",
+            ),
+            GroupsError::MembershipEnforcementSourceConflict => PortError::forbidden(
+                "groups.membership_enforcement_source_conflict",
+                "direct local enforcement cannot revoke moderation-decision enforcement",
             ),
             GroupsError::Conflict(message) => PortError::conflict("groups.conflict", message),
             GroupsError::Persistence(message) => PortError::new(

--- a/crates/rustok-groups/src/lib.rs
+++ b/crates/rustok-groups/src/lib.rs
@@ -48,6 +48,7 @@ mod invitations_legacy {
 }
 pub mod localization;
 pub mod membership_enforcement;
+mod membership_enforcement_command;
 pub mod membership_enforcement_entities;
 mod membership_enforcement_transaction;
 pub mod migrations;
@@ -118,6 +119,10 @@ pub use governance::*;
 pub use invitations::*;
 pub use localization::GroupLocalizationService;
 pub use membership_enforcement::GroupMembershipEnforcementService;
+pub use membership_enforcement_command::{
+    GroupMembershipEnforcementCommandService, GroupMembershipEnforcementMutationResult,
+    RevokeGroupMembershipSuspensionRequest, SuspendGroupMembershipRequest,
+};
 pub use policy_history::*;
 pub use ports::*;
 pub use targeted_invitations::*;
@@ -189,7 +194,7 @@ mod tests {
         assert_eq!(module.slug(), "groups");
         assert_eq!(module.name(), "Groups");
         assert!(module.dependencies().is_empty());
-        assert_eq!(module.migrations().len(), 8);
+        assert_eq!(module.migrations().len(), 9);
         assert_eq!(module.permissions().len(), 7);
     }
 
@@ -203,6 +208,11 @@ mod tests {
             descriptor
                 .ports
                 .contains(&"GroupMembershipEnforcementReadPort")
+        );
+        assert!(
+            descriptor
+                .ports
+                .contains(&"GroupMembershipEnforcementCommandPort")
         );
     }
 }

--- a/crates/rustok-groups/src/membership_enforcement.rs
+++ b/crates/rustok-groups/src/membership_enforcement.rs
@@ -14,6 +14,7 @@ use crate::dto::{
     GroupMembershipEffectiveState, GroupMembershipEnforcementSummary,
     ReadGroupMembershipEnforcementRequest,
 };
+use crate::entities::group;
 use crate::error::{GroupsError, GroupsResult};
 use crate::membership_enforcement_entities::{membership_enforcement, membership_state};
 use crate::ports::GroupMembershipEnforcementReadPort;
@@ -91,6 +92,26 @@ where
     let role = GroupRole::from_str(&membership.role).map_err(GroupsError::Invariant)?;
     let stored_status =
         GroupMembershipStatus::from_str(&membership.status).map_err(GroupsError::Invariant)?;
+
+    // Local authority derives from both the membership role and the canonical group owner pointer.
+    // Fail closed if those owner identities ever drift instead of letting a stray `role=owner`
+    // membership gain effective management authority.
+    let group_owner_user_id = group::Entity::find()
+        .filter(group::Column::TenantId.eq(tenant_id))
+        .filter(group::Column::Id.eq(group_id))
+        .one(connection)
+        .await?
+        .ok_or_else(|| {
+            GroupsError::Invariant(
+                "group membership references a missing Groups owner aggregate".to_string(),
+            )
+        })?
+        .owner_user_id;
+    if (role == GroupRole::Owner) != (membership.user_id == group_owner_user_id) {
+        return Err(GroupsError::Invariant(
+            "group owner reference and owner membership role disagree".to_string(),
+        ));
+    }
 
     let enforcement = membership_enforcement::Entity::find_by_id(membership.id)
         .filter(membership_enforcement::Column::TenantId.eq(tenant_id))

--- a/crates/rustok-groups/src/membership_enforcement_command.rs
+++ b/crates/rustok-groups/src/membership_enforcement_command.rs
@@ -1,0 +1,1076 @@
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, ConnectionTrait, DatabaseBackend,
+    DatabaseConnection, DatabaseTransaction, EntityTrait, QueryFilter, QuerySelect, Set, Statement,
+    TransactionTrait,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::domain::{
+    GroupMembershipEffectiveStatus, GroupMembershipEnforcementSourceKind, GroupMembershipStatus,
+    GroupRole,
+};
+use crate::entities::group;
+use crate::error::{GroupsError, GroupsResult};
+use crate::governance_entities::{audit_entry, command_receipt};
+use crate::group_event_entities;
+use crate::membership_enforcement::resolve_group_membership_enforcement;
+use crate::membership_enforcement_entities::{membership_enforcement, membership_state};
+use crate::ports::GroupMembershipEnforcementCommandPort;
+
+const SUSPEND_COMMAND: &str = "groups.membership.suspend.v1";
+const REVOKE_SUSPENSION_COMMAND: &str = "groups.membership.suspension_revoke.v1";
+const SUSPENDED_EVENT: &str = "groups.membership.suspended";
+const REVOKED_EVENT: &str = "groups.membership.suspension_revoked";
+const MAX_REASON_CODE_BYTES: usize = 80;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SuspendGroupMembershipRequest {
+    pub group_id: Uuid,
+    pub target_user_id: Uuid,
+    pub expected_membership_revision: i64,
+    pub reason_code: String,
+    pub effective_until: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevokeGroupMembershipSuspensionRequest {
+    pub group_id: Uuid,
+    pub target_user_id: Uuid,
+    pub expected_membership_revision: i64,
+    pub reason_code: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroupMembershipEnforcementMutationResult {
+    pub group_id: Uuid,
+    pub membership_id: Uuid,
+    pub user_id: Uuid,
+    pub membership_revision: i64,
+    pub group_version: i64,
+    /// Stored-lifecycle member count. Temporary enforcement deliberately does not change it.
+    pub member_count: i64,
+    pub effective_status: GroupMembershipEffectiveStatus,
+    pub enforcement_revision: i64,
+    pub effective_until: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub replayed: bool,
+}
+
+/// Provenance passed to the shared Groups-owned enforcement mutation.
+///
+/// Direct local commands use `DirectLocal`. The later neutral Moderation adapter can reuse the
+/// same owner mutation by supplying `ModerationDecision` plus immutable decision identity; no
+/// moderation case, queue or policy data belongs here.
+#[derive(Clone, Debug)]
+pub(crate) struct MembershipEnforcementProvenance {
+    pub(crate) source_kind: GroupMembershipEnforcementSourceKind,
+    pub(crate) moderation_decision_id: Option<Uuid>,
+    pub(crate) moderation_decision_hash: Option<String>,
+    pub(crate) actor_kind: String,
+    pub(crate) actor_id: String,
+    pub(crate) audit_actor_user_id: Option<Uuid>,
+}
+
+impl MembershipEnforcementProvenance {
+    fn direct_local(actor_user_id: Uuid) -> Self {
+        Self {
+            source_kind: GroupMembershipEnforcementSourceKind::DirectLocal,
+            moderation_decision_id: None,
+            moderation_decision_hash: None,
+            actor_kind: "user".to_string(),
+            actor_id: actor_user_id.to_string(),
+            audit_actor_user_id: Some(actor_user_id),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GroupMembershipEnforcementCommandService {
+    db: DatabaseConnection,
+}
+
+impl GroupMembershipEnforcementCommandService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    async fn suspend_owned(
+        &self,
+        context: &PortContext,
+        request: SuspendGroupMembershipRequest,
+    ) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
+        require_write(context)?;
+        validate_identity(request.group_id, request.target_user_id, request.expected_membership_revision)?;
+        let tenant_id = context_tenant_id(context)?;
+        let actor_user_id = actor_user_id(context)?;
+        if actor_user_id == request.target_user_id {
+            return Err(GroupsError::MembershipEnforcementSelfTarget);
+        }
+        let idempotency_key = idempotency_key(context)?;
+        let reason_code = normalize_reason_code(&request.reason_code)?;
+        let normalized_request = SuspendGroupMembershipRequest {
+            reason_code,
+            ..request
+        };
+        let request_hash = request_hash(&normalized_request)?;
+
+        let transaction = self.db.begin().await?;
+        let locked_group = lock_group(&transaction, tenant_id, normalized_request.group_id).await?;
+        if let Some(replayed) = replay_receipt::<GroupMembershipEnforcementMutationResult>(
+            &transaction,
+            tenant_id,
+            normalized_request.group_id,
+            actor_user_id,
+            &idempotency_key,
+            SUSPEND_COMMAND,
+            &request_hash,
+        )
+        .await?
+        {
+            transaction.commit().await?;
+            return Ok(GroupMembershipEnforcementMutationResult {
+                replayed: true,
+                ..replayed
+            });
+        }
+
+        let now = Utc::now();
+        if normalized_request
+            .effective_until
+            .is_some_and(|until| until <= now)
+        {
+            return Err(GroupsError::Validation(
+                "membership suspension expiry must be in the future".to_string(),
+            ));
+        }
+
+        let platform_moderate = has_platform_moderate(context);
+        let locked = lock_command_memberships(
+            &transaction,
+            tenant_id,
+            locked_group.id,
+            actor_user_id,
+            normalized_request.target_user_id,
+            !platform_moderate,
+        )
+        .await?;
+        authorize_direct_enforcement(
+            &transaction,
+            context,
+            tenant_id,
+            &locked_group,
+            &locked,
+            actor_user_id,
+            normalized_request.target_user_id,
+            platform_moderate,
+            now,
+        )
+        .await?;
+
+        let target = locked
+            .target(normalized_request.target_user_id)
+            .ok_or_else(|| GroupsError::Conflict("target group membership is required".to_string()))?;
+        let target_enforcement = locked.enforcement(target.id);
+        let result = apply_membership_suspension_in_tx(
+            &transaction,
+            context,
+            locked_group,
+            target,
+            target_enforcement,
+            normalized_request.expected_membership_revision,
+            normalized_request.reason_code.clone(),
+            normalized_request.effective_until,
+            MembershipEnforcementProvenance::direct_local(actor_user_id),
+            now,
+        )
+        .await?;
+
+        store_receipt(
+            &transaction,
+            tenant_id,
+            normalized_request.group_id,
+            actor_user_id,
+            idempotency_key,
+            SUSPEND_COMMAND,
+            request_hash,
+            &result,
+        )
+        .await?;
+        transaction.commit().await?;
+        Ok(result)
+    }
+
+    async fn revoke_owned(
+        &self,
+        context: &PortContext,
+        request: RevokeGroupMembershipSuspensionRequest,
+    ) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
+        require_write(context)?;
+        validate_identity(request.group_id, request.target_user_id, request.expected_membership_revision)?;
+        let tenant_id = context_tenant_id(context)?;
+        let actor_user_id = actor_user_id(context)?;
+        if actor_user_id == request.target_user_id {
+            return Err(GroupsError::MembershipEnforcementSelfTarget);
+        }
+        let idempotency_key = idempotency_key(context)?;
+        let reason_code = normalize_reason_code(&request.reason_code)?;
+        let normalized_request = RevokeGroupMembershipSuspensionRequest {
+            reason_code,
+            ..request
+        };
+        let request_hash = request_hash(&normalized_request)?;
+
+        let transaction = self.db.begin().await?;
+        let locked_group = lock_group(&transaction, tenant_id, normalized_request.group_id).await?;
+        if let Some(replayed) = replay_receipt::<GroupMembershipEnforcementMutationResult>(
+            &transaction,
+            tenant_id,
+            normalized_request.group_id,
+            actor_user_id,
+            &idempotency_key,
+            REVOKE_SUSPENSION_COMMAND,
+            &request_hash,
+        )
+        .await?
+        {
+            transaction.commit().await?;
+            return Ok(GroupMembershipEnforcementMutationResult {
+                replayed: true,
+                ..replayed
+            });
+        }
+
+        let now = Utc::now();
+        let platform_moderate = has_platform_moderate(context);
+        let locked = lock_command_memberships(
+            &transaction,
+            tenant_id,
+            locked_group.id,
+            actor_user_id,
+            normalized_request.target_user_id,
+            !platform_moderate,
+        )
+        .await?;
+        authorize_direct_enforcement(
+            &transaction,
+            context,
+            tenant_id,
+            &locked_group,
+            &locked,
+            actor_user_id,
+            normalized_request.target_user_id,
+            platform_moderate,
+            now,
+        )
+        .await?;
+
+        let target = locked
+            .target(normalized_request.target_user_id)
+            .ok_or_else(|| GroupsError::Conflict("target group membership is required".to_string()))?;
+        let target_enforcement = locked.enforcement(target.id);
+        let result = revoke_membership_suspension_in_tx(
+            &transaction,
+            context,
+            locked_group,
+            target,
+            target_enforcement,
+            normalized_request.expected_membership_revision,
+            normalized_request.reason_code.clone(),
+            MembershipEnforcementProvenance::direct_local(actor_user_id),
+            now,
+        )
+        .await?;
+
+        store_receipt(
+            &transaction,
+            tenant_id,
+            normalized_request.group_id,
+            actor_user_id,
+            idempotency_key,
+            REVOKE_SUSPENSION_COMMAND,
+            request_hash,
+            &result,
+        )
+        .await?;
+        transaction.commit().await?;
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl GroupMembershipEnforcementCommandPort for GroupMembershipEnforcementCommandService {
+    async fn suspend_membership(
+        &self,
+        context: PortContext,
+        request: SuspendGroupMembershipRequest,
+    ) -> Result<GroupMembershipEnforcementMutationResult, PortError> {
+        self.suspend_owned(&context, request).await.map_err(Into::into)
+    }
+
+    async fn revoke_membership_suspension(
+        &self,
+        context: PortContext,
+        request: RevokeGroupMembershipSuspensionRequest,
+    ) -> Result<GroupMembershipEnforcementMutationResult, PortError> {
+        self.revoke_owned(&context, request).await.map_err(Into::into)
+    }
+}
+
+struct LockedCommandState {
+    memberships: Vec<membership_state::Model>,
+    enforcements: Vec<membership_enforcement::Model>,
+}
+
+impl LockedCommandState {
+    fn target(&self, user_id: Uuid) -> Option<membership_state::Model> {
+        self.memberships
+            .iter()
+            .find(|row| row.user_id == user_id)
+            .cloned()
+    }
+
+    fn enforcement(&self, membership_id: Uuid) -> Option<membership_enforcement::Model> {
+        self.enforcements
+            .iter()
+            .find(|row| row.membership_id == membership_id)
+            .cloned()
+    }
+}
+
+async fn lock_group(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+) -> GroupsResult<group::Model> {
+    match transaction.get_database_backend() {
+        DatabaseBackend::Sqlite => {
+            transaction
+                .execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Sqlite,
+                    "UPDATE groups SET version = version WHERE tenant_id = ? AND id = ?",
+                    vec![tenant_id.into(), group_id.into()],
+                ))
+                .await?;
+            group::Entity::find()
+                .filter(group::Column::TenantId.eq(tenant_id))
+                .filter(group::Column::Id.eq(group_id))
+                .one(transaction)
+                .await?
+                .ok_or(GroupsError::NotFound)
+        }
+        DatabaseBackend::Postgres | DatabaseBackend::MySql => group::Entity::find()
+            .filter(group::Column::TenantId.eq(tenant_id))
+            .filter(group::Column::Id.eq(group_id))
+            .lock_exclusive()
+            .one(transaction)
+            .await?
+            .ok_or(GroupsError::NotFound),
+    }
+}
+
+async fn lock_command_memberships(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    target_user_id: Uuid,
+    require_actor_membership: bool,
+) -> GroupsResult<LockedCommandState> {
+    let mut user_ids = vec![target_user_id];
+    if require_actor_membership {
+        user_ids.push(actor_user_id);
+    }
+    user_ids.sort_unstable();
+    user_ids.dedup();
+
+    let mut memberships = Vec::with_capacity(user_ids.len());
+    for user_id in user_ids {
+        let mut query = membership_state::Entity::find()
+            .filter(membership_state::Column::TenantId.eq(tenant_id))
+            .filter(membership_state::Column::GroupId.eq(group_id))
+            .filter(membership_state::Column::UserId.eq(user_id));
+        if transaction.get_database_backend() != DatabaseBackend::Sqlite {
+            query = query.lock_exclusive();
+        }
+        if let Some(row) = query.one(transaction).await? {
+            memberships.push(row);
+        }
+    }
+
+    let mut membership_ids = memberships.iter().map(|row| row.id).collect::<Vec<_>>();
+    membership_ids.sort_unstable();
+    let mut enforcements = Vec::with_capacity(membership_ids.len());
+    for membership_id in membership_ids {
+        let mut query = membership_enforcement::Entity::find_by_id(membership_id)
+            .filter(membership_enforcement::Column::TenantId.eq(tenant_id));
+        if transaction.get_database_backend() != DatabaseBackend::Sqlite {
+            query = query.lock_exclusive();
+        }
+        if let Some(row) = query.one(transaction).await? {
+            enforcements.push(row);
+        }
+    }
+
+    Ok(LockedCommandState {
+        memberships,
+        enforcements,
+    })
+}
+
+async fn authorize_direct_enforcement(
+    transaction: &DatabaseTransaction,
+    context: &PortContext,
+    tenant_id: Uuid,
+    group_model: &group::Model,
+    locked: &LockedCommandState,
+    actor_user_id: Uuid,
+    target_user_id: Uuid,
+    platform_moderate: bool,
+    now: DateTime<Utc>,
+) -> GroupsResult<()> {
+    let target = locked
+        .target(target_user_id)
+        .ok_or_else(|| GroupsError::Conflict("target group membership is required".to_string()))?;
+    let target_role = GroupRole::from_str(&target.role).map_err(GroupsError::Invariant)?;
+    let owner_identity_matches = target.user_id == group_model.owner_user_id;
+    if owner_identity_matches != (target_role == GroupRole::Owner) {
+        return Err(GroupsError::Invariant(
+            "group owner reference and owner membership role disagree".to_string(),
+        ));
+    }
+    if owner_identity_matches {
+        return Err(GroupsError::MembershipEnforcementOwnerProtected);
+    }
+
+    let target_status =
+        GroupMembershipStatus::from_str(&target.status).map_err(GroupsError::Invariant)?;
+    if target_status == GroupMembershipStatus::Banned {
+        return Err(GroupsError::MembershipBanned);
+    }
+    if platform_moderate {
+        return Ok(());
+    }
+
+    let actor = locked
+        .target(actor_user_id)
+        .ok_or_else(|| GroupsError::ManagerRequired("active local moderator authority is required".to_string()))?;
+    let actor_state = resolve_group_membership_enforcement(
+        transaction,
+        tenant_id,
+        group_model.id,
+        actor_user_id,
+        now,
+    )
+    .await?;
+    match actor_state.effective_status {
+        GroupMembershipEffectiveStatus::Suspended => return Err(GroupsError::MembershipSuspended),
+        GroupMembershipEffectiveStatus::LegacyBanned => return Err(GroupsError::MembershipBanned),
+        GroupMembershipEffectiveStatus::Active => {}
+        _ => {
+            return Err(GroupsError::ManagerRequired(
+                "active local moderator authority is required".to_string(),
+            ));
+        }
+    }
+
+    let actor_role = GroupRole::from_str(&actor.role).map_err(GroupsError::Invariant)?;
+    let allowed = match actor_role {
+        GroupRole::Owner => true,
+        GroupRole::Admin => matches!(target_role, GroupRole::Moderator | GroupRole::Member),
+        GroupRole::Moderator => target_role == GroupRole::Member,
+        GroupRole::Member => false,
+    };
+    if allowed {
+        Ok(())
+    } else {
+        Err(GroupsError::ManagerRequired(
+            "local moderation hierarchy does not permit this membership enforcement mutation"
+                .to_string(),
+        ))
+    }
+}
+
+/// Shared Groups-owned suspension mutation used by the direct command and, later, the neutral
+/// Moderation adapter after that caller has completed its own receipt admission and authorization.
+/// The caller must hold the group, target membership and target enforcement locks.
+pub(crate) async fn apply_membership_suspension_in_tx(
+    transaction: &DatabaseTransaction,
+    context: &PortContext,
+    group_model: group::Model,
+    target: membership_state::Model,
+    current_enforcement: Option<membership_enforcement::Model>,
+    expected_membership_revision: i64,
+    reason_code: String,
+    effective_until: Option<DateTime<Utc>>,
+    provenance: MembershipEnforcementProvenance,
+    now: DateTime<Utc>,
+) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
+    validate_mutation_identity(&group_model, &target, expected_membership_revision)?;
+    validate_provenance(&provenance)?;
+    let target_status =
+        GroupMembershipStatus::from_str(&target.status).map_err(GroupsError::Invariant)?;
+    if target_status == GroupMembershipStatus::Banned {
+        return Err(GroupsError::MembershipBanned);
+    }
+    if effective_until.is_some_and(|until| until <= now) {
+        return Err(GroupsError::Validation(
+            "membership suspension expiry must be in the future".to_string(),
+        ));
+    }
+
+    if let Some(existing) = current_enforcement.as_ref() {
+        let existing_effective = existing.revoked_at.is_none()
+            && existing.effective_from.with_timezone(&Utc) <= now
+            && existing
+                .effective_until
+                .as_ref()
+                .is_none_or(|until| now < until.with_timezone(&Utc));
+        if existing_effective {
+            return Err(GroupsError::MembershipEnforcementAlreadySuspended);
+        }
+    }
+
+    let fixed_now = now.fixed_offset();
+    let effective_until_fixed = effective_until.map(|value| value.fixed_offset());
+    if let Some(existing) = current_enforcement {
+        let mut active: membership_enforcement::ActiveModel = existing.into();
+        active.state = Set("suspended".to_string());
+        active.reason_code = Set(reason_code.clone());
+        active.source_kind = Set(provenance.source_kind.as_str().to_string());
+        active.effective_from = Set(fixed_now);
+        active.effective_until = Set(effective_until_fixed);
+        active.restore_status = Set(target_status.as_str().to_string());
+        active.moderation_decision_id = Set(provenance.moderation_decision_id);
+        active.moderation_decision_hash = Set(provenance.moderation_decision_hash.clone());
+        active.actor_kind = Set(provenance.actor_kind.clone());
+        active.actor_id = Set(provenance.actor_id.clone());
+        active.revoked_at = Set(None);
+        active.updated_at = Set(fixed_now);
+        active.update(transaction).await?;
+    } else {
+        membership_enforcement::ActiveModel {
+            membership_id: Set(target.id),
+            tenant_id: Set(target.tenant_id),
+            group_id: Set(target.group_id),
+            user_id: Set(target.user_id),
+            state: Set("suspended".to_string()),
+            reason_code: Set(reason_code.clone()),
+            source_kind: Set(provenance.source_kind.as_str().to_string()),
+            effective_from: Set(fixed_now),
+            effective_until: Set(effective_until_fixed),
+            restore_status: Set(target_status.as_str().to_string()),
+            moderation_decision_id: Set(provenance.moderation_decision_id),
+            moderation_decision_hash: Set(provenance.moderation_decision_hash.clone()),
+            actor_kind: Set(provenance.actor_kind.clone()),
+            actor_id: Set(provenance.actor_id.clone()),
+            revision: Set(1),
+            revoked_at: Set(None),
+            created_at: Set(fixed_now),
+            updated_at: Set(fixed_now),
+        }
+        .insert(transaction)
+        .await?;
+    }
+
+    let group_after = bump_group_version_without_member_count_change(transaction, group_model, fixed_now).await?;
+    let state = resolve_group_membership_enforcement(
+        transaction,
+        target.tenant_id,
+        target.group_id,
+        target.user_id,
+        now,
+    )
+    .await?;
+    let result = mutation_result(&group_after, &state, false)?;
+
+    append_audit(
+        transaction,
+        context,
+        target.tenant_id,
+        target.group_id,
+        provenance.audit_actor_user_id,
+        "group.membership_suspended",
+        Some(target.user_id),
+        json!({
+            "membership_id": target.id,
+            "reason_code": reason_code,
+            "source_kind": provenance.source_kind.as_str(),
+            "effective_until": effective_until,
+            "previous_membership_revision": expected_membership_revision,
+            "membership_revision": result.membership_revision,
+            "group_version": result.group_version,
+            "member_count": result.member_count,
+            "member_count_semantics": "stored_lifecycle_active"
+        }),
+    )
+    .await?;
+    append_domain_event(
+        transaction,
+        target.tenant_id,
+        target.id,
+        SUSPENDED_EVENT,
+        provenance.audit_actor_user_id,
+        json!({
+            "group_id": target.group_id,
+            "membership_id": target.id,
+            "user_id": target.user_id,
+            "reason_code": reason_code,
+            "source_kind": provenance.source_kind.as_str(),
+            "effective_until": effective_until,
+            "membership_revision": result.membership_revision,
+            "group_version": result.group_version
+        }),
+        fixed_now,
+    )
+    .await?;
+    Ok(result)
+}
+
+/// Shared Groups-owned revocation mutation. Direct local revocation may only revoke a direct-local
+/// suspension; a local moderator cannot erase moderation-decision provenance.
+pub(crate) async fn revoke_membership_suspension_in_tx(
+    transaction: &DatabaseTransaction,
+    context: &PortContext,
+    group_model: group::Model,
+    target: membership_state::Model,
+    current_enforcement: Option<membership_enforcement::Model>,
+    expected_membership_revision: i64,
+    revocation_reason_code: String,
+    provenance: MembershipEnforcementProvenance,
+    now: DateTime<Utc>,
+) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
+    validate_mutation_identity(&group_model, &target, expected_membership_revision)?;
+    validate_provenance(&provenance)?;
+    let existing = current_enforcement.ok_or(GroupsError::MembershipEnforcementNotActive)?;
+    let existing_source = GroupMembershipEnforcementSourceKind::from_str(&existing.source_kind)
+        .map_err(GroupsError::Invariant)?;
+    if provenance.source_kind == GroupMembershipEnforcementSourceKind::DirectLocal
+        && existing_source != GroupMembershipEnforcementSourceKind::DirectLocal
+    {
+        return Err(GroupsError::MembershipEnforcementSourceConflict);
+    }
+    let existing_effective = existing.revoked_at.is_none()
+        && existing.effective_from.with_timezone(&Utc) <= now
+        && existing
+            .effective_until
+            .as_ref()
+            .is_none_or(|until| now < until.with_timezone(&Utc));
+    if !existing_effective {
+        return Err(GroupsError::MembershipEnforcementNotActive);
+    }
+
+    let previous_reason_code = existing.reason_code.clone();
+    let previous_effective_until = existing.effective_until.map(|value| value.with_timezone(&Utc));
+    let fixed_now = now.fixed_offset();
+    let mut active: membership_enforcement::ActiveModel = existing.into();
+    active.revoked_at = Set(Some(fixed_now));
+    active.actor_kind = Set(provenance.actor_kind.clone());
+    active.actor_id = Set(provenance.actor_id.clone());
+    active.updated_at = Set(fixed_now);
+    active.update(transaction).await?;
+
+    let group_after = bump_group_version_without_member_count_change(transaction, group_model, fixed_now).await?;
+    let state = resolve_group_membership_enforcement(
+        transaction,
+        target.tenant_id,
+        target.group_id,
+        target.user_id,
+        now,
+    )
+    .await?;
+    let result = mutation_result(&group_after, &state, false)?;
+
+    append_audit(
+        transaction,
+        context,
+        target.tenant_id,
+        target.group_id,
+        provenance.audit_actor_user_id,
+        "group.membership_suspension_revoked",
+        Some(target.user_id),
+        json!({
+            "membership_id": target.id,
+            "revocation_reason_code": revocation_reason_code,
+            "previous_reason_code": previous_reason_code,
+            "previous_effective_until": previous_effective_until,
+            "source_kind": existing_source.as_str(),
+            "previous_membership_revision": expected_membership_revision,
+            "membership_revision": result.membership_revision,
+            "group_version": result.group_version,
+            "member_count": result.member_count,
+            "member_count_semantics": "stored_lifecycle_active"
+        }),
+    )
+    .await?;
+    append_domain_event(
+        transaction,
+        target.tenant_id,
+        target.id,
+        REVOKED_EVENT,
+        provenance.audit_actor_user_id,
+        json!({
+            "group_id": target.group_id,
+            "membership_id": target.id,
+            "user_id": target.user_id,
+            "revocation_reason_code": revocation_reason_code,
+            "previous_reason_code": previous_reason_code,
+            "source_kind": existing_source.as_str(),
+            "membership_revision": result.membership_revision,
+            "group_version": result.group_version
+        }),
+        fixed_now,
+    )
+    .await?;
+    Ok(result)
+}
+
+fn validate_mutation_identity(
+    group_model: &group::Model,
+    target: &membership_state::Model,
+    expected_membership_revision: i64,
+) -> GroupsResult<()> {
+    if target.tenant_id != group_model.tenant_id || target.group_id != group_model.id {
+        return Err(GroupsError::Invariant(
+            "membership enforcement target does not belong to the locked group".to_string(),
+        ));
+    }
+    let target_role = GroupRole::from_str(&target.role).map_err(GroupsError::Invariant)?;
+    if target.user_id == group_model.owner_user_id || target_role == GroupRole::Owner {
+        return Err(GroupsError::MembershipEnforcementOwnerProtected);
+    }
+    if target.revision != expected_membership_revision {
+        return Err(GroupsError::MembershipEnforcementRevisionConflict);
+    }
+    Ok(())
+}
+
+fn validate_provenance(provenance: &MembershipEnforcementProvenance) -> GroupsResult<()> {
+    if !matches!(provenance.actor_kind.as_str(), "user" | "service" | "system")
+        || provenance.actor_id.trim().is_empty()
+    {
+        return Err(GroupsError::Invariant(
+            "membership enforcement provenance actor is invalid".to_string(),
+        ));
+    }
+    match provenance.source_kind {
+        GroupMembershipEnforcementSourceKind::DirectLocal => {
+            if provenance.moderation_decision_id.is_some()
+                || provenance.moderation_decision_hash.is_some()
+            {
+                return Err(GroupsError::Invariant(
+                    "direct local membership enforcement cannot carry moderation decision identity"
+                        .to_string(),
+                ));
+            }
+        }
+        GroupMembershipEnforcementSourceKind::ModerationDecision => {
+            let Some(decision_id) = provenance.moderation_decision_id else {
+                return Err(GroupsError::Invariant(
+                    "moderation-driven membership enforcement requires decision identity"
+                        .to_string(),
+                ));
+            };
+            let Some(hash) = provenance.moderation_decision_hash.as_deref() else {
+                return Err(GroupsError::Invariant(
+                    "moderation-driven membership enforcement requires decision hash".to_string(),
+                ));
+            };
+            if decision_id.is_nil()
+                || hash.len() != 64
+                || !hash
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            {
+                return Err(GroupsError::Invariant(
+                    "moderation-driven membership enforcement decision identity is invalid"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn bump_group_version_without_member_count_change(
+    transaction: &DatabaseTransaction,
+    group_model: group::Model,
+    now: chrono::DateTime<chrono::FixedOffset>,
+) -> GroupsResult<group::Model> {
+    if group_model.member_count < 0 || group_model.version < 1 {
+        return Err(GroupsError::Invariant(
+            "group member count and version must be valid before enforcement mutation".to_string(),
+        ));
+    }
+    let next_version = group_model.version.checked_add(1).ok_or_else(|| {
+        GroupsError::Invariant("group version overflow during enforcement mutation".to_string())
+    })?;
+    let mut active: group::ActiveModel = group_model.into();
+    active.version = Set(next_version);
+    active.updated_at = Set(now);
+    Ok(active.update(transaction).await?)
+}
+
+fn mutation_result(
+    group_model: &group::Model,
+    state: &crate::dto::GroupMembershipEffectiveState,
+    replayed: bool,
+) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
+    let membership_id = state.membership_id.ok_or_else(|| {
+        GroupsError::Invariant("membership disappeared during enforcement mutation".to_string())
+    })?;
+    let membership_revision = state.membership_revision.ok_or_else(|| {
+        GroupsError::Invariant("membership revision disappeared during enforcement mutation".to_string())
+    })?;
+    if membership_revision < 1 || group_model.version < 1 || group_model.member_count < 0 {
+        return Err(GroupsError::Invariant(
+            "invalid owner revisions after membership enforcement mutation".to_string(),
+        ));
+    }
+    let enforcement = state.enforcement.as_ref().ok_or_else(|| {
+        GroupsError::Invariant("enforcement row disappeared during enforcement mutation".to_string())
+    })?;
+    Ok(GroupMembershipEnforcementMutationResult {
+        group_id: state.group_id,
+        membership_id,
+        user_id: state.user_id,
+        membership_revision,
+        group_version: group_model.version,
+        member_count: group_model.member_count,
+        effective_status: state.effective_status,
+        enforcement_revision: enforcement.revision,
+        effective_until: enforcement.effective_until,
+        revoked_at: enforcement.revoked_at,
+        replayed,
+    })
+}
+
+async fn replay_receipt<T: DeserializeOwned>(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    idempotency_key: &str,
+    command_type: &str,
+    request_hash: &str,
+) -> GroupsResult<Option<T>> {
+    let Some(receipt) = command_receipt::Entity::find()
+        .filter(command_receipt::Column::TenantId.eq(tenant_id))
+        .filter(command_receipt::Column::IdempotencyKey.eq(idempotency_key))
+        .one(transaction)
+        .await?
+    else {
+        return Ok(None);
+    };
+    if receipt.group_id != group_id
+        || receipt.actor_user_id != actor_user_id
+        || receipt.command_type != command_type
+        || receipt.request_hash != request_hash
+    {
+        return Err(GroupsError::Conflict(
+            "idempotency key was already used for another group enforcement command".to_string(),
+        ));
+    }
+    serde_json::from_value(receipt.response)
+        .map(Some)
+        .map_err(|error| GroupsError::Invariant(format!("invalid group command receipt: {error}")))
+}
+
+async fn store_receipt<T: Serialize>(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    idempotency_key: String,
+    command_type: &str,
+    request_hash: String,
+    response: &T,
+) -> GroupsResult<()> {
+    command_receipt::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        tenant_id: Set(tenant_id),
+        group_id: Set(group_id),
+        actor_user_id: Set(actor_user_id),
+        idempotency_key: Set(idempotency_key),
+        command_type: Set(command_type.to_string()),
+        request_hash: Set(request_hash),
+        response: Set(serde_json::to_value(response).map_err(|error| {
+            GroupsError::Invariant(format!(
+                "group enforcement command response is not serializable: {error}"
+            ))
+        })?),
+        created_at: Set(Utc::now().fixed_offset()),
+    }
+    .insert(transaction)
+    .await?;
+    Ok(())
+}
+
+async fn append_audit(
+    transaction: &DatabaseTransaction,
+    context: &PortContext,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Option<Uuid>,
+    action: &str,
+    target_user_id: Option<Uuid>,
+    details: Value,
+) -> GroupsResult<()> {
+    audit_entry::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        tenant_id: Set(tenant_id),
+        group_id: Set(group_id),
+        actor_user_id: Set(actor_user_id),
+        action: Set(action.to_string()),
+        target_user_id: Set(target_user_id),
+        details: Set(details),
+        correlation_id: Set(context.correlation_id.clone()),
+        created_at: Set(Utc::now().fixed_offset()),
+    }
+    .insert(transaction)
+    .await?;
+    Ok(())
+}
+
+async fn append_domain_event(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    membership_id: Uuid,
+    event_type: &str,
+    actor_id: Option<Uuid>,
+    payload: Value,
+    created_at: chrono::DateTime<chrono::FixedOffset>,
+) -> GroupsResult<()> {
+    group_event_entities::ActiveModel {
+        sequence_no: NotSet,
+        event_id: Set(Uuid::new_v4()),
+        tenant_id: Set(tenant_id),
+        aggregate_type: Set("membership".to_string()),
+        aggregate_id: Set(membership_id),
+        event_type: Set(event_type.to_string()),
+        schema_version: Set(1),
+        actor_id: Set(actor_id),
+        payload: Set(payload),
+        created_at: Set(created_at),
+    }
+    .insert(transaction)
+    .await?;
+    Ok(())
+}
+
+fn validate_identity(group_id: Uuid, target_user_id: Uuid, expected_revision: i64) -> GroupsResult<()> {
+    if group_id.is_nil() || target_user_id.is_nil() || expected_revision < 1 {
+        return Err(GroupsError::Validation(
+            "group, target membership identity and positive expected revision are required"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_reason_code(value: &str) -> GroupsResult<String> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > MAX_REASON_CODE_BYTES {
+        return Err(GroupsError::Validation(
+            "membership enforcement reason code must contain 1..80 bytes".to_string(),
+        ));
+    }
+    if !value.bytes().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || matches!(byte, b'.' | b':' | b'_' | b'-')
+    }) {
+        return Err(GroupsError::Validation(
+            "membership enforcement reason code must be canonical lowercase ASCII".to_string(),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn request_hash<T: Serialize>(request: &T) -> GroupsResult<String> {
+    let bytes = serde_json::to_vec(request).map_err(|error| {
+        GroupsError::Validation(format!(
+            "group enforcement command request is not serializable: {error}"
+        ))
+    })?;
+    Ok(crate::domain::sha256_hex(&bytes))
+}
+
+fn require_write(context: &PortContext) -> GroupsResult<()> {
+    context
+        .require_policy(PortCallPolicy::write())
+        .map_err(|error| GroupsError::Validation(error.message))
+}
+
+fn context_tenant_id(context: &PortContext) -> GroupsResult<Uuid> {
+    Uuid::parse_str(context.tenant_id.trim())
+        .map_err(|_| GroupsError::Validation("tenant_id must be a UUID".to_string()))
+}
+
+fn actor_user_id(context: &PortContext) -> GroupsResult<Uuid> {
+    if context.actor.kind != PortActorKind::User {
+        return Err(GroupsError::Forbidden(
+            "a user actor is required for direct group membership enforcement".to_string(),
+        ));
+    }
+    Uuid::parse_str(context.actor.id.trim())
+        .map_err(|_| GroupsError::Validation("actor.id must be a UUID".to_string()))
+}
+
+fn idempotency_key(context: &PortContext) -> GroupsResult<String> {
+    context
+        .idempotency_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && value.len() <= 160)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            GroupsError::Validation("bounded idempotency key is required".to_string())
+        })
+}
+
+fn has_platform_moderate(context: &PortContext) -> bool {
+    context.claims.iter().any(|claim| {
+        matches!(
+            claim.as_str(),
+            "groups:moderate" | "groups:manage" | "groups:*" | "*:*"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reason_codes_are_bounded_and_canonical() {
+        assert_eq!(normalize_reason_code(" harassment ").unwrap(), "harassment");
+        assert!(normalize_reason_code("Human readable reason").is_err());
+        assert!(normalize_reason_code(&"x".repeat(81)).is_err());
+    }
+
+    #[test]
+    fn moderation_provenance_requires_canonical_decision_identity() {
+        let valid = MembershipEnforcementProvenance {
+            source_kind: GroupMembershipEnforcementSourceKind::ModerationDecision,
+            moderation_decision_id: Some(Uuid::new_v4()),
+            moderation_decision_hash: Some("a".repeat(64)),
+            actor_kind: "service".to_string(),
+            actor_id: "rustok-moderation".to_string(),
+            audit_actor_user_id: None,
+        };
+        assert!(validate_provenance(&valid).is_ok());
+
+        let invalid = MembershipEnforcementProvenance {
+            moderation_decision_hash: Some("A".repeat(64)),
+            ..valid
+        };
+        assert!(validate_provenance(&invalid).is_err());
+    }
+}

--- a/crates/rustok-groups/src/membership_enforcement_command.rs
+++ b/crates/rustok-groups/src/membership_enforcement_command.rs
@@ -54,7 +54,7 @@ pub struct GroupMembershipEnforcementMutationResult {
     pub user_id: Uuid,
     pub membership_revision: i64,
     pub group_version: i64,
-    /// Stored-lifecycle member count. Temporary enforcement deliberately does not change it.
+    /// Stored-lifecycle active count. Temporary enforcement deliberately does not change it.
     pub member_count: i64,
     pub effective_status: GroupMembershipEffectiveStatus,
     pub enforcement_revision: i64,
@@ -65,9 +65,9 @@ pub struct GroupMembershipEnforcementMutationResult {
 
 /// Provenance passed to the shared Groups-owned enforcement mutation.
 ///
-/// Direct local commands use `DirectLocal`. The later neutral Moderation adapter can reuse the
-/// same owner mutation by supplying `ModerationDecision` plus immutable decision identity; no
-/// moderation case, queue or policy data belongs here.
+/// Direct commands use `DirectLocal`. The later neutral Moderation adapter can reuse these owner
+/// mutations with `ModerationDecision` provenance after its own receipt, subject/scope and revision
+/// validation. Moderation cases, queue state and policy snapshots never belong here.
 #[derive(Clone, Debug)]
 pub(crate) struct MembershipEnforcementProvenance {
     pub(crate) source_kind: GroupMembershipEnforcementSourceKind,
@@ -107,7 +107,11 @@ impl GroupMembershipEnforcementCommandService {
         request: SuspendGroupMembershipRequest,
     ) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
         require_write(context)?;
-        validate_identity(request.group_id, request.target_user_id, request.expected_membership_revision)?;
+        validate_identity(
+            request.group_id,
+            request.target_user_id,
+            request.expected_membership_revision,
+        )?;
         let tenant_id = context_tenant_id(context)?;
         let actor_user_id = actor_user_id(context)?;
         if actor_user_id == request.target_user_id {
@@ -115,18 +119,18 @@ impl GroupMembershipEnforcementCommandService {
         }
         let idempotency_key = idempotency_key(context)?;
         let reason_code = normalize_reason_code(&request.reason_code)?;
-        let normalized_request = SuspendGroupMembershipRequest {
+        let request = SuspendGroupMembershipRequest {
             reason_code,
             ..request
         };
-        let request_hash = request_hash(&normalized_request)?;
+        let request_hash = request_hash(&request)?;
 
         let transaction = self.db.begin().await?;
-        let locked_group = lock_group(&transaction, tenant_id, normalized_request.group_id).await?;
+        let locked_group = lock_group(&transaction, tenant_id, request.group_id).await?;
         if let Some(replayed) = replay_receipt::<GroupMembershipEnforcementMutationResult>(
             &transaction,
             tenant_id,
-            normalized_request.group_id,
+            request.group_id,
             actor_user_id,
             &idempotency_key,
             SUSPEND_COMMAND,
@@ -142,10 +146,7 @@ impl GroupMembershipEnforcementCommandService {
         }
 
         let now = Utc::now();
-        if normalized_request
-            .effective_until
-            .is_some_and(|until| until <= now)
-        {
+        if request.effective_until.is_some_and(|until| until <= now) {
             return Err(GroupsError::Validation(
                 "membership suspension expiry must be in the future".to_string(),
             ));
@@ -157,45 +158,42 @@ impl GroupMembershipEnforcementCommandService {
             tenant_id,
             locked_group.id,
             actor_user_id,
-            normalized_request.target_user_id,
+            request.target_user_id,
             !platform_moderate,
         )
         .await?;
         authorize_direct_enforcement(
             &transaction,
-            context,
             tenant_id,
             &locked_group,
             &locked,
             actor_user_id,
-            normalized_request.target_user_id,
+            request.target_user_id,
             platform_moderate,
             now,
         )
         .await?;
 
         let target = locked
-            .target(normalized_request.target_user_id)
+            .membership(request.target_user_id)
             .ok_or_else(|| GroupsError::Conflict("target group membership is required".to_string()))?;
-        let target_enforcement = locked.enforcement(target.id);
         let result = apply_membership_suspension_in_tx(
             &transaction,
             context,
             locked_group,
-            target,
-            target_enforcement,
-            normalized_request.expected_membership_revision,
-            normalized_request.reason_code.clone(),
-            normalized_request.effective_until,
+            target.clone(),
+            locked.enforcement(target.id),
+            request.expected_membership_revision,
+            request.reason_code.clone(),
+            request.effective_until,
             MembershipEnforcementProvenance::direct_local(actor_user_id),
             now,
         )
         .await?;
-
         store_receipt(
             &transaction,
             tenant_id,
-            normalized_request.group_id,
+            request.group_id,
             actor_user_id,
             idempotency_key,
             SUSPEND_COMMAND,
@@ -213,7 +211,11 @@ impl GroupMembershipEnforcementCommandService {
         request: RevokeGroupMembershipSuspensionRequest,
     ) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
         require_write(context)?;
-        validate_identity(request.group_id, request.target_user_id, request.expected_membership_revision)?;
+        validate_identity(
+            request.group_id,
+            request.target_user_id,
+            request.expected_membership_revision,
+        )?;
         let tenant_id = context_tenant_id(context)?;
         let actor_user_id = actor_user_id(context)?;
         if actor_user_id == request.target_user_id {
@@ -221,18 +223,18 @@ impl GroupMembershipEnforcementCommandService {
         }
         let idempotency_key = idempotency_key(context)?;
         let reason_code = normalize_reason_code(&request.reason_code)?;
-        let normalized_request = RevokeGroupMembershipSuspensionRequest {
+        let request = RevokeGroupMembershipSuspensionRequest {
             reason_code,
             ..request
         };
-        let request_hash = request_hash(&normalized_request)?;
+        let request_hash = request_hash(&request)?;
 
         let transaction = self.db.begin().await?;
-        let locked_group = lock_group(&transaction, tenant_id, normalized_request.group_id).await?;
+        let locked_group = lock_group(&transaction, tenant_id, request.group_id).await?;
         if let Some(replayed) = replay_receipt::<GroupMembershipEnforcementMutationResult>(
             &transaction,
             tenant_id,
-            normalized_request.group_id,
+            request.group_id,
             actor_user_id,
             &idempotency_key,
             REVOKE_SUSPENSION_COMMAND,
@@ -254,44 +256,41 @@ impl GroupMembershipEnforcementCommandService {
             tenant_id,
             locked_group.id,
             actor_user_id,
-            normalized_request.target_user_id,
+            request.target_user_id,
             !platform_moderate,
         )
         .await?;
         authorize_direct_enforcement(
             &transaction,
-            context,
             tenant_id,
             &locked_group,
             &locked,
             actor_user_id,
-            normalized_request.target_user_id,
+            request.target_user_id,
             platform_moderate,
             now,
         )
         .await?;
 
         let target = locked
-            .target(normalized_request.target_user_id)
+            .membership(request.target_user_id)
             .ok_or_else(|| GroupsError::Conflict("target group membership is required".to_string()))?;
-        let target_enforcement = locked.enforcement(target.id);
         let result = revoke_membership_suspension_in_tx(
             &transaction,
             context,
             locked_group,
-            target,
-            target_enforcement,
-            normalized_request.expected_membership_revision,
-            normalized_request.reason_code.clone(),
+            target.clone(),
+            locked.enforcement(target.id),
+            request.expected_membership_revision,
+            request.reason_code.clone(),
             MembershipEnforcementProvenance::direct_local(actor_user_id),
             now,
         )
         .await?;
-
         store_receipt(
             &transaction,
             tenant_id,
-            normalized_request.group_id,
+            request.group_id,
             actor_user_id,
             idempotency_key,
             REVOKE_SUSPENSION_COMMAND,
@@ -329,7 +328,7 @@ struct LockedCommandState {
 }
 
 impl LockedCommandState {
-    fn target(&self, user_id: Uuid) -> Option<membership_state::Model> {
+    fn membership(&self, user_id: Uuid) -> Option<membership_state::Model> {
         self.memberships
             .iter()
             .find(|row| row.user_id == user_id)
@@ -426,7 +425,6 @@ async fn lock_command_memberships(
 
 async fn authorize_direct_enforcement(
     transaction: &DatabaseTransaction,
-    context: &PortContext,
     tenant_id: Uuid,
     group_model: &group::Model,
     locked: &LockedCommandState,
@@ -436,16 +434,16 @@ async fn authorize_direct_enforcement(
     now: DateTime<Utc>,
 ) -> GroupsResult<()> {
     let target = locked
-        .target(target_user_id)
+        .membership(target_user_id)
         .ok_or_else(|| GroupsError::Conflict("target group membership is required".to_string()))?;
     let target_role = GroupRole::from_str(&target.role).map_err(GroupsError::Invariant)?;
-    let owner_identity_matches = target.user_id == group_model.owner_user_id;
-    if owner_identity_matches != (target_role == GroupRole::Owner) {
+    let target_is_owner = target.user_id == group_model.owner_user_id;
+    if target_is_owner != (target_role == GroupRole::Owner) {
         return Err(GroupsError::Invariant(
             "group owner reference and owner membership role disagree".to_string(),
         ));
     }
-    if owner_identity_matches {
+    if target_is_owner {
         return Err(GroupsError::MembershipEnforcementOwnerProtected);
     }
 
@@ -458,9 +456,9 @@ async fn authorize_direct_enforcement(
         return Ok(());
     }
 
-    let actor = locked
-        .target(actor_user_id)
-        .ok_or_else(|| GroupsError::ManagerRequired("active local moderator authority is required".to_string()))?;
+    let actor = locked.membership(actor_user_id).ok_or_else(|| {
+        GroupsError::ManagerRequired("active local moderator authority is required".to_string())
+    })?;
     let actor_state = resolve_group_membership_enforcement(
         transaction,
         tenant_id,
@@ -497,9 +495,8 @@ async fn authorize_direct_enforcement(
     }
 }
 
-/// Shared Groups-owned suspension mutation used by the direct command and, later, the neutral
-/// Moderation adapter after that caller has completed its own receipt admission and authorization.
-/// The caller must hold the group, target membership and target enforcement locks.
+/// Shared Groups-owned suspension mutation used by the direct command and later by the neutral
+/// Moderation adapter. The caller must hold the group, target membership and enforcement locks.
 pub(crate) async fn apply_membership_suspension_in_tx(
     transaction: &DatabaseTransaction,
     context: &PortContext,
@@ -525,27 +522,22 @@ pub(crate) async fn apply_membership_suspension_in_tx(
         ));
     }
 
-    if let Some(existing) = current_enforcement.as_ref() {
-        let existing_effective = existing.revoked_at.is_none()
-            && existing.effective_from.with_timezone(&Utc) <= now
-            && existing
-                .effective_until
-                .as_ref()
-                .is_none_or(|until| now < until.with_timezone(&Utc));
-        if existing_effective {
-            return Err(GroupsError::MembershipEnforcementAlreadySuspended);
-        }
+    if current_enforcement
+        .as_ref()
+        .is_some_and(|row| enforcement_is_effective(row, now))
+    {
+        return Err(GroupsError::MembershipEnforcementAlreadySuspended);
     }
 
     let fixed_now = now.fixed_offset();
-    let effective_until_fixed = effective_until.map(|value| value.fixed_offset());
+    let fixed_until = effective_until.map(|value| value.fixed_offset());
     if let Some(existing) = current_enforcement {
         let mut active: membership_enforcement::ActiveModel = existing.into();
         active.state = Set("suspended".to_string());
         active.reason_code = Set(reason_code.clone());
         active.source_kind = Set(provenance.source_kind.as_str().to_string());
         active.effective_from = Set(fixed_now);
-        active.effective_until = Set(effective_until_fixed);
+        active.effective_until = Set(fixed_until);
         active.restore_status = Set(target_status.as_str().to_string());
         active.moderation_decision_id = Set(provenance.moderation_decision_id);
         active.moderation_decision_hash = Set(provenance.moderation_decision_hash.clone());
@@ -564,7 +556,7 @@ pub(crate) async fn apply_membership_suspension_in_tx(
             reason_code: Set(reason_code.clone()),
             source_kind: Set(provenance.source_kind.as_str().to_string()),
             effective_from: Set(fixed_now),
-            effective_until: Set(effective_until_fixed),
+            effective_until: Set(fixed_until),
             restore_status: Set(target_status.as_str().to_string()),
             moderation_decision_id: Set(provenance.moderation_decision_id),
             moderation_decision_hash: Set(provenance.moderation_decision_hash.clone()),
@@ -579,7 +571,8 @@ pub(crate) async fn apply_membership_suspension_in_tx(
         .await?;
     }
 
-    let group_after = bump_group_version_without_member_count_change(transaction, group_model, fixed_now).await?;
+    let group_after =
+        bump_group_version_without_member_count_change(transaction, group_model, fixed_now).await?;
     let state = resolve_group_membership_enforcement(
         transaction,
         target.tenant_id,
@@ -633,8 +626,8 @@ pub(crate) async fn apply_membership_suspension_in_tx(
     Ok(result)
 }
 
-/// Shared Groups-owned revocation mutation. Direct local revocation may only revoke a direct-local
-/// suspension; a local moderator cannot erase moderation-decision provenance.
+/// Shared Groups-owned revocation mutation. A direct-local caller may only revoke direct-local
+/// enforcement, so local moderation cannot erase moderation-decision provenance.
 pub(crate) async fn revoke_membership_suspension_in_tx(
     transaction: &DatabaseTransaction,
     context: &PortContext,
@@ -656,13 +649,7 @@ pub(crate) async fn revoke_membership_suspension_in_tx(
     {
         return Err(GroupsError::MembershipEnforcementSourceConflict);
     }
-    let existing_effective = existing.revoked_at.is_none()
-        && existing.effective_from.with_timezone(&Utc) <= now
-        && existing
-            .effective_until
-            .as_ref()
-            .is_none_or(|until| now < until.with_timezone(&Utc));
-    if !existing_effective {
+    if !enforcement_is_effective(&existing, now) {
         return Err(GroupsError::MembershipEnforcementNotActive);
     }
 
@@ -670,13 +657,14 @@ pub(crate) async fn revoke_membership_suspension_in_tx(
     let previous_effective_until = existing.effective_until.map(|value| value.with_timezone(&Utc));
     let fixed_now = now.fixed_offset();
     let mut active: membership_enforcement::ActiveModel = existing.into();
+    // Preserve the original suspension actor/source provenance. The revoking actor is retained in
+    // immutable audit/event facts instead of overwriting who established the enforcement row.
     active.revoked_at = Set(Some(fixed_now));
-    active.actor_kind = Set(provenance.actor_kind.clone());
-    active.actor_id = Set(provenance.actor_id.clone());
     active.updated_at = Set(fixed_now);
     active.update(transaction).await?;
 
-    let group_after = bump_group_version_without_member_count_change(transaction, group_model, fixed_now).await?;
+    let group_after =
+        bump_group_version_without_member_count_change(transaction, group_model, fixed_now).await?;
     let state = resolve_group_membership_enforcement(
         transaction,
         target.tenant_id,
@@ -729,6 +717,15 @@ pub(crate) async fn revoke_membership_suspension_in_tx(
     )
     .await?;
     Ok(result)
+}
+
+fn enforcement_is_effective(row: &membership_enforcement::Model, now: DateTime<Utc>) -> bool {
+    row.revoked_at.is_none()
+        && row.effective_from.with_timezone(&Utc) <= now
+        && row
+            .effective_until
+            .as_ref()
+            .is_none_or(|until| now < until.with_timezone(&Utc))
 }
 
 fn validate_mutation_identity(
@@ -1030,9 +1027,7 @@ fn idempotency_key(context: &PortContext) -> GroupsResult<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty() && value.len() <= 160)
         .map(str::to_string)
-        .ok_or_else(|| {
-            GroupsError::Validation("bounded idempotency key is required".to_string())
-        })
+        .ok_or_else(|| GroupsError::Validation("bounded idempotency key is required".to_string()))
 }
 
 fn has_platform_moderate(context: &PortContext) -> bool {

--- a/crates/rustok-groups/src/membership_enforcement_command.rs
+++ b/crates/rustok-groups/src/membership_enforcement_command.rs
@@ -106,7 +106,6 @@ impl GroupMembershipEnforcementCommandService {
         context: &PortContext,
         request: SuspendGroupMembershipRequest,
     ) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
-        require_write(context)?;
         validate_identity(
             request.group_id,
             request.target_user_id,
@@ -210,7 +209,6 @@ impl GroupMembershipEnforcementCommandService {
         context: &PortContext,
         request: RevokeGroupMembershipSuspensionRequest,
     ) -> GroupsResult<GroupMembershipEnforcementMutationResult> {
-        require_write(context)?;
         validate_identity(
             request.group_id,
             request.target_user_id,
@@ -310,6 +308,7 @@ impl GroupMembershipEnforcementCommandPort for GroupMembershipEnforcementCommand
         context: PortContext,
         request: SuspendGroupMembershipRequest,
     ) -> Result<GroupMembershipEnforcementMutationResult, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
         self.suspend_owned(&context, request).await.map_err(Into::into)
     }
 
@@ -318,6 +317,7 @@ impl GroupMembershipEnforcementCommandPort for GroupMembershipEnforcementCommand
         context: PortContext,
         request: RevokeGroupMembershipSuspensionRequest,
     ) -> Result<GroupMembershipEnforcementMutationResult, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
         self.revoke_owned(&context, request).await.map_err(Into::into)
     }
 }
@@ -595,6 +595,10 @@ pub(crate) async fn apply_membership_suspension_in_tx(
             "membership_id": target.id,
             "reason_code": reason_code,
             "source_kind": provenance.source_kind.as_str(),
+            "moderation_decision_id": provenance.moderation_decision_id,
+            "moderation_decision_hash": provenance.moderation_decision_hash.clone(),
+            "mutation_actor_kind": provenance.actor_kind,
+            "mutation_actor_id": provenance.actor_id,
             "effective_until": effective_until,
             "previous_membership_revision": expected_membership_revision,
             "membership_revision": result.membership_revision,
@@ -616,6 +620,10 @@ pub(crate) async fn apply_membership_suspension_in_tx(
             "user_id": target.user_id,
             "reason_code": reason_code,
             "source_kind": provenance.source_kind.as_str(),
+            "moderation_decision_id": provenance.moderation_decision_id,
+            "moderation_decision_hash": provenance.moderation_decision_hash,
+            "mutation_actor_kind": provenance.actor_kind,
+            "mutation_actor_id": provenance.actor_id,
             "effective_until": effective_until,
             "membership_revision": result.membership_revision,
             "group_version": result.group_version
@@ -655,6 +663,8 @@ pub(crate) async fn revoke_membership_suspension_in_tx(
 
     let previous_reason_code = existing.reason_code.clone();
     let previous_effective_until = existing.effective_until.map(|value| value.with_timezone(&Utc));
+    let previous_moderation_decision_id = existing.moderation_decision_id;
+    let previous_moderation_decision_hash = existing.moderation_decision_hash.clone();
     let fixed_now = now.fixed_offset();
     let mut active: membership_enforcement::ActiveModel = existing.into();
     // Preserve the original suspension actor/source provenance. The revoking actor is retained in
@@ -689,6 +699,10 @@ pub(crate) async fn revoke_membership_suspension_in_tx(
             "previous_reason_code": previous_reason_code,
             "previous_effective_until": previous_effective_until,
             "source_kind": existing_source.as_str(),
+            "previous_moderation_decision_id": previous_moderation_decision_id,
+            "previous_moderation_decision_hash": previous_moderation_decision_hash.clone(),
+            "mutation_actor_kind": provenance.actor_kind,
+            "mutation_actor_id": provenance.actor_id,
             "previous_membership_revision": expected_membership_revision,
             "membership_revision": result.membership_revision,
             "group_version": result.group_version,
@@ -710,6 +724,10 @@ pub(crate) async fn revoke_membership_suspension_in_tx(
             "revocation_reason_code": revocation_reason_code,
             "previous_reason_code": previous_reason_code,
             "source_kind": existing_source.as_str(),
+            "previous_moderation_decision_id": previous_moderation_decision_id,
+            "previous_moderation_decision_hash": previous_moderation_decision_hash,
+            "mutation_actor_kind": provenance.actor_kind,
+            "mutation_actor_id": provenance.actor_id,
             "membership_revision": result.membership_revision,
             "group_version": result.group_version
         }),
@@ -997,12 +1015,6 @@ fn request_hash<T: Serialize>(request: &T) -> GroupsResult<String> {
         ))
     })?;
     Ok(crate::domain::sha256_hex(&bytes))
-}
-
-fn require_write(context: &PortContext) -> GroupsResult<()> {
-    context
-        .require_policy(PortCallPolicy::write())
-        .map_err(|error| GroupsError::Validation(error.message))
 }
 
 fn context_tenant_id(context: &PortContext) -> GroupsResult<Uuid> {

--- a/crates/rustok-groups/src/migrations/m20260808_000009_extend_group_domain_events_for_membership_enforcement.rs
+++ b/crates/rustok-groups/src/migrations/m20260808_000009_extend_group_domain_events_for_membership_enforcement.rs
@@ -1,0 +1,213 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => postgres_up(manager).await,
+            DatabaseBackend::Sqlite => sqlite_up(manager).await,
+            backend => Err(DbErr::Migration(format!(
+                "Groups membership enforcement events do not support {backend:?}"
+            ))),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        ensure_no_membership_events(manager).await?;
+        match manager.get_database_backend() {
+            DatabaseBackend::Postgres => postgres_down(manager).await,
+            DatabaseBackend::Sqlite => sqlite_down(manager).await,
+            backend => Err(DbErr::Migration(format!(
+                "Groups membership enforcement events do not support {backend:?}"
+            ))),
+        }
+    }
+}
+
+async fn ensure_no_membership_events(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let backend = manager.get_database_backend();
+    let row = manager
+        .get_connection()
+        .query_one(Statement::from_string(
+            backend,
+            "SELECT COUNT(*) AS event_count FROM group_domain_events WHERE aggregate_type = 'membership'"
+                .to_string(),
+        ))
+        .await?
+        .ok_or_else(|| DbErr::Migration("Groups domain-event count query returned no row".into()))?;
+    let count: i64 = row.try_get("", "event_count")?;
+    if count != 0 {
+        return Err(DbErr::Migration(
+            "cannot downgrade Groups membership enforcement events while append-only membership events exist"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn postgres_up(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+ALTER TABLE group_domain_events
+    DROP CONSTRAINT IF EXISTS chk_group_domain_events_aggregate_type,
+    DROP CONSTRAINT IF EXISTS chk_group_domain_events_event_type,
+    DROP CONSTRAINT IF EXISTS chk_group_domain_events_kind;
+
+ALTER TABLE group_domain_events
+    ADD CONSTRAINT chk_group_domain_events_kind CHECK (
+        (aggregate_type = 'invitation' AND event_type = 'groups.invitation.targeted_created')
+        OR
+        (aggregate_type = 'membership' AND event_type IN (
+            'groups.membership.suspended',
+            'groups.membership.suspension_revoked'
+        ))
+    );
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn postgres_down(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+ALTER TABLE group_domain_events
+    DROP CONSTRAINT IF EXISTS chk_group_domain_events_kind;
+
+ALTER TABLE group_domain_events
+    ADD CONSTRAINT chk_group_domain_events_aggregate_type CHECK (aggregate_type = 'invitation'),
+    ADD CONSTRAINT chk_group_domain_events_event_type CHECK (event_type = 'groups.invitation.targeted_created');
+"#,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn sqlite_up(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    rebuild_sqlite_events(manager, true).await
+}
+
+async fn sqlite_down(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    rebuild_sqlite_events(manager, false).await
+}
+
+async fn rebuild_sqlite_events(
+    manager: &SchemaManager<'_>,
+    allow_membership_events: bool,
+) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    for statement in [
+        "DROP TRIGGER IF EXISTS groups_targeted_invitation_created_event",
+        "DROP TRIGGER IF EXISTS group_domain_events_immutable_update",
+        "DROP TRIGGER IF EXISTS group_domain_events_immutable_delete",
+        "DROP TABLE IF EXISTS group_domain_events_next",
+    ] {
+        connection.execute_unprepared(statement).await?;
+    }
+
+    let kind_check = if allow_membership_events {
+        "CHECK ((aggregate_type = 'invitation' AND event_type = 'groups.invitation.targeted_created') OR (aggregate_type = 'membership' AND event_type IN ('groups.membership.suspended', 'groups.membership.suspension_revoked')))"
+    } else {
+        "CHECK (aggregate_type = 'invitation' AND event_type = 'groups.invitation.targeted_created')"
+    };
+
+    connection
+        .execute_unprepared(&format!(
+            r#"CREATE TABLE group_domain_events_next (
+    sequence_no INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    tenant_id TEXT NOT NULL,
+    aggregate_type TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1 CHECK (schema_version = 1),
+    actor_id TEXT,
+    payload TEXT NOT NULL DEFAULT '{{}}',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    {kind_check}
+)"#
+        ))
+        .await?;
+
+    connection
+        .execute_unprepared(
+            r#"INSERT INTO group_domain_events_next (
+    sequence_no, event_id, tenant_id, aggregate_type, aggregate_id,
+    event_type, schema_version, actor_id, payload, created_at
+)
+SELECT
+    sequence_no, event_id, tenant_id, aggregate_type, aggregate_id,
+    event_type, schema_version, actor_id, payload, created_at
+FROM group_domain_events
+ORDER BY sequence_no"#,
+        )
+        .await?;
+    connection
+        .execute_unprepared("DROP TABLE group_domain_events")
+        .await?;
+    connection
+        .execute_unprepared("ALTER TABLE group_domain_events_next RENAME TO group_domain_events")
+        .await?;
+
+    for statement in [
+        "CREATE INDEX idx_group_domain_events_tenant_sequence ON group_domain_events (tenant_id, sequence_no)",
+        "CREATE INDEX idx_group_domain_events_tenant_aggregate ON group_domain_events (tenant_id, aggregate_type, aggregate_id, sequence_no)",
+        "CREATE INDEX idx_group_domain_events_tenant_type ON group_domain_events (tenant_id, event_type, sequence_no)",
+        r#"CREATE TRIGGER group_domain_events_immutable_update
+BEFORE UPDATE ON group_domain_events
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'group domain events are append-only');
+END"#,
+        r#"CREATE TRIGGER group_domain_events_immutable_delete
+BEFORE DELETE ON group_domain_events
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'group domain events are append-only');
+END"#,
+        r#"CREATE TRIGGER groups_targeted_invitation_created_event
+AFTER INSERT ON group_invitations
+FOR EACH ROW
+WHEN NEW.target_user_id IS NOT NULL
+BEGIN
+    INSERT INTO group_domain_events (
+        event_id,
+        tenant_id,
+        aggregate_type,
+        aggregate_id,
+        event_type,
+        schema_version,
+        actor_id,
+        payload
+    ) VALUES (
+        lower(hex(randomblob(4))) || '-' ||
+        lower(hex(randomblob(2))) || '-' ||
+        lower(hex(randomblob(2))) || '-' ||
+        lower(hex(randomblob(2))) || '-' ||
+        lower(hex(randomblob(6))),
+        NEW.tenant_id,
+        'invitation',
+        NEW.id,
+        'groups.invitation.targeted_created',
+        1,
+        NEW.invited_by_user_id,
+        json_object(
+            'invitation_id', NEW.id,
+            'group_id', NEW.group_id,
+            'target_user_id', NEW.target_user_id
+        )
+    );
+END"#,
+    ] {
+        connection.execute_unprepared(statement).await?;
+    }
+    Ok(())
+}

--- a/crates/rustok-groups/src/migrations/mod.rs
+++ b/crates/rustok-groups/src/migrations/mod.rs
@@ -6,6 +6,7 @@ mod m20260721_000005_create_group_domain_events;
 mod m20260722_000006_create_group_membership_applications;
 mod m20260722_000007_create_group_membership_policy_revisions;
 mod m20260723_000008_create_group_membership_enforcement_state;
+mod m20260808_000009_extend_group_domain_events_for_membership_enforcement;
 
 use sea_orm_migration::MigrationTrait;
 
@@ -19,5 +20,6 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260722_000006_create_group_membership_applications::Migration),
         Box::new(m20260722_000007_create_group_membership_policy_revisions::Migration),
         Box::new(m20260723_000008_create_group_membership_enforcement_state::Migration),
+        Box::new(m20260808_000009_extend_group_domain_events_for_membership_enforcement::Migration),
     ]
 }

--- a/crates/rustok-groups/src/ports.rs
+++ b/crates/rustok-groups/src/ports.rs
@@ -11,6 +11,10 @@ use crate::dto::{
     ReadGroupMembershipEnforcementRequest, ReadGroupMembershipRequest, ReadGroupRequest,
     SetGroupFeatureRequest, UpsertGroupTranslationRequest,
 };
+use crate::membership_enforcement_command::{
+    GroupMembershipEnforcementMutationResult, RevokeGroupMembershipSuspensionRequest,
+    SuspendGroupMembershipRequest,
+};
 
 #[async_trait]
 pub trait GroupSummaryReadPort: Send + Sync {
@@ -51,6 +55,26 @@ pub trait GroupMembershipEnforcementReadPort: Send + Sync {
         context: PortContext,
         request: ReadGroupMembershipEnforcementRequest,
     ) -> Result<GroupMembershipEffectiveState, PortError>;
+}
+
+/// Direct Groups-owned single-membership enforcement boundary.
+///
+/// The neutral Moderation adapter does not call this user-authorized port. It reuses the same
+/// crate-private owner mutation after its own trusted receipt/revision validation, preserving one
+/// Groups write path without pretending a service actor is a local moderator.
+#[async_trait]
+pub trait GroupMembershipEnforcementCommandPort: Send + Sync {
+    async fn suspend_membership(
+        &self,
+        context: PortContext,
+        request: SuspendGroupMembershipRequest,
+    ) -> Result<GroupMembershipEnforcementMutationResult, PortError>;
+
+    async fn revoke_membership_suspension(
+        &self,
+        context: PortContext,
+        request: RevokeGroupMembershipSuspensionRequest,
+    ) -> Result<GroupMembershipEnforcementMutationResult, PortError>;
 }
 
 #[async_trait]
@@ -122,6 +146,8 @@ pub trait GroupLocalizationCommandPort: Send + Sync {
 pub type SharedGroupSummaryReadPort = Arc<dyn GroupSummaryReadPort>;
 pub type SharedGroupMembershipReadPort = Arc<dyn GroupMembershipReadPort>;
 pub type SharedGroupMembershipEnforcementReadPort = Arc<dyn GroupMembershipEnforcementReadPort>;
+pub type SharedGroupMembershipEnforcementCommandPort =
+    Arc<dyn GroupMembershipEnforcementCommandPort>;
 pub type SharedGroupAccessReadPort = Arc<dyn GroupAccessReadPort>;
 pub type SharedGroupLocalizationReadPort = Arc<dyn GroupLocalizationReadPort>;
 pub type SharedGroupCommandPort = Arc<dyn GroupCommandPort>;
@@ -145,6 +171,7 @@ impl Default for GroupCapabilityDescriptor {
                 "GroupSummaryReadPort",
                 "GroupMembershipReadPort",
                 "GroupMembershipEnforcementReadPort",
+                "GroupMembershipEnforcementCommandPort",
                 "GroupAccessReadPort",
                 "GroupLocalizationReadPort",
                 "GroupInvitationReadPort",

--- a/scripts/verify/verify-groups-membership-enforcement-command.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-command.mjs
@@ -4,7 +4,15 @@ const command = fs.readFileSync(
   "crates/rustok-groups/src/membership_enforcement_command.rs",
   "utf8",
 );
+const resolver = fs.readFileSync(
+  "crates/rustok-groups/src/membership_enforcement.rs",
+  "utf8",
+);
 const ports = fs.readFileSync("crates/rustok-groups/src/ports.rs", "utf8");
+const registry = fs.readFileSync(
+  "crates/rustok-groups/contracts/groups-fba-registry.json",
+  "utf8",
+);
 const migration = fs.readFileSync(
   "crates/rustok-groups/src/migrations/m20260808_000009_extend_group_domain_events_for_membership_enforcement.rs",
   "utf8",
@@ -51,10 +59,27 @@ for (const marker of [
 }
 
 for (const marker of [
+  "group owner reference and owner membership role disagree",
+  "membership.user_id == group_owner_user_id",
+]) {
+  requireText(resolver, marker, `Groups owner identity resolver is missing ${marker}`);
+}
+
+for (const marker of [
   "GroupMembershipEnforcementCommandPort",
   "SharedGroupMembershipEnforcementCommandPort",
 ]) {
   requireText(ports, marker, `Groups enforcement port surface is missing ${marker}`);
+}
+
+for (const marker of [
+  '"name": "GroupMembershipEnforcementCommandPort"',
+  '"direct_command_port": "implemented_source"',
+  '"member_count_semantics": "stored_lifecycle_active_unchanged_by_temporary_enforcement"',
+  '"membership_enforcement_command_static_boundary"',
+  '"membership_enforcement_command_transport_parity": null',
+]) {
+  requireText(registry, marker, `Groups FBA enforcement contract is missing ${marker}`);
 }
 
 for (const marker of [
@@ -72,7 +97,7 @@ for (const marker of [
 
 for (const marker of [
   "stored lifecycle active count",
-  "Direct suspend/revoke command",
+  "Source-complete direct enforcement command",
   "shared Groups enforcement command",
   "neutral moderation subject adapter",
 ]) {

--- a/scripts/verify/verify-groups-membership-enforcement-command.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-command.mjs
@@ -53,6 +53,12 @@ for (const marker of [
   "group.membership_suspension_revoked",
   "groups.membership.suspended",
   "groups.membership.suspension_revoked",
+  '"moderation_decision_id": provenance.moderation_decision_id',
+  '"moderation_decision_hash": provenance.moderation_decision_hash',
+  '"previous_moderation_decision_id": previous_moderation_decision_id',
+  '"previous_moderation_decision_hash": previous_moderation_decision_hash',
+  '"mutation_actor_kind": provenance.actor_kind',
+  '"mutation_actor_id": provenance.actor_id',
   "ModerationDecision",
 ]) {
   requireText(command, marker, `Groups enforcement command is missing ${marker}`);

--- a/scripts/verify/verify-groups-membership-enforcement-command.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-command.mjs
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+
+const command = fs.readFileSync(
+  "crates/rustok-groups/src/membership_enforcement_command.rs",
+  "utf8",
+);
+const ports = fs.readFileSync("crates/rustok-groups/src/ports.rs", "utf8");
+const migration = fs.readFileSync(
+  "crates/rustok-groups/src/migrations/m20260808_000009_extend_group_domain_events_for_membership_enforcement.rs",
+  "utf8",
+);
+const plan = fs.readFileSync(
+  "crates/rustok-groups/docs/implementation-plan.md",
+  "utf8",
+);
+const docs = fs.readFileSync(
+  "crates/rustok-groups/docs/membership-enforcement-command-contract.md",
+  "utf8",
+);
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  "GroupMembershipEnforcementCommandService",
+  "suspend_membership",
+  "revoke_membership_suspension",
+  "groups.membership.suspend.v1",
+  "groups.membership.suspension_revoke.v1",
+  "expected_membership_revision",
+  "MembershipEnforcementRevisionConflict",
+  "MembershipEnforcementOwnerProtected",
+  "MembershipEnforcementSourceConflict",
+  "lock_group",
+  "lock_command_memberships",
+  "sort_unstable",
+  "replay_receipt",
+  "receipt.actor_user_id != actor_user_id",
+  "apply_membership_suspension_in_tx",
+  "revoke_membership_suspension_in_tx",
+  "bump_group_version_without_member_count_change",
+  '"member_count_semantics": "stored_lifecycle_active"',
+  "group.membership_suspended",
+  "group.membership_suspension_revoked",
+  "groups.membership.suspended",
+  "groups.membership.suspension_revoked",
+  "ModerationDecision",
+]) {
+  requireText(command, marker, `Groups enforcement command is missing ${marker}`);
+}
+
+for (const marker of [
+  "GroupMembershipEnforcementCommandPort",
+  "SharedGroupMembershipEnforcementCommandPort",
+]) {
+  requireText(ports, marker, `Groups enforcement port surface is missing ${marker}`);
+}
+
+for (const marker of [
+  "chk_group_domain_events_kind",
+  "groups.membership.suspended",
+  "groups.membership.suspension_revoked",
+  "group_domain_events_next",
+  "cannot downgrade Groups membership enforcement events while append-only membership events exist",
+  "groups_targeted_invitation_created_event",
+  "group_domain_events_immutable_update",
+  "group_domain_events_immutable_delete",
+]) {
+  requireText(migration, marker, `Groups enforcement event migration is missing ${marker}`);
+}
+
+for (const marker of [
+  "stored lifecycle active count",
+  "Direct suspend/revoke command",
+  "shared Groups enforcement command",
+  "neutral moderation subject adapter",
+]) {
+  requireText(plan, marker, `Canonical Groups plan is missing ${marker}`);
+}
+
+for (const marker of [
+  "Member-count semantics",
+  "stored lifecycle active count",
+  "receipt replay",
+  "local moderation cannot erase moderation-decision provenance",
+  "m20260808_000009_extend_group_domain_events_for_membership_enforcement",
+  "cargo test -p rustok-groups",
+]) {
+  requireText(docs, marker, `Groups enforcement command handoff is missing ${marker}`);
+}
+
+console.log("Groups membership enforcement command source guard passed");

--- a/scripts/verify/verify-groups-membership-enforcement-read-path.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-read-path.mjs
@@ -9,9 +9,12 @@ const files = {
   dto: "crates/rustok-groups/src/dto.rs",
   ports: "crates/rustok-groups/src/ports.rs",
   service: "crates/rustok-groups/src/membership_enforcement.rs",
+  command: "crates/rustok-groups/src/membership_enforcement_command.rs",
   entities: "crates/rustok-groups/src/membership_enforcement_entities.rs",
   migration:
     "crates/rustok-groups/src/migrations/m20260723_000008_create_group_membership_enforcement_state.rs",
+  eventMigration:
+    "crates/rustok-groups/src/migrations/m20260808_000009_extend_group_domain_events_for_membership_enforcement.rs",
   migrationRegistry: "crates/rustok-groups/src/migrations/mod.rs",
   module: "crates/rustok-groups/src/lib.rs",
   registry: "crates/rustok-groups/contracts/groups-fba-registry.json",
@@ -54,10 +57,8 @@ if (failures.length === 0) {
     "GroupMembershipEnforcementReadPort",
     "read_membership_enforcement",
     "SharedGroupMembershipEnforcementReadPort",
+    "GroupMembershipEnforcementCommandPort",
   ]);
-  if (read(files.ports).includes("GroupMembershipEnforcementCommandPort")) {
-    failures.push(`${files.ports}: read-only slice must not publish enforcement commands`);
-  }
   requireMarkers(files.service, [
     "GroupMembershipEnforcementService",
     "resolve_group_membership_enforcement",
@@ -68,6 +69,8 @@ if (failures.length === 0) {
     "&effective_from <= evaluated_at",
     "evaluated_at < until",
     "moderation-driven enforcement decision identity is invalid",
+    "group owner reference and owner membership role disagree",
+    "membership.user_id == group_owner_user_id",
     "groups.membership_enforcement_forbidden",
     '"groups:access:read"',
     '"groups:moderate"',
@@ -81,10 +84,21 @@ if (failures.length === 0) {
     "policy_snapshot:",
     "appeal_id",
   ]) {
-    if (read(files.service).includes(forbidden) || read(files.entities).includes(forbidden)) {
-      failures.push(`Groups enforcement read boundary contains forbidden owner copy/import ${JSON.stringify(forbidden)}`);
+    if (
+      read(files.service).includes(forbidden) ||
+      read(files.command).includes(forbidden) ||
+      read(files.entities).includes(forbidden)
+    ) {
+      failures.push(`Groups enforcement boundary contains forbidden owner copy/import ${JSON.stringify(forbidden)}`);
     }
   }
+  requireMarkers(files.command, [
+    "GroupMembershipEnforcementCommandService",
+    "apply_membership_suspension_in_tx",
+    "revoke_membership_suspension_in_tx",
+    "expected_membership_revision",
+    "bump_group_version_without_member_count_change",
+  ]);
   requireMarkers(files.entities, [
     'table_name = "group_memberships"',
     "pub revision: i64",
@@ -110,28 +124,39 @@ if (failures.length === 0) {
     "groups_27_membership_enforcement_revision_bump",
     "groups_30_enforcement_membership_revision_insert",
   ]);
+  requireMarkers(files.eventMigration, [
+    "groups.membership.suspended",
+    "groups.membership.suspension_revoked",
+    "cannot downgrade Groups membership enforcement events while append-only membership events exist",
+  ]);
   requireMarkers(files.migrationRegistry, [
     "m20260723_000008_create_group_membership_enforcement_state",
+    "m20260808_000009_extend_group_domain_events_for_membership_enforcement",
   ]);
   requireMarkers(files.module, [
     "pub mod membership_enforcement;",
-    "pub mod membership_enforcement_entities;",
+    "mod membership_enforcement_command;",
     "GroupMembershipEnforcementService",
-    "module.migrations().len(), 8",
+    "GroupMembershipEnforcementCommandService",
+    "module.migrations().len(), 9",
   ]);
   requireMarkers(files.registry, [
     '"name": "GroupMembershipEnforcementReadPort"',
+    '"name": "GroupMembershipEnforcementCommandPort"',
     '"effective_clock": "groups_owner_utc_clock"',
     '"legacy_banned_behavior": "deny_reentry"',
-    '"command_port": "not_published_in_this_slice"',
-    '"access_path_integration": "open"',
+    '"direct_command_port": "implemented_source"',
+    '"access_path_integration": "implemented_source"',
+    '"moderation_adapter": "not_published_in_this_slice"',
   ]);
   requireMarkers(files.plan, [
-    "membership revision and read-only enforcement projection/resolver are source-complete",
+    "Source-complete direct enforcement command",
     "GroupMembershipEnforcementReadPort",
-    "status-only access-path conversion remains open",
+    "GroupMembershipEnforcementCommandPort",
+    "neutral moderation subject adapter",
     "GROUPS-07 | in_progress",
     "verify-groups-membership-enforcement-read-path.mjs",
+    "verify-groups-membership-enforcement-command.mjs",
   ]);
 }
 
@@ -142,5 +167,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Groups monotonic membership revision, bounded enforcement projection, owner-clock resolver, read port, and open integration gates passed source verification.",
+  "Groups monotonic membership revision, bounded enforcement projection, owner-clock resolver, direct command seam, and open moderation/runtime gates passed source verification.",
 );


### PR DESCRIPTION
## Summary
- add the first Groups-owned direct membership enforcement write boundary with `GroupMembershipEnforcementCommandPort`
- add replay-safe single-membership suspend/revoke commands with a real user actor, bounded idempotency key, exact expected membership revision, local hierarchy/platform authority and hard owner/self-target protection
- reuse the established Groups lock family: group serialization, deterministic membership UUID order and enforcement membership-ID order
- add shared crate-private suspension/revocation owner mutations reserved for the later neutral Moderation adapter so Groups keeps one enforcement write path
- keep `groups.member_count` as stored-lifecycle active count: temporary owner-clock suspension/revocation does not change it, while every enforcement mutation advances `groups.version` and trigger-owned membership revision
- preserve direct-local vs moderation-decision provenance; direct revoke cannot erase active moderation-decision enforcement and does not overwrite the original suspension actor/source
- harden the canonical effective resolver so owner-role identity drift (`role=owner` vs `groups.owner_user_id`) fails closed for all effective-authority reads
- extend append-only `group_domain_events` on PostgreSQL/SQLite for exact membership suspended/revoked semantic events, with downgrade refusal while membership history exists
- publish the command through module capability metadata and the FBA registry while leaving GraphQL/runtime evidence explicitly open
- update the canonical Groups plan, README, focused contract docs and enforcement source guards

## Plan context
The canonical GROUPS-07 plan requires a direct suspend/revoke owner command and shared Groups mutation path before the neutral Moderation adapter. This PR closes that source prerequisite without importing Moderation owner persistence or creating a second enforcement model.

The next moderation-specific slice can add `rustok-moderation-api`/producer receipt integration and map `GroupMembership + SuspendSubject { effective_until }` onto these shared owner mutations.

## Verification
Static source review only. Cargo commands, tests, Node source guards, formatters, PostgreSQL/SQLite migrations, workflows and CI were intentionally not run per maintainer request.