### PR TITLE
feat(index): add Product Storefront serving-budget policy

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -14,6 +14,12 @@ mod storefront_projection;
 pub(crate) use storefront_projection::{
     ProductStorefrontIndexPublicProjectionError, project_product_storefront_index_page,
 };
+mod storefront_serving_budget;
+pub(crate) use storefront_serving_budget::{
+    ProductStorefrontIndexServingBudget, ProductStorefrontIndexServingBudgetDecision,
+    ProductStorefrontIndexServingBudgetError, ProductStorefrontIndexServingBudgetObservation,
+    classify_product_storefront_index_serving_budget,
+};
 mod storefront_shadow;
 pub(crate) use storefront_shadow::{
     ProductStorefrontIndexShadowError, build_product_storefront_index_shadow_query,

--- a/crates/rustok-distribution/src/product_index/storefront_serving_budget.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_serving_budget.rs
@@ -1,0 +1,274 @@
+use rustok_api::PortContext;
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProductStorefrontIndexServingBudget {
+    index_execution_ms: u64,
+    tag_hydration_ms: u64,
+    safety_margin_ms: u64,
+    required_ms: u64,
+}
+
+impl ProductStorefrontIndexServingBudget {
+    pub(crate) fn new(
+        index_execution_ms: u64,
+        tag_hydration_ms: u64,
+        safety_margin_ms: u64,
+    ) -> Result<Self, ProductStorefrontIndexServingBudgetError> {
+        if index_execution_ms == 0 {
+            return Err(ProductStorefrontIndexServingBudgetError::ZeroIndexExecutionBudget);
+        }
+        if tag_hydration_ms == 0 {
+            return Err(ProductStorefrontIndexServingBudgetError::ZeroTagHydrationBudget);
+        }
+        let required_ms = index_execution_ms
+            .checked_add(tag_hydration_ms)
+            .and_then(|value| value.checked_add(safety_margin_ms))
+            .ok_or(ProductStorefrontIndexServingBudgetError::BudgetOverflow)?;
+        Ok(Self {
+            index_execution_ms,
+            tag_hydration_ms,
+            safety_margin_ms,
+            required_ms,
+        })
+    }
+
+    pub(crate) const fn index_execution_ms(self) -> u64 {
+        self.index_execution_ms
+    }
+
+    pub(crate) const fn tag_hydration_ms(self) -> u64 {
+        self.tag_hydration_ms
+    }
+
+    pub(crate) const fn safety_margin_ms(self) -> u64 {
+        self.safety_margin_ms
+    }
+
+    pub(crate) const fn required_ms(self) -> u64 {
+        self.required_ms
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProductStorefrontIndexServingBudgetObservation {
+    /// Remaining request budget measured by the host at the post-owner handoff point.
+    ///
+    /// This must not be reconstructed from `PortContext.deadline_ms`: that field carries the original
+    /// duration budget and does not automatically decrease while the authoritative owner call executes.
+    pub(crate) remaining_ms: Option<u64>,
+    pub(crate) tag_hydration_available: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProductStorefrontIndexServingBudgetDecision {
+    Eligible {
+        index_execution_ms: u64,
+        tag_hydration_ms: u64,
+        safety_margin_ms: u64,
+    },
+    OwnerNativeMissingDeadline,
+    OwnerNativeBudgetPolicyUnavailable,
+    OwnerNativeRemainingBudgetUnavailable,
+    OwnerNativeInvalidRemainingBudget {
+        deadline_ms: u64,
+        remaining_ms: u64,
+    },
+    OwnerNativeTagHydrationUnavailable,
+    OwnerNativeInsufficientBudget {
+        required_ms: u64,
+        remaining_ms: u64,
+    },
+}
+
+impl ProductStorefrontIndexServingBudgetDecision {
+    pub(crate) const fn is_eligible(self) -> bool {
+        matches!(self, Self::Eligible { .. })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub(crate) enum ProductStorefrontIndexServingBudgetError {
+    #[error("Product Storefront Index serving budget requires a positive Index execution phase")]
+    ZeroIndexExecutionBudget,
+    #[error("Product Storefront Index serving budget requires a positive Product tag hydration phase")]
+    ZeroTagHydrationBudget,
+    #[error("Product Storefront Index serving budget exceeds the supported millisecond range")]
+    BudgetOverflow,
+}
+
+/// Classify whether a future serving router may spend the remaining request budget on Index plus owner
+/// hydration after the authoritative Product owner call has already completed.
+///
+/// The caller must supply a host-measured `remaining_ms` observation at that exact handoff point. The policy
+/// deliberately does not treat `PortContext.deadline_ms` as remaining time because it is only the original
+/// duration budget. Missing/inconsistent timing information, missing tag capability, or insufficient budget
+/// keeps the request owner-native rather than allowing an unbounded shadow/serving tail.
+pub(crate) fn classify_product_storefront_index_serving_budget(
+    context: &PortContext,
+    budget: Option<ProductStorefrontIndexServingBudget>,
+    observation: ProductStorefrontIndexServingBudgetObservation,
+) -> ProductStorefrontIndexServingBudgetDecision {
+    let Some(deadline_ms) = context.deadline_ms.filter(|deadline_ms| *deadline_ms > 0) else {
+        return ProductStorefrontIndexServingBudgetDecision::OwnerNativeMissingDeadline;
+    };
+    let Some(budget) = budget else {
+        return ProductStorefrontIndexServingBudgetDecision::OwnerNativeBudgetPolicyUnavailable;
+    };
+    let Some(remaining_ms) = observation.remaining_ms else {
+        return ProductStorefrontIndexServingBudgetDecision::OwnerNativeRemainingBudgetUnavailable;
+    };
+    if remaining_ms > deadline_ms {
+        return ProductStorefrontIndexServingBudgetDecision::OwnerNativeInvalidRemainingBudget {
+            deadline_ms,
+            remaining_ms,
+        };
+    }
+    if !observation.tag_hydration_available {
+        return ProductStorefrontIndexServingBudgetDecision::OwnerNativeTagHydrationUnavailable;
+    }
+    if remaining_ms < budget.required_ms() {
+        return ProductStorefrontIndexServingBudgetDecision::OwnerNativeInsufficientBudget {
+            required_ms: budget.required_ms(),
+            remaining_ms,
+        };
+    }
+    ProductStorefrontIndexServingBudgetDecision::Eligible {
+        index_execution_ms: budget.index_execution_ms(),
+        tag_hydration_ms: budget.tag_hydration_ms(),
+        safety_margin_ms: budget.safety_margin_ms(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rustok_api::PortActor;
+
+    use super::*;
+
+    fn context(deadline_ms: Option<u64>) -> PortContext {
+        let context = PortContext::new("tenant", PortActor::system(), "en", "correlation");
+        match deadline_ms {
+            Some(deadline_ms) => context.with_deadline(Duration::from_millis(deadline_ms)),
+            None => context,
+        }
+    }
+
+    fn budget() -> ProductStorefrontIndexServingBudget {
+        ProductStorefrontIndexServingBudget::new(80, 40, 20).unwrap()
+    }
+
+    #[test]
+    fn requires_host_measured_remaining_budget_and_owner_tag_capability() {
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(None),
+                Some(budget()),
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: Some(200),
+                    tag_hydration_available: true,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeMissingDeadline
+        );
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(Some(300)),
+                None,
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: Some(200),
+                    tag_hydration_available: true,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeBudgetPolicyUnavailable
+        );
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(Some(300)),
+                Some(budget()),
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: None,
+                    tag_hydration_available: true,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeRemainingBudgetUnavailable
+        );
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(Some(300)),
+                Some(budget()),
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: Some(301),
+                    tag_hydration_available: true,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeInvalidRemainingBudget {
+                deadline_ms: 300,
+                remaining_ms: 301,
+            }
+        );
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(Some(300)),
+                Some(budget()),
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: Some(200),
+                    tag_hydration_available: false,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeTagHydrationUnavailable
+        );
+    }
+
+    #[test]
+    fn admits_only_when_remaining_budget_covers_all_bounded_phases() {
+        assert_eq!(budget().required_ms(), 140);
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(Some(300)),
+                Some(budget()),
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: Some(139),
+                    tag_hydration_available: true,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeInsufficientBudget {
+                required_ms: 140,
+                remaining_ms: 139,
+            }
+        );
+        assert_eq!(
+            classify_product_storefront_index_serving_budget(
+                &context(Some(300)),
+                Some(budget()),
+                ProductStorefrontIndexServingBudgetObservation {
+                    remaining_ms: Some(140),
+                    tag_hydration_available: true,
+                },
+            ),
+            ProductStorefrontIndexServingBudgetDecision::Eligible {
+                index_execution_ms: 80,
+                tag_hydration_ms: 40,
+                safety_margin_ms: 20,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_zero_phase_budgets_and_overflow() {
+        assert_eq!(
+            ProductStorefrontIndexServingBudget::new(0, 1, 0),
+            Err(ProductStorefrontIndexServingBudgetError::ZeroIndexExecutionBudget)
+        );
+        assert_eq!(
+            ProductStorefrontIndexServingBudget::new(1, 0, 0),
+            Err(ProductStorefrontIndexServingBudgetError::ZeroTagHydrationBudget)
+        );
+        assert_eq!(
+            ProductStorefrontIndexServingBudget::new(u64::MAX, 1, 0),
+            Err(ProductStorefrontIndexServingBudgetError::BudgetOverflow)
+        );
+    }
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product Storefront public projection merge
-`f949c7c3ee25dcabbf33ff2b7627fae1ea3b9e3b` and continued on
-`agent/product-storefront-tag-hydration-20260808`.
+Status overlay rechecked after Product Storefront tag hydration merge
+`5a37e78d50b37785a2a5c119689887f441a94cf9` and continued on
+`agent/product-storefront-serving-budget-policy-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -33,7 +33,9 @@ Source-complete:
   remain typed owner-native without clamp or cursor rewriting;
 - Product Storefront post-page public placeholder projection that keeps raw Index null evidence intact;
 - Product-owned bounded post-page tag hydration keyed by already-selected Product IDs, preserving Taxonomy
-  requested->fallback/canonical-key semantics **and** legacy metadata-only tag fallback;
+  requested->fallback/canonical-key semantics and legacy metadata-only tag fallback;
+- explicit **post-owner serving-budget policy** that requires host-measured remaining budget, positive bounded
+  Index/tag phases, safety margin and selected tag-hydration capability before a future serving path is eligible;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
@@ -57,48 +59,46 @@ offsets above that bound remain typed owner-native after owner success; no clamp
 The raw generic `IndexQueryPage` remains Product-neutral. When requested/fallback localized rows are absent,
 root `title`/`handle` remain `IndexValue::Null` in `projected` and in raw PostgreSQL evidence.
 
-`public_projected` is derived from a clone of successful raw `projected` and maps only:
-
-- `title: Null` -> `"Untitled product"`;
-- `handle: Null` -> `""`.
-
-It preserves item identity/order, count, page boundary, cursor, unrelated fields and `tag_ids`; missing,
-duplicate or wrong-typed title/handle fields fail closed. Raw comparison still uses `projected`.
+`public_projected` is derived from a clone of successful raw `projected` and maps only `title: Null` to
+`"Untitled product"` and `handle: Null` to `""`. It preserves item identity/order, count, page boundary,
+cursor, unrelated fields and `tag_ids`; raw comparison still uses `projected`.
 
 ### Product-owned tag hydration
 
-A naive `tag_ids -> Taxonomy names` adapter is insufficient. Current Product Index `tag_ids` are materialized
-only from `product_tags`, while Product owner read semantics still support legacy `metadata.tags` when a Product
-has no tag relations.
+`ProductStorefrontTagReadPort` accepts only already-selected Product IDs plus fallback locale. The embedded
+Product runtime wires `CatalogService` as this optional capability; external runtimes do not gain an implicit
+embedded fallback.
 
-`ProductStorefrontTagReadPort` therefore accepts only the **already-selected Product IDs** plus fallback locale.
-The embedded Product runtime wires `CatalogService` as this optional capability; external runtimes do not gain
-an implicit embedded fallback.
+It preserves relation ordering, Taxonomy requested->fallback/canonical-key resolution and legacy normalized
+`metadata.tags` when relation-backed tags are absent. `tag_hydration` runs only after raw `projected` succeeds
+and cannot mutate or replace the raw/public page.
 
-The Product owner capability:
+## Post-owner serving-budget policy
 
-- accepts at most 48 unique, non-nil Product IDs;
-- tenant-scopes and verifies every requested Product identity;
-- reuses `CatalogService::load_product_tag_map` rather than reimplementing storage rules;
-- preserves product-tag relation ordering;
-- uses existing `TaxonomyService::resolve_term_names` requested->fallback resolution and canonical-key fallback;
-- preserves legacy normalized `metadata.tags` when no relations exist;
-- returns results in the same Product-ID order supplied by the fixed raw Index page.
+`PortContext.deadline_ms` is the original duration budget, not an automatically decreasing remaining deadline.
+A future serving router must provide a monotonic host-measured `remaining_ms` at the handoff **after** the
+authoritative Product owner call.
 
-`ProductStorefrontIndexShadowExecution.tag_hydration` is populated only after raw `projected` succeeds. The
-executor extracts Product IDs from `projected.items`; distribution never reads Product/Taxonomy storage or
-constructs `TaxonomyService`. Missing external capability or owner hydration error is retained separately and
-cannot mutate/replace raw or public projected pages.
+`ProductStorefrontIndexServingBudget` contains host-selected:
 
-This closes the Storefront tag **source hydration boundary** without copying localized tag names into Product
-Index schema and without pretending `tag_ids` represent legacy metadata-only tags.
+- positive `index_execution_ms`;
+- positive `tag_hydration_ms`;
+- `safety_margin_ms`;
+- checked `required_ms` sum.
+
+No production SLO numbers are hard-coded by this slice. `classify_product_storefront_index_serving_budget`
+keeps the request owner-native when deadline semantics, configured budget, measured remaining time or tag
+capability are missing/inconsistent, or when remaining time is below the required bounded phases. Only an
+internally consistent observation with sufficient budget returns `Eligible`.
+
+This is a **policy only**. It does not run timers and is deliberately not called by the current shadow executor
+or mounted Storefront. Real phase timeout enforcement remains the next source step.
 
 ## Remaining Storefront parity/evidence blockers
 
 - execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the retained deployment matrix agrees;
-- define serving latency/deadline/budget policy for owner-first Index + post-page Product tag hydration before
-  any shadow-to-serving transition;
+- add non-serving enforcement of admitted Index/tag-hydration phase timeouts and retain timeout behavior;
 - preserve channel-less and deep-page owner-native routing in any future serving composition;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence.
 
@@ -109,7 +109,7 @@ query freshness, Product/Channel convergence, Channel identity transitions, link
 linked-target availability equivalence and linked-target replay/redelivery. ProductVariant remains key `2`
 and SalesChannel remains key `1`.
 
-Existing Product taxonomy source evidence also retains normalized legacy metadata-tag read fallback. It is not
+Existing Product taxonomy source evidence retains normalized legacy metadata-tag read fallback. It is not
 reinterpreted as Index tag identity evidence.
 
 ## M5 incremental ingestion
@@ -149,9 +149,11 @@ reinterpreted as Index tag identity evidence.
 - [x] Map raw no-localized-row title/handle nulls to Product public placeholders in a post-page derived layer.
 - [x] Batch-hydrate Product tags after raw page selection through a Product-owned capability, including legacy
       metadata-only fallback rather than relying solely on Index `tag_ids`.
+- [x] Define post-owner serving-budget eligibility using host-measured remaining time and explicit bounded
+      Index/tag phases without choosing unevidenced global SLO values.
+- [ ] Enforce admitted Index/tag phase timeouts in a non-serving execution adapter.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Define/admit serving latency and deadline policy for eligible Storefront Index + owner hydration.
 - [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
@@ -160,10 +162,9 @@ reinterpreted as Index tag identity evidence.
 
 ## Next source-code step
 
-Define a non-serving Storefront Index serving-budget contract before any traffic-switch adapter. It must bound
-Index execution plus Product post-page owner hydration, preserve owner success/fail-closed behavior, and make
-an exceeded/missing deadline a reason to keep the request owner-native rather than introducing unbounded tail
-latency. Do not switch mounted Storefront traffic in that slice.
+Add a **non-serving budgeted execution adapter** that accepts only an `Eligible` budget decision and actually
+applies the admitted Index and Product-tag phase timeouts. Timeout/unavailable/error outcomes must remain
+separate from the already-successful Product owner result. Do not mount that adapter into Storefront traffic.
 
-No tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `tag_hydration_source_complete_serving_budget_pending`.
+Status: `serving_budget_policy_source_complete_timeout_enforcement_pending`.
 
 ## Current boundary
 
@@ -19,45 +19,44 @@ maintainer execution/admission is not claimed.
 - deeper owner-valid pages remain typed owner-native;
 - no visibility sentinel, page clamp, cursor rewrite or Product key-5 approximation is used.
 
-## Product public placeholder projection — source complete
+## Product public projection and tags — source complete
 
-Raw localized Index results remain Product-neutral. No requested/fallback row means raw root `title`/`handle`
-are `IndexValue::Null` and retained PostgreSQL evidence continues to observe that state.
+Raw localized Index results remain Product-neutral. `public_projected` maps no-requested/fallback `title` and
+`handle` nulls to Product public placeholders only after the raw page is fixed.
 
-`public_projected` is derived only from a clone of a successful raw page and maps:
+`ProductStorefrontTagReadPort` performs bounded post-page Product tag hydration keyed by already-selected
+Product IDs, preserving Taxonomy requested->fallback/canonical-key semantics and legacy normalized
+`metadata.tags` fallback. Embedded Product runtime selects the capability; external profiles do not receive an
+implicit embedded fallback.
 
-- `title: Null` -> `"Untitled product"`;
-- `handle: Null` -> `""`.
+Raw `projected`, `public_projected` and `tag_hydration` remain separate results. Tag/public failures cannot
+replace the authoritative owner result or change identity/order/count/page/cursor evidence.
 
-Identity/order/count/page/cursor and unrelated fields, including `tag_ids`, remain unchanged. Raw comparison
-continues to use `projected`, not the public layer.
+## Post-owner serving-budget policy — source complete
 
-## Product-owned tag hydration — source complete
+`PortContext.deadline_ms` carries the original duration budget; it is not a decreasing remaining deadline. A
+future serving router must supply a host-measured `remaining_ms` at the handoff after authoritative Product
+owner success.
 
-Current Product Index `tag_ids` are relation-backed UUIDs from `product_tags`. Product owner semantics are
-broader: when no relations exist, legacy normalized `metadata.tags` remain a read fallback. Therefore a
-`tag_ids -> names` adapter would lose valid owner-visible tags.
+`ProductStorefrontIndexServingBudget` contains host-selected positive Index-execution and Product-tag-hydration
+phase budgets plus a safety margin. The source constructor checked-adds the phases and rejects zero required
+phases/overflow. This slice deliberately does **not** hard-code an unevidenced production SLO value.
 
-Product now publishes optional `ProductStorefrontTagReadPort` with a bounded page request:
+`classify_product_storefront_index_serving_budget` returns owner-native decisions for:
 
-- at most 48 unique, non-nil already-selected Product IDs;
-- tenant-scoped verification of every Product identity;
-- requested locale from `PortContext`, explicit fallback locale from the request;
-- reuse of `CatalogService::load_product_tag_map`;
-- existing Taxonomy requested->fallback name resolution and canonical-key fallback;
-- existing legacy metadata-only tag fallback;
-- response order matching the supplied Product-ID order.
+- absent/zero original request deadline;
+- absent configured budget policy;
+- absent host-measured remaining budget;
+- remaining budget greater than the original deadline (inconsistent observation);
+- unavailable Product tag-hydration capability;
+- remaining budget below the checked required Index + tag + safety budget.
 
-`ProductCatalogReadRuntime::in_process` selects this capability from the same `CatalogService` owner. External
-runtime profiles remain source-compatible and do **not** silently gain an embedded tag provider.
+Only an internally consistent observation with enough remaining time returns `Eligible` and carries the phase
+budgets forward.
 
-`ProductStorefrontIndexShadowExecutor.tag_hydration` is created only after raw `projected` succeeds. Product
-IDs come from `projected.items`; distribution does not construct `TaxonomyService`, query `product_tags`, or
-read Product storage directly. Missing capability/owner error is retained separately and cannot replace or
-mutate the authoritative owner result, raw Index page, or `public_projected` page.
-
-This closes the tag-hydration **source boundary** without adding localized tag names to Product Index schema and
-without pretending relation-backed `tag_ids` cover legacy metadata-only tags.
+This is a **classification policy**, not runtime timeout enforcement. It does not start timers, execute Index,
+call tag hydration or alter the current non-serving shadow executor. Mounted Storefront does not reference the
+policy.
 
 ## Search/collation/EAV source state
 
@@ -71,28 +70,29 @@ evidence.
 
 ## Remaining fail-closed parity/evidence gates
 
-1. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
-2. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
-3. Define/admit serving latency/deadline/budget policy for Index execution plus post-page Product hydration.
-4. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
-5. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
+1. Add non-serving execution that actually enforces an admitted Index phase timeout and Product tag-hydration
+   phase timeout while preserving the successful owner result.
+2. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
+3. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
+4. Retain serving-budget/timeout latency evidence before any mounted traffic switch.
+5. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
+6. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
 
 ## Next source slice
 
-Define a **non-serving serving-budget policy** before any traffic-switch adapter. It must place explicit bounds
-on Index work and post-page Product owner hydration, honor request deadlines, and retain owner-native behavior
-when the required budget/capability is unavailable. Do not switch mounted Storefront traffic in that slice.
+Add a **non-serving budgeted execution adapter** that accepts only an `Eligible` budget decision and applies the
+admitted Index and Product-tag phase timeouts. Timeout/unavailable/error results must remain separate from the
+already-successful Product owner result. Do not mount that adapter into Storefront traffic.
 
 ## Source guards
 
 - `verify-index-product-storefront-channel-scope-policy.mjs` locks channel-less owner-native policy;
 - `verify-index-product-storefront-deep-page-policy.mjs` locks deep-page owner-native policy;
 - `verify-index-product-storefront-public-projection.mjs` locks raw/public placeholder separation;
-- `verify-index-product-storefront-tag-hydration.mjs` locks bounded Product-owned tag hydration including
-  Taxonomy and legacy metadata fallback semantics;
-- `verify-index-product-storefront-shadow-executor.mjs` locks post-page enrichment after raw Index execution;
-- `verify-product-catalog-read-runtime-composition.mjs` locks optional embedded tag capability without external
-  implicit fallback;
+- `verify-index-product-storefront-tag-hydration.mjs` locks bounded Product-owned tag hydration;
+- `verify-index-product-storefront-serving-budget-policy.mjs` locks the host-measured remaining-budget contract
+  and keeps policy distinct from timeout enforcement/serving;
+- `verify-index-product-storefront-shadow-executor.mjs` locks current owner-first evidence execution;
 - current Storefront equivalence/EAV/collation/key-4 guards remain retained;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 

--- a/crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md
+++ b/crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md
@@ -1,0 +1,57 @@
+# M7 Product Storefront serving-budget policy
+
+Status: `policy_source_complete_timeout_enforcement_pending`.
+
+## Why `PortContext.deadline_ms` is not enough
+
+`PortContext.deadline_ms` carries the original duration budget for a port call. It is not an absolute deadline
+and does not automatically decrease while the authoritative Product owner read executes.
+
+A future Storefront Index router therefore must not treat `deadline_ms` as the remaining time available for
+Index execution and Product post-page hydration. At the post-owner handoff it must provide a monotonic,
+host-measured `remaining_ms` observation.
+
+## Explicit host policy
+
+`ProductStorefrontIndexServingBudget` carries host-selected positive phase budgets:
+
+- `index_execution_ms`;
+- `tag_hydration_ms`;
+- `safety_margin_ms`.
+
+The constructor rejects zero Index/tag phases and checked-add overflow. This source slice deliberately does not
+choose global production SLO numbers; those values belong to host configuration/admission and require runtime
+evidence.
+
+## Classification
+
+`classify_product_storefront_index_serving_budget` receives:
+
+- the request `PortContext` with original deadline semantics;
+- an optional configured serving budget;
+- `ProductStorefrontIndexServingBudgetObservation` containing host-measured `remaining_ms` and whether the
+  required Product tag-hydration capability is selected.
+
+The request remains owner-native when any of these are true:
+
+- original deadline is absent/zero;
+- serving budget policy is unavailable;
+- post-owner remaining budget was not measured;
+- measured remaining budget exceeds the original deadline and is therefore inconsistent;
+- Product tag hydration capability is unavailable;
+- remaining budget is below `index + tag hydration + safety margin`.
+
+Only an internally consistent observation with enough remaining budget returns `Eligible` and carries the two
+phase limits plus safety margin forward to a later enforcement adapter.
+
+## Boundary
+
+This policy does not execute Index queries, call Product hydration, create timers, or switch traffic. The current
+non-serving shadow executor is deliberately not changed to consume it. Mounted Storefront remains owner-native.
+
+The next source slice must add a non-serving budgeted execution adapter that actually applies the admitted
+Index and tag-hydration phase timeouts. Timeout/error results must remain separate from the already-successful
+owner response, and no mounted Storefront cutover may occur in that slice.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -29,6 +29,8 @@ for (const forbidden of [
   'execute_localized_query',
   'project_product_storefront_index_page',
   'hydrate_storefront_product_tags',
+  'ProductStorefrontIndexServingBudget',
+  'classify_product_storefront_index_serving_budget',
 ]) {
   if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
 }
@@ -36,7 +38,6 @@ for (const forbidden of [
 requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
   'pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;',
   'search: normalize_storefront_product_search(search)?',
-  'pub(crate) fn validate_storefront_product_search(',
 ]);
 
 const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
@@ -70,28 +71,11 @@ if (modernList.includes('10_000')) {
   fail(`${ownerPath} must not narrow owner-valid Storefront page depth to the Index offset bound`);
 }
 
-requireMarkers('crates/rustok-product/src/services/catalog/helpers.rs', [
-  'pub(crate) fn product_channel_visibility_condition(',
-  "metadata->'channel_visibility'->'allowed_channel_slugs'",
-  "jsonb_array_length(COALESCE(products.metadata->'channel_visibility'->'allowed_channel_slugs', '[]'::jsonb)) = 0",
-]);
-requireMarkers('crates/rustok-distribution/src/product_index/channel_relation_resolver.rs', [
-  'ProductChannelVisibility::Unrestricted => (',
-  'SELECT id FROM channels WHERE tenant_id = $1 ORDER BY id ASC LIMIT $2',
-]);
-
 const tagPortPath = 'crates/rustok-product/src/storefront_tag_read_port.rs';
 const tagPort = requireMarkers(tagPortPath, [
   'const MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48;',
-  'pub struct ProductStorefrontTagHydrationRequest',
-  'pub product_ids: Vec<Uuid>',
-  'pub fallback_locale: String',
-  'pub struct ProductStorefrontTagHydration',
   'pub trait ProductStorefrontTagReadPort',
   'impl ProductStorefrontTagReadPort for CatalogService',
-  'entities::product::Column::TenantId.eq(tenant_id)',
-  'entities::product::Column::Id.is_in(request.product_ids.clone())',
-  'products.len() != request.product_ids.len()',
   '.load_product_tag_map(',
   'context.locale.as_str()',
   'Some(request.fallback_locale.as_str())',
@@ -100,68 +84,33 @@ for (const forbidden of ['rustok_index', 'IndexQueryPage', 'IndexValue']) {
   if (tagPort.includes(forbidden)) fail(`${tagPortPath} must remain Product-owned and Index-neutral: ${forbidden}`);
 }
 requireMarkers('crates/rustok-product/src/services/catalog/tags.rs', [
-  'pub async fn load_product_tag_map(',
   'TaxonomyService::new(self.db.clone())',
   '.resolve_term_names(tenant_id, &ordered_term_ids, locale, fallback_locale)',
   'metadata_has_tags_field(&product.metadata)',
   'normalize_tag_names(&extract_metadata_tags(&product.metadata))',
 ]);
-requireMarkers('crates/rustok-taxonomy/src/services.rs', [
-  'pub async fn resolve_term_names(',
-  'resolve_by_locale_with_fallback(',
-  '.unwrap_or_else(|| term.canonical_key.clone())',
-]);
-requireMarkers('crates/rustok-commerce/tests/product_taxonomy_tags.rs', [
-  'legacy_metadata_tags_are_used_as_read_fallback_but_not_exposed_publicly',
-  '"tags": ["legacy", "sale", "legacy"]',
-  'vec!["legacy".to_string(), "sale".to_string()]',
-]);
-
-const runtimePath = 'crates/rustok-product/src/runtime.rs';
-const runtime = requireMarkers(runtimePath, [
-  'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
-  'storefront_tag_read_port: None',
-  '.with_storefront_tag_read_port(catalog)',
-  'pub fn with_storefront_tag_read_port(',
-  'pub fn storefront_tag_read_port(&self)',
-  'pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)',
-]);
-const externalStart = runtime.indexOf('pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)');
-const withTagStart = runtime.indexOf('pub fn with_storefront_tag_read_port(');
-if (externalStart < 0 || withTagStart <= externalStart || runtime.slice(externalStart, withTagStart).includes('with_storefront_tag_read_port')) {
-  fail(`${runtimePath} external profile must remain compatible without an implicit embedded tag provider`);
-}
 
 const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
 const executor = requireMarkers(executorPath, [
-  'pub(crate) enum ProductStorefrontIndexChannelScopeDecision',
   'OwnerNativeChannelLess',
   'ChannelLessOwnerNative',
-  'pub(crate) enum ProductStorefrontIndexPageScopeDecision',
   'OwnerNativeDeepPage { offset: u64 }',
   'DeepPageOwnerNative { offset: u64 }',
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
   'pub(crate) public_projected:',
-  'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
   'pub(crate) tag_hydration:',
-  'Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>>',
   'TagReadPortUnavailable',
   'list_filtered_published_products(',
-  'classify_product_storefront_index_page_scope(&query)',
-  '.resolve_storefront_attribute_filters(',
   '.execute_localized_query(index_query)',
   'let public_projected = projected',
   '.map(project_product_storefront_index_page);',
   'let tag_hydration = match projected.as_ref()',
   'self.hydrate_projected_tags(context, fallback_locale, projected)',
-  'async fn hydrate_projected_tags(',
   '.storefront_tag_read_port()',
   '.map(|item| item.entity_id)',
-  'ProductStorefrontTagHydrationRequest',
   '.hydrate_storefront_product_tags(',
   'let comparison = projected',
   'compare_owner_and_index(&authoritative, projected)',
-  'pub(crate) authoritative: StorefrontProductList',
 ]);
 for (const forbidden of [
   'CHANNEL_LESS_SENTINEL',
@@ -171,18 +120,42 @@ for (const forbidden of [
   'TaxonomyService',
   'product_tag::',
   'DatabaseConnection',
+  'classify_product_storefront_index_serving_budget',
 ]) {
-  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden shortcut/storage dependency ${forbidden}`);
+  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden shortcut/storage/serving marker ${forbidden}`);
 }
-const executeProjectedStart = executor.indexOf('async fn execute_projected(');
-const compareStart = executor.indexOf('fn compare_owner_and_index(');
-if (executeProjectedStart < 0 || compareStart <= executeProjectedStart) {
-  fail(`${executorPath} raw Index execution boundary is missing`);
-}
-const rawExecution = executor.slice(executeProjectedStart, compareStart);
-for (const forbidden of ['project_product_storefront_index_page', 'hydrate_storefront_product_tags', 'storefront_tag_read_port()']) {
-  if (rawExecution.includes(forbidden)) {
-    fail(`${executorPath} post-page enrichment leaked into raw Index execution: ${forbidden}`);
+
+const policyPath = 'crates/rustok-distribution/src/product_index/storefront_serving_budget.rs';
+const policy = requireMarkers(policyPath, [
+  'pub(crate) struct ProductStorefrontIndexServingBudget',
+  'index_execution_ms: u64',
+  'tag_hydration_ms: u64',
+  'safety_margin_ms: u64',
+  'required_ms: u64',
+  'checked_add(tag_hydration_ms)',
+  'checked_add(safety_margin_ms)',
+  'pub(crate) struct ProductStorefrontIndexServingBudgetObservation',
+  'pub(crate) remaining_ms: Option<u64>',
+  'pub(crate) tag_hydration_available: bool',
+  'pub(crate) enum ProductStorefrontIndexServingBudgetDecision',
+  'OwnerNativeMissingDeadline',
+  'OwnerNativeBudgetPolicyUnavailable',
+  'OwnerNativeRemainingBudgetUnavailable',
+  'OwnerNativeInvalidRemainingBudget',
+  'OwnerNativeTagHydrationUnavailable',
+  'OwnerNativeInsufficientBudget',
+  'pub(crate) fn classify_product_storefront_index_serving_budget(',
+  'context.deadline_ms.filter(|deadline_ms| *deadline_ms > 0)',
+  'if remaining_ms > deadline_ms',
+  'if !observation.tag_hydration_available',
+  'if remaining_ms < budget.required_ms()',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'does not automatically decrease',
+]);
+const productionPolicy = policy.split('#[cfg(test)]')[0];
+for (const forbidden of ['Instant::now()', 'SystemTime::now()', 'tokio::time::timeout']) {
+  if (productionPolicy.includes(forbidden)) {
+    fail(`${policyPath} policy must classify host observations without manufacturing/enforcing timing: ${forbidden}`);
   }
 }
 
@@ -190,26 +163,21 @@ const projectionPath = 'crates/rustok-distribution/src/product_index/storefront_
 const projection = requireMarkers(projectionPath, [
   'const UNTITLED_PRODUCT: &str = "Untitled product";',
   'pub(crate) fn project_product_storefront_index_page(',
-  'apply_string_placeholder(item, "title", UNTITLED_PRODUCT)?;',
-  'apply_string_placeholder(item, "handle", "")?;',
-  'projected.exact_count, Some(9)',
-  'projected.next_cursor.as_deref(), Some("opaque-cursor")',
   'value(&projected.items[0], "tag_ids")',
 ]);
 for (const forbidden of ['FilterExpr', 'OrderExpr', 'LocalizedEntityQuery', 'execute_localized_query']) {
   if (projection.includes(forbidden)) fail(`${projectionPath} must remain post-page only; found ${forbidden}`);
 }
 
-const builderPath = 'crates/rustok-distribution/src/product_index/storefront_shadow.rs';
-const builder = requireMarkers(builderPath, [
-  'services::MAX_STOREFRONT_PRODUCT_SEARCH_BYTES',
-  'PublicChannelRequired',
-  'root_field("sales_channel_ids")?',
-  'const MAX_INDEX_OFFSET_DEPTH: u64 = 10_000;',
-  'ProductStorefrontIndexShadowError::OffsetTooDeep',
+const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
+const productIndex = requireMarkers(productIndexPath, [
+  'assert_eq!(schema.fields.len(), 15);',
+  'many_field("tag_ids", IndexValueType::Uuid, true, false)',
+  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
-for (const forbidden of ['Untitled product', 'project_product_storefront_index_page', 'hydrate_storefront_product_tags']) {
-  if (builder.includes(forbidden)) fail(`${builderPath} must not feed post-page Product semantics into query construction: ${forbidden}`);
+for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'tag_names', 'localized_tag_names']) {
+  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema/source marker ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
@@ -218,53 +186,29 @@ requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_p
   'assert_eq!(owner_c.title, "Untitled product");',
   'assert_eq!(projected_string(index_c, "title")?, None);',
 ]);
-requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_eav_postgres_tests.rs', [
-  'RUSTOK_PRODUCT_STOREFRONT_EAV_EQUIVALENCE_DATABASE_URL',
-  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
-  'weight=7',
-  'color=missing',
-]);
 requireMarkers('crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs', [
   'RUSTOK_PRODUCT_STOREFRONT_COLLATION_DATABASE_URL',
   'translation.title LIKE $2',
   '(translation.title COLLATE "C") LIKE $2',
-  "current_setting('lc_collate')",
 ]);
-
-const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
-const productIndex = requireMarkers(productIndexPath, [
-  'assert_eq!(schema.fields.len(), 15);',
-  'many_field("tag_ids", IndexValueType::Uuid, true, false)',
-  'jsonb_agg(product_tag.term_id ORDER BY product_tag.term_id) AS tag_ids',
-  'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
-  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
-]);
-for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'tag_names', 'localized_tag_names']) {
-  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema/source marker ${forbidden}`);
-}
 
 requireMarkers('scripts/verify/verify-index-product-storefront-public-projection.mjs', [
   'Product public placeholders are post-page only',
-  'raw Index null evidence and tag_ids remain unchanged',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-tag-hydration.mjs', [
   'Product IDs from the fixed raw Index page drive bounded Product-owned tag hydration',
-  'legacy metadata semantics retained',
 ]);
-requireMarkers('scripts/verify/verify-product-catalog-read-runtime-composition.mjs', [
-  'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
-  'external profile must not silently install embedded tag hydration',
+requireMarkers('scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs', [
+  'future serving handoff requires explicit host-measured remaining budget',
+  'mounted Storefront remains owner-native',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-deep-page-policy.mjs', [
   'OwnerNativeDeepPage { offset: u64 }',
-  'must preserve owner pagination without clamp/rewrite',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs', [
   'OwnerNativeChannelLess',
-  'must not infer or fabricate visibility membership',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs', [
-  'must remain the owner/default-collation side',
   'must observe deployment/default collation rather than manufacture parity',
 ]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
@@ -272,28 +216,23 @@ requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `tag_hydration_source_complete_serving_budget_pending`',
+  'Status: `serving_budget_policy_source_complete_timeout_enforcement_pending`',
   'Mounted Storefront remains owner-native',
-  'Product-owned tag hydration — source complete',
-  '`ProductStorefrontTagReadPort`',
-  'legacy `metadata.tags`',
-  'serving latency/deadline/budget policy',
+  'Post-owner serving-budget policy — source complete',
+  'host-measured `remaining_ms`',
+  'classification policy',
+  'runtime timeout enforcement',
 ]);
-requireMarkers('crates/rustok-index/docs/m7-product-storefront-tag-hydration.md', [
-  'Status: `source_complete_serving_budget_pending`',
-  '`ProductStorefrontTagReadPort::hydrate_storefront_product_tags`',
-  'already-selected Product IDs',
-  'legacy `metadata.tags`',
-]);
-requireMarkers('crates/rustok-index/docs/m7-product-storefront-public-projection.md', [
-  'Status: `source_complete_with_separate_tag_hydration`',
-  '`tag_hydration` — separate Product-owner tag projection',
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md', [
+  'Status: `policy_source_complete_timeout_enforcement_pending`',
+  '`PortContext.deadline_ms` is not enough',
+  'host-measured `remaining_ms`',
+  'non-serving budgeted execution adapter',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
-  "'verify-index-product-storefront-public-projection.mjs'",
   "'verify-index-product-storefront-tag-hydration.mjs'",
-  "'verify-index-product-storefront-deep-page-policy.mjs'",
+  "'verify-index-product-storefront-serving-budget-policy.mjs'",
   "'verify-index-product-storefront-collation-postgres-packet.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; raw Index page, public placeholders and Product-owned tag hydration are source-separated while serving budget and evidence admission remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; request shape, post-page owner projection and host-measured serving-budget policy are source-complete while timeout enforcement and evidence admission remain pending');

--- a/scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs
+++ b/scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-serving-budget-policy] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const portContextPath = 'crates/rustok-api/src/ports.rs';
+requireMarkers(portContextPath, [
+  'pub deadline_ms: Option<u64>',
+  'pub fn with_deadline(mut self, deadline: Duration)',
+  'self.deadline_ms = Some(deadline.as_millis()',
+  'pub fn require_deadline_semantics(&self)',
+]);
+
+const policyPath = 'crates/rustok-distribution/src/product_index/storefront_serving_budget.rs';
+const policy = requireMarkers(policyPath, [
+  'pub(crate) struct ProductStorefrontIndexServingBudget',
+  'index_execution_ms: u64',
+  'tag_hydration_ms: u64',
+  'safety_margin_ms: u64',
+  'required_ms: u64',
+  'pub(crate) fn new(',
+  'checked_add(tag_hydration_ms)',
+  'checked_add(safety_margin_ms)',
+  'ZeroIndexExecutionBudget',
+  'ZeroTagHydrationBudget',
+  'BudgetOverflow',
+  'pub(crate) struct ProductStorefrontIndexServingBudgetObservation',
+  'pub(crate) remaining_ms: Option<u64>',
+  'pub(crate) tag_hydration_available: bool',
+  'pub(crate) enum ProductStorefrontIndexServingBudgetDecision',
+  'OwnerNativeMissingDeadline',
+  'OwnerNativeBudgetPolicyUnavailable',
+  'OwnerNativeRemainingBudgetUnavailable',
+  'OwnerNativeInvalidRemainingBudget',
+  'OwnerNativeTagHydrationUnavailable',
+  'OwnerNativeInsufficientBudget',
+  'pub(crate) fn classify_product_storefront_index_serving_budget(',
+  'context.deadline_ms.filter(|deadline_ms| *deadline_ms > 0)',
+  'let Some(budget) = budget else',
+  'let Some(remaining_ms) = observation.remaining_ms else',
+  'if remaining_ms > deadline_ms',
+  'if !observation.tag_hydration_available',
+  'if remaining_ms < budget.required_ms()',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'requires_host_measured_remaining_budget_and_owner_tag_capability',
+  'admits_only_when_remaining_budget_covers_all_bounded_phases',
+]);
+
+const productionPolicy = policy.split('#[cfg(test)]')[0];
+for (const forbidden of [
+  'remaining_ms: context.deadline_ms',
+  'remaining_ms = context.deadline_ms',
+  'unwrap_or(context.deadline_ms',
+  'Instant::now()',
+  'SystemTime::now()',
+  'tokio::time::timeout',
+]) {
+  if (productionPolicy.includes(forbidden)) {
+    fail(`${policyPath} must consume host-measured remaining budget rather than manufacture/enforce it here: ${forbidden}`);
+  }
+}
+if (!productionPolicy.includes('does not automatically decrease')) {
+  fail(`${policyPath} must document that PortContext.deadline_ms is not remaining time`);
+}
+
+const productRuntimePath = 'crates/rustok-product/src/runtime.rs';
+requireMarkers(productRuntimePath, [
+  'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
+  'pub fn storefront_tag_read_port(&self)',
+]);
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod storefront_serving_budget;',
+  'ProductStorefrontIndexServingBudget',
+  'ProductStorefrontIndexServingBudgetDecision',
+  'ProductStorefrontIndexServingBudgetObservation',
+  'classify_product_storefront_index_serving_budget',
+]);
+
+const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
+const mounted = read(mountedPath);
+for (const forbidden of [
+  'ProductStorefrontIndexServingBudget',
+  'classify_product_storefront_index_serving_budget',
+  'ProductStorefrontIndexShadowExecutor',
+  'execute_localized_query',
+]) {
+  if (mounted.includes(forbidden)) {
+    fail(`${mountedPath} must remain owner-native and must not consume serving-budget/Index policy yet: ${forbidden}`);
+  }
+}
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) tag_hydration:',
+  'TagReadPortUnavailable',
+  'let tag_hydration = match projected.as_ref()',
+]);
+if (executor.includes('classify_product_storefront_index_serving_budget')) {
+  fail(`${executorPath} current evidence executor must not be silently promoted into a serving router`);
+}
+
+console.log('[verify-index-product-storefront-serving-budget-policy] future serving handoff requires explicit host-measured remaining budget, bounded Index/tag phases, and tag capability; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -89,6 +89,7 @@ const scripts = [
   'verify-index-product-storefront-deep-page-policy.mjs',
   'verify-index-product-storefront-public-projection.mjs',
   'verify-index-product-storefront-tag-hydration.mjs',
+  'verify-index-product-storefront-serving-budget-policy.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',


### PR DESCRIPTION
## Summary

- add a pure non-serving Product Storefront Index serving-budget policy for the post-owner handoff;
- explicitly distinguish the original `PortContext.deadline_ms` duration from host-measured remaining time after authoritative Product owner success;
- require the future host/router to supply `remaining_ms` instead of reconstructing it from `deadline_ms`;
- define host-configured positive Index-execution and Product-tag-hydration phase budgets plus a safety margin with checked overflow handling;
- keep the request owner-native when deadline semantics, configured budget, remaining-budget observation or Product tag capability are unavailable/inconsistent, or when remaining time cannot cover all bounded phases;
- return `Eligible` only with internally consistent timing and enough remaining budget;
- deliberately avoid hard-coding unevidenced production SLO milliseconds in production source;
- do not start timers or modify the current owner-first shadow executor in this slice;
- keep mounted Storefront owner-native and add guards/docs that make phase timeout enforcement the next source cursor.

## Boundary

This PR is classification policy only. It does not enforce runtime timeouts, execute Index/tag hydration through the policy, switch Storefront traffic, alter Product schema/routing key, execute retained PostgreSQL evidence, or admit collation/latency evidence.

A future serving handoff must measure remaining budget monotonically after owner success. Missing or insufficient budget keeps the request owner-native.

## Main recheck

The branch started from tag-hydration merge `5a37e78d50b37785a2a5c119689887f441a94cf9`. Current `main@579e20b087d70640b975a502b3383f7c947665e8` advanced only through disjoint Forum #3254. Final compare contains 8 expected Product/Index policy, guard and documentation files; the current shadow executor, Product schema/source/query builder and mounted Storefront are unchanged.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.