### PR TITLE
feat(index): enforce Storefront projection phase budgets

### DIFF
--- a/crates/rustok-distribution/Cargo.toml
+++ b/crates/rustok-distribution/Cargo.toml
@@ -85,7 +85,7 @@ rustok-marketplace-listing = { workspace = true, optional = true }
 rustok-marketplace-allocation = { workspace = true, optional = true }
 rustok-marketplace-commission = { workspace = true, optional = true }
 rustok-marketplace-ledger = { workspace = true, optional = true }
-rustok-marketplace-payout = { workspace = true, optional = true }
+rustok-marketplace_payout = { workspace = true, optional = true }
 rustok-marketplace = { workspace = true, optional = true }
 rustok-moderation = { workspace = true, optional = true }
 rustok-content = { workspace = true, optional = true }
@@ -97,7 +97,7 @@ rustok-notifications = { workspace = true, optional = true }
 rustok-comments = { workspace = true, optional = true }
 rustok-pages = { workspace = true, optional = true }
 rustok-navigation = { workspace = true, optional = true }
-rustok-page-builder = { workspace = true, optional = true }
+rustok-page_builder = { workspace = true, optional = true }
 rustok-taxonomy = { workspace = true, optional = true }
 rustok-media = { workspace = true, optional = true }
 rustok-translation = { workspace = true, optional = true }
@@ -110,8 +110,8 @@ flex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
 sea-orm-migration.workspace = true
-tokio.workspace = true

--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -10,6 +10,12 @@ mod product;
 pub(crate) use product::PRODUCT_INDEX_SOURCE;
 mod query_admission;
 pub(crate) mod relation_admission;
