### PR TITLE
test(index): retain Product Storefront collation parity packet

### DIFF
--- a/crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs
+++ b/crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs
@@ -2,6 +2,7 @@
 
 use std::{env, error::Error};
 
+use rustok_core::MigrationSource;
 use rustok_index::IndexModule;
 use sea_orm::{
     ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value,
@@ -274,7 +275,7 @@ async fn seed_titles(db: &DatabaseConnection) -> TestResult<()> {
     db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT_ID}')"))
         .await?;
     for (offset, (product_id, title, handle)) in products.into_iter().enumerate() {
-        let translation_id = Uuid::from_u128(0x7300 + offset as u128 + 1);
+        let translation_id = Uuid::from_u128(0x7300_u128 + offset as u128 + 1);
         db.execute(Statement::from_sql_and_values(
             DbBackend::Postgres,
             "INSERT INTO products (id, tenant_id) VALUES ($1, $2)",

--- a/crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs
+++ b/crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs
@@ -1,0 +1,327 @@
+#![cfg(feature = "mod-product")]
+
+use std::{env, error::Error};
+
+use rustok_index::IndexModule;
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value,
+};
+use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_PRODUCT_STOREFRONT_COLLATION_DATABASE_URL";
+const TENANT_ID: Uuid = Uuid::from_u128(0x7100);
+const PRODUCT_NEEDLE_UPPER: Uuid = Uuid::from_u128(0x7201);
+const PRODUCT_NEEDLE_LOWER: Uuid = Uuid::from_u128(0x7202);
+const PRODUCT_CAFE_NFC: Uuid = Uuid::from_u128(0x7203);
+const PRODUCT_CAFE_NFD: Uuid = Uuid::from_u128(0x7204);
+const PRODUCT_UNDERSCORE: Uuid = Uuid::from_u128(0x7205);
+const PRODUCT_UNDERSCORE_WILDCARD: Uuid = Uuid::from_u128(0x7206);
+const PRODUCT_PERCENT: Uuid = Uuid::from_u128(0x7207);
+const PRODUCT_PERCENT_WILDCARD: Uuid = Uuid::from_u128(0x7208);
+const PRODUCT_STRASSE_SHARP_S: Uuid = Uuid::from_u128(0x7209);
+const PRODUCT_STRASSE_ASCII: Uuid = Uuid::from_u128(0x7210);
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct ProductMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for ProductMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_product::migrations::migrations()
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    query: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Product Storefront collation packet"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_product_storefront_collation_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let query = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("product_storefront_collation_{suffix}"),
+        )
+        .await?;
+        create_product_migration_prerequisites(&query).await?;
+        ProductMigrator::up(&query, None).await?;
+        // Keep Index migrations in the retained packet so the database shape is compatible with the
+        // same distribution evidence environment used by the owner-vs-shadow packets. The collation
+        // probe itself intentionally compares the two exact LIKE expressions on the owner column.
+        let manager = SchemaManager::new(&query);
+        for migration in IndexModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        seed_titles(&query).await?;
+
+        Ok(Some(Self {
+            control,
+            query,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.query.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LikeCase {
+    label: &'static str,
+    search: &'static str,
+    expected_c_ids: &'static [Uuid],
+}
+
+const CASES: &[LikeCase] = &[
+    LikeCase {
+        label: "ASCII case-sensitive upper",
+        search: "Needle",
+        expected_c_ids: &[PRODUCT_NEEDLE_UPPER],
+    },
+    LikeCase {
+        label: "ASCII case-sensitive lower",
+        search: "needle",
+        expected_c_ids: &[PRODUCT_NEEDLE_LOWER],
+    },
+    LikeCase {
+        label: "Unicode NFC remains byte-distinct",
+        search: "café",
+        expected_c_ids: &[PRODUCT_CAFE_NFC],
+    },
+    LikeCase {
+        label: "Unicode NFD remains byte-distinct",
+        search: "cafe\u{301}",
+        expected_c_ids: &[PRODUCT_CAFE_NFD],
+    },
+    LikeCase {
+        label: "underscore wildcard",
+        search: "A_B",
+        expected_c_ids: &[PRODUCT_UNDERSCORE, PRODUCT_UNDERSCORE_WILDCARD],
+    },
+    LikeCase {
+        label: "escaped underscore literal",
+        search: r"A\_B",
+        expected_c_ids: &[PRODUCT_UNDERSCORE],
+    },
+    LikeCase {
+        label: "percent wildcard",
+        search: "100%",
+        expected_c_ids: &[PRODUCT_PERCENT, PRODUCT_PERCENT_WILDCARD],
+    },
+    LikeCase {
+        label: "escaped percent literal",
+        search: r"100\%",
+        expected_c_ids: &[PRODUCT_PERCENT],
+    },
+    LikeCase {
+        label: "sharp-s remains distinct from ASCII SS",
+        search: "straße",
+        expected_c_ids: &[PRODUCT_STRASSE_SHARP_S],
+    },
+    LikeCase {
+        label: "ASCII SS remains distinct from sharp-s",
+        search: "STRASSE",
+        expected_c_ids: &[PRODUCT_STRASSE_ASCII],
+    },
+];
+
+#[tokio::test]
+async fn product_storefront_default_like_matches_index_c_collation_matrix() -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+
+    let outcome = run_collation_matrix(&database.query).await;
+    let cleanup = database.cleanup().await;
+    outcome?;
+    cleanup
+}
+
+async fn run_collation_matrix(db: &DatabaseConnection) -> TestResult<()> {
+    let lc_collate = current_lc_collate(db).await?;
+    for case in CASES {
+        let owner_ids = title_like_ids(db, case.search, false).await?;
+        let index_c_ids = title_like_ids(db, case.search, true).await?;
+        assert_eq!(
+            index_c_ids,
+            case.expected_c_ids,
+            "retained C-collation expectation changed for {}",
+            case.label
+        );
+        if owner_ids != index_c_ids {
+            return Err(std::io::Error::other(format!(
+                "Product Storefront title LIKE collation mismatch for {} under lc_collate={lc_collate:?}: owner-default={owner_ids:?}, index-C={index_c_ids:?}",
+                case.label,
+            ))
+            .into());
+        }
+    }
+    Ok(())
+}
+
+async fn title_like_ids(
+    db: &DatabaseConnection,
+    search: &str,
+    explicit_c_collation: bool,
+) -> TestResult<Vec<Uuid>> {
+    let pattern = format!("%{search}%");
+    let sql = if explicit_c_collation {
+        r#"
+SELECT translation.product_id
+FROM product_translations translation
+WHERE translation.tenant_id = $1
+  AND (translation.title COLLATE "C") LIKE $2 ESCAPE E'\\'
+ORDER BY translation.product_id ASC
+"#
+    } else {
+        // Mirrors Product owner `product_title_search_condition`: no explicit collation and no explicit
+        // ESCAPE clause. PostgreSQL's default LIKE escape remains backslash.
+        r#"
+SELECT translation.product_id
+FROM product_translations translation
+WHERE translation.tenant_id = $1
+  AND translation.title LIKE $2
+ORDER BY translation.product_id ASC
+"#
+    };
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            vec![TENANT_ID.into(), pattern.into()],
+        ))
+        .await?;
+    rows.into_iter()
+        .map(|row| row.try_get("", "product_id").map_err(Into::into))
+        .collect()
+}
+
+async fn current_lc_collate(db: &DatabaseConnection) -> TestResult<String> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT current_setting('lc_collate') AS lc_collate",
+            Vec::<Value>::new(),
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other("PostgreSQL lc_collate probe returned no row"))?;
+    Ok(row.try_get("", "lc_collate")?)
+}
+
+async fn create_product_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE channel_index_identity_generations (
+    tenant_id UUID PRIMARY KEY,
+    generation BIGINT NOT NULL CHECK (generation > 0)
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_titles(db: &DatabaseConnection) -> TestResult<()> {
+    let products = [
+        (PRODUCT_NEEDLE_UPPER, "Needle ASCII", "needle-upper"),
+        (PRODUCT_NEEDLE_LOWER, "needle ascii", "needle-lower"),
+        (PRODUCT_CAFE_NFC, "café", "cafe-nfc"),
+        (PRODUCT_CAFE_NFD, "cafe\u{301}", "cafe-nfd"),
+        (PRODUCT_UNDERSCORE, "A_B", "underscore-literal"),
+        (PRODUCT_UNDERSCORE_WILDCARD, "AxB", "underscore-wildcard"),
+        (PRODUCT_PERCENT, "100% real", "percent-literal"),
+        (PRODUCT_PERCENT_WILDCARD, "100 percent real", "percent-wildcard"),
+        (PRODUCT_STRASSE_SHARP_S, "straße", "strasse-sharp-s"),
+        (PRODUCT_STRASSE_ASCII, "STRASSE", "strasse-ascii"),
+    ];
+
+    db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT_ID}')"))
+        .await?;
+    for (offset, (product_id, title, handle)) in products.into_iter().enumerate() {
+        let translation_id = Uuid::from_u128(0x7300 + offset as u128 + 1);
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO products (id, tenant_id) VALUES ($1, $2)",
+            vec![product_id.into(), TENANT_ID.into()],
+        ))
+        .await?;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES ($1, $2, $3, 'en', $4, $5)",
+            vec![
+                translation_id.into(),
+                product_id.into(),
+                TENANT_ID.into(),
+                title.to_owned().into(),
+                handle.to_owned().into(),
+            ],
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after retained Product PostgreSQL key-4 actualization merge
-`07117d8c88608625a941de501464002aa835897d` and continued on
-`agent/product-storefront-search-bound-20260808`.
+Status overlay rechecked after Product-owned Storefront search-bound merge
+`98757e58af94f4df20c14429c0eb6bdaea173b36` and continued on
+`agent/product-storefront-collation-evidence-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -25,6 +25,8 @@ Source-complete:
 - generic String `TextLike` with a 1024-byte pattern bound;
 - Product-owned Storefront title-search input bound of 1022 effective UTF-8 bytes, leaving exactly two bytes
   for the owner `%{search}%` pattern without truncation;
+- retained PostgreSQL title-search collation packet comparing owner/default `LIKE` against the Index-equivalent
+  explicit `COLLATE "C"` + backslash escape matrix on the real Product translation column;
 - localized Product-ID tie-break direction matching owner Asc/Desc ordering;
 - Product-owned public Storefront attribute-filter -> neutral canonical term resolution;
 - pure Storefront shadow builder consuming only Product-owned filter terms and the Product-owned search bound;
@@ -33,18 +35,24 @@ Source-complete:
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
 The Product search bound is enforced both by `StorefrontProductListQuery::try_new*` and immediately before
-`CatalogService::list_published_products_with_query` constructs owner SQL. Public struct fields therefore
-cannot bypass the owner contract. Distribution imports the same Product constant; it no longer owns a second
-Product-specific search length value.
+`CatalogService::list_published_products_with_query` constructs owner SQL. Distribution consumes the same
+Product constant.
 
-Core/EAV Storefront packets and historical Product packets remain source-only until maintainer execution.
-The core packet also retains the no-requested/fallback-translation projection gap: owner emits
-`Untitled product`/empty handle while generic localized Index returns null.
+The collation packet does not manufacture a favorable database locale. It runs Product migrations, seeds the
+real `product_translations.title` column, then compares production-owner `translation.title LIKE pattern`
+against `(translation.title COLLATE "C") LIKE pattern ESCAPE '\\'` for ASCII case, NFC/NFD Unicode,
+`%`, `_`, escaped wildcards and sharp-s/ASCII-SS distinctions. It records `lc_collate` in mismatch diagnostics.
+Any default-vs-C result difference is a retained fail-closed cutover signal.
+
+All PostgreSQL packets remain source-only until maintainer execution. The core Storefront packet also retains
+the no-requested/fallback-translation projection gap: owner emits `Untitled product`/empty handle while generic
+localized Index returns null.
 
 ## Remaining Storefront parity/evidence blockers
 
-- execute/review current-key Storefront and actualized retained Product PostgreSQL packets;
-- owner/default PostgreSQL title `LIKE` collation vs Index deterministic `COLLATE "C"`;
+- execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
+- admit collation parity only for deployments where the retained default-vs-C matrix agrees; a mismatch keeps
+  Storefront Index cutover fail-closed;
 - channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
 - owner page depth exceeds Index bounded offset depth;
 - map localized null title/handle to owner public placeholders in final projection;
@@ -88,14 +96,15 @@ and SalesChannel remains key `1`.
 - [x] Localized PostgreSQL compiler/decoder/runtime.
 - [x] Generic scalar String `TextLike`.
 - [x] Product-owned 1022-byte Storefront search input bound compatible with the 1024-byte TextLike pattern.
+- [x] Retain owner/default-vs-Index-`C` PostgreSQL title-search collation packet source.
 - [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
 - [x] Product Storefront Index shadow/evidence query builder.
 - [x] Product-owned Storefront attribute-filter resolution.
 - [x] Compose non-serving Product-owner + Index shadow executor.
 - [x] Retain current-key core and EAV owner-vs-shadow PostgreSQL packet source.
 - [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
-- [ ] Execute/review the retained Product/Storefront PostgreSQL packets.
-- [ ] Resolve/admit owner/default vs Index `COLLATE "C"` title-search collation parity.
+- [ ] Execute/review the retained Product/Storefront/collation PostgreSQL packets.
+- [ ] Admit owner/default vs Index `COLLATE "C"` title-search collation parity for a deployment.
 - [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
 - [ ] Decide authoritative deep-page policy.
 - [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
@@ -107,10 +116,11 @@ and SalesChannel remains key `1`.
 
 ## Next source-code step
 
-Retain explicit PostgreSQL collation equivalence evidence for the owner all-translations `pt.title LIKE $1`
-query versus Index `TextLike` compiled with deterministic `COLLATE "C"`. The packet must include ASCII,
-non-ASCII/case-sensitive and wildcard/escape cases and must not weaken Index deterministic collation merely to
-match one deployment's database default.
+Resolve the channel-less Storefront visibility shape without weakening owner semantics. Owner channel-less
+means metadata-unrestricted only, while current `sales_channel_ids` stores resolved channel membership and
+cannot distinguish unrestricted from a restricted Product that happens to contain every current channel.
+Prefer a Product-owned materialized visibility identity/capability over inference from the channel UUID set;
+keep channel-less shadow execution fail-closed until the distinction is representable and freshness-covered.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `search_bound_source_complete_collation_evidence_pending`.
+Status: `collation_packet_source_complete_execution_and_visibility_pending`.
 
 ## Current boundary
 
@@ -8,81 +8,80 @@ Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
 The Product-owned EAV resolver, pure localized shadow builder and non-serving owner-first shadow executor are
-source-complete. Current-key core/EAV Storefront PostgreSQL packets and the historical retained Product
-PostgreSQL packet set are retained in source on Product routing key `4`. They have **not** been executed or
-admitted by the implementation agent.
+source-complete. Current-key core/EAV Storefront PostgreSQL packets, a focused title-search collation packet,
+and the historical retained Product PostgreSQL packet set are retained in source on Product routing key `4`.
+They have **not** been executed or admitted by the implementation agent.
 
 ## Product-owned Storefront search bound — source complete
 
-Product now owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022` as the authoritative effective title-search
-input bound, measured in UTF-8 bytes after whitespace normalization. The owner SQL wraps the effective search
-as `%{search}%`; the two ASCII wildcard bytes make the resulting pattern exactly representable by the generic
-Index `TextLike` maximum of 1024 bytes.
+Product owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022` as the authoritative effective title-search input
+bound, measured in UTF-8 bytes after whitespace normalization. The owner wraps the effective search as
+`%{search}%`; the two wildcard bytes make the resulting pattern exactly representable by the generic Index
+`TextLike` maximum of 1024 bytes.
 
 `StorefrontProductListQuery::try_new*` validates the normalized input, and
-`CatalogService::list_published_products_with_query` validates again immediately before constructing owner
-SQL. The second check is deliberate because the query struct has public fields and may be constructed without
-its helpers. Over-bound input is rejected; it is never truncated.
+`CatalogService::list_published_products_with_query` validates again before owner SQL construction so direct
+public query-struct construction cannot bypass the contract. Over-bound input is rejected, never truncated.
+The shadow builder imports the same Product-owned constant.
 
-The Index shadow builder imports the same Product-owned constant through
-`rustok_product::services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES`. Distribution no longer owns a duplicate
-Product-specific pattern bound. A manually constructed over-bound owner query remains fail-closed in shadow
-translation. Generic Index validation continues to own the independent 1024-byte `TextLike` pattern contract.
+## Title-search collation packet — source complete, execution pending
 
-This closes the source-level search-length mismatch only. It does not establish PostgreSQL collation parity.
+`product_storefront_search_collation_postgres.rs` is a focused opt-in PostgreSQL packet that observes the
+actual database/default Product title collation rather than manufacturing parity.
+
+It runs real Product migrations, seeds the real `product_translations.title` column and compares, for the same
+`%{search}%` patterns:
+
+- owner-equivalent `translation.title LIKE $2` using the database/default collation and PostgreSQL default
+  backslash escape;
+- Index-equivalent `(translation.title COLLATE "C") LIKE $2 ESCAPE E'\\'` using the deterministic collation
+  contract locked by the localized Index compiler.
+
+The retained matrix covers ASCII upper/lower case, NFC and NFD Unicode forms, `_` and `%` wildcards, escaped
+underscore/percent literals, and `straße` versus ASCII `STRASSE`. The packet records `lc_collate` in a mismatch
+diagnostic and fails if the owner/default identity set differs from the `C` identity set.
+
+This packet does **not** mutate the deployment collation, create a test collation, add `ILIKE`, lower-case the
+owner field or weaken Index `COLLATE "C"`. Source presence is not collation admission; a maintainer-run packet
+must agree for a deployment before this gate can be closed there.
 
 ## Product-owned EAV resolution and shadow execution
 
-`ProductCatalogSchemaReadPort::resolve_storefront_attribute_filters` remains the only Product metadata
-boundary used by shadow execution. It preserves mounted owner semantics for typed values, localized
-requested/fallback text and Select/Multiselect UUID/code resolution, returning neutral
-`ProductAttributeTermExpr` values owned by Product.
+`ProductCatalogSchemaReadPort::resolve_storefront_attribute_filters` remains the Product metadata boundary
+used by shadow execution. It preserves typed values, localized requested/fallback text and Select/Multiselect
+UUID/code resolution, returning neutral `ProductAttributeTermExpr` values owned by Product.
 
-Distribution translates those owner-owned expressions into `attribute_terms` predicates. `Never` maps to a
-bind-free false predicate using the current Product schema's required/non-null `id` invariant.
+Distribution translates those expressions into `attribute_terms` predicates. `Never` maps to a bind-free
+false predicate using the current Product schema's required/non-null `id` invariant.
 
 `ProductStorefrontIndexShadowExecutor` executes the authoritative Product owner list first. Only after owner
 success does it resolve EAV metadata, build `LocalizedEntityQuery` and call `execute_localized_query`.
 Projected failures cannot replace the successful owner result. It remains non-serving.
 
-## Core PostgreSQL packet — source complete, execution pending
+## Core and EAV PostgreSQL packets — source complete, execution pending
 
-`storefront_shadow_postgres_tests.rs` uses current Product routing key `4`, real Product/Index migrations,
-channel relation freshness, Product source/mutation materialization, persisted Index schema registration,
-real Product owner reads and the non-serving shadow executor.
+`storefront_shadow_postgres_tests.rs` retains requested/fallback/neither localized projection, third-locale
+title matching, wildcard behavior, locale identity de-duplication, exact count, Asc/Desc equal-timestamp ties,
+offset page boundaries and trusted public-channel membership on current Product key `4`.
 
-It retains requested/fallback/neither localized projection, third-locale title matching, `%`/`_`/escaped `_`
-LIKE behavior, locale identity de-duplication, exact count, Asc/Desc equal-timestamp Product-ID ties, offset
-page boundaries and trusted public-channel membership.
+It also records the public projection gap: when neither requested nor fallback translation exists, owner uses
+`"Untitled product"` and empty handle while generic localized Index returns null. Final serving projection must
+map that state only after Product page identity/order/count are fixed.
 
-It also records the remaining public projection adapter gap: owner uses `"Untitled product"` and empty handle
-when neither requested nor fallback translation exists, while generic localized Index returns null. Final
-serving projection must map that null state only after Product page identity/order/count are fixed.
-
-## EAV PostgreSQL packet — source complete, execution pending
-
-`storefront_shadow_eav_postgres_tests.rs` is a separate crate-internal opt-in packet on routing key `4`.
-It retains nonlocalized integer, localized requested/fallback, Select exact option code, direct option UUID,
-Multiselect exact option code and missing/nil option `Never` behavior, including owner/Index identity/count
-agreement.
-
-The EAV fixture deliberately does not call `save_product_attribute_values`: Product EAV owner-clock command
-semantics have a separate retained gate, so query resolution/materialization failures remain attributable.
+`storefront_shadow_eav_postgres_tests.rs` separately retains nonlocalized integer, localized
+requested/fallback, Select code, direct option UUID, Multiselect code and missing/nil option `Never` behavior.
 
 ## Historical retained Product packets — key 4 source actualized
 
 The retained Product locale-absence, materialized-freshness, Product/Channel convergence, Channel
 identity-transition and linked-target recreate/availability/replay packets use current Product routing key
-`4` while preserving their scenarios. ProductVariant stays on key `2`, SalesChannel stays on key `1`, and no
-Product key-3 compatibility path exists.
-
-`verify-index-product-postgres-key4-fixtures.mjs` locks that boundary. Source actualization does not claim that
-the packets pass; execution/review remains a maintainer gate.
+`4`. ProductVariant stays on key `2`, SalesChannel stays on key `1`, and no Product key-3 compatibility path
+exists. Execution/review remains a maintainer gate.
 
 ## Remaining fail-closed parity/evidence gates
 
-1. Maintainer execution/review of the Storefront core/EAV and actualized retained Product PostgreSQL packets.
-2. Owner/default PostgreSQL `pt.title LIKE $1` collation vs Index deterministic `COLLATE "C"`.
+1. Maintainer execution/review of the Storefront core/EAV, collation and actualized retained Product packets.
+2. Collation admission per deployment: any owner/default-vs-`C` matrix difference keeps cutover fail-closed.
 3. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot represent
    that distinction exactly.
 4. Owner page depth exceeds the Index 10,000 offset bound.
@@ -93,17 +92,18 @@ the packets pass; execution/review remains a maintainer gate.
 
 ## Next source slice
 
-Retain explicit PostgreSQL collation evidence for owner all-translations `pt.title LIKE $1` versus Index
-`TextLike` compiled with deterministic `COLLATE "C"`. Include ASCII, non-ASCII/case-sensitive and
-wildcard/escape cases. Do not weaken deterministic Index collation merely to match one deployment's database
-default; if the owner deployment collation cannot preserve equivalence, keep the cutover fail-closed and make
-the deployment/owner contract explicit.
+Resolve channel-less visibility without inferring unrestricted metadata from resolved UUID membership. A
+restricted Product may currently contain every channel and therefore have the same `sales_channel_ids` as an
+unrestricted Product. Prefer a Product-owned materialized visibility identity/capability with the same
+freshness fence as channel membership, and keep channel-less shadow execution fail-closed until the owner
+semantic is representable exactly.
 
 ## Source guards
 
 - `verify-product-storefront-attribute-filter-terms.mjs` locks Product-owned EAV resolution;
-- `verify-product-storefront-search-bound.mjs` locks the Product-owned 1022-byte effective search bound and
-  proves that adding the two owner LIKE wildcards equals the generic 1024-byte Index `TextLike` bound;
+- `verify-product-storefront-search-bound.mjs` locks the Product-owned search-length contract;
+- `verify-index-product-storefront-collation-postgres-packet.mjs` locks owner/default-vs-Index-`C` collation
+  evidence without manufacturing a favorable collation;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;
 - `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution;
 - `verify-index-product-storefront-equivalence-postgres-packet.mjs` locks the core current-key packet;

--- a/scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs
+++ b/scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-collation-postgres-packet] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const owner = requireMarkers(ownerPath, [
+  'fn product_title_search_condition(',
+  'let pattern = format!("%{search}%");',
+  'pt.title LIKE $1',
+]);
+const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
+if (titleSearch.includes('COLLATE')) {
+  fail(`${ownerPath} must remain the owner/default-collation side of the retained evidence packet`);
+}
+
+const localizedCompilerPath = 'crates/rustok-index/src/application/postgres_localized_query.rs';
+requireMarkers(localizedCompilerPath, [
+  'FilterExpr::TextLike(path, pattern)',
+  'COALESCE({} LIKE {pattern} ESCAPE E\'\\\\\\\\\', FALSE)',
+  'IndexValueType::String => format!("({scalar_text} COLLATE \\"C\\")")',
+]);
+
+const packetPath = 'crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs';
+const packet = requireMarkers(packetPath, [
+  'RUSTOK_PRODUCT_STOREFRONT_COLLATION_DATABASE_URL',
+  'rustok_product::migrations::migrations()',
+  'IndexModule.migrations()',
+  'product_storefront_default_like_matches_index_c_collation_matrix',
+  'translation.title LIKE $2',
+  '(translation.title COLLATE "C") LIKE $2 ESCAPE E\'\\\\\'',
+  "current_setting('lc_collate')",
+  'owner_ids != index_c_ids',
+  'Product Storefront title LIKE collation mismatch',
+  'ASCII case-sensitive upper',
+  'ASCII case-sensitive lower',
+  'Unicode NFC remains byte-distinct',
+  'Unicode NFD remains byte-distinct',
+  'underscore wildcard',
+  'escaped underscore literal',
+  'percent wildcard',
+  'escaped percent literal',
+  'sharp-s remains distinct from ASCII SS',
+  'ASCII SS remains distinct from sharp-s',
+  'search: r"A\\_B"',
+  'search: r"100\\%"',
+]);
+
+for (const forbidden of [
+  'CREATE COLLATION',
+  'ALTER TABLE product_translations',
+  'SET lc_collate',
+  'lower(translation.title)',
+  'ILIKE',
+]) {
+  if (packet.includes(forbidden)) {
+    fail(`${packetPath} must observe deployment/default collation rather than manufacture parity: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
+  'pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;',
+]);
+requireMarkers('crates/rustok-index/src/application/validation.rs', [
+  'const MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024;',
+]);
+
+console.log('[verify-index-product-storefront-collation-postgres-packet] retained default-vs-C Product title LIKE matrix is source-locked; PostgreSQL execution/admission remains maintainer-owned');

--- a/scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs
+++ b/scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs
@@ -30,11 +30,15 @@ if (titleSearch.includes('COLLATE')) {
 }
 
 const localizedCompilerPath = 'crates/rustok-index/src/application/postgres_localized_query.rs';
-requireMarkers(localizedCompilerPath, [
+const localizedCompiler = requireMarkers(localizedCompilerPath, [
   'FilterExpr::TextLike(path, pattern)',
-  'COALESCE({} LIKE {pattern} ESCAPE E\'\\\\\\\\\', FALSE)',
-  'IndexValueType::String => format!("({scalar_text} COLLATE \\"C\\")")',
+  'IndexValueType::String => format!',
+  'COLLATE \\"C\\"',
+  "ESCAPE E'",
 ]);
+if (!localizedCompiler.includes('COALESCE({} LIKE {pattern}')) {
+  fail(`${localizedCompilerPath} no longer compiles TextLike through PostgreSQL LIKE`);
+}
 
 const packetPath = 'crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs';
 const packet = requireMarkers(packetPath, [
@@ -43,7 +47,8 @@ const packet = requireMarkers(packetPath, [
   'IndexModule.migrations()',
   'product_storefront_default_like_matches_index_c_collation_matrix',
   'translation.title LIKE $2',
-  '(translation.title COLLATE "C") LIKE $2 ESCAPE E\'\\\\\'',
+  '(translation.title COLLATE "C") LIKE $2',
+  "ESCAPE E'\\\\'",
   "current_setting('lc_collate')",
   'owner_ids != index_c_ids',
   'Product Storefront title LIKE collation mismatch',

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -52,6 +52,9 @@ const owner = requireMarkers(ownerPath, [
 ]);
 const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
 if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
+if (titleSearch.includes('COLLATE')) {
+  fail(`${ownerPath} owner title search changed collation before retained default-vs-C evidence admission`);
+}
 const ownerValidation = owner.indexOf(
   'types::validate_storefront_product_search(list_query.search.as_deref())?;',
 );
@@ -100,6 +103,15 @@ requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_e
   'color=missing',
   'color=00000000-0000-0000-0000-000000000000',
 ]);
+requireMarkers('crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs', [
+  'RUSTOK_PRODUCT_STOREFRONT_COLLATION_DATABASE_URL',
+  'translation.title LIKE $2',
+  '(translation.title COLLATE "C") LIKE $2',
+  "current_setting('lc_collate')",
+  'owner_ids != index_c_ids',
+  'Unicode NFC remains byte-distinct',
+  'escaped percent literal',
+]);
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
@@ -114,6 +126,12 @@ requireMarkers('scripts/verify/verify-product-storefront-search-bound.mjs', [
   'ownerBytes + 2 !== indexBytes',
   'reject over-bound input rather than truncate it',
 ]);
+requireMarkers('scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs', [
+  'must remain the owner/default-collation side',
+  'COLLATE \\"C\\"',
+  'owner_ids != index_c_ids',
+  'must observe deployment/default collation rather than manufacture parity',
+]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
   'product_locale_absence_postgres.rs',
   'product_materialized_query_freshness_postgres.rs',
@@ -127,14 +145,14 @@ requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `search_bound_source_complete_collation_evidence_pending`',
+  'Status: `collation_packet_source_complete_execution_and_visibility_pending`',
   'Mounted Storefront remains owner-native',
   'Product-owned Storefront search bound — source complete',
+  'Title-search collation packet — source complete, execution pending',
   '`MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022`',
-  'Core PostgreSQL packet — source complete, execution pending',
-  'EAV PostgreSQL packet — source complete, execution pending',
+  'Core and EAV PostgreSQL packets — source complete, execution pending',
   'Historical retained Product packets — key 4 source actualized',
-  'Owner/default PostgreSQL `pt.title LIKE $1` collation',
+  'Collation admission per deployment',
   'ProductVariant stays on key',
   'SalesChannel stays on key',
 ]);
@@ -144,7 +162,8 @@ requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-product-storefront-search-bound.mjs'",
+  "'verify-index-product-storefront-collation-postgres-packet.mjs'",
   "'verify-index-product-postgres-key4-fixtures.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; Product search length is source-aligned with TextLike while collation, execution/admission and remaining serving-policy gates stay pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; search length and collation packet source are complete while PostgreSQL execution/admission, channel-less visibility and serving-policy gates stay pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -87,6 +87,7 @@ const scripts = [
   'verify-index-product-storefront-shadow-executor.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
+  'verify-index-product-storefront-collation-postgres-packet.mjs',
   'verify-index-localized-query-contract.mjs',
   'verify-index-localized-query-postgres-fold.mjs',
   'verify-index-localized-query-runtime.mjs',


### PR DESCRIPTION
## Summary

- retain a focused opt-in PostgreSQL Product Storefront title-search collation packet without changing production owner or Index SQL;
- run real Product migrations and seed the real `product_translations.title` column;
- compare production-owner-equivalent `translation.title LIKE pattern` under the deployment/database default collation with Index-equivalent `(translation.title COLLATE "C") LIKE pattern ESCAPE E'\\'` for the exact same `%{search}%` pattern;
- retain C-side expected identity sets and require owner/default identities to equal them;
- cover ASCII upper/lower case, NFC/NFD Unicode distinctions, `_` and `%` wildcard behavior, escaped underscore/percent literals, and `straße` vs ASCII `STRASSE`;
- include `lc_collate` in mismatch diagnostics so a failed packet is an actionable deployment/collation cutover blocker;
- do not create a favorable test collation, alter Product columns, use `ILIKE`, lowercase owner values, or weaken deterministic Index `COLLATE "C"`;
- add source guards that pin the real owner to default collation, the localized Index compiler to `COLLATE "C"` + explicit escape, and the retained default-vs-C matrix;
- advance M7 docs to collation-packet-source-complete while leaving execution/admission and channel-less visibility pending.

## Boundary

This PR does not execute the packet, claim collation equivalence for any deployment, change Product owner search semantics, alter Index `TextLike`, switch Storefront traffic, resolve channel-less/deep-page parity, map localized placeholders, hydrate Taxonomy tags, or admit any PostgreSQL evidence.

A deployment where the retained owner/default identity set differs from the `C` identity set must remain fail-closed for Storefront Index cutover.

## Main recheck

The branch started from Product search-bound merge `98757e58af94f4df20c14429c0eb6bdaea173b36`. Current `main@f609acbde8bcfaf25fc90cd8cc42bcf8a69299bd` advanced only through #3242 Groups ownership work, which is disjoint from this six-file Product/Index evidence slice.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.