### PR TITLE
refactor(groups): enforce effective localization authorization

### DIFF
--- a/crates/rustok-groups/contracts/groups-fba-registry.json
+++ b/crates/rustok-groups/contracts/groups-fba-registry.json
@@ -69,7 +69,7 @@
         "transactional_audit": true,
         "transactional_semantic_event": true,
         "transport_status": "rust_and_graphql_source",
-        "graphql_root": "graphql_membership_enforcement::GroupsMutationRoot",
+        "graphql_root": "graphql_application_cas::GroupsMutationRoot",
         "graphql_mutations": [
           "suspendGroupMembership",
           "revokeGroupMembershipSuspension"
@@ -93,7 +93,9 @@
         "policy": "read",
         "deadline_required": true,
         "idempotency_key_required": false,
-        "authorization": "active_owner_or_admin_or_platform_manage"
+        "authorization": "effective_active_owner_or_admin_or_platform_manage",
+        "effective_clock": "groups_owner_utc_clock",
+        "stored_status": "compatibility_only"
       },
       {
         "name": "GroupInvitationReadPort",
@@ -274,7 +276,10 @@
         "policy": "write",
         "deadline_required": true,
         "idempotency_key_required": true,
-        "authorization": "active_owner_or_admin_or_platform_manage",
+        "authorization": "effective_active_owner_or_admin_or_platform_manage",
+        "authorization_clock": "groups_owner_utc_clock",
+        "authorization_lock_order": "group_then_membership_then_enforcement",
+        "authorization_before_translation_state": true,
         "exact_locale_only": true,
         "last_translation_delete": "deny",
         "transactional_group_version": true,
@@ -401,15 +406,23 @@
     "effective_locale_owner": "host_runtime",
     "module_local_fallback": false,
     "management_selection": "exact_normalized_locale",
+    "effective_authorization": "implemented_source",
+    "effective_authorization_clock": "groups_owner_utc_clock",
+    "read_authorization": "owner_clock_effective_manager",
+    "write_authorization": "transactional_owner_clock_effective_manager",
+    "write_lock_order": "group_then_membership_then_enforcement",
+    "suspended_manager": "groups.membership_suspended",
+    "legacy_banned_manager": "groups.membership_banned",
+    "inactive_or_insufficient_manager": "groups.manager_required",
     "delete_last_translation": "deny",
     "version_bump": "same_transaction",
-    "mutation_serialization": "base_group_row"
+    "mutation_serialization": "base_group_row_then_effective_membership_locks"
   },
   "invitations": {
     "plaintext_token_storage": "never",
     "token_digest": "sha256_hex",
     "token_delivery": "create_response_once",
-    "create_replay_token": "null",
+    "create_replay_token": null,
     "targeted_max_uses": 1,
     "shareable_max_uses": 100,
     "minimum_expiry_seconds": 300,
@@ -468,7 +481,6 @@
       "pending"
     ],
     "candidate_cancel_membership_state": "left",
-    "candidate_cancel_snapshot": "preserve",
     "candidate_cancel_query_clear": "never",
     "manager_reopen_from": [
       "rejected",
@@ -576,7 +588,9 @@
       "surfaces": [
         "rust_port",
         "graphql",
-        "leptos_server_function"
+        "leptos_server_function",
+        "owner_clock_effective_manager_read",
+        "transactional_effective_manager_write"
       ],
       "implicit_fallback": false
     },

--- a/crates/rustok-groups/contracts/groups-fba-registry.json
+++ b/crates/rustok-groups/contracts/groups-fba-registry.json
@@ -481,6 +481,7 @@
       "pending"
     ],
     "candidate_cancel_membership_state": "left",
+    "candidate_cancel_snapshot": "preserve",
     "candidate_cancel_query_clear": "never",
     "manager_reopen_from": [
       "rejected",

--- a/crates/rustok-groups/contracts/groups-fba-registry.json
+++ b/crates/rustok-groups/contracts/groups-fba-registry.json
@@ -422,7 +422,7 @@
     "plaintext_token_storage": "never",
     "token_digest": "sha256_hex",
     "token_delivery": "create_response_once",
-    "create_replay_token": null,
+    "create_replay_token": "null",
     "targeted_max_uses": 1,
     "shareable_max_uses": 100,
     "minimum_expiry_seconds": 300,

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -124,6 +124,9 @@ Source exists for:
 - append-only membership suspend/revoke semantic events beside targeted invitation events;
 - effective core `GroupsService` for access, redaction, join/rejoin, membership listing, enabled
   features, and feature settings;
+- effective localization management reads plus transaction-aware translation upsert/delete using the
+  same owner-clock manager semantics and `Group -> GroupMembership -> GroupMembershipEnforcement`
+  write lock protocol;
 - sealed effective public invitation/application services with compatibility module paths;
 - transaction-aware invitation/application writes using the group/membership/enforcement lock
   protocol;
@@ -138,9 +141,11 @@ Evidence still open:
 - direct enforcement replay, expected-revision contention, hierarchy, owner-protection, expiry,
   revoke, lifecycle-count invariance, audit/event atomicity and security evidence;
 - executed native/GraphQL parity and schema/error-mapping evidence for direct enforcement;
+- executed localization suspension/expiry, native/GraphQL parity, and concurrent enforcement-vs-write
+  evidence;
 - native/GraphQL parity, CAS, lifecycle, bulk-review, retry, recovery, security, and accessibility
   evidence for the broader module;
-- localization and governance effective authorization;
+- governance effective authorization;
 - provider ACL integration and remote/degraded profiles;
 - neutral moderation adapter and durable moderation application orchestration.
 
@@ -155,7 +160,7 @@ Evidence still open:
 | GROUPS-04 | in_progress | typed summary/membership/access/localization/invitation/application/governance/enforcement ports | consumer/fallback runtime matrix |
 | GROUPS-05 | in_progress | GraphQL/native transports, invitation acceptance/delivery | parity and Notifications evidence |
 | GROUPS-06 | in_progress | localized policy, CAS, lifecycle, focused/bulk review, FFA UX | profiles/events/parity/concurrency/accessibility |
-| GROUPS-07 | in_progress | revision, enforcement read/direct command/GraphQL, effective core access, transactional invitation/application authorization | moderation adapter, runtime/concurrency/parity evidence |
+| GROUPS-07 | in_progress | revision, enforcement read/direct command/GraphQL, effective core/localization access, transactional invitation/application authorization | moderation adapter, governance/provider cutover, runtime/concurrency/parity evidence |
 | GROUPS-08 | planned | dynamic feature-provider registry and navigation | registry/degradation evidence |
 | GROUPS-09 | planned | Forum group spaces and ACL inheritance | Forum integration evidence |
 | GROUPS-10 | planned | Blog and Pages/Wiki group contexts | owner/privacy evidence |
@@ -308,6 +313,26 @@ expiry/revocation state and replay flag.
 Runtime schema execution, error-code parity, replay/CAS and authorization parity remain evidence
 gates; source composition is not promoted to `done`.
 
+### Source-complete localization effective authorization
+
+Localization management no longer authorizes against raw stored membership status. Read-only
+`list_group_translations` first preserves exact group existence semantics, then evaluates the shared
+Groups owner-clock manager state. Translation `upsert` and `delete` first serialize the group row and
+then evaluate `GroupManagerCapability::ManageSettings` through the canonical transaction-aware
+`Group -> GroupMembership -> GroupMembershipEnforcement` lock protocol before the first translation
+read or write.
+
+This means an active owner/admin role is authoritative only while its effective membership is active.
+An active suspension returns `groups.membership_suspended`; legacy banned state returns
+`groups.membership_banned`; an inactive or insufficient role returns `groups.manager_required`.
+Expiry/revocation takes effect immediately through the Groups owner clock without cleanup. Platform
+`groups:manage` authority remains the explicit bypass, while write serialization still retains the
+group owner row before mutation.
+
+Exact-locale behavior, last-translation deletion denial, translation mutation semantics and
+`groups.version` advancement are unchanged. Runtime PostgreSQL/SQLite contention and native/GraphQL
+parity evidence remain open.
+
 ### Planned moderation adapter
 
 Initial mapping remains:
@@ -340,12 +365,11 @@ above rather than introduce a second Groups enforcement state path.
 
 ## Remaining implementation order
 
-1. Convert localization management authorization to the transaction-aware resolver.
-2. Convert governance role/ownership commands with owner protection and the same lock protocol.
-3. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
-4. Convert provider ACL consumers and remote/degraded profiles.
-5. Produce direct-enforcement and adapter runtime, parity, concurrency, security, migration and
-   accessibility evidence.
+1. Convert governance role/ownership commands with owner protection and the same lock protocol.
+2. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
+3. Convert provider ACL consumers and remote/degraded profiles.
+4. Produce direct-enforcement, localization, governance and adapter runtime, parity, concurrency,
+   security, migration and accessibility evidence.
 
 ## Degraded modes
 
@@ -374,6 +398,7 @@ cargo check -p rustok-groups-admin --features ssr
 cargo check -p rustok-groups-storefront --features ssr
 cargo test -p rustok-groups
 node scripts/verify/verify-groups-boundary.mjs
+node scripts/verify/verify-groups-localization-boundary.mjs
 node scripts/verify/verify-groups-invitations-boundary.mjs
 node scripts/verify/verify-groups-membership-applications.mjs
 node scripts/verify/verify-groups-application-policy-cas.mjs

--- a/crates/rustok-groups/src/effective_membership_guard.rs
+++ b/crates/rustok-groups/src/effective_membership_guard.rs
@@ -64,6 +64,33 @@ pub(crate) async fn require_effective_manager_owned(
     require_manager_state(effective, capability)
 }
 
+/// Canonical owner-clock manager authorization for read-only owner surfaces.
+///
+/// This shares the exact effective-state semantics with the transactional guard without acquiring
+/// write locks. Callers that mutate owner state must use `require_effective_manager_owned` instead.
+pub(crate) async fn require_effective_manager_direct_owned(
+    db: &DatabaseConnection,
+    context: &PortContext,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    capability: GroupManagerCapability,
+) -> GroupsResult<()> {
+    if has_platform_manage(context) {
+        return Ok(());
+    }
+
+    let effective = resolve_group_membership_enforcement(
+        db,
+        tenant_id,
+        group_id,
+        actor_user_id,
+        Utc::now(),
+    )
+    .await?;
+    require_manager_state(effective, capability)
+}
+
 /// Canonical transaction-aware candidate/subject authorization under the same owner lock order.
 pub(crate) async fn require_user_not_denied_owned(
     transaction: &DatabaseTransaction,
@@ -91,16 +118,16 @@ pub(crate) async fn require_effective_manager(
     if has_platform_manage(context) {
         return Ok(());
     }
-    let effective = resolve_group_membership_enforcement(
+    require_effective_manager_direct_owned(
         db,
+        context,
         tenant_id(context)?,
         group_id,
         actor_user_id(context)?,
-        Utc::now(),
+        capability,
     )
     .await
-    .map_err(PortError::from)?;
-    require_manager_state(effective, capability).map_err(Into::into)
+    .map_err(Into::into)
 }
 
 pub(crate) async fn require_candidate_not_denied(

--- a/crates/rustok-groups/src/localization.rs
+++ b/crates/rustok-groups/src/localization.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use chrono::Utc;
 use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError, normalize_locale_tag};
@@ -10,12 +8,15 @@ use sea_orm::{
 };
 use uuid::Uuid;
 
-use crate::domain::{GroupMembershipStatus, GroupRole};
 use crate::dto::{
     DeleteGroupTranslationRequest, DeleteGroupTranslationResult, GroupTranslation,
     GroupTranslationMutationResult, ListGroupTranslationsRequest, UpsertGroupTranslationRequest,
 };
-use crate::entities::{group, membership, translation};
+use crate::effective_membership_guard::{
+    GroupManagerCapability, require_effective_manager_direct_owned,
+    require_effective_manager_owned,
+};
+use crate::entities::{group, translation};
 use crate::error::{GroupsError, GroupsResult};
 use crate::ports::{GroupLocalizationCommandPort, GroupLocalizationReadPort};
 
@@ -191,16 +192,16 @@ impl GroupLocalizationService {
             .one(&self.db)
             .await?
             .ok_or(GroupsError::NotFound)?;
-        if has_platform_manage(context) {
-            return Ok(());
-        }
-        let membership = membership::Entity::find()
-            .filter(membership::Column::TenantId.eq(tenant_id))
-            .filter(membership::Column::GroupId.eq(group_id))
-            .filter(membership::Column::UserId.eq(actor_user_id))
-            .one(&self.db)
-            .await?;
-        require_local_manager(membership.as_ref())
+
+        require_effective_manager_direct_owned(
+            &self.db,
+            context,
+            tenant_id,
+            group_id,
+            actor_user_id,
+            GroupManagerCapability::ManageSettings,
+        )
+        .await
     }
 
     async fn require_manage_in_transaction(
@@ -223,16 +224,16 @@ impl GroupLocalizationService {
             }
         }
         .ok_or(GroupsError::NotFound)?;
-        if has_platform_manage(context) {
-            return Ok(group_model);
-        }
-        let membership = membership::Entity::find()
-            .filter(membership::Column::TenantId.eq(tenant_id))
-            .filter(membership::Column::GroupId.eq(group_id))
-            .filter(membership::Column::UserId.eq(actor_user_id))
-            .one(transaction)
-            .await?;
-        require_local_manager(membership.as_ref())?;
+
+        require_effective_manager_owned(
+            transaction,
+            context,
+            tenant_id,
+            group_id,
+            actor_user_id,
+            GroupManagerCapability::ManageSettings,
+        )
+        .await?;
         Ok(group_model)
     }
 }
@@ -270,20 +271,6 @@ impl GroupLocalizationCommandPort for GroupLocalizationService {
         self.delete_group_translation_owned(&context, request)
             .await
             .map_err(Into::into)
-    }
-}
-
-fn require_local_manager(model: Option<&membership::Model>) -> GroupsResult<()> {
-    let allowed = model
-        .filter(|row| row.status == GroupMembershipStatus::Active.as_str())
-        .and_then(|row| GroupRole::from_str(&row.role).ok())
-        .is_some_and(GroupRole::can_manage_settings);
-    if allowed {
-        Ok(())
-    } else {
-        Err(GroupsError::Forbidden(
-            "group owner or administrator role is required".to_string(),
-        ))
     }
 }
 
@@ -364,11 +351,4 @@ fn actor_user_id(context: &PortContext) -> GroupsResult<Uuid> {
     }
     Uuid::parse_str(&context.actor.id)
         .map_err(|_| GroupsError::Validation("actor.id must be a UUID".to_string()))
-}
-
-fn has_platform_manage(context: &PortContext) -> bool {
-    context
-        .claims
-        .iter()
-        .any(|claim| matches!(claim.as_str(), "groups:manage" | "groups:*" | "*:*"))
 }

--- a/crates/rustok-groups/src/localization.rs
+++ b/crates/rustok-groups/src/localization.rs
@@ -2,9 +2,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError, normalize_locale_tag};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, DatabaseTransaction,
-    DbBackend, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set,
-    TransactionTrait,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DatabaseTransaction, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use uuid::Uuid;
 
@@ -18,6 +17,7 @@ use crate::effective_membership_guard::{
 };
 use crate::entities::{group, translation};
 use crate::error::{GroupsError, GroupsResult};
+use crate::membership_enforcement_transaction::reserve_group_write_for_update;
 use crate::ports::{GroupLocalizationCommandPort, GroupLocalizationReadPort};
 
 #[derive(Clone)]
@@ -212,18 +212,13 @@ impl GroupLocalizationService {
         group_id: Uuid,
         actor_user_id: Uuid,
     ) -> GroupsResult<group::Model> {
-        let query = || {
-            group::Entity::find()
-                .filter(group::Column::TenantId.eq(tenant_id))
-                .filter(group::Column::Id.eq(group_id))
-        };
-        let group_model = match transaction.get_database_backend() {
-            DbBackend::Sqlite => query().one(transaction).await?,
-            DbBackend::Postgres | DbBackend::MySql => {
-                query().lock_exclusive().one(transaction).await?
-            }
-        }
-        .ok_or(GroupsError::NotFound)?;
+        reserve_group_write_for_update(transaction, tenant_id, group_id).await?;
+        let group_model = group::Entity::find()
+            .filter(group::Column::TenantId.eq(tenant_id))
+            .filter(group::Column::Id.eq(group_id))
+            .one(transaction)
+            .await?
+            .ok_or(GroupsError::NotFound)?;
 
         require_effective_manager_owned(
             transaction,

--- a/crates/rustok-groups/src/membership_enforcement_transaction.rs
+++ b/crates/rustok-groups/src/membership_enforcement_transaction.rs
@@ -11,24 +11,19 @@ use crate::error::GroupsResult;
 use crate::membership_enforcement::resolve_group_membership_enforcement;
 use crate::membership_enforcement_entities::{membership_enforcement, membership_state};
 
-/// Resolve effective membership under the Groups owner write-lock protocol.
+/// Acquire the Groups owner aggregate writer reservation before reading mutable group state.
 ///
-/// The lock order is always `Group -> GroupMembership -> GroupMembershipEnforcement`.
-/// PostgreSQL/MySQL use row locks. SQLite acquires the database writer reservation through a
-/// no-op group update before reading membership/enforcement, preventing another owner transaction
-/// from committing enforcement or membership changes between authorization and mutation.
-pub(crate) async fn resolve_group_membership_enforcement_for_update(
+/// PostgreSQL/MySQL retain an exclusive row lock. SQLite obtains the writer reservation through a
+/// no-op update so subsequent group-version and membership/enforcement reads cannot race another
+/// owner writer. Existence remains the caller's domain concern; do not use rows-affected here as an
+/// existence signal because SQLite may report zero for a no-op assignment.
+pub(crate) async fn reserve_group_write_for_update(
     transaction: &DatabaseTransaction,
     tenant_id: Uuid,
     group_id: Uuid,
-    user_id: Uuid,
-    evaluated_at: DateTime<Utc>,
-) -> GroupsResult<GroupMembershipEffectiveState> {
+) -> GroupsResult<()> {
     match transaction.get_database_backend() {
         DbBackend::Sqlite => {
-            // The command has already resolved the group row before entering the effective guard.
-            // Do not use rows_affected as an existence test: SQLite may report zero for a no-op
-            // assignment depending on connection settings even though the writer lock was acquired.
             transaction
                 .execute(Statement::from_sql_and_values(
                     DbBackend::Sqlite,
@@ -46,6 +41,23 @@ pub(crate) async fn resolve_group_membership_enforcement_for_update(
                 .await?;
         }
     }
+    Ok(())
+}
+
+/// Resolve effective membership under the Groups owner write-lock protocol.
+///
+/// The lock order is always `Group -> GroupMembership -> GroupMembershipEnforcement`.
+/// PostgreSQL/MySQL use row locks. SQLite acquires the database writer reservation through a
+/// no-op group update before reading membership/enforcement, preventing another owner transaction
+/// from committing enforcement or membership changes between authorization and mutation.
+pub(crate) async fn resolve_group_membership_enforcement_for_update(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+    evaluated_at: DateTime<Utc>,
+) -> GroupsResult<GroupMembershipEffectiveState> {
+    reserve_group_write_for_update(transaction, tenant_id, group_id).await?;
 
     let membership = match transaction.get_database_backend() {
         DbBackend::Sqlite => {

--- a/scripts/verify/verify-groups-localization-boundary.mjs
+++ b/scripts/verify/verify-groups-localization-boundary.mjs
@@ -33,9 +33,9 @@ requireMarkers("crates/rustok-groups/src/localization.rs", [
   "translation::Column::Locale.eq(locale.clone())",
   "the last group translation cannot be deleted",
   "version.saturating_add(1)",
-  "lock_exclusive()",
   "PortCallPolicy::read()",
   "PortCallPolicy::write()",
+  "reserve_group_write_for_update",
   "require_effective_manager_direct_owned",
   "require_effective_manager_owned",
   "GroupManagerCapability::ManageSettings",
@@ -55,6 +55,13 @@ requireMarkers("crates/rustok-groups/src/effective_membership_guard.rs", [
   "GroupMembershipEffectiveStatus::Suspended",
   "GroupMembershipEffectiveStatus::LegacyBanned",
   "GroupManagerCapability::ManageSettings",
+]);
+
+requireMarkers("crates/rustok-groups/src/membership_enforcement_transaction.rs", [
+  "reserve_group_write_for_update",
+  "UPDATE groups SET version = version WHERE tenant_id = ? AND id = ?",
+  "lock_exclusive()",
+  "resolve_group_membership_enforcement_for_update",
 ]);
 
 requireMarkers("crates/rustok-groups/src/graphql_localization.rs", [
@@ -136,8 +143,12 @@ for (const relative of [
 
 if (requireFile("crates/rustok-groups/contracts/groups-fba-registry.json")) {
   const registry = JSON.parse(read("crates/rustok-groups/contracts/groups-fba-registry.json"));
+  const enforcementPort = registry?.provider?.ports?.find((port) => port?.name === "GroupMembershipEnforcementCommandPort");
   const readPort = registry?.provider?.ports?.find((port) => port?.name === "GroupLocalizationReadPort");
   const commandPort = registry?.provider?.ports?.find((port) => port?.name === "GroupLocalizationCommandPort");
+  if (enforcementPort?.graphql_root !== "graphql_application_cas::GroupsMutationRoot") {
+    failures.push("Groups enforcement registry must point at the stable final GraphQL root");
+  }
   if (!readPort?.operations?.includes("list_group_translations")) {
     failures.push("Groups registry is missing localization read operation");
   }
@@ -162,6 +173,9 @@ if (requireFile("crates/rustok-groups/contracts/groups-fba-registry.json")) {
   if (registry?.localization?.effective_authorization !== "implemented_source") {
     failures.push("Groups localization effective authorization must be source-complete");
   }
+  if (registry?.localization?.write_lock_order !== "group_then_membership_then_enforcement") {
+    failures.push("Groups localization registry must publish the shared write lock order");
+  }
   if (registry?.evidence?.localization_transport_parity !== null || registry?.evidence?.localization_concurrency !== null) {
     failures.push("unexecuted localization runtime evidence must remain null");
   }
@@ -173,4 +187,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Groups exact-locale localization, effective owner-clock authorization, no-bypass CAS composition, FBA, FFA, last-row, and no-fallback boundary checks passed.");
+console.log("Groups exact-locale localization, effective owner-clock authorization, shared writer reservation, stable GraphQL root, FBA, FFA, last-row, and no-fallback boundary checks passed.");

--- a/scripts/verify/verify-groups-localization-boundary.mjs
+++ b/scripts/verify/verify-groups-localization-boundary.mjs
@@ -36,11 +36,25 @@ requireMarkers("crates/rustok-groups/src/localization.rs", [
   "lock_exclusive()",
   "PortCallPolicy::read()",
   "PortCallPolicy::write()",
+  "require_effective_manager_direct_owned",
+  "require_effective_manager_owned",
+  "GroupManagerCapability::ManageSettings",
 ]);
 forbidMarkers("crates/rustok-groups/src/localization.rs", [
   "PLATFORM_FALLBACK_LOCALE",
   "build_locale_candidates",
   "rows.first()",
+  "GroupMembershipStatus::Active.as_str()",
+  "fn require_local_manager(",
+]);
+
+requireMarkers("crates/rustok-groups/src/effective_membership_guard.rs", [
+  "require_effective_manager_direct_owned",
+  "require_effective_manager_owned",
+  "resolve_group_membership_enforcement_now_for_update",
+  "GroupMembershipEffectiveStatus::Suspended",
+  "GroupMembershipEffectiveStatus::LegacyBanned",
+  "GroupManagerCapability::ManageSettings",
 ]);
 
 requireMarkers("crates/rustok-groups/src/graphql_localization.rs", [
@@ -130,11 +144,23 @@ if (requireFile("crates/rustok-groups/contracts/groups-fba-registry.json")) {
   if (!commandPort?.operations?.includes("upsert_group_translation") || !commandPort?.operations?.includes("delete_group_translation")) {
     failures.push("Groups registry is missing localization command operations");
   }
+  if (readPort?.authorization !== "effective_active_owner_or_admin_or_platform_manage") {
+    failures.push("Groups localization read authorization must use effective manager state");
+  }
+  if (commandPort?.authorization !== "effective_active_owner_or_admin_or_platform_manage") {
+    failures.push("Groups localization command authorization must use effective manager state");
+  }
+  if (commandPort?.authorization_lock_order !== "group_then_membership_then_enforcement") {
+    failures.push("Groups localization command must retain canonical enforcement lock order");
+  }
   if (commandPort?.exact_locale_only !== true || commandPort?.last_translation_delete !== "deny") {
     failures.push("Groups localization command invariants are not locked");
   }
   if (registry?.localization?.module_local_fallback !== false) {
     failures.push("Groups localization must reject module-local fallback");
+  }
+  if (registry?.localization?.effective_authorization !== "implemented_source") {
+    failures.push("Groups localization effective authorization must be source-complete");
   }
   if (registry?.evidence?.localization_transport_parity !== null || registry?.evidence?.localization_concurrency !== null) {
     failures.push("unexecuted localization runtime evidence must remain null");
@@ -147,4 +173,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Groups exact-locale localization, no-bypass CAS composition, FBA, FFA, last-row, and no-fallback boundary checks passed.");
+console.log("Groups exact-locale localization, effective owner-clock authorization, no-bypass CAS composition, FBA, FFA, last-row, and no-fallback boundary checks passed.");


### PR DESCRIPTION
## Summary
- move Groups localization management authorization from stored membership status to the shared owner-clock effective membership resolver
- keep list/read semantics fail-closed while preserving exact group NotFound behavior
- route translation upsert/delete through the canonical transaction-aware `Group -> GroupMembership -> GroupMembershipEnforcement` manager guard before translation state is read or written
- extract and reuse the Groups owner aggregate writer reservation so SQLite obtains writer serialization before reading `groups.version`, while PostgreSQL/MySQL retain the group row lock
- preserve exact-locale behavior, last-translation deletion denial and group version advancement
- preserve platform `groups:manage` authority while suspended/banned/inactive local managers receive the existing stable effective errors
- update the canonical plan, FBA registry and localization source guard; runtime parity/concurrency evidence remains open
- repair the stale enforcement GraphQL-root metadata to the already-existing stable `graphql_application_cas::GroupsMutationRoot`

## Verification
Static source review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows and CI were intentionally not run per maintainer request.