+mod storefront_budgeted_execution;
+pub(crate) use storefront_budgeted_execution::{
+    ProductStorefrontIndexBudgetedExecution, ProductStorefrontIndexBudgetedProjectionError,
+    ProductStorefrontIndexBudgetedProjectionExecutor, ProductStorefrontIndexBudgetedStartError,
+    ProductStorefrontIndexBudgetedTagHydrationError,
+};
 mod storefront_projection;
 pub(crate) use storefront_projection::{
     ProductStorefrontIndexPublicProjectionError, project_product_storefront_index_page,

--- a/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
@@ -200,7 +200,7 @@ mod tests {
         let authoritative = StorefrontProductList {
             items: vec![rustok_product::StorefrontProductListItem {
                 id: entity_id,
-                status: "active".to_owned(),
+                status: rustok_product::entities::product::ProductStatus::Active,
                 title: "Untitled product".to_owned(),
                 handle: String::new(),
                 seller_id: None,

--- a/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use rustok_api::PortContext;
-use rustok_index::{IndexQueryPage, IndexValue};
+use rustok_index::IndexQueryPage;
 use rustok_product::{
     ProductStorefrontTagHydration, StorefrontProductList, StorefrontProductListQuery,
 };
@@ -179,6 +179,8 @@ fn compare_owner_and_projected(
 
 #[cfg(test)]
 mod tests {
+    use rustok_index::IndexValue;
+
     use super::*;
 
     #[test]

--- a/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
@@ -1,0 +1,234 @@
+use std::time::Duration;
+
+use rustok_api::PortContext;
+use rustok_index::{IndexQueryPage, IndexValue};
+use rustok_product::{
+    ProductStorefrontTagHydration, StorefrontProductList, StorefrontProductListQuery,
+};
+use thiserror::Error;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+use super::{
+    ProductStorefrontIndexPublicProjectionError, ProductStorefrontIndexServingBudgetDecision,
+    ProductStorefrontIndexShadowComparison, ProductStorefrontIndexShadowExecutor,
+    ProductStorefrontIndexShadowProjectionError, ProductStorefrontIndexTagHydrationError,
+    project_product_storefront_index_page,
+};
+
+#[derive(Debug)]
+pub(crate) struct ProductStorefrontIndexBudgetedExecution {
+    /// Already-successful authoritative owner result. Budgeted projection can never replace it.
+    pub(crate) authoritative: StorefrontProductList,
+    pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexBudgetedProjectionError>,
+    pub(crate) public_projected:
+        Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>,
+    pub(crate) tag_hydration:
+        Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexBudgetedTagHydrationError>>,
+    pub(crate) comparison: Option<ProductStorefrontIndexShadowComparison>,
+    pub(crate) index_execution_budget_ms: u64,
+    pub(crate) tag_hydration_budget_ms: u64,
+    pub(crate) safety_margin_ms: u64,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProductStorefrontIndexBudgetedStartError {
+    #[error("Product Storefront budgeted projection requires an eligible serving-budget decision: {0:?}")]
+    BudgetNotEligible(ProductStorefrontIndexServingBudgetDecision),
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProductStorefrontIndexBudgetedProjectionError {
+    #[error("Product Storefront projected Index phase exceeded its {budget_ms} ms budget")]
+    TimedOut { budget_ms: u64 },
+    #[error(transparent)]
+    Projection(#[from] ProductStorefrontIndexShadowProjectionError),
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProductStorefrontIndexBudgetedTagHydrationError {
+    #[error("Product Storefront tag hydration phase exceeded its {budget_ms} ms budget")]
+    TimedOut { budget_ms: u64 },
+    #[error(transparent)]
+    Hydration(#[from] ProductStorefrontIndexTagHydrationError),
+}
+
+/// Non-serving executor for an already-authoritative Product Storefront page.
+///
+/// The caller must first produce the authoritative owner result and classify the post-owner remaining budget.
+/// This adapter accepts only `Eligible` phase limits. It narrows Product port contexts to those phase budgets
+/// and applies outer Tokio timeouts so local and external selected capabilities cannot create an unbounded tail.
+/// Mounted Storefront does not call this adapter.
+#[derive(Clone)]
+pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor {
+    shadow: ProductStorefrontIndexShadowExecutor,
+}
+
+impl ProductStorefrontIndexBudgetedProjectionExecutor {
+    pub(crate) fn new(shadow: ProductStorefrontIndexShadowExecutor) -> Self {
+        Self { shadow }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn execute_after_owner(
+        &self,
+        authoritative: StorefrontProductList,
+        context: PortContext,
+        fallback_locale: String,
+        public_channel_slug: Option<String>,
+        public_channel_id: Option<Uuid>,
+        query: StorefrontProductListQuery,
+        decision: ProductStorefrontIndexServingBudgetDecision,
+    ) -> Result<ProductStorefrontIndexBudgetedExecution, ProductStorefrontIndexBudgetedStartError> {
+        let (index_execution_budget_ms, tag_hydration_budget_ms, safety_margin_ms) = match decision {
+            ProductStorefrontIndexServingBudgetDecision::Eligible {
+                index_execution_ms,
+                tag_hydration_ms,
+                safety_margin_ms,
+            } => (index_execution_ms, tag_hydration_ms, safety_margin_ms),
+            other => return Err(ProductStorefrontIndexBudgetedStartError::BudgetNotEligible(other)),
+        };
+
+        let mut index_context = context.clone();
+        index_context.deadline_ms = Some(index_execution_budget_ms);
+        let projected = match timeout(
+            Duration::from_millis(index_execution_budget_ms),
+            self.shadow.execute_projected(
+                index_context,
+                fallback_locale.clone(),
+                public_channel_slug,
+                public_channel_id,
+                query,
+            ),
+        )
+        .await
+        {
+            Ok(result) => result.map_err(ProductStorefrontIndexBudgetedProjectionError::Projection),
+            Err(_) => Err(ProductStorefrontIndexBudgetedProjectionError::TimedOut {
+                budget_ms: index_execution_budget_ms,
+            }),
+        };
+
+        let public_projected = projected
+            .as_ref()
+            .ok()
+            .cloned()
+            .map(project_product_storefront_index_page);
+
+        let tag_hydration = match projected.as_ref() {
+            Ok(projected) => {
+                let mut tag_context = context;
+                tag_context.deadline_ms = Some(tag_hydration_budget_ms);
+                Some(
+                    match timeout(
+                        Duration::from_millis(tag_hydration_budget_ms),
+                        self.shadow
+                            .hydrate_projected_tags(tag_context, fallback_locale, projected),
+                    )
+                    .await
+                    {
+                        Ok(result) => result
+                            .map_err(ProductStorefrontIndexBudgetedTagHydrationError::Hydration),
+                        Err(_) => Err(ProductStorefrontIndexBudgetedTagHydrationError::TimedOut {
+                            budget_ms: tag_hydration_budget_ms,
+                        }),
+                    },
+                )
+            }
+            Err(_) => None,
+        };
+
+        let comparison = projected
+            .as_ref()
+            .ok()
+            .map(|projected| compare_owner_and_projected(&authoritative, projected));
+
+        Ok(ProductStorefrontIndexBudgetedExecution {
+            authoritative,
+            projected,
+            public_projected,
+            tag_hydration,
+            comparison,
+            index_execution_budget_ms,
+            tag_hydration_budget_ms,
+            safety_margin_ms,
+        })
+    }
+}
+
+fn compare_owner_and_projected(
+    authoritative: &StorefrontProductList,
+    projected: &IndexQueryPage,
+) -> ProductStorefrontIndexShadowComparison {
+    let authoritative_ids = authoritative
+        .items
+        .iter()
+        .map(|item| item.id)
+        .collect::<Vec<_>>();
+    let projected_ids = projected
+        .items
+        .iter()
+        .map(|item| item.entity_id)
+        .collect::<Vec<_>>();
+    ProductStorefrontIndexShadowComparison {
+        identities_match: authoritative_ids == projected_ids,
+        exact_count_matches: projected.exact_count == Some(authoritative.total),
+        has_more_matches: projected.has_more == authoritative.has_next,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noneligible_decision_is_representable_without_starting_projection() {
+        let error = ProductStorefrontIndexBudgetedStartError::BudgetNotEligible(
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeInsufficientBudget {
+                required_ms: 140,
+                remaining_ms: 139,
+            },
+        );
+        assert!(error.to_string().contains("requires an eligible serving-budget decision"));
+    }
+
+    #[test]
+    fn comparison_contract_still_uses_raw_identity_count_and_boundary() {
+        let entity_id = Uuid::new_v4();
+        let authoritative = StorefrontProductList {
+            items: vec![rustok_product::StorefrontProductListItem {
+                id: entity_id,
+                status: "active".to_owned(),
+                title: "Untitled product".to_owned(),
+                handle: String::new(),
+                seller_id: None,
+                vendor: None,
+                product_type: None,
+                tags: Vec::new(),
+                created_at: chrono::Utc::now(),
+                published_at: None,
+            }],
+            total: 1,
+            page: 1,
+            per_page: 12,
+            has_next: false,
+        };
+        let projected = IndexQueryPage {
+            items: vec![rustok_index::IndexQueryItem {
+                entity_id,
+                relations: Vec::new(),
+                fields: vec![rustok_index::IndexProjectedValue {
+                    path: rustok_index::FieldPath::new(
+                        rustok_index::FieldName::new("title").unwrap(),
+                    ),
+                    value: IndexValue::Null,
+                }],
+                nested_relations: Vec::new(),
+            }],
+            exact_count: Some(1),
+            has_more: false,
+            next_cursor: None,
+        };
+        assert!(compare_owner_and_projected(&authoritative, &projected).is_match());
+    }
+}

--- a/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs
@@ -47,14 +47,12 @@ impl ProductStorefrontIndexShadowComparison {
     }
 }
 
-/// Request-shape decision for the current Product key-4 channel projection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ProductStorefrontIndexChannelScopeDecision {
     ShadowEligible { public_channel_id: Uuid },
     OwnerNativeChannelLess,
 }
 
-/// Request-shape decision for owner-valid Product Storefront offset pagination.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ProductStorefrontIndexPageScopeDecision {
     ShadowEligible { offset: u64 },
@@ -196,7 +194,7 @@ impl ProductStorefrontIndexShadowExecutor {
         })
     }
 
-    async fn hydrate_projected_tags(
+    pub(crate) async fn hydrate_projected_tags(
         &self,
         context: PortContext,
         fallback_locale: String,
@@ -223,7 +221,7 @@ impl ProductStorefrontIndexShadowExecutor {
             .map_err(ProductStorefrontIndexTagHydrationError::Owner)
     }
 
-    async fn execute_projected(
+    pub(crate) async fn execute_projected(
         &self,
         context: PortContext,
         fallback_locale: String,

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product Storefront tag hydration merge
-`5a37e78d50b37785a2a5c119689887f441a94cf9` and continued on
-`agent/product-storefront-serving-budget-policy-20260808`.
+Status overlay rechecked after Storefront serving-budget policy merge
+`0c40387d9bb2257f8345448792f9c9ddd6b38480` and continued on
+`agent/product-storefront-budgeted-execution-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -20,97 +20,65 @@ Source-complete:
 - one current 15-field Product schema on routing key `4`; lower keys are historical storage identities only;
 - schema-scoped Product replay IDs, Product owner clock and canonical typed `attribute_terms`;
 - Product channel relation/freshness materialization;
-- localized entity identity fold, cursor v3 and requested -> fallback projection;
-- localized PostgreSQL compiler/decoder/runtime with readiness/admission and one repeatable-read page/count snapshot;
-- generic String `TextLike` plus the Product-owned 1022-byte effective Storefront search bound;
+- localized identity fold, cursor v3 and requested -> fallback projection;
+- localized PostgreSQL compiler/decoder/runtime with readiness/admission and repeatable-read page/count snapshot;
+- Product-owned 1022-byte Storefront title-search bound compatible with generic 1024-byte `TextLike`;
 - retained owner/default-vs-Index-`C` PostgreSQL title-search collation packet source;
-- localized Product-ID tie-break direction matching owner Asc/Desc ordering;
-- Product-owned Storefront attribute-filter -> neutral canonical term resolution;
-- pure Storefront shadow builder and owner-first non-serving shadow executor;
-- explicit current-key channel-scope policy: trusted non-empty slug + non-nil UUID is shadow-eligible, while
-  channel-less owner requests remain owner-native and malformed identity fails closed;
-- explicit deep-page policy: owner-valid offsets through `10_000` are shadow-eligible while deeper offsets
-  remain typed owner-native without clamp or cursor rewriting;
-- Product Storefront post-page public placeholder projection that keeps raw Index null evidence intact;
-- Product-owned bounded post-page tag hydration keyed by already-selected Product IDs, preserving Taxonomy
-  requested->fallback/canonical-key semantics and legacy metadata-only tag fallback;
-- explicit **post-owner serving-budget policy** that requires host-measured remaining budget, positive bounded
-  Index/tag phases, safety margin and selected tag-hydration capability before a future serving path is eligible;
+- Product-owned Storefront EAV filter -> neutral canonical term resolution;
+- pure Storefront shadow builder and owner-first non-serving evidence executor;
+- channel-less current-key policy: trusted slug/UUID is eligible; channel-less remains owner-native;
+- deep-page policy: offsets through `10_000` are eligible; deeper owner-valid pages remain owner-native;
+- post-page Product public title/handle placeholder projection while preserving raw Index null evidence;
+- bounded Product-owned post-page tag hydration keyed by selected Product IDs, including Taxonomy fallback and
+  legacy metadata-only tags;
+- host-measured post-owner serving-budget eligibility policy without hard-coded production SLO values;
+- **non-serving post-owner budgeted execution** that accepts only `Eligible`, narrows phase port deadlines and
+  enforces outer Tokio timeouts for raw Index/EAV execution and Product tag hydration;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
 ## Request-shape owner-native policies
 
-### Channel-less
+Channel-less owner semantics are metadata-unrestricted only and cannot be recovered exactly from current
+`sales_channel_ids`, so channel-less stays owner-native on key `4`.
 
-Owner channel-less semantics are **metadata-unrestricted only**. Current key `4` cannot distinguish unrestricted
-metadata from a restricted Product that resolves to the same complete current Channel UUID set. Channel-less
-therefore remains owner-native; trusted slug/UUID scope remains shadow-eligible; malformed identity fails closed.
+The Product owner has no generic Index offset ceiling, while Index offset is bounded to `10_000`; deeper valid
+pages therefore stay owner-native without clamp or cursor rewrite.
 
-### Deep page
+## Post-page Product projection
 
-The Product owner has no generic Index-style maximum offset. The Index path is bounded to `10_000`. Valid
-offsets above that bound remain typed owner-native after owner success; no clamp or cursor rewrite is used.
+Raw `projected` remains the generic Index page and the source for identity/order/count/page comparison.
+`public_projected` maps only no-localized-row title/handle nulls to Product public placeholders after the raw
+page is fixed.
 
-## Post-page Product projection layers
-
-### Public title/handle placeholders
-
-The raw generic `IndexQueryPage` remains Product-neutral. When requested/fallback localized rows are absent,
-root `title`/`handle` remain `IndexValue::Null` in `projected` and in raw PostgreSQL evidence.
-
-`public_projected` is derived from a clone of successful raw `projected` and maps only `title: Null` to
-`"Untitled product"` and `handle: Null` to `""`. It preserves item identity/order, count, page boundary,
-cursor, unrelated fields and `tag_ids`; raw comparison still uses `projected`.
-
-### Product-owned tag hydration
-
-`ProductStorefrontTagReadPort` accepts only already-selected Product IDs plus fallback locale. The embedded
-Product runtime wires `CatalogService` as this optional capability; external runtimes do not gain an implicit
+`ProductStorefrontTagReadPort` hydrates tags using already-selected Product IDs rather than only `tag_ids`, so
+Product relation ordering, Taxonomy requested->fallback/canonical-key resolution and legacy `metadata.tags`
+fallback remain owner semantics. Embedded runtime selects the capability; external profiles have no implicit
 embedded fallback.
 
-It preserves relation ordering, Taxonomy requested->fallback/canonical-key resolution and legacy normalized
-`metadata.tags` when relation-backed tags are absent. `tag_hydration` runs only after raw `projected` succeeds
-and cannot mutate or replace the raw/public page.
+## Serving budget and timeout enforcement
 
-## Post-owner serving-budget policy
+`PortContext.deadline_ms` is the original duration budget. A future host/router must measure `remaining_ms`
+after owner success. `ProductStorefrontIndexServingBudget` carries host-selected positive Index/tag phase
+budgets plus safety margin; classification stays owner-native when timing/capability state is missing,
+inconsistent or insufficient.
 
-`PortContext.deadline_ms` is the original duration budget, not an automatically decreasing remaining deadline.
-A future serving router must provide a monotonic host-measured `remaining_ms` at the handoff **after** the
-authoritative Product owner call.
+`ProductStorefrontIndexBudgetedProjectionExecutor` is post-owner only: it receives the already-successful owner
+page, rejects non-`Eligible` decisions before work starts, narrows the projected phase context and applies an
+outer timeout, then separately narrows and times Product tag hydration. Public placeholder mapping occurs only
+after successful raw projection. Timeout/error results remain separate and never replace owner success.
 
-`ProductStorefrontIndexServingBudget` contains host-selected:
-
-- positive `index_execution_ms`;
-- positive `tag_hydration_ms`;
-- `safety_margin_ms`;
-- checked `required_ms` sum.
-
-No production SLO numbers are hard-coded by this slice. `classify_product_storefront_index_serving_budget`
-keeps the request owner-native when deadline semantics, configured budget, measured remaining time or tag
-capability are missing/inconsistent, or when remaining time is below the required bounded phases. Only an
-internally consistent observation with sufficient budget returns `Eligible`.
-
-This is a **policy only**. It does not run timers and is deliberately not called by the current shadow executor
-or mounted Storefront. Real phase timeout enforcement remains the next source step.
+The ordinary owner-first shadow executor remains the unbudgeted evidence path. Mounted Storefront still uses
+only Product owner reads and does not call either serving-budget classification or budgeted execution.
 
 ## Remaining Storefront parity/evidence blockers
 
-- execute/review current-key Storefront, collation and actualized retained Product PostgreSQL packets;
-- admit collation parity only where the retained deployment matrix agrees;
-- add non-serving enforcement of admitted Index/tag-hydration phase timeouts and retain timeout behavior;
-- preserve channel-less and deep-page owner-native routing in any future serving composition;
-- complete maintainer-executed stale locale/readiness/admission/restart evidence.
-
-## Retained Product evidence state
-
-The retained Product PostgreSQL fixture set is source-aligned on routing key `4`: locale absence, materialized
-query freshness, Product/Channel convergence, Channel identity transitions, linked-target delete/recreate,
-linked-target availability equivalence and linked-target replay/redelivery. ProductVariant remains key `2`
-and SalesChannel remains key `1`.
-
-Existing Product taxonomy source evidence retains normalized legacy metadata-tag read fallback. It is not
-reinterpreted as Index tag identity evidence.
+- retain and execute deterministic timeout/latency evidence for budgeted post-owner execution;
+- execute/review current-key Storefront core/EAV/collation and actualized retained Product PostgreSQL packets;
+- admit collation parity only where the deployment default-vs-`C` packet agrees;
+- complete maintainer-executed stale locale/readiness/admission/restart evidence;
+- execute/admit current Product replacement evidence and stage/rebuild/promote key `4`;
+- move only eligible Storefront traffic after every evidence/latency gate; channel-less/deep pages stay owner-native.
 
 ## M5 incremental ingestion
 
@@ -135,36 +103,33 @@ reinterpreted as Index tag identity evidence.
 - [x] Current Product/ProductVariant/SalesChannel sources and graph freshness.
 - [x] One current 15-field Product contract and schema-safe replacement mechanism.
 - [x] Canonical typed EAV terms and Product owner clock.
-- [x] Localized identity/fallback architecture and query/cursor contract.
-- [x] Localized PostgreSQL compiler/decoder/runtime.
+- [x] Localized identity/fallback architecture and PostgreSQL query/runtime contract.
 - [x] Generic scalar String `TextLike` and Product-owned compatible search bound.
-- [x] Retain owner/default-vs-Index-`C` PostgreSQL title-search collation packet source.
-- [x] Explicit localized entity-ID tie-break direction matching owner Asc/Desc ordering.
+- [x] Retain owner/default-vs-Index-`C` title-search collation packet source.
 - [x] Product Storefront shadow query builder and Product-owned EAV resolution.
-- [x] Compose non-serving Product-owner + Index shadow executor.
+- [x] Compose non-serving Product-owner + Index evidence executor.
 - [x] Retain current-key core/EAV owner-vs-shadow PostgreSQL packet source.
 - [x] Actualize historical retained Product PostgreSQL packets to routing key `4`.
-- [x] Keep channel-less Storefront owner-native on current key `4`; distinguish malformed channel identity.
+- [x] Keep channel-less Storefront owner-native on current key `4`.
 - [x] Keep owner-valid offsets above `10_000` owner-native without clamp/rewrite.
-- [x] Map raw no-localized-row title/handle nulls to Product public placeholders in a post-page derived layer.
-- [x] Batch-hydrate Product tags after raw page selection through a Product-owned capability, including legacy
-      metadata-only fallback rather than relying solely on Index `tag_ids`.
-- [x] Define post-owner serving-budget eligibility using host-measured remaining time and explicit bounded
-      Index/tag phases without choosing unevidenced global SLO values.
-- [ ] Enforce admitted Index/tag phase timeouts in a non-serving execution adapter.
+- [x] Map raw title/handle nulls to Product public placeholders only post-page.
+- [x] Batch-hydrate Product tags post-page through Product owner capability, including legacy metadata fallback.
+- [x] Define host-measured post-owner serving-budget eligibility.
+- [x] Enforce admitted Index/tag phase timeouts in a separate non-serving post-owner adapter.
+- [ ] Retain deterministic runtime timeout/latency evidence for the budgeted adapter.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Extend folded linked paths only with dedicated target-availability evidence.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
-- [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes;
-      channel-less and deep-page shapes remain owner-native under the current contracts.
+- [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes.
 
 ## Next source-code step
 
-Add a **non-serving budgeted execution adapter** that accepts only an `Eligible` budget decision and actually
-applies the admitted Index and Product-tag phase timeouts. Timeout/unavailable/error outcomes must remain
-separate from the already-successful Product owner result. Do not mount that adapter into Storefront traffic.
+Retain deterministic non-serving timeout-behavior evidence for `ProductStorefrontIndexBudgetedProjectionExecutor`.
+The source packet should prove: a non-eligible decision starts no projected work; Index timeout preserves the
+owner page; raw projection failure skips public/tag enrichment; tag timeout preserves raw/public pages; phase
+`deadline_ms` values reach Product capabilities; and an eligible fast path preserves raw identity/count/page
+semantics. Do not run the packet and do not mount Storefront traffic.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-budgeted-execution.md
+++ b/crates/rustok-index/docs/m7-product-storefront-budgeted-execution.md
@@ -1,0 +1,52 @@
+# M7 Product Storefront budgeted execution
+
+Status: `source_complete_runtime_latency_evidence_pending`.
+
+## Post-owner only
+
+`ProductStorefrontIndexBudgetedProjectionExecutor` receives an already-successful authoritative Product
+Storefront page. It does not call `list_filtered_published_products` and cannot replace the owner result.
+
+The adapter starts only with `ProductStorefrontIndexServingBudgetDecision::Eligible`. Any owner-native budget
+decision is rejected before the first timeout or Index operation.
+
+## Bounded phases
+
+The admitted Index phase budget is enforced twice:
+
+- copied into the projected `PortContext.deadline_ms` so Product schema/EAV owner capabilities see the same
+  bounded phase contract;
+- enforced externally with `tokio::time::timeout` around raw `execute_projected`.
+
+Only a successful raw page reaches Product public placeholder projection and Product tag hydration.
+
+The admitted tag phase budget is likewise copied into the Product tag `PortContext.deadline_ms` and enforced
+with an outer `tokio::time::timeout` around Product-owned `hydrate_projected_tags`.
+
+The safety margin is retained in the result for evidence/telemetry but is not spent as another phase.
+
+## Failure separation
+
+The result retains:
+
+- authoritative owner page;
+- raw projected page or Index-phase timeout/error;
+- optional public title/handle projection;
+- optional Product tag hydration or tag-phase timeout/error;
+- raw identity/count/page comparison;
+- admitted phase/safety budgets.
+
+A raw Index failure skips public projection and tag hydration. A tag failure/timeout leaves the successful raw
+and public pages intact. None of these outcomes changes the authoritative Product owner result.
+
+## Separation from evidence and serving
+
+The existing owner-first shadow executor remains the unbudgeted evidence path. Its post-owner phase methods are
+crate-visible only so this separate adapter can enforce phase budgets around them.
+
+Mounted Storefront does not call the budgeted adapter. Source completeness here does not establish acceptable
+latency, timeout cancellation behavior, external-provider deadline propagation or serving readiness. Those
+require retained runtime evidence and maintainer execution/admission before any traffic switch.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `serving_budget_policy_source_complete_timeout_enforcement_pending`.
+Status: `budgeted_execution_source_complete_latency_evidence_pending`.
 
 ## Current boundary
 
@@ -12,88 +12,77 @@ maintainer execution/admission is not claimed.
 
 ## Request-shape policy — source complete
 
-- trusted non-empty public channel slug + non-nil UUID is shadow-eligible;
-- channel-less requests remain typed owner-native because key `4` cannot distinguish unrestricted metadata
-  from restricted membership that resolves to every current Channel;
-- owner-valid offsets through `10_000` are shadow-eligible;
-- deeper owner-valid pages remain typed owner-native;
+- trusted non-empty public channel slug + non-nil UUID is Index-eligible;
+- channel-less requests remain typed owner-native on Product key `4`;
+- owner-valid offsets through `10_000` are Index-eligible;
+- deeper valid pages remain typed owner-native;
 - no visibility sentinel, page clamp, cursor rewrite or Product key-5 approximation is used.
 
-## Product public projection and tags — source complete
+## Post-page Product projection — source complete
 
-Raw localized Index results remain Product-neutral. `public_projected` maps no-requested/fallback `title` and
-`handle` nulls to Product public placeholders only after the raw page is fixed.
+Raw `projected` remains the generic Index page used for identity/order/count/page evidence.
+`public_projected` derives Product title/handle placeholders only after raw page completion.
+`tag_hydration` is Product-owned, bounded to the selected page identities, and preserves Taxonomy
+requested->fallback/canonical-key semantics plus legacy `metadata.tags` fallback.
 
-`ProductStorefrontTagReadPort` performs bounded post-page Product tag hydration keyed by already-selected
-Product IDs, preserving Taxonomy requested->fallback/canonical-key semantics and legacy normalized
-`metadata.tags` fallback. Embedded Product runtime selects the capability; external profiles do not receive an
-implicit embedded fallback.
+These layers remain separate; post-page errors cannot replace the authoritative owner result or mutate the raw
+Index page.
 
-Raw `projected`, `public_projected` and `tag_hydration` remain separate results. Tag/public failures cannot
-replace the authoritative owner result or change identity/order/count/page/cursor evidence.
+## Serving-budget policy and timeout enforcement — source complete
 
-## Post-owner serving-budget policy — source complete
+`PortContext.deadline_ms` is the original duration budget, not remaining time. The eligibility classifier
+therefore requires a host-measured post-owner `remaining_ms`, a configured positive Index/tag phase budget,
+safety margin and selected tag capability. Missing/inconsistent/insufficient budget remains owner-native.
 
-`PortContext.deadline_ms` carries the original duration budget; it is not a decreasing remaining deadline. A
-future serving router must supply a host-measured `remaining_ms` at the handoff after authoritative Product
-owner success.
+`ProductStorefrontIndexBudgetedProjectionExecutor` is a separate **post-owner, non-serving** adapter. It accepts
+the already-successful `StorefrontProductList` and only an `Eligible` decision; it does not repeat the owner
+read.
 
-`ProductStorefrontIndexServingBudget` contains host-selected positive Index-execution and Product-tag-hydration
-phase budgets plus a safety margin. The source constructor checked-adds the phases and rejects zero required
-phases/overflow. This slice deliberately does **not** hard-code an unevidenced production SLO value.
+For an eligible handoff it:
 
-`classify_product_storefront_index_serving_budget` returns owner-native decisions for:
+1. sets projected phase `PortContext.deadline_ms` to the admitted Index budget;
+2. applies an outer `tokio::time::timeout` to raw projected Index/EAV execution;
+3. applies Product public placeholders only after a successful raw page;
+4. sets Product tag phase `PortContext.deadline_ms` to the admitted tag budget;
+5. applies an outer `tokio::time::timeout` to Product-owned tag hydration;
+6. keeps timeout/error outcomes separate while preserving the authoritative owner page.
 
-- absent/zero original request deadline;
-- absent configured budget policy;
-- absent host-measured remaining budget;
-- remaining budget greater than the original deadline (inconsistent observation);
-- unavailable Product tag-hydration capability;
-- remaining budget below the checked required Index + tag + safety budget.
-
-Only an internally consistent observation with enough remaining time returns `Eligible` and carries the phase
-budgets forward.
-
-This is a **classification policy**, not runtime timeout enforcement. It does not start timers, execute Index,
-call tag hydration or alter the current non-serving shadow executor. Mounted Storefront does not reference the
-policy.
+The ordinary `ProductStorefrontIndexShadowExecutor::execute` remains the unbudgeted owner-first evidence path.
+Only crate-private post-owner phase methods are reused by the budgeted adapter. Mounted Storefront references
+neither budget policy nor budgeted execution.
 
 ## Search/collation/EAV source state
 
 Product owns the 1022-byte effective Storefront title-search bound compatible with generic 1024-byte
-`TextLike`. The retained collation packet observes real owner/default `LIKE` against Index `COLLATE "C"` and
+`TextLike`. The retained collation packet observes actual owner/default `LIKE` against Index `COLLATE "C"` and
 remains execution/admission pending.
 
-Product-owned EAV resolution still supplies neutral typed term expressions to the shadow builder; missing
-option identities remain bind-free `Never`. The raw core/EAV PostgreSQL packets remain current-key source
-evidence.
+Product-owned EAV resolution supplies neutral typed term expressions; missing option identities remain
+bind-free `Never`. Current Product Index remains one 15-field schema on routing key `4`.
 
 ## Remaining fail-closed parity/evidence gates
 
-1. Add non-serving execution that actually enforces an admitted Index phase timeout and Product tag-hydration
-   phase timeout while preserving the successful owner result.
+1. Retain and maintainer-execute deterministic runtime timeout/latency evidence for the budgeted adapter.
 2. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
-3. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible Index cutover closed.
-4. Retain serving-budget/timeout latency evidence before any mounted traffic switch.
-5. Stale locale/readiness/admission/restart cases still require maintainer-executed retained evidence.
-6. Any future serving router must preserve typed channel-less and deep-page owner-native branches.
+3. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible cutover closed.
+4. Stale locale/readiness/admission/restart evidence remains maintainer-run.
+5. Stage/rebuild/promote current Product key `4` and admit replacement evidence.
+6. Any serving router must preserve channel-less/deep-page owner-native branches and traffic switch remains last.
 
 ## Next source slice
 
-Add a **non-serving budgeted execution adapter** that accepts only an `Eligible` budget decision and applies the
-admitted Index and Product-tag phase timeouts. Timeout/unavailable/error results must remain separate from the
-already-successful Product owner result. Do not mount that adapter into Storefront traffic.
+Retain deterministic **budgeted execution runtime evidence source** without mounting Storefront traffic. Cover:
+non-eligible decisions starting no projected work, Index timeout preserving owner result, raw failure skipping
+enrichment, tag timeout preserving raw/public pages, phase deadlines reaching Product capabilities, and a fast
+eligible path preserving raw identity/count semantics. Maintainer execution/admission remains separate.
 
 ## Source guards
 
-- `verify-index-product-storefront-channel-scope-policy.mjs` locks channel-less owner-native policy;
-- `verify-index-product-storefront-deep-page-policy.mjs` locks deep-page owner-native policy;
-- `verify-index-product-storefront-public-projection.mjs` locks raw/public placeholder separation;
-- `verify-index-product-storefront-tag-hydration.mjs` locks bounded Product-owned tag hydration;
-- `verify-index-product-storefront-serving-budget-policy.mjs` locks the host-measured remaining-budget contract
-  and keeps policy distinct from timeout enforcement/serving;
-- `verify-index-product-storefront-shadow-executor.mjs` locks current owner-first evidence execution;
-- current Storefront equivalence/EAV/collation/key-4 guards remain retained;
+- `verify-index-product-storefront-serving-budget-policy.mjs` locks host-measured budget classification and
+  separation from enforcement;
+- `verify-index-product-storefront-budgeted-execution.mjs` locks post-owner phase timeout enforcement;
+- `verify-index-product-storefront-shadow-executor.mjs` keeps the ordinary evidence executor separate;
+- request-shape, public-projection, tag-hydration, collation and key-4 guards remain retained;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or

--- a/crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md
+++ b/crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md
@@ -1,57 +1,50 @@
 # M7 Product Storefront serving-budget policy
 
-Status: `policy_source_complete_timeout_enforcement_pending`.
+Status: `policy_and_timeout_enforcement_source_complete_runtime_evidence_pending`.
 
-## Why `PortContext.deadline_ms` is not enough
+## Remaining budget contract
 
-`PortContext.deadline_ms` carries the original duration budget for a port call. It is not an absolute deadline
-and does not automatically decrease while the authoritative Product owner read executes.
+`PortContext.deadline_ms` is the original duration budget, not a decreasing remaining deadline. A future
+Storefront Index router must measure `remaining_ms` monotonically after the authoritative Product owner call.
 
-A future Storefront Index router therefore must not treat `deadline_ms` as the remaining time available for
-Index execution and Product post-page hydration. At the post-owner handoff it must provide a monotonic,
-host-measured `remaining_ms` observation.
+`ProductStorefrontIndexServingBudget` carries host-selected positive `index_execution_ms`,
+`tag_hydration_ms` and `safety_margin_ms`. The constructor checked-adds the phases and rejects zero required
+phases/overflow. No production SLO values are hard-coded in this source.
 
-## Explicit host policy
+`classify_product_storefront_index_serving_budget` keeps the request owner-native when the original deadline,
+configured policy, host-measured remaining budget or required Product tag capability is unavailable, when the
+observation is inconsistent, or when remaining budget is below the checked phase total. Only then can it return
+`Eligible` with the admitted phase limits.
 
-`ProductStorefrontIndexServingBudget` carries host-selected positive phase budgets:
+## Non-serving timeout enforcement
 
-- `index_execution_ms`;
-- `tag_hydration_ms`;
-- `safety_margin_ms`.
+`ProductStorefrontIndexBudgetedProjectionExecutor` is a separate post-owner adapter. The caller supplies the
+already-successful authoritative `StorefrontProductList`; the adapter never repeats the owner list read.
 
-The constructor rejects zero Index/tag phases and checked-add overflow. This source slice deliberately does not
-choose global production SLO numbers; those values belong to host configuration/admission and require runtime
-evidence.
+It accepts only an `Eligible` decision. A non-eligible decision returns `BudgetNotEligible` before projected
+work starts.
 
-## Classification
+For an eligible decision the adapter:
 
-`classify_product_storefront_index_serving_budget` receives:
+1. narrows a cloned `PortContext.deadline_ms` to `index_execution_ms`;
+2. wraps the raw `execute_projected` phase in `tokio::time::timeout` with the same budget;
+3. derives public title/handle placeholders only from a successful raw page;
+4. narrows the Product tag context to `tag_hydration_ms`;
+5. wraps Product-owned tag hydration in a second `tokio::time::timeout`;
+6. retains raw identity/count/page comparison only when the raw Index phase succeeded.
 
-- the request `PortContext` with original deadline semantics;
-- an optional configured serving budget;
-- `ProductStorefrontIndexServingBudgetObservation` containing host-measured `remaining_ms` and whether the
-  required Product tag-hydration capability is selected.
+Index timeout, raw projection error, public projection error, Product tag error and tag timeout remain separate
+outcomes. None can replace or mutate the already-successful authoritative owner result.
 
-The request remains owner-native when any of these are true:
-
-- original deadline is absent/zero;
-- serving budget policy is unavailable;
-- post-owner remaining budget was not measured;
-- measured remaining budget exceeds the original deadline and is therefore inconsistent;
-- Product tag hydration capability is unavailable;
-- remaining budget is below `index + tag hydration + safety margin`.
-
-Only an internally consistent observation with enough remaining budget returns `Eligible` and carries the two
-phase limits plus safety margin forward to a later enforcement adapter.
+The existing `ProductStorefrontIndexShadowExecutor::execute` remains the unbudgeted owner-first evidence path.
+Only its crate-private `execute_projected` and `hydrate_projected_tags` phases are reused by the budgeted adapter.
+It does not consume serving-budget decisions or start timers itself.
 
 ## Boundary
 
-This policy does not execute Index queries, call Product hydration, create timers, or switch traffic. The current
-non-serving shadow executor is deliberately not changed to consume it. Mounted Storefront remains owner-native.
-
-The next source slice must add a non-serving budgeted execution adapter that actually applies the admitted
-Index and tag-hydration phase timeouts. Timeout/error results must remain separate from the already-successful
-owner response, and no mounted Storefront cutover may occur in that slice.
+Mounted Storefront remains owner-native and does not call the serving-budget policy or budgeted executor.
+This source proves only the structure of timeout enforcement, not production latency or timeout behavior.
+Maintainer-run runtime evidence is required before any traffic-switch adapter can be admitted.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-product-storefront-budgeted-execution.mjs
+++ b/scripts/verify/verify-index-product-storefront-budgeted-execution.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-budgeted-execution] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const cargoPath = 'crates/rustok-distribution/Cargo.toml';
+const cargo = requireMarkers(cargoPath, [
+  '[dependencies]',
+  'tokio.workspace = true',
+]);
+const devSection = cargo.split('[dev-dependencies]')[1] ?? '';
+if (devSection.includes('tokio.workspace = true')) {
+  fail(`${cargoPath} must not retain a duplicate dev-only Tokio declaration once timeout enforcement is production source`);
+}
+
+const budgetPath = 'crates/rustok-distribution/src/product_index/storefront_serving_budget.rs';
+requireMarkers(budgetPath, [
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'index_execution_ms: u64',
+  'tag_hydration_ms: u64',
+  'safety_margin_ms: u64',
+]);
+
+const executionPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
+const execution = requireMarkers(executionPath, [
+  'use tokio::time::timeout;',
+  'pub(crate) struct ProductStorefrontIndexBudgetedExecution',
+  'pub(crate) authoritative: StorefrontProductList',
+  'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexBudgetedProjectionError>',
+  'pub(crate) public_projected:',
+  'pub(crate) tag_hydration:',
+  'pub(crate) comparison: Option<ProductStorefrontIndexShadowComparison>',
+  'pub(crate) index_execution_budget_ms: u64',
+  'pub(crate) tag_hydration_budget_ms: u64',
+  'pub(crate) safety_margin_ms: u64',
+  'BudgetNotEligible(ProductStorefrontIndexServingBudgetDecision)',
+  'ProductStorefrontIndexBudgetedProjectionError',
+  'TimedOut { budget_ms: u64 }',
+  'ProductStorefrontIndexBudgetedTagHydrationError',
+  'pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor',
+  'pub(crate) async fn execute_after_owner(',
+  'authoritative: StorefrontProductList',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'other => return Err(ProductStorefrontIndexBudgetedStartError::BudgetNotEligible(other))',
+  'index_context.deadline_ms = Some(index_execution_budget_ms);',
+  'timeout(',
+  'Duration::from_millis(index_execution_budget_ms)',
+  'self.shadow.execute_projected(',
+  'ProductStorefrontIndexBudgetedProjectionError::TimedOut',
+  '.map(project_product_storefront_index_page);',
+  'tag_context.deadline_ms = Some(tag_hydration_budget_ms);',
+  'Duration::from_millis(tag_hydration_budget_ms)',
+  '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
+  'ProductStorefrontIndexBudgetedTagHydrationError::TimedOut',
+  'compare_owner_and_projected(&authoritative, projected)',
+]);
+
+for (const forbidden of [
+  'list_filtered_published_products(',
+  'ProductCatalogReadRuntime',
+  'CatalogService::new',
+  'DatabaseConnection',
+  'TaxonomyService',
+  'query_all(',
+  'query_one(',
+]) {
+  if (execution.includes(forbidden)) {
+    fail(`${executionPath} must remain a post-owner adapter over selected shadow capabilities; found ${forbidden}`);
+  }
+}
+
+const matchPosition = execution.indexOf('let (index_execution_budget_ms, tag_hydration_budget_ms, safety_margin_ms) = match decision');
+const firstTimeoutPosition = execution.indexOf('let projected = match timeout(');
+if (matchPosition < 0 || firstTimeoutPosition <= matchPosition) {
+  fail('budget eligibility must be resolved before any timeout/execution starts');
+}
+const preTimeout = execution.slice(matchPosition, firstTimeoutPosition);
+if (!preTimeout.includes('BudgetNotEligible')) {
+  fail('non-eligible decisions must fail closed before projected execution');
+}
+
+const projectedPosition = execution.indexOf('let projected = match timeout(');
+const publicPosition = execution.indexOf('let public_projected = projected');
+const tagPosition = execution.indexOf('let tag_hydration = match projected.as_ref()');
+const comparisonPosition = execution.indexOf('let comparison = projected');
+if (
+  projectedPosition < 0 ||
+  publicPosition <= projectedPosition ||
+  tagPosition <= projectedPosition ||
+  comparisonPosition <= projectedPosition
+) {
+  fail('public projection, tag hydration and comparison must follow the bounded raw Index phase');
+}
+
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) async fn execute_projected(',
+  'pub(crate) async fn hydrate_projected_tags(',
+  'pub(crate) async fn execute(',
+]);
+if (executor.includes('tokio::time::timeout') || executor.includes('ProductStorefrontIndexServingBudgetDecision')) {
+  fail(`${executorPath} evidence executor must stay separate from serving-budget timeout enforcement`);
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'mod storefront_budgeted_execution;',
+  'ProductStorefrontIndexBudgetedExecution',
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
+  'ProductStorefrontIndexBudgetedStartError',
+  'ProductStorefrontIndexBudgetedProjectionError',
+  'ProductStorefrontIndexBudgetedTagHydrationError',
+]);
+
+const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
+const mounted = read(mountedPath);
+for (const forbidden of [
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
+  'ProductStorefrontIndexServingBudget',
+  'classify_product_storefront_index_serving_budget',
+  'execute_localized_query',
+]) {
+  if (mounted.includes(forbidden)) {
+    fail(`${mountedPath} must remain owner-native; found budgeted serving marker ${forbidden}`);
+  }
+}
+
+console.log('[verify-index-product-storefront-budgeted-execution] eligible post-owner projection applies bounded Index/tag timeouts while preserving the authoritative owner result; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -18,155 +18,94 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
-const storefrontPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
-const storefront = requireMarkers(storefrontPath, [
+const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
+const mounted = requireMarkers(mountedPath, [
   'CatalogService::new(runtime_ctx.db_clone(), event_bus)',
   '.list_published_products_with_query(',
 ]);
 for (const forbidden of [
   'rustok_index',
-  'SharedIndexQueryRuntime',
-  'execute_localized_query',
-  'project_product_storefront_index_page',
-  'hydrate_storefront_product_tags',
+  'ProductStorefrontIndexShadowExecutor',
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
   'ProductStorefrontIndexServingBudget',
   'classify_product_storefront_index_serving_budget',
+  'execute_localized_query',
 ]) {
-  if (storefront.includes(forbidden)) fail(`${storefrontPath} contains forbidden marker ${forbidden}`);
+  if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-product/src/services/catalog/types.rs', [
   'pub const MAX_STOREFRONT_PRODUCT_SEARCH_BYTES: usize = 1022;',
-  'search: normalize_storefront_product_search(search)?',
 ]);
-
-const ownerPath = 'crates/rustok-product/src/services/catalog/queries.rs';
-const owner = requireMarkers(ownerPath, [
-  'ProductStatus::Active',
-  'Column::PublishedAt.is_not_null()',
+requireMarkers('crates/rustok-product/src/services/catalog/queries.rs', [
   'product_channel_visibility_condition(',
   'attribute_filters::load_catalog_attribute_filter_conditions(',
   'types::validate_storefront_product_search(list_query.search.as_deref())?;',
-  'product_title_search_condition(',
   'let total = query.clone().count(&self.db).await?',
-  'pick_product_translation(items.as_slice(), locale, fallback_locale)',
   '.unwrap_or_else(|| "Untitled product".to_string())',
-  'handle: translation',
-  '.unwrap_or_default()',
   'let pattern = format!("%{search}%");',
   'pt.title LIKE $1',
-  'if page == 0 || per_page == 0 || per_page > 48',
   'let offset = (page.saturating_sub(1)) * per_page;',
 ]);
-const titleSearch = owner.slice(owner.indexOf('fn product_title_search_condition('));
-if (titleSearch.includes('pt.locale')) fail(`${ownerPath} title search became locale-scoped`);
-if (titleSearch.includes('COLLATE')) {
-  fail(`${ownerPath} owner title search changed collation before retained default-vs-C evidence admission`);
-}
-const modernList = owner.slice(
-  owner.indexOf('pub async fn list_published_products_with_query('),
-  owner.indexOf('pub(crate) async fn list_legacy_storefront_products_with_locale_fallback('),
-);
-if (modernList.includes('10_000')) {
-  fail(`${ownerPath} must not narrow owner-valid Storefront page depth to the Index offset bound`);
-}
-
-const tagPortPath = 'crates/rustok-product/src/storefront_tag_read_port.rs';
-const tagPort = requireMarkers(tagPortPath, [
-  'const MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48;',
+requireMarkers('crates/rustok-product/src/storefront_tag_read_port.rs', [
+  'MAX_STOREFRONT_TAG_HYDRATION_PRODUCTS: usize = 48',
   'pub trait ProductStorefrontTagReadPort',
-  'impl ProductStorefrontTagReadPort for CatalogService',
   '.load_product_tag_map(',
-  'context.locale.as_str()',
-  'Some(request.fallback_locale.as_str())',
-]);
-for (const forbidden of ['rustok_index', 'IndexQueryPage', 'IndexValue']) {
-  if (tagPort.includes(forbidden)) fail(`${tagPortPath} must remain Product-owned and Index-neutral: ${forbidden}`);
-}
-requireMarkers('crates/rustok-product/src/services/catalog/tags.rs', [
-  'TaxonomyService::new(self.db.clone())',
-  '.resolve_term_names(tenant_id, &ordered_term_ids, locale, fallback_locale)',
-  'metadata_has_tags_field(&product.metadata)',
-  'normalize_tag_names(&extract_metadata_tags(&product.metadata))',
 ]);
 
-const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
-const executor = requireMarkers(executorPath, [
+const shadowPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const shadow = requireMarkers(shadowPath, [
   'OwnerNativeChannelLess',
-  'ChannelLessOwnerNative',
   'OwnerNativeDeepPage { offset: u64 }',
-  'DeepPageOwnerNative { offset: u64 }',
-  'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
-  'pub(crate) public_projected:',
-  'pub(crate) tag_hydration:',
-  'TagReadPortUnavailable',
+  'pub(crate) async fn execute_projected(',
+  'pub(crate) async fn hydrate_projected_tags(',
   'list_filtered_published_products(',
   '.execute_localized_query(index_query)',
-  'let public_projected = projected',
-  '.map(project_product_storefront_index_page);',
-  'let tag_hydration = match projected.as_ref()',
-  'self.hydrate_projected_tags(context, fallback_locale, projected)',
-  '.storefront_tag_read_port()',
-  '.map(|item| item.entity_id)',
   '.hydrate_storefront_product_tags(',
-  'let comparison = projected',
-  'compare_owner_and_index(&authoritative, projected)',
 ]);
-for (const forbidden of [
-  'CHANNEL_LESS_SENTINEL',
-  'UNRESTRICTED_CHANNEL_SENTINEL',
-  '.min(MAX_INDEX_OFFSET_DEPTH)',
-  'Pagination::Cursor',
-  'TaxonomyService',
-  'product_tag::',
-  'DatabaseConnection',
-  'classify_product_storefront_index_serving_budget',
-]) {
-  if (executor.includes(forbidden)) fail(`${executorPath} contains forbidden shortcut/storage/serving marker ${forbidden}`);
+for (const forbidden of ['tokio::time::timeout', 'ProductStorefrontIndexServingBudgetDecision']) {
+  if (shadow.includes(forbidden)) fail(`${shadowPath} evidence executor must stay unbudgeted: ${forbidden}`);
 }
 
 const policyPath = 'crates/rustok-distribution/src/product_index/storefront_serving_budget.rs';
 const policy = requireMarkers(policyPath, [
-  'pub(crate) struct ProductStorefrontIndexServingBudget',
-  'index_execution_ms: u64',
-  'tag_hydration_ms: u64',
-  'safety_margin_ms: u64',
-  'required_ms: u64',
-  'checked_add(tag_hydration_ms)',
-  'checked_add(safety_margin_ms)',
-  'pub(crate) struct ProductStorefrontIndexServingBudgetObservation',
+  'ProductStorefrontIndexServingBudget',
+  'ProductStorefrontIndexServingBudgetObservation',
   'pub(crate) remaining_ms: Option<u64>',
-  'pub(crate) tag_hydration_available: bool',
-  'pub(crate) enum ProductStorefrontIndexServingBudgetDecision',
   'OwnerNativeMissingDeadline',
   'OwnerNativeBudgetPolicyUnavailable',
   'OwnerNativeRemainingBudgetUnavailable',
-  'OwnerNativeInvalidRemainingBudget',
   'OwnerNativeTagHydrationUnavailable',
   'OwnerNativeInsufficientBudget',
-  'pub(crate) fn classify_product_storefront_index_serving_budget(',
-  'context.deadline_ms.filter(|deadline_ms| *deadline_ms > 0)',
-  'if remaining_ms > deadline_ms',
-  'if !observation.tag_hydration_available',
-  'if remaining_ms < budget.required_ms()',
   'ProductStorefrontIndexServingBudgetDecision::Eligible',
   'does not automatically decrease',
 ]);
-const productionPolicy = policy.split('#[cfg(test)]')[0];
-for (const forbidden of ['Instant::now()', 'SystemTime::now()', 'tokio::time::timeout']) {
-  if (productionPolicy.includes(forbidden)) {
-    fail(`${policyPath} policy must classify host observations without manufacturing/enforcing timing: ${forbidden}`);
-  }
+if (policy.split('#[cfg(test)]')[0].includes('tokio::time::timeout')) {
+  fail(`${policyPath} classification policy must remain separate from timeout enforcement`);
 }
 
-const projectionPath = 'crates/rustok-distribution/src/product_index/storefront_projection.rs';
-const projection = requireMarkers(projectionPath, [
-  'const UNTITLED_PRODUCT: &str = "Untitled product";',
-  'pub(crate) fn project_product_storefront_index_page(',
-  'value(&projected.items[0], "tag_ids")',
+const budgetedPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
+const budgeted = requireMarkers(budgetedPath, [
+  'use tokio::time::timeout;',
+  'pub(crate) struct ProductStorefrontIndexBudgetedExecution',
+  'pub(crate) authoritative: StorefrontProductList',
+  'pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor',
+  'pub(crate) async fn execute_after_owner(',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'BudgetNotEligible',
+  'index_context.deadline_ms = Some(index_execution_budget_ms);',
+  'Duration::from_millis(index_execution_budget_ms)',
+  'self.shadow.execute_projected(',
+  'ProductStorefrontIndexBudgetedProjectionError::TimedOut',
+  '.map(project_product_storefront_index_page);',
+  'tag_context.deadline_ms = Some(tag_hydration_budget_ms);',
+  'Duration::from_millis(tag_hydration_budget_ms)',
+  '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
+  'ProductStorefrontIndexBudgetedTagHydrationError::TimedOut',
+  'compare_owner_and_projected(&authoritative, projected)',
 ]);
-for (const forbidden of ['FilterExpr', 'OrderExpr', 'LocalizedEntityQuery', 'execute_localized_query']) {
-  if (projection.includes(forbidden)) fail(`${projectionPath} must remain post-page only; found ${forbidden}`);
+if (budgeted.includes('list_filtered_published_products(')) {
+  fail(`${budgetedPath} must be post-owner and must not repeat the authoritative Product read`);
 }
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
@@ -176,63 +115,60 @@ const productIndex = requireMarkers(productIndexPath, [
   'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
-for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'tag_names', 'localized_tag_names']) {
-  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema/source marker ${forbidden}`);
+for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'localized_tag_names']) {
+  if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema marker ${forbidden}`);
 }
 
+requireMarkers('crates/rustok-distribution/src/product_index/storefront_projection.rs', [
+  'const UNTITLED_PRODUCT: &str = "Untitled product";',
+  'pub(crate) fn project_product_storefront_index_page(',
+  'value(&projected.items[0], "tag_ids")',
+]);
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_shadow_postgres_tests.rs', [
-  'RUSTOK_PRODUCT_STOREFRONT_EQUIVALENCE_DATABASE_URL',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
   'assert_eq!(owner_c.title, "Untitled product");',
   'assert_eq!(projected_string(index_c, "title")?, None);',
 ]);
 requireMarkers('crates/rustok-distribution/tests/product_storefront_search_collation_postgres.rs', [
-  'RUSTOK_PRODUCT_STOREFRONT_COLLATION_DATABASE_URL',
   'translation.title LIKE $2',
   '(translation.title COLLATE "C") LIKE $2',
 ]);
 
-requireMarkers('scripts/verify/verify-index-product-storefront-public-projection.mjs', [
-  'Product public placeholders are post-page only',
+requireMarkers('scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs', [
+  'separate budgeted execution enforces admitted phase timeouts',
+]);
+requireMarkers('scripts/verify/verify-index-product-storefront-budgeted-execution.mjs', [
+  'eligible post-owner projection applies bounded Index/tag timeouts',
+]);
+requireMarkers('scripts/verify/verify-index-product-storefront-shadow-executor.mjs', [
+  'separate budgeted adapter while mounted Storefront remains owner-native',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-tag-hydration.mjs', [
   'Product IDs from the fixed raw Index page drive bounded Product-owned tag hydration',
-]);
-requireMarkers('scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs', [
-  'future serving handoff requires explicit host-measured remaining budget',
-  'mounted Storefront remains owner-native',
-]);
-requireMarkers('scripts/verify/verify-index-product-storefront-deep-page-policy.mjs', [
-  'OwnerNativeDeepPage { offset: u64 }',
-]);
-requireMarkers('scripts/verify/verify-index-product-storefront-channel-scope-policy.mjs', [
-  'OwnerNativeChannelLess',
-]);
-requireMarkers('scripts/verify/verify-index-product-storefront-collation-postgres-packet.mjs', [
-  'must observe deployment/default collation rather than manufacture parity',
 ]);
 requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs', [
   'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `serving_budget_policy_source_complete_timeout_enforcement_pending`',
+  'Status: `budgeted_execution_source_complete_latency_evidence_pending`',
   'Mounted Storefront remains owner-native',
-  'Post-owner serving-budget policy — source complete',
-  'host-measured `remaining_ms`',
-  'classification policy',
-  'runtime timeout enforcement',
+  'Serving-budget policy and timeout enforcement — source complete',
+  '`ProductStorefrontIndexBudgetedProjectionExecutor`',
+  'runtime timeout/latency evidence',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md', [
-  'Status: `policy_source_complete_timeout_enforcement_pending`',
-  '`PortContext.deadline_ms` is not enough',
-  'host-measured `remaining_ms`',
-  'non-serving budgeted execution adapter',
+  'Status: `policy_and_timeout_enforcement_source_complete_runtime_evidence_pending`',
+  '`tokio::time::timeout`',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-storefront-budgeted-execution.md', [
+  'Status: `source_complete_runtime_latency_evidence_pending`',
+  'Post-owner only',
+  'Failure separation',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
-  "'verify-index-product-storefront-tag-hydration.mjs'",
   "'verify-index-product-storefront-serving-budget-policy.mjs'",
-  "'verify-index-product-storefront-collation-postgres-packet.mjs'",
+  "'verify-index-product-storefront-budgeted-execution.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; request shape, post-page owner projection and host-measured serving-budget policy are source-complete while timeout enforcement and evidence admission remain pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; budget policy and non-serving phase timeout enforcement are source-complete while runtime latency/evidence admission remains pending');

--- a/scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs
+++ b/scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs
@@ -18,8 +18,7 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
-const portContextPath = 'crates/rustok-api/src/ports.rs';
-requireMarkers(portContextPath, [
+requireMarkers('crates/rustok-api/src/ports.rs', [
   'pub deadline_ms: Option<u64>',
   'pub fn with_deadline(mut self, deadline: Duration)',
   'self.deadline_ms = Some(deadline.as_millis()',
@@ -33,7 +32,6 @@ const policy = requireMarkers(policyPath, [
   'tag_hydration_ms: u64',
   'safety_margin_ms: u64',
   'required_ms: u64',
-  'pub(crate) fn new(',
   'checked_add(tag_hydration_ms)',
   'checked_add(safety_margin_ms)',
   'ZeroIndexExecutionBudget',
@@ -51,16 +49,12 @@ const policy = requireMarkers(policyPath, [
   'OwnerNativeInsufficientBudget',
   'pub(crate) fn classify_product_storefront_index_serving_budget(',
   'context.deadline_ms.filter(|deadline_ms| *deadline_ms > 0)',
-  'let Some(budget) = budget else',
-  'let Some(remaining_ms) = observation.remaining_ms else',
   'if remaining_ms > deadline_ms',
   'if !observation.tag_hydration_available',
   'if remaining_ms < budget.required_ms()',
   'ProductStorefrontIndexServingBudgetDecision::Eligible',
-  'requires_host_measured_remaining_budget_and_owner_tag_capability',
-  'admits_only_when_remaining_budget_covers_all_bounded_phases',
+  'does not automatically decrease',
 ]);
-
 const productionPolicy = policy.split('#[cfg(test)]')[0];
 for (const forbidden of [
   'remaining_ms: context.deadline_ms',
@@ -71,25 +65,55 @@ for (const forbidden of [
   'tokio::time::timeout',
 ]) {
   if (productionPolicy.includes(forbidden)) {
-    fail(`${policyPath} must consume host-measured remaining budget rather than manufacture/enforce it here: ${forbidden}`);
+    fail(`${policyPath} must classify host-measured remaining budget, not manufacture or enforce timing: ${forbidden}`);
   }
 }
-if (!productionPolicy.includes('does not automatically decrease')) {
-  fail(`${policyPath} must document that PortContext.deadline_ms is not remaining time`);
+
+const budgetedPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
+const budgeted = requireMarkers(budgetedPath, [
+  'use tokio::time::timeout;',
+  'pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor',
+  'pub(crate) async fn execute_after_owner(',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'BudgetNotEligible',
+  'index_context.deadline_ms = Some(index_execution_budget_ms);',
+  'Duration::from_millis(index_execution_budget_ms)',
+  'self.shadow.execute_projected(',
+  'tag_context.deadline_ms = Some(tag_hydration_budget_ms);',
+  'Duration::from_millis(tag_hydration_budget_ms)',
+  '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
+  'ProductStorefrontIndexBudgetedProjectionError::TimedOut',
+  'ProductStorefrontIndexBudgetedTagHydrationError::TimedOut',
+  'pub(crate) authoritative: StorefrontProductList',
+]);
+if (budgeted.includes('list_filtered_published_products(')) {
+  fail(`${budgetedPath} is post-owner only and must not repeat the authoritative owner read`);
 }
 
-const productRuntimePath = 'crates/rustok-product/src/runtime.rs';
-requireMarkers(productRuntimePath, [
+const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
+const executor = requireMarkers(executorPath, [
+  'pub(crate) async fn execute_projected(',
+  'pub(crate) async fn hydrate_projected_tags(',
+  'pub(crate) async fn execute(',
+]);
+for (const forbidden of ['tokio::time::timeout', 'ProductStorefrontIndexServingBudgetDecision']) {
+  if (executor.includes(forbidden)) {
+    fail(`${executorPath} evidence executor must remain separate from serving-budget enforcement: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-product/src/runtime.rs', [
   'storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>',
   'pub fn storefront_tag_read_port(&self)',
 ]);
-
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'mod storefront_serving_budget;',
+  'mod storefront_budgeted_execution;',
   'ProductStorefrontIndexServingBudget',
   'ProductStorefrontIndexServingBudgetDecision',
   'ProductStorefrontIndexServingBudgetObservation',
   'classify_product_storefront_index_serving_budget',
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -97,22 +121,13 @@ const mounted = read(mountedPath);
 for (const forbidden of [
   'ProductStorefrontIndexServingBudget',
   'classify_product_storefront_index_serving_budget',
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
   'ProductStorefrontIndexShadowExecutor',
   'execute_localized_query',
 ]) {
   if (mounted.includes(forbidden)) {
-    fail(`${mountedPath} must remain owner-native and must not consume serving-budget/Index policy yet: ${forbidden}`);
+    fail(`${mountedPath} must remain owner-native; found serving-budget/Index marker ${forbidden}`);
   }
 }
 
-const executorPath = 'crates/rustok-distribution/src/product_index/storefront_shadow_executor.rs';
-const executor = requireMarkers(executorPath, [
-  'pub(crate) tag_hydration:',
-  'TagReadPortUnavailable',
-  'let tag_hydration = match projected.as_ref()',
-]);
-if (executor.includes('classify_product_storefront_index_serving_budget')) {
-  fail(`${executorPath} current evidence executor must not be silently promoted into a serving router`);
-}
-
-console.log('[verify-index-product-storefront-serving-budget-policy] future serving handoff requires explicit host-measured remaining budget, bounded Index/tag phases, and tag capability; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-serving-budget-policy] host-measured eligibility stays pure, separate budgeted execution enforces admitted phase timeouts, and mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -27,50 +27,42 @@ const source = requireMarkers(executorPath, [
   'pub(crate) authoritative: StorefrontProductList',
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>',
   'pub(crate) public_projected:',
-  'Option<Result<IndexQueryPage, ProductStorefrontIndexPublicProjectionError>>',
   'pub(crate) tag_hydration:',
-  'Option<Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>>',
-  'ProductStorefrontIndexTagHydrationError',
-  'TagReadPortUnavailable',
+  'list_filtered_published_products(',
   'let projected = self',
   '.execute_projected(',
   'let public_projected = projected',
   '.map(project_product_storefront_index_page);',
   'let tag_hydration = match projected.as_ref()',
   'self.hydrate_projected_tags(context, fallback_locale, projected)',
-  'async fn hydrate_projected_tags(',
+  'pub(crate) async fn hydrate_projected_tags(',
   '.storefront_tag_read_port()',
-  '.map(|item| item.entity_id)',
-  'ProductStorefrontTagHydrationRequest',
   '.hydrate_storefront_product_tags(',
-  'let comparison = projected',
-  'compare_owner_and_index(&authoritative, projected)',
-  'classify_product_storefront_index_channel_scope(',
-  'classify_product_storefront_index_page_scope(&query)',
+  'pub(crate) async fn execute_projected(',
   '.schema_read_port()',
   '.resolve_storefront_attribute_filters(',
   'build_product_storefront_index_shadow_query(',
   '.execute_localized_query(index_query)',
+  'let comparison = projected',
+  'compare_owner_and_index(&authoritative, projected)',
 ]);
 
 const ownerPosition = source.indexOf('list_filtered_published_products(');
 const projectedPosition = source.indexOf('let projected = self');
 const publicPosition = source.indexOf('let public_projected = projected');
 const hydrationPosition = source.indexOf('let tag_hydration = match projected.as_ref()');
-const comparisonPosition = source.indexOf('let comparison = projected');
 if (
   ownerPosition < 0 ||
   projectedPosition <= ownerPosition ||
   publicPosition <= projectedPosition ||
-  hydrationPosition <= projectedPosition ||
-  comparisonPosition <= projectedPosition
+  hydrationPosition <= projectedPosition
 ) {
-  fail('owner success must precede raw Index page, and all enrichment/comparison must follow that raw page');
+  fail('owner success must precede raw Index evidence, and post-page enrichment must follow it');
 }
 
-const rawStart = source.indexOf('async fn execute_projected(');
+const rawStart = source.indexOf('pub(crate) async fn execute_projected(');
 const compareStart = source.indexOf('fn compare_owner_and_index(');
-if (rawStart < 0 || compareStart <= rawStart) fail('raw projected execution boundary is missing');
+if (rawStart < 0 || compareStart <= rawStart) fail('crate-private raw projected execution boundary is missing');
 const rawExecution = source.slice(rawStart, compareStart);
 for (const forbidden of [
   'project_product_storefront_index_page',
@@ -95,9 +87,20 @@ for (const forbidden of [
   'UNRESTRICTED_CHANNEL_SENTINEL',
   '.min(MAX_INDEX_OFFSET_DEPTH)',
   'Pagination::Cursor',
+  'tokio::time::timeout',
+  'ProductStorefrontIndexServingBudgetDecision',
 ]) {
-  if (source.includes(forbidden)) fail(`${executorPath} must compose selected ports only; found ${forbidden}`);
+  if (source.includes(forbidden)) fail(`${executorPath} must remain the unbudgeted evidence executor; found ${forbidden}`);
 }
+
+const budgetedPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
+requireMarkers(budgetedPath, [
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'self.shadow.execute_projected(',
+  '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
+  'use tokio::time::timeout;',
+]);
 
 requireMarkers('crates/rustok-product/src/storefront_tag_read_port.rs', [
   'pub trait ProductStorefrontTagReadPort',
@@ -110,6 +113,7 @@ requireMarkers('crates/rustok-distribution/src/product_index/storefront_projecti
 ]);
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'ProductStorefrontIndexTagHydrationError',
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -119,6 +123,7 @@ const mounted = requireMarkers(mountedPath, [
 ]);
 for (const forbidden of [
   'ProductStorefrontIndexShadowExecutor',
+  'ProductStorefrontIndexBudgetedProjectionExecutor',
   'execute_localized_query',
   'project_product_storefront_index_page',
   'hydrate_storefront_product_tags',
@@ -126,4 +131,4 @@ for (const forbidden of [
   if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
-console.log('[verify-index-product-storefront-shadow-executor] raw Index page, public placeholders and Product-owned tag hydration are source-separated; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-shadow-executor] owner-first evidence executor exposes crate-private post-owner phases to a separate budgeted adapter while mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -90,6 +90,7 @@ const scripts = [
   'verify-index-product-storefront-public-projection.mjs',
   'verify-index-product-storefront-tag-hydration.mjs',
   'verify-index-product-storefront-serving-budget-policy.mjs',
+  'verify-index-product-storefront-budgeted-execution.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',


### PR DESCRIPTION
## Summary

- add a separate non-serving post-owner `ProductStorefrontIndexBudgetedProjectionExecutor`;
- require the caller to provide the already-successful authoritative Product Storefront page, so budgeted projection never repeats or replaces the owner read;
- accept only `ProductStorefrontIndexServingBudgetDecision::Eligible`; reject all owner-native budget decisions before any timeout or projected work starts;
- narrow the projected phase `PortContext.deadline_ms` to the admitted Index budget and apply an outer `tokio::time::timeout` around the existing raw Index/EAV projected phase;
- derive Product public title/handle placeholders only after raw projected success;
- narrow the Product tag phase context to the admitted hydration budget and apply a second outer timeout around Product-owned tag hydration;
- retain Index timeout/error, public projection error, tag timeout/error and raw comparison as separate results while preserving the authoritative owner page;
- keep the existing owner-first shadow executor as the unbudgeted evidence path; only its post-owner projected/tag phase methods become crate-visible for the separate budgeted adapter;
- promote the already-workspace Tokio dependency from dev-only to production in `rustok-distribution` for timeout enforcement;
- add focused source guards/docs and advance M7 to deterministic runtime timeout/latency evidence.

## Boundary

Mounted Storefront remains owner-native. This PR does not switch traffic, choose production SLO milliseconds, alter Product schema/source/routing key, run or admit latency/PostgreSQL evidence, or change channel-less/deep-page owner-native policy.

The serving-budget classifier remains pure and host-measured; timeout enforcement exists only in the separate post-owner adapter.

## Main recheck

The branch started from serving-budget policy merge `0c40387d9bb2257f8345448792f9c9ddd6b38480`. Current `main@acb81ef9c1ee71f34ab269bd0ab928c87e08ba8f` advanced through Groups #3257/#3258 only; their changed paths are disjoint from this Product/Index slice. Final compare contains 13 expected dependency, Product/Index runtime, guard and documentation files and no Product Index schema/source/query-builder or mounted Storefront changes.

## Validation

Static source review found and corrected a typed `ProductStatus` test literal mismatch and confirmed workspace Tokio uses `features = ["full"]`, including `time`. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.