### PR TITLE
test(groups): add PostgreSQL governance enforcement evidence

### DIFF
--- a/apps/server/tests/groups_governance_enforcement_postgres.rs
+++ b/apps/server/tests/groups_governance_enforcement_postgres.rs
@@ -1,0 +1,443 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    ChangeGroupRoleRequest, GroupGovernanceCommandPort, GroupGovernanceService,
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService, GroupRole,
+    SuspendGroupMembershipRequest, TransferGroupOwnershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+    TransactionTrait,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const POSTGRES_URL_ENV: &str = "RUSTOK_GROUPS_TEST_POSTGRES_URL";
+
+fn schema_url(base: &str, schema: &str) -> String {
+    let separator = if base.contains('?') { '&' } else { '?' };
+    format!(
+        "{base}{separator}options=-csearch_path%3D{schema}%2Cpublic"
+    )
+}
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("PostgreSQL Groups evidence connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply in evidence schema");
+    }
+}
+
+fn user_write_context(
+    tenant_id: Uuid,
+    user_id: Uuid,
+    idempotency_key: impl Into<String>,
+) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        "en",
+        format!("groups-postgres-evidence-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn platform_write_context(
+    tenant_id: Uuid,
+    user_id: Uuid,
+    idempotency_key: impl Into<String>,
+) -> PortContext {
+    user_write_context(tenant_id, user_id, idempotency_key).with_claim("groups:manage")
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+    replay_target_id: Uuid,
+    race_target_id: Uuid,
+    replacement_owner_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'governance-evidence', 5);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{replay_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{race_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{replacement_owner_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups governance evidence fixture should seed");
+}
+
+async fn membership_revision(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership revision query should succeed")
+        .expect("membership should exist");
+    row.try_get("", "revision")
+        .expect("membership revision should decode")
+}
+
+async fn membership_role(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> String {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT role FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership role query should succeed")
+        .expect("membership should exist");
+    row.try_get("", "role")
+        .expect("membership role should decode")
+}
+
+async fn enforcement_count(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT COUNT(*)::BIGINT AS count FROM group_membership_enforcements WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}' AND revoked_at IS NULL"
+            ),
+        ))
+        .await
+        .expect("membership enforcement count query should succeed")
+        .expect("enforcement count should exist");
+    row.try_get("", "count")
+        .expect("enforcement count should decode")
+}
+
+async fn group_owner(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> Uuid {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT owner_user_id FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group owner query should succeed")
+        .expect("group should exist");
+    row.try_get("", "owner_user_id")
+        .expect("group owner UUID should decode")
+}
+
+async fn install_moderation_owned_owner_suspension(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+) {
+    let transaction = db
+        .begin()
+        .await
+        .expect("owner recovery fixture transaction should begin");
+    let row = transaction
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT id FROM group_memberships WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}' AND user_id = '{owner_id}'"
+            ),
+        ))
+        .await
+        .expect("owner membership lookup should succeed")
+        .expect("owner membership should exist");
+    let membership_id: Uuid = row
+        .try_get("", "id")
+        .expect("owner membership ID should decode");
+    let decision_id = Uuid::new_v4();
+    transaction
+        .execute_unprepared(&format!(
+            r#"
+INSERT INTO group_membership_enforcements
+    (membership_id, tenant_id, group_id, user_id, state, reason_code, source_kind,
+     effective_from, restore_status, moderation_decision_id, moderation_decision_hash,
+     actor_kind, actor_id)
+VALUES
+    ('{membership_id}', '{tenant_id}', '{group_id}', '{owner_id}', 'suspended',
+     'harassment', 'moderation_decision', CURRENT_TIMESTAMP - INTERVAL '1 second', 'active',
+     '{decision_id}', '{}', 'service', 'rustok-moderation');
+UPDATE groups
+   SET version = version + 1,
+       updated_at = CURRENT_TIMESTAMP
+ WHERE tenant_id = '{tenant_id}'
+   AND id = '{group_id}';
+"#,
+            "a".repeat(64),
+        ))
+        .await
+        .expect("moderation-owned owner suspension fixture should install");
+    transaction
+        .commit()
+        .await
+        .expect("owner recovery fixture transaction should commit");
+}
+
+#[tokio::test]
+#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]
+async fn postgres_groups_governance_and_enforcement_are_replay_safe_serialized_and_recoverable() {
+    let base_url = std::env::var(POSTGRES_URL_ENV)
+        .expect("RUSTOK_GROUPS_TEST_POSTGRES_URL must be configured");
+    let schema = format!("groups_governance_evidence_{}", Uuid::new_v4().simple());
+    let admin = connect(&base_url).await;
+    admin
+        .execute_unprepared(&format!("CREATE SCHEMA {schema}"))
+        .await
+        .expect("isolated Groups evidence schema should create");
+    let scoped_url = schema_url(&base_url, &schema);
+    let fixture = connect(&scoped_url).await;
+    install_groups_schema(&fixture).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    let replay_target_id = Uuid::new_v4();
+    let race_target_id = Uuid::new_v4();
+    let replacement_owner_id = Uuid::new_v4();
+    let platform_user_id = Uuid::new_v4();
+    seed_group_fixture(
+        &fixture,
+        tenant_id,
+        group_id,
+        owner_id,
+        admin_id,
+        replay_target_id,
+        race_target_id,
+        replacement_owner_id,
+    )
+    .await;
+
+    // A completed governance receipt must replay before current effective authorization. The admin
+    // first changes a member role, is then suspended by the owner, and finally replays the exact
+    // lost-response request successfully despite no longer having current authority.
+    let replay_key = format!("governance-replay-{}", Uuid::new_v4());
+    let replay_request = ChangeGroupRoleRequest {
+        group_id,
+        target_user_id: replay_target_id,
+        role: GroupRole::Moderator,
+    };
+    let first_governance = GroupGovernanceService::new(connect(&scoped_url).await);
+    let first = GroupGovernanceCommandPort::change_group_role(
+        &first_governance,
+        user_write_context(tenant_id, admin_id, replay_key.clone()),
+        replay_request.clone(),
+    )
+    .await
+    .expect("active admin should change member role");
+    assert!(!first.replayed);
+    assert_eq!(first.previous_role, GroupRole::Member);
+    assert_eq!(first.current_role, GroupRole::Moderator);
+
+    let admin_revision = membership_revision(&fixture, tenant_id, admin_id).await;
+    let enforcement = GroupMembershipEnforcementCommandService::new(connect(&scoped_url).await);
+    GroupMembershipEnforcementCommandPort::suspend_membership(
+        &enforcement,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("suspend-admin-{}", Uuid::new_v4()),
+        ),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: admin_id,
+            expected_membership_revision: admin_revision,
+            reason_code: "harassment".to_string(),
+            effective_until: None,
+        },
+    )
+    .await
+    .expect("owner should suspend admin after governance commit");
+
+    let replay_governance = GroupGovernanceService::new(connect(&scoped_url).await);
+    let replayed = GroupGovernanceCommandPort::change_group_role(
+        &replay_governance,
+        user_write_context(tenant_id, admin_id, replay_key.clone()),
+        replay_request.clone(),
+    )
+    .await
+    .expect("matching lost-response receipt should replay before suspended admin authorization");
+    assert!(replayed.replayed);
+    assert_eq!(replayed.previous_role, first.previous_role);
+    assert_eq!(replayed.current_role, first.current_role);
+    assert_eq!(replayed.group_version, first.group_version);
+
+    let wrong_actor_governance = GroupGovernanceService::new(connect(&scoped_url).await);
+    let wrong_actor = GroupGovernanceCommandPort::change_group_role(
+        &wrong_actor_governance,
+        user_write_context(tenant_id, owner_id, replay_key),
+        replay_request.clone(),
+    )
+    .await
+    .expect_err("another actor must not reuse the completed admin receipt");
+    assert_eq!(wrong_actor.code, "groups.conflict");
+
+    let suspended_admin_governance = GroupGovernanceService::new(connect(&scoped_url).await);
+    let suspended_admin = GroupGovernanceCommandPort::change_group_role(
+        &suspended_admin_governance,
+        user_write_context(
+            tenant_id,
+            admin_id,
+            format!("fresh-governance-{}", Uuid::new_v4()),
+        ),
+        ChangeGroupRoleRequest {
+            group_id,
+            target_user_id: replay_target_id,
+            role: GroupRole::Member,
+        },
+    )
+    .await
+    .expect_err("fresh governance must re-check the suspended admin effective state");
+    assert_eq!(suspended_admin.code, "groups.membership_suspended");
+
+    // Governance role mutation and direct suspension share the group serialization row. Racing the
+    // two from independent connections can only serialize in one of two safe ways: the role wins
+    // and makes the prepared suspension revision stale, or suspension wins and governance observes
+    // the effective denial. They must never both commit against the same reviewed revision.
+    let race_revision = membership_revision(&fixture, tenant_id, race_target_id).await;
+    let race_governance = GroupGovernanceService::new(connect(&scoped_url).await);
+    let race_enforcement = GroupMembershipEnforcementCommandService::new(connect(&scoped_url).await);
+    let role_future = GroupGovernanceCommandPort::change_group_role(
+        &race_governance,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("race-role-{}", Uuid::new_v4()),
+        ),
+        ChangeGroupRoleRequest {
+            group_id,
+            target_user_id: race_target_id,
+            role: GroupRole::Moderator,
+        },
+    );
+    let suspension_future = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &race_enforcement,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("race-suspend-{}", Uuid::new_v4()),
+        ),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: race_target_id,
+            expected_membership_revision: race_revision,
+            reason_code: "harassment".to_string(),
+            effective_until: None,
+        },
+    );
+    let (role_result, suspension_result) = tokio::join!(role_future, suspension_future);
+    match (role_result, suspension_result) {
+        (Ok(role), Err(suspension_error)) => {
+            assert_eq!(role.current_role, GroupRole::Moderator);
+            assert_eq!(
+                suspension_error.code,
+                "groups.membership_enforcement_revision_conflict"
+            );
+            assert_eq!(
+                membership_role(&fixture, tenant_id, race_target_id).await,
+                "moderator"
+            );
+            assert_eq!(enforcement_count(&fixture, tenant_id, race_target_id).await, 0);
+        }
+        (Err(role_error), Ok(suspension)) => {
+            assert_eq!(role_error.code, "groups.membership_suspended");
+            assert_eq!(suspension.user_id, race_target_id);
+            assert_eq!(
+                membership_role(&fixture, tenant_id, race_target_id).await,
+                "member"
+            );
+            assert_eq!(enforcement_count(&fixture, tenant_id, race_target_id).await, 1);
+        }
+        (role_result, suspension_result) => panic!(
+            "governance/enforcement race must produce exactly one safe commit: role={role_result:?}, suspension={suspension_result:?}"
+        ),
+    }
+    assert_eq!(
+        membership_revision(&fixture, tenant_id, race_target_id).await,
+        race_revision + 1,
+        "exactly one serialized material change should advance the raced membership revision"
+    );
+
+    // Platform recovery is allowed to transfer away from a suspended current owner, but the owner
+    // enforcement row is still resolved fail-closed and the replacement owner must be effective
+    // active. This fixture writes the future moderation-owned projection shape directly because the
+    // neutral Groups Moderation adapter is intentionally not part of this evidence slice.
+    install_moderation_owned_owner_suspension(&fixture, tenant_id, group_id, owner_id).await;
+    let platform_governance = GroupGovernanceService::new(connect(&scoped_url).await);
+    let recovered = GroupGovernanceCommandPort::transfer_group_ownership(
+        &platform_governance,
+        platform_write_context(
+            tenant_id,
+            platform_user_id,
+            format!("platform-recovery-{}", Uuid::new_v4()),
+        ),
+        TransferGroupOwnershipRequest {
+            group_id,
+            new_owner_user_id: replacement_owner_id,
+        },
+    )
+    .await
+    .expect("platform manager should recover ownership from a valid suspended current owner");
+    assert_eq!(recovered.current_role, GroupRole::Owner);
+    assert_eq!(recovered.target_user_id, replacement_owner_id);
+    assert_eq!(group_owner(&fixture, tenant_id, group_id).await, replacement_owner_id);
+    assert_eq!(membership_role(&fixture, tenant_id, owner_id).await, "admin");
+    assert_eq!(
+        membership_role(&fixture, tenant_id, replacement_owner_id).await,
+        "owner"
+    );
+
+    drop(race_governance);
+    drop(race_enforcement);
+    drop(first_governance);
+    drop(enforcement);
+    drop(replay_governance);
+    drop(wrong_actor_governance);
+    drop(suspended_admin_governance);
+    drop(platform_governance);
+    drop(fixture);
+    admin
+        .execute_unprepared(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .expect("isolated Groups evidence schema should drop");
+}

