### PR TITLE
refactor(commerce): cut Product REST lifecycle to owner port

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL read paths against `main` at `fe0bddc83c7f81431c731e823fe87ef9b558f807`, then continued the Product schema-read and legacy catalog-read cutover through the current implementation branch.
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL/HTTP paths against `main` at `26d6e340ee6d1be462f29da6b95b6539458b843f`, then continued the Product owner-boundary cutover through the current implementation branch.
 
 The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
 
@@ -12,8 +12,9 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 2. PR #3203 published `ProductCatalogSchemaReadPort::read_product_attribute_values`, and mounted `productAttributeValues` is now cut over to that owner capability.
 3. `storefrontCatalogSearchOptions` was the remaining mounted direct `ProductCatalogSchemaService` schema-read consumer. Its current projection needs only categories and filterable/sortable attributes, so the already-published `list_categories` and `list_attributes` owner capabilities preserve the existing data and ordering semantics without a new Product projection.
 4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths already use `ProductCatalogReadRuntime`, and the mounted legacy admin `product`/`products` roots are cut over to the Product owner read runtime.
-5. PR #3238 published optional fail-closed legacy storefront detail/list capabilities without changing mounted serving. The continuation below cuts mounted `storefrontProduct` / `storefrontProducts` to those capabilities, so these production reads no longer choose Product lifecycle/channel/inventory policy or query Product entities directly.
-6. The broad ecommerce owner-boundary invariant remains open because Product schema writes, REST delete/publish/unpublish lifecycle commands, and remaining GraphQL Product lifecycle operations still require owner-port cutover and explicit idempotency contracts. Source inspection does not justify a status promotion.
+5. PR #3238 published optional fail-closed legacy storefront detail/list capabilities without changing mounted serving. Mounted `storefrontProduct` / `storefrontProducts` are now cut to those capabilities, so these production reads no longer choose Product lifecycle/channel/inventory policy or query Product entities directly.
+6. `CommerceHttpRuntime` already host-composes `ProductCatalogCommandRuntime`, and Product already publishes typed `delete_product`, `publish_product`, and `unpublish_product` command methods. The mounted REST lifecycle handlers were still bypassing that runtime through direct `CatalogService` construction and did not have an explicit caller retry identity.
+7. The continuation below cuts REST delete/publish/unpublish to the host-selected Product command port and introduces an explicit caller-provided `Idempotency-Key` contract for those repeatable lifecycle calls. The broad ecommerce owner-boundary invariant remains open because Product GraphQL lifecycle operations and schema writes still require owner-port cutover. Source inspection does not justify a status promotion.
 
 ## PR #3203 source change
 
@@ -61,11 +62,22 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Extend `verify-commerce-product-storefront-graphql-read.mjs` so the mounted detail/list slices require the host-selected runtime and new owner capabilities and forbid the previous direct `CatalogService`, Product entity, visibility SQL, translation-search, and inventory-enrichment calls inside those serving resolver slices.
 - Keep the old private Commerce list helper as unmounted compatibility source in this source-only slice; its cleanup remains separate from the mounted serving cutover and should follow compile/evidence work.
 
+## REST Product lifecycle continuation
+
+- Require a non-empty caller-provided `Idempotency-Key` header of at most 191 bytes for mounted admin REST delete, publish, and unpublish operations. The key identifies one logical lifecycle invocation and must not be reused for a distinct later invocation.
+- Scope-hash the caller key with tenant, authenticated actor, product id, and lifecycle operation before placing it into `PortContext`, so equal caller keys on different products or operations cannot alias owner command identity.
+- Build the existing bounded Product command context with authenticated actor, request locale, request channel, explicit idempotency key, and two-second deadline.
+- Cut shared mounted REST delete/publish/unpublish handlers from direct `CatalogService` construction to `CommerceHttpRuntime::product_catalog_command_port()` and Product's typed `delete_product`, `publish_product`, and `unpublish_product` commands.
+- Preserve Product permission admission, delete `204 No Content`, publish/unpublish Product response envelopes, lifecycle conflict/not-found/storage failure mapping, and correlation-aware stable public owner errors.
+- Expose the required `Idempotency-Key` contract in the mounted admin OpenAPI declarations and forward `RequestContext`/headers through the route wrappers.
+- Add `verify-commerce-product-rest-lifecycle-command-cutover.mjs` to lock the source contract: host-composed runtime, caller identity scoping, mounted forwarding, typed owner calls, and no direct `CatalogService` use inside the three lifecycle handler slices.
+
 ## Remaining execution order
 
-1. Continue remaining Product schema writes and Product lifecycle command cutovers from the canonical ecommerce plan, including REST delete/publish/unpublish and remaining GraphQL lifecycle operations. Repeatable commands require explicit caller idempotency semantics before cutover.
-2. Remove superseded private Product read compatibility helpers only after compile/source evidence confirms there are no remaining consumers.
-3. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
+1. Cut remaining mounted GraphQL Product create/update/publish/delete operations to host-composed Product command capabilities with an explicit GraphQL caller idempotency contract.
+2. Cut Product schema writes away from direct `ProductCatalogSchemaService` construction through typed owner write capabilities.
+3. Remove superseded private Product read compatibility helpers only after compile/source evidence confirms there are no remaining consumers.
+4. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 
 ## Verification state
 

--- a/crates/rustok-commerce/src/controllers/admin/products.rs
+++ b/crates/rustok-commerce/src/controllers/admin/products.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use rustok_api::Permission;
 use rustok_api::{AuthContext, RequestContext, TenantContext};
@@ -499,9 +499,13 @@ pub async fn update_product(
     delete,
     path = "/admin/products/{id}",
     tag = "admin",
-    params(("id" = Uuid, Path, description = "Product ID")),
+    params(
+        ("id" = Uuid, Path, description = "Product ID"),
+        ("Idempotency-Key" = String, Header, description = "Stable identity for this logical lifecycle command, maximum 191 bytes")
+    ),
     responses(
         (status = 204, description = "Product deleted successfully"),
+        (status = 400, description = "Missing or invalid idempotency key"),
         (status = 401, description = "Unauthorized")
     )
 )]
@@ -509,9 +513,19 @@ pub async fn delete_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
+    headers: HeaderMap,
     path: Path<Uuid>,
 ) -> HttpResult<StatusCode> {
-    super::super::products::delete_product(state, tenant, auth, path).await
+    super::super::products::delete_product(
+        state,
+        tenant,
+        auth,
+        request_context,
+        headers,
+        path,
+    )
+    .await
 }
 
 /// Publish admin ecommerce product
@@ -519,9 +533,13 @@ pub async fn delete_product(
     post,
     path = "/admin/products/{id}/publish",
     tag = "admin",
-    params(("id" = Uuid, Path, description = "Product ID")),
+    params(
+        ("id" = Uuid, Path, description = "Product ID"),
+        ("Idempotency-Key" = String, Header, description = "Stable identity for this logical lifecycle command, maximum 191 bytes")
+    ),
     responses(
         (status = 200, description = "Product published successfully", body = ProductResponse),
+        (status = 400, description = "Missing or invalid idempotency key"),
         (status = 401, description = "Unauthorized")
     )
 )]
@@ -529,9 +547,19 @@ pub async fn publish_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
+    headers: HeaderMap,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::publish_product(state, tenant, auth, path).await
+    super::super::products::publish_product(
+        state,
+        tenant,
+        auth,
+        request_context,
+        headers,
+        path,
+    )
+    .await
 }
 
 /// Unpublish admin ecommerce product
@@ -539,9 +567,13 @@ pub async fn publish_product(
     post,
     path = "/admin/products/{id}/unpublish",
     tag = "admin",
-    params(("id" = Uuid, Path, description = "Product ID")),
+    params(
+        ("id" = Uuid, Path, description = "Product ID"),
+        ("Idempotency-Key" = String, Header, description = "Stable identity for this logical lifecycle command, maximum 191 bytes")
+    ),
     responses(
         (status = 200, description = "Product unpublished successfully", body = ProductResponse),
+        (status = 400, description = "Missing or invalid idempotency key"),
         (status = 401, description = "Unauthorized")
     )
 )]
@@ -549,7 +581,17 @@ pub async fn unpublish_product(
     state: State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
+    headers: HeaderMap,
     path: Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
-    super::super::products::unpublish_product(state, tenant, auth, path).await
+    super::super::products::unpublish_product(
+        state,
+        tenant,
+        auth,
+        request_context,
+        headers,
+        path,
+    )
+    .await
 }

--- a/crates/rustok-commerce/src/controllers/products.rs
+++ b/crates/rustok-commerce/src/controllers/products.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use rustok_api::Permission;
 use rustok_api::locale_tags_match;
@@ -32,6 +32,7 @@ use super::common::{PaginatedResponse, PaginationMeta, PaginationParams, ensure_
 
 const ADMIN_PRODUCT_OWNER: &str = "rustok_product.catalog";
 const ADMIN_PRODUCT_BOUNDARY: &str = "commerce_admin_product_http";
+const MAX_ADMIN_PRODUCT_LIFECYCLE_KEY_LENGTH: usize = 191;
 
 type AdminProductHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
 
@@ -208,6 +209,45 @@ pub(crate) fn admin_product_command_idempotency_key<T: Serialize>(
         digest.update(product_id.as_bytes());
     }
     digest.update(payload);
+    Ok(format!(
+        "commerce-admin-product:{operation}:{}",
+        hex::encode(digest.finalize())
+    ))
+}
+
+pub(crate) fn admin_product_lifecycle_idempotency_key(
+    headers: &HeaderMap,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    product_id: Uuid,
+    operation: &'static str,
+) -> HttpResult<String> {
+    let caller_key = headers
+        .get("idempotency-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            HttpError::bad_request(
+                "product_idempotency_key_required",
+                "Idempotency-Key header is required",
+            )
+        })?;
+    if caller_key.len() > MAX_ADMIN_PRODUCT_LIFECYCLE_KEY_LENGTH {
+        return Err(HttpError::bad_request(
+            "product_idempotency_key_invalid",
+            format!(
+                "Idempotency-Key must contain at most {MAX_ADMIN_PRODUCT_LIFECYCLE_KEY_LENGTH} bytes"
+            ),
+        ));
+    }
+
+    let mut digest = Sha256::new();
+    digest.update(tenant_id.as_bytes());
+    digest.update(actor_id.as_bytes());
+    digest.update(product_id.as_bytes());
+    digest.update(operation.as_bytes());
+    digest.update(caller_key.as_bytes());
     Ok(format!(
         "commerce-admin-product:{operation}:{}",
         hex::encode(digest.finalize())
@@ -543,6 +583,8 @@ pub async fn delete_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
 ) -> HttpResult<StatusCode> {
     ensure_permissions(
@@ -551,13 +593,23 @@ pub async fn delete_product(
         "Permission denied: products:delete required",
     )?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    service
-        .delete_product(tenant.id, auth.user_id, id)
+    let idempotency_key = admin_product_lifecycle_idempotency_key(
+        &headers,
+        tenant.id,
+        auth.user_id,
+        id,
+        "delete_product",
+    )?;
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
+    runtime
+        .product_catalog_command_port()
+        .delete_product(port_context.clone(), id)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "delete_product"),
+                &port_context,
                 error,
             )
         })?;
@@ -570,6 +622,8 @@ pub async fn publish_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     ensure_permissions(
@@ -578,13 +632,23 @@ pub async fn publish_product(
         "Permission denied: products:update required",
     )?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    let product = service
-        .publish_product(tenant.id, auth.user_id, id)
+    let idempotency_key = admin_product_lifecycle_idempotency_key(
+        &headers,
+        tenant.id,
+        auth.user_id,
+        id,
+        "publish_product",
+    )?;
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
+    let product = runtime
+        .product_catalog_command_port()
+        .publish_product(port_context.clone(), id)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(tenant.id, auth.user_id, Some(id), "publish_product"),
+                &port_context,
                 error,
             )
         })?;
