### PR TITLE
refactor(commerce): cut Product GraphQL lifecycle to owner port

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -253,12 +253,26 @@ These are source-contract defects, not verification-only tasks.
   status/vendor/search filters, created-at-desc ordering, clamped pagination,
   `Untitled product`, normalized/default shipping-profile fallback, tags, telemetry,
   response projection, and shared stable Product GraphQL public errors.
-- [ ] Cut legacy mounted storefront GraphQL `storefrontProduct` / `storefrontProducts`,
-  remaining Product schema writes, REST delete/publish/unpublish lifecycle commands,
-  and remaining GraphQL Product lifecycle operations over to host-composed Product owner
-  ports. Direct Product entities, `CatalogService`, and remaining write-side
-  `ProductCatalogSchemaService` usage remain explicit source debt; repeatable lifecycle
-  commands need an explicit caller idempotency contract before cutover.
+- [x] Cut mounted legacy storefront GraphQL `storefrontProduct` / `storefrontProducts`
+  to host-composed Product read capabilities while preserving storefront admission,
+  current tenant, id-over-handle detail semantics, locale/channel visibility, public
+  inventory, legacy filters/order/pagination, title/shipping fallback, tags, telemetry,
+  and stable public errors.
+- [x] Cut mounted admin REST Product delete/publish/unpublish lifecycle commands to the
+  host-composed Product command runtime with required caller `Idempotency-Key`, scoped
+  command identity, bounded context, unchanged permissions/responses, and stable owner
+  errors.
+- [x] Cut mounted GraphQL Product create/update/publish/delete lifecycle execution to
+  the host-selected `ProductCatalogCommandRuntime` / `ProductCatalogCommandPort`, keep
+  create/update compatibility validation and public error identities, and publish an
+  optional explicit `idempotencyKey`; omitted keys use a logged one-request compatibility
+  identity and do not claim replay semantics.
+- [ ] Teach Product Admin FFA lifecycle commands to retain one GraphQL caller
+  idempotency key across explicit retries, then make mounted GraphQL `idempotencyKey`
+  mandatory without breaking current UI callers.
+- [ ] Cut remaining Product schema writes away from direct
+  `ProductCatalogSchemaService` construction through typed Product owner write
+  capabilities with explicit write idempotency semantics.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -656,6 +670,8 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-ecommerce-public-port-error-safety-v2.mjs`
 - [ ] `node scripts/verify/verify-commerce-marketplace-financial-capability.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-command-port.mjs`
+- [ ] `node scripts/verify/verify-commerce-product-rest-lifecycle-command-cutover.mjs`
+- [ ] `node scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-detail-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-list-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-graphql-read.mjs`
@@ -693,10 +709,11 @@ Source inspection is not execution evidence.
   mutation, payment, or fulfillment ownership; unmounted admin compatibility GET
   handlers remain explicit source debt.
 - [ ] Execute the new public-error, typed-lifecycle, storefront-cutover, order-read,
-  marketplace-financial topology, Product command-port, Product admin-detail read,
-  Product admin-list read, Product admin-GraphQL read, Product storefront-GraphQL read,
-  and Product schema-directory read static guards against a repository checkout and
-  retain their output.
+  marketplace-financial topology, Product command-port, Product REST lifecycle,
+  Product GraphQL lifecycle, Product admin-detail read, Product admin-list read,
+  Product admin-GraphQL read, Product storefront-GraphQL read, and Product
+  schema-directory read static guards against a repository checkout and retain their
+  output.
 
 ### Compile/tests
 
@@ -868,26 +885,24 @@ Source inspection is not execution evidence.
   closed before capture when marketplace lines reach a base-only checkout.
 - [x] Publish and host-compose Product catalog command ports, then cut mounted admin
   REST product create/update away from `CatalogService` with payload-bound write
-  identity and stable public error mapping; lifecycle/read/GraphQL cutover remains open.
+  identity and stable public error mapping.
 - [x] Cut mounted admin REST Product detail over to the host-selected Product read port
-  while preserving locale fallback, request context, permissions, and public envelope;
-  admin list and GraphQL Product reads remain separate source debt.
+  while preserving locale fallback, request context, permissions, and public envelope.
 - [x] Cut mounted admin REST Product list over to the optional host-selected Product
   read-port capability while preserving legacy filters, ordering, pagination, locale
   fallback, empty-title/default-shipping envelope, and source compatibility for existing
-  Product read-port adapters; GraphQL catalog and lifecycle cutover remain open.
+  Product read-port adapters.
 - [x] Cut mounted admin GraphQL Product catalog reads to the host-selected Product read
   runtime/port with authenticated actor, request channel/locale context, bounded deadline,
   existing filter/pagination semantics, unchanged response projection, and safe stable
-  public owner errors; storefront catalog and lifecycle/schema cutover remain open.
+  public owner errors.
 - [x] Publish the optional filtered storefront Product read capability and cut mounted
   storefront GraphQL catalog reads to the host-selected Product runtime/port without
   changing the existing published-list request, filter/pagination/channel semantics, or
-  GraphQL projection; Product lifecycle/schema cutover remains open.
+  GraphQL projection.
 - [x] Publish the optional Product schema-directory read capability on the host-selected
   Product read runtime and cut `productAttributes`, `catalogCategories`, and
-  `productAttributeSchemas` away from direct `ProductCatalogSchemaService` construction;
-  Product schema writes and lifecycle operations remain open.
+  `productAttributeSchemas` away from direct `ProductCatalogSchemaService` construction.
 - [x] Cut mounted `productEffectiveForm` to the host-selected Product schema read port,
   preserving tenant/permission/actor/channel/locale/deadline context and moving aggregate
   reconstruction plus invariant handling back behind the Product owner boundary.
@@ -901,8 +916,15 @@ Source inspection is not execution evidence.
 - [x] Publish the optional legacy admin Product list compatibility capability and cut
   mounted legacy admin GraphQL `product` / `products` to the host-selected Product read
   runtime while preserving legacy detail/list admission, locale, filtering, ordering,
-  pagination, title/shipping fallback, tags, telemetry, projection, and stable errors;
-  legacy storefront Product reads remain separate source debt.
+  pagination, title/shipping fallback, tags, telemetry, projection, and stable errors.
+- [x] Cut mounted legacy storefront Product detail/list reads to host-selected Product
+  capabilities with lifecycle/channel/inventory/localization and legacy list parity.
+- [x] Cut mounted REST Product delete/publish/unpublish lifecycle commands to the
+  host-composed Product command runtime with required caller idempotency identity.
+- [x] Cut mounted GraphQL Product create/update/publish/delete execution to the
+  host-selected Product command runtime, preserve lifecycle public-error identities,
+  and expose optional explicit caller idempotency while retaining a logged one-request
+  compatibility path for current callers; mandatory FFA retry identity remains open.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-read-recheck-2026-08-08.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL/HTTP paths against `main` at `26d6e340ee6d1be462f29da6b95b6539458b843f`, then continued the Product owner-boundary cutover through the current implementation branch.
+Rechecked the canonical ecommerce execution plan and the currently mounted Product GraphQL/HTTP paths against `main` at `442e5e591f68ec93a527630a14fbce8e6de2ba5e`, then continued the Product owner-boundary cutover through the current implementation branch.
 
 The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This packet does not promote FBA/FFA or verification status and does not replace that plan.
 
@@ -13,8 +13,10 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 3. `storefrontCatalogSearchOptions` was the remaining mounted direct `ProductCatalogSchemaService` schema-read consumer. Its current projection needs only categories and filterable/sortable attributes, so the already-published `list_categories` and `list_attributes` owner capabilities preserve the existing data and ordering semantics without a new Product projection.
 4. The active `CommerceQueryRoot` mounts both `query::CommerceQuery` and `product_catalog::ProductCatalogQuery`. The newer `adminProductCatalog`/`storefrontProductCatalog` paths already use `ProductCatalogReadRuntime`, and the mounted legacy admin `product`/`products` roots are cut over to the Product owner read runtime.
 5. PR #3238 published optional fail-closed legacy storefront detail/list capabilities without changing mounted serving. Mounted `storefrontProduct` / `storefrontProducts` are now cut to those capabilities, so these production reads no longer choose Product lifecycle/channel/inventory policy or query Product entities directly.
-6. `CommerceHttpRuntime` already host-composes `ProductCatalogCommandRuntime`, and Product already publishes typed `delete_product`, `publish_product`, and `unpublish_product` command methods. The mounted REST lifecycle handlers were still bypassing that runtime through direct `CatalogService` construction and did not have an explicit caller retry identity.
-7. The continuation below cuts REST delete/publish/unpublish to the host-selected Product command port and introduces an explicit caller-provided `Idempotency-Key` contract for those repeatable lifecycle calls. The broad ecommerce owner-boundary invariant remains open because Product GraphQL lifecycle operations and schema writes still require owner-port cutover. Source inspection does not justify a status promotion.
+6. Mounted admin REST Product create/update and delete/publish/unpublish now use the host-composed `ProductCatalogCommandRuntime` / `ProductCatalogCommandPort`; repeatable REST lifecycle operations have an explicit caller-provided `Idempotency-Key` contract.
+7. The mounted GraphQL `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct` mutations were the remaining direct `CatalogService` Product lifecycle consumers. Product already publishes the typed command capabilities and server composition already installs `ProductCatalogCommandRuntime` into `HostRuntimeContext`.
+8. The continuation below cuts those four GraphQL lifecycle mutations to the host-selected Product command runtime. It publishes an optional caller `idempotencyKey`; explicit keys are scope-stable, while omitted keys use a visibly logged one-request compatibility identity so existing Product Admin FFA and regression callers are not broken. Making the key mandatory requires a separate FFA contract cutover that preserves one identity across explicit retries.
+9. The broad ecommerce owner-boundary invariant remains open because Product schema writes still construct `ProductCatalogSchemaService` directly, the Product Admin FFA retry identity is not yet retained across explicit retries, and runtime/compile/parity evidence has not been executed. Source inspection does not justify a status promotion.
 
 ## PR #3203 source change
 
@@ -72,10 +74,21 @@ The source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`
 - Expose the required `Idempotency-Key` contract in the mounted admin OpenAPI declarations and forward `RequestContext`/headers through the route wrappers.
 - Add `verify-commerce-product-rest-lifecycle-command-cutover.mjs` to lock the source contract: host-composed runtime, caller identity scoping, mounted forwarding, typed owner calls, and no direct `CatalogService` use inside the three lifecycle handler slices.
 