--- a/crates/rustok-groups/docs/governance-enforcement-postgres-contract.md
+++ b/crates/rustok-groups/docs/governance-enforcement-postgres-contract.md
@@ -1,0 +1,97 @@
+# Groups governance/enforcement PostgreSQL evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_governance_enforcement_postgres.rs` retains executable PostgreSQL evidence for the GROUPS-07 owner-lock and replay boundary shared by governance and membership enforcement.
+
+The test is compiled only with the server `mod-groups` feature and is ignored unless `RUSTOK_GROUPS_TEST_POSTGRES_URL` is configured. It uses the production `rustok-groups` services and production Groups migrations. No duplicate governance or enforcement implementation exists in the fixture.
+
+## Isolation
+
+Every execution creates a unique PostgreSQL schema and connects through a schema-scoped PostgreSQL startup `search_path`. This matters because SeaORM uses a connection pool: a one-shot `SET search_path` on one pooled session would not be a safe isolation mechanism for subsequent queries on other sessions.
+
+The fixture applies all production migrations returned by `rustok_groups::migrations::migrations()` inside the isolated schema, opens independent pooled connections for governance/enforcement calls, and drops the schema after the evidence assertions.
+
+## Evidence 1: receipt-first lost-response replay and actor binding
+
+The fixture starts with an owner, an admin and active members.
+
+1. The admin changes a member from `member` to `moderator` through `GroupGovernanceCommandPort`.
+2. The owner then suspends that admin through `GroupMembershipEnforcementCommandPort`.
+3. The now-suspended admin retries the exact original governance command with the exact original idempotency key.
+4. The stored result must replay successfully with `replayed=true`, the same previous/current role and the original group version.
+5. A different actor using that idempotency key and the same request must conflict.
+6. A fresh governance command from the suspended admin must fail with `groups.membership_suspended`.
+
+This proves the intended ordering: group serialization -> actor-bound completed receipt -> current effective authorization.
+
+## Evidence 2: concurrent role mutation versus direct suspension
+
+Two independent PostgreSQL connections race against the same active member and the same prepared membership revision:
+
+- governance attempts `member -> moderator`;
+- direct enforcement attempts `SuspendGroupMembershipRequest`.
+
+Both production commands serialize on the Groups owner row before their membership/enforcement work. Exactly two outcomes are accepted:
+
+- **role wins first**: role becomes `moderator`; the later suspension sees a stale reviewed membership revision and returns `groups.membership_enforcement_revision_conflict`; no enforcement row commits;
+- **suspension wins first**: the enforcement row commits; the later governance command resolves the member as suspended and returns `groups.membership_suspended`; stored role remains `member`.
+
+The test rejects any outcome in which both commands succeed. It also requires the raced membership revision to advance by exactly one material change.
+
+This is the executable concurrency counterpart to the deterministic lock order `Group -> membership rows in user UUID order -> enforcement rows in membership-ID order`.
+
+## Evidence 3: platform ownership recovery
+
+The direct local enforcement command correctly forbids suspending the current group owner, so the fixture installs the already-defined moderation-owned enforcement projection shape directly for the current owner. This does **not** stand in for the missing neutral Moderation adapter; it only creates the owner state that governance recovery must safely consume.
+
+The fixture records:
+
+- `state=suspended`;
+- `source_kind=moderation_decision`;
+- bounded moderation decision UUID/hash provenance;
+- stored restore status `active`;
+- a service actor;
+- the membership revision trigger effect and a matching group-version advance.
+
+A platform actor with `groups:manage` then transfers ownership to an effective-active replacement member through the real `GroupGovernanceCommandPort`.
+
+The evidence requires:
+
+- the suspended current-owner enforcement row to be resolved through the normal owner-clock resolver;
+- platform recovery to succeed only for the explicitly recoverable current-owner state;
+- the replacement owner to remain effective-active;
+- old owner role to become `admin`;
+- replacement role to become `owner`;
+- `groups.owner_user_id` to point at the replacement.
+
+Corrupt or unsupported current-owner enforcement still fails closed in production governance source.
+
+## What this source does not prove until executed
+
+The file is intentionally ignored and was not executed while preparing this slice. Therefore the following remain open evidence gates:
+
+- actual PostgreSQL scheduler/timing behavior on the maintainer environment;
+- transport parity;
+- SQLite parity;
+- repeated stress/deadlock statistics;
+- Moderation adapter application/lost-response behavior;
+- CI/runtime readiness promotion.
+
+## Maintainer execution
+
+```bash
+RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' \
+  cargo test -p rustok-server --features mod-groups \
+  --test groups_governance_enforcement_postgres -- --ignored --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-governance-enforcement-postgres.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this evidence source.

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -128,6 +128,8 @@ Source exists for:
   write lock protocol;
 - effective governance role/ownership commands with group-serialized actor-bound replay,
   deterministic membership/enforcement locks, owner-reference consistency and owner-clock authority;
+- executable governance/enforcement PostgreSQL evidence source for replay, actor binding, concurrent
+  role-versus-suspension serialization, revision fencing and platform owner recovery;
 - sealed effective public invitation/application services with compatibility module paths;
 - transaction-aware invitation/application writes using the group/membership/enforcement lock
   protocol;
@@ -144,8 +146,8 @@ Evidence still open:
 - executed native/GraphQL parity and schema/error-mapping evidence for direct enforcement;
 - executed localization suspension/expiry, native/GraphQL parity, and concurrent enforcement-vs-write
   evidence;
-- governance concurrency, replay/lost-response, suspension/expiry, platform-recovery and native/GraphQL
-  parity evidence;
+- maintainer execution of the governance/enforcement PostgreSQL evidence source plus remaining
+  governance suspension/expiry, stress/deadlock, SQLite and native/GraphQL parity evidence;
 - native/GraphQL parity, CAS, lifecycle, bulk-review, retry, recovery, security, and accessibility
   evidence for the broader module;
 - provider ACL integration and remote/degraded profiles;
@@ -362,6 +364,29 @@ receipt remain in one Groups transaction. The existing GraphQL governance transp
 Compilation, PostgreSQL/SQLite contention, replay/lost-response, suspension/expiry, platform recovery,
 governance concurrency and native/GraphQL parity evidence remain open.
 
+### Executable governance/enforcement PostgreSQL evidence source
+
+`apps/server/tests/groups_governance_enforcement_postgres.rs` now retains an ignored, schema-isolated
+PostgreSQL evidence source over the production Groups migrations and production governance/enforcement
+ports. It covers actor-bound lost-response replay after the actor becomes suspended, a concurrent
+role-change versus suspension race using the same prepared membership revision, and platform ownership
+recovery from a valid suspended current owner.
+
+The concurrency contract accepts only the two outcomes implied by group serialization: governance
+wins and makes the prepared suspension CAS stale, or suspension wins and the later governance command
+observes `groups.membership_suspended`. Both commands succeeding is forbidden, and the raced membership
+revision must advance by exactly one material change.
+
+The platform recovery fixture writes the already-defined moderation-owned enforcement projection shape
+directly because the neutral Moderation adapter is not part of this slice; the actual transfer still
+uses `GroupGovernanceCommandPort` and the production owner-clock resolver. This fixture is not adapter
+evidence and does not relax the adapter dependency/receipt gates.
+
+Status is **maintainer execution pending**. The executable source does not populate runtime
+`governance_concurrency` or other evidence fields until it is actually run on PostgreSQL. The handoff is
+documented in `docs/governance-enforcement-postgres-contract.md` and guarded by
+`scripts/verify/verify-groups-governance-enforcement-postgres.mjs`.
+
 ### Planned moderation adapter
 
 Initial mapping remains:
@@ -396,8 +421,9 @@ above rather than introduce a second Groups enforcement state path.
 
 1. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
 2. Convert provider ACL consumers and remote/degraded profiles.
-3. Produce direct-enforcement, localization, governance and adapter runtime, parity, concurrency,
-   security, migration and accessibility evidence.
+3. Execute and retain the governance/enforcement PostgreSQL evidence source, then produce remaining
+   direct-enforcement, localization, governance and adapter runtime, parity, concurrency, security,
+   migration and accessibility evidence.
 
 ## Degraded modes
 
@@ -425,9 +451,11 @@ cargo check -p rustok-groups --features graphql
 cargo check -p rustok-groups-admin --features ssr
 cargo check -p rustok-groups-storefront --features ssr
 cargo test -p rustok-groups
+RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' cargo test -p rustok-server --features mod-groups --test groups_governance_enforcement_postgres -- --ignored --nocapture
 node scripts/verify/verify-groups-boundary.mjs
 node scripts/verify/verify-groups-localization-boundary.mjs
 node scripts/verify/verify-groups-governance-effective-authorization.mjs
+node scripts/verify/verify-groups-governance-enforcement-postgres.mjs
 node scripts/verify/verify-groups-invitations-boundary.mjs
 node scripts/verify/verify-groups-membership-applications.mjs
 node scripts/verify/verify-groups-application-policy-cas.mjs

--- a/scripts/verify/verify-groups-governance-enforcement-postgres.mjs
+++ b/scripts/verify/verify-groups-governance-enforcement-postgres.mjs
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_governance_enforcement_postgres.rs";
+const docsPath = "crates/rustok-groups/docs/governance-enforcement-postgres-contract.md";
+const planPath = "crates/rustok-groups/docs/implementation-plan.md";
+
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+const plan = fs.readFileSync(planPath, "utf8");
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  '#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]',
+  "RUSTOK_GROUPS_TEST_POSTGRES_URL",
+  "rustok_groups::migrations::migrations()",
+  "GroupGovernanceCommandPort::change_group_role",
+  "GroupGovernanceCommandPort::transfer_group_ownership",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  'assert_eq!(wrong_actor.code, "groups.conflict")',
+  'assert_eq!(suspended_admin.code, "groups.membership_suspended")',
+  '"groups.membership_enforcement_revision_conflict"',
+  '"groups.membership_suspended"',
+  "tokio::join!",
+  "race_revision + 1",
+  "moderation_decision",
+  "groups:manage",
+  "install_moderation_owned_owner_suspension",
+  "DROP SCHEMA",
+  "options=-csearch_path%3D",
+]) {
+  requireText(test, marker, `Groups PostgreSQL governance evidence is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "rustok_moderation::",
+  "rustok_forum::",
+  "SET search_path",
+  "cargo test",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups PostgreSQL governance evidence contains forbidden shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "receipt-first lost-response replay and actor binding",
+  "concurrent role mutation versus direct suspension",
+  "platform ownership recovery",
+  "exactly one material change",
+  "RUSTOK_GROUPS_TEST_POSTGRES_URL",
+  "execution pending",
+]) {
+  requireText(docs, marker, `Groups PostgreSQL governance evidence handoff is missing ${marker}`);
+}
+
+for (const marker of [
+  "governance/enforcement PostgreSQL evidence source",
+  "groups_governance_enforcement_postgres.rs",
+  "maintainer execution pending",
+  "governance_concurrency",
+]) {
+  requireText(plan, marker, `Canonical Groups plan is missing ${marker}`);
+}
+
+console.log("Groups PostgreSQL governance/enforcement evidence source guard passed");


### PR DESCRIPTION
## Summary
- add ignored PostgreSQL integration evidence in `apps/server` without new Cargo dependencies or lockfile changes
- apply the production Groups migration set inside a unique schema using schema-scoped PostgreSQL startup `search_path`
- prove governance lost-response replay still succeeds after the original admin becomes suspended
- prove governance receipts are actor-bound and cannot be reused by another caller
- race production `change_group_role` against production direct suspension from independent PostgreSQL connections and accept only the two serialized fail-closed outcomes
- require the raced membership revision to advance by exactly one material change
- retain platform ownership-recovery evidence from a valid moderation-owned suspended current-owner projection while the replacement owner remains effective-active
- keep runtime evidence explicitly pending until maintainers execute the ignored test
- document the contract, add a static source guard, and update the canonical Groups plan

## Verification
Source review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows and CI were intentionally not run per maintainer request.