### PR TITLE
refactor(groups): enforce effective governance authorization

### DIFF
--- a/crates/rustok-groups/contracts/groups-fba-registry.json
+++ b/crates/rustok-groups/contracts/groups-fba-registry.json
@@ -348,6 +348,17 @@
         "policy": "write",
         "deadline_required": true,
         "idempotency_key_required": true,
+        "authorization": "effective_owner_admin_hierarchy_or_platform_manage",
+        "effective_clock": "groups_owner_utc_clock",
+        "role_change_target_effective_state": "active_required",
+        "new_owner_effective_state": "active_required",
+        "platform_owner_recovery": "current_stored_active_owner_may_be_suspended",
+        "owner_reference_consistency": "fail_closed",
+        "receipt_replay_order": "after_group_serialization_before_current_effective_authorization",
+        "receipt_identity": "tenant_group_actor_command_request_hash",
+        "lock_order": "group_then_memberships_uuid_order_then_enforcements_membership_id_order",
+        "transactional_group_version": true,
+        "transactional_membership_revision": "database_role_trigger",
         "transactional_receipt": true,
         "transactional_audit": true
       }
@@ -417,6 +428,20 @@
     "delete_last_translation": "deny",
     "version_bump": "same_transaction",
     "mutation_serialization": "base_group_row_then_effective_membership_locks"
+  },
+  "governance": {
+    "effective_authorization": "implemented_source",
+    "effective_clock": "groups_owner_utc_clock",
+    "role_change_actor": "effective_active_owner_or_admin_unless_platform_manage",
+    "role_change_target": "effective_active_non_owner_membership",
+    "ownership_transfer_actor": "effective_active_current_owner_unless_platform_manage",
+    "ownership_transfer_new_owner": "effective_active_membership",
+    "platform_owner_recovery": "may_transfer_away_from_suspended_current_owner",
+    "owner_reference_consistency": "group_owner_user_id_must_match_owner_role",
+    "receipt_replay_order": "group_lock_then_actor_bound_receipt_then_effective_authorization",
+    "lock_order": "group_then_memberships_uuid_order_then_enforcements_membership_id_order",
+    "stored_lifecycle_role_mutation": "same_transaction",
+    "group_version_bump": "same_transaction"
   },
   "invitations": {
     "plaintext_token_storage": "never",
@@ -667,11 +692,14 @@
     {
       "name": "embedded_governance_native",
       "provider": "GroupGovernanceService",
-      "status": "implemented",
+      "status": "implemented_source",
       "surfaces": [
         "rust_port",
         "graphql",
-        "leptos_server_function"
+        "leptos_server_function",
+        "owner_clock_effective_governance",
+        "actor_bound_receipt_replay",
+        "deterministic_membership_enforcement_locks"
       ],
       "implicit_fallback": false
     },
@@ -697,6 +725,7 @@
     "membership_enforcement_read_static_boundary": "scripts/verify/verify-groups-membership-enforcement-read-path.mjs",
     "membership_enforcement_command_static_boundary": "scripts/verify/verify-groups-membership-enforcement-command.mjs",
     "membership_enforcement_graphql_static_boundary": "scripts/verify/verify-groups-membership-enforcement-graphql.mjs",
+    "governance_effective_authorization_static_boundary": "scripts/verify/verify-groups-governance-effective-authorization.mjs",
     "runtime_provider_consumer": null,
     "runtime_fallback": null,
     "runtime_retry_recovery": null,

--- a/crates/rustok-groups/contracts/groups-fba-registry.json
+++ b/crates/rustok-groups/contracts/groups-fba-registry.json
@@ -692,7 +692,7 @@
     {
       "name": "embedded_governance_native",
       "provider": "GroupGovernanceService",
-      "status": "implemented_source",
+      "status": "implemented",
       "surfaces": [
         "rust_port",
         "graphql",

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -91,9 +91,8 @@ Group -> GroupMembership -> GroupMembershipEnforcement
 
 PostgreSQL/MySQL use row locks. SQLite obtains writer serialization through a no-op update of the
 already resolved group before membership/enforcement reads. Authorization runs after receipt replay
-and owner locking but before the first domain mutation. Direct enforcement commands lock actor and
-target memberships in deterministic UUID order and their enforcement rows in deterministic
-membership-ID order.
+and owner locking but before the first domain mutation. Commands that lock multiple memberships use
+deterministic user UUID order, followed by deterministic membership-ID enforcement-row order.
 
 Application CAS preserves existing application-before-group ordering where an application row
 already exists. Invitation/application identity locks do not create a cycle with enforcement because
@@ -127,6 +126,8 @@ Source exists for:
 - effective localization management reads plus transaction-aware translation upsert/delete using the
   same owner-clock manager semantics and `Group -> GroupMembership -> GroupMembershipEnforcement`
   write lock protocol;
+- effective governance role/ownership commands with group-serialized actor-bound replay,
+  deterministic membership/enforcement locks, owner-reference consistency and owner-clock authority;
 - sealed effective public invitation/application services with compatibility module paths;
 - transaction-aware invitation/application writes using the group/membership/enforcement lock
   protocol;
@@ -143,9 +144,10 @@ Evidence still open:
 - executed native/GraphQL parity and schema/error-mapping evidence for direct enforcement;
 - executed localization suspension/expiry, native/GraphQL parity, and concurrent enforcement-vs-write
   evidence;
+- governance concurrency, replay/lost-response, suspension/expiry, platform-recovery and native/GraphQL
+  parity evidence;
 - native/GraphQL parity, CAS, lifecycle, bulk-review, retry, recovery, security, and accessibility
   evidence for the broader module;
-- governance effective authorization;
 - provider ACL integration and remote/degraded profiles;
 - neutral moderation adapter and durable moderation application orchestration.
 
@@ -160,7 +162,7 @@ Evidence still open:
 | GROUPS-04 | in_progress | typed summary/membership/access/localization/invitation/application/governance/enforcement ports | consumer/fallback runtime matrix |
 | GROUPS-05 | in_progress | GraphQL/native transports, invitation acceptance/delivery | parity and Notifications evidence |
 | GROUPS-06 | in_progress | localized policy, CAS, lifecycle, focused/bulk review, FFA UX | profiles/events/parity/concurrency/accessibility |
-| GROUPS-07 | in_progress | revision, enforcement read/direct command/GraphQL, effective core/localization access, transactional invitation/application authorization | moderation adapter, governance/provider cutover, runtime/concurrency/parity evidence |
+| GROUPS-07 | in_progress | revision, enforcement read/direct command/GraphQL, effective core/localization/governance access, transactional invitation/application authorization | moderation adapter, provider cutover, runtime/concurrency/parity evidence |
 | GROUPS-08 | planned | dynamic feature-provider registry and navigation | registry/degradation evidence |
 | GROUPS-09 | planned | Forum group spaces and ACL inheritance | Forum integration evidence |
 | GROUPS-10 | planned | Blog and Pages/Wiki group contexts | owner/privacy evidence |
@@ -333,6 +335,33 @@ Exact-locale behavior, last-translation deletion denial, translation mutation se
 `groups.version` advancement are unchanged. Runtime PostgreSQL/SQLite contention and native/GraphQL
 parity evidence remain open.
 
+### Source-complete governance effective authorization
+
+`GroupGovernanceCommandPort` now follows the same owner serialization and effective-membership
+boundary as enforcement/localization. Both `change_group_role` and `transfer_group_ownership` lock
+the group before receipt lookup. Replay identity is bound to tenant + group + actor + command + request hash,
+so a caller cannot reuse another actor's completed governance receipt. Matching replay returns before
+current membership/enforcement authorization, preserving lost-response semantics when authority has
+changed after the original commit.
+
+After replay admission, governance locks every required membership in deterministic user UUID order,
+then every corresponding enforcement row in deterministic membership-ID order. Local role changes
+require an effective-active owner/admin actor and an effective-active non-owner target. Ownership
+transfer requires an effective-active current owner for local authority and an effective-active new owner.
+Suspended/banned local actors or targets fail with the existing effective errors instead of being
+treated as active because their stored lifecycle row still says `active`.
+
+Platform `groups:manage` remains an explicit recovery authority. It may transfer ownership away from
+a suspended current owner as long as the stored current-owner membership is still lifecycle-active
+and its role agrees with `groups.owner_user_id`; the replacement owner must still be effective-active.
+Any owner-reference/owner-role disagreement fails closed before mutation.
+
+Role/ownership writes, membership revision trigger effects, group-version advance, audit and command
+receipt remain in one Groups transaction. The existing GraphQL governance transport still calls only
+`GroupGovernanceCommandPort`; no transport fallback or second governance mutation path is introduced.
+Compilation, PostgreSQL/SQLite contention, replay/lost-response, suspension/expiry, platform recovery,
+governance concurrency and native/GraphQL parity evidence remain open.
+
 ### Planned moderation adapter
 
 Initial mapping remains:
@@ -365,10 +394,9 @@ above rather than introduce a second Groups enforcement state path.
 
 ## Remaining implementation order
 
-1. Convert governance role/ownership commands with owner protection and the same lock protocol.
-2. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
-3. Convert provider ACL consumers and remote/degraded profiles.
-4. Produce direct-enforcement, localization, governance and adapter runtime, parity, concurrency,
+1. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
+2. Convert provider ACL consumers and remote/degraded profiles.
+3. Produce direct-enforcement, localization, governance and adapter runtime, parity, concurrency,
    security, migration and accessibility evidence.
 
 ## Degraded modes
@@ -399,6 +427,7 @@ cargo check -p rustok-groups-storefront --features ssr
 cargo test -p rustok-groups
 node scripts/verify/verify-groups-boundary.mjs
 node scripts/verify/verify-groups-localization-boundary.mjs
+node scripts/verify/verify-groups-governance-effective-authorization.mjs
 node scripts/verify/verify-groups-invitations-boundary.mjs
 node scripts/verify/verify-groups-membership-applications.mjs
 node scripts/verify/verify-groups-application-policy-cas.mjs

--- a/crates/rustok-groups/src/governance.rs
+++ b/crates/rustok-groups/src/governance.rs
@@ -4,17 +4,20 @@ use async_trait::async_trait;
 use chrono::Utc;
 use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, DatabaseTransaction, EntityTrait,
-    QueryFilter, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection,
+    DatabaseTransaction, EntityTrait, QueryFilter, QuerySelect, Set, TransactionTrait,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::domain::{GroupMembershipStatus, GroupRole};
+use crate::domain::{GroupMembershipEffectiveStatus, GroupMembershipStatus, GroupRole};
 use crate::entities::{group, membership};
 use crate::error::{GroupsError, GroupsResult};
 use crate::governance_entities::{audit_entry, command_receipt};
+use crate::membership_enforcement::resolve_group_membership_enforcement;
+use crate::membership_enforcement_entities::membership_enforcement;
+use crate::membership_enforcement_transaction::reserve_group_write_for_update;
 
 const CHANGE_ROLE_COMMAND: &str = "groups.change_role.v1";
 const TRANSFER_OWNERSHIP_COMMAND: &str = "groups.transfer_ownership.v1";
@@ -90,9 +93,12 @@ impl GroupGovernanceService {
         let idempotency_key = idempotency_key(context)?;
         let request_hash = request_hash(&request)?;
         let transaction = self.db.begin().await?;
+        let mut group_model = lock_group(&transaction, tenant_id, request.group_id).await?;
         if let Some(replayed) = replay_receipt::<GroupGovernanceResult>(
             &transaction,
             tenant_id,
+            request.group_id,
+            actor_user_id,
             &idempotency_key,
             CHANGE_ROLE_COMMAND,
             &request_hash,
@@ -106,43 +112,68 @@ impl GroupGovernanceService {
             });
         }
 
-        let mut group_model = find_group(&transaction, tenant_id, request.group_id).await?;
-        let actor_membership =
-            find_membership(&transaction, tenant_id, request.group_id, actor_user_id).await?;
-        let target_membership = find_membership(
+        let platform_manage = has_platform_manage(context);
+        let locked = lock_governance_memberships(
             &transaction,
             tenant_id,
             request.group_id,
+            actor_user_id,
             request.target_user_id,
+            !platform_manage,
         )
         .await?;
-
-        let actor_role = active_role(&actor_membership)?;
-        let target_role = active_role(&target_membership)?;
-        if target_role == GroupRole::Owner {
+        let target_membership = locked
+            .membership(request.target_user_id)
+            .ok_or_else(|| GroupsError::Conflict("an active group membership is required".to_string()))?;
+        validate_owner_identity(&group_model, &target_membership)?;
+        if target_membership.user_id == group_model.owner_user_id {
             return Err(GroupsError::Invariant(
                 "the owner role can only change through ownership transfer".to_string(),
             ));
         }
-        authorize_role_change(
-            actor_role,
-            target_role,
-            request.role,
-            has_platform_manage(context),
-        )?;
 
-        let now = Utc::now().fixed_offset();
+        let now = Utc::now();
+        let target_role = effective_governance_role(
+            &transaction,
+            tenant_id,
+            request.group_id,
+            request.target_user_id,
+            now,
+        )
+        .await?;
+        let actor_role = if platform_manage {
+            None
+        } else {
+            if locked.membership(actor_user_id).is_none() {
+                return Err(GroupsError::ManagerRequired(
+                    "an active group owner or administrator role is required".to_string(),
+                ));
+            }
+            Some(
+                effective_manager_role(
+                    &transaction,
+                    tenant_id,
+                    request.group_id,
+                    actor_user_id,
+                    now,
+                )
+                .await?,
+            )
+        };
+        authorize_role_change(actor_role, target_role, request.role, platform_manage)?;
+
+        let fixed_now = now.fixed_offset();
         let mut target_active: membership::ActiveModel = target_membership.into();
         target_active.role = Set(request.role.as_str().to_string());
-        target_active.updated_at = Set(now);
+        target_active.updated_at = Set(fixed_now);
         target_active.update(&transaction).await?;
 
         group_model.version = group_model.version.saturating_add(1);
-        group_model.updated_at = now;
+        group_model.updated_at = fixed_now;
         let group_version = group_model.version.max(1) as u64;
         let mut group_active: group::ActiveModel = group_model.into();
         group_active.version = Set(group_version as i64);
-        group_active.updated_at = Set(now);
+        group_active.updated_at = Set(fixed_now);
         group_active.update(&transaction).await?;
 
         let result = GroupGovernanceResult {
@@ -165,7 +196,8 @@ impl GroupGovernanceService {
             json!({
                 "previous_role": target_role.as_str(),
                 "current_role": request.role.as_str(),
-                "group_version": group_version
+                "group_version": group_version,
+                "authorization": if platform_manage { "platform_manage" } else { "effective_local_manager" }
             }),
         )
         .await?;
@@ -201,9 +233,12 @@ impl GroupGovernanceService {
         let idempotency_key = idempotency_key(context)?;
         let request_hash = request_hash(&request)?;
         let transaction = self.db.begin().await?;
+        let group_model = lock_group(&transaction, tenant_id, request.group_id).await?;
         if let Some(replayed) = replay_receipt::<GroupGovernanceResult>(
             &transaction,
             tenant_id,
+            request.group_id,
+            actor_user_id,
             &idempotency_key,
             TRANSFER_OWNERSHIP_COMMAND,
             &request_hash,
@@ -217,46 +252,89 @@ impl GroupGovernanceService {
             });
         }
 
-        let group_model = find_group(&transaction, tenant_id, request.group_id).await?;
-        if group_model.owner_user_id != actor_user_id && !has_platform_manage(context) {
+        let platform_manage = has_platform_manage(context);
+        if group_model.owner_user_id != actor_user_id && !platform_manage {
             return Err(GroupsError::Forbidden(
                 "only the current owner or a platform group manager may transfer ownership"
                     .to_string(),
             ));
         }
+
         let previous_owner_id = group_model.owner_user_id;
-        let previous_owner =
-            find_membership(&transaction, tenant_id, request.group_id, previous_owner_id).await?;
-        let new_owner = find_membership(
+        let locked = lock_ownership_memberships(
             &transaction,
             tenant_id,
             request.group_id,
+            previous_owner_id,
             request.new_owner_user_id,
+            actor_user_id,
+            !platform_manage,
         )
         .await?;
-        if active_role(&previous_owner)? != GroupRole::Owner {
+        let previous_owner = locked.membership(previous_owner_id).ok_or_else(|| {
+            GroupsError::Invariant(
+                "group owner membership does not match the group owner reference".to_string(),
+            )
+        })?;
+        validate_owner_identity(&group_model, &previous_owner)?;
+        if stored_active_role(&previous_owner)? != GroupRole::Owner {
             return Err(GroupsError::Invariant(
                 "group owner membership does not match the group owner reference".to_string(),
             ));
         }
-        let previous_target_role = active_role(&new_owner)?;
 
-        let now = Utc::now().fixed_offset();
+        let new_owner = locked
+            .membership(request.new_owner_user_id)
+            .ok_or_else(|| GroupsError::Conflict("an active group membership is required".to_string()))?;
+        validate_owner_identity(&group_model, &new_owner)?;
+        if new_owner.user_id == previous_owner_id {
+            return Err(GroupsError::Conflict(
+                "the selected user already acts as the requested owner".to_string(),
+            ));
+        }
+
+        let now = Utc::now();
+        if !platform_manage {
+            let actor_role = effective_manager_role(
+                &transaction,
+                tenant_id,
+                request.group_id,
+                actor_user_id,
+                now,
+            )
+            .await?;
+            if actor_role != GroupRole::Owner {
+                return Err(GroupsError::Forbidden(
+                    "only the current owner or a platform group manager may transfer ownership"
+                        .to_string(),
+                ));
+            }
+        }
+        let previous_target_role = effective_governance_role(
+            &transaction,
+            tenant_id,
+            request.group_id,
+            request.new_owner_user_id,
+            now,
+        )
+        .await?;
+
+        let fixed_now = now.fixed_offset();
         let mut previous_owner_active: membership::ActiveModel = previous_owner.into();
         previous_owner_active.role = Set(GroupRole::Admin.as_str().to_string());
-        previous_owner_active.updated_at = Set(now);
+        previous_owner_active.updated_at = Set(fixed_now);
         previous_owner_active.update(&transaction).await?;
 
         let mut new_owner_active: membership::ActiveModel = new_owner.into();
         new_owner_active.role = Set(GroupRole::Owner.as_str().to_string());
-        new_owner_active.updated_at = Set(now);
+        new_owner_active.updated_at = Set(fixed_now);
         new_owner_active.update(&transaction).await?;
 
         let group_version = group_model.version.saturating_add(1).max(1) as u64;
         let mut group_active: group::ActiveModel = group_model.into();
         group_active.owner_user_id = Set(request.new_owner_user_id);
         group_active.version = Set(group_version as i64);
-        group_active.updated_at = Set(now);
+        group_active.updated_at = Set(fixed_now);
         group_active.update(&transaction).await?;
 
         let result = GroupGovernanceResult {
@@ -281,7 +359,8 @@ impl GroupGovernanceService {
                 "new_owner_user_id": request.new_owner_user_id,
                 "previous_target_role": previous_target_role.as_str(),
                 "previous_owner_role": GroupRole::Admin.as_str(),
-                "group_version": group_version
+                "group_version": group_version,
+                "authorization": if platform_manage { "platform_manage" } else { "effective_current_owner" }
             }),
         )
         .await?;
@@ -324,11 +403,25 @@ impl GroupGovernanceCommandPort for GroupGovernanceService {
     }
 }
 
-async fn find_group(
+struct LockedGovernanceState {
+    memberships: Vec<membership::Model>,
+}
+
+impl LockedGovernanceState {
+    fn membership(&self, user_id: Uuid) -> Option<membership::Model> {
+        self.memberships
+            .iter()
+            .find(|row| row.user_id == user_id)
+            .cloned()
+    }
+}
+
+async fn lock_group(
     transaction: &DatabaseTransaction,
     tenant_id: Uuid,
     group_id: Uuid,
 ) -> GroupsResult<group::Model> {
+    reserve_group_write_for_update(transaction, tenant_id, group_id).await?;
     group::Entity::find()
         .filter(group::Column::TenantId.eq(tenant_id))
         .filter(group::Column::Id.eq(group_id))
@@ -337,22 +430,140 @@ async fn find_group(
         .ok_or(GroupsError::NotFound)
 }
 
-async fn find_membership(
+async fn lock_governance_memberships(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    target_user_id: Uuid,
+    require_actor_membership: bool,
+) -> GroupsResult<LockedGovernanceState> {
+    let mut user_ids = vec![target_user_id];
+    if require_actor_membership {
+        user_ids.push(actor_user_id);
+    }
+    lock_membership_set(transaction, tenant_id, group_id, user_ids).await
+}
+
+async fn lock_ownership_memberships(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    previous_owner_user_id: Uuid,
+    new_owner_user_id: Uuid,
+    actor_user_id: Uuid,
+    require_actor_membership: bool,
+) -> GroupsResult<LockedGovernanceState> {
+    let mut user_ids = vec![previous_owner_user_id, new_owner_user_id];
+    if require_actor_membership {
+        user_ids.push(actor_user_id);
+    }
+    lock_membership_set(transaction, tenant_id, group_id, user_ids).await
+}
+
+async fn lock_membership_set(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    mut user_ids: Vec<Uuid>,
+) -> GroupsResult<LockedGovernanceState> {
+    user_ids.sort_unstable();
+    user_ids.dedup();
+
+    let mut memberships = Vec::with_capacity(user_ids.len());
+    for user_id in user_ids {
+        let mut query = membership::Entity::find()
+            .filter(membership::Column::TenantId.eq(tenant_id))
+            .filter(membership::Column::GroupId.eq(group_id))
+            .filter(membership::Column::UserId.eq(user_id));
+        if transaction.get_database_backend() != DatabaseBackend::Sqlite {
+            query = query.lock_exclusive();
+        }
+        if let Some(row) = query.one(transaction).await? {
+            memberships.push(row);
+        }
+    }
+
+    let mut membership_ids = memberships.iter().map(|row| row.id).collect::<Vec<_>>();
+    membership_ids.sort_unstable();
+    for membership_id in membership_ids {
+        let mut query = membership_enforcement::Entity::find_by_id(membership_id)
+            .filter(membership_enforcement::Column::TenantId.eq(tenant_id));
+        if transaction.get_database_backend() != DatabaseBackend::Sqlite {
+            query = query.lock_exclusive();
+        }
+        query.one(transaction).await?;
+    }
+
+    Ok(LockedGovernanceState { memberships })
+}
+
+fn validate_owner_identity(
+    group_model: &group::Model,
+    membership_model: &membership::Model,
+) -> GroupsResult<()> {
+    let role = GroupRole::from_str(&membership_model.role).map_err(GroupsError::Invariant)?;
+    let is_owner_reference = membership_model.user_id == group_model.owner_user_id;
+    if is_owner_reference != (role == GroupRole::Owner) {
+        return Err(GroupsError::Invariant(
+            "group owner reference and owner membership role disagree".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn effective_manager_role(
     transaction: &DatabaseTransaction,
     tenant_id: Uuid,
     group_id: Uuid,
     user_id: Uuid,
-) -> GroupsResult<membership::Model> {
-    membership::Entity::find()
-        .filter(membership::Column::TenantId.eq(tenant_id))
-        .filter(membership::Column::GroupId.eq(group_id))
-        .filter(membership::Column::UserId.eq(user_id))
-        .one(transaction)
-        .await?
-        .ok_or_else(|| GroupsError::Conflict("an active group membership is required".to_string()))
+    now: chrono::DateTime<Utc>,
+) -> GroupsResult<GroupRole> {
+    let state = resolve_group_membership_enforcement(transaction, tenant_id, group_id, user_id, now)
+        .await?;
+    match state.effective_status {
+        GroupMembershipEffectiveStatus::Suspended => Err(GroupsError::MembershipSuspended),
+        GroupMembershipEffectiveStatus::LegacyBanned => Err(GroupsError::MembershipBanned),
+        GroupMembershipEffectiveStatus::Active => {
+            let role = state.role.ok_or_else(|| {
+                GroupsError::Invariant("active group membership is missing a local role".to_string())
+            })?;
+            if role.can_manage_settings() {
+                Ok(role)
+            } else {
+                Err(GroupsError::ManagerRequired(
+                    "an active group owner or administrator role is required".to_string(),
+                ))
+            }
+        }
+        _ => Err(GroupsError::ManagerRequired(
+            "an active group owner or administrator role is required".to_string(),
+        )),
+    }
 }
 
-fn active_role(model: &membership::Model) -> GroupsResult<GroupRole> {
+async fn effective_governance_role(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+    now: chrono::DateTime<Utc>,
+) -> GroupsResult<GroupRole> {
+    let state = resolve_group_membership_enforcement(transaction, tenant_id, group_id, user_id, now)
+        .await?;
+    match state.effective_status {
+        GroupMembershipEffectiveStatus::Suspended => Err(GroupsError::MembershipSuspended),
+        GroupMembershipEffectiveStatus::LegacyBanned => Err(GroupsError::MembershipBanned),
+        GroupMembershipEffectiveStatus::Active => state.role.ok_or_else(|| {
+            GroupsError::Invariant("active group membership is missing a local role".to_string())
+        }),
+        _ => Err(GroupsError::Conflict(
+            "an active group membership is required".to_string(),
+        )),
+    }
+}
+
+fn stored_active_role(model: &membership::Model) -> GroupsResult<GroupRole> {
     let status = GroupMembershipStatus::from_str(&model.status).map_err(GroupsError::Invariant)?;
     if status != GroupMembershipStatus::Active {
         return Err(GroupsError::Conflict(
@@ -363,7 +574,7 @@ fn active_role(model: &membership::Model) -> GroupsResult<GroupRole> {
 }
 
 fn authorize_role_change(
-    actor_role: GroupRole,
+    actor_role: Option<GroupRole>,
     target_role: GroupRole,
     requested_role: GroupRole,
     platform_manage: bool,
@@ -371,6 +582,11 @@ fn authorize_role_change(
     if platform_manage {
         return Ok(());
     }
+    let actor_role = actor_role.ok_or_else(|| {
+        GroupsError::ManagerRequired(
+            "an active group owner or administrator role is required".to_string(),
+        )
+    })?;
     let allowed = match actor_role {
         GroupRole::Owner => true,
         GroupRole::Admin => {
@@ -391,6 +607,8 @@ fn authorize_role_change(
 async fn replay_receipt<T: DeserializeOwned>(
     transaction: &DatabaseTransaction,
     tenant_id: Uuid,
+    group_id: Uuid,
+    actor_user_id: Uuid,
     idempotency_key: &str,
     command_type: &str,
     request_hash: &str,
@@ -403,7 +621,11 @@ async fn replay_receipt<T: DeserializeOwned>(
     else {
         return Ok(None);
     };
-    if receipt.command_type != command_type || receipt.request_hash != request_hash {
+    if receipt.group_id != group_id
+        || receipt.actor_user_id != actor_user_id
+        || receipt.command_type != command_type
+        || receipt.request_hash != request_hash
+    {
         return Err(GroupsError::Conflict(
             "idempotency key was already used for another group command".to_string(),
         ));
@@ -524,7 +746,7 @@ mod tests {
     fn admins_cannot_promote_another_admin() {
         assert!(
             authorize_role_change(
-                GroupRole::Admin,
+                Some(GroupRole::Admin),
                 GroupRole::Admin,
                 GroupRole::Moderator,
                 false,
@@ -537,7 +759,7 @@ mod tests {
     fn admins_can_manage_moderators_and_members() {
         assert!(
             authorize_role_change(
-                GroupRole::Admin,
+                Some(GroupRole::Admin),
                 GroupRole::Member,
                 GroupRole::Moderator,
                 false,
@@ -549,8 +771,13 @@ mod tests {
     #[test]
     fn owners_can_delegate_all_non_owner_roles() {
         assert!(
-            authorize_role_change(GroupRole::Owner, GroupRole::Admin, GroupRole::Member, false,)
-                .is_ok()
+            authorize_role_change(
+                Some(GroupRole::Owner),
+                GroupRole::Admin,
+                GroupRole::Member,
+                false,
+            )
+            .is_ok()
         );
     }
 }

--- a/crates/rustok-groups/src/governance.rs
+++ b/crates/rustok-groups/src/governance.rs
@@ -294,7 +294,16 @@ impl GroupGovernanceService {
         }
 
         let now = Utc::now();
-        if !platform_manage {
+        if platform_manage {
+            validate_platform_recovery_owner_state(
+                &transaction,
+                tenant_id,
+                request.group_id,
+                previous_owner_id,
+                now,
+            )
+            .await?;
+        } else {
             let actor_role = effective_manager_role(
                 &transaction,
                 tenant_id,
@@ -559,6 +568,30 @@ async fn effective_governance_role(
         }),
         _ => Err(GroupsError::Conflict(
             "an active group membership is required".to_string(),
+        )),
+    }
+}
+
+async fn validate_platform_recovery_owner_state(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_user_id: Uuid,
+    now: chrono::DateTime<Utc>,
+) -> GroupsResult<()> {
+    let state = resolve_group_membership_enforcement(
+        transaction,
+        tenant_id,
+        group_id,
+        owner_user_id,
+        now,
+    )
+    .await?;
+    match state.effective_status {
+        GroupMembershipEffectiveStatus::Active | GroupMembershipEffectiveStatus::Suspended => Ok(()),
+        GroupMembershipEffectiveStatus::LegacyBanned => Err(GroupsError::MembershipBanned),
+        _ => Err(GroupsError::Invariant(
+            "current group owner effective membership is not recoverable".to_string(),
         )),
     }
 }

--- a/scripts/verify/verify-groups-governance-effective-authorization.mjs
+++ b/scripts/verify/verify-groups-governance-effective-authorization.mjs
@@ -27,6 +27,8 @@ for (const marker of [
   "GroupMembershipEffectiveStatus::LegacyBanned",
   "effective_manager_role",
   "effective_governance_role",
+  "validate_platform_recovery_owner_state",
+  "current group owner effective membership is not recoverable",
   "validate_owner_identity",
   "effective_local_manager",
   "effective_current_owner",
@@ -81,6 +83,9 @@ if (port.new_owner_effective_state !== "active_required") {
 if (registry?.governance?.effective_authorization !== "implemented_source") {
   throw new Error("Groups governance effective authorization is not source-complete in registry");
 }
+if (registry?.governance?.platform_owner_recovery !== "may_transfer_away_from_suspended_current_owner") {
+  throw new Error("Groups governance platform recovery contract is not locked");
+}
 if (registry?.evidence?.governance_transport_parity !== null || registry?.evidence?.governance_concurrency !== null) {
   throw new Error("Unexecuted governance runtime evidence must remain null");
 }
@@ -89,6 +94,8 @@ for (const marker of [
   "Source-complete governance effective authorization",
   "tenant + group + actor + command + request hash",
   "effective-active new owner",
+  "suspended current owner",
+  "Corrupt enforcement row",
   "verify-groups-governance-effective-authorization.mjs",
   "governance concurrency",
 ]) {

--- a/scripts/verify/verify-groups-governance-effective-authorization.mjs
+++ b/scripts/verify/verify-groups-governance-effective-authorization.mjs
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+
+const read = (path) => fs.readFileSync(path, "utf8");
+const governance = read("crates/rustok-groups/src/governance.rs");
+const transaction = read("crates/rustok-groups/src/membership_enforcement_transaction.rs");
+const graphql = read("crates/rustok-groups/src/graphql_governance.rs");
+const registry = JSON.parse(read("crates/rustok-groups/contracts/groups-fba-registry.json"));
+const plan = read("crates/rustok-groups/docs/implementation-plan.md");
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  "lock_group(&transaction",
+  "reserve_group_write_for_update",
+  "replay_receipt::<GroupGovernanceResult>",
+  "receipt.group_id != group_id",
+  "receipt.actor_user_id != actor_user_id",
+  "lock_governance_memberships",
+  "lock_ownership_memberships",
+  "user_ids.sort_unstable()",
+  "membership_ids.sort_unstable()",
+  "membership_enforcement::Entity::find_by_id",
+  "resolve_group_membership_enforcement",
+  "GroupMembershipEffectiveStatus::Suspended",
+  "GroupMembershipEffectiveStatus::LegacyBanned",
+  "effective_manager_role",
+  "effective_governance_role",
+  "validate_owner_identity",
+  "effective_local_manager",
+  "effective_current_owner",
+]) {
+  requireText(governance, marker, `Groups governance source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "async fn find_membership(",
+  "fn active_role(",
+  "replay_receipt::<GroupGovernanceResult>(\n            &transaction,\n            tenant_id,\n            &idempotency_key",
+]) {
+  if (governance.includes(forbidden)) {
+    throw new Error(`Groups governance retains a pre-cutover shortcut: ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "reserve_group_write_for_update",
+  "UPDATE groups SET version = version WHERE tenant_id = ? AND id = ?",
+  "lock_exclusive()",
+]) {
+  requireText(transaction, marker, `Shared Groups writer reservation is missing ${marker}`);
+}
+
+for (const marker of [
+  "GroupGovernanceCommandPort::change_group_role",
+  "GroupGovernanceCommandPort::transfer_group_ownership",
+  "PortActor::user",
+  "with_claim(permission.to_string())",
+]) {
+  requireText(graphql, marker, `Groups governance GraphQL transport is missing ${marker}`);
+}
+
+const port = registry?.provider?.ports?.find((item) => item?.name === "GroupGovernanceCommandPort");
+if (!port) throw new Error("Groups FBA registry is missing GroupGovernanceCommandPort");
+if (port.authorization !== "effective_owner_admin_hierarchy_or_platform_manage") {
+  throw new Error("Groups governance must publish effective owner/admin authorization");
+}
+if (port.receipt_replay_order !== "after_group_serialization_before_current_effective_authorization") {
+  throw new Error("Groups governance receipt replay order is not locked");
+}
+if (port.receipt_identity !== "tenant_group_actor_command_request_hash") {
+  throw new Error("Groups governance receipt identity is not actor/group bound");
+}
+if (port.lock_order !== "group_then_memberships_uuid_order_then_enforcements_membership_id_order") {
+  throw new Error("Groups governance lock order is not deterministic");
+}
+if (port.new_owner_effective_state !== "active_required") {
+  throw new Error("Groups ownership transfer must require an effective-active new owner");
+}
+if (registry?.governance?.effective_authorization !== "implemented_source") {
+  throw new Error("Groups governance effective authorization is not source-complete in registry");
+}
+if (registry?.evidence?.governance_transport_parity !== null || registry?.evidence?.governance_concurrency !== null) {
+  throw new Error("Unexecuted governance runtime evidence must remain null");
+}
+
+for (const marker of [
+  "Source-complete governance effective authorization",
+  "tenant + group + actor + command + request hash",
+  "effective-active new owner",
+  "verify-groups-governance-effective-authorization.mjs",
+  "governance concurrency",
+]) {
+  requireText(plan, marker, `Canonical Groups plan is missing ${marker}`);
+}
+
+console.log("Groups governance effective authorization source guard passed");


### PR DESCRIPTION
## Summary
- serialize Groups governance on the owner group row before receipt lookup
- bind governance receipt replay to tenant + group + actor + command + request hash
- preserve matching lost-response replay before current effective authorization
- lock all required membership rows in deterministic user UUID order and enforcement rows in deterministic membership-ID order
- require effective-active local owner/admin authority for role changes and an effective-active non-owner target
- require an effective-active current owner for local ownership transfer and an effective-active replacement owner
- preserve explicit platform `groups:manage` recovery, including transfer away from a suspended current owner when stored owner identity remains consistent
- fail closed on `groups.owner_user_id` / owner-role drift
- keep role writes, membership revision trigger effects, group version, audit and receipt in the same Groups transaction
- keep the existing GraphQL transport on `GroupGovernanceCommandPort` with no fallback
- update canonical plan/FBA metadata and add a focused static source guard; runtime/concurrency/parity evidence remains open

## Verification
Static source review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows and CI were intentionally not run per maintainer request.