### PR TITLE
test(groups): add SQLite governance enforcement evidence

### DIFF
--- a/apps/server/tests/groups_governance_enforcement_sqlite.rs
+++ b/apps/server/tests/groups_governance_enforcement_sqlite.rs
@@ -1,0 +1,398 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    ChangeGroupRoleRequest, GroupGovernanceCommandPort, GroupGovernanceService,
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService, GroupRole,
+    SuspendGroupMembershipRequest, TransferGroupOwnershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+    TransactionTrait,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("SQLite Groups evidence connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply in SQLite evidence database");
+    }
+}
+
+fn user_write_context(
+    tenant_id: Uuid,
+    user_id: Uuid,
+    idempotency_key: impl Into<String>,
+) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        "en",
+        format!("groups-sqlite-evidence-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn platform_write_context(
+    tenant_id: Uuid,
+    user_id: Uuid,
+    idempotency_key: impl Into<String>,
+) -> PortContext {
+    user_write_context(tenant_id, user_id, idempotency_key).with_claim("groups:manage")
+}
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp.path().join("groups-governance-evidence.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+    replay_target_id: Uuid,
+    race_target_id: Uuid,
+    replacement_owner_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'governance-sqlite-evidence', 5);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{replay_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{race_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{replacement_owner_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups SQLite governance evidence fixture should seed");
+}
+
+async fn membership_revision(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership revision query should succeed")
+        .expect("membership should exist");
+    row.try_get("", "revision")
+        .expect("membership revision should decode")
+}
+
+async fn membership_role(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> String {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT role FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership role query should succeed")
+        .expect("membership should exist");
+    row.try_get("", "role")
+        .expect("membership role should decode")
+}
+
+async fn enforcement_count(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT COUNT(*) AS count FROM group_membership_enforcements WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}' AND revoked_at IS NULL"
+            ),
+        ))
+        .await
+        .expect("membership enforcement count query should succeed")
+        .expect("enforcement count should exist");
+    row.try_get("", "count")
+        .expect("enforcement count should decode")
+}
+
+async fn group_owner(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> Uuid {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT owner_user_id FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group owner query should succeed")
+        .expect("group should exist");
+    row.try_get("", "owner_user_id")
+        .expect("group owner UUID should decode")
+}
+
+async fn install_moderation_owned_owner_suspension(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+) {
+    let transaction = db
+        .begin()
+        .await
+        .expect("owner recovery fixture transaction should begin");
+    let row = transaction
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT id FROM group_memberships WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}' AND user_id = '{owner_id}'"
+            ),
+        ))
+        .await
+        .expect("owner membership lookup should succeed")
+        .expect("owner membership should exist");
+    let membership_id: Uuid = row
+        .try_get("", "id")
+        .expect("owner membership ID should decode");
+    let decision_id = Uuid::new_v4();
+    transaction
+        .execute_unprepared(&format!(
+            r#"
+INSERT INTO group_membership_enforcements
+    (membership_id, tenant_id, group_id, user_id, state, reason_code, source_kind,
+     effective_from, restore_status, moderation_decision_id, moderation_decision_hash,
+     actor_kind, actor_id)
+VALUES
+    ('{membership_id}', '{tenant_id}', '{group_id}', '{owner_id}', 'suspended',
+     'harassment', 'moderation_decision', datetime('now', '-1 second'), 'active',
+     '{decision_id}', '{}', 'service', 'rustok-moderation');
+UPDATE groups
+   SET version = version + 1,
+       updated_at = CURRENT_TIMESTAMP
+ WHERE tenant_id = '{tenant_id}'
+   AND id = '{group_id}';
+"#,
+            "b".repeat(64),
+        ))
+        .await
+        .expect("moderation-owned owner suspension fixture should install");
+    transaction
+        .commit()
+        .await
+        .expect("owner recovery fixture transaction should commit");
+}
+
+#[tokio::test]
+async fn sqlite_groups_governance_and_enforcement_are_replay_safe_serialized_and_recoverable() {
+    let temp = tempfile::tempdir().expect("temporary SQLite evidence directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let fixture = connect(&url).await;
+    install_groups_schema(&fixture).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    let replay_target_id = Uuid::new_v4();
+    let race_target_id = Uuid::new_v4();
+    let replacement_owner_id = Uuid::new_v4();
+    let platform_user_id = Uuid::new_v4();
+    seed_group_fixture(
+        &fixture,
+        tenant_id,
+        group_id,
+        owner_id,
+        admin_id,
+        replay_target_id,
+        race_target_id,
+        replacement_owner_id,
+    )
+    .await;
+
+    let replay_key = format!("sqlite-governance-replay-{}", Uuid::new_v4());
+    let replay_request = ChangeGroupRoleRequest {
+        group_id,
+        target_user_id: replay_target_id,
+        role: GroupRole::Moderator,
+    };
+    let first_governance = GroupGovernanceService::new(connect(&url).await);
+    let first = GroupGovernanceCommandPort::change_group_role(
+        &first_governance,
+        user_write_context(tenant_id, admin_id, replay_key.clone()),
+        replay_request.clone(),
+    )
+    .await
+    .expect("active admin should change member role on SQLite");
+    assert!(!first.replayed);
+    assert_eq!(first.previous_role, GroupRole::Member);
+    assert_eq!(first.current_role, GroupRole::Moderator);
+
+    let admin_revision = membership_revision(&fixture, tenant_id, admin_id).await;
+    let enforcement = GroupMembershipEnforcementCommandService::new(connect(&url).await);
+    GroupMembershipEnforcementCommandPort::suspend_membership(
+        &enforcement,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("sqlite-suspend-admin-{}", Uuid::new_v4()),
+        ),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: admin_id,
+            expected_membership_revision: admin_revision,
+            reason_code: "harassment".to_string(),
+            effective_until: None,
+        },
+    )
+    .await
+    .expect("owner should suspend admin after SQLite governance commit");
+
+    let replay_governance = GroupGovernanceService::new(connect(&url).await);
+    let replayed = GroupGovernanceCommandPort::change_group_role(
+        &replay_governance,
+        user_write_context(tenant_id, admin_id, replay_key.clone()),
+        replay_request.clone(),
+    )
+    .await
+    .expect("SQLite lost-response receipt should replay before suspended admin authorization");
+    assert!(replayed.replayed);
+    assert_eq!(replayed.previous_role, first.previous_role);
+    assert_eq!(replayed.current_role, first.current_role);
+    assert_eq!(replayed.group_version, first.group_version);
+
+    let wrong_actor_governance = GroupGovernanceService::new(connect(&url).await);
+    let wrong_actor = GroupGovernanceCommandPort::change_group_role(
+        &wrong_actor_governance,
+        user_write_context(tenant_id, owner_id, replay_key),
+        replay_request,
+    )
+    .await
+    .expect_err("another actor must not reuse the completed SQLite admin receipt");
+    assert_eq!(wrong_actor.code, "groups.conflict");
+
+    let race_revision = membership_revision(&fixture, tenant_id, race_target_id).await;
+    let race_governance = GroupGovernanceService::new(connect(&url).await);
+    let race_enforcement = GroupMembershipEnforcementCommandService::new(connect(&url).await);
+    let role_future = GroupGovernanceCommandPort::change_group_role(
+        &race_governance,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("sqlite-race-role-{}", Uuid::new_v4()),
+        ),
+        ChangeGroupRoleRequest {
+            group_id,
+            target_user_id: race_target_id,
+            role: GroupRole::Moderator,
+        },
+    );
+    let suspension_future = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &race_enforcement,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("sqlite-race-suspend-{}", Uuid::new_v4()),
+        ),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: race_target_id,
+            expected_membership_revision: race_revision,
+            reason_code: "harassment".to_string(),
+            effective_until: None,
+        },
+    );
+    let (role_result, suspension_result) = tokio::join!(role_future, suspension_future);
+    match (role_result, suspension_result) {
+        (Ok(role), Err(suspension_error)) => {
+            assert_eq!(role.current_role, GroupRole::Moderator);
+            assert_eq!(
+                suspension_error.code,
+                "groups.membership_enforcement_revision_conflict"
+            );
+            assert_eq!(
+                membership_role(&fixture, tenant_id, race_target_id).await,
+                "moderator"
+            );
+            assert_eq!(enforcement_count(&fixture, tenant_id, race_target_id).await, 0);
+        }
+        (Err(role_error), Ok(suspension)) => {
+            assert_eq!(role_error.code, "groups.membership_suspended");
+            assert_eq!(suspension.user_id, race_target_id);
+            assert_eq!(
+                membership_role(&fixture, tenant_id, race_target_id).await,
+                "member"
+            );
+            assert_eq!(enforcement_count(&fixture, tenant_id, race_target_id).await, 1);
+        }
+        (role_result, suspension_result) => panic!(
+            "SQLite governance/enforcement race must produce exactly one safe commit: role={role_result:?}, suspension={suspension_result:?}"
+        ),
+    }
+    assert_eq!(
+        membership_revision(&fixture, tenant_id, race_target_id).await,
+        race_revision + 1,
+        "SQLite writer reservation should admit exactly one material raced membership change"
+    );
+
+    install_moderation_owned_owner_suspension(&fixture, tenant_id, group_id, owner_id).await;
+    let platform_governance = GroupGovernanceService::new(connect(&url).await);
+    let recovered = GroupGovernanceCommandPort::transfer_group_ownership(
+        &platform_governance,
+        platform_write_context(
+            tenant_id,
+            platform_user_id,
+            format!("sqlite-platform-recovery-{}", Uuid::new_v4()),
+        ),
+        TransferGroupOwnershipRequest {
+            group_id,
+            new_owner_user_id: replacement_owner_id,
+        },
+    )
+    .await
+    .expect("platform manager should recover SQLite ownership from valid suspended current owner");
+    assert_eq!(recovered.current_role, GroupRole::Owner);
+    assert_eq!(group_owner(&fixture, tenant_id, group_id).await, replacement_owner_id);
+    assert_eq!(membership_role(&fixture, tenant_id, owner_id).await, "admin");
+    assert_eq!(
+        membership_role(&fixture, tenant_id, replacement_owner_id).await,
+        "owner"
+    );
+
+    drop(platform_governance);
+    drop(race_governance);
+    drop(race_enforcement);
+    drop(first_governance);
+    drop(enforcement);
+    drop(replay_governance);
+    drop(wrong_actor_governance);
+    drop(fixture);
+    drop(temp);
+}

--- a/crates/rustok-groups/docs/governance-enforcement-sqlite-contract.md
+++ b/crates/rustok-groups/docs/governance-enforcement-sqlite-contract.md
@@ -1,0 +1,72 @@
+# Groups governance/enforcement SQLite evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_governance_enforcement_sqlite.rs` is the SQLite counterpart to the PostgreSQL GROUPS-07 governance/enforcement evidence packet.
+
+It runs against a real temporary SQLite file, not `sqlite::memory:`. Multiple production Groups services therefore use independent SeaORM pools against the same database file and exercise the actual SQLite writer-reservation path.
+
+## Production surface
+
+The fixture:
+
+- requires the server `mod-groups` feature;
+- uses the existing `tempfile` server dev-dependency;
+- applies every production migration returned by `rustok_groups::migrations::migrations()`;
+- uses `GroupGovernanceCommandPort` and `GroupMembershipEnforcementCommandPort` only;
+- adds no crate dependency, manifest change, lockfile change, or alternative owner implementation.
+
+## SQLite writer serialization
+
+PostgreSQL/MySQL use row locks. SQLite cannot provide the same row-lock primitive, so the production owner protocol reserves the writer before mutable aggregate reads with:
+
+```sql
+UPDATE groups SET version = version WHERE tenant_id = ? AND id = ?
+```
+
+The file-backed test races governance and direct enforcement from separate pools. It accepts only the same two serialized outcomes as PostgreSQL:
+
+- governance commits first, bumps membership revision through the role trigger, and the prepared suspension fails with `groups.membership_enforcement_revision_conflict`;
+- suspension commits first, bumps membership revision through the enforcement trigger, and governance later fails with `groups.membership_suspended`.
+
+Both commands succeeding is forbidden. The target revision must advance by exactly one material change.
+
+## Replay parity
+
+The SQLite packet also retains receipt-order evidence:
+
+1. an active admin successfully changes a member role;
+2. the owner suspends that admin;
+3. the same admin replays the exact completed governance request and receives the stored result despite current suspension;
+4. another actor using the same idempotency key receives `groups.conflict`.
+
+This protects the same group-lock -> actor-bound receipt -> current effective authorization ordering as PostgreSQL.
+
+## Platform recovery parity
+
+As in the PostgreSQL packet, the fixture installs the already-defined moderation-owned enforcement projection for the current owner directly because the neutral Groups Moderation adapter remains a separate blocked slice.
+
+The actual ownership transfer still goes through production `GroupGovernanceCommandPort` with `groups:manage`. The replacement must be effective-active; the suspended current owner is demoted to admin and `groups.owner_user_id` moves atomically to the replacement.
+
+The fixture is only owner-state setup. It is not Moderation adapter evidence.
+
+## Execution status
+
+This source was not executed while preparing the PR. Until maintainers run it, SQLite concurrency/replay/recovery remain **execution pending**, not completed runtime evidence.
+
+Maintainer command:
+
+```bash
+cargo test -p rustok-server --features mod-groups \
+  --test groups_governance_enforcement_sqlite -- --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-governance-enforcement-sqlite.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this source.

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -130,6 +130,8 @@ Source exists for:
   deterministic membership/enforcement locks, owner-reference consistency and owner-clock authority;
 - executable governance/enforcement PostgreSQL evidence source for replay, actor binding, concurrent
   role-versus-suspension serialization, revision fencing and platform owner recovery;
+- executable governance/enforcement SQLite evidence source using a shared temporary database file and
+  independent SeaORM pools for the same replay/race/recovery contract;
 - sealed effective public invitation/application services with compatibility module paths;
 - transaction-aware invitation/application writes using the group/membership/enforcement lock
   protocol;
@@ -146,8 +148,8 @@ Evidence still open:
 - executed native/GraphQL parity and schema/error-mapping evidence for direct enforcement;
 - executed localization suspension/expiry, native/GraphQL parity, and concurrent enforcement-vs-write
   evidence;
-- maintainer execution of the governance/enforcement PostgreSQL evidence source plus remaining
-  governance suspension/expiry, stress/deadlock, SQLite and native/GraphQL parity evidence;
+- maintainer execution of the PostgreSQL and SQLite governance/enforcement evidence sources plus
+  remaining governance suspension/expiry, stress/deadlock and native/GraphQL parity evidence;
 - native/GraphQL parity, CAS, lifecycle, bulk-review, retry, recovery, security, and accessibility
   evidence for the broader module;
 - provider ACL integration and remote/degraded profiles;
@@ -387,6 +389,28 @@ Status is **maintainer execution pending**. The executable source does not popul
 documented in `docs/governance-enforcement-postgres-contract.md` and guarded by
 `scripts/verify/verify-groups-governance-enforcement-postgres.mjs`.
 
+### Executable governance/enforcement SQLite evidence source
+
+`apps/server/tests/groups_governance_enforcement_sqlite.rs` mirrors the PostgreSQL replay/race/recovery
+packet against a real temporary SQLite file and independent SeaORM pools. It applies the same production
+Groups migration list and invokes only the production governance/enforcement ports.
+
+The SQLite concurrency contract exercises the owner writer reservation rather than row locks. The first
+command to execute the no-op `groups.version` update owns the writer; the other command must observe the
+committed material change before continuing. The accepted outcomes therefore remain identical to
+PostgreSQL: stale suspension CAS after a role win, or `groups.membership_suspended` after a suspension
+win, with exactly one membership revision advance.
+
+Replay remains actor-bound and must occur before current effective authorization. Platform recovery
+uses the same valid moderation-owned suspended-owner projection fixture and the same production ownership
+transfer port. `sqlite::memory:` is intentionally forbidden because independent pools would otherwise
+observe independent databases and provide false concurrency evidence.
+
+Status is **maintainer execution pending**. SQLite concurrency/replay/recovery is not runtime evidence
+until this test is actually executed. The handoff is documented in
+`docs/governance-enforcement-sqlite-contract.md` and guarded by
+`scripts/verify/verify-groups-governance-enforcement-sqlite.mjs`.
+
 ### Planned moderation adapter
 
 Initial mapping remains:
@@ -421,9 +445,9 @@ above rather than introduce a second Groups enforcement state path.
 
 1. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
 2. Convert provider ACL consumers and remote/degraded profiles.
-3. Execute and retain the governance/enforcement PostgreSQL evidence source, then produce remaining
-   direct-enforcement, localization, governance and adapter runtime, parity, concurrency, security,
-   migration and accessibility evidence.
+3. Execute and retain the PostgreSQL/SQLite governance-enforcement evidence sources, then produce
+   remaining direct-enforcement, localization, governance and adapter runtime, parity, concurrency,
+   security, migration and accessibility evidence.
 
 ## Degraded modes
 
@@ -452,10 +476,12 @@ cargo check -p rustok-groups-admin --features ssr
 cargo check -p rustok-groups-storefront --features ssr
 cargo test -p rustok-groups
 RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' cargo test -p rustok-server --features mod-groups --test groups_governance_enforcement_postgres -- --ignored --nocapture
+cargo test -p rustok-server --features mod-groups --test groups_governance_enforcement_sqlite -- --nocapture
 node scripts/verify/verify-groups-boundary.mjs
 node scripts/verify/verify-groups-localization-boundary.mjs
 node scripts/verify/verify-groups-governance-effective-authorization.mjs
 node scripts/verify/verify-groups-governance-enforcement-postgres.mjs
+node scripts/verify/verify-groups-governance-enforcement-sqlite.mjs
 node scripts/verify/verify-groups-invitations-boundary.mjs
 node scripts/verify/verify-groups-membership-applications.mjs
 node scripts/verify/verify-groups-application-policy-cas.mjs

--- a/scripts/verify/verify-groups-governance-enforcement-sqlite.mjs
+++ b/scripts/verify/verify-groups-governance-enforcement-sqlite.mjs
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_governance_enforcement_sqlite.rs";
+const docsPath = "crates/rustok-groups/docs/governance-enforcement-sqlite-contract.md";
+const planPath = "crates/rustok-groups/docs/implementation-plan.md";
+
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+const plan = fs.readFileSync(planPath, "utf8");
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "rustok_groups::migrations::migrations()",
+  "GroupGovernanceCommandPort::change_group_role",
+  "GroupGovernanceCommandPort::transfer_group_ownership",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  'assert_eq!(wrong_actor.code, "groups.conflict")',
+  '"groups.membership_enforcement_revision_conflict"',
+  '"groups.membership_suspended"',
+  "tokio::join!",
+  "race_revision + 1",
+  "moderation_decision",
+  "groups:manage",
+  "install_moderation_owned_owner_suspension",
+]) {
+  requireText(test, marker, `Groups SQLite governance evidence is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "sqlite::memory:",
+  "rustok_moderation::",
+  "rustok_forum::",
+  "cargo test",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups SQLite governance evidence contains forbidden shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "real temporary SQLite file",
+  "SQLite writer serialization",
+  "Replay parity",
+  "Platform recovery parity",
+  "execution pending",
+]) {
+  requireText(docs, marker, `Groups SQLite governance evidence handoff is missing ${marker}`);
+}
+
+for (const marker of [
+  "governance/enforcement SQLite evidence source",
+  "groups_governance_enforcement_sqlite.rs",
+  "maintainer execution pending",
+  "SQLite concurrency/replay/recovery",
+]) {
+  requireText(plan, marker, `Canonical Groups plan is missing ${marker}`);
+}
+
+console.log("Groups SQLite governance/enforcement evidence source guard passed");


### PR DESCRIPTION
## Summary
- add file-backed SQLite governance/enforcement evidence in `apps/server` with no new dependencies or lockfile changes
- use a real temporary SQLite file and independent SeaORM pools instead of `sqlite::memory:`
- apply the production Groups migration set and invoke only production governance/enforcement ports
- retain actor-bound governance lost-response replay after the original admin becomes suspended
- race production role change against production direct suspension and require exactly one serialized material outcome
- require the raced membership revision to advance by exactly one
- retain platform ownership recovery from a valid moderation-owned suspended current-owner projection
- document the SQLite writer-reservation contract, add a static source guard, and update the canonical Groups plan
- leave SQLite runtime/concurrency evidence explicitly pending until maintainers execute the test

## Verification
Static source review only. Cargo commands, tests, Node verifiers, formatters, migration execution, workflows and CI were intentionally not run per maintainer request.