### PR TITLE
feat(index): retain real deep Storefront page policy

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -16,9 +16,10 @@ pub(crate) use storefront_shadow::{
 };
 mod storefront_shadow_executor;
 pub(crate) use storefront_shadow_executor::{
-    ProductStorefrontIndexChannelScopeDecision, ProductStorefrontIndexShadowComparison,
-    ProductStorefrontIndexShadowExecution, ProductStorefrontIndexShadowExecutor,
-    ProductStorefrontIndexShadowProjectionError, classify_product_storefront_index_channel_scope,
+    ProductStorefrontIndexChannelScopeDecision, ProductStorefrontIndexPageScopeDecision,
+    ProductStorefrontIndexShadowComparison, ProductStorefrontIndexShadowExecution,
+    ProductStorefrontIndexShadowExecutor, ProductStorefrontIndexShadowProjectionError,
+    classify_product_storefront_index_channel_scope, classify_product_storefront_index_page_scope,
 };
 #[cfg(test)]
 mod storefront_shadow_eav_postgres_tests;

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -15,6 +15,8 @@ use super::{
     ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,
 };
 
+const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;
+
 /// Non-serving Product Storefront parity execution result.
 ///
 /// The authoritative owner result is always produced first. Projected failures or mismatches are retained
@@ -51,6 +53,17 @@ pub(crate) enum ProductStorefrontIndexChannelScopeDecision {
     OwnerNativeChannelLess,
 }
 
+/// Request-shape decision for owner-valid Product Storefront offset pagination.
+///
+/// The Product owner has no explicit maximum offset, while the generic Index offset contract is bounded at
+/// 10,000. Requests inside that bound remain shadow-eligible. Owner-valid deeper pages remain owner-native;
+/// they are never clamped or rewritten to cursor pagination because either would change owner semantics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProductStorefrontIndexPageScopeDecision {
+    ShadowEligible { offset: u64 },
+    OwnerNativeDeepPage { offset: u64 },
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum ProductStorefrontIndexShadowProjectionError {
     #[error("Product Storefront shadow schema-read capability is unavailable")]
@@ -59,6 +72,8 @@ pub(crate) enum ProductStorefrontIndexShadowProjectionError {
     InvalidTenant,
     #[error("Product Storefront channel-less requests remain owner-native for the current Index key-4 contract")]
     ChannelLessOwnerNative,
+    #[error("Product Storefront deep page at offset {offset} remains owner-native beyond the Index offset bound")]
+    DeepPageOwnerNative { offset: u64 },
     #[error("Product Storefront shadow requires a trusted public channel slug/id pair")]
     PublicChannelIdentityUnavailable,
     #[error("Product Storefront shadow attribute-filter owner resolution failed: {0}")]
@@ -90,6 +105,29 @@ pub(crate) fn classify_product_storefront_index_channel_scope(
     }
 }
 
+/// Classify Product owner offset pagination before projected metadata or Index work begins.
+///
+/// Invalid pagination remains an error and is not treated as an owner-native fallback shape. A valid offset
+/// above the generic Index bound is a deliberate owner-native request shape. The pure shadow query builder
+/// retains its own `OffsetTooDeep` fail-closed check as a second boundary for direct callers.
+pub(crate) fn classify_product_storefront_index_page_scope(
+    query: &StorefrontProductListQuery,
+) -> Result<ProductStorefrontIndexPageScopeDecision, ProductStorefrontIndexShadowProjectionError> {
+    if query.page == 0 || query.per_page == 0 || query.per_page > 48 {
+        return Err(ProductStorefrontIndexShadowError::InvalidPagination.into());
+    }
+    let offset = query
+        .page
+        .checked_sub(1)
+        .and_then(|page| page.checked_mul(query.per_page))
+        .ok_or(ProductStorefrontIndexShadowError::InvalidPagination)?;
+    if offset > MAX_INDEX_OFFSET_DEPTH {
+        Ok(ProductStorefrontIndexPageScopeDecision::OwnerNativeDeepPage { offset })
+    } else {
+        Ok(ProductStorefrontIndexPageScopeDecision::ShadowEligible { offset })
+    }
+}
+
 /// Owner-first, non-serving Product Storefront shadow executor.
 ///
 /// This object composes only host-selected Product and Index capabilities. It never constructs
@@ -98,8 +136,8 @@ pub(crate) fn classify_product_storefront_index_channel_scope(
 /// Index readiness/admission, or Index execution fails.
 ///
 /// Channel-scoped projection requires a trusted current slug/UUID pair supplied by the caller's current
-/// channel context. Channel-less requests are intentionally retained as typed owner-native projected results
-/// for the current key-4 schema rather than approximated from `sales_channel_ids`.
+/// channel context. Channel-less requests and owner-valid deep offset pages are intentionally retained as
+/// typed owner-native projected results rather than approximated by Index.
 #[derive(Clone)]
 pub(crate) struct ProductStorefrontIndexShadowExecutor {
     product: ProductCatalogReadRuntime,
@@ -176,6 +214,14 @@ impl ProductStorefrontIndexShadowExecutor {
                 return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);
             }
         };
+        match classify_product_storefront_index_page_scope(&query)? {
+            ProductStorefrontIndexPageScopeDecision::ShadowEligible { .. } => {}
+            ProductStorefrontIndexPageScopeDecision::OwnerNativeDeepPage { offset } => {
+                return Err(ProductStorefrontIndexShadowProjectionError::DeepPageOwnerNative {
+                    offset,
+                });
+            }
+        }
         let tenant_id = Uuid::parse_str(context.tenant_id.as_str())
             .map_err(|_| ProductStorefrontIndexShadowProjectionError::InvalidTenant)?;
         let schema_read = self
@@ -280,6 +326,37 @@ mod tests {
         assert!(matches!(
             classify_product_storefront_index_channel_scope(Some("web"), Some(Uuid::nil())),
             Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
+        ));
+    }
+
+    #[test]
+    fn page_scope_distinguishes_shallow_from_owner_native_deep_pages() {
+        let shallow = StorefrontProductListQuery::default().with_pagination(209, 48);
+        assert_eq!(
+            classify_product_storefront_index_page_scope(&shallow).unwrap(),
+            ProductStorefrontIndexPageScopeDecision::ShadowEligible { offset: 9_984 }
+        );
+
+        let deep = StorefrontProductListQuery::default().with_pagination(210, 48);
+        assert_eq!(
+            classify_product_storefront_index_page_scope(&deep).unwrap(),
+            ProductStorefrontIndexPageScopeDecision::OwnerNativeDeepPage { offset: 10_032 }
+        );
+
+        let invalid = StorefrontProductListQuery::default().with_pagination(0, 48);
+        assert!(matches!(
+            classify_product_storefront_index_page_scope(&invalid),
+            Err(ProductStorefrontIndexShadowProjectionError::QueryBuild(
+                ProductStorefrontIndexShadowError::InvalidPagination
+            ))
+        ));
+
+        let overflow = StorefrontProductListQuery::default().with_pagination(u64::MAX, 48);
+        assert!(matches!(
+            classify_product_storefront_index_page_scope(&overflow),
+            Err(ProductStorefrontIndexShadowProjectionError::QueryBuild(
+                ProductStorefrontIndexShadowError::InvalidPagination
+            ))
         ));
     }
 }

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product Storefront collation packet merge
-`26d6e340ee6d1be462f29da6b95b6539458b843f` and continued on
-`agent/product-storefront-channel-scope-policy-20260808`.
+Status overlay rechecked on current `main` at
+`442e5e591f68ec93a527630a14fbce8e6de2ba5e` and continued on
+`agent/product-storefront-deep-page-policy-v2-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -29,6 +29,8 @@ Source-complete:
 - pure Storefront shadow builder and owner-first non-serving shadow executor;
 - explicit current-key channel-scope policy: trusted non-empty slug + non-nil UUID is shadow-eligible, while
   channel-less owner requests remain owner-native and partial/invalid channel identity fails closed;
+- explicit deep-page policy: owner-valid offsets through `10_000` are shadow-eligible while deeper offsets
+  remain typed owner-native without clamp or cursor rewriting;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
@@ -47,27 +49,42 @@ request-specific Product visibility predicate. Consequently the current source d
 encode visibility into unrelated `attribute_terms`, or introduce a key-5 schema without the replacement
 protocol/evidence required for a real schema change.
 
-`classify_product_storefront_index_channel_scope` now makes the request policy explicit:
+`classify_product_storefront_index_channel_scope` makes the request policy explicit:
 
 - absent/blank slug + absent UUID => `OwnerNativeChannelLess`;
 - non-empty slug + non-nil UUID => `ShadowEligible`;
 - partial, contradictory or nil channel identity => `PublicChannelIdentityUnavailable`.
 
-The shadow executor still runs the authoritative Product owner list first. For channel-less requests it retains
-that result and records typed projected reason `ChannelLessOwnerNative`; it never approximates an Index result.
+The shadow executor runs the authoritative Product owner list first. For channel-less requests it retains that
+result and records typed projected reason `ChannelLessOwnerNative`; it never approximates an Index result.
 This closes the current-key **policy decision**, not channel-less Index parity. Any future serving router must
 continue to route this shape owner-native unless a later schema/query capability represents the distinction
 exactly with freshness evidence.
+
+## Deep-page decision
+
+The Product owner validates `page >= 1` and `1 <= per_page <= 48` but has no generic Index-style maximum
+offset. The generic Index path is bounded to offset `10_000`.
+
+`classify_product_storefront_index_page_scope` preserves that difference after owner success and before
+projected schema/EAV work:
+
+- offset `<= 10_000` => `ShadowEligible { offset }`;
+- offset `> 10_000` => `OwnerNativeDeepPage { offset }` and projected `DeepPageOwnerNative { offset }`;
+- invalid page/per-page or arithmetic overflow => existing invalid-pagination query-build error.
+
+No page/offset clamp or cursor rewrite is introduced. The pure shadow builder independently retains
+`OffsetTooDeep` as its direct-call fail-closed boundary.
 
 ## Remaining Storefront parity/evidence blockers
 
 - execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the retained deployment matrix agrees;
-- owner page depth exceeds the Index bounded offset depth;
-- map localized null title/handle to owner public placeholders in final projection;
+- map localized null title/handle to owner public placeholders in final projection **after** Index page
+  identity/order/count is fixed;
 - hydrate localized Taxonomy tag names only after Product page identity/count is fixed;
 - define serving latency/deadline policy before any shadow-to-serving transition;
-- preserve channel-less owner-native routing in any future serving composition;
+- preserve channel-less and deep-page owner-native routing in any future serving composition;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence.
 
 ## Retained Product evidence state
@@ -110,24 +127,23 @@ and SalesChannel remains key `1`.
 - [x] Retain current-key core/EAV owner-vs-shadow PostgreSQL packet source.
 - [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
 - [x] Keep channel-less Storefront owner-native on current key `4`; distinguish malformed channel identity.
+- [x] Keep owner-valid offsets above `10_000` owner-native without clamp/rewrite.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Decide authoritative deep-page policy.
 - [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
 - [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
 - [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes;
-      channel-less remains owner-native unless a later exact representation is admitted.
+      channel-less and deep-page shapes remain owner-native under the current contracts.
 
 ## Next source-code step
 
-Resolve deep-page request policy without silently narrowing owner semantics. The owner accepts any checked
-`(page - 1) * per_page` offset representable by its query path, while generic Index offset pagination is
-bounded to `10_000`. Classify an otherwise valid owner request whose computed offset exceeds that bound as a
-typed **owner-native deep-page** shape, distinct from invalid pagination, and keep shallow pages shadow-eligible.
-Do not clamp page/offset or silently switch pagination semantics.
+Add a Product Storefront post-page projection adapter for the current Index page. It must map a localized
+`title` null to `"Untitled product"` and localized `handle` null to `""` only **after** the Index page has fixed
+entity identity, ordering, exact count and page boundary. It must not use placeholders in filtering, sorting,
+identity folding or count and must not claim Taxonomy tag-name parity yet.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-deep-page-policy.md
+++ b/crates/rustok-index/docs/m7-product-storefront-deep-page-policy.md
@@ -1,0 +1,39 @@
+# M7 Product Storefront deep-page policy
+
+Status: `source_complete_owner_execution_policy_retained`.
+
+## Owner boundary
+
+The modern Product Storefront owner validates `page >= 1` and `1 <= per_page <= 48`, then executes the
+requested offset. It does not impose the generic Index offset ceiling.
+
+The generic Product Storefront Index shadow builder remains bounded to offset `10_000`. That bound is an Index
+query safety contract; it is not an owner Product validation rule and must not silently narrow owner-visible
+Storefront behavior.
+
+## Current policy
+
+`ProductStorefrontIndexShadowExecutor` classifies owner-valid pagination after authoritative owner success and
+before Product EAV/schema-read work:
+
+- computed offset `<= 10_000` => `ShadowEligible { offset }`;
+- computed offset `> 10_000` => `OwnerNativeDeepPage { offset }`;
+- invalid page/per-page or arithmetic overflow => the existing invalid-pagination query-build error.
+
+For an owner-native deep page, the authoritative Product owner list has already completed successfully. The
+projected side returns typed `DeepPageOwnerNative { offset }`; no Index page is fabricated and the successful
+owner result remains authoritative.
+
+The policy does not clamp page or offset, rewrite the request to cursor pagination, or reinterpret an
+owner-valid deep page as invalid input. The pure shadow builder still retains `OffsetTooDeep` as a defensive
+fail-closed boundary when called directly.
+
+## Evidence and serving boundary
+
+This is a request-shape policy decision, not proof that deep pages execute acceptably at serving latency. The
+mounted Storefront remains owner-native. A future serving router may send only eligible shallow requests to an
+admitted Index path; deep pages must continue through the Product owner unless a later generic pagination
+contract preserves the owner semantics exactly.
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `channel_scope_policy_source_complete_deep_page_pending`.
+Status: `deep_page_policy_source_complete_projection_placeholder_pending`.
 
 ## Current boundary
 
@@ -40,6 +40,23 @@ No sentinel UUID, `attribute_terms` visibility encoding, key-5 Product schema, o
 is introduced. Any future serving composition must preserve owner-native handling for this shape until a later
 exact representation is implemented with the normal schema replacement and freshness evidence gates.
 
+## Deep-page serving policy — source complete
+
+The Product owner validates `page >= 1` and `1 <= per_page <= 48`, but it does not impose the generic Index
+offset ceiling. The generic Product Storefront shadow builder remains bounded at offset `10_000`.
+
+`classify_product_storefront_index_page_scope` now preserves this owner/Index difference after the authoritative
+owner list succeeds and before projected schema/EAV work:
+
+- checked offset `<= 10_000` => `ShadowEligible { offset }`;
+- checked offset `> 10_000` => `OwnerNativeDeepPage { offset }` and projected
+  `DeepPageOwnerNative { offset }`;
+- invalid page/per-page or arithmetic overflow => existing invalid-pagination query-build error.
+
+The policy does not clamp page/offset or rewrite the request to cursor pagination. The pure shadow builder
+retains `OffsetTooDeep` as a second fail-closed boundary for direct callers. Deep pages therefore remain
+owner-native under the current contracts rather than being made artificially representable.
+
 ## Product-owned Storefront search bound — source complete
 
 Product owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022`. The owner wraps normalized search as
@@ -62,8 +79,8 @@ used by shadow execution. Distribution translates Product-owned neutral term exp
 `attribute_terms`; missing option identities remain `Never` and map to a bind-free false predicate.
 
 `ProductStorefrontIndexShadowExecutor` executes the authoritative Product owner list first. Only eligible
-channel-scoped projected work proceeds through Product metadata resolution, localized query construction and
-`execute_localized_query`. Projected failures cannot replace the successful owner result.
+channel-scoped, shallow projected work proceeds through Product metadata resolution, localized query
+construction and `execute_localized_query`. Projected failures cannot replace the successful owner result.
 
 ## Core/EAV and retained Product PostgreSQL packets
 
@@ -82,28 +99,30 @@ key `2`, SalesChannel key `1`. Execution/review remains maintainer-owned.
 
 1. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
 2. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
-3. Owner page depth exceeds the generic Index 10,000 offset bound; deep-page policy remains unresolved.
-4. Final Storefront projection must map no-localized-row null title/handle to owner placeholders.
-5. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
-6. Shadow execution has no serving latency/deadline policy and remains non-serving.
-7. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
-8. Any future serving router must preserve the typed channel-less owner-native branch.
+3. Final Storefront projection must map no-localized-row null title/handle to owner placeholders only after
+   entity identity/order/count/page boundary are fixed.
+4. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
+5. Shadow execution has no serving latency/deadline policy and remains non-serving.
+6. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
+7. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
 
 ## Next source slice
 
-Decide deep-page policy without narrowing owner semantics. An owner-valid request whose checked offset exceeds
-the generic Index 10,000 offset maximum should become a typed **owner-native deep-page** projected reason,
-while invalid page/per-page remains a validation failure and shallow pages remain shadow-eligible. Do not
-clamp page/offset or silently change pagination strategy.
+Add a post-page Product Storefront projection adapter for the Index result. A localized null `title` must map to
+owner public placeholder `"Untitled product"` and a localized null `handle` to `""`, but only after the Index
+query has already fixed identity, ordering, exact count and page boundary. Do not feed placeholders back into
+filtering, sorting, identity folding or count. Taxonomy tag-name hydration remains a later slice.
 
 ## Source guards
 
 - `verify-index-product-storefront-channel-scope-policy.mjs` locks owner channel-less semantics, unrestricted
   relation materialization and the typed current-key owner-native decision without sentinels;
+- `verify-index-product-storefront-deep-page-policy.mjs` locks owner-valid shallow/deep classification and
+  forbids page/offset clamp or cursor rewriting;
 - `verify-product-storefront-search-bound.mjs` locks the Product-owned search-length contract;
 - `verify-index-product-storefront-collation-postgres-packet.mjs` locks retained collation evidence;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;
-- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first execution plus typed channel scope;
+- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first execution plus typed request scopes;
 - `verify-index-product-storefront-equivalence-postgres-packet.mjs` and the EAV counterpart lock current-key
   parity packets;
 - `verify-index-product-postgres-key4-fixtures.mjs` locks retained Product packets on key `4`;

--- a/scripts/verify/verify-index-product-storefront-deep-page-policy.mjs
+++ b/scripts/verify/verify-index-product-storefront-deep-page-policy.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-deep-page-policy] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+const owner = requireMarkers(ownerPath, [
+  'if page == 0 || per_page == 0 || per_page > 48',
+  'let offset = (page.saturating_sub(1)) * per_page;',
+  'query.offset(offset).limit(per_page).all(&self.db).await?',
+]);
+const modernList = owner.slice(
+  owner.indexOf('pub async fn list_published_products_with_query('),
+  owner.indexOf('pub(crate) async fn list_legacy_storefront_products_with_locale_fallback('),
+);
+if (modernList.includes('10_000')) {
+  fail(`${ownerPath} must not silently narrow owner-valid modern Storefront depth to the Index bound`);
+}
+
+const builderPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
+const builder = requireMarkers(builderPath, [
+  'const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;',
+  'if offset > MAX_INDEX_OFFSET_DEPTH',
+  'ProductStorefrontIndexShadowError::OffsetTooDeep',
+]);
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;',
+  'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
+  'ShadowEligible { offset: u64 }',
+  'OwnerNativeDeepPage { offset: u64 }',
+  'DeepPageOwnerNative { offset: u64 }',
+  'pub(crate) fn classify_product_storefront_index_page_scope(',
+  'checked_sub(1)',
+  'checked_mul(query.per_page)',
+  'if offset > MAX_INDEX_OFFSET_DEPTH',
+  'classify_product_storefront_index_page_scope(&query)',
+  'return Err(ProductStorefrontIndexShadowProjectionError::DeepPageOwnerNative',
+  'page_scope_distinguishes_shallow_from_owner_native_deep_pages',
+  'ShadowEligible { offset: 9_984 }',
+  'OwnerNativeDeepPage { offset: 10_032 }',
+]);
+
+const builderMatch = builder.match(/MAX_INDEX_OFFSET_DEPTH: u64 = ([\d_]+);/);
+const executorMatch = executor.match(/MAX_INDEX_OFFSET_DEPTH: u64 = ([\d_]+);/);
+if (!builderMatch || !executorMatch || builderMatch[1] !== executorMatch[1]) {
+  fail('shadow builder and executor page classifier must retain the same Index offset depth');
+}
+
+for (const forbidden of [
+  '.min(MAX_INDEX_OFFSET_DEPTH)',
+  'offset = MAX_INDEX_OFFSET_DEPTH',
+  'query.page =',
+  'query.per_page =',
+  'Pagination::Cursor',
+]) {
+  if (executor.includes(forbidden)) {
+    fail(`${executorPath} must preserve owner pagination without clamp/rewrite: ${forbidden}`);
+  }
+}
+
+const ownerPosition = executor.indexOf('list_filtered_published_products(');
+const classifierPosition = executor.indexOf('classify_product_storefront_index_page_scope(&query)');
+const schemaReadPosition = executor.indexOf('.schema_read_port()');
+if (
+  ownerPosition < 0 ||
+  classifierPosition < 0 ||
+  schemaReadPosition < 0 ||
+  ownerPosition > classifierPosition ||
+  classifierPosition > schemaReadPosition
+) {
+  fail('deep-page classification must happen after owner success and before projected schema/EAV reads');
+}
+
+console.log('[verify-index-product-storefront-deep-page-policy] shallow pages stay shadow-eligible; owner-valid offsets above 10000 stay typed owner-native without clamp/rewrite');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -45,11 +45,20 @@ const owner = requireMarkers(ownerPath, [
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
   'let pattern = format!("%{search}%");',
   'pt.title LIKE $1',
+  'if page == 0 || per_page == 0 || per_page > 48',
+  'let offset = (page.saturating_sub(1)) * per_page;',
 ]);
 const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
 if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
 if (titleSearch.includes('COLLATE')) {
   fail(`${ownerPath} owner title search changed collation before retained default-vs-C evidence admission`);
+}
+const modernList = owner.slice(
+  owner.indexOf('pub async fn list_published_products_with_query('),
+  owner.indexOf('pub(crate) async fn list_legacy_storefront_products_with_locale_fallback('),
+);
+if (modernList.includes('10_000')) {
+  fail(`${ownerPath} must not narrow owner-valid Storefront page depth to the Index offset bound`);
 }
 
 requireMarkers('crates/rustok-product/src/services/catalog/helpers.rs', [
@@ -71,19 +80,31 @@ const executor = requireMarkers(executorPath, [
   'pub(crate) fn classify_product_storefront_index_channel_scope(',
   '(None, None) => Ok(ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess)',
   'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
+  'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
+  'OwnerNativeDeepPage { offset: u64 }',
+  'DeepPageOwnerNative { offset: u64 }',
+  'pub(crate) fn classify_product_storefront_index_page_scope(',
+  'classify_product_storefront_index_page_scope(&query)',
   'list_filtered_published_products(',
   '.resolve_storefront_attribute_filters(',
   '.execute_localized_query(index_query)',
   'pub(crate) authoritative: StorefrontProductList',
 ]);
-for (const forbidden of ['CHANNEL_LESS_SENTINEL', 'UNRESTRICTED_CHANNEL_SENTINEL']) {
-  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden visibility sentinel ${forbidden}`);
+for (const forbidden of [
+  'CHANNEL_LESS_SENTINEL',
+  'UNRESTRICTED_CHANNEL_SENTINEL',
+  '.min(MAX_INDEX_OFFSET_DEPTH)',
+  'Pagination::Cursor',
+]) {
+  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden request-shape shortcut ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow.rs', [
   'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
   'PublicChannelRequired',
   'root_field("sales_channel_ids")?',
+  'const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;',
+  'ProductStorefrontIndexShadowError::OffsetTooDeep',
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
@@ -127,23 +148,37 @@ requireMarkers('scripts/verify/verify-index-product-storefront-channel-scope-pol
   'ShadowEligible { public_channel_id: Uuid }',
   'must not infer or fabricate visibility membership',
 ]);
+requireMarkers('scripts/verify/verify-index-product-storefront-deep-page-policy.mjs', [
+  'OwnerNativeDeepPage { offset: u64 }',
+  'DeepPageOwnerNative { offset: u64 }',
+  'ShadowEligible { offset: 9_984 }',
+  'OwnerNativeDeepPage { offset: 10_032 }',
+  'must preserve owner pagination without clamp/rewrite',
+]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `channel_scope_policy_source_complete_deep_page_pending`',
+  'Status: `deep_page_policy_source_complete_projection_placeholder_pending`',
   'Mounted Storefront remains owner-native',
   'Channel-less serving policy — source complete for current key 4',
+  'Deep-page serving policy — source complete',
   '`OwnerNativeChannelLess`',
-  '`ShadowEligible`',
-  '`PublicChannelIdentityUnavailable`',
-  'No sentinel UUID',
-  'deep-page policy remains unresolved',
+  '`OwnerNativeDeepPage { offset }`',
+  '`DeepPageOwnerNative { offset }`',
+  'no-localized-row null title/handle',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-deep-page-policy.md', [
+  'Status: `source_complete_owner_execution_policy_retained`',
+  '`OwnerNativeDeepPage { offset }`',
+  '`DeepPageOwnerNative { offset }`',
+  'no Index page is fabricated',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-storefront-channel-scope-policy.mjs'",
+  "'verify-index-product-storefront-deep-page-policy.mjs'",
   "'verify-index-product-storefront-collation-postgres-packet.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; current key-4 channel-less requests have a typed owner-native policy while deep-page, evidence admission and serving gates remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; channel-less and deep-page request shapes have typed owner-native policies while projection, evidence admission and serving gates remain pending');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -31,10 +31,16 @@ const source = requireMarkers(executorPath, [
   'OwnerNativeChannelLess',
   'ChannelLessOwnerNative',
   'pub(crate) fn classify_product_storefront_index_channel_scope(',
+  'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
+  'OwnerNativeDeepPage { offset: u64 }',
+  'DeepPageOwnerNative { offset: u64 }',
+  'pub(crate) fn classify_product_storefront_index_page_scope(',
   'list_filtered_published_products(',
   'let projected = self',
   'classify_product_storefront_index_channel_scope(',
+  'classify_product_storefront_index_page_scope(&query)',
   'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
+  'return Err(ProductStorefrontIndexShadowProjectionError::DeepPageOwnerNative',
   '.schema_read_port()',
   '.resolve_storefront_attribute_filters(',
   'build_product_storefront_index_shadow_query(',
@@ -62,8 +68,10 @@ for (const forbidden of [
   'query_one(',
   'CHANNEL_LESS_SENTINEL',
   'UNRESTRICTED_CHANNEL_SENTINEL',
+  '.min(MAX_INDEX_OFFSET_DEPTH)',
+  'Pagination::Cursor',
 ]) {
-  if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports only; found ${forbidden}`);
+  if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports and preserve owner request semantics; found ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
@@ -72,7 +80,9 @@ requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'ProductStorefrontIndexShadowExecution',
   'ProductStorefrontIndexShadowComparison',
   'ProductStorefrontIndexChannelScopeDecision',
+  'ProductStorefrontIndexPageScopeDecision',
   'classify_product_storefront_index_channel_scope',
+  'classify_product_storefront_index_page_scope',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -84,4 +94,4 @@ for (const forbidden of ['ProductStorefrontIndexShadowExecutor', 'execute_locali
   if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
-console.log('[verify-index-product-storefront-shadow-executor] owner-first non-serving shadow execution and typed channel-less owner-native policy are source-locked; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-shadow-executor] owner-first non-serving shadow execution plus channel-less and deep-page typed owner-native policies are source-locked; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -86,6 +86,7 @@ const scripts = [
   'verify-index-product-storefront-shadow-adapter.mjs',
   'verify-index-product-storefront-shadow-executor.mjs',
   'verify-index-product-storefront-channel-scope-policy.mjs',
+  'verify-index-product-storefront-deep-page-policy.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',


### PR DESCRIPTION
## Summary

- correct the earlier deep-page status: the prior commit message claimed deep-page handling, but current `main` still contained only the channel-scope implementation;
- add an actual `ProductStorefrontIndexPageScopeDecision` in the non-serving owner-first executor;
- classify owner-valid checked offsets `<= 10_000` as shadow-eligible and offsets `> 10_000` as typed `OwnerNativeDeepPage { offset }`;
- return projected `DeepPageOwnerNative { offset }` only after the authoritative Product owner list succeeds, and before schema/EAV reads or Index execution;
- keep invalid page/per-page and arithmetic overflow as the existing invalid-pagination query-build error;
- preserve the pure shadow builder's independent `OffsetTooDeep` fail-closed boundary for direct callers;
- do not clamp page/offset, rewrite to cursor pagination, narrow Product owner validation, or alter Product schema/source/routing key;
- expose the crate-private page classifier/decision for future serving composition;
- add a focused deep-page source guard, wire it into the aggregate query verifier, and advance M7 docs so post-page title/handle placeholder projection is the next source slice.

## Boundary

Mounted Storefront remains owner-native. This PR does not execute tests or PostgreSQL evidence, admit collation parity, map localized placeholders, hydrate Taxonomy tags, add serving latency/deadline behavior, or switch Storefront traffic.

Deep pages remain owner-native under the current contracts.

## Main recheck

The branch is based on current `main@442e5e591f68ec93a527630a14fbce8e6de2ba5e`. Final compare is ahead-only with 9 expected Product/Index policy, guard and documentation files.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.