@@ -597,6 +661,8 @@ pub async fn unpublish_product(
     State(runtime): State<crate::controllers::CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
+    headers: HeaderMap,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ProductResponse>> {
     ensure_permissions(
@@ -605,18 +671,28 @@ pub async fn unpublish_product(
         "Permission denied: products:update required",
     )?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
-    let product = service
-        .unpublish_product(tenant.id, auth.user_id, id)
+    let idempotency_key = admin_product_lifecycle_idempotency_key(
+        &headers,
+        tenant.id,
+        auth.user_id,
+        id,
+        "unpublish_product",
+    )?;
+    let port_context =
+        admin_product_command_context(tenant.id, &auth, &request_context, idempotency_key);
+    let product = runtime
+        .product_catalog_command_port()
+        .unpublish_product(port_context.clone(), id)
         .await
         .map_err(|error| {
-            map_admin_product_error(
+            map_admin_product_port_error(
                 AdminProductErrorContext::new(
                     tenant.id,
                     auth.user_id,
                     Some(id),
                     "unpublish_product",
                 ),
+                &port_context,
                 error,
             )
         })?;

--- a/scripts/verify/verify-commerce-product-rest-lifecycle-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-rest-lifecycle-command-cutover.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`commerce Product REST lifecycle cutover guard failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireText(source, text, message) {
+  if (!source.includes(text)) fail(message);
+}
+
+function forbidText(source, text, message) {
+  if (source.includes(text)) fail(message);
+}
+
+function functionSlice(source, name, nextName) {
+  const start = source.indexOf(`pub async fn ${name}(`);
+  if (start < 0) {
+    fail(`missing function ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`pub async fn ${nextName}(`, start + 1) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const shared = read("crates/rustok-commerce/src/controllers/products.rs");
+const mounted = read("crates/rustok-commerce/src/controllers/admin/products.rs");
+const router = read("crates/rustok-commerce/src/controllers/admin/mod.rs");
+const runtime = read("crates/rustok-commerce/src/controllers/mod.rs");
+const ownerPort = read("crates/rustok-product/src/catalog_command_port.rs");
+
+for (const required of [
+  "async fn delete_product(",
+  "async fn publish_product(",
+  "async fn unpublish_product(",
+  "PortCallPolicy::write()",
+]) {
+  requireText(ownerPort, required, `Product owner command port must contain ${required}`);
+}
+
+for (const required of [
+  "product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime",
+  "fn product_catalog_command_port(",
+  ".product_catalog_command_runtime.command_port()",
+  ".shared_get::<rustok_product::ProductCatalogCommandRuntime>()",
+]) {
+  requireText(runtime, required, `Commerce HTTP runtime must contain ${required}`);
+}
+
+const lifecycleKeyStart = shared.indexOf("pub(crate) fn admin_product_lifecycle_idempotency_key(");
+const lifecycleContextStart = shared.indexOf("pub(crate) fn admin_product_command_context(", lifecycleKeyStart);
+const lifecycleKey = shared.slice(lifecycleKeyStart, lifecycleContextStart);
+for (const required of [
+  'headers.get("idempotency-key")',
+  '"product_idempotency_key_required"',
+  '"Idempotency-Key header is required"',
+  "MAX_ADMIN_PRODUCT_LIFECYCLE_KEY_LENGTH",
+  '"product_idempotency_key_invalid"',
+  "digest.update(tenant_id.as_bytes())",
+  "digest.update(actor_id.as_bytes())",
+  "digest.update(product_id.as_bytes())",
+  "digest.update(operation.as_bytes())",
+  "digest.update(caller_key.as_bytes())",
+]) {
+  requireText(lifecycleKey, required, `lifecycle caller identity must contain ${required}`);
+}
+
+const deleteHandler = functionSlice(shared, "delete_product", "publish_product");
+const publishHandler = functionSlice(shared, "publish_product", "unpublish_product");
+const unpublishHandler = functionSlice(shared, "unpublish_product", null);
+
+for (const [handler, operation, permission, portCall] of [
+  [deleteHandler, "delete_product", "Permission::PRODUCTS_DELETE", ".delete_product(port_context.clone(), id)"],
+  [publishHandler, "publish_product", "Permission::PRODUCTS_UPDATE", ".publish_product(port_context.clone(), id)"],
+  [unpublishHandler, "unpublish_product", "Permission::PRODUCTS_UPDATE", ".unpublish_product(port_context.clone(), id)"],
+]) {
+  for (const required of [
+    permission,
+    "request_context: RequestContext",
+    "headers: HeaderMap",
+    "admin_product_lifecycle_idempotency_key(",
+    `"${operation}"`,
+    "admin_product_command_context(",
+    ".product_catalog_command_port()",
+    portCall,
+    "map_admin_product_port_error(",
+  ]) {
+    requireText(handler, required, `${operation} handler must contain ${required}`);
+  }
+  for (const forbidden of [
+    "CatalogService::new",
+    `.operate_product(tenant.id, auth.user_id, id)`,
+    `.delete_product(tenant.id, auth.user_id, id)`,
+    `.publish_product(tenant.id, auth.user_id, id)`,
+    `.unpublish_product(tenant.id, auth.user_id, id)`,
+    "map_admin_product_error(",
+  ]) {
+    forbidText(handler, forbidden, `${operation} handler must not contain ${forbidden}`);
+  }
+}
+
+for (const [name, nextName] of [
+  ["delete_product", "publish_product"],
+  ["publish_product", "unpublish_product"],
+  ["unpublish_product", null],
+]) {
+  const handler = functionSlice(mounted, name, nextName);
+  for (const required of [
+    '("Idempotency-Key" = String, Header',
+    "request_context: RequestContext",
+    "headers: HeaderMap",
+    `super::super::products::${name}(`,
+    "request_context,",
+    "headers,",
+  ]) {
+    requireText(handler, required, `mounted ${name} wrapper must contain ${required}`);
+  }
+}
+
+for (const required of [
+  ".delete(products::delete_product)",
+  "axum::routing::post(products::publish_product)",
+  "axum::routing::post(products::unpublish_product)",
+]) {
+  requireText(router, required, `mounted Product lifecycle route must contain ${required}`);
+}
+
+if (!process.exitCode) {
+  console.log("commerce Product REST lifecycle cutover guard: source contract OK");
+}


### PR DESCRIPTION
## Summary

- cut mounted admin REST Product delete/publish/unpublish handlers from direct `CatalogService` construction to the host-composed `ProductCatalogCommandRuntime` / `ProductCatalogCommandPort`
- preserve `PRODUCTS_DELETE` / `PRODUCTS_UPDATE` admission, delete `204 No Content`, publish/unpublish Product response envelopes, request locale/channel context, two-second deadline, and correlation-aware stable Product owner error mapping
- require a non-empty caller-provided `Idempotency-Key` header (maximum 191 bytes) for these repeatable lifecycle endpoints before owner-port cutover
- scope-hash the caller key with tenant, authenticated actor, product id, and lifecycle operation before forwarding it as the Product command `PortContext` idempotency/correlation identity, preventing cross-product or cross-operation aliasing
- expose the required header and 400 missing/invalid response in the mounted OpenAPI declarations and forward `RequestContext`/headers through the admin wrappers
- add a source guard for host composition, caller identity scoping, mounted forwarding, typed owner calls, and absence of direct `CatalogService` use inside the three lifecycle handler slices
- update the Product ecommerce recheck packet; the broad owner-boundary invariant remains open for GraphQL Product lifecycle commands and Product schema writes, so no FBA/FFA or verification status is promoted

`Idempotency-Key` identifies one logical lifecycle invocation and must not be reused for a distinct later invocation. This PR establishes and forwards the caller retry identity; it does not claim new durable replay storage inside the Product owner.

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction.