### PR TITLE
feat(product): bound Storefront title search for Index parity

### DIFF
--- a/crates/rustok-distribution/src/product_index/storefront_shadow.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow.rs
@@ -9,11 +9,11 @@ use rustok_index::{
 use rustok_product::{
     ProductAttributeTermExpr, ProductResolvedAttributeFilter, StorefrontProductListQuery,
     StorefrontProductSortBy, StorefrontProductSortDirection, entities::product::ProductStatus,
+    services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES,
 };
 
 use super::PRODUCT_SCHEMA_ROUTING_KEY;
 
-const MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024;
 const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;
 const MAX_STOREFRONT_ATTRIBUTE_FILTERS: usize = 8;
 
@@ -116,10 +116,10 @@ pub(crate) fn build_product_storefront_index_shadow_query(
         .map(str::trim)
         .filter(|search| !search.is_empty())
         .map(|search| {
-            let pattern = format!("%{search}%");
-            if pattern.len() > MAX_TEXT_LIKE_PATTERN_BYTES {
+            if search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES {
                 return Err(ProductStorefrontIndexShadowError::SearchPatternTooLong);
             }
+            let pattern = format!("%{search}%");
             if pattern.contains('\0') {
                 return Err(ProductStorefrontIndexShadowError::SearchPatternContainsNul);
             }
@@ -423,6 +423,23 @@ mod tests {
                 vec![attribute_term()],
             ),
             Err(ProductStorefrontIndexShadowError::OffsetTooDeep)
+        );
+    }
+
+    #[test]
+    fn fails_closed_when_public_query_fields_bypass_owner_search_constructor_bound() {
+        let mut owner = owner_query(StorefrontProductSortDirection::Asc);
+        owner.search = Some("a".repeat(MAX_STOREFRONT_PRODUCT_SEARCH_BYTES + 1));
+        assert_eq!(
+            build_product_storefront_index_shadow_query(
+                Uuid::new_v4(),
+                "fi",
+                "en",
+                Some(Uuid::new_v4()),
+                &owner,
+                vec![attribute_term()],
+            ),
+            Err(ProductStorefrontIndexShadowError::SearchPatternTooLong)
         );
     }
 }

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product Storefront EAV PostgreSQL packet merge
-`2098ab10cbac4741d83a06f49bb4de21a605b909` and continued on
-`agent/index-product-postgres-key4-actualize-20260808`.
+Status overlay rechecked after retained Product PostgreSQL key-4 actualization merge
+`07117d8c88608625a941de501464002aa835897d` and continued on
+`agent/product-storefront-search-bound-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -20,60 +20,46 @@ Source-complete:
 - one current 15-field Product schema on routing key `4`; lower keys are historical storage identities only;
 - schema-scoped Product replay IDs, Product owner clock and canonical typed `attribute_terms`;
 - Product channel relation/freshness materialization;
-- localized entity identity fold, scoped cursor v3 and requested -> fallback projection;
-- localized PostgreSQL compiler/decoder/runtime with persisted readiness, generic admission and one
-  `REPEATABLE READ, READ ONLY` page/count snapshot;
-- bounded generic String `TextLike` for all-translations title matching;
+- localized entity identity fold, cursor v3 and requested -> fallback projection;
+- localized PostgreSQL compiler/decoder/runtime with readiness/admission and one repeatable-read page/count snapshot;
+- generic String `TextLike` with a 1024-byte pattern bound;
+- Product-owned Storefront title-search input bound of 1022 effective UTF-8 bytes, leaving exactly two bytes
+  for the owner `%{search}%` pattern without truncation;
 - localized Product-ID tie-break direction matching owner Asc/Desc ordering;
 - Product-owned public Storefront attribute-filter -> neutral canonical term resolution;
-- pure Storefront shadow builder consuming only `ProductResolvedAttributeFilter`;
+- pure Storefront shadow builder consuming only Product-owned filter terms and the Product-owned search bound;
 - non-serving owner-first `ProductStorefrontIndexShadowExecutor`;
-- current-key core Product Storefront owner-vs-shadow PostgreSQL packet source;
-- separate current-key Product Storefront EAV owner-vs-shadow PostgreSQL packet source;
-- historical retained Product PostgreSQL fixtures actualized to current Product routing key `4` without a
-  key-3 runtime alias.
+- current-key core and EAV Product Storefront owner-vs-shadow PostgreSQL packet source;
+- historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
-The core packet retains localized projection/search, identity de-duplication, equal-timestamp ordering,
-page/count and public-channel scenarios. The EAV packet isolates Product term resolution/materialization and
-retains integer, localized requested/fallback, Select/Multiselect option code, direct option UUID and
-missing/nil option `Never` scenarios. Both remain source-only until maintainer execution.
+The Product search bound is enforced both by `StorefrontProductListQuery::try_new*` and immediately before
+`CatalogService::list_published_products_with_query` constructs owner SQL. Public struct fields therefore
+cannot bypass the owner contract. Distribution imports the same Product constant; it no longer owns a second
+Product-specific search length value.
 
-Historical Product freshness, locale-absence, Channel convergence/identity-transition and linked-target
-recreate/availability/replay packets now target the same current Product key `4`. Their scenario semantics are
-unchanged; ProductVariant remains key `2` and SalesChannel remains key `1`.
-
-The core Storefront packet also records a public projection gap: owner uses `Untitled product`/empty handle
-when no requested/fallback translation exists, while generic localized Index returns null. Final Storefront
-projection must apply public placeholders only after Product page identity/order/count are fixed.
+Core/EAV Storefront packets and historical Product packets remain source-only until maintainer execution.
+The core packet also retains the no-requested/fallback-translation projection gap: owner emits
+`Untitled product`/empty handle while generic localized Index returns null.
 
 ## Remaining Storefront parity/evidence blockers
 
-- execute/review both current-key Storefront PostgreSQL packets and the actualized retained Product packets;
-  source presence is not evidence admission;
-- owner title search has no explicit length bound vs Index `TextLike` 1024-byte bound;
-- owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`;
+- execute/review current-key Storefront and actualized retained Product PostgreSQL packets;
+- owner/default PostgreSQL title `LIKE` collation vs Index deterministic `COLLATE "C"`;
 - channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
 - owner page depth exceeds Index bounded offset depth;
-- map localized null title/handle to owner public placeholders in final Storefront projection;
-- localized Taxonomy tag names must be hydrated after Product page identity/count is fixed;
-- shadow execution has no serving latency/deadline policy and must remain non-serving;
-- stale locale/readiness/admission/restart evidence still requires maintainer execution/extension.
+- map localized null title/handle to owner public placeholders in final projection;
+- hydrate localized Taxonomy tag names only after Product page identity/count is fixed;
+- define serving latency/deadline policy before any shadow-to-serving transition;
+- complete maintainer-executed stale locale/readiness/admission/restart evidence.
 
 ## Retained Product evidence state
 
-The retained Product PostgreSQL fixture set is now source-aligned on routing key `4`:
+The retained Product PostgreSQL fixture set is source-aligned on routing key `4`: locale absence, materialized
+query freshness, Product/Channel convergence, Channel identity transitions, linked-target delete/recreate,
+linked-target availability equivalence and linked-target replay/redelivery. ProductVariant remains key `2`
+and SalesChannel remains key `1`.
 
-- Product locale absence;
-- Product materialized query freshness;
-- Product/Channel convergence;
-- Channel identity transitions;
-- linked-target delete/recreate;
-- linked-target availability equivalence;
-- linked-target replay/redelivery.
-
-`verify-index-product-postgres-key4-fixtures.mjs` prevents these packets from restoring Product key `3` while
-also pinning the current 15-field Product bridge and unchanged ProductVariant/SalesChannel target keys.
-Execution and evidence admission remain separate maintainer gates.
+`verify-index-product-postgres-key4-fixtures.mjs` locks that boundary. Execution/admission remains separate.
 
 ## M5 incremental ingestion
 
@@ -101,18 +87,15 @@ Execution and evidence admission remain separate maintainer gates.
 - [x] Localized identity/fallback architecture and query/cursor contract.
 - [x] Localized PostgreSQL compiler/decoder/runtime.
 - [x] Generic scalar String `TextLike`.
+- [x] Product-owned 1022-byte Storefront search input bound compatible with the 1024-byte TextLike pattern.
 - [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
 - [x] Product Storefront Index shadow/evidence query builder.
-- [x] Product-owned Storefront attribute-filter resolution to neutral canonical term expressions.
-- [x] Wire Product term expressions into the shadow builder.
+- [x] Product-owned Storefront attribute-filter resolution.
 - [x] Compose non-serving Product-owner + Index shadow executor.
-- [x] Retain current-key core owner-vs-shadow localized PostgreSQL packet source.
-- [x] Retain Product EAV owner-vs-shadow PostgreSQL packet source.
+- [x] Retain current-key core and EAV owner-vs-shadow PostgreSQL packet source.
 - [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
-- [ ] Execute/review the core Storefront PostgreSQL packet.
-- [ ] Execute/review the EAV Storefront PostgreSQL packet.
-- [ ] Execute/review the actualized retained Product PostgreSQL packets.
-- [ ] Resolve/admit search-length and collation parity.
+- [ ] Execute/review the retained Product/Storefront PostgreSQL packets.
+- [ ] Resolve/admit owner/default vs Index `COLLATE "C"` title-search collation parity.
 - [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
 - [ ] Decide authoritative deep-page policy.
 - [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
@@ -124,10 +107,10 @@ Execution and evidence admission remain separate maintainer gates.
 
 ## Next source-code step
 
-Keep serving owner-native and resolve the next source-level parity mismatch: establish an authoritative Product
-Storefront title-search length contract compatible with bounded Index `TextLike`, then retain explicit
-PostgreSQL collation evidence. Do not silently truncate owner-valid input or weaken deterministic Index
-collation.
+Retain explicit PostgreSQL collation equivalence evidence for the owner all-translations `pt.title LIKE $1`
+query versus Index `TextLike` compiled with deterministic `COLLATE "C"`. The packet must include ASCII,
+non-ASCII/case-sensitive and wildcard/escape cases and must not weaken Index deterministic collation merely to
+match one deployment's database default.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `core_eav_and_retained_key4_packets_source_complete_execution_pending`.
+Status: `search_bound_source_complete_collation_evidence_pending`.
 
 ## Current boundary
 
@@ -8,10 +8,28 @@ Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
 The Product-owned EAV resolver, pure localized shadow builder and non-serving owner-first shadow executor are
-source-complete. Two current-key PostgreSQL owner-vs-shadow Storefront packets are retained in source: the
-localized core packet and a separate EAV packet. Historical retained Product PostgreSQL packets are also
-source-actualized to Product routing key `4`. None of those packets has been executed or admitted by the
-implementation agent.
+source-complete. Current-key core/EAV Storefront PostgreSQL packets and the historical retained Product
+PostgreSQL packet set are retained in source on Product routing key `4`. They have **not** been executed or
+admitted by the implementation agent.
+
+## Product-owned Storefront search bound — source complete
+
+Product now owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022` as the authoritative effective title-search
+input bound, measured in UTF-8 bytes after whitespace normalization. The owner SQL wraps the effective search
+as `%{search}%`; the two ASCII wildcard bytes make the resulting pattern exactly representable by the generic
+Index `TextLike` maximum of 1024 bytes.
+
+`StorefrontProductListQuery::try_new*` validates the normalized input, and
+`CatalogService::list_published_products_with_query` validates again immediately before constructing owner
+SQL. The second check is deliberate because the query struct has public fields and may be constructed without
+its helpers. Over-bound input is rejected; it is never truncated.
+
+The Index shadow builder imports the same Product-owned constant through
+`rustok_product::services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES`. Distribution no longer owns a duplicate
+Product-specific pattern bound. A manually constructed over-bound owner query remains fail-closed in shadow
+translation. Generic Index validation continues to own the independent 1024-byte `TextLike` pattern contract.
+
+This closes the source-level search-length mismatch only. It does not establish PostgreSQL collation parity.
 
 ## Product-owned EAV resolution and shadow execution
 
@@ -44,74 +62,53 @@ serving projection must map that null state only after Product page identity/ord
 ## EAV PostgreSQL packet — source complete, execution pending
 
 `storefront_shadow_eav_postgres_tests.rs` is a separate crate-internal opt-in packet on routing key `4`.
-Its clean fixture seeds real active/filterable Product attributes, active options and value rows before the
-first Index materialization, then uses the real Product resolver and shadow executor side-by-side.
-
-The packet retains source scenarios for:
-
-- nonlocalized integer term (`weight=7`);
-- requested localized text (`label=Punainen`);
-- requested-locale-present fallback suppression plus requested-missing fallback (`label=Red` admits B, not A);
-- Select exact option code (`color=red` / `color=blue`);
-- direct Select option UUID;
-- Multiselect exact option code (`features=wifi`);
-- missing option code -> Product `Never` -> empty owner/Index result;
-- nil option UUID -> Product `Never` -> empty owner/Index result;
-- owner/Index ordered identity list, exact count and page-boundary agreement for every scenario.
+It retains nonlocalized integer, localized requested/fallback, Select exact option code, direct option UUID,
+Multiselect exact option code and missing/nil option `Never` behavior, including owner/Index identity/count
+agreement.
 
 The EAV fixture deliberately does not call `save_product_attribute_values`: Product EAV owner-clock command
-semantics already have a separate retained gate. This packet isolates query resolution/materialization parity
-from command-publication evidence.
+semantics have a separate retained gate, so query resolution/materialization failures remain attributable.
 
 ## Historical retained Product packets — key 4 source actualized
 
-The following retained PostgreSQL fixtures now use the current Product routing key `4` while preserving their
-existing scenario semantics:
+The retained Product locale-absence, materialized-freshness, Product/Channel convergence, Channel
+identity-transition and linked-target recreate/availability/replay packets use current Product routing key
+`4` while preserving their scenarios. ProductVariant stays on key `2`, SalesChannel stays on key `1`, and no
+Product key-3 compatibility path exists.
 
-- `product_locale_absence_postgres.rs`;
-- `product_materialized_query_freshness_postgres.rs`;
-- `product_channel_convergence_postgres.rs`;
-- `product_channel_identity_transitions_postgres.rs`;
-- `product_linked_target_recreate_postgres.rs`;
-- `product_linked_target_availability_equivalence_postgres.rs`;
-- `product_linked_target_replay_redelivery_postgres.rs`.
-
-They continue to build the real distribution schema/source registries, so current Product materialization is
-against the 15-field key-4 contract rather than a test-only compatibility schema. ProductVariant stays on key
-`2`, SalesChannel stays on key `1`, and no Product key-3 runtime alias exists.
-
-`verify-index-product-postgres-key4-fixtures.mjs` locks that boundary. Actualization is source maintenance,
-not proof that the packets pass; execution/review remains a maintainer gate.
+`verify-index-product-postgres-key4-fixtures.mjs` locks that boundary. Source actualization does not claim that
+the packets pass; execution/review remains a maintainer gate.
 
 ## Remaining fail-closed parity/evidence gates
 
-1. Maintainer execution/review of the Storefront core/EAV packets and actualized retained Product packets;
-   source presence is not evidence admission.
-2. Search-length mismatch: owner search is not explicitly bounded while Index `TextLike` is capped at 1024
-   UTF-8 bytes.
-3. Owner/default PostgreSQL collation vs Index deterministic `COLLATE "C"`.
-4. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot represent
+1. Maintainer execution/review of the Storefront core/EAV and actualized retained Product PostgreSQL packets.
+2. Owner/default PostgreSQL `pt.title LIKE $1` collation vs Index deterministic `COLLATE "C"`.
+3. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot represent
    that distinction exactly.
-5. Owner page depth exceeds the Index 10,000 offset bound.
-6. Final Storefront projection must map no-localized-row null title/handle to owner placeholders.
-7. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
-8. Shadow execution has no serving latency/deadline policy and remains non-serving.
-9. Stale locale/readiness/admission/restart cases still need maintainer-executed retained Storefront evidence.
+4. Owner page depth exceeds the Index 10,000 offset bound.
+5. Final Storefront projection must map no-localized-row null title/handle to owner placeholders.
+6. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
+7. Shadow execution has no serving latency/deadline policy and remains non-serving.
+8. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
 
 ## Next source slice
 
-Establish an authoritative Product Storefront title-search length contract compatible with bounded Index
-`TextLike`. Do not silently truncate owner-valid input. After that contract is source-aligned, retain explicit
-PostgreSQL evidence for owner/default title `LIKE` collation versus deterministic Index `COLLATE "C"`.
+Retain explicit PostgreSQL collation evidence for owner all-translations `pt.title LIKE $1` versus Index
+`TextLike` compiled with deterministic `COLLATE "C"`. Include ASCII, non-ASCII/case-sensitive and
+wildcard/escape cases. Do not weaken deterministic Index collation merely to match one deployment's database
+default; if the owner deployment collation cannot preserve equivalence, keep the cutover fail-closed and make
+the deployment/owner contract explicit.
 
 ## Source guards
 
 - `verify-product-storefront-attribute-filter-terms.mjs` locks Product-owned EAV resolution;
+- `verify-product-storefront-search-bound.mjs` locks the Product-owned 1022-byte effective search bound and
+  proves that adding the two owner LIKE wildcards equals the generic 1024-byte Index `TextLike` bound;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;
 - `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution;
 - `verify-index-product-storefront-equivalence-postgres-packet.mjs` locks the core current-key packet;
 - `verify-index-product-storefront-eav-equivalence-postgres-packet.mjs` locks the EAV current-key packet;
-- `verify-index-product-postgres-key4-fixtures.mjs` locks all actualized retained Product packets on key `4`;
+- `verify-index-product-postgres-key4-fixtures.mjs` locks actualized retained Product packets on key `4`;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or

--- a/crates/rustok-product/src/services/catalog.rs
+++ b/crates/rustok-product/src/services/catalog.rs
@@ -8,8 +8,9 @@ mod tags;
 pub mod types;
 
 pub use types::{
-    AdminProductList, AdminProductListItem, AdminProductListQuery, ProductAttributeFilter,
-    ProductTagState, StorefrontProductList, StorefrontProductListItem, StorefrontProductListQuery,
+    AdminProductList, AdminProductListItem, AdminProductListQuery,
+    MAX_STOREFRONT_PRODUCT_SEARCH_BYTES, ProductAttributeFilter, ProductTagState,
+    StorefrontProductList, StorefrontProductListItem, StorefrontProductListQuery,
     StorefrontProductSortBy, StorefrontProductSortDirection,
 };
 

--- a/crates/rustok-product/src/services/catalog/queries.rs
+++ b/crates/rustok-product/src/services/catalog/queries.rs
@@ -38,6 +38,7 @@ impl CatalogService {
                 "page must be at least 1 and per_page must be between 1 and 48".to_owned(),
             ));
         }
+        types::validate_storefront_product_search(list_query.search.as_deref())?;
         let offset = (page.saturating_sub(1)) * per_page;
 
         let mut query = entities::product::Entity::find()

--- a/crates/rustok-product/src/services/catalog/types.rs
+++ b/crates/rustok-product/src/services/catalog/types.rs
@@ -8,6 +8,13 @@ const MAX_ATTRIBUTE_FILTERS: usize = 8;
 const MAX_ATTRIBUTE_FILTER_CODE_LENGTH: usize = 128;
 const MAX_ATTRIBUTE_FILTER_VALUE_LENGTH: usize = 512;
 
+/// Maximum effective Storefront Product title-search input in UTF-8 bytes.
+///
+/// The owner query wraps the effective search with one leading and one trailing `%`. The shared Index
+/// `TextLike` contract accepts at most 1024 bytes, so 1022 keeps the owner-owned search surface exactly
+/// representable without truncation in the non-serving Index shadow path.
+pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum StorefrontProductSortBy {
     #[default]
@@ -180,7 +187,7 @@ impl StorefrontProductListQuery {
         attribute_filters: Vec<String>,
     ) -> CommerceResult<Self> {
         Ok(Self {
-            search: normalize_optional_text(search),
+            search: normalize_storefront_product_search(search)?,
             category_id,
             sort_by: StorefrontProductSortBy::parse(sort_by)?,
             sort_direction: StorefrontProductSortDirection::parse(sort_direction)?,
@@ -331,6 +338,27 @@ pub struct ProductTagState {
     pub tags: Vec<String>,
 }
 
+pub(crate) fn validate_storefront_product_search(search: Option<&str>) -> CommerceResult<()> {
+    let Some(search) = search
+        .map(str::trim)
+        .filter(|search| !search.is_empty())
+    else {
+        return Ok(());
+    };
+    if search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES {
+        return Err(CommerceError::Validation(format!(
+            "search must contain at most {MAX_STOREFRONT_PRODUCT_SEARCH_BYTES} UTF-8 bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_storefront_product_search(value: Option<String>) -> CommerceResult<Option<String>> {
+    let value = normalize_optional_text(value);
+    validate_storefront_product_search(value.as_deref())?;
+    Ok(value)
+}
+
 fn normalize_optional_text(value: Option<String>) -> Option<String> {
     value
         .map(|value| value.trim().to_string())
@@ -372,6 +400,42 @@ mod tests {
                 None,
                 None,
                 vec!["color".to_string()],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn storefront_search_bound_uses_effective_utf8_bytes() {
+        let ascii = "a".repeat(MAX_STOREFRONT_PRODUCT_SEARCH_BYTES);
+        assert_eq!(
+            StorefrontProductListQuery::try_new(Some(format!("  {ascii}  ")), None, None, None)
+                .expect("bounded search must be accepted")
+                .search
+                .as_deref(),
+            Some(ascii.as_str())
+        );
+        assert!(
+            StorefrontProductListQuery::try_new(
+                Some("a".repeat(MAX_STOREFRONT_PRODUCT_SEARCH_BYTES + 1)),
+                None,
+                None,
+                None,
+            )
+            .is_err()
+        );
+
+        let multibyte = "é".repeat(MAX_STOREFRONT_PRODUCT_SEARCH_BYTES / 2);
+        assert_eq!(multibyte.len(), MAX_STOREFRONT_PRODUCT_SEARCH_BYTES);
+        assert!(
+            StorefrontProductListQuery::try_new(Some(multibyte), None, None, None).is_ok()
+        );
+        assert!(
+            StorefrontProductListQuery::try_new(
+                Some("é".repeat(MAX_STOREFRONT_PRODUCT_SEARCH_BYTES / 2 + 1)),
+                None,
+                None,
+                None,
             )
             .is_err()
         );

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -12,8 +12,9 @@ mod write_transaction;
 
 pub use catalog::{
     AdminProductList, AdminProductListItem, AdminProductListQuery, CatalogService,
-    ProductAttributeFilter, StorefrontProductList, StorefrontProductListItem,
-    StorefrontProductListQuery, StorefrontProductSortBy, StorefrontProductSortDirection,
+    MAX_STOREFRONT_PRODUCT_SEARCH_BYTES, ProductAttributeFilter, StorefrontProductList,
+    StorefrontProductListItem, StorefrontProductListQuery, StorefrontProductSortBy,
+    StorefrontProductSortDirection,
 };
 pub use catalog_attribute_terms::{
     ProductAttributeTermError, ProductAttributeTermExpr, ProductResolvedAttributeFilter,

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -27,12 +27,21 @@ for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'execute_loc
   if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
 }
 
+const typesPath = 'crates/rustok-product/src/services/catalog/types.rs';
+requireMarkers(typesPath, [
+  'pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;',
+  'search: normalize_storefront_product_search(search)?',
+  'pub(crate) fn validate_storefront_product_search(',
+  'search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+]);
+
 const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
 const owner = requireMarkers(ownerPath, [
   'ProductStatus::Active',
   'Column::PublishedAt.is_not_null()',
   'product_channel_visibility_condition(',
   'attribute_filters::load_catalog_attribute_filter_conditions(',
+  'types::validate_storefront_product_search(list_query.search.as_deref())?;',
   'product_title_search_condition(',
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
@@ -43,6 +52,13 @@ const owner = requireMarkers(ownerPath, [
 ]);
 const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
 if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
+const ownerValidation = owner.indexOf(
+  'types::validate_storefront_product_search(list_query.search.as_deref())?;',
+);
+const ownerSql = owner.indexOf('let mut query = entities::product::Entity::find()');
+if (ownerValidation < 0 || ownerSql <= ownerValidation) {
+  fail(`${ownerPath} must validate Storefront search before constructing owner SQL`);
+}
 
 requireMarkers('crates/rustok-product/src/catalog_schema_read_port.rs', [
   'ProductStorefrontAttributeFilterResolutionRequest',
@@ -54,6 +70,11 @@ requireMarkers('crates/rustok-product/src/services/catalog_attribute_terms.rs', 
   'pub struct ProductResolvedAttributeFilter',
   'product_attribute_localized_text_expr(',
   'ProductAttributeTermExpr::Never',
+]);
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow.rs', [
+  'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+  'if search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+  'FilterExpr::TextLike(root_field("title")?, pattern)',
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs', [
   'pub(crate) struct ProductStorefrontIndexShadowExecutor',
@@ -87,6 +108,12 @@ const productIndex = requireMarkers(productIndexPath, [
 ]);
 if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
 
+requireMarkers('scripts/verify/verify-product-storefront-search-bound.mjs', [
+  'MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022',
+  'MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024',
+  'ownerBytes + 2 !== indexBytes',
+  'reject over-bound input rather than truncate it',
+]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
   'product_locale_absence_postgres.rs',
   'product_materialized_query_freshness_postgres.rs',
@@ -100,15 +127,14 @@ requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `core_eav_and_retained_key4_packets_source_complete_execution_pending`',
+  'Status: `search_bound_source_complete_collation_evidence_pending`',
   'Mounted Storefront remains owner-native',
+  'Product-owned Storefront search bound — source complete',
+  '`MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022`',
   'Core PostgreSQL packet — source complete, execution pending',
   'EAV PostgreSQL packet — source complete, execution pending',
   'Historical retained Product packets — key 4 source actualized',
-  'routing key `4`',
-  'missing option code',
-  'nil option UUID',
-  'placeholder',
+  'Owner/default PostgreSQL `pt.title LIKE $1` collation',
   'ProductVariant stays on key',
   'SalesChannel stays on key',
 ]);
@@ -117,7 +143,8 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
   '`requested-value OR (NOT requested-present AND fallback-value)`',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-product-storefront-search-bound.mjs'",
   "'verify-index-product-postgres-key4-fixtures.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; Storefront core/EAV and retained Product PostgreSQL packets are source-aligned on key 4 while execution/admission and policy gates remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; Product search length is source-aligned with TextLike while collation, execution/admission and remaining serving-policy gates stay pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -66,6 +66,7 @@ const scripts = [
   'verify-index-product-eav-owner-clock.mjs',
   'verify-index-product-attribute-term-contract.mjs',
   'verify-product-storefront-attribute-filter-terms.mjs',
+  'verify-product-storefront-search-bound.mjs',
   'verify-index-product-variant-refresh-ledger.mjs',
   'verify-index-product-refresh-canonical-writer.mjs',
   'verify-index-product-refresh-relay-step.mjs',

--- a/scripts/verify/verify-product-storefront-search-bound.mjs
+++ b/scripts/verify/verify-product-storefront-search-bound.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-product-storefront-search-bound] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const typesPath = 'crates/rustok-product/src/services/catalog/types.rs';
+const types = requireMarkers(typesPath, [
+  'pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;',
+  'pub(crate) fn validate_storefront_product_search(',
+  'search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+  'search must contain at most {MAX_STOREFRONT_PRODUCT_SEARCH_BYTES} UTF-8 bytes',
+  'search: normalize_storefront_product_search(search)?',
+  'fn storefront_search_bound_uses_effective_utf8_bytes()',
+]);
+
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const owner = requireMarkers(ownerPath, [
+  'pub async fn list_published_products_with_query(',
+  'types::validate_storefront_product_search(list_query.search.as_deref())?;',
+  'let pattern = format!("%{search}%");',
+  'pt.title LIKE $1',
+]);
+const ownerValidation = owner.indexOf(
+  'types::validate_storefront_product_search(list_query.search.as_deref())?;',
+);
+const ownerQuery = owner.indexOf('let mut query = entities::product::Entity::find()');
+if (ownerValidation < 0 || ownerQuery <= ownerValidation) {
+  fail(`${ownerPath} must validate the Storefront search before constructing owner SQL`);
+}
+
+const shadowPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
+const shadow = requireMarkers(shadowPath, [
+  'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+  'if search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+  'let pattern = format!("%{search}%");',
+  'FilterExpr::TextLike(root_field("title")?, pattern)',
+  'fails_closed_when_public_query_fields_bypass_owner_search_constructor_bound',
+]);
+if (shadow.includes('const MAX_TEXT_LIKE_PATTERN_BYTES')) {
+  fail(`${shadowPath} must consume the Product-owned search bound instead of owning another limit`);
+}
+
+const indexValidationPath = 'crates/rustok-index/src/application/validation.rs';
+const indexValidation = requireMarkers(indexValidationPath, [
+  'const MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024;',
+]);
+
+const ownerMatch = types.match(/MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = (\d+);/);
+const indexMatch = indexValidation.match(/MAX_TEXT_LIKE_PATTERN_BYTES: usize = (\d+);/);
+if (!ownerMatch || !indexMatch) fail('could not decode owner/Index search bounds');
+const ownerBytes = Number(ownerMatch[1]);
+const indexBytes = Number(indexMatch[1]);
+if (ownerBytes + 2 !== indexBytes) {
+  fail(`Product search bound ${ownerBytes} plus two LIKE wildcards does not equal Index TextLike bound ${indexBytes}`);
+}
+
+for (const relative of [
+  'crates/rustok-product/src/services/catalog.rs',
+  'crates/rustok-product/src/services/mod.rs',
+]) {
+  requireMarkers(relative, ['MAX_STOREFRONT_PRODUCT_SEARCH_BYTES']);
+}
+
+for (const forbidden of ['truncate(', '.take(MAX_STOREFRONT_PRODUCT_SEARCH_BYTES)', 'chars().take(']) {
+  if (types.includes(forbidden) || owner.includes(forbidden) || shadow.includes(forbidden)) {
+    fail(`Storefront search contract must reject over-bound input rather than truncate it: ${forbidden}`);
+  }
+}
+
+console.log('[verify-product-storefront-search-bound] Product owns a 1022-byte Storefront search bound exactly representable by the 1024-byte Index TextLike pattern');


### PR DESCRIPTION
## Summary

- make Product own an authoritative `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022` effective UTF-8 byte bound for the modern Storefront Product list title search;
- preserve existing whitespace normalization and reject over-bound input rather than truncate it;
- enforce the bound in both `StorefrontProductListQuery::try_new*` and `CatalogService::list_published_products_with_query` before owner SQL construction so direct public query-struct construction cannot bypass the contract;
- keep owner all-translations SQL unchanged: it still binds `%{search}%` to `pt.title LIKE $1` with no locale predicate;
- re-export the Product-owned bound through `rustok_product::services` and make the non-serving Index shadow builder consume that exact value instead of owning a second Product-specific limit;
- retain shadow fail-closed behavior for manually constructed over-bound queries;
- add a source guard that decodes Product's 1022-byte bound and generic Index's 1024-byte `TextLike` pattern bound and requires `1022 + 2 == 1024`, accounting for the two owner `%` wildcards;
- update the M7 cursor/parity gate so search length is source-aligned while PostgreSQL collation remains the next independent blocker.

## Boundary

This PR does not change owner title-search matching semantics, truncate input, weaken generic Index `TextLike`, resolve owner/default PostgreSQL collation vs Index `COLLATE "C"`, alter channel-less/deep-page policy, map localized null placeholders, hydrate Taxonomy tags, execute retained PostgreSQL evidence, or switch Storefront traffic.

The admin Product list search contract and legacy compatibility list are not widened into this modern Storefront/Index parity contract.

## Main recheck

The branch is based on current `main@07117d8c88608625a941de501464002aa835897d`; final compare is ahead-only with 10 expected Product/Index source, guard and documentation files.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.