### PR TITLE
feat(index): keep channel-less Storefront owner-native

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -106,7 +106,7 @@ mod tests {
         register(&mut extensions).unwrap();
 
         let admissions = extensions
-            .get::<rustok_index::PostgresQueryEntityAdmissionCatalog>()
+            .get::<rustok_index::PostgresIndexQueryAdmissionCatalog>()
             .expect("Product+Channel selection must publish graph entity admissions");
         assert_eq!(admissions.len(), 3);
         assert_eq!(admissions.link_availability_len(), 1);

--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -16,8 +16,9 @@ pub(crate) use storefront_shadow::{
 };
 mod storefront_shadow_executor;
 pub(crate) use storefront_shadow_executor::{
-    ProductStorefrontIndexShadowComparison, ProductStorefrontIndexShadowExecution,
-    ProductStorefrontIndexShadowExecutor, ProductStorefrontIndexShadowProjectionError,
+    ProductStorefrontIndexChannelScopeDecision, ProductStorefrontIndexShadowComparison,
+    ProductStorefrontIndexShadowExecution, ProductStorefrontIndexShadowExecutor,
+    ProductStorefrontIndexShadowProjectionError, classify_product_storefront_index_channel_scope,
 };
 #[cfg(test)]
 mod storefront_shadow_eav_postgres_tests;
@@ -105,7 +106,7 @@ mod tests {
         register(&mut extensions).unwrap();
 
         let admissions = extensions
-            .get::<rustok_index::PostgresIndexQueryAdmissionCatalog>()
+            .get::<rustok_index::PostgresQueryEntityAdmissionCatalog>()
             .expect("Product+Channel selection must publish graph entity admissions");
         assert_eq!(admissions.len(), 3);
         assert_eq!(admissions.link_availability_len(), 1);

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -39,12 +39,26 @@ impl ProductStorefrontIndexShadowComparison {
     }
 }
 
+/// Request-shape decision for the current Product key-4 channel projection.
+///
+/// `sales_channel_ids` stores resolved Channel UUID membership. For unrestricted Product metadata this is
+/// the set of all current Channels, so it cannot distinguish an unrestricted Product from a restricted
+/// Product whose allowed slugs currently resolve to that same complete set. Channel-less owner semantics
+/// therefore remain owner-native instead of being inferred from membership equality.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProductStorefrontIndexChannelScopeDecision {
+    ShadowEligible { public_channel_id: Uuid },
+    OwnerNativeChannelLess,
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum ProductStorefrontIndexShadowProjectionError {
     #[error("Product Storefront shadow schema-read capability is unavailable")]
     SchemaReadPortUnavailable,
     #[error("Product Storefront shadow request tenant identity is invalid")]
     InvalidTenant,
+    #[error("Product Storefront channel-less requests remain owner-native for the current Index key-4 contract")]
+    ChannelLessOwnerNative,
     #[error("Product Storefront shadow requires a trusted public channel slug/id pair")]
     PublicChannelIdentityUnavailable,
     #[error("Product Storefront shadow attribute-filter owner resolution failed: {0}")]
@@ -55,6 +69,27 @@ pub(crate) enum ProductStorefrontIndexShadowProjectionError {
     Index(#[from] IndexQueryExecutionError),
 }
 
+/// Classify the caller's public-channel context without guessing channel-less visibility from Index
+/// membership.
+///
+/// An absent/blank slug paired with no UUID is the owner's channel-less shape and is deliberately retained as
+/// owner-native. A present non-empty slug plus a non-nil UUID is eligible for channel-scoped shadow
+/// translation. Partial, contradictory or nil identities fail closed as malformed context rather than being
+/// treated as channel-less.
+pub(crate) fn classify_product_storefront_index_channel_scope(
+    public_channel_slug: Option<&str>,
+    public_channel_id: Option<Uuid>,
+) -> Result<ProductStorefrontIndexChannelScopeDecision, ProductStorefrontIndexShadowProjectionError> {
+    let public_channel_slug = public_channel_slug.map(str::trim).filter(|slug| !slug.is_empty());
+    match (public_channel_slug, public_channel_id) {
+        (None, None) => Ok(ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess),
+        (Some(_), Some(public_channel_id)) if !public_channel_id.is_nil() => {
+            Ok(ProductStorefrontIndexChannelScopeDecision::ShadowEligible { public_channel_id })
+        }
+        _ => Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable),
+    }
+}
+
 /// Owner-first, non-serving Product Storefront shadow executor.
 ///
 /// This object composes only host-selected Product and Index capabilities. It never constructs
@@ -62,9 +97,9 @@ pub(crate) enum ProductStorefrontIndexShadowProjectionError {
 /// The owner list result remains authoritative even when Product metadata resolution, shadow query build,
 /// Index readiness/admission, or Index execution fails.
 ///
-/// `public_channel_slug` and `public_channel_id` must be a trusted pair supplied by the caller's current
-/// channel context. This executor only checks that both identities are present and non-empty/non-nil; it
-/// does not independently prove slug/UUID correspondence.
+/// Channel-scoped projection requires a trusted current slug/UUID pair supplied by the caller's current
+/// channel context. Channel-less requests are intentionally retained as typed owner-native projected results
+/// for the current key-4 schema rather than approximated from `sales_channel_ids`.
 #[derive(Clone)]
 pub(crate) struct ProductStorefrontIndexShadowExecutor {
     product: ProductCatalogReadRuntime,
@@ -130,15 +165,15 @@ impl ProductStorefrontIndexShadowExecutor {
         public_channel_id: Option<Uuid>,
         query: StorefrontProductListQuery,
     ) -> Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError> {
-        let public_channel_id = match (
-            public_channel_slug.as_deref().map(str::trim),
+        let public_channel_id = match classify_product_storefront_index_channel_scope(
+            public_channel_slug.as_deref(),
             public_channel_id,
-        ) {
-            (Some(slug), Some(channel_id)) if !slug.is_empty() && !channel_id.is_nil() => channel_id,
-            _ => {
-                return Err(
-                    ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable,
-                );
+        )? {
+            ProductStorefrontIndexChannelScopeDecision::ShadowEligible { public_channel_id } => {
+                public_channel_id
+            }
+            ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess => {
+                return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);
             }
         };
         let tenant_id = Uuid::parse_str(context.tenant_id.as_str())
@@ -214,5 +249,37 @@ mod tests {
         };
         let comparison = compare_owner_and_index(&authoritative, &projected);
         assert!(comparison.is_match());
+    }
+
+    #[test]
+    fn channel_scope_distinguishes_owner_native_channel_less_from_invalid_identity() {
+        assert_eq!(
+            classify_product_storefront_index_channel_scope(None, None).unwrap(),
+            ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess
+        );
+        assert_eq!(
+            classify_product_storefront_index_channel_scope(Some("   "), None).unwrap(),
+            ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess
+        );
+
+        let channel_id = Uuid::new_v4();
+        assert_eq!(
+            classify_product_storefront_index_channel_scope(Some(" web "), Some(channel_id))
+                .unwrap(),
+            ProductStorefrontIndexChannelScopeDecision::ShadowEligible { public_channel_id: channel_id }
+        );
+
+        assert!(matches!(
+            classify_product_storefront_index_channel_scope(Some("web"), None),
+            Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
+        ));
+        assert!(matches!(
+            classify_product_storefront_index_channel_scope(None, Some(channel_id)),
+            Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
+        ));
+        assert!(matches!(
+            classify_product_storefront_index_channel_scope(Some("web"), Some(Uuid::nil())),
+            Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
+        ));
     }
 }

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product-owned Storefront search-bound merge
-`98757e58af94f4df20c14429c0eb6bdaea173b36` and continued on
-`agent/product-storefront-collation-evidence-20260808`.
+Status overlay rechecked after Product Storefront collation packet merge
+`26d6e340ee6d1be462f29da6b95b6539458b843f` and continued on
+`agent/product-storefront-channel-scope-policy-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -22,42 +22,52 @@ Source-complete:
 - Product channel relation/freshness materialization;
 - localized entity identity fold, cursor v3 and requested -> fallback projection;
 - localized PostgreSQL compiler/decoder/runtime with readiness/admission and one repeatable-read page/count snapshot;
-- generic String `TextLike` with a 1024-byte pattern bound;
-- Product-owned Storefront title-search input bound of 1022 effective UTF-8 bytes, leaving exactly two bytes
-  for the owner `%{search}%` pattern without truncation;
-- retained PostgreSQL title-search collation packet comparing owner/default `LIKE` against the Index-equivalent
-  explicit `COLLATE "C"` + backslash escape matrix on the real Product translation column;
+- generic String `TextLike` plus the Product-owned 1022-byte effective Storefront search bound;
+- retained owner/default-vs-Index-`C` PostgreSQL title-search collation packet source;
 - localized Product-ID tie-break direction matching owner Asc/Desc ordering;
-- Product-owned public Storefront attribute-filter -> neutral canonical term resolution;
-- pure Storefront shadow builder consuming only Product-owned filter terms and the Product-owned search bound;
-- non-serving owner-first `ProductStorefrontIndexShadowExecutor`;
-- current-key core and EAV Product Storefront owner-vs-shadow PostgreSQL packet source;
+- Product-owned Storefront attribute-filter -> neutral canonical term resolution;
+- pure Storefront shadow builder and owner-first non-serving shadow executor;
+- explicit current-key channel-scope policy: trusted non-empty slug + non-nil UUID is shadow-eligible, while
+  channel-less owner requests remain owner-native and partial/invalid channel identity fails closed;
+- current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
-The Product search bound is enforced both by `StorefrontProductListQuery::try_new*` and immediately before
-`CatalogService::list_published_products_with_query` constructs owner SQL. Distribution consumes the same
-Product constant.
+## Channel-less visibility decision for current Product key 4
 
-The collation packet does not manufacture a favorable database locale. It runs Product migrations, seeds the
-real `product_translations.title` column, then compares production-owner `translation.title LIKE pattern`
-against `(translation.title COLLATE "C") LIKE pattern ESCAPE '\\'` for ASCII case, NFC/NFD Unicode,
-`%`, `_`, escaped wildcards and sharp-s/ASCII-SS distinctions. It records `lc_collate` in mismatch diagnostics.
-Any default-vs-C result difference is a retained fail-closed cutover signal.
+Owner channel-less semantics are **metadata-unrestricted only**: the Product owner predicate admits rows whose
+`metadata.channel_visibility.allowed_channel_slugs` is absent or empty.
 
-All PostgreSQL packets remain source-only until maintainer execution. The core Storefront packet also retains
-the no-requested/fallback-translation projection gap: owner emits `Untitled product`/empty handle while generic
-localized Index returns null.
+The Product -> SalesChannel relation resolver intentionally represents unrestricted visibility as membership
+in **all current Channel UUIDs**. A restricted Product whose allowed slugs currently resolve to every Channel
+therefore has the same `sales_channel_ids` value as an unrestricted Product. Current Product key `4` cannot
+recover the owner distinction from resolved membership.
+
+The generic PostgreSQL entity-admission catalog is schema-scoped and does not carry an arbitrary
+request-specific Product visibility predicate. Consequently the current source does not fabricate a sentinel,
+encode visibility into unrelated `attribute_terms`, or introduce a key-5 schema without the replacement
+protocol/evidence required for a real schema change.
+
+`classify_product_storefront_index_channel_scope` now makes the request policy explicit:
+
+- absent/blank slug + absent UUID => `OwnerNativeChannelLess`;
+- non-empty slug + non-nil UUID => `ShadowEligible`;
+- partial, contradictory or nil channel identity => `PublicChannelIdentityUnavailable`.
+
+The shadow executor still runs the authoritative Product owner list first. For channel-less requests it retains
+that result and records typed projected reason `ChannelLessOwnerNative`; it never approximates an Index result.
+This closes the current-key **policy decision**, not channel-less Index parity. Any future serving router must
+continue to route this shape owner-native unless a later schema/query capability represents the distinction
+exactly with freshness evidence.
 
 ## Remaining Storefront parity/evidence blockers
 
 - execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
-- admit collation parity only for deployments where the retained default-vs-C matrix agrees; a mismatch keeps
-  Storefront Index cutover fail-closed;
-- channel-less owner visibility cannot currently be represented exactly by `sales_channel_ids`;
-- owner page depth exceeds Index bounded offset depth;
+- admit collation parity only where the retained deployment matrix agrees;
+- owner page depth exceeds the Index bounded offset depth;
 - map localized null title/handle to owner public placeholders in final projection;
 - hydrate localized Taxonomy tag names only after Product page identity/count is fixed;
 - define serving latency/deadline policy before any shadow-to-serving transition;
+- preserve channel-less owner-native routing in any future serving composition;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence.
 
 ## Retained Product evidence state
@@ -66,8 +76,6 @@ The retained Product PostgreSQL fixture set is source-aligned on routing key `4`
 query freshness, Product/Channel convergence, Channel identity transitions, linked-target delete/recreate,
 linked-target availability equivalence and linked-target replay/redelivery. ProductVariant remains key `2`
 and SalesChannel remains key `1`.
-
-`verify-index-product-postgres-key4-fixtures.mjs` locks that boundary. Execution/admission remains separate.
 
 ## M5 incremental ingestion
 
@@ -94,33 +102,32 @@ and SalesChannel remains key `1`.
 - [x] Canonical typed EAV terms and Product owner clock.
 - [x] Localized identity/fallback architecture and query/cursor contract.
 - [x] Localized PostgreSQL compiler/decoder/runtime.
-- [x] Generic scalar String `TextLike`.
-- [x] Product-owned 1022-byte Storefront search input bound compatible with the 1024-byte TextLike pattern.
+- [x] Generic scalar String `TextLike` and Product-owned compatible search bound.
 - [x] Retain owner/default-vs-Index-`C` PostgreSQL title-search collation packet source.
 - [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
-- [x] Product Storefront Index shadow/evidence query builder.
-- [x] Product-owned Storefront attribute-filter resolution.
+- [x] Product Storefront shadow query builder and Product-owned EAV resolution.
 - [x] Compose non-serving Product-owner + Index shadow executor.
-- [x] Retain current-key core and EAV owner-vs-shadow PostgreSQL packet source.
+- [x] Retain current-key core/EAV owner-vs-shadow PostgreSQL packet source.
 - [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
-- [ ] Execute/review the retained Product/Storefront/collation PostgreSQL packets.
-- [ ] Admit owner/default vs Index `COLLATE "C"` title-search collation parity for a deployment.
-- [ ] Resolve channel-less unrestricted visibility parity or keep that shape owner-native.
+- [x] Keep channel-less Storefront owner-native on current key `4`; distinguish malformed channel identity.
+- [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
+- [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
 - [ ] Decide authoritative deep-page policy.
 - [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
 - [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
-- [ ] Move Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes.
+- [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes;
+      channel-less remains owner-native unless a later exact representation is admitted.
 
 ## Next source-code step
 
-Resolve the channel-less Storefront visibility shape without weakening owner semantics. Owner channel-less
-means metadata-unrestricted only, while current `sales_channel_ids` stores resolved channel membership and
-cannot distinguish unrestricted from a restricted Product that happens to contain every current channel.
-Prefer a Product-owned materialized visibility identity/capability over inference from the channel UUID set;
-keep channel-less shadow execution fail-closed until the distinction is representable and freshness-covered.
+Resolve deep-page request policy without silently narrowing owner semantics. The owner accepts any checked
+`(page - 1) * per_page` offset representable by its query path, while generic Index offset pagination is
+bounded to `10_000`. Classify an otherwise valid owner request whose computed offset exceeds that bound as a
+typed **owner-native deep-page** shape, distinct from invalid pagination, and keep shallow pages shadow-eligible.
+Do not clamp page/offset or silently switch pagination semantics.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,114 +1,112 @@
 # M7 Product Storefront Index parity gate
 
-Status: `collation_packet_source_complete_execution_and_visibility_pending`.
+Status: `channel_scope_policy_source_complete_deep_page_pending`.
 
 ## Current boundary
 
 Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
-The Product-owned EAV resolver, pure localized shadow builder and non-serving owner-first shadow executor are
-source-complete. Current-key core/EAV Storefront PostgreSQL packets, a focused title-search collation packet,
-and the historical retained Product PostgreSQL packet set are retained in source on Product routing key `4`.
-They have **not** been executed or admitted by the implementation agent.
+The Product-owned EAV resolver, localized shadow builder and owner-first non-serving shadow executor are
+source-complete. Current-key Storefront core/EAV/collation PostgreSQL packets and the historical retained
+Product packet set are retained in source on Product routing key `4`. They have **not** been executed or
+admitted by the implementation agent.
+
+## Channel-less serving policy — source complete for current key 4
+
+Owner channel-less semantics are stricter than resolved membership. With no public channel slug, Product owner
+admits only Products whose `metadata.channel_visibility.allowed_channel_slugs` is absent or empty.
+
+The Product relation resolver represents unrestricted metadata by resolving **all current Channel UUIDs** into
+`sales_channel_ids`. A restricted Product whose allowed slugs currently resolve to every Channel therefore has
+the same membership vector as an unrestricted Product. Current key `4` cannot distinguish those states.
+
+The generic entity-admission catalog is schema-scoped rather than an arbitrary request-scoped Product
+predicate channel, so the shadow path cannot recover the owner metadata distinction at query time without a
+new generic contract or a persisted Product field/schema replacement.
+
+For the current key-4 contract the policy is explicit:
+
+- absent/blank slug and absent channel UUID => `OwnerNativeChannelLess`;
+- trusted non-empty slug and non-nil UUID => `ShadowEligible`;
+- partial identity, UUID-without-slug, slug-without-UUID, or nil UUID =>
+  `PublicChannelIdentityUnavailable`.
+
+The shadow executor still produces the authoritative owner result first. A channel-less request then retains
+that result and records `ChannelLessOwnerNative` in `projected`; it does not fabricate an Index page. This is a
+serving-policy decision, not a claim of channel-less Index parity.
+
+No sentinel UUID, `attribute_terms` visibility encoding, key-5 Product schema, or membership-equality inference
+is introduced. Any future serving composition must preserve owner-native handling for this shape until a later
+exact representation is implemented with the normal schema replacement and freshness evidence gates.
 
 ## Product-owned Storefront search bound — source complete
 
-Product owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022` as the authoritative effective title-search input
-bound, measured in UTF-8 bytes after whitespace normalization. The owner wraps the effective search as
-`%{search}%`; the two wildcard bytes make the resulting pattern exactly representable by the generic Index
-`TextLike` maximum of 1024 bytes.
-
-`StorefrontProductListQuery::try_new*` validates the normalized input, and
-`CatalogService::list_published_products_with_query` validates again before owner SQL construction so direct
-public query-struct construction cannot bypass the contract. Over-bound input is rejected, never truncated.
-The shadow builder imports the same Product-owned constant.
+Product owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022`. The owner wraps normalized search as
+`%{search}%`, making the maximum pattern exactly representable by generic Index `TextLike`'s 1024-byte bound.
+The constructor and owner SQL path both enforce the Product bound; over-bound input is rejected, never
+truncated. The shadow builder imports the same Product constant.
 
 ## Title-search collation packet — source complete, execution pending
 
-`product_storefront_search_collation_postgres.rs` is a focused opt-in PostgreSQL packet that observes the
-actual database/default Product title collation rather than manufacturing parity.
-
-It runs real Product migrations, seeds the real `product_translations.title` column and compares, for the same
-`%{search}%` patterns:
-
-- owner-equivalent `translation.title LIKE $2` using the database/default collation and PostgreSQL default
-  backslash escape;
-- Index-equivalent `(translation.title COLLATE "C") LIKE $2 ESCAPE E'\\'` using the deterministic collation
-  contract locked by the localized Index compiler.
-
-The retained matrix covers ASCII upper/lower case, NFC and NFD Unicode forms, `_` and `%` wildcards, escaped
-underscore/percent literals, and `straße` versus ASCII `STRASSE`. The packet records `lc_collate` in a mismatch
-diagnostic and fails if the owner/default identity set differs from the `C` identity set.
-
-This packet does **not** mutate the deployment collation, create a test collation, add `ILIKE`, lower-case the
-owner field or weaken Index `COLLATE "C"`. Source presence is not collation admission; a maintainer-run packet
-must agree for a deployment before this gate can be closed there.
+`product_storefront_search_collation_postgres.rs` compares real owner/default `title LIKE pattern` with the
+Index-equivalent `(title COLLATE "C") LIKE pattern ESCAPE E'\\'` on the real Product translation column. It
+covers ASCII case, NFC/NFD Unicode, `%`, `_`, escaped wildcards and sharp-s/ASCII-SS distinctions and reports
+`lc_collate` on mismatch. It does not manufacture a favorable collation. Deployment admission remains a
+maintainer-run gate.
 
 ## Product-owned EAV resolution and shadow execution
 
 `ProductCatalogSchemaReadPort::resolve_storefront_attribute_filters` remains the Product metadata boundary
-used by shadow execution. It preserves typed values, localized requested/fallback text and Select/Multiselect
-UUID/code resolution, returning neutral `ProductAttributeTermExpr` values owned by Product.
+used by shadow execution. Distribution translates Product-owned neutral term expressions into
+`attribute_terms`; missing option identities remain `Never` and map to a bind-free false predicate.
 
-Distribution translates those expressions into `attribute_terms` predicates. `Never` maps to a bind-free
-false predicate using the current Product schema's required/non-null `id` invariant.
+`ProductStorefrontIndexShadowExecutor` executes the authoritative Product owner list first. Only eligible
+channel-scoped projected work proceeds through Product metadata resolution, localized query construction and
+`execute_localized_query`. Projected failures cannot replace the successful owner result.
 
-`ProductStorefrontIndexShadowExecutor` executes the authoritative Product owner list first. Only after owner
-success does it resolve EAV metadata, build `LocalizedEntityQuery` and call `execute_localized_query`.
-Projected failures cannot replace the successful owner result. It remains non-serving.
+## Core/EAV and retained Product PostgreSQL packets
 
-## Core and EAV PostgreSQL packets — source complete, execution pending
+The core Storefront packet retains localized requested/fallback/neither projection, all-locale title matching,
+wildcards, identity de-duplication, count, Asc/Desc tie ordering, pagination and trusted public-channel
+membership. It also records the null-vs-public-placeholder projection gap.
 
-`storefront_shadow_postgres_tests.rs` retains requested/fallback/neither localized projection, third-locale
-title matching, wildcard behavior, locale identity de-duplication, exact count, Asc/Desc equal-timestamp ties,
-offset page boundaries and trusted public-channel membership on current Product key `4`.
+The EAV packet separately retains scalar/localized terms, Select/Multiselect option code/direct UUID and
+missing/nil option `Never` behavior.
 
-It also records the public projection gap: when neither requested nor fallback translation exists, owner uses
-`"Untitled product"` and empty handle while generic localized Index returns null. Final serving projection must
-map that state only after Product page identity/order/count are fixed.
-
-`storefront_shadow_eav_postgres_tests.rs` separately retains nonlocalized integer, localized
-requested/fallback, Select code, direct option UUID, Multiselect code and missing/nil option `Never` behavior.
-
-## Historical retained Product packets — key 4 source actualized
-
-The retained Product locale-absence, materialized-freshness, Product/Channel convergence, Channel
-identity-transition and linked-target recreate/availability/replay packets use current Product routing key
-`4`. ProductVariant stays on key `2`, SalesChannel stays on key `1`, and no Product key-3 compatibility path
-exists. Execution/review remains a maintainer gate.
+Historical Product locale-absence, materialized-freshness, channel convergence/identity-transition and
+linked-target recreate/availability/replay packets are source-aligned on Product key `4`. ProductVariant stays
+key `2`, SalesChannel key `1`. Execution/review remains maintainer-owned.
 
 ## Remaining fail-closed parity/evidence gates
 
-1. Maintainer execution/review of the Storefront core/EAV, collation and actualized retained Product packets.
-2. Collation admission per deployment: any owner/default-vs-`C` matrix difference keeps cutover fail-closed.
-3. Channel-less owner requests mean metadata-unrestricted only; current `sales_channel_ids` cannot represent
-   that distinction exactly.
-4. Owner page depth exceeds the Index 10,000 offset bound.
-5. Final Storefront projection must map no-localized-row null title/handle to owner placeholders.
-6. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
-7. Shadow execution has no serving latency/deadline policy and remains non-serving.
-8. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
+1. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
+2. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
+3. Owner page depth exceeds the generic Index 10,000 offset bound; deep-page policy remains unresolved.
+4. Final Storefront projection must map no-localized-row null title/handle to owner placeholders.
+5. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
+6. Shadow execution has no serving latency/deadline policy and remains non-serving.
+7. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
+8. Any future serving router must preserve the typed channel-less owner-native branch.
 
 ## Next source slice
 
-Resolve channel-less visibility without inferring unrestricted metadata from resolved UUID membership. A
-restricted Product may currently contain every channel and therefore have the same `sales_channel_ids` as an
-unrestricted Product. Prefer a Product-owned materialized visibility identity/capability with the same
-freshness fence as channel membership, and keep channel-less shadow execution fail-closed until the owner
-semantic is representable exactly.
+Decide deep-page policy without narrowing owner semantics. An owner-valid request whose checked offset exceeds
+the generic Index 10,000 offset maximum should become a typed **owner-native deep-page** projected reason,
+while invalid page/per-page remains a validation failure and shallow pages remain shadow-eligible. Do not
+clamp page/offset or silently change pagination strategy.
 
 ## Source guards
 
-- `verify-product-storefront-attribute-filter-terms.mjs` locks Product-owned EAV resolution;
+- `verify-index-product-storefront-channel-scope-policy.mjs` locks owner channel-less semantics, unrestricted
+  relation materialization and the typed current-key owner-native decision without sentinels;
 - `verify-product-storefront-search-bound.mjs` locks the Product-owned search-length contract;
-- `verify-index-product-storefront-collation-postgres-packet.mjs` locks owner/default-vs-Index-`C` collation
-  evidence without manufacturing a favorable collation;
+- `verify-index-product-storefront-collation-postgres-packet.mjs` locks retained collation evidence;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;
-- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first non-serving execution;
-- `verify-index-product-storefront-equivalence-postgres-packet.mjs` locks the core current-key packet;
-- `verify-index-product-storefront-eav-equivalence-postgres-packet.mjs` locks the EAV current-key packet;
-- `verify-index-product-postgres-key4-fixtures.mjs` locks actualized retained Product packets on key `4`;
+- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first execution plus typed channel scope;
+- `verify-index-product-storefront-equivalence-postgres-packet.mjs` and the EAV counterpart lock current-key
+  parity packets;
+- `verify-index-product-postgres-key4-fixtures.mjs` locks retained Product packets on key `4`;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or

--- a/scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs
+++ b/scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-channel-scope-policy] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const ownerHelpers = requireMarkers('crates/rustok-product/src/services/catalog/helpers.rs', [
+  'pub(crate) fn product_channel_visibility_condition(',
+  'None => sea_orm::Condition::all().add(sea_orm::sea_query::Expr::cust(',
+  "metadata->'channel_visibility'->'allowed_channel_slugs'",
+  "jsonb_array_length(COALESCE(products.metadata->'channel_visibility'->'allowed_channel_slugs', '[]'::jsonb)) = 0",
+]);
+
+const resolver = requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_resolver.rs', [
+  'ProductChannelVisibility::Unrestricted => (',
+  'SELECT id FROM channels WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2',
+  'ProductChannelVisibility::Restricted(slugs)',
+]);
+
+const productBridgePath = 'crates/rustok-distribution/src/product_index/product.rs';
+const productBridge = requireMarkers(productBridgePath, [
+  'assert_eq!(schema.fields.len(), 15);',
+  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+]);
+if (productBridge.includes('SchemaVersion::new(5)')) {
+  fail(`${productBridgePath} must not invent a replacement schema merely to approximate channel-less visibility`);
+}
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
+  'ShadowEligible { public_channel_id: Uuid }',
+  'OwnerNativeChannelLess',
+  'ChannelLessOwnerNative',
+  'pub(crate) fn classify_product_storefront_index_channel_scope(',
+  '(None, None) => Ok(ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess)',
+  '(Some(_), Some(public_channel_id)) if !public_channel_id.is_nil()',
+  'Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)',
+  'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
+  'channel_scope_distinguishes_owner_native_channel_less_from_invalid_identity',
+]);
+for (const forbidden of [
+  'UNRESTRICTED_CHANNEL_SENTINEL',
+  'CHANNEL_LESS_SENTINEL',
+  'infer_unrestricted_from_channel_ids',
+]) {
+  if (executor.includes(forbidden) || productBridge.includes(forbidden) || resolver.includes(forbidden)) {
+    fail(`channel-less policy must not infer or fabricate visibility membership: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow.rs', [
+  'PublicChannelRequired',
+  'FilterExpr::Contains(',
+  'root_field("sales_channel_ids")?',
+]);
+
+console.log('[verify-index-product-storefront-channel-scope-policy] channel-less Storefront remains owner-native on Product key 4; channel-scoped shadow requires a trusted slug/UUID identity');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -27,12 +27,10 @@ for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'execute_loc
   if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
 }
 
-const typesPath = 'crates/rustok-product/src/services/catalog/types.rs';
-requireMarkers(typesPath, [
+requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
   'pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;',
   'search: normalize_storefront_product_search(search)?',
   'pub(crate) fn validate_storefront_product_search(',
-  'search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
 ]);
 
 const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
@@ -47,44 +45,45 @@ const owner = requireMarkers(ownerPath, [
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
   'let pattern = format!("%{search}%");',
   'pt.title LIKE $1',
-  '.order_by_asc(entities::product::Column::Id)',
-  '.order_by_desc(entities::product::Column::Id)',
 ]);
 const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
 if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
 if (titleSearch.includes('COLLATE')) {
   fail(`${ownerPath} owner title search changed collation before retained default-vs-C evidence admission`);
 }
-const ownerValidation = owner.indexOf(
-  'types::validate_storefront_product_search(list_query.search.as_deref())?;',
-);
-const ownerSql = owner.indexOf('let mut query = entities::product::Entity::find()');
-if (ownerValidation < 0 || ownerSql <= ownerValidation) {
-  fail(`${ownerPath} must validate Storefront search before constructing owner SQL`);
-}
 
-requireMarkers('crates/rustok-product/src/catalog_schema_read_port.rs', [
-  'ProductStorefrontAttributeFilterResolutionRequest',
-  'async fn resolve_storefront_attribute_filters(',
-  '"product.storefront_attribute_filter_resolution_unavailable"',
+requireMarkers('crates/rustok-product/src/services/catalog/helpers.rs', [
+  'pub(crate) fn product_channel_visibility_condition(',
+  "metadata->'channel_visibility'->'allowed_channel_slugs'",
+  "jsonb_array_length(COALESCE(products.metadata->'channel_visibility'->'allowed_channel_slugs', '[]'::jsonb)) = 0",
 ]);
-requireMarkers('crates/rustok-product/src/services/catalog_attribute_terms.rs', [
-  'pub enum ProductAttributeTermExpr',
-  'pub struct ProductResolvedAttributeFilter',
-  'product_attribute_localized_text_expr(',
-  'ProductAttributeTermExpr::Never',
+requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_resolver.rs', [
+  'ProductChannelVisibility::Unrestricted => (',
+  'SELECT id FROM channels WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2',
 ]);
-requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow.rs', [
-  'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
-  'if search.len() > MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
-  'FilterExpr::TextLike(root_field("title")?, pattern)',
-]);
-requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs', [
-  'pub(crate) struct ProductStorefrontIndexShadowExecutor',
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
+  'ShadowEligible { public_channel_id: Uuid }',
+  'OwnerNativeChannelLess',
+  'ChannelLessOwnerNative',
+  'pub(crate) fn classify_product_storefront_index_channel_scope(',
+  '(None, None) => Ok(ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess)',
+  'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
   'list_filtered_published_products(',
   '.resolve_storefront_attribute_filters(',
   '.execute_localized_query(index_query)',
   'pub(crate) authoritative: StorefrontProductList',
+]);
+for (const forbidden of ['CHANNEL_LESS_SENTINEL', 'UNRESTRICTED_CHANNEL_SENTINEL']) {
+  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden visibility sentinel ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow.rs', [
+  'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
+  'PublicChannelRequired',
+  'root_field("sales_channel_ids")?',
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
@@ -96,74 +95,55 @@ requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_e
   'RUSTOK_PRODUCT_STOREFRONT_EAV_EQUIVALENCE_DATABASE_URL',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'weight=7',
-  'label=Punainen',
-  'label=Red',
-  'color=red',
-  'features=wifi',
   'color=missing',
-  'color=00000000-0000-0000-0000-000000000000',
 ]);
 requireMarkers('crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_COLLATION_DATABASE_URL',
   'translation.title LIKE $2',
   '(translation.title COLLATE "C") LIKE $2',
   "current_setting('lc_collate')",
-  'owner_ids != index_c_ids',
-  'Unicode NFC remains byte-distinct',
-  'escaped percent literal',
 ]);
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
   'assert_eq!(schema.fields.len(), 15);',
+  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
-if (productIndex.includes('SchemaVersion::new(3)')) fail(`${productIndexPath} restored historical key 3`);
+for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)']) {
+  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema marker ${forbidden}`);
+}
 
 requireMarkers('scripts/verify/verify-product-storefront-search-bound.mjs', [
   'MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022',
   'MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024',
-  'ownerBytes + 2 !== indexBytes',
-  'reject over-bound input rather than truncate it',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs', [
   'must remain the owner/default-collation side',
-  'COLLATE \\"C\\"',
-  'owner_ids != index_c_ids',
   'must observe deployment/default collation rather than manufacture parity',
 ]);
+requireMarkers('scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs', [
+  'OwnerNativeChannelLess',
+  'ShadowEligible { public_channel_id: Uuid }',
+  'must not infer or fabricate visibility membership',
+]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
-  'product_locale_absence_postgres.rs',
-  'product_materialized_query_freshness_postgres.rs',
-  'product_channel_convergence_postgres.rs',
-  'product_channel_identity_transitions_postgres.rs',
-  'product_linked_target_recreate_postgres.rs',
-  'product_linked_target_availability_equivalence_postgres.rs',
-  'product_linked_target_replay_redelivery_postgres.rs',
-  "source.includes('SchemaVersion::new(3)')",
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `collation_packet_source_complete_execution_and_visibility_pending`',
+  'Status: `channel_scope_policy_source_complete_deep_page_pending`',
   'Mounted Storefront remains owner-native',
-  'Product-owned Storefront search bound — source complete',
-  'Title-search collation packet — source complete, execution pending',
-  '`MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022`',
-  'Core and EAV PostgreSQL packets — source complete, execution pending',
-  'Historical retained Product packets — key 4 source actualized',
-  'Collation admission per deployment',
-  'ProductVariant stays on key',
-  'SalesChannel stays on key',
-]);
-requireMarkers('crates/rustok-index/docs/m7-product-attribute-term-contract.md', [
-  'Status: `source_complete_materialized_rebuild_pending`',
-  '`requested-value OR (NOT requested-present AND fallback-value)`',
+  'Channel-less serving policy — source complete for current key 4',
+  '`OwnerNativeChannelLess`',
+  '`ShadowEligible`',
+  '`PublicChannelIdentityUnavailable`',
+  'No sentinel UUID',
+  'deep-page policy remains unresolved',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
-  "'verify-product-storefront-search-bound.mjs'",
+  "'verify-index-product-storefront-channel-scope-policy.mjs'",
   "'verify-index-product-storefront-collation-postgres-packet.mjs'",
-  "'verify-index-product-postgres-key4-fixtures.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; search length and collation packet source are complete while PostgreSQL execution/admission, channel-less visibility and serving-policy gates stay pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; current key-4 channel-less requests have a typed owner-native policy while deep-page, evidence admission and serving gates remain pending');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -26,8 +26,15 @@ const source = requireMarkers(executorPath, [
   'pub(crate) struct ProductStorefrontIndexShadowExecution',
   'pub(crate) authoritative: StorefrontProductList',
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
+  'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
+  'ShadowEligible { public_channel_id: Uuid }',
+  'OwnerNativeChannelLess',
+  'ChannelLessOwnerNative',
+  'pub(crate) fn classify_product_storefront_index_channel_scope(',
   'list_filtered_published_products(',
   'let projected = self',
+  'classify_product_storefront_index_channel_scope(',
+  'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
   '.schema_read_port()',
   '.resolve_storefront_attribute_filters(',
   'build_product_storefront_index_shadow_query(',
@@ -53,6 +60,8 @@ for (const forbidden of [
   'PostgresIndexQueryPort',
   'query_all(',
   'query_one(',
+  'CHANNEL_LESS_SENTINEL',
+  'UNRESTRICTED_CHANNEL_SENTINEL',
 ]) {
   if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports only; found ${forbidden}`);
 }
@@ -62,6 +71,8 @@ requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'ProductStorefrontIndexShadowExecutor',
   'ProductStorefrontIndexShadowExecution',
   'ProductStorefrontIndexShadowComparison',
+  'ProductStorefrontIndexChannelScopeDecision',
+  'classify_product_storefront_index_channel_scope',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -73,4 +84,4 @@ for (const forbidden of ['ProductStorefrontIndexShadowExecutor', 'execute_locali
   if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
-console.log('[verify-index-product-storefront-shadow-executor] owner-first non-serving shadow execution is source-locked; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-shadow-executor] owner-first non-serving shadow execution and typed channel-less owner-native policy are source-locked; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -85,6 +85,7 @@ const scripts = [
   'verify-index-product-storefront-localized-query-architecture.mjs',
   'verify-index-product-storefront-shadow-adapter.mjs',
   'verify-index-product-storefront-shadow-executor.mjs',
+  'verify-index-product-storefront-channel-scope-policy.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',


### PR DESCRIPTION
## Summary

- make the current Product key-4 Storefront channel request shape explicit instead of inferring channel-less visibility from `sales_channel_ids`;
- classify absent/blank slug + absent UUID as typed `OwnerNativeChannelLess`;
- classify a trusted non-empty slug + non-nil UUID as `ShadowEligible`;
- keep partial, contradictory or nil channel identity fail-closed as `PublicChannelIdentityUnavailable`;
- retain owner-first shadow behavior: the authoritative Product owner list executes first, and a channel-less request records `ChannelLessOwnerNative` only in the projected result without fabricating an Index page;
- document why current key `4` cannot distinguish unrestricted metadata from restricted-to-all-current-channels: unrestricted relation materialization resolves to all current Channel UUIDs;
- do not add sentinel UUIDs, overload `attribute_terms`, infer unrestricted visibility from membership equality, or introduce a Product key-5 schema without the normal replacement protocol;
- re-export the crate-private classifier/decision for future serving composition and add source guards that lock the owner semantics, resolver behavior and typed policy;
- advance the M7 cursor so deep-page handling is the next source-level Storefront request-shape policy.

## Boundary

This PR does not claim channel-less Index parity, change Product schema/source fields, switch Storefront traffic, execute PostgreSQL evidence, admit collation evidence, resolve deep-page policy, map localized placeholders, hydrate Taxonomy tags, or add serving latency/deadline behavior.

Any future serving router must keep channel-less requests owner-native unless a later exact visibility representation is implemented and admitted with freshness/schema-replacement evidence.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.