### PR TITLE
feat(product): add Storefront post-page tag hydration

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -23,7 +23,8 @@ pub(crate) use storefront_shadow_executor::{
     ProductStorefrontIndexChannelScopeDecision, ProductStorefrontIndexPageScopeDecision,
     ProductStorefrontIndexShadowComparison, ProductStorefrontIndexShadowExecution,
     ProductStorefrontIndexShadowExecutor, ProductStorefrontIndexShadowProjectionError,
-    classify_product_storefront_index_channel_scope, classify_product_storefront_index_page_scope,
+    ProductStorefrontIndexTagHydrationError, classify_product_storefront_index_channel_scope,
+    classify_product_storefront_index_page_scope,
 };
 #[cfg(test)]
 mod storefront_shadow_eav_postgres_tests;

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -7,8 +7,8 @@ use rustok_index::{
 };
 use rustok_product::{
     FilteredPublishedProductsRequest, ProductCatalogReadRuntime,
-    ProductStorefrontAttributeFilterResolutionRequest, StorefrontProductList,
-    StorefrontProductListQuery,
+    ProductStorefrontAttributeFilterResolutionRequest, ProductStorefrontTagHydration,
+    ProductStorefrontTagHydrationRequest, StorefrontProductList, StorefrontProductListQuery,
 };
 
 use super::{
@@ -21,14 +21,16 @@ const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;
 /// Non-serving Product Storefront parity execution result.
 ///
 /// The authoritative owner result is always produced first. `projected` retains the raw generic Index page
-/// for identity/count evidence. `public_projected` is derived only after that page exists and applies the
-/// Product owner public placeholder contract without feeding values back into Index query semantics.
+/// for identity/count evidence. `public_projected` derives Product title/handle placeholders from that page.
+/// `tag_hydration` is a separate Product-owned post-page read keyed only by identities from the raw Index page.
 #[derive(Debug)]
 pub(crate) struct ProductStorefrontIndexShadowExecution {
     pub(crate) authoritative: StorefrontProductList,
     pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>,
     pub(crate) public_projected:
         Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>,
+    pub(crate) tag_hydration:
+        Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>>,
     pub(crate) comparison: Option<ProductStorefrontIndexShadowComparison>,
 }
 
@@ -46,11 +48,6 @@ impl ProductStorefrontIndexShadowComparison {
 }
 
 /// Request-shape decision for the current Product key-4 channel projection.
-///
-/// `sales_channel_ids` stores resolved Channel UUID membership. For unrestricted Product metadata this is
-/// the set of all current Channels, so it cannot distinguish an unrestricted Product from a restricted
-/// Product whose allowed slugs currently resolve to that same complete set. Channel-less owner semantics
-/// therefore remain owner-native instead of being inferred from membership equality.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ProductStorefrontIndexChannelScopeDecision {
     ShadowEligible { public_channel_id: Uuid },
@@ -58,10 +55,6 @@ pub(crate) enum ProductStorefrontIndexChannelScopeDecision {
 }
 
 /// Request-shape decision for owner-valid Product Storefront offset pagination.
-///
-/// The Product owner has no explicit maximum offset, while the generic Index offset contract is bounded at
-/// 10,000. Requests inside that bound remain shadow-eligible. Owner-valid deeper pages remain owner-native;
-/// they are never clamped or rewritten to cursor pagination because either would change owner semantics.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ProductStorefrontIndexPageScopeDecision {
     ShadowEligible { offset: u64 },
@@ -88,13 +81,14 @@ pub(crate) enum ProductStorefrontIndexShadowProjectionError {
     Index(#[from] IndexQueryExecutionError),
 }
 
-/// Classify the caller's public-channel context without guessing channel-less visibility from Index
-/// membership.
-///
-/// An absent/blank slug paired with no UUID is the owner's channel-less shape and is deliberately retained as
-/// owner-native. A present non-empty slug plus a non-nil UUID is eligible for channel-scoped shadow
-/// translation. Partial, contradictory or nil identities fail closed as malformed context rather than being
-/// treated as channel-less.
+#[derive(Debug, Error)]
+pub(crate) enum ProductStorefrontIndexTagHydrationError {
+    #[error("Product Storefront tag hydration capability is unavailable")]
+    TagReadPortUnavailable,
+    #[error("Product Storefront tag hydration owner read failed: {0}")]
+    Owner(PortError),
+}
+
 pub(crate) fn classify_product_storefront_index_channel_scope(
     public_channel_slug: Option<&str>,
     public_channel_id: Option<Uuid>,
@@ -109,11 +103,6 @@ pub(crate) fn classify_product_storefront_index_channel_scope(
     }
 }
 
-/// Classify Product owner offset pagination before projected metadata or Index work begins.
-///
-/// Invalid pagination remains an error and is not treated as an owner-native fallback shape. A valid offset
-/// above the generic Index bound is a deliberate owner-native request shape. The pure shadow query builder
-/// retains its own `OffsetTooDeep` fail-closed check as a second boundary for direct callers.
 pub(crate) fn classify_product_storefront_index_page_scope(
     query: &StorefrontProductListQuery,
 ) -> Result<ProductStorefrontIndexPageScopeDecision, ProductStorefrontIndexShadowProjectionError> {
@@ -134,14 +123,8 @@ pub(crate) fn classify_product_storefront_index_page_scope(
 
 /// Owner-first, non-serving Product Storefront shadow executor.
 ///
-/// This object composes only host-selected Product and Index capabilities. It never constructs
-/// `CatalogService`, `ProductCatalogSchemaService`, a PostgreSQL Index port, or a database connection.
-/// The owner list result remains authoritative even when Product metadata resolution, shadow query build,
-/// Index readiness/admission, Index execution, or public post-page projection fails.
-///
-/// Channel-scoped projection requires a trusted current slug/UUID pair supplied by the caller's current
-/// channel context. Channel-less requests and owner-valid deep offset pages are intentionally retained as
-/// typed owner-native projected results rather than approximated by Index.
+/// All enrichment happens only after a successful raw Index page. Product public placeholder projection and
+/// Product-owned tag hydration are retained separately; neither can change raw Index identity/order/count.
 #[derive(Clone)]
 pub(crate) struct ProductStorefrontIndexShadowExecutor {
     product: ProductCatalogReadRuntime,
@@ -180,8 +163,8 @@ impl ProductStorefrontIndexShadowExecutor {
 
         let projected = self
             .execute_projected(
-                context,
-                fallback_locale,
+                context.clone(),
+                fallback_locale.clone(),
                 public_channel_slug,
                 public_channel_id,
                 query,
@@ -192,6 +175,13 @@ impl ProductStorefrontIndexShadowExecutor {
             .ok()
             .cloned()
             .map(project_product_storefront_index_page);
+        let tag_hydration = match projected.as_ref() {
+            Ok(projected) => Some(
+                self.hydrate_projected_tags(context, fallback_locale, projected)
+                    .await,
+            ),
+            Err(_) => None,
+        };
         let comparison = projected
             .as_ref()
             .ok()
@@ -201,8 +191,36 @@ impl ProductStorefrontIndexShadowExecutor {
             authoritative,
             projected,
             public_projected,
+            tag_hydration,
             comparison,
         })
+    }
+
+    async fn hydrate_projected_tags(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        projected: &IndexQueryPage,
+    ) -> Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError> {
+        let tag_read = self
+            .product
+            .storefront_tag_read_port()
+            .ok_or(ProductStorefrontIndexTagHydrationError::TagReadPortUnavailable)?;
+        let product_ids = projected
+            .items
+            .iter()
+            .map(|item| item.entity_id)
+            .collect::<Vec<_>>();
+        tag_read
+            .hydrate_storefront_product_tags(
+                context,
+                ProductStorefrontTagHydrationRequest {
+                    product_ids,
+                    fallback_locale,
+                },
+            )
+            .await
+            .map_err(ProductStorefrontIndexTagHydrationError::Owner)
     }
 
     async fn execute_projected(
@@ -313,28 +331,14 @@ mod tests {
             classify_product_storefront_index_channel_scope(None, None).unwrap(),
             ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess
         );
-        assert_eq!(
-            classify_product_storefront_index_channel_scope(Some("   "), None).unwrap(),
-            ProductStorefrontIndexChannelScopeDecision::OwnerNativeChannelLess
-        );
-
         let channel_id = Uuid::new_v4();
         assert_eq!(
             classify_product_storefront_index_channel_scope(Some(" web "), Some(channel_id))
                 .unwrap(),
             ProductStorefrontIndexChannelScopeDecision::ShadowEligible { public_channel_id: channel_id }
         );
-
         assert!(matches!(
             classify_product_storefront_index_channel_scope(Some("web"), None),
-            Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
-        ));
-        assert!(matches!(
-            classify_product_storefront_index_channel_scope(None, Some(channel_id)),
-            Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
-        ));
-        assert!(matches!(
-            classify_product_storefront_index_channel_scope(Some("web"), Some(Uuid::nil())),
             Err(ProductStorefrontIndexShadowProjectionError::PublicChannelIdentityUnavailable)
         ));
     }
@@ -352,21 +356,5 @@ mod tests {
             classify_product_storefront_index_page_scope(&deep).unwrap(),
             ProductStorefrontIndexPageScopeDecision::OwnerNativeDeepPage { offset: 10_032 }
         );
-
-        let invalid = StorefrontProductListQuery::default().with_pagination(0, 48);
-        assert!(matches!(
-            classify_product_storefront_index_page_scope(&invalid),
-            Err(ProductStorefrontIndexShadowProjectionError::QueryBuild(
-                ProductStorefrontIndexShadowError::InvalidPagination
-            ))
-        ));
-
-        let overflow = StorefrontProductListQuery::default().with_pagination(u64::MAX, 48);
-        assert!(matches!(
-            classify_product_storefront_index_page_scope(&overflow),
-            Err(ProductStorefrontIndexShadowProjectionError::QueryBuild(
-                ProductStorefrontIndexShadowError::InvalidPagination
-            ))
-        ));
     }
 }

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after real Product Storefront deep-page policy merge
-`ac399264f12dd71439861e60a5df86ac9ab496bb` and continued on
-`agent/product-storefront-placeholder-projection-v2-20260808`.
+Status overlay rechecked after Product Storefront public projection merge
+`f949c7c3ee25dcabbf33ff2b7627fae1ea3b9e3b` and continued on
+`agent/product-storefront-tag-hydration-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -28,12 +28,12 @@ Source-complete:
 - Product-owned Storefront attribute-filter -> neutral canonical term resolution;
 - pure Storefront shadow builder and owner-first non-serving shadow executor;
 - explicit current-key channel-scope policy: trusted non-empty slug + non-nil UUID is shadow-eligible, while
-  channel-less owner requests remain owner-native and partial/invalid channel identity fails closed;
+  channel-less owner requests remain owner-native and malformed identity fails closed;
 - explicit deep-page policy: owner-valid offsets through `10_000` are shadow-eligible while deeper offsets
   remain typed owner-native without clamp or cursor rewriting;
-- Product Storefront **post-page public projection**: raw generic Index rows remain intact for equivalence
-  evidence, while a derived page maps root `title: null` to `"Untitled product"` and root `handle: null` to
-  `""` only after page identity/order/count/cursor are fixed;
+- Product Storefront post-page public placeholder projection that keeps raw Index null evidence intact;
+- Product-owned bounded post-page tag hydration keyed by already-selected Product IDs, preserving Taxonomy
+  requested->fallback/canonical-key semantics **and** legacy metadata-only tag fallback;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
@@ -41,56 +41,64 @@ Source-complete:
 
 ### Channel-less
 
-Owner channel-less semantics are **metadata-unrestricted only**. Current key `4` stores unrestricted visibility
-as membership in all current Channel UUIDs, which is indistinguishable from a restricted Product that currently
-resolves to the same complete set. Therefore:
-
-- absent/blank slug + absent UUID => `OwnerNativeChannelLess`;
-- trusted non-empty slug + non-nil UUID => channel-scoped shadow eligible;
-- malformed/partial identity => fail closed.
-
-No visibility sentinel or key-5 approximation is used.
+Owner channel-less semantics are **metadata-unrestricted only**. Current key `4` cannot distinguish unrestricted
+metadata from a restricted Product that resolves to the same complete current Channel UUID set. Channel-less
+therefore remains owner-native; trusted slug/UUID scope remains shadow-eligible; malformed identity fails closed.
 
 ### Deep page
 
-The Product owner accepts valid `page/per_page` without the generic Index offset ceiling. The Index path is
-bounded to offset `10_000`. Therefore:
+The Product owner has no generic Index-style maximum offset. The Index path is bounded to `10_000`. Valid
+offsets above that bound remain typed owner-native after owner success; no clamp or cursor rewrite is used.
 
-- offset `<= 10_000` => shadow eligible;
-- offset `> 10_000` => typed `OwnerNativeDeepPage` / `DeepPageOwnerNative` after owner success;
-- invalid pagination/overflow => fail closed as invalid pagination.
+## Post-page Product projection layers
 
-No clamp or cursor rewrite is used.
+### Public title/handle placeholders
 
-## Post-page public placeholder projection
+The raw generic `IndexQueryPage` remains Product-neutral. When requested/fallback localized rows are absent,
+root `title`/`handle` remain `IndexValue::Null` in `projected` and in raw PostgreSQL evidence.
 
-The generic localized Index decoder deliberately remains Product-neutral. When neither requested nor fallback
-translation row exists, raw root `title`/`handle` remain `IndexValue::Null`. Existing PostgreSQL parity evidence
-continues to retain that raw state.
+`public_projected` is derived from a clone of successful raw `projected` and maps only:
 
-`project_product_storefront_index_page` is a distribution-owned Product adapter applied only to a clone of a
-successful raw `IndexQueryPage`. It:
+- `title: Null` -> `"Untitled product"`;
+- `handle: Null` -> `""`.
 
-- maps root `title: Null` -> `String("Untitled product")`;
-- maps root `handle: Null` -> `String("")`;
-- preserves already-present strings;
-- fails closed on missing, duplicate, or non-string/non-null root title/handle projections;
-- preserves item identity/order, exact count, page boundary, cursor, unrelated projected fields and `tag_ids`.
+It preserves item identity/order, count, page boundary, cursor, unrelated fields and `tag_ids`; missing,
+duplicate or wrong-typed title/handle fields fail closed. Raw comparison still uses `projected`.
 
-`ProductStorefrontIndexShadowExecution.projected` remains the raw generic Index page. New
-`public_projected` is derived after raw execution. Identity/count/page comparison still uses raw `projected`, so
-owner public placeholders cannot affect filtering, sorting, identity folding, exact count, pagination, or cursor
-construction.
+### Product-owned tag hydration
 
-This closes the no-localized-row public placeholder **source adapter** gap. It does not yet produce final
-Storefront tags: `tag_ids` remain IDs until the separate Taxonomy hydration slice.
+A naive `tag_ids -> Taxonomy names` adapter is insufficient. Current Product Index `tag_ids` are materialized
+only from `product_tags`, while Product owner read semantics still support legacy `metadata.tags` when a Product
+has no tag relations.
+
+`ProductStorefrontTagReadPort` therefore accepts only the **already-selected Product IDs** plus fallback locale.
+The embedded Product runtime wires `CatalogService` as this optional capability; external runtimes do not gain
+an implicit embedded fallback.
+
+The Product owner capability:
+
+- accepts at most 48 unique, non-nil Product IDs;
+- tenant-scopes and verifies every requested Product identity;
+- reuses `CatalogService::load_product_tag_map` rather than reimplementing storage rules;
+- preserves product-tag relation ordering;
+- uses existing `TaxonomyService::resolve_term_names` requested->fallback resolution and canonical-key fallback;
+- preserves legacy normalized `metadata.tags` when no relations exist;
+- returns results in the same Product-ID order supplied by the fixed raw Index page.
+
+`ProductStorefrontIndexShadowExecution.tag_hydration` is populated only after raw `projected` succeeds. The
+executor extracts Product IDs from `projected.items`; distribution never reads Product/Taxonomy storage or
+constructs `TaxonomyService`. Missing external capability or owner hydration error is retained separately and
+cannot mutate/replace raw or public projected pages.
+
+This closes the Storefront tag **source hydration boundary** without copying localized tag names into Product
+Index schema and without pretending `tag_ids` represent legacy metadata-only tags.
 
 ## Remaining Storefront parity/evidence blockers
 
 - execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the retained deployment matrix agrees;
-- batch-hydrate localized Taxonomy tag names only after Product page identity/count is fixed;
-- define serving latency/deadline policy before any shadow-to-serving transition;
+- define serving latency/deadline/budget policy for owner-first Index + post-page Product tag hydration before
+  any shadow-to-serving transition;
 - preserve channel-less and deep-page owner-native routing in any future serving composition;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence.
 
@@ -100,6 +108,9 @@ The retained Product PostgreSQL fixture set is source-aligned on routing key `4`
 query freshness, Product/Channel convergence, Channel identity transitions, linked-target delete/recreate,
 linked-target availability equivalence and linked-target replay/redelivery. ProductVariant remains key `2`
 and SalesChannel remains key `1`.
+
+Existing Product taxonomy source evidence also retains normalized legacy metadata-tag read fallback. It is not
+reinterpreted as Index tag identity evidence.
 
 ## M5 incremental ingestion
 
@@ -136,9 +147,11 @@ and SalesChannel remains key `1`.
 - [x] Keep channel-less Storefront owner-native on current key `4`; distinguish malformed channel identity.
 - [x] Keep owner-valid offsets above `10_000` owner-native without clamp/rewrite.
 - [x] Map raw no-localized-row title/handle nulls to Product public placeholders in a post-page derived layer.
+- [x] Batch-hydrate Product tags after raw page selection through a Product-owned capability, including legacy
+      metadata-only fallback rather than relying solely on Index `tag_ids`.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Batch-hydrate Taxonomy tag names after the Product page is fixed.
+- [ ] Define/admit serving latency and deadline policy for eligible Storefront Index + owner hydration.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
@@ -147,10 +160,10 @@ and SalesChannel remains key `1`.
 
 ## Next source-code step
 
-Add a post-page Product Storefront Taxonomy tag hydration boundary. The Index page already carries `tag_ids`;
-resolve their requested-locale -> fallback-locale names in one bounded/batched owner capability **after** page
-identity/order/exact-count are fixed. Hydration failure must not alter the raw Index page or be interpreted as a
-different Product page. Do not add Taxonomy tag names to Product Index schema merely to avoid owner hydration.
+Define a non-serving Storefront Index serving-budget contract before any traffic-switch adapter. It must bound
+Index execution plus Product post-page owner hydration, preserve owner success/fail-closed behavior, and make
+an exceeded/missing deadline a reason to keep the request owner-native rather than introducing unbounded tail
+latency. Do not switch mounted Storefront traffic in that slice.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,149 +1,100 @@
 # M7 Product Storefront Index parity gate
 
-Status: `public_projection_source_complete_taxonomy_hydration_pending`.
+Status: `tag_hydration_source_complete_serving_budget_pending`.
 
 ## Current boundary
 
 Mounted Storefront remains owner-native and continues to execute
 `CatalogService::list_published_products_with_query`. No Index traffic switch is part of this state.
 
-The Product-owned EAV resolver, localized shadow builder and owner-first non-serving shadow executor are
-source-complete. Current-key Storefront core/EAV/collation PostgreSQL packets and the historical retained
-Product packet set are retained in source on Product routing key `4`. They have **not** been executed or
-admitted by the implementation agent.
+Current-key Storefront core/EAV/collation PostgreSQL packets and retained Product packets remain source-only;
+maintainer execution/admission is not claimed.
 
-## Channel-less serving policy — source complete for current key 4
+## Request-shape policy — source complete
 
-Owner channel-less semantics are stricter than resolved membership. With no public channel slug, Product owner
-admits only Products whose `metadata.channel_visibility.allowed_channel_slugs` is absent or empty.
-
-The Product relation resolver represents unrestricted metadata by resolving **all current Channel UUIDs** into
-`sales_channel_ids`. A restricted Product whose allowed slugs currently resolve to every Channel therefore has
-the same membership vector as an unrestricted Product. Current key `4` cannot distinguish those states.
-
-For the current key-4 contract:
-
-- absent/blank slug and absent channel UUID => `OwnerNativeChannelLess`;
-- trusted non-empty slug and non-nil UUID => `ShadowEligible`;
-- malformed/partial identity => `PublicChannelIdentityUnavailable`.
-
-The shadow executor produces the authoritative owner result first. A channel-less request records
-`ChannelLessOwnerNative` on the projected side and never fabricates an Index page. No sentinel UUID, unrelated
-`attribute_terms` encoding or key-5 approximation is used.
-
-## Deep-page serving policy — source complete
-
-The Product owner validates `page >= 1` and `1 <= per_page <= 48`, but it does not impose the generic Index
-offset ceiling. The generic Product Storefront path remains bounded at offset `10_000`.
-
-`classify_product_storefront_index_page_scope` preserves this owner/Index difference after authoritative owner
-success and before projected schema/EAV work:
-
-- checked offset `<= 10_000` => `ShadowEligible { offset }`;
-- checked offset `> 10_000` => `OwnerNativeDeepPage { offset }` and `DeepPageOwnerNative { offset }`;
-- invalid pagination/overflow => existing invalid-pagination failure.
-
-The policy does not clamp page/offset or rewrite to cursor pagination. The pure shadow builder independently
-retains `OffsetTooDeep` for direct callers.
+- trusted non-empty public channel slug + non-nil UUID is shadow-eligible;
+- channel-less requests remain typed owner-native because key `4` cannot distinguish unrestricted metadata
+  from restricted membership that resolves to every current Channel;
+- owner-valid offsets through `10_000` are shadow-eligible;
+- deeper owner-valid pages remain typed owner-native;
+- no visibility sentinel, page clamp, cursor rewrite or Product key-5 approximation is used.
 
 ## Product public placeholder projection — source complete
 
-The raw localized Index page deliberately remains Product-neutral. If no requested or fallback translation row
-exists, raw root `title` and `handle` remain `IndexValue::Null`. The retained core PostgreSQL packet continues
-to preserve that raw evidence beside the authoritative owner result (`"Untitled product"` / empty handle).
+Raw localized Index results remain Product-neutral. No requested/fallback row means raw root `title`/`handle`
+are `IndexValue::Null` and retained PostgreSQL evidence continues to observe that state.
 
-`storefront_projection.rs` adds a Product distribution-owned **post-page** transform:
+`public_projected` is derived only from a clone of a successful raw page and maps:
 
-- root `title: Null` => `String("Untitled product")`;
-- root `handle: Null` => `String("")`;
-- existing strings are preserved;
-- missing, duplicate, or wrong-typed root title/handle fields fail closed;
-- item identities/order, `exact_count`, `has_more`, `next_cursor`, unrelated fields and `tag_ids` are preserved.
+- `title: Null` -> `"Untitled product"`;
+- `handle: Null` -> `""`.
 
-`ProductStorefrontIndexShadowExecution` now retains two explicit layers:
+Identity/order/count/page/cursor and unrelated fields, including `tag_ids`, remain unchanged. Raw comparison
+continues to use `projected`, not the public layer.
 
-- `projected`: the raw generic `IndexQueryPage`, still used for identity/order/count/page comparison;
-- `public_projected`: an optional result derived only from a clone of a successful raw page by
-  `project_product_storefront_index_page`.
+## Product-owned tag hydration — source complete
 
-The public transform is not called inside `execute_projected`, the shadow query builder contains no owner
-placeholder strings, and generic `rustok-index` remains unaware of Product public placeholder semantics.
-Therefore placeholders cannot influence title search, filters, ordering, localized identity folding, exact
-count, offset/cursor construction or raw equivalence evidence.
+Current Product Index `tag_ids` are relation-backed UUIDs from `product_tags`. Product owner semantics are
+broader: when no relations exist, legacy normalized `metadata.tags` remain a read fallback. Therefore a
+`tag_ids -> names` adapter would lose valid owner-visible tags.
 
-This closes the no-requested/fallback public title/handle **source adapter** gap. It does not close Taxonomy tag
-parity: current Index projection still carries `tag_ids`, while Product owner list returns localized tag names.
+Product now publishes optional `ProductStorefrontTagReadPort` with a bounded page request:
 
-## Product-owned Storefront search bound — source complete
+- at most 48 unique, non-nil already-selected Product IDs;
+- tenant-scoped verification of every Product identity;
+- requested locale from `PortContext`, explicit fallback locale from the request;
+- reuse of `CatalogService::load_product_tag_map`;
+- existing Taxonomy requested->fallback name resolution and canonical-key fallback;
+- existing legacy metadata-only tag fallback;
+- response order matching the supplied Product-ID order.
 
-Product owns `MAX_STOREFRONT_PRODUCT_SEARCH_BYTES = 1022`. The owner wraps normalized search as
-`%{search}%`, making the maximum pattern exactly representable by generic Index `TextLike`'s 1024-byte bound.
-The constructor and owner SQL path both enforce the Product bound; over-bound input is rejected, never
-truncated. The shadow builder imports the same Product constant.
+`ProductCatalogReadRuntime::in_process` selects this capability from the same `CatalogService` owner. External
+runtime profiles remain source-compatible and do **not** silently gain an embedded tag provider.
 
-## Title-search collation packet — source complete, execution pending
+`ProductStorefrontIndexShadowExecutor.tag_hydration` is created only after raw `projected` succeeds. Product
+IDs come from `projected.items`; distribution does not construct `TaxonomyService`, query `product_tags`, or
+read Product storage directly. Missing capability/owner error is retained separately and cannot replace or
+mutate the authoritative owner result, raw Index page, or `public_projected` page.
 
-`product_storefront_search_collation_postgres.rs` compares real owner/default `title LIKE pattern` with the
-Index-equivalent `(title COLLATE "C") LIKE pattern ESCAPE E'\\'` on the real Product translation column. It
-covers ASCII case, NFC/NFD Unicode, `%`, `_`, escaped wildcards and sharp-s/ASCII-SS distinctions and reports
-`lc_collate` on mismatch. It does not manufacture a favorable collation. Deployment admission remains a
-maintainer-run gate.
+This closes the tag-hydration **source boundary** without adding localized tag names to Product Index schema and
+without pretending relation-backed `tag_ids` cover legacy metadata-only tags.
 
-## Product-owned EAV resolution and shadow execution
+## Search/collation/EAV source state
 
-`ProductCatalogSchemaReadPort::resolve_storefront_attribute_filters` remains the Product metadata boundary
-used by shadow execution. Distribution translates Product-owned neutral term expressions into
-`attribute_terms`; missing option identities remain `Never` and map to a bind-free false predicate.
+Product owns the 1022-byte effective Storefront title-search bound compatible with generic 1024-byte
+`TextLike`. The retained collation packet observes real owner/default `LIKE` against Index `COLLATE "C"` and
+remains execution/admission pending.
 
-`ProductStorefrontIndexShadowExecutor` executes the authoritative Product owner list first. Only eligible
-channel-scoped, shallow projected work proceeds through Product metadata resolution, localized query
-construction and `execute_localized_query`. Projected or public-projection failures cannot replace the
-successful authoritative owner result.
-
-## Core/EAV and retained Product PostgreSQL packets
-
-The core Storefront packet retains localized requested/fallback/neither projection, all-locale title matching,
-wildcards, identity de-duplication, count, Asc/Desc tie ordering, pagination and trusted public-channel
-membership. Its raw null-vs-owner-placeholder assertions intentionally remain unchanged.
-
-The EAV packet separately retains scalar/localized terms, Select/Multiselect option code/direct UUID and
-missing/nil option `Never` behavior.
-
-Historical Product locale-absence, materialized-freshness, channel convergence/identity-transition and
-linked-target recreate/availability/replay packets are source-aligned on Product key `4`. ProductVariant stays
-key `2`, SalesChannel key `1`. Execution/review remains maintainer-owned.
+Product-owned EAV resolution still supplies neutral typed term expressions to the shadow builder; missing
+option identities remain bind-free `Never`. The raw core/EAV PostgreSQL packets remain current-key source
+evidence.
 
 ## Remaining fail-closed parity/evidence gates
 
 1. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
 2. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
-3. Taxonomy tag names must be batch-hydrated requested-locale -> fallback-locale only after Product page
-   identity/order/count is fixed; current post-page adapter intentionally leaves `tag_ids` unchanged.
-4. Shadow execution has no serving latency/deadline policy and remains non-serving.
-5. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
-6. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
+3. Define/admit serving latency/deadline/budget policy for Index execution plus post-page Product hydration.
+4. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
+5. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
 
 ## Next source slice
 
-Add a Product/Taxonomy owner capability for bounded batched hydration of the already-selected Product page's
-`tag_ids`. Resolve requested-locale then fallback-locale display names only after Index identity/order/count is
-fixed. Hydration failure must be retained separately and must not replace the raw Product page. Do not copy tag
-names into Product Index schema merely to avoid post-page owner hydration.
+Define a **non-serving serving-budget policy** before any traffic-switch adapter. It must place explicit bounds
+on Index work and post-page Product owner hydration, honor request deadlines, and retain owner-native behavior
+when the required budget/capability is unavailable. Do not switch mounted Storefront traffic in that slice.
 
 ## Source guards
 
-- `verify-index-product-storefront-channel-scope-policy.mjs` locks current-key channel-less owner-native policy;
-- `verify-index-product-storefront-deep-page-policy.mjs` locks owner-valid shallow/deep classification;
-- `verify-index-product-storefront-public-projection.mjs` locks raw-vs-public page separation, Product public
-  placeholder values and preservation of page metadata/`tag_ids`;
-- `verify-product-storefront-search-bound.mjs` locks the Product-owned search-length contract;
-- `verify-index-product-storefront-collation-postgres-packet.mjs` locks retained collation evidence;
-- `verify-index-product-storefront-shadow-adapter.mjs` locks Product-term -> localized query translation;
-- `verify-index-product-storefront-shadow-executor.mjs` locks owner-first execution plus typed request scopes;
-- `verify-index-product-storefront-equivalence-postgres-packet.mjs` and the EAV counterpart lock current-key
-  parity packets;
-- `verify-index-product-postgres-key4-fixtures.mjs` locks retained Product packets on key `4`;
+- `verify-index-product-storefront-channel-scope-policy.mjs` locks channel-less owner-native policy;
+- `verify-index-product-storefront-deep-page-policy.mjs` locks deep-page owner-native policy;
+- `verify-index-product-storefront-public-projection.mjs` locks raw/public placeholder separation;
+- `verify-index-product-storefront-tag-hydration.mjs` locks bounded Product-owned tag hydration including
+  Taxonomy and legacy metadata fallback semantics;
+- `verify-index-product-storefront-shadow-executor.mjs` locks post-page enrichment after raw Index execution;
+- `verify-product-catalog-read-runtime-composition.mjs` locks optional embedded tag capability without external
+  implicit fallback;
+- current Storefront equivalence/EAV/collation/key-4 guards remain retained;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 
-No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-public-projection.md
+++ b/crates/rustok-index/docs/m7-product-storefront-public-projection.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront public projection boundary
 
-Status: `source_complete_taxonomy_hydration_pending`.
+Status: `source_complete_with_separate_tag_hydration`.
 
 ## Raw Index page remains generic
 
@@ -23,32 +23,35 @@ an already-decoded `IndexQueryPage`:
 The adapter preserves item identity/order, exact count, `has_more`, cursor, unrelated projected fields and
 `tag_ids`. It has no query, filtering, sorting, localized-fold or execution dependency.
 
-`ProductStorefrontIndexShadowExecution` retains both layers:
+`ProductStorefrontIndexShadowExecution` retains separate layers:
 
-- `projected` — raw generic Index page and the input to identity/count/page comparison;
-- `public_projected` — optional Product public page derived from a clone of successful `projected`.
+- `projected` — raw generic Index page and input to identity/count/page comparison;
+- `public_projected` — Product title/handle page derived from a clone of successful `projected`;
+- `tag_hydration` — separate Product-owner tag projection keyed by identities from raw `projected`.
 
-A raw projection failure produces no public page. A public projection failure is retained separately and never
-replaces the successful Product owner result or mutates the raw Index page.
+A raw projection failure produces neither public page nor tag hydration. Public projection and tag-hydration
+failures are retained independently and never replace the successful Product owner result or mutate the raw
+Index page.
 
-## Why this is post-page only
+## Why placeholders stay post-page
 
-The Product owner placeholders describe public presentation when no requested/fallback translation is
-available. They are not stored translation values and must not become search/filter/order identities. Applying
-them before query completion would change owner semantics by making a display fallback participate in
-selection, ordering, exact count or pagination.
+Product owner placeholders describe public presentation when no requested/fallback translation is available.
+They are not stored translation values and must not become search/filter/order identities. Applying them before
+query completion would change selection, ordering, exact count or pagination semantics.
 
-Keeping them post-page also leaves generic `rustok-index` reusable for entities whose no-localized-row public
+Keeping them outside generic `rustok-index` also preserves reuse for entities whose no-localized-row public
 contract differs from Product.
 
-## Remaining projection gap
+## Tags remain a separate owner projection
 
-Product owner list returns localized Taxonomy tag names, while the current Index Product page retains
-`tag_ids`. The public placeholder adapter deliberately does not transform these IDs.
+The placeholder adapter intentionally leaves `tag_ids` unchanged. Product tag parity is handled by
+`ProductStorefrontTagReadPort` after the raw page is fixed.
 
-The next source slice must batch-hydrate tag names through an owner capability after Product page identity,
-ordering and exact count are fixed. Tag hydration failure must remain separate from the raw Index page and must
-not cause a different Product selection.
+That capability is keyed by Product IDs rather than only `tag_ids` because Product owner reads preserve a
+legacy `metadata.tags` fallback when relation-backed tags are absent. The separate tag result therefore carries
+owner semantics without changing the generic Index page contract.
+
+See `m7-product-storefront-tag-hydration.md` for the retained boundary and remaining serving-budget gate.
 
 No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-tag-hydration.md
+++ b/crates/rustok-index/docs/m7-product-storefront-tag-hydration.md
@@ -1,0 +1,58 @@
+# M7 Product Storefront tag hydration boundary
+
+Status: `source_complete_serving_budget_pending`.
+
+## Why raw `tag_ids` are not enough
+
+Product Index materializes `tag_ids` from `product_tags`. That is correct canonical relation identity, but it is
+not the complete public Product read contract: legacy Products with no tag relations may still expose
+normalized `metadata.tags` through Product owner reads.
+
+A post-page adapter that resolves only Index `tag_ids` would therefore drop owner-visible legacy tags. The
+hydration boundary must be keyed by the already-selected Product identities, not treated as a pure UUID-name
+lookup over Index fields.
+
+## Product-owned capability
+
+`ProductStorefrontTagReadPort::hydrate_storefront_product_tags` accepts:
+
+- up to 48 already-selected Product IDs;
+- fallback locale;
+- requested locale and tenant identity from `PortContext`.
+
+The embedded implementation is `CatalogService` and:
+
+1. requires a read policy;
+2. rejects nil/duplicate/over-bound Product identities;
+3. tenant-scopes and verifies every requested Product row;
+4. calls the existing `load_product_tag_map` owner helper;
+5. preserves Taxonomy requested->fallback resolution and canonical-key fallback;
+6. preserves legacy normalized `metadata.tags` only when relation-backed tags are absent;
+7. returns one item per requested Product ID in input order, with empty tags represented explicitly by an empty
+   vector.
+
+`ProductCatalogReadRuntime::in_process` selects the tag capability from the same Product owner instance.
+External profiles remain compatible but have no implicit embedded tag capability.
+
+## Index composition
+
+The non-serving Storefront shadow executor calls tag hydration only after raw `IndexQueryPage` success. It
+extracts Product IDs from `projected.items`, not from the authoritative owner page and not from `tag_ids`.
+
+Hydration is retained as a separate `tag_hydration` result. It does not mutate:
+
+- raw `projected`;
+- Product placeholder `public_projected`;
+- identity/order/exact-count/page/cursor comparison.
+
+Distribution does not query Product/Taxonomy storage and does not construct `TaxonomyService`.
+
+## Serving boundary
+
+This source capability removes the semantic tag-name/legacy-fallback gap, but it adds an owner read after the
+Index page. Before any serving cutover, the combined Index + Product hydration path needs an explicit deadline
+and latency budget plus maintainer-run evidence. Missing external capability must remain fail-closed/owner-native
+rather than silently dropping tags.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-product/docs/storefront-tag-hydration-read-port.md
+++ b/crates/rustok-product/docs/storefront-tag-hydration-read-port.md
@@ -1,0 +1,27 @@
+# Product Storefront tag hydration read capability
+
+Status: `embedded_optional_source_complete_external_transport_open`.
+
+`ProductStorefrontTagReadPort` is an optional Product-owned post-page read capability for consumers that have
+already fixed a Product page and need exact Product public tag semantics.
+
+The capability is intentionally separate from `ProductCatalogReadPort` / `product.catalog_read.v1`.
+Existing Product catalog gRPC clients/servers and external adapters therefore remain source-compatible; the
+current external transport contract is not widened by this slice.
+
+`ProductCatalogReadRuntime::in_process` selects the same `CatalogService` instance as both the canonical
+catalog read provider and the optional Storefront tag provider. `ProductCatalogReadRuntime::external` does not
+install an embedded fallback. A consumer that requires tag hydration must treat an absent external capability
+as unavailable/fail-closed until a concrete external transport is defined.
+
+The request is bounded to 48 unique, non-nil Product IDs and uses `PortContext` for tenant/requested locale plus
+an explicit fallback locale. The implementation tenant-scopes all Product identities and delegates to the
+existing `CatalogService::load_product_tag_map` owner helper, preserving relation ordering, Taxonomy
+requested->fallback/canonical-key resolution, and legacy normalized `metadata.tags` fallback when no
+relation-backed tags exist.
+
+This capability is post-page projection only. It does not select Products, change Product Index schema, or
+make legacy metadata tags into Index identities.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -25,6 +25,7 @@ mod public_error;
 mod runtime;
 mod seo_targets;
 pub mod services;
+mod storefront_tag_read_port;
 
 pub use catalog_command_port::ProductCatalogCommandPort;
 pub use catalog_schema_read_port::{
@@ -68,6 +69,10 @@ pub use services::{
     product_attribute_integer_term, product_attribute_localized_presence_term,
     product_attribute_localized_text_expr, product_attribute_localized_text_term,
     product_attribute_option_term, product_attribute_text_term,
+};
+pub use storefront_tag_read_port::{
+    ProductStorefrontTagHydration, ProductStorefrontTagHydrationItem,
+    ProductStorefrontTagHydrationRequest, ProductStorefrontTagReadPort,
 };
 
 /// Typed marker proving that `ProductModule` participated in runtime extension registration.

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -5,7 +5,7 @@ use sea_orm::DatabaseConnection;
 
 use crate::{
     CatalogService, ProductCatalogCommandPort, ProductCatalogReadPort, ProductCatalogSchemaReadPort,
-    ProductCatalogSchemaService,
+    ProductCatalogSchemaService, ProductStorefrontTagReadPort,
 };
 
 /// Host-selected execution profile for the Product catalog read boundary.
@@ -27,11 +27,13 @@ impl ProductCatalogReadProfile {
 /// Canonical host-composed Product catalog read capability.
 ///
 /// Consumers receive this wrapper rather than constructing `CatalogService` directly. A host can
-/// therefore replace the embedded provider with a remote adapter without changing consumer code.
+/// therefore replace the embedded provider with a remote adapter without changing consumer code. Optional
+/// owner capabilities remain explicit and fail closed when an external profile has not selected them.
 #[derive(Clone)]
 pub struct ProductCatalogReadRuntime {
     read_port: Arc<dyn ProductCatalogReadPort>,
     schema_read_port: Option<Arc<dyn ProductCatalogSchemaReadPort>>,
+    storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>,
     profile: ProductCatalogReadProfile,
 }
 
@@ -43,16 +45,16 @@ impl ProductCatalogReadRuntime {
         Self {
             read_port,
             schema_read_port: None,
+            storefront_tag_read_port: None,
             profile,
         }
     }
 
     pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
-        Self::new(
-            Arc::new(CatalogService::new(db.clone(), event_bus.clone())),
-            ProductCatalogReadProfile::EmbeddedNative,
-        )
-        .with_schema_read_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))
+        let catalog = Arc::new(CatalogService::new(db.clone(), event_bus.clone()));
+        Self::new(catalog.clone(), ProductCatalogReadProfile::EmbeddedNative)
+            .with_schema_read_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))
+            .with_storefront_tag_read_port(catalog)
     }
 
     pub fn external(read_port: Arc<dyn ProductCatalogReadPort>) -> Self {
@@ -67,12 +69,24 @@ impl ProductCatalogReadRuntime {
         self
     }
 
+    pub fn with_storefront_tag_read_port(
+        mut self,
+        storefront_tag_read_port: Arc<dyn ProductStorefrontTagReadPort>,
+    ) -> Self {
+        self.storefront_tag_read_port = Some(storefront_tag_read_port);
+        self
+    }
+
     pub fn read_port(&self) -> Arc<dyn ProductCatalogReadPort> {
         self.read_port.clone()
     }
 
     pub fn schema_read_port(&self) -> Option<Arc<dyn ProductCatalogSchemaReadPort>> {
         self.schema_read_port.clone()
+    }
+
+    pub fn storefront_tag_read_port(&self) -> Option<Arc<dyn ProductStorefrontTagReadPort>> {
+        self.storefront_tag_read_port.clone()
     }
 
     pub const fn profile(&self) -> ProductCatalogReadProfile {

--- a/crates/rustok-product/src/storefront_tag_read_port.rs
+++ b/crates/rustok-product/src/storefront_tag_read_port.rs
@@ -1,0 +1,261 @@
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{CatalogService, CommerceError, entities};
+
+const HYDRATE_STOREFRONT_PRODUCT_TAGS_OPERATION: &str = "hydrate_storefront_product_tags";
+const MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProductStorefrontTagHydrationRequest {
+    pub product_ids: Vec<Uuid>,
+    pub fallback_locale: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProductStorefrontTagHydration {
+    pub items: Vec<ProductStorefrontTagHydrationItem>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProductStorefrontTagHydrationItem {
+    pub product_id: Uuid,
+    pub tags: Vec<String>,
+}
+
+/// Product-owned post-page tag projection.
+///
+/// Consumers provide only Product identities that were already selected by an authoritative page. Product
+/// remains responsible for product-tag relation ordering, Taxonomy requested/fallback name resolution,
+/// canonical-key fallback, and legacy metadata-tag compatibility.
+#[async_trait]
+pub trait ProductStorefrontTagReadPort: Send + Sync {
+    async fn hydrate_storefront_product_tags(
+        &self,
+        context: PortContext,
+        request: ProductStorefrontTagHydrationRequest,
+    ) -> Result<ProductStorefrontTagHydration, PortError>;
+}
+
+#[async_trait]
+impl ProductStorefrontTagReadPort for CatalogService {
+    async fn hydrate_storefront_product_tags(
+        &self,
+        context: PortContext,
+        request: ProductStorefrontTagHydrationRequest,
+    ) -> Result<ProductStorefrontTagHydration, PortError> {
+        let owner_operation = HYDRATE_STOREFRONT_PRODUCT_TAGS_OPERATION;
+        require_tag_read_context(&context, owner_operation)?;
+        validate_request(&context, owner_operation, &request)?;
+        let tenant_id = parse_tenant_id(&context, owner_operation)?;
+        if request.product_ids.is_empty() {
+            return Ok(ProductStorefrontTagHydration { items: Vec::new() });
+        }
+
+        let products = entities::product::Entity::find()
+            .filter(entities::product::Column::TenantId.eq(tenant_id))
+            .filter(entities::product::Column::Id.is_in(request.product_ids.clone()))
+            .all(self.database())
+            .await
+            .map_err(|error| {
+                tag_error_to_port_error(
+                    &context,
+                    owner_operation,
+                    CommerceError::Database(error),
+                )
+            })?;
+        if products.len() != request.product_ids.len() {
+            tracing::error!(
+                requested = request.product_ids.len(),
+                found = products.len(),
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                operation = owner_operation,
+                code = "product.storefront_tag_product_missing",
+                "Storefront tag hydration Product page contains an owner-missing identity"
+            );
+            return Err(PortError::invariant_violation(
+                "product.storefront_tag_product_missing",
+                "product tag projection could not be completed safely",
+            ));
+        }
+
+        let mut tags_by_product = self
+            .load_product_tag_map(
+                tenant_id,
+                &products,
+                context.locale.as_str(),
+                Some(request.fallback_locale.as_str()),
+            )
+            .await
+            .map_err(|error| tag_error_to_port_error(&context, owner_operation, error))?;
+        let items = request
+            .product_ids
+            .into_iter()
+            .map(|product_id| ProductStorefrontTagHydrationItem {
+                product_id,
+                tags: tags_by_product.remove(&product_id).unwrap_or_default(),
+            })
+            .collect();
+        Ok(ProductStorefrontTagHydration { items })
+    }
+}
+
+fn validate_request(
+    context: &PortContext,
+    owner_operation: &'static str,
+    request: &ProductStorefrontTagHydrationRequest,
+) -> Result<(), PortError> {
+    if request.product_ids.len() > MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS {
+        return Err(tag_validation_error(
+            context,
+            owner_operation,
+            "product.storefront_tag_page_too_large",
+            "product tag projection request is too large",
+        ));
+    }
+    if request.fallback_locale.trim().is_empty() {
+        return Err(tag_validation_error(
+            context,
+            owner_operation,
+            "product.storefront_tag_fallback_locale_required",
+            "product tag projection fallback locale is required",
+        ));
+    }
+
+    let mut seen = HashSet::with_capacity(request.product_ids.len());
+    for product_id in &request.product_ids {
+        if product_id.is_nil() {
+            return Err(tag_validation_error(
+                context,
+                owner_operation,
+                "product.storefront_tag_product_id_invalid",
+                "product tag projection Product identity is invalid",
+            ));
+        }
+        if !seen.insert(*product_id) {
+            return Err(tag_validation_error(
+                context,
+                owner_operation,
+                "product.storefront_tag_product_id_duplicate",
+                "product tag projection Product identities must be unique",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn require_tag_read_context(
+    context: &PortContext,
+    owner_operation: &'static str,
+) -> Result<(), PortError> {
+    context
+        .require_policy(PortCallPolicy::read())
+        .map_err(|error| {
+            tracing::warn!(
+                internal_code = %error.code,
+                internal_message = %error.message,
+                kind = ?error.kind,
+                retryable = error.retryable,
+                correlation_id = %context.correlation_id,
+                tenant_id = %context.tenant_id,
+                operation = owner_operation,
+                code = "product.storefront_tag_context_invalid",
+                "Product Storefront tag read context was rejected"
+            );
+            let PortError {
+                kind,
+                code,
+                retryable,
+                ..
+            } = error;
+            match kind {
+                PortErrorKind::Timeout => PortError::timeout(code, "product tag request context is invalid"),
+                PortErrorKind::Validation => {
+                    PortError::validation(code, "product tag request context is invalid")
+                }
+                kind => PortError::new(
+                    kind,
+                    "product.storefront_tag_context_invalid",
+                    "product tag request context is invalid",
+                    retryable,
+                ),
+            }
+        })
+}
+
+fn parse_tenant_id(context: &PortContext, owner_operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|error| {
+        tracing::warn!(
+            error = ?error,
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation = owner_operation,
+            code = "product.tenant_id_invalid",
+            "Product Storefront tag tenant context is invalid"
+        );
+        PortError::validation(
+            "product.tenant_id_invalid",
+            "product tag request context is invalid",
+        )
+    })
+}
+
+fn tag_validation_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    code: &'static str,
+    message: &'static str,
+) -> PortError {
+    tracing::warn!(
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation = owner_operation,
+        code,
+        "Product Storefront tag hydration request was rejected"
+    );
+    PortError::validation(code, message)
+}
+
+fn tag_error_to_port_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    error: CommerceError,
+) -> PortError {
+    let code = match &error {
+        CommerceError::Database(_) => "product.database_unavailable",
+        CommerceError::Validation(_) => "product.validation",
+        CommerceError::ProductNotFound(_) => "product.product_not_found",
+        _ => "product.invariant_violation",
+    };
+    tracing::error!(
+        error = ?error,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation = owner_operation,
+        code,
+        "Product Storefront tag owner read failed"
+    );
+
+    match error {
+        CommerceError::Database(_) => PortError::unavailable(
+            "product.database_unavailable",
+            "product storage is temporarily unavailable",
+        ),
+        CommerceError::Validation(_) => {
+            PortError::validation("product.validation", "product tag request is invalid")
+        }
+        CommerceError::ProductNotFound(_) => {
+            PortError::not_found("product.product_not_found", "product was not found")
+        }
+        _ => PortError::invariant_violation(
+            "product.invariant_violation",
+            "product tag projection could not be completed safely",
+        ),
+    }
+}

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -28,6 +28,7 @@ for (const forbidden of [
   'SharedIndexQueryRuntime',
   'execute_localized_query',
   'project_product_storefront_index_page',
+  'hydrate_storefront_product_tags',
 ]) {
   if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
 }
@@ -79,6 +80,58 @@ requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_re
   'SELECT id FROM channels WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2',
 ]);
 
+const tagPortPath = 'crates/rustok-product/src/storefront_tag_read_port.rs';
+const tagPort = requireMarkers(tagPortPath, [
+  'const MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48;',
+  'pub struct ProductStorefrontTagHydrationRequest',
+  'pub product_ids: Vec<Uuid>',
+  'pub fallback_locale: String',
+  'pub struct ProductStorefrontTagHydration',
+  'pub trait ProductStorefrontTagReadPort',
+  'impl ProductStorefrontTagReadPort for CatalogService',
+  'entities::product::Column::TenantId.eq(tenant_id)',
+  'entities::product::Column::Id.is_in(request.product_ids.clone())',
+  'products.len() != request.product_ids.len()',
+  '.load_product_tag_map(',
+  'context.locale.as_str()',
+  'Some(request.fallback_locale.as_str())',
+]);
+for (const forbidden of ['rustok_index', 'IndexQueryPage', 'IndexValue']) {
+  if (tagPort.includes(forbidden)) fail(`${tagPortPath} must remain Product-owned and Index-neutral: ${forbidden}`);
+}
+requireMarkers('crates/rustok-product/src/services/catalog/tags.rs', [
+  'pub async fn load_product_tag_map(',
+  'TaxonomyService::new(self.db.clone())',
+  '.resolve_term_names(tenant_id, &ordered_term_ids, locale, fallback_locale)',
+  'metadata_has_tags_field(&product.metadata)',
+  'normalize_tag_names(&extract_metadata_tags(&product.metadata))',
+]);
+requireMarkers('crates/rustok-taxonomy/src/services.rs', [
+  'pub async fn resolve_term_names(',
+  'resolve_by_locale_with_fallback(',
+  '.unwrap_or_else(|| term.canonical_key.clone())',
+]);
+requireMarkers('crates/rustok-commerce/tests/product_taxonomy_tags.rs', [
+  'legacy_metadata_tags_are_used_as_read_fallback_but_not_exposed_publicly',
+  '"tags": ["legacy", "sale", "legacy"]',
+  'vec!["legacy".to_string(), "sale".to_string()]',
+]);
+
+const runtimePath = 'crates/rustok-product/src/runtime.rs';
+const runtime = requireMarkers(runtimePath, [
+  'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
+  'storefront_tag_read_port: None',
+  '.with_storefront_tag_read_port(catalog)',
+  'pub fn with_storefront_tag_read_port(',
+  'pub fn storefront_tag_read_port(&self)',
+  'pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)',
+]);
+const externalStart = runtime.indexOf('pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)');
+const withTagStart = runtime.indexOf('pub fn with_storefront_tag_read_port(');
+if (externalStart < 0 || withTagStart <= externalStart || runtime.slice(externalStart, withTagStart).includes('with_storefront_tag_read_port')) {
+  fail(`${runtimePath} external profile must remain compatible without an implicit embedded tag provider`);
+}
+
 const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
 const executor = requireMarkers(executorPath, [
   'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
@@ -90,12 +143,22 @@ const executor = requireMarkers(executorPath, [
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
   'pub(crate) public_projected:',
   'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
+  'pub(crate) tag_hydration:',
+  'Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>>',
+  'TagReadPortUnavailable',
   'list_filtered_published_products(',
   'classify_product_storefront_index_page_scope(&query)',
   '.resolve_storefront_attribute_filters(',
   '.execute_localized_query(index_query)',
   'let public_projected = projected',
   '.map(project_product_storefront_index_page);',
+  'let tag_hydration = match projected.as_ref()',
+  'self.hydrate_projected_tags(context, fallback_locale, projected)',
+  'async fn hydrate_projected_tags(',
+  '.storefront_tag_read_port()',
+  '.map(|item| item.entity_id)',
+  'ProductStorefrontTagHydrationRequest',
+  '.hydrate_storefront_product_tags(',
   'let comparison = projected',
   'compare_owner_and_index(&authoritative, projected)',
   'pub(crate) authoritative: StorefrontProductList',
@@ -105,37 +168,36 @@ for (const forbidden of [
   'UNRESTRICTED_CHANNEL_SENTINEL',
   '.min(MAX_INDEX_OFFSET_DEPTH)',
   'Pagination::Cursor',
+  'TaxonomyService',
+  'product_tag::',
+  'DatabaseConnection',
 ]) {
-  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden request-shape shortcut ${forbidden}`);
+  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden shortcut/storage dependency ${forbidden}`);
 }
 const executeProjectedStart = executor.indexOf('async fn execute_projected(');
 const compareStart = executor.indexOf('fn compare_owner_and_index(');
-if (
-  executeProjectedStart < 0 ||
-  compareStart <= executeProjectedStart ||
-  executor.slice(executeProjectedStart, compareStart).includes('project_product_storefront_index_page')
-) {
-  fail(`${executorPath} public Product projection must remain outside raw Index execution`);
+if (executeProjectedStart < 0 || compareStart <= executeProjectedStart) {
+  fail(`${executorPath} raw Index execution boundary is missing`);
+}
+const rawExecution = executor.slice(executeProjectedStart, compareStart);
+for (const forbidden of ['project_product_storefront_index_page', 'hydrate_storefront_product_tags', 'storefront_tag_read_port()']) {
+  if (rawExecution.includes(forbidden)) {
+    fail(`${executorPath} post-page enrichment leaked into raw Index execution: ${forbidden}`);
+  }
 }
 
 const projectionPath = 'crates/rustok-distribution/src/product_index/storefront_projection.rs';
 const projection = requireMarkers(projectionPath, [
   'const UNTITLED_PRODUCT: &str = "Untitled product";',
-  'pub(crate) enum ProductStorefrontIndexPublicProjectionError',
   'pub(crate) fn project_product_storefront_index_page(',
   'apply_string_placeholder(item, "title", UNTITLED_PRODUCT)?;',
   'apply_string_placeholder(item, "handle", "")?;',
-  'MissingField',
-  'DuplicateField',
-  'InvalidFieldValue',
   'projected.exact_count, Some(9)',
   'projected.next_cursor.as_deref(), Some("opaque-cursor")',
   'value(&projected.items[0], "tag_ids")',
 ]);
 for (const forbidden of ['FilterExpr', 'OrderExpr', 'LocalizedEntityQuery', 'execute_localized_query']) {
-  if (projection.includes(forbidden)) {
-    fail(`${projectionPath} must remain post-page only; found ${forbidden}`);
-  }
+  if (projection.includes(forbidden)) fail(`${projectionPath} must remain post-page only; found ${forbidden}`);
 }
 
 const builderPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
@@ -146,19 +208,15 @@ const builder = requireMarkers(builderPath, [
   'const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;',
   'ProductStorefrontIndexShadowError::OffsetTooDeep',
 ]);
-for (const forbidden of ['Untitled product', 'project_product_storefront_index_page']) {
-  if (builder.includes(forbidden)) {
-    fail(`${builderPath} must not feed Product public placeholders into query construction: ${forbidden}`);
-  }
+for (const forbidden of ['Untitled product', 'project_product_storefront_index_page', 'hydrate_storefront_product_tags']) {
+  if (builder.includes(forbidden)) fail(`${builderPath} must not feed post-page Product semantics into query construction: ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'assert_eq!(owner_c.title, "Untitled product");',
-  'assert_eq!(owner_c.handle, "");',
   'assert_eq!(projected_string(index_c, "title")?, None);',
-  'assert_eq!(projected_string(index_c, "handle")?, None);',
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_eav_postgres_tests.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_EAV_EQUIVALENCE_DATABASE_URL',
@@ -177,16 +235,25 @@ const productIndexPath = 'crates/rustok-distribution/src/product_index/product.r
 const productIndex = requireMarkers(productIndexPath, [
   'assert_eq!(schema.fields.len(), 15);',
   'many_field("tag_ids", IndexValueType::Uuid, true, false)',
+  'jsonb_agg(product_tag.term_id ORDER BY product_tag.term_id) AS tag_ids',
   'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
-for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)']) {
-  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema marker ${forbidden}`);
+for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'tag_names', 'localized_tag_names']) {
+  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema/source marker ${forbidden}`);
 }
 
 requireMarkers('scripts/verify/verify-index-product-storefront-public-projection.mjs', [
   'Product public placeholders are post-page only',
   'raw Index null evidence and tag_ids remain unchanged',
+]);
+requireMarkers('scripts/verify/verify-index-product-storefront-tag-hydration.mjs', [
+  'Product IDs from the fixed raw Index page drive bounded Product-owned tag hydration',
+  'legacy metadata semantics retained',
+]);
+requireMarkers('scripts/verify/verify-product-catalog-read-runtime-composition.mjs', [
+  'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
+  'external profile must not silently install embedded tag hydration',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-deep-page-policy.mjs', [
   'OwnerNativeDeepPage { offset: u64 }',
@@ -205,22 +272,28 @@ requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `public_projection_source_complete_taxonomy_hydration_pending`',
+  'Status: `tag_hydration_source_complete_serving_budget_pending`',
   'Mounted Storefront remains owner-native',
-  'Product public placeholder projection — source complete',
-  '`public_projected`',
-  'Taxonomy tag names',
+  'Product-owned tag hydration — source complete',
+  '`ProductStorefrontTagReadPort`',
+  'legacy `metadata.tags`',
+  'serving latency/deadline/budget policy',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-tag-hydration.md', [
+  'Status: `source_complete_serving_budget_pending`',
+  '`ProductStorefrontTagReadPort::hydrate_storefront_product_tags`',
+  'already-selected Product IDs',
+  'legacy `metadata.tags`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-public-projection.md', [
-  'Status: `source_complete_taxonomy_hydration_pending`',
-  '`projected` — raw generic Index page',
-  '`public_projected` — optional Product public page',
-  '`tag_ids`',
+  'Status: `source_complete_with_separate_tag_hydration`',
+  '`tag_hydration` — separate Product-owner tag projection',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-storefront-public-projection.mjs'",
+  "'verify-index-product-storefront-tag-hydration.mjs'",
   "'verify-index-product-storefront-deep-page-policy.mjs'",
   "'verify-index-product-storefront-collation-postgres-packet.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; raw Index evidence and Product post-page public placeholders are separated while Taxonomy hydration, evidence admission and serving gates remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; raw Index page, public placeholders and Product-owned tag hydration are source-separated while serving budget and evidence admission remain pending');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -28,20 +28,21 @@ const source = requireMarkers(executorPath, [
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
   'pub(crate) public_projected:',
   'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
-  'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
-  'OwnerNativeChannelLess',
-  'ChannelLessOwnerNative',
-  'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
-  'OwnerNativeDeepPage { offset: u64 }',
-  'DeepPageOwnerNative { offset: u64 }',
-  'list_filtered_published_products(',
+  'pub(crate) tag_hydration:',
+  'Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>>',
+  'ProductStorefrontIndexTagHydrationError',
+  'TagReadPortUnavailable',
   'let projected = self',
   '.execute_projected(',
   'let public_projected = projected',
-  '.as_ref()',
-  '.ok()',
-  '.cloned()',
   '.map(project_product_storefront_index_page);',
+  'let tag_hydration = match projected.as_ref()',
+  'self.hydrate_projected_tags(context, fallback_locale, projected)',
+  'async fn hydrate_projected_tags(',
+  '.storefront_tag_read_port()',
+  '.map(|item| item.entity_id)',
+  'ProductStorefrontTagHydrationRequest',
+  '.hydrate_storefront_product_tags(',
   'let comparison = projected',
   'compare_owner_and_index(&authoritative, projected)',
   'classify_product_storefront_index_channel_scope(',
@@ -50,29 +51,35 @@ const source = requireMarkers(executorPath, [
   '.resolve_storefront_attribute_filters(',
   'build_product_storefront_index_shadow_query(',
   '.execute_localized_query(index_query)',
-  'identities_match: authoritative_ids == projected_ids',
-  'projected.exact_count == Some(authoritative.total)',
-  'projected.has_more == authoritative.has_next',
 ]);
 
 const ownerPosition = source.indexOf('list_filtered_published_products(');
 const projectedPosition = source.indexOf('let projected = self');
 const publicPosition = source.indexOf('let public_projected = projected');
+const hydrationPosition = source.indexOf('let tag_hydration = match projected.as_ref()');
 const comparisonPosition = source.indexOf('let comparison = projected');
 if (
   ownerPosition < 0 ||
   projectedPosition <= ownerPosition ||
   publicPosition <= projectedPosition ||
+  hydrationPosition <= projectedPosition ||
   comparisonPosition <= projectedPosition
 ) {
-  fail('owner success must precede raw Index projection, and raw page must precede public projection/comparison');
+  fail('owner success must precede raw Index page, and all enrichment/comparison must follow that raw page');
 }
 
 const rawStart = source.indexOf('async fn execute_projected(');
 const compareStart = source.indexOf('fn compare_owner_and_index(');
 if (rawStart < 0 || compareStart <= rawStart) fail('raw projected execution boundary is missing');
-if (source.slice(rawStart, compareStart).includes('project_product_storefront_index_page')) {
-  fail('Product public placeholder transform must not run inside raw Index execution');
+const rawExecution = source.slice(rawStart, compareStart);
+for (const forbidden of [
+  'project_product_storefront_index_page',
+  'hydrate_storefront_product_tags',
+  'storefront_tag_read_port()',
+]) {
+  if (rawExecution.includes(forbidden)) {
+    fail(`post-page enrichment must not run inside raw Index execution: ${forbidden}`);
+  }
 }
 
 for (const forbidden of [
@@ -80,6 +87,8 @@ for (const forbidden of [
   'CatalogService::new',
   'ProductCatalogSchemaService::new',
   'PostgresIndexQueryPort',
+  'TaxonomyService',
+  'product_tag::',
   'query_all(',
   'query_one(',
   'CHANNEL_LESS_SENTINEL',
@@ -87,21 +96,20 @@ for (const forbidden of [
   '.min(MAX_INDEX_OFFSET_DEPTH)',
   'Pagination::Cursor',
 ]) {
-  if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports and preserve owner request semantics; found ${forbidden}`);
+  if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports only; found ${forbidden}`);
 }
 
+requireMarkers('crates/rustok-product/src/storefront_tag_read_port.rs', [
+  'pub trait ProductStorefrontTagReadPort',
+  'MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48',
+  '.load_product_tag_map(',
+]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_projection.rs', [
   'pub(crate) fn project_product_storefront_index_page(',
-  'const UNTITLED_PRODUCT: &str = "Untitled product";',
-  'apply_string_placeholder(item, "handle", "")?;',
+  'value(&projected.items[0], "tag_ids")',
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
-  'mod storefront_projection;',
-  'ProductStorefrontIndexPublicProjectionError',
-  'project_product_storefront_index_page',
-  'mod storefront_shadow_executor;',
-  'ProductStorefrontIndexShadowExecutor',
-  'ProductStorefrontIndexPageScopeDecision',
+  'ProductStorefrontIndexTagHydrationError',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -113,8 +121,9 @@ for (const forbidden of [
   'ProductStorefrontIndexShadowExecutor',
   'execute_localized_query',
   'project_product_storefront_index_page',
+  'hydrate_storefront_product_tags',
 ]) {
   if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
-console.log('[verify-index-product-storefront-shadow-executor] owner-first raw Index evidence and derived post-page Product public projection are source-locked; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-shadow-executor] raw Index page, public placeholders and Product-owned tag hydration are source-separated; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-product-storefront-tag-hydration.mjs
+++ b/scripts/verify/verify-index-product-storefront-tag-hydration.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-tag-hydration] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const portPath = 'crates/rustok-product/src/storefront_tag_read_port.rs';
+const port = requireMarkers(portPath, [
+  'const MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48;',
+  'pub struct ProductStorefrontTagHydrationRequest',
+  'pub product_ids: Vec<Uuid>',
+  'pub fallback_locale: String',
+  'pub struct ProductStorefrontTagHydration',
+  'pub struct ProductStorefrontTagHydrationItem',
+  'pub trait ProductStorefrontTagReadPort',
+  'async fn hydrate_storefront_product_tags(',
+  'impl ProductStorefrontTagReadPort for CatalogService',
+  'entities::product::Column::TenantId.eq(tenant_id)',
+  'entities::product::Column::Id.is_in(request.product_ids.clone())',
+  'products.len() != request.product_ids.len()',
+  '.load_product_tag_map(',
+  'context.locale.as_str()',
+  'Some(request.fallback_locale.as_str())',
+  'request.product_ids',
+  'tags: tags_by_product.remove(&product_id).unwrap_or_default()',
+  'product.storefront_tag_product_missing',
+]);
+for (const forbidden of [
+  'rustok_index',
+  'IndexQueryPage',
+  'IndexValue',
+]) {
+  if (port.includes(forbidden)) fail(`${portPath} Product owner capability must not depend on Index: ${forbidden}`);
+}
+
+const ownerTagsPath = 'crates/rustok-product/src/services/catalog/tags.rs';
+requireMarkers(ownerTagsPath, [
+  'pub async fn load_product_tag_map(',
+  'product_tag::Column::ProductId.is_in(product_ids.clone())',
+  'TaxonomyService::new(self.db.clone())',
+  '.resolve_term_names(tenant_id, &ordered_term_ids, locale, fallback_locale)',
+  'metadata_has_tags_field(&product.metadata)',
+  'normalize_tag_names(&extract_metadata_tags(&product.metadata))',
+]);
+
+const taxonomyPath = 'crates/rustok-taxonomy/src/services.rs';
+requireMarkers(taxonomyPath, [
+  'pub async fn resolve_term_names(',
+  'resolve_by_locale_with_fallback(',
+  '.unwrap_or_else(|| term.canonical_key.clone())',
+]);
+
+const legacyEvidencePath = 'crates/rustok-commerce/tests/product_taxonomy_tags.rs';
+requireMarkers(legacyEvidencePath, [
+  'legacy_metadata_tags_are_used_as_read_fallback_but_not_exposed_publicly',
+  '"tags": ["legacy", "sale", "legacy"]',
+  'vec!["legacy".to_string(), "sale".to_string()]',
+]);
+
+const sourcePath = 'crates/rustok-distribution/src/product_index/product.rs';
+const productSource = requireMarkers(sourcePath, [
+  'product_tag_ids AS (',
+  'jsonb_agg(product_tag.term_id ORDER BY product_tag.term_id) AS tag_ids',
+  'LEFT JOIN product_tag_ids tags',
+  "COALESCE(tags.tag_ids, '[]'::jsonb) AS tag_ids",
+  'many_field("tag_ids", IndexValueType::Uuid, true, false)',
+]);
+if (productSource.includes('metadata.tags') || productSource.includes("metadata->'tags'")) {
+  fail(`${sourcePath} must not invent tag identities from legacy metadata strings`);
+}
+
+const runtimePath = 'crates/rustok-product/src/runtime.rs';
+const runtime = requireMarkers(runtimePath, [
+  'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
+  'storefront_tag_read_port: None',
+  '.with_storefront_tag_read_port(catalog)',
+  'pub fn with_storefront_tag_read_port(',
+  'pub fn storefront_tag_read_port(&self)',
+  'pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)',
+]);
+const externalStart = runtime.indexOf('pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)');
+const withTagStart = runtime.indexOf('pub fn with_storefront_tag_read_port(');
+if (externalStart < 0 || withTagStart <= externalStart) fail('Product external runtime boundary markers are missing');
+const externalBody = runtime.slice(externalStart, withTagStart);
+if (externalBody.includes('with_storefront_tag_read_port')) {
+  fail(`${runtimePath} external Product runtime must not silently install an embedded tag provider`);
+}
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) tag_hydration:',
+  'Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>>',
+  'ProductStorefrontIndexTagHydrationError',
+  'TagReadPortUnavailable',
+  'let tag_hydration = match projected.as_ref()',
+  'self.hydrate_projected_tags(context, fallback_locale, projected)',
+  'async fn hydrate_projected_tags(',
+  '.storefront_tag_read_port()',
+  '.map(|item| item.entity_id)',
+  'ProductStorefrontTagHydrationRequest',
+  'product_ids,',
+  'fallback_locale,',
+  '.hydrate_storefront_product_tags(',
+]);
+for (const forbidden of [
+  'TaxonomyService',
+  'taxonomy_term',
+  'product_tag::',
+  'DatabaseConnection',
+  'query_all(',
+  'query_one(',
+]) {
+  if (executor.includes(forbidden)) {
+    fail(`${executorPath} must consume Product owner tag capability, not read storage/Taxonomy directly: ${forbidden}`);
+  }
+}
+const projectedPosition = executor.indexOf('let projected = self');
+const hydrationPosition = executor.indexOf('let tag_hydration = match projected.as_ref()');
+if (projectedPosition < 0 || hydrationPosition <= projectedPosition) {
+  fail('tag hydration must begin only after the raw Index page exists');
+}
+
+const publicProjectionPath = 'crates/rustok-distribution/src/product_index/storefront_projection.rs';
+requireMarkers(publicProjectionPath, [
+  'value(&projected.items[0], "tag_ids")',
+  'IndexValue::List(vec![IndexValue::Uuid(tag_id)])',
+]);
+
+console.log('[verify-index-product-storefront-tag-hydration] Product IDs from the fixed raw Index page drive bounded Product-owned tag hydration with Taxonomy and legacy metadata semantics retained');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -88,6 +88,7 @@ const scripts = [
   'verify-index-product-storefront-channel-scope-policy.mjs',
   'verify-index-product-storefront-deep-page-policy.mjs',
   'verify-index-product-storefront-public-projection.mjs',
+  'verify-index-product-storefront-tag-hydration.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',

--- a/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
+++ b/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
@@ -31,11 +31,13 @@ function forbid(source, marker, description) {
 
 const runtimePath = "crates/rustok-product/src/runtime.rs";
 const libPath = "crates/rustok-product/src/lib.rs";
+const tagPortPath = "crates/rustok-product/src/storefront_tag_read_port.rs";
 const hostPath = "apps/server/src/services/commerce_provider_runtime.rs";
 const registryPath = "crates/rustok-product/contracts/product-fba-registry.json";
 const planPath = "crates/rustok-product/docs/implementation-plan.md";
 const runtime = read(runtimePath);
 const lib = read(libPath);
+const tagPort = read(tagPortPath);
 const host = read(hostPath);
 const registry = read(registryPath);
 const plan = read(planPath);
@@ -45,16 +47,28 @@ requireAll(runtime, [
   "EmbeddedNative",
   "External",
   "pub struct ProductCatalogReadRuntime",
+  "storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>",
   "pub fn in_process",
+  ".with_storefront_tag_read_port(catalog)",
   "pub fn external",
   "pub fn read_port",
+  "pub fn storefront_tag_read_port",
   "pub const fn profile",
 ], "Product owner runtime");
 requireAll(lib, [
   "mod runtime;",
+  "mod storefront_tag_read_port;",
   "ProductCatalogReadProfile",
   "ProductCatalogReadRuntime",
+  "ProductStorefrontTagReadPort",
+  "ProductStorefrontTagHydrationRequest",
 ], "Product public exports");
+requireAll(tagPort, [
+  "pub trait ProductStorefrontTagReadPort",
+  "impl ProductStorefrontTagReadPort for CatalogService",
+  "MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48",
+  ".load_product_tag_map(",
+], "Product optional Storefront tag capability");
 requireAll(host, [
   "host.shared_get::<rustok_product::ProductCatalogReadRuntime>()",
   "server.shared_get::<rustok_product::ProductCatalogReadRuntime>()",
@@ -94,6 +108,14 @@ requireAll(plan, [
   "Concrete external transport execution remains open",
   "verify-product-catalog-read-runtime-composition.mjs",
 ], "Product implementation plan");
+
+const externalStart = runtime.indexOf("pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)");
+const withTagStart = runtime.indexOf("pub fn with_storefront_tag_read_port(");
+if (externalStart < 0 || withTagStart <= externalStart) {
+  failures.push("Product owner runtime: external/tag capability boundaries are missing");
+} else if (runtime.slice(externalStart, withTagStart).includes("with_storefront_tag_read_port")) {
+  failures.push("Product owner runtime: external profile must not silently install embedded tag hydration");
+}
 
 if (failures.length > 0) {
   console.error("product catalog read runtime composition verification failed:");


### PR DESCRIPTION
## Summary

- add a separate optional Product-owned `ProductStorefrontTagReadPort` for post-page Storefront tag hydration;
- key hydration by the already-selected Product IDs rather than only Index `tag_ids`, because current Index `tag_ids` are relation-backed while Product owner reads still preserve legacy `metadata.tags` when no tag relations exist;
- bound requests to at most 48 unique, non-nil Product IDs and verify every identity tenant-scoped before hydration;
- reuse `CatalogService::load_product_tag_map` so relation ordering, Taxonomy requested→fallback localization, canonical-key fallback, and legacy normalized metadata-tag fallback remain Product-owned;
- wire the same `CatalogService` as the optional capability in `ProductCatalogReadRuntime::in_process` while keeping `external(...)` source-compatible and without an implicit embedded fallback;
- keep `product.catalog_read.v1` / existing gRPC adapters unchanged in this slice; the new capability is embedded-optional and external transport remains open;
- extend the non-serving Storefront shadow execution with a separate `tag_hydration` result only after raw Index `projected` succeeds;
- derive hydration Product IDs from `projected.items`, not the authoritative owner page and not `tag_ids`;
- keep distribution free of Product/Taxonomy SQL and `TaxonomyService` construction;
- preserve raw `projected`, `public_projected`, identity/order/count/page comparison, Product key 4 and the 15-field schema unchanged;
- add focused source guards/docs and advance the M7 cursor to a non-serving serving-budget/deadline policy.

## Boundary

Mounted Storefront remains owner-native. This PR does not add tag names to Product Index schema, change routing key, widen `product.catalog_read.v1` transport, execute PostgreSQL evidence, admit collation parity, define serving latency/deadline budgets, or switch Storefront traffic.

Missing external tag capability or hydration failure remains a separate fail-closed post-page result and cannot replace the successful Product owner result or mutate the raw/public Index pages.

## Main recheck

The implementation branch started from `main@f949c7c3ee25dcabbf33ff2b7627fae1ea3b9e3b`. Current `main@08ae9c8b0debc83486beac8ec00a97960fee0c8b` advanced through #3253 Product GraphQL lifecycle and #3252 Groups governance. #3253 changed only `crates/rustok-product/src/catalog_command_port.rs` on the Product side; none of the tag-hydration Product/runtime files overlap. Final compare contains 15 expected Product/Index capability, composition, guard and documentation files and no Product Index schema/source/query-builder changes.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.