### PR TITLE
feat(index): add Product Storefront post-page public projection

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -10,6 +10,10 @@ mod product;
 pub(crate) use product::PRODUCT_INDEX_SOURCE;
 mod query_admission;
 pub(crate) mod relation_admission;
+mod storefront_projection;
+pub(crate) use storefront_projection::{
+    ProductStorefrontIndexPublicProjectionError, project_product_storefront_index_page,
+};
 mod storefront_shadow;
 pub(crate) use storefront_shadow::{
     ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,

--- a/crates/rustok-distribution/src/product_index/storefront_projection.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_projection.rs
@@ -59,9 +59,10 @@ fn apply_string_placeholder(
         entity_id: item.entity_id,
         field,
     })?;
-    match &mut item.fields[position].value {
+    let value = &mut item.fields[position].value;
+    match value {
         IndexValue::Null => {
-            item.fields[position].value = IndexValue::String(placeholder.to_owned());
+            *value = IndexValue::String(placeholder.to_owned());
             Ok(())
         }
         IndexValue::String(_) => Ok(()),
@@ -108,6 +109,7 @@ mod tests {
     fn maps_only_public_placeholders_after_page_identity_is_fixed() {
         let first = Uuid::new_v4();
         let second = Uuid::new_v4();
+        let tag_id = Uuid::new_v4();
         let page = IndexQueryPage {
             items: vec![
                 item(
@@ -116,6 +118,7 @@ mod tests {
                         projected("title", IndexValue::Null),
                         projected("handle", IndexValue::Null),
                         projected("vendor", IndexValue::Null),
+                        projected("tag_ids", IndexValue::List(vec![IndexValue::Uuid(tag_id)])),
                     ],
                 ),
                 item(
@@ -124,6 +127,7 @@ mod tests {
                         projected("title", IndexValue::String("Existing".to_owned())),
                         projected("handle", IndexValue::String("existing".to_owned())),
                         projected("vendor", IndexValue::String("Vendor".to_owned())),
+                        projected("tag_ids", IndexValue::List(Vec::new())),
                     ],
                 ),
             ],
@@ -149,6 +153,10 @@ mod tests {
             &IndexValue::String(String::new())
         );
         assert_eq!(value(&projected.items[0], "vendor"), &IndexValue::Null);
+        assert_eq!(
+            value(&projected.items[0], "tag_ids"),
+            &IndexValue::List(vec![IndexValue::Uuid(tag_id)])
+        );
         assert_eq!(
             value(&projected.items[1], "title"),
             &IndexValue::String("Existing".to_owned())

--- a/crates/rustok-distribution/src/product_index/storefront_projection.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_projection.rs
@@ -1,0 +1,222 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+use rustok_index::{IndexQueryItem, IndexQueryPage, IndexValue};
+
+const UNTITLED_PRODUCT: &str = "Untitled product";
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum ProductStorefrontIndexPublicProjectionError {
+    #[error("Product Storefront Index item {entity_id} is missing projected root field {field}")]
+    MissingField {
+        entity_id: Uuid,
+        field: &'static str,
+    },
+    #[error("Product Storefront Index item {entity_id} projects root field {field} more than once")]
+    DuplicateField {
+        entity_id: Uuid,
+        field: &'static str,
+    },
+    #[error("Product Storefront Index item {entity_id} projected root field {field} must be string or null")]
+    InvalidFieldValue {
+        entity_id: Uuid,
+        field: &'static str,
+    },
+}
+
+/// Apply Product owner public placeholders only after the generic Index page is fully decoded.
+///
+/// This transform never participates in filtering, sorting, localized identity folding, exact count,
+/// pagination, or cursor construction. It changes only already-projected root `title`/`handle` nulls on the
+/// retained page. `tag_ids` remain untouched until the separate post-page Taxonomy hydration slice.
+pub(crate) fn project_product_storefront_index_page(
+    mut page: IndexQueryPage,
+) -> Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError> {
+    for item in &mut page.items {
+        apply_string_placeholder(item, "title", UNTITLED_PRODUCT)?;
+        apply_string_placeholder(item, "handle", "")?;
+    }
+    Ok(page)
+}
+
+fn apply_string_placeholder(
+    item: &mut IndexQueryItem,
+    field: &'static str,
+    placeholder: &'static str,
+) -> Result<(), ProductStorefrontIndexPublicProjectionError> {
+    let mut position = None;
+    for (candidate, projected) in item.fields.iter().enumerate() {
+        if projected.path.links().is_empty() && projected.path.field().as_str() == field {
+            if position.replace(candidate).is_some() {
+                return Err(ProductStorefrontIndexPublicProjectionError::DuplicateField {
+                    entity_id: item.entity_id,
+                    field,
+                });
+            }
+        }
+    }
+    let position = position.ok_or(ProductStorefrontIndexPublicProjectionError::MissingField {
+        entity_id: item.entity_id,
+        field,
+    })?;
+    match &mut item.fields[position].value {
+        IndexValue::Null => {
+            item.fields[position].value = IndexValue::String(placeholder.to_owned());
+            Ok(())
+        }
+        IndexValue::String(_) => Ok(()),
+        _ => Err(ProductStorefrontIndexPublicProjectionError::InvalidFieldValue {
+            entity_id: item.entity_id,
+            field,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_index::{FieldName, FieldPath, IndexProjectedValue};
+
+    fn projected(field: &str, value: IndexValue) -> IndexProjectedValue {
+        IndexProjectedValue {
+            path: FieldPath::new(FieldName::new(field).unwrap()),
+            value,
+        }
+    }
+
+    fn item(entity_id: Uuid, fields: Vec<IndexProjectedValue>) -> IndexQueryItem {
+        IndexQueryItem {
+            entity_id,
+            relations: Vec::new(),
+            fields,
+            nested_relations: Vec::new(),
+        }
+    }
+
+    fn value<'a>(item: &'a IndexQueryItem, field: &str) -> &'a IndexValue {
+        &item
+            .fields
+            .iter()
+            .find(|projected| {
+                projected.path.links().is_empty() && projected.path.field().as_str() == field
+            })
+            .unwrap()
+            .value
+    }
+
+    #[test]
+    fn maps_only_public_placeholders_after_page_identity_is_fixed() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let page = IndexQueryPage {
+            items: vec![
+                item(
+                    first,
+                    vec![
+                        projected("title", IndexValue::Null),
+                        projected("handle", IndexValue::Null),
+                        projected("vendor", IndexValue::Null),
+                    ],
+                ),
+                item(
+                    second,
+                    vec![
+                        projected("title", IndexValue::String("Existing".to_owned())),
+                        projected("handle", IndexValue::String("existing".to_owned())),
+                        projected("vendor", IndexValue::String("Vendor".to_owned())),
+                    ],
+                ),
+            ],
+            exact_count: Some(9),
+            has_more: true,
+            next_cursor: Some("opaque-cursor".to_owned()),
+        };
+
+        let projected = project_product_storefront_index_page(page).unwrap();
+        assert_eq!(
+            projected.items.iter().map(|item| item.entity_id).collect::<Vec<_>>(),
+            vec![first, second]
+        );
+        assert_eq!(projected.exact_count, Some(9));
+        assert!(projected.has_more);
+        assert_eq!(projected.next_cursor.as_deref(), Some("opaque-cursor"));
+        assert_eq!(
+            value(&projected.items[0], "title"),
+            &IndexValue::String("Untitled product".to_owned())
+        );
+        assert_eq!(
+            value(&projected.items[0], "handle"),
+            &IndexValue::String(String::new())
+        );
+        assert_eq!(value(&projected.items[0], "vendor"), &IndexValue::Null);
+        assert_eq!(
+            value(&projected.items[1], "title"),
+            &IndexValue::String("Existing".to_owned())
+        );
+        assert_eq!(
+            value(&projected.items[1], "handle"),
+            &IndexValue::String("existing".to_owned())
+        );
+    }
+
+    #[test]
+    fn fails_closed_on_missing_duplicate_or_wrong_typed_public_fields() {
+        let missing = IndexQueryPage {
+            items: vec![item(
+                Uuid::new_v4(),
+                vec![projected("title", IndexValue::Null)],
+            )],
+            exact_count: Some(1),
+            has_more: false,
+            next_cursor: None,
+        };
+        assert!(matches!(
+            project_product_storefront_index_page(missing),
+            Err(ProductStorefrontIndexPublicProjectionError::MissingField {
+                field: "handle",
+                ..
+            })
+        ));
+
+        let duplicate = IndexQueryPage {
+            items: vec![item(
+                Uuid::new_v4(),
+                vec![
+                    projected("title", IndexValue::Null),
+                    projected("title", IndexValue::String("duplicate".to_owned())),
+                    projected("handle", IndexValue::Null),
+                ],
+            )],
+            exact_count: Some(1),
+            has_more: false,
+            next_cursor: None,
+        };
+        assert!(matches!(
+            project_product_storefront_index_page(duplicate),
+            Err(ProductStorefrontIndexPublicProjectionError::DuplicateField {
+                field: "title",
+                ..
+            })
+        ));
+
+        let wrong_typed = IndexQueryPage {
+            items: vec![item(
+                Uuid::new_v4(),
+                vec![
+                    projected("title", IndexValue::Uuid(Uuid::new_v4())),
+                    projected("handle", IndexValue::Null),
+                ],
+            )],
+            exact_count: Some(1),
+            has_more: false,
+            next_cursor: None,
+        };
+        assert!(matches!(
+            project_product_storefront_index_page(wrong_typed),
+            Err(ProductStorefrontIndexPublicProjectionError::InvalidFieldValue {
+                field: "title",
+                ..
+            })
+        ));
+    }
+}

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -12,19 +12,23 @@ use rustok_product::{
 };
 
 use super::{
-    ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,
+    ProductStorefrontIndexPublicProjectionError, ProductStorefrontIndexShadowError,
+    build_product_storefront_index_shadow_query, project_product_storefront_index_page,
 };
 
 const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;
 
 /// Non-serving Product Storefront parity execution result.
 ///
-/// The authoritative owner result is always produced first. Projected failures or mismatches are retained
-/// separately and never replace the owner result.
+/// The authoritative owner result is always produced first. `projected` retains the raw generic Index page
+/// for identity/count evidence. `public_projected` is derived only after that page exists and applies the
+/// Product owner public placeholder contract without feeding values back into Index query semantics.
 #[derive(Debug)]
 pub(crate) struct ProductStorefrontIndexShadowExecution {
     pub(crate) authoritative: StorefrontProductList,
     pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>,
+    pub(crate) public_projected:
+        Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>,
     pub(crate) comparison: Option<ProductStorefrontIndexShadowComparison>,
 }
 
@@ -133,7 +137,7 @@ pub(crate) fn classify_product_storefront_index_page_scope(
 /// This object composes only host-selected Product and Index capabilities. It never constructs
 /// `CatalogService`, `ProductCatalogSchemaService`, a PostgreSQL Index port, or a database connection.
 /// The owner list result remains authoritative even when Product metadata resolution, shadow query build,
-/// Index readiness/admission, or Index execution fails.
+/// Index readiness/admission, Index execution, or public post-page projection fails.
 ///
 /// Channel-scoped projection requires a trusted current slug/UUID pair supplied by the caller's current
 /// channel context. Channel-less requests and owner-valid deep offset pages are intentionally retained as
@@ -183,6 +187,11 @@ impl ProductStorefrontIndexShadowExecutor {
                 query,
             )
             .await;
+        let public_projected = projected
+            .as_ref()
+            .ok()
+            .cloned()
+            .map(project_product_storefront_index_page);
         let comparison = projected
             .as_ref()
             .ok()
@@ -191,6 +200,7 @@ impl ProductStorefrontIndexShadowExecutor {
         Ok(ProductStorefrontIndexShadowExecution {
             authoritative,
             projected,
+            public_projected,
             comparison,
         })
     }

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked on current `main` at
-`442e5e591f68ec93a527630a14fbce8e6de2ba5e` and continued on
-`agent/product-storefront-deep-page-policy-v2-20260808`.
+Status overlay rechecked after real Product Storefront deep-page policy merge
+`ac399264f12dd71439861e60a5df86ac9ab496bb` and continued on
+`agent/product-storefront-placeholder-projection-v2-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -31,58 +31,65 @@ Source-complete:
   channel-less owner requests remain owner-native and partial/invalid channel identity fails closed;
 - explicit deep-page policy: owner-valid offsets through `10_000` are shadow-eligible while deeper offsets
   remain typed owner-native without clamp or cursor rewriting;
+- Product Storefront **post-page public projection**: raw generic Index rows remain intact for equivalence
+  evidence, while a derived page maps root `title: null` to `"Untitled product"` and root `handle: null` to
+  `""` only after page identity/order/count/cursor are fixed;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
-## Channel-less visibility decision for current Product key 4
+## Request-shape owner-native policies
 
-Owner channel-less semantics are **metadata-unrestricted only**: the Product owner predicate admits rows whose
-`metadata.channel_visibility.allowed_channel_slugs` is absent or empty.
+### Channel-less
 
-The Product -> SalesChannel relation resolver intentionally represents unrestricted visibility as membership
-in **all current Channel UUIDs**. A restricted Product whose allowed slugs currently resolve to every Channel
-therefore has the same `sales_channel_ids` value as an unrestricted Product. Current Product key `4` cannot
-recover the owner distinction from resolved membership.
-
-The generic PostgreSQL entity-admission catalog is schema-scoped and does not carry an arbitrary
-request-specific Product visibility predicate. Consequently the current source does not fabricate a sentinel,
-encode visibility into unrelated `attribute_terms`, or introduce a key-5 schema without the replacement
-protocol/evidence required for a real schema change.
-
-`classify_product_storefront_index_channel_scope` makes the request policy explicit:
+Owner channel-less semantics are **metadata-unrestricted only**. Current key `4` stores unrestricted visibility
+as membership in all current Channel UUIDs, which is indistinguishable from a restricted Product that currently
+resolves to the same complete set. Therefore:
 
 - absent/blank slug + absent UUID => `OwnerNativeChannelLess`;
-- non-empty slug + non-nil UUID => `ShadowEligible`;
-- partial, contradictory or nil channel identity => `PublicChannelIdentityUnavailable`.
+- trusted non-empty slug + non-nil UUID => channel-scoped shadow eligible;
+- malformed/partial identity => fail closed.
 
-The shadow executor runs the authoritative Product owner list first. For channel-less requests it retains that
-result and records typed projected reason `ChannelLessOwnerNative`; it never approximates an Index result.
-This closes the current-key **policy decision**, not channel-less Index parity. Any future serving router must
-continue to route this shape owner-native unless a later schema/query capability represents the distinction
-exactly with freshness evidence.
+No visibility sentinel or key-5 approximation is used.
 
-## Deep-page decision
+### Deep page
 
-The Product owner validates `page >= 1` and `1 <= per_page <= 48` but has no generic Index-style maximum
-offset. The generic Index path is bounded to offset `10_000`.
+The Product owner accepts valid `page/per_page` without the generic Index offset ceiling. The Index path is
+bounded to offset `10_000`. Therefore:
 
-`classify_product_storefront_index_page_scope` preserves that difference after owner success and before
-projected schema/EAV work:
+- offset `<= 10_000` => shadow eligible;
+- offset `> 10_000` => typed `OwnerNativeDeepPage` / `DeepPageOwnerNative` after owner success;
+- invalid pagination/overflow => fail closed as invalid pagination.
 
-- offset `<= 10_000` => `ShadowEligible { offset }`;
-- offset `> 10_000` => `OwnerNativeDeepPage { offset }` and projected `DeepPageOwnerNative { offset }`;
-- invalid page/per-page or arithmetic overflow => existing invalid-pagination query-build error.
+No clamp or cursor rewrite is used.
 
-No page/offset clamp or cursor rewrite is introduced. The pure shadow builder independently retains
-`OffsetTooDeep` as its direct-call fail-closed boundary.
+## Post-page public placeholder projection
+
+The generic localized Index decoder deliberately remains Product-neutral. When neither requested nor fallback
+translation row exists, raw root `title`/`handle` remain `IndexValue::Null`. Existing PostgreSQL parity evidence
+continues to retain that raw state.
+
+`project_product_storefront_index_page` is a distribution-owned Product adapter applied only to a clone of a
+successful raw `IndexQueryPage`. It:
+
+- maps root `title: Null` -> `String("Untitled product")`;
+- maps root `handle: Null` -> `String("")`;
+- preserves already-present strings;
+- fails closed on missing, duplicate, or non-string/non-null root title/handle projections;
+- preserves item identity/order, exact count, page boundary, cursor, unrelated projected fields and `tag_ids`.
+
+`ProductStorefrontIndexShadowExecution.projected` remains the raw generic Index page. New
+`public_projected` is derived after raw execution. Identity/count/page comparison still uses raw `projected`, so
+owner public placeholders cannot affect filtering, sorting, identity folding, exact count, pagination, or cursor
+construction.
+
+This closes the no-localized-row public placeholder **source adapter** gap. It does not yet produce final
+Storefront tags: `tag_ids` remain IDs until the separate Taxonomy hydration slice.
 
 ## Remaining Storefront parity/evidence blockers
 
 - execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the retained deployment matrix agrees;
-- map localized null title/handle to owner public placeholders in final projection **after** Index page
-  identity/order/count is fixed;
-- hydrate localized Taxonomy tag names only after Product page identity/count is fixed;
+- batch-hydrate localized Taxonomy tag names only after Product page identity/count is fixed;
 - define serving latency/deadline policy before any shadow-to-serving transition;
 - preserve channel-less and deep-page owner-native routing in any future serving composition;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence.
@@ -128,9 +135,9 @@ and SalesChannel remains key `1`.
 - [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
 - [x] Keep channel-less Storefront owner-native on current key `4`; distinguish malformed channel identity.
 - [x] Keep owner-valid offsets above `10_000` owner-native without clamp/rewrite.
+- [x] Map raw no-localized-row title/handle nulls to Product public placeholders in a post-page derived layer.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Map no-localized-row nulls to owner public title/handle placeholders in final projection.
 - [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
@@ -140,10 +147,10 @@ and SalesChannel remains key `1`.
 
 ## Next source-code step
 
-Add a Product Storefront post-page projection adapter for the current Index page. It must map a localized
-`title` null to `"Untitled product"` and localized `handle` null to `""` only **after** the Index page has fixed
-entity identity, ordering, exact count and page boundary. It must not use placeholders in filtering, sorting,
-identity folding or count and must not claim Taxonomy tag-name parity yet.
+Add a post-page Product Storefront Taxonomy tag hydration boundary. The Index page already carries `tag_ids`;
+resolve their requested-locale -> fallback-locale names in one bounded/batched owner capability **after** page
+identity/order/exact-count are fixed. Hydration failure must not alter the raw Index page or be interpreted as a
+different Product page. Do not add Taxonomy tag names to Product Index schema merely to avoid owner hydration.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `deep_page_policy_source_complete_projection_placeholder_pending`.
+Status: `public_projection_source_complete_taxonomy_hydration_pending`.
 
 ## Current boundary
 
@@ -21,41 +21,58 @@ The Product relation resolver represents unrestricted metadata by resolving **al
 `sales_channel_ids`. A restricted Product whose allowed slugs currently resolve to every Channel therefore has
 the same membership vector as an unrestricted Product. Current key `4` cannot distinguish those states.
 
-The generic entity-admission catalog is schema-scoped rather than an arbitrary request-scoped Product
-predicate channel, so the shadow path cannot recover the owner metadata distinction at query time without a
-new generic contract or a persisted Product field/schema replacement.
-
-For the current key-4 contract the policy is explicit:
+For the current key-4 contract:
 
 - absent/blank slug and absent channel UUID => `OwnerNativeChannelLess`;
 - trusted non-empty slug and non-nil UUID => `ShadowEligible`;
-- partial identity, UUID-without-slug, slug-without-UUID, or nil UUID =>
-  `PublicChannelIdentityUnavailable`.
+- malformed/partial identity => `PublicChannelIdentityUnavailable`.
 
-The shadow executor still produces the authoritative owner result first. A channel-less request then retains
-that result and records `ChannelLessOwnerNative` in `projected`; it does not fabricate an Index page. This is a
-serving-policy decision, not a claim of channel-less Index parity.
-
-No sentinel UUID, `attribute_terms` visibility encoding, key-5 Product schema, or membership-equality inference
-is introduced. Any future serving composition must preserve owner-native handling for this shape until a later
-exact representation is implemented with the normal schema replacement and freshness evidence gates.
+The shadow executor produces the authoritative owner result first. A channel-less request records
+`ChannelLessOwnerNative` on the projected side and never fabricates an Index page. No sentinel UUID, unrelated
+`attribute_terms` encoding or key-5 approximation is used.
 
 ## Deep-page serving policy — source complete
 
 The Product owner validates `page >= 1` and `1 <= per_page <= 48`, but it does not impose the generic Index
-offset ceiling. The generic Product Storefront shadow builder remains bounded at offset `10_000`.
+offset ceiling. The generic Product Storefront path remains bounded at offset `10_000`.
 
-`classify_product_storefront_index_page_scope` now preserves this owner/Index difference after the authoritative
-owner list succeeds and before projected schema/EAV work:
+`classify_product_storefront_index_page_scope` preserves this owner/Index difference after authoritative owner
+success and before projected schema/EAV work:
 
 - checked offset `<= 10_000` => `ShadowEligible { offset }`;
-- checked offset `> 10_000` => `OwnerNativeDeepPage { offset }` and projected
-  `DeepPageOwnerNative { offset }`;
-- invalid page/per-page or arithmetic overflow => existing invalid-pagination query-build error.
+- checked offset `> 10_000` => `OwnerNativeDeepPage { offset }` and `DeepPageOwnerNative { offset }`;
+- invalid pagination/overflow => existing invalid-pagination failure.
 
-The policy does not clamp page/offset or rewrite the request to cursor pagination. The pure shadow builder
-retains `OffsetTooDeep` as a second fail-closed boundary for direct callers. Deep pages therefore remain
-owner-native under the current contracts rather than being made artificially representable.
+The policy does not clamp page/offset or rewrite to cursor pagination. The pure shadow builder independently
+retains `OffsetTooDeep` for direct callers.
+
+## Product public placeholder projection — source complete
+
+The raw localized Index page deliberately remains Product-neutral. If no requested or fallback translation row
+exists, raw root `title` and `handle` remain `IndexValue::Null`. The retained core PostgreSQL packet continues
+to preserve that raw evidence beside the authoritative owner result (`"Untitled product"` / empty handle).
+
+`storefront_projection.rs` adds a Product distribution-owned **post-page** transform:
+
+- root `title: Null` => `String("Untitled product")`;
+- root `handle: Null` => `String("")`;
+- existing strings are preserved;
+- missing, duplicate, or wrong-typed root title/handle fields fail closed;
+- item identities/order, `exact_count`, `has_more`, `next_cursor`, unrelated fields and `tag_ids` are preserved.
+
+`ProductStorefrontIndexShadowExecution` now retains two explicit layers:
+
+- `projected`: the raw generic `IndexQueryPage`, still used for identity/order/count/page comparison;
+- `public_projected`: an optional result derived only from a clone of a successful raw page by
+  `project_product_storefront_index_page`.
+
+The public transform is not called inside `execute_projected`, the shadow query builder contains no owner
+placeholder strings, and generic `rustok-index` remains unaware of Product public placeholder semantics.
+Therefore placeholders cannot influence title search, filters, ordering, localized identity folding, exact
+count, offset/cursor construction or raw equivalence evidence.
+
+This closes the no-requested/fallback public title/handle **source adapter** gap. It does not close Taxonomy tag
+parity: current Index projection still carries `tag_ids`, while Product owner list returns localized tag names.
 
 ## Product-owned Storefront search bound — source complete
 
@@ -80,13 +97,14 @@ used by shadow execution. Distribution translates Product-owned neutral term exp
 
 `ProductStorefrontIndexShadowExecutor` executes the authoritative Product owner list first. Only eligible
 channel-scoped, shallow projected work proceeds through Product metadata resolution, localized query
-construction and `execute_localized_query`. Projected failures cannot replace the successful owner result.
+construction and `execute_localized_query`. Projected or public-projection failures cannot replace the
+successful authoritative owner result.
 
 ## Core/EAV and retained Product PostgreSQL packets
 
 The core Storefront packet retains localized requested/fallback/neither projection, all-locale title matching,
 wildcards, identity de-duplication, count, Asc/Desc tie ordering, pagination and trusted public-channel
-membership. It also records the null-vs-public-placeholder projection gap.
+membership. Its raw null-vs-owner-placeholder assertions intentionally remain unchanged.
 
 The EAV packet separately retains scalar/localized terms, Select/Multiselect option code/direct UUID and
 missing/nil option `Never` behavior.
@@ -99,26 +117,25 @@ key `2`, SalesChannel key `1`. Execution/review remains maintainer-owned.
 
 1. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
 2. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
-3. Final Storefront projection must map no-localized-row null title/handle to owner placeholders only after
-   entity identity/order/count/page boundary are fixed.
-4. Taxonomy tag names must be hydrated only after Product page identity/order/count is fixed.
-5. Shadow execution has no serving latency/deadline policy and remains non-serving.
-6. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
-7. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
+3. Taxonomy tag names must be batch-hydrated requested-locale -> fallback-locale only after Product page
+   identity/order/count is fixed; current post-page adapter intentionally leaves `tag_ids` unchanged.
+4. Shadow execution has no serving latency/deadline policy and remains non-serving.
+5. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
+6. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
 
 ## Next source slice
 
-Add a post-page Product Storefront projection adapter for the Index result. A localized null `title` must map to
-owner public placeholder `"Untitled product"` and a localized null `handle` to `""`, but only after the Index
-query has already fixed identity, ordering, exact count and page boundary. Do not feed placeholders back into
-filtering, sorting, identity folding or count. Taxonomy tag-name hydration remains a later slice.
+Add a Product/Taxonomy owner capability for bounded batched hydration of the already-selected Product page's
+`tag_ids`. Resolve requested-locale then fallback-locale display names only after Index identity/order/count is
+fixed. Hydration failure must be retained separately and must not replace the raw Product page. Do not copy tag
+names into Product Index schema merely to avoid post-page owner hydration.
 
 ## Source guards
 
-- `verify-index-product-storefront-channel-scope-policy.mjs` locks owner channel-less semantics, unrestricted
-  relation materialization and the typed current-key owner-native decision without sentinels;
-- `verify-index-product-storefront-deep-page-policy.mjs` locks owner-valid shallow/deep classification and
-  forbids page/offset clamp or cursor rewriting;
+- `verify-index-product-storefront-channel-scope-policy.mjs` locks current-key channel-less owner-native policy;
+- `verify-index-product-storefront-deep-page-policy.mjs` locks owner-valid shallow/deep classification;
+- `verify-index-product-storefront-public-projection.mjs` locks raw-vs-public page separation, Product public
+  placeholder values and preservation of page metadata/`tag_ids`;
 - `verify-product-storefront-search-bound.mjs` locks the Product-owned search-length contract;
 - `verify-index-product-storefront-collation-postgres-packet.mjs` locks retained collation evidence;
 - `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;

--- a/crates/rustok-index/docs/m7-product-storefront-public-projection.md
+++ b/crates/rustok-index/docs/m7-product-storefront-public-projection.md
@@ -1,0 +1,54 @@
+# M7 Product Storefront public projection boundary
+
+Status: `source_complete_taxonomy_hydration_pending`.
+
+## Raw Index page remains generic
+
+The localized Index query and decoder remain Product-neutral. If a Product has neither the requested nor the
+fallback translation row, raw projected `title` and `handle` are `IndexValue::Null`.
+
+That raw state is retained intentionally. It participates in no Product public placeholder logic, and existing
+PostgreSQL equivalence evidence continues to observe it directly.
+
+## Product public post-page layer
+
+`rustok-distribution::product_index::storefront_projection` applies owner public placeholder semantics only to
+an already-decoded `IndexQueryPage`:
+
+- root `title: Null` becomes `"Untitled product"`;
+- root `handle: Null` becomes `""`;
+- existing string values remain unchanged;
+- missing, duplicate or wrong-typed root title/handle projections fail closed.
+
+The adapter preserves item identity/order, exact count, `has_more`, cursor, unrelated projected fields and
+`tag_ids`. It has no query, filtering, sorting, localized-fold or execution dependency.
+
+`ProductStorefrontIndexShadowExecution` retains both layers:
+
+- `projected` — raw generic Index page and the input to identity/count/page comparison;
+- `public_projected` — optional Product public page derived from a clone of successful `projected`.
+
+A raw projection failure produces no public page. A public projection failure is retained separately and never
+replaces the successful Product owner result or mutates the raw Index page.
+
+## Why this is post-page only
+
+The Product owner placeholders describe public presentation when no requested/fallback translation is
+available. They are not stored translation values and must not become search/filter/order identities. Applying
+them before query completion would change owner semantics by making a display fallback participate in
+selection, ordering, exact count or pagination.
+
+Keeping them post-page also leaves generic `rustok-index` reusable for entities whose no-localized-row public
+contract differs from Product.
+
+## Remaining projection gap
+
+Product owner list returns localized Taxonomy tag names, while the current Index Product page retains
+`tag_ids`. The public placeholder adapter deliberately does not transform these IDs.
+
+The next source slice must batch-hydrate tag names through an owner capability after Product page identity,
+ordering and exact count are fixed. Tag hydration failure must remain separate from the raw Index page and must
+not cause a different Product selection.
+
+No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -23,7 +23,12 @@ const storefront = requireMarkers(storefrontPath, [
   'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
   '.list_published_products_with_query(',
 ]);
-for (const forbidden of ['rustok_index', 'SharedIndexQueryRuntime', 'execute_localized_query']) {
+for (const forbidden of [
+  'rustok_index',
+  'SharedIndexQueryRuntime',
+  'execute_localized_query',
+  'project_product_storefront_index_page',
+]) {
   if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
 }
 
@@ -43,6 +48,9 @@ const owner = requireMarkers(ownerPath, [
   'product_title_search_condition(',
   'let total = query.clone().count(&self.db).await?',
   'pick_product_translation(items.as_slice(), locale, fallback_locale)',
+  '.unwrap_or_else(|| "Untitled product".to_string())',
+  'handle: translation',
+  '.unwrap_or_default()',
   'let pattern = format!("%{search}%");',
   'pt.title LIKE $1',
   'if page == 0 || per_page == 0 || per_page > 48',
@@ -74,20 +82,22 @@ requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_re
 const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
 const executor = requireMarkers(executorPath, [
   'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
-  'ShadowEligible { public_channel_id: Uuid }',
   'OwnerNativeChannelLess',
   'ChannelLessOwnerNative',
-  'pub(crate) fn classify_product_storefront_index_channel_scope(',
-  '(None, None) => Ok(ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess)',
-  'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
   'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
   'OwnerNativeDeepPage { offset: u64 }',
   'DeepPageOwnerNative { offset: u64 }',
-  'pub(crate) fn classify_product_storefront_index_page_scope(',
-  'classify_product_storefront_index_page_scope(&query)',
+  'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
+  'pub(crate) public_projected:',
+  'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
   'list_filtered_published_products(',
+  'classify_product_storefront_index_page_scope(&query)',
   '.resolve_storefront_attribute_filters(',
   '.execute_localized_query(index_query)',
+  'let public_projected = projected',
+  '.map(project_product_storefront_index_page);',
+  'let comparison = projected',
+  'compare_owner_and_index(&authoritative, projected)',
   'pub(crate) authoritative: StorefrontProductList',
 ]);
 for (const forbidden of [
@@ -98,19 +108,57 @@ for (const forbidden of [
 ]) {
   if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden request-shape shortcut ${forbidden}`);
 }
+const executeProjectedStart = executor.indexOf('async fn execute_projected(');
+const compareStart = executor.indexOf('fn compare_owner_and_index(');
+if (
+  executeProjectedStart < 0 ||
+  compareStart <= executeProjectedStart ||
+  executor.slice(executeProjectedStart, compareStart).includes('project_product_storefront_index_page')
+) {
+  fail(`${executorPath} public Product projection must remain outside raw Index execution`);
+}
 
-requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow.rs', [
+const projectionPath = 'crates/rustok-distribution/src/product_index/storefront_projection.rs';
+const projection = requireMarkers(projectionPath, [
+  'const UNTITLED_PRODUCT: &str = "Untitled product";',
+  'pub(crate) enum ProductStorefrontIndexPublicProjectionError',
+  'pub(crate) fn project_product_storefront_index_page(',
+  'apply_string_placeholder(item, "title", UNTITLED_PRODUCT)?;',
+  'apply_string_placeholder(item, "handle", "")?;',
+  'MissingField',
+  'DuplicateField',
+  'InvalidFieldValue',
+  'projected.exact_count, Some(9)',
+  'projected.next_cursor.as_deref(), Some("opaque-cursor")',
+  'value(&projected.items[0], "tag_ids")',
+]);
+for (const forbidden of ['FilterExpr', 'OrderExpr', 'LocalizedEntityQuery', 'execute_localized_query']) {
+  if (projection.includes(forbidden)) {
+    fail(`${projectionPath} must remain post-page only; found ${forbidden}`);
+  }
+}
+
+const builderPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
+const builder = requireMarkers(builderPath, [
   'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
   'PublicChannelRequired',
   'root_field("sales_channel_ids")?',
   'const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;',
   'ProductStorefrontIndexShadowError::OffsetTooDeep',
 ]);
+for (const forbidden of ['Untitled product', 'project_product_storefront_index_page']) {
+  if (builder.includes(forbidden)) {
+    fail(`${builderPath} must not feed Product public placeholders into query construction: ${forbidden}`);
+  }
+}
+
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'assert_eq!(owner_c.title, "Untitled product");',
+  'assert_eq!(owner_c.handle, "");',
   'assert_eq!(projected_string(index_c, "title")?, None);',
+  'assert_eq!(projected_string(index_c, "handle")?, None);',
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_eav_postgres_tests.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_EAV_EQUIVALENCE_DATABASE_URL',
@@ -128,6 +176,7 @@ requireMarkers('crates/rustok-distribution/tests/product_storefront_search_colla
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
   'assert_eq!(schema.fields.len(), 15);',
+  'many_field("tag_ids", IndexValueType::Uuid, true, false)',
   'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
@@ -135,50 +184,43 @@ for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)']) {
   if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema marker ${forbidden}`);
 }
 
-requireMarkers('scripts/verify/verify-product-storefront-search-bound.mjs', [
-  'MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022',
-  'MAX_TEXT_LIKE_PATTERN_BYTES: usize = 1024',
+requireMarkers('scripts/verify/verify-index-product-storefront-public-projection.mjs', [
+  'Product public placeholders are post-page only',
+  'raw Index null evidence and tag_ids remain unchanged',
+]);
+requireMarkers('scripts/verify/verify-index-product-storefront-deep-page-policy.mjs', [
+  'OwnerNativeDeepPage { offset: u64 }',
+  'must preserve owner pagination without clamp/rewrite',
+]);
+requireMarkers('scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs', [
+  'OwnerNativeChannelLess',
+  'must not infer or fabricate visibility membership',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs', [
   'must remain the owner/default-collation side',
   'must observe deployment/default collation rather than manufacture parity',
-]);
-requireMarkers('scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs', [
-  'OwnerNativeChannelLess',
-  'ShadowEligible { public_channel_id: Uuid }',
-  'must not infer or fabricate visibility membership',
-]);
-requireMarkers('scripts/verify/verify-index-product-storefront-deep-page-policy.mjs', [
-  'OwnerNativeDeepPage { offset: u64 }',
-  'DeepPageOwnerNative { offset: u64 }',
-  'ShadowEligible { offset: 9_984 }',
-  'OwnerNativeDeepPage { offset: 10_032 }',
-  'must preserve owner pagination without clamp/rewrite',
 ]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `deep_page_policy_source_complete_projection_placeholder_pending`',
+  'Status: `public_projection_source_complete_taxonomy_hydration_pending`',
   'Mounted Storefront remains owner-native',
-  'Channel-less serving policy — source complete for current key 4',
-  'Deep-page serving policy — source complete',
-  '`OwnerNativeChannelLess`',
-  '`OwnerNativeDeepPage { offset }`',
-  '`DeepPageOwnerNative { offset }`',
-  'no-localized-row null title/handle',
+  'Product public placeholder projection — source complete',
+  '`public_projected`',
+  'Taxonomy tag names',
 ]);
-requireMarkers('crates/rustok-index/docs/m7-product-storefront-deep-page-policy.md', [
-  'Status: `source_complete_owner_execution_policy_retained`',
-  '`OwnerNativeDeepPage { offset }`',
-  '`DeepPageOwnerNative { offset }`',
-  'no Index page is fabricated',
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-public-projection.md', [
+  'Status: `source_complete_taxonomy_hydration_pending`',
+  '`projected` — raw generic Index page',
+  '`public_projected` — optional Product public page',
+  '`tag_ids`',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
-  "'verify-index-product-storefront-channel-scope-policy.mjs'",
+  "'verify-index-product-storefront-public-projection.mjs'",
   "'verify-index-product-storefront-deep-page-policy.mjs'",
   "'verify-index-product-storefront-collation-postgres-packet.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; channel-less and deep-page request shapes have typed owner-native policies while projection, evidence admission and serving gates remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; raw Index evidence and Product post-page public placeholders are separated while Taxonomy hydration, evidence admission and serving gates remain pending');

--- a/scripts/verify/verify-index-product-storefront-public-projection.mjs
+++ b/scripts/verify/verify-index-product-storefront-public-projection.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-public-projection] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
+requireMarkers(ownerPath, [
+  'title: translation',
+  '.unwrap_or_else(|| "Untitled product".to_string())',
+  'handle: translation',
+  '.unwrap_or_default()',
+]);
+
+const rawPacketPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs';
+requireMarkers(rawPacketPath, [
+  'assert_eq!(owner_c.title, "Untitled product");',
+  'assert_eq!(owner_c.handle, "");',
+  'assert_eq!(projected_string(index_c, "title")?, None);',
+  'assert_eq!(projected_string(index_c, "handle")?, None);',
+]);
+
+const projectionPath = 'crates/rustok-distribution/src/product_index/storefront_projection.rs';
+const projection = requireMarkers(projectionPath, [
+  'const UNTITLED_PRODUCT: &str = "Untitled product";',
+  'pub(crate) enum ProductStorefrontIndexPublicProjectionError',
+  'MissingField',
+  'DuplicateField',
+  'InvalidFieldValue',
+  'pub(crate) fn project_product_storefront_index_page(',
+  'apply_string_placeholder(item, "title", UNTITLED_PRODUCT)?;',
+  'apply_string_placeholder(item, "handle", "")?;',
+  'projected.exact_count, Some(9)',
+  'projected.next_cursor.as_deref(), Some("opaque-cursor")',
+  'value(&projected.items[0], "tag_ids")',
+  'IndexValue::List(vec![IndexValue::Uuid(tag_id)])',
+  'fails_closed_on_missing_duplicate_or_wrong_typed_public_fields',
+]);
+for (const forbidden of [
+  'FilterExpr',
+  'OrderExpr',
+  'Pagination::',
+  'LocalizedEntityQuery',
+  'execute_localized_query',
+]) {
+  if (projection.includes(forbidden)) {
+    fail(`${projectionPath} must remain a post-page transform; found query/execution marker ${forbidden}`);
+  }
+}
+
+const builderPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
+const builder = read(builderPath);
+for (const forbidden of ['Untitled product', 'project_product_storefront_index_page']) {
+  if (builder.includes(forbidden)) {
+    fail(`${builderPath} must not feed owner public placeholders into query construction: ${forbidden}`);
+  }
+}
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
+  'pub(crate) public_projected:',
+  'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
+  'let projected = self',
+  '.execute_projected(',
+  'let public_projected = projected',
+  '.as_ref()',
+  '.ok()',
+  '.cloned()',
+  '.map(project_product_storefront_index_page);',
+  'let comparison = projected',
+  'compare_owner_and_index(&authoritative, projected)',
+]);
+const executeProjectedStart = executor.indexOf('async fn execute_projected(');
+const compareStart = executor.indexOf('fn compare_owner_and_index(');
+if (executeProjectedStart < 0 || compareStart <= executeProjectedStart) {
+  fail(`${executorPath} projected execution/comparison boundaries are missing`);
+}
+const rawExecution = executor.slice(executeProjectedStart, compareStart);
+if (rawExecution.includes('project_product_storefront_index_page')) {
+  fail(`${executorPath} owner public placeholders must be applied after raw Index execution, not inside it`);
+}
+const rawPosition = executor.indexOf('let projected = self');
+const publicPosition = executor.indexOf('let public_projected = projected');
+const comparisonPosition = executor.indexOf('let comparison = projected');
+if (
+  rawPosition < 0 ||
+  publicPosition <= rawPosition ||
+  comparisonPosition <= rawPosition
+) {
+  fail('raw Index page must exist before public projection and raw equivalence comparison');
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod storefront_projection;',
+  'ProductStorefrontIndexPublicProjectionError',
+  'project_product_storefront_index_page',
+]);
+
+console.log('[verify-index-product-storefront-public-projection] Product public placeholders are post-page only; raw Index null evidence and tag_ids remain unchanged');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -26,28 +26,30 @@ const source = requireMarkers(executorPath, [
   'pub(crate) struct ProductStorefrontIndexShadowExecution',
   'pub(crate) authoritative: StorefrontProductList',
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
+  'pub(crate) public_projected:',
+  'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
   'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
-  'ShadowEligible { public_channel_id: Uuid }',
   'OwnerNativeChannelLess',
   'ChannelLessOwnerNative',
-  'pub(crate) fn classify_product_storefront_index_channel_scope(',
   'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
   'OwnerNativeDeepPage { offset: u64 }',
   'DeepPageOwnerNative { offset: u64 }',
-  'pub(crate) fn classify_product_storefront_index_page_scope(',
   'list_filtered_published_products(',
   'let projected = self',
+  '.execute_projected(',
+  'let public_projected = projected',
+  '.as_ref()',
+  '.ok()',
+  '.cloned()',
+  '.map(project_product_storefront_index_page);',
+  'let comparison = projected',
+  'compare_owner_and_index(&authoritative, projected)',
   'classify_product_storefront_index_channel_scope(',
   'classify_product_storefront_index_page_scope(&query)',
-  'return Err(ProductStorefrontIndexShadowProjectionError::ChannelLessOwnerNative);',
-  'return Err(ProductStorefrontIndexShadowProjectionError::DeepPageOwnerNative',
   '.schema_read_port()',
   '.resolve_storefront_attribute_filters(',
   'build_product_storefront_index_shadow_query(',
   '.execute_localized_query(index_query)',
-  'PublicChannelIdentityUnavailable',
-  'SchemaReadPortUnavailable',
-  'compare_owner_and_index(&authoritative, projected)',
   'identities_match: authoritative_ids == projected_ids',
   'projected.exact_count == Some(authoritative.total)',
   'projected.has_more == authoritative.has_next',
@@ -55,8 +57,22 @@ const source = requireMarkers(executorPath, [
 
 const ownerPosition = source.indexOf('list_filtered_published_products(');
 const projectedPosition = source.indexOf('let projected = self');
-if (ownerPosition < 0 || projectedPosition < 0 || ownerPosition > projectedPosition) {
-  fail('authoritative Product owner list must execute before any Index shadow work');
+const publicPosition = source.indexOf('let public_projected = projected');
+const comparisonPosition = source.indexOf('let comparison = projected');
+if (
+  ownerPosition < 0 ||
+  projectedPosition <= ownerPosition ||
+  publicPosition <= projectedPosition ||
+  comparisonPosition <= projectedPosition
+) {
+  fail('owner success must precede raw Index projection, and raw page must precede public projection/comparison');
+}
+
+const rawStart = source.indexOf('async fn execute_projected(');
+const compareStart = source.indexOf('fn compare_owner_and_index(');
+if (rawStart < 0 || compareStart <= rawStart) fail('raw projected execution boundary is missing');
+if (source.slice(rawStart, compareStart).includes('project_product_storefront_index_page')) {
+  fail('Product public placeholder transform must not run inside raw Index execution');
 }
 
 for (const forbidden of [
@@ -74,15 +90,18 @@ for (const forbidden of [
   if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports and preserve owner request semantics; found ${forbidden}`);
 }
 
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_projection.rs', [
+  'pub(crate) fn project_product_storefront_index_page(',
+  'const UNTITLED_PRODUCT: &str = "Untitled product";',
+  'apply_string_placeholder(item, "handle", "")?;',
+]);
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod storefront_projection;',
+  'ProductStorefrontIndexPublicProjectionError',
+  'project_product_storefront_index_page',
   'mod storefront_shadow_executor;',
   'ProductStorefrontIndexShadowExecutor',
-  'ProductStorefrontIndexShadowExecution',
-  'ProductStorefrontIndexShadowComparison',
-  'ProductStorefrontIndexChannelScopeDecision',
   'ProductStorefrontIndexPageScopeDecision',
-  'classify_product_storefront_index_channel_scope',
-  'classify_product_storefront_index_page_scope',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -90,8 +109,12 @@ const mounted = requireMarkers(mountedPath, [
   'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
   '.list_published_products_with_query(',
 ]);
-for (const forbidden of ['ProductStorefrontIndexShadowExecutor', 'execute_localized_query']) {
+for (const forbidden of [
+  'ProductStorefrontIndexShadowExecutor',
+  'execute_localized_query',
+  'project_product_storefront_index_page',
+]) {
   if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
-console.log('[verify-index-product-storefront-shadow-executor] owner-first non-serving shadow execution plus channel-less and deep-page typed owner-native policies are source-locked; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-shadow-executor] owner-first raw Index evidence and derived post-page Product public projection are source-locked; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -87,6 +87,7 @@ const scripts = [
   'verify-index-product-storefront-shadow-executor.mjs',
   'verify-index-product-storefront-channel-scope-policy.mjs',
   'verify-index-product-storefront-deep-page-policy.mjs',
+  'verify-index-product-storefront-public-projection.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',


### PR DESCRIPTION
## Summary

- add a Product distribution-owned post-page public projection for already-decoded Storefront Index pages;
- preserve raw generic Index semantics: no requested/fallback localized row remains `IndexValue::Null` in `projected` and in the retained PostgreSQL packet;
- derive a separate `public_projected` layer only from a clone of a successful raw Index page;
- map root `title: Null` to owner public `"Untitled product"` and root `handle: Null` to `""`;
- preserve existing string values and fail closed on missing, duplicate or wrong-typed root title/handle fields;
- preserve Product entity identity/order, exact count, page boundary, cursor, unrelated fields and `tag_ids`;
- keep raw identity/count/page comparison on `projected`, so placeholders cannot influence filtering, sorting, localized folding, exact count or pagination;
- keep the query builder and generic `rustok-index` free of Product placeholder strings;
- add focused source guards/docs and advance the M7 cursor to post-page Taxonomy tag hydration.

## Boundary

This PR does not hydrate Taxonomy tag names, alter Product schema/source/routing key, change title search/filter/order semantics, execute PostgreSQL evidence, admit collation parity, add serving latency/deadline behavior, or switch Storefront traffic.

Mounted Storefront remains owner-native. Channel-less and deep-page shapes remain owner-native under current contracts.

## Main recheck

The branch is based on current `main@ac399264f12dd71439861e60a5df86ac9ab496bb`. Final compare is ahead-only with 10 expected Product/Index projection, guard and documentation files; Product schema/source/query builder and the raw core PostgreSQL packet are unchanged.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.