+## GraphQL Product lifecycle continuation
+
+- Publish optional `idempotencyKey: String` arguments on mounted `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct`. A supplied non-empty caller key may contain at most 191 bytes and identifies one logical GraphQL Product lifecycle invocation.
+- Scope-hash a supplied caller key with tenant, authenticated actor, operation, and Product id when one exists. The scoped identity is used for both `PortContext.idempotency_key` and correlation so explicit retries of one logical invocation can remain stable without aliasing another Product or operation.
+- When an existing caller omits `idempotencyKey`, create a fresh one-request compatibility identity and log that compatibility path. This preserves current Product Admin FFA/runtime callers but intentionally does not claim retry replay semantics for omitted keys.
+- Preserve Product module enablement and existing Product permission/tenant admission before owner execution. The command context carries the authenticated user actor, effective permission claims, request locale, request channel, and a bounded two-second deadline.
+- Carry the host-selected `ProductCatalogCommandRuntime` through `CommerceGraphqlRuntimeData` and the existing resolver-scoped task-local bridge beside Product reads. Mounted schema attachment requires the composed command runtime; directly embedded compatibility schemas that lack the mounted extension retain the explicit in-process fallback in the scoped runtime accessor.
+- Keep Commerce shipping-profile validation and the existing create/update input conversions unchanged, then delegate lifecycle execution only through Product's typed `create_product`, `update_product`, `publish_product`, and `delete_product` command port methods.
+- Preserve the pre-cutover GraphQL lifecycle public error identities through typed Product `PortError.code`: `DUPLICATE_HANDLE`, `DUPLICATE_SKU`, `NO_VARIANTS`, `CANNOT_DELETE_PUBLISHED`, `PRODUCT_VALIDATION`, `PRODUCT_NOT_FOUND`, `PRODUCT_TEMPORARILY_UNAVAILABLE`, and `PRODUCT_OPERATION_FAILED`. Product now publishes a distinct `product.no_variants` command error code instead of folding it into generic validation.
+- Add `verify-commerce-product-graphql-lifecycle-command-cutover.mjs` to retain host composition, resolver-scoped runtime propagation, explicit/compatibility caller identity behavior, command context, typed owner calls, public-error parity, create/update compatibility semantics, and the remaining schema-write debt in source.
+
 ## Remaining execution order
 
-1. Cut remaining mounted GraphQL Product create/update/publish/delete operations to host-composed Product command capabilities with an explicit GraphQL caller idempotency contract.
-2. Cut Product schema writes away from direct `ProductCatalogSchemaService` construction through typed owner write capabilities.
+1. Teach Product Admin FFA lifecycle commands to retain one caller idempotency key across explicit retries, then make GraphQL lifecycle `idempotencyKey` mandatory without breaking mounted UI callers.
+2. Cut Product schema writes away from direct `ProductCatalogSchemaService` construction through typed owner write capabilities with explicit write idempotency semantics.
 3. Remove superseded private Product read compatibility helpers only after compile/source evidence confirms there are no remaining consumers.
 4. Only after the source cutovers, run the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before changing promotion status.
 

--- a/crates/rustok-commerce/src/graphql/mutations/catalog.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/catalog.rs
@@ -1,15 +1,23 @@
 use async_graphql::{Context, ErrorExtensions, Object, Result};
-use rustok_api::Permission;
 use rustok_api::graphql::require_module_enabled;
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use sha2::{Digest, Sha256};
+use std::time::Duration;
 use uuid::Uuid;
 
-use rustok_product::{CatalogService, ProductCatalogSchemaService};
+use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogSchemaService};
 
 use super::super::{
     PRODUCT_MODULE_SLUG as MODULE_SLUG, map_product_service_error, product_mutation_actor,
     require_commerce_permission, types::*,
 };
 use super::helpers::*;
+
+const PRODUCT_COMMAND_DEADLINE: Duration = Duration::from_secs(2);
+const MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH: usize = 191;
 
 #[derive(Default)]
 pub struct CommerceCatalogMutation;
@@ -24,11 +32,156 @@ fn invalid_catalog_input(error: impl std::fmt::Debug) -> async_graphql::Error {
         .extend_with(|_, extensions| extensions.set("code", "INVALID_PRODUCT_CATALOG_INPUT"))
 }
 
+fn invalid_product_idempotency_key(message: impl Into<String>) -> async_graphql::Error {
+    async_graphql::Error::new(message.into())
+        .extend_with(|_, extensions| extensions.set("code", "BAD_USER_INPUT"))
+}
+
+fn product_command_runtime(ctx: &Context<'_>) -> Result<ProductCatalogCommandRuntime> {
+    let db = ctx.data::<sea_orm::DatabaseConnection>()?;
+    let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
+    Ok(
+        crate::graphql_runtime::product_catalog_command_runtime_for_current_graphql_scope(
+            db.clone(),
+            event_bus.clone(),
+        ),
+    )
+}
+
+fn product_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    product_id: Option<Uuid>,
+    idempotency_key: Option<String>,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let caller_key = match idempotency_key {
+        Some(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                return Err(invalid_product_idempotency_key(
+                    "Product mutation idempotency key must not be empty",
+                ));
+            }
+            if value.len() > MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH {
+                return Err(invalid_product_idempotency_key(format!(
+                    "Product mutation idempotency key must contain at most {MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH} bytes"
+                )));
+            }
+            value.to_string()
+        }
+        None => {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                actor_id = %user_id,
+                product_id = ?product_id,
+                operation,
+                "Product GraphQL lifecycle caller omitted idempotency key; using one-request compatibility identity"
+            );
+            format!("compatibility-{}", Uuid::new_v4())
+        }
+    };
+
+    let tenant = ctx.data::<TenantContext>()?;
+    let auth = ctx.data::<AuthContext>()?;
+    let request_context = ctx.data_opt::<RequestContext>();
+    let locale = request_context
+        .map(|request| request.locale.clone())
+        .unwrap_or_else(|| tenant.default_locale.clone());
+
+    let mut digest = Sha256::new();
+    digest.update(tenant_id.as_bytes());
+    digest.update(user_id.as_bytes());
+    digest.update(operation.as_bytes());
+    if let Some(product_id) = product_id {
+        digest.update(product_id.as_bytes());
+    }
+    digest.update(caller_key.as_bytes());
+    let scoped_key = format!(
+        "commerce-graphql-product:{operation}:{}",
+        hex::encode(digest.finalize())
+    );
+
+    let mut context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        locale,
+        scoped_key.clone(),
+    )
+    .with_idempotency_key(scoped_key)
+    .with_deadline(PRODUCT_COMMAND_DEADLINE);
+    for permission in &auth.permissions {
+        context = context.with_claim(permission.to_string());
+    }
+    if let Some(channel) = request_context
+        .and_then(|request| request.channel_slug.as_deref())
+        .map(str::trim)
+        .filter(|channel| !channel.is_empty())
+    {
+        context = context.with_channel(channel);
+    }
+    Ok(context)
+}
+
+fn product_command_port_error(
+    context: &PortContext,
+    error: PortError,
+    operation: &'static str,
+) -> async_graphql::Error {
+    let (message, code) = match (&error.kind, error.code.as_str()) {
+        (PortErrorKind::Unavailable | PortErrorKind::Timeout, _) => (
+            "Product data is temporarily unavailable",
+            "PRODUCT_TEMPORARILY_UNAVAILABLE",
+        ),
+        (PortErrorKind::NotFound, _) => ("Product was not found", "PRODUCT_NOT_FOUND"),
+        (PortErrorKind::Conflict, "product.duplicate_handle") => (
+            "Product handle conflicts with an existing product",
+            "DUPLICATE_HANDLE",
+        ),
+        (PortErrorKind::Conflict, "product.duplicate_sku") => (
+            "Product SKU conflicts with an existing product",
+            "DUPLICATE_SKU",
+        ),
+        (PortErrorKind::Conflict, "product.lifecycle_conflict") => (
+            "Published products must be archived before removal",
+            "CANNOT_DELETE_PUBLISHED",
+        ),
+        (PortErrorKind::Validation, "product.no_variants") => (
+            "Product requires at least one variant",
+            "NO_VARIANTS",
+        ),
+        (PortErrorKind::Validation, _) => ("Product request is invalid", "PRODUCT_VALIDATION"),
+        (PortErrorKind::Forbidden, _) => ("Product access is denied", "PRODUCT_ACCESS_DENIED"),
+        (PortErrorKind::Conflict | PortErrorKind::InvariantViolation, _) => (
+            "Product operation could not be completed safely",
+            "PRODUCT_OPERATION_FAILED",
+        ),
+    };
+
+    tracing::error!(
+        operation,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        public_code = code,
+        "Product GraphQL owner command failed"
+    );
+
+    async_graphql::Error::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", error.retryable);
+        extensions.set("correlation_id", context.correlation_id.clone());
+    })
+}
+
 #[Object]
 impl CommerceCatalogMutation {
     async fn create_product(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         input: CreateProductInput,
     ) -> Result<GqlProduct> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -40,8 +193,6 @@ impl CommerceCatalogMutation {
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let catalog = CatalogService::new(db.clone(), event_bus.clone());
         validate_product_shipping_profile_input(
             db,
             tenant_id,
@@ -49,10 +200,19 @@ impl CommerceCatalogMutation {
         )
         .await?;
         let domain_input = convert_create_product_input(input)?;
-        let product = catalog
-            .create_product(tenant_id, user_id, domain_input)
+        let port_context = product_command_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_product",
+        )?;
+        let product = product_command_runtime(ctx)?
+            .command_port()
+            .create_product(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| product_command_port_error(&port_context, error, "create_product"))?;
 
         Ok(product.into())
     }
@@ -60,6 +220,7 @@ impl CommerceCatalogMutation {
     async fn update_product(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         id: Uuid,
         input: UpdateProductInput,
     ) -> Result<GqlProduct> {
@@ -72,8 +233,6 @@ impl CommerceCatalogMutation {
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let catalog = CatalogService::new(db.clone(), event_bus.clone());
         validate_product_shipping_profile_input(
             db,
             tenant_id,
@@ -104,15 +263,29 @@ impl CommerceCatalogMutation {
             status: input.status.map(Into::into),
         };
 
-        let product = catalog
-            .update_product(tenant_id, user_id, id, domain_input)
+        let port_context = product_command_context(
+            ctx,
+            tenant_id,
+            user_id,
+            Some(id),
+            idempotency_key,
+            "update_product",
+        )?;
+        let product = product_command_runtime(ctx)?
+            .command_port()
+            .update_product(port_context.clone(), id, domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| product_command_port_error(&port_context, error, "update_product"))?;
 
         Ok(product.into())
     }
 
-    async fn publish_product(&self, ctx: &Context<'_>, id: Uuid) -> Result<GqlProduct> {
+    async fn publish_product(
+        &self,
+        ctx: &Context<'_>,
+        idempotency_key: Option<String>,
+        id: Uuid,
+    ) -> Result<GqlProduct> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
         require_commerce_permission(
             ctx,
@@ -121,18 +294,29 @@ impl CommerceCatalogMutation {
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
 
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let catalog = CatalogService::new(db.clone(), event_bus.clone());
-        let product = catalog
-            .publish_product(tenant_id, user_id, id)
+        let port_context = product_command_context(
+            ctx,
+            tenant_id,
+            user_id,
+            Some(id),
+            idempotency_key,
+            "publish_product",
+        )?;
+        let product = product_command_runtime(ctx)?
+            .command_port()
+            .publish_product(port_context.clone(), id)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| product_command_port_error(&port_context, error, "publish_product"))?;
 
         Ok(product.into())
     }
 
-    async fn delete_product(&self, ctx: &Context<'_>, id: Uuid) -> Result<bool> {
+    async fn delete_product(
+        &self,
+        ctx: &Context<'_>,
+        idempotency_key: Option<String>,
+        id: Uuid,
+    ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
         require_commerce_permission(
             ctx,
@@ -141,13 +325,19 @@ impl CommerceCatalogMutation {
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
 
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let catalog = CatalogService::new(db.clone(), event_bus.clone());
-        catalog
-            .delete_product(tenant_id, user_id, id)
+        let port_context = product_command_context(
+            ctx,
+            tenant_id,
+            user_id,
+            Some(id),
+            idempotency_key,
+            "delete_product",
+        )?;
+        product_command_runtime(ctx)?
+            .command_port()
+            .delete_product(port_context.clone(), id)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| product_command_port_error(&port_context, error, "delete_product"))?;
 
         Ok(true)
     }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -13,7 +13,7 @@ use rustok_fulfillment::{
 };
 use rustok_order::{OrderReadPort, in_process_order_read_port};
 use rustok_payment::providers::PaymentProviderRegistry;
-use rustok_product::ProductCatalogReadRuntime;
+use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogReadRuntime};
 use sea_orm::DatabaseConnection;
 
 /// Host-selected shipping-option read ports used by mounted commerce GraphQL resolvers.
@@ -185,14 +185,15 @@ tokio::task_local! {
     static CURRENT_COMMERCE_ORDER_READ_RUNTIME: CommerceOrderReadRuntime;
     static CURRENT_COMMERCE_ORDER_READ_CALL_CONTEXT: CommerceOrderReadCallContext;
     static CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME: ProductCatalogReadRuntime;
+    static CURRENT_COMMERCE_PRODUCT_CATALOG_COMMAND_RUNTIME: ProductCatalogCommandRuntime;
 }
 
 /// Resolver-scoped bridge from schema runtime data to private compatibility facades.
 ///
 /// The mounted extension carries shipping-option, fulfillment-lifecycle, order, and Product catalog
-/// owner ports plus validated order actor/channel/locale and fulfillment public-channel facts so
-/// every included Commerce resolver uses host-selected adapters and request-owned context for the
-/// current async task.
+/// owner read/command ports plus validated order actor/channel/locale and fulfillment public-channel
+/// facts so every included Commerce resolver uses host-selected adapters and request-owned context
+/// for the current async task.
 #[derive(Default)]
 pub struct CommerceShippingOptionReadScope;
 
@@ -231,7 +232,10 @@ impl Extension for CommerceShippingOptionReadScopeExtension {
                                 runtime_data.order_read_runtime(),
                                 CURRENT_COMMERCE_PRODUCT_CATALOG_READ_RUNTIME.scope(
                                     runtime_data.product_catalog_read_runtime(),
-                                    next.run(ctx, info),
+                                    CURRENT_COMMERCE_PRODUCT_CATALOG_COMMAND_RUNTIME.scope(
+                                        runtime_data.product_catalog_command_runtime(),
+                                        next.run(ctx, info),
+                                    ),
                                 ),
                             ),
                         ),
@@ -289,12 +293,21 @@ pub(crate) fn product_catalog_read_runtime_for_current_graphql_scope(
         .unwrap_or_else(|_| ProductCatalogReadRuntime::in_process(db, event_bus))
 }
 
+pub(crate) fn product_catalog_command_runtime_for_current_graphql_scope(
+    db: DatabaseConnection,
+    event_bus: rustok_outbox::TransactionalEventBus,
+) -> ProductCatalogCommandRuntime {
+    CURRENT_COMMERCE_PRODUCT_CATALOG_COMMAND_RUNTIME
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| ProductCatalogCommandRuntime::in_process(db, event_bus))
+}
+
 /// Provider registries and host-selectable ports available to every commerce GraphQL resolver.
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual provider
 /// registries remain deterministic fallbacks. Mounted shipping-option, fulfillment-lifecycle,
-/// Product catalog, and order reads consume host-selected runtime data. Directly embedded
-/// compatibility schemas retain explicit in-process read fallbacks.
+/// Product catalog reads/commands, and order reads consume host-selected runtime data. Directly
+/// embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
@@ -305,6 +318,7 @@ pub struct CommerceGraphqlRuntimeData {
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
     product_catalog_read_runtime: ProductCatalogReadRuntime,
+    product_catalog_command_runtime: ProductCatalogCommandRuntime,
 }
 
 impl CommerceGraphqlRuntimeData {
@@ -335,6 +349,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn product_catalog_read_runtime(&self) -> ProductCatalogReadRuntime {
         self.product_catalog_read_runtime.clone()
+    }
+
+    pub fn product_catalog_command_runtime(&self) -> ProductCatalogCommandRuntime {
+        self.product_catalog_command_runtime.clone()
     }
 }
 
@@ -376,6 +394,12 @@ pub fn attach_schema_data(
             .shared_get::<ProductCatalogReadRuntime>()
             .ok_or_else(|| {
                 "commerce GraphQL requires ProductCatalogReadRuntime in host composition"
+                    .to_string()
+            })?,
+        product_catalog_command_runtime: inputs
+            .shared_get::<ProductCatalogCommandRuntime>()
+            .ok_or_else(|| {
+                "commerce GraphQL requires ProductCatalogCommandRuntime in host composition"
                     .to_string()
             })?,
     })

--- a/crates/rustok-product/src/catalog_command_port.rs
+++ b/crates/rustok-product/src/catalog_command_port.rs
@@ -193,9 +193,13 @@ fn product_command_error(
             "product.duplicate_sku",
             "product SKU conflicts with an existing variant",
         ),
-        CommerceError::Validation(_) | CommerceError::NoVariants => {
+        CommerceError::Validation(_) => {
             PortError::validation("product.validation", "product request is invalid")
         }
+        CommerceError::NoVariants => PortError::validation(
+            "product.no_variants",
+            "product requires at least one variant",
+        ),
         CommerceError::CannotDeletePublished => PortError::conflict(
             "product.lifecycle_conflict",
             "product operation conflicts with the current state",
@@ -226,7 +230,8 @@ fn product_error_code(error: &CommerceError) -> &'static str {
         CommerceError::ProductNotFound(_) => "product.product_not_found",
         CommerceError::DuplicateHandle { .. } => "product.duplicate_handle",
         CommerceError::DuplicateSku(_) => "product.duplicate_sku",
-        CommerceError::Validation(_) | CommerceError::NoVariants => "product.validation",
+        CommerceError::Validation(_) => "product.validation",
+        CommerceError::NoVariants => "product.no_variants",
         CommerceError::CannotDeletePublished => "product.lifecycle_conflict",
         CommerceError::Core(_) => "product.invariant_violation",
     }

--- a/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const mutations = read("crates/rustok-commerce/src/graphql/mutations/catalog.rs");
+const graphqlRuntime = read("crates/rustok-commerce/src/graphql_runtime.rs");
+const ownerPort = read("crates/rustok-product/src/catalog_command_port.rs");
+const hostComposition = read("apps/server/src/services/commerce_provider_runtime.rs");
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function requireText(source, text, label) {
+  if (!source.includes(text)) fail(`${label}: missing ${text}`);
+}
+
+function forbidText(source, text, label) {
+  if (source.includes(text)) fail(`${label}: forbidden ${text}`);
+}
+
+function functionSlice(source, name, nextName) {
+  const start = source.indexOf(`async fn ${name}(`);
+  if (start < 0) {
+    fail(`missing function ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+for (const required of [
+  "pub trait ProductCatalogCommandPort",
+  "async fn create_product(",
+  "async fn update_product(",
+  "async fn publish_product(",
+  "async fn delete_product(",
+  "PortCallPolicy::write()",
+  '"product.duplicate_handle"',
+  '"product.duplicate_sku"',
+  '"product.no_variants"',
+  '"product.lifecycle_conflict"',
+]) {
+  requireText(ownerPort, required, "Product owner command port");
+}
+
+for (const required of [
+  "ProductCatalogCommandRuntime",
+  ".shared_get::<rustok_product::ProductCatalogCommandRuntime>()",
+  "ProductCatalogCommandRuntime::in_process(",
+  "host.with_shared_value(runtime)",
+]) {
+  requireText(hostComposition, required, "host Product command composition");
+}
+
+for (const required of [
+  "ProductCatalogCommandRuntime",
+  "CURRENT_COMMERCE_PRODUCT_CATALOG_COMMAND_RUNTIME",
+  "runtime_data.product_catalog_command_runtime()",
+  "product_catalog_command_runtime_for_current_graphql_scope(",
+  "ProductCatalogCommandRuntime::in_process(db, event_bus)",
+  "product_catalog_command_runtime: ProductCatalogCommandRuntime",
+  "pub fn product_catalog_command_runtime(&self) -> ProductCatalogCommandRuntime",
+  ".shared_get::<ProductCatalogCommandRuntime>()",
+  "commerce GraphQL requires ProductCatalogCommandRuntime in host composition",
+]) {
+  requireText(graphqlRuntime, required, "scoped GraphQL Product command runtime");
+}
+
+for (const required of [
+  "ProductCatalogCommandRuntime",
+  "product_catalog_command_runtime_for_current_graphql_scope(",
+  "MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH: usize = 191",
+  "PRODUCT_COMMAND_DEADLINE: Duration = Duration::from_secs(2)",
+  "idempotency_key: Option<String>",
+  "Product mutation idempotency key must not be empty",
+  "BAD_USER_INPUT",
+  "one-request compatibility identity",
+  'format!("compatibility-{}", Uuid::new_v4())',
+  "digest.update(tenant_id.as_bytes())",
+  "digest.update(user_id.as_bytes())",
+  "digest.update(operation.as_bytes())",
+  "digest.update(product_id.as_bytes())",
+  "digest.update(caller_key.as_bytes())",
+  "PortActor::user(user_id.to_string())",
+  ".with_idempotency_key(scoped_key)",
+  ".with_deadline(PRODUCT_COMMAND_DEADLINE)",
+  "context = context.with_claim(permission.to_string())",
+  "context = context.with_channel(channel)",
+]) {
+  requireText(mutations, required, "GraphQL Product command context");
+}
+
+forbidText(
+  mutations,
+  "HostRuntimeContext",
+  "Product lifecycle resolver must use Commerce GraphQL scoped runtime instead of direct host lookup",
+);
+
+for (const required of [
+  '"DUPLICATE_HANDLE"',
+  '"DUPLICATE_SKU"',
+  '"NO_VARIANTS"',
+  '"CANNOT_DELETE_PUBLISHED"',
+  '"PRODUCT_VALIDATION"',
+  '"PRODUCT_NOT_FOUND"',
+  '"PRODUCT_TEMPORARILY_UNAVAILABLE"',
+  '"PRODUCT_OPERATION_FAILED"',
+  'extensions.set("retryable", error.retryable)',
+  'extensions.set("correlation_id", context.correlation_id.clone())',
+]) {
+  requireText(mutations, required, "GraphQL Product lifecycle error parity");
+}
+
+const create = functionSlice(mutations, "create_product", "update_product");
+const update = functionSlice(mutations, "update_product", "publish_product");
+const publish = functionSlice(mutations, "publish_product", "delete_product");
+const remove = functionSlice(mutations, "delete_product", "create_product_attribute");
+
+for (const [slice, operation, permission, portCall, productIdentity] of [
+  [create, "create_product", "Permission::PRODUCTS_CREATE", ".create_product(port_context.clone(), domain_input)", "None"],
+  [update, "update_product", "Permission::PRODUCTS_UPDATE", ".update_product(port_context.clone(), id, domain_input)", "Some(id)"],
+  [publish, "publish_product", "Permission::PRODUCTS_UPDATE", ".publish_product(port_context.clone(), id)", "Some(id)"],
+  [remove, "delete_product", "Permission::PRODUCTS_DELETE", ".delete_product(port_context.clone(), id)", "Some(id)"],
+]) {
+  for (const required of [
+    "idempotency_key: Option<String>",
+    permission,
+    "product_mutation_actor(ctx)?",
+    "product_command_context(",
+    productIdentity,
+    `"${operation}"`,
+    "product_command_runtime(ctx)?",
+    ".command_port()",
+    portCall,
+    "product_command_port_error(",
+  ]) {
+    requireText(slice, required, `${operation} GraphQL mutation`);
+  }
+  for (const forbidden of [
+    "CatalogService::new",
+    `.create_product(tenant_id, user_id`,
+    `.update_product(tenant_id, user_id`,
+    `.publish_product(tenant_id, user_id`,
+    `.delete_product(tenant_id, user_id`,
+    "product_catalog_port_error(",
+  ]) {
+    forbidText(slice, forbidden, `${operation} GraphQL mutation`);
+  }
+}
+
+for (const required of [
+  "validate_product_shipping_profile_input(",
+  "input.shipping_profile_slug.as_deref()",
+  "convert_create_product_input(input)?",
+]) {
+  requireText(create, required, "create Product compatibility semantics");
+}
+for (const required of [
+  "validate_product_shipping_profile_input(",
+  "input.shipping_profile_slug.as_deref()",
+  "metadata: None",
+  "status: input.status.map(Into::into)",
+]) {
+  requireText(update, required, "update Product compatibility semantics");
+}
+
+requireText(
+  mutations,
+  "ProductCatalogSchemaService::new",
+  "remaining Product schema-write debt must stay explicit",
+);
+forbidText(
+  mutations,
+  "use rustok_product::{CatalogService,",
+  "GraphQL lifecycle must not import CatalogService",
+);
+
+if (failures.length) {
+  console.error("Commerce Product GraphQL lifecycle command cutover verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("✔ Product GraphQL lifecycle mutations use scoped host-composed owner commands with explicit optional caller idempotency and compatibility fallback");


### PR DESCRIPTION
## Summary

- cut mounted Commerce GraphQL Product `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct` execution from direct `CatalogService` construction to `ProductCatalogCommandRuntime` / `ProductCatalogCommandPort`
- carry the host-selected Product command runtime through the existing `CommerceGraphqlRuntimeData` + resolver task-local scope beside Product reads; directly embedded compatibility schemas keep an explicit in-process fallback
- preserve Product module/permission admission, authenticated user actor, request locale/channel, effective permission claims, two-second command deadline, shipping-profile validation, and existing create/update input conversion semantics
- publish optional `idempotencyKey` lifecycle arguments: explicit non-empty keys (max 191 bytes) are scope-hashed with tenant/actor/operation/Product identity and used as command idempotency/correlation identity
- preserve current Product Admin FFA and existing GraphQL callers when `idempotencyKey` is omitted by using a visibly logged one-request compatibility identity; this path intentionally does **not** claim stable retry/replay semantics
- preserve pre-cutover lifecycle GraphQL public error identities through typed Product `PortError.code`, including `DUPLICATE_HANDLE`, `DUPLICATE_SKU`, `NO_VARIANTS`, `CANNOT_DELETE_PUBLISHED`, validation/not-found/unavailable and fail-closed operation errors; Product command mapping now distinguishes `product.no_variants`
- add a source guard for scoped runtime composition, typed owner calls, idempotency context, error parity, and absence of direct `CatalogService` use in the four lifecycle slices
- normalize the canonical ecommerce plan: storefront and REST lifecycle source work are recorded complete, this GraphQL owner-port cutover is complete, while mandatory Product Admin FFA retry identity and remaining Product schema writes stay open
- update the Product recheck packet without promoting FBA/FFA or verification state

## Remaining Product debt

- Product Admin FFA must retain one caller idempotency key across explicit retries before GraphQL `idempotencyKey` can become mandatory without breaking mounted UI callers
- Product schema writes still construct `ProductCatalogSchemaService` directly and need typed owner write capabilities
- compile/static/parity/remote/runtime evidence remains unexecuted

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction.