### PR TITLE
test(groups): add SQLite enforcement expiry and revoke evidence

### DIFF
--- a/apps/server/tests/groups_membership_enforcement_expiry_sqlite.rs
+++ b/apps/server/tests/groups_membership_enforcement_expiry_sqlite.rs
@@ -1,0 +1,381 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    GroupMembershipEffectiveStatus, GroupMembershipEnforcementCommandPort,
+    GroupMembershipEnforcementCommandService, GroupMembershipEnforcementReadPort,
+    GroupMembershipEnforcementService, ReadGroupMembershipEnforcementRequest,
+    RevokeGroupMembershipSuspensionRequest, SuspendGroupMembershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("SQLite Groups expiry evidence connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply in SQLite expiry evidence database");
+    }
+}
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp.path().join("groups-enforcement-expiry.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+fn user_write_context(
+    tenant_id: Uuid,
+    user_id: Uuid,
+    idempotency_key: impl Into<String>,
+) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(user_id.to_string()),
+        "en",
+        format!("groups-expiry-evidence-write-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn owner_read_context(tenant_id: Uuid, owner_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(owner_id.to_string()),
+        "en",
+        format!("groups-expiry-evidence-read-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_claim("groups:access:read")
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    expiring_user_id: Uuid,
+    revoked_user_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'enforcement-expiry-evidence', 3);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{expiring_user_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{revoked_user_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups SQLite expiry evidence fixture should seed");
+}
+
+async fn membership_revision(db: &DatabaseConnection, tenant_id: Uuid, user_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership revision query should succeed")
+        .expect("membership should exist");
+    row.try_get("", "revision")
+        .expect("membership revision should decode")
+}
+
+async fn group_member_count(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT member_count FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group member_count query should succeed")
+        .expect("group should exist");
+    row.try_get("", "member_count")
+        .expect("group member_count should decode")
+}
+
+async fn enforcement_projection(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> (i64, Option<String>, Option<String>, String) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT revision, effective_until, revoked_at, source_kind FROM group_membership_enforcements WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("enforcement projection query should succeed")
+        .expect("enforcement projection should remain stored");
+    (
+        row.try_get("", "revision")
+            .expect("enforcement revision should decode"),
+        row.try_get("", "effective_until")
+            .expect("effective_until should decode"),
+        row.try_get("", "revoked_at")
+            .expect("revoked_at should decode"),
+        row.try_get("", "source_kind")
+            .expect("source_kind should decode"),
+    )
+}
+
+async fn read_effective_state(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    owner_id: Uuid,
+    group_id: Uuid,
+    target_user_id: Uuid,
+) -> rustok_groups::GroupMembershipEffectiveState {
+    let service = GroupMembershipEnforcementService::new(db.clone());
+    GroupMembershipEnforcementReadPort::read_membership_enforcement(
+        &service,
+        owner_read_context(tenant_id, owner_id),
+        ReadGroupMembershipEnforcementRequest {
+            group_id,
+            user_id: target_user_id,
+        },
+    )
+    .await
+    .expect("owner read claim should resolve effective membership state")
+}
+
+#[tokio::test]
+async fn sqlite_group_membership_enforcement_expiry_and_revoke_restore_without_cleanup() {
+    let temp = tempfile::tempdir().expect("temporary SQLite expiry evidence directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let fixture = connect(&url).await;
+    install_groups_schema(&fixture).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let expiring_user_id = Uuid::new_v4();
+    let revoked_user_id = Uuid::new_v4();
+    seed_group_fixture(
+        &fixture,
+        tenant_id,
+        group_id,
+        owner_id,
+        expiring_user_id,
+        revoked_user_id,
+    )
+    .await;
+    assert_eq!(group_member_count(&fixture, tenant_id, group_id).await, 3);
+
+    let expiring_initial_revision =
+        membership_revision(&fixture, tenant_id, expiring_user_id).await;
+    let expiring_until = Utc::now() + chrono::Duration::seconds(2);
+    let expiring_command = GroupMembershipEnforcementCommandService::new(connect(&url).await);
+    let expiring_suspension = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &expiring_command,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("expiry-suspend-{}", Uuid::new_v4()),
+        ),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: expiring_user_id,
+            expected_membership_revision: expiring_initial_revision,
+            reason_code: "temporary_review".to_string(),
+            effective_until: Some(expiring_until),
+        },
+    )
+    .await
+    .expect("owner should create an expiring direct-local suspension");
+    assert_eq!(
+        expiring_suspension.effective_status,
+        GroupMembershipEffectiveStatus::Suspended
+    );
+    assert_eq!(
+        expiring_suspension.membership_revision,
+        expiring_initial_revision + 1
+    );
+    assert_eq!(expiring_suspension.member_count, 3);
+    assert_eq!(group_member_count(&fixture, tenant_id, group_id).await, 3);
+
+    let during_expiry = read_effective_state(
+        &fixture,
+        tenant_id,
+        owner_id,
+        group_id,
+        expiring_user_id,
+    )
+    .await;
+    assert_eq!(
+        during_expiry.effective_status,
+        GroupMembershipEffectiveStatus::Suspended
+    );
+    assert!(!during_expiry.active_member);
+    let during_projection = during_expiry
+        .enforcement
+        .as_ref()
+        .expect("active suspension should expose the current owner projection");
+    assert!(during_projection.is_effective);
+    assert_eq!(during_projection.source_kind.as_str(), "direct_local");
+
+    tokio::time::sleep(Duration::from_millis(2300)).await;
+
+    let after_expiry = read_effective_state(
+        &fixture,
+        tenant_id,
+        owner_id,
+        group_id,
+        expiring_user_id,
+    )
+    .await;
+    assert_eq!(
+        after_expiry.effective_status,
+        GroupMembershipEffectiveStatus::Active
+    );
+    assert!(after_expiry.active_member);
+    let expired_projection = after_expiry
+        .enforcement
+        .as_ref()
+        .expect("expired suspension projection should remain stored for owner evidence");
+    assert!(!expired_projection.is_effective);
+    assert!(expired_projection.effective_until.is_some());
+    assert!(expired_projection.revoked_at.is_none());
+    assert_eq!(expired_projection.source_kind.as_str(), "direct_local");
+    assert_eq!(
+        membership_revision(&fixture, tenant_id, expiring_user_id).await,
+        expiring_initial_revision + 1,
+        "clock expiry must not require a cleanup write or synthetic membership revision bump"
+    );
+    assert_eq!(group_member_count(&fixture, tenant_id, group_id).await, 3);
+    let (_, persisted_until, persisted_revoked_at, persisted_source) =
+        enforcement_projection(&fixture, tenant_id, expiring_user_id).await;
+    assert!(persisted_until.is_some());
+    assert!(persisted_revoked_at.is_none());
+    assert_eq!(persisted_source, "direct_local");
+
+    let revoke_initial_revision = membership_revision(&fixture, tenant_id, revoked_user_id).await;
+    let revoke_command = GroupMembershipEnforcementCommandService::new(connect(&url).await);
+    let permanent_suspension = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &revoke_command,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("revoke-suspend-{}", Uuid::new_v4()),
+        ),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: revoked_user_id,
+            expected_membership_revision: revoke_initial_revision,
+            reason_code: "manual_review".to_string(),
+            effective_until: None,
+        },
+    )
+    .await
+    .expect("owner should create a direct-local suspension for revoke evidence");
+    assert_eq!(
+        permanent_suspension.effective_status,
+        GroupMembershipEffectiveStatus::Suspended
+    );
+    assert_eq!(group_member_count(&fixture, tenant_id, group_id).await, 3);
+
+    let before_revoke_projection = enforcement_projection(&fixture, tenant_id, revoked_user_id).await;
+    assert!(before_revoke_projection.2.is_none());
+    assert_eq!(before_revoke_projection.3, "direct_local");
+
+    let revoked = GroupMembershipEnforcementCommandPort::revoke_membership_suspension(
+        &revoke_command,
+        user_write_context(
+            tenant_id,
+            owner_id,
+            format!("revoke-direct-{}", Uuid::new_v4()),
+        ),
+        RevokeGroupMembershipSuspensionRequest {
+            group_id,
+            target_user_id: revoked_user_id,
+            expected_membership_revision: permanent_suspension.membership_revision,
+            reason_code: "review_complete".to_string(),
+        },
+    )
+    .await
+    .expect("owner should revoke an active direct-local suspension");
+    assert_eq!(revoked.effective_status, GroupMembershipEffectiveStatus::Active);
+    assert!(revoked.revoked_at.is_some());
+    assert_eq!(
+        revoked.membership_revision,
+        permanent_suspension.membership_revision + 1
+    );
+    assert_eq!(revoked.member_count, 3);
+    assert_eq!(group_member_count(&fixture, tenant_id, group_id).await, 3);
+
+    let after_revoke = read_effective_state(
+        &fixture,
+        tenant_id,
+        owner_id,
+        group_id,
+        revoked_user_id,
+    )
+    .await;
+    assert_eq!(
+        after_revoke.effective_status,
+        GroupMembershipEffectiveStatus::Active
+    );
+    assert!(after_revoke.active_member);
+    let revoked_projection = after_revoke
+        .enforcement
+        .as_ref()
+        .expect("revoked suspension projection should remain stored for owner evidence");
+    assert!(!revoked_projection.is_effective);
+    assert!(revoked_projection.revoked_at.is_some());
+    assert_eq!(revoked_projection.source_kind.as_str(), "direct_local");
+
+    let after_revoke_projection = enforcement_projection(&fixture, tenant_id, revoked_user_id).await;
+    assert_eq!(
+        after_revoke_projection.0,
+        before_revoke_projection.0 + 1,
+        "revoke should mutate the current projection in place rather than delete it"
+    );
+    assert!(after_revoke_projection.2.is_some());
+    assert_eq!(after_revoke_projection.3, "direct_local");
+    assert_eq!(
+        membership_revision(&fixture, tenant_id, revoked_user_id).await,
+        revoke_initial_revision + 2,
+        "suspend and revoke should each advance the membership revision exactly once"
+    );
+    assert_eq!(group_member_count(&fixture, tenant_id, group_id).await, 3);
+
+    drop(expiring_command);
+    drop(revoke_command);
+    drop(fixture);
+    drop(temp);
+}

--- a/crates/rustok-groups/docs/membership-enforcement-expiry-sqlite-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-expiry-sqlite-contract.md
@@ -1,0 +1,78 @@
+# Groups membership enforcement expiry/revoke SQLite evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_membership_enforcement_expiry_sqlite.rs` retains executable owner-state evidence that temporary Groups membership suspension does not require cleanup to restore effective membership and that direct revoke preserves the current enforcement projection instead of deleting history-bearing owner state.
+
+The packet uses a real temporary SQLite file, all production Groups migrations, `GroupMembershipEnforcementCommandPort`, and `GroupMembershipEnforcementReadPort`. It adds no dependency or alternate enforcement implementation.
+
+The canonical Groups plan already lists expiry/revoke and lifecycle-count invariance as open GROUPS-07 evidence. This packet supplies executable source for that existing gate; it does not promote the gate to completed runtime evidence.
+
+## Expiry contract
+
+One lifecycle-active member is suspended through the production direct command with a short future `effective_until`.
+
+Immediately after the command the evidence requires:
+
+- effective status `Suspended`;
+- `active_member=false`;
+- current projection `is_effective=true`;
+- `source_kind=direct_local`;
+- membership revision advanced exactly once;
+- stored group `member_count` unchanged.
+
+After the owner clock passes `effective_until`, the test performs **no cleanup mutation**. A fresh production read must resolve:
+
+- effective status `Active`;
+- `active_member=true`;
+- the same current enforcement projection still present;
+- `is_effective=false`;
+- original expiry still present;
+- `revoked_at` still null;
+- `source_kind=direct_local` unchanged;
+- membership revision unchanged since the original suspension;
+- group `member_count` unchanged.
+
+This is the executable form of the rule that expiry is read-time owner-clock semantics, not a scheduled lifecycle transition.
+
+## Direct revoke contract
+
+A second lifecycle-active member receives a non-expiring direct-local suspension through the production command. The owner then calls the production revoke command using the post-suspend membership revision as the CAS precondition.
+
+The evidence requires:
+
+- revoke result effective status `Active`;
+- revoke timestamp present;
+- membership revision advances exactly once for suspend and once for revoke;
+- enforcement projection revision advances in place;
+- the projection remains stored with `source_kind=direct_local`;
+- `revoked_at` becomes non-null;
+- a fresh production read reports the projection as non-effective and membership as active;
+- stored lifecycle `member_count` never changes.
+
+The packet intentionally does not test revocation of `source_kind=moderation_decision`; production source forbids that through the direct-local revoke command.
+
+## Timing
+
+The expiry test uses a two-second future expiry and waits slightly beyond that boundary before the second owner read. If the runtime cannot observe the expected owner-clock transition, the test should fail rather than silently introducing cleanup or fallback behavior.
+
+## Execution status
+
+This file was not executed while preparing the slice. SQLite expiry/revoke runtime evidence therefore remains **maintainer execution pending**.
+
+Maintainer command:
+
+```bash
+cargo test -p rustok-server --features mod-groups \
+  --test groups_membership_enforcement_expiry_sqlite -- --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-membership-enforcement-expiry-sqlite.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this evidence source.

--- a/scripts/verify/verify-groups-membership-enforcement-expiry-sqlite.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-expiry-sqlite.mjs
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_membership_enforcement_expiry_sqlite.rs";
+const docsPath = "crates/rustok-groups/docs/membership-enforcement-expiry-sqlite-contract.md";
+
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+
+function requireText(source, needle, message) {
+  if (!source.includes(needle)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "rustok_groups::migrations::migrations()",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "GroupMembershipEnforcementCommandPort::revoke_membership_suspension",
+  "GroupMembershipEnforcementReadPort::read_membership_enforcement",
+  'with_claim("groups:access:read")',
+  "chrono::Duration::seconds(2)",
+  "tokio::time::sleep",
+  "GroupMembershipEffectiveStatus::Suspended",
+  "GroupMembershipEffectiveStatus::Active",
+  "expired_projection.is_effective",
+  "expired_projection.revoked_at.is_none()",
+  "revoked_projection.revoked_at.is_some()",
+  "before_revoke_projection.0 + 1",
+  "revoke_initial_revision + 2",
+  "group_member_count",
+  '"direct_local"',
+]) {
+  requireText(test, marker, `Groups SQLite expiry/revoke evidence is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "sqlite::memory:",
+  "DELETE FROM group_membership_enforcements",
+  "UPDATE group_membership_enforcements SET effective_until",
+  "rustok_moderation::",
+  "cargo test",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups SQLite expiry/revoke evidence contains forbidden shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "canonical Groups plan already lists expiry/revoke",
+  "Expiry contract",
+  "Direct revoke contract",
+  "no cleanup mutation",
+  "member_count",
+  "maintainer execution pending",
+]) {
+  requireText(docs, marker, `Groups SQLite expiry/revoke handoff is missing ${marker}`);
+}
+
+console.log("Groups membership enforcement expiry/revoke SQLite source guard passed");


### PR DESCRIPTION
## Summary
- add file-backed SQLite evidence for owner-clock expiry and direct-local revoke using production Groups migrations and services
- suspend one lifecycle-active member with a short `effective_until`, then prove a fresh owner read restores effective-active state after the clock boundary without cleanup
- prove the expired enforcement projection remains stored, non-effective, unrevoked and `direct_local`
- suspend and canonically revoke a second member, proving in-place projection revision, revocation provenance and two exact membership revision advances
- assert stored lifecycle `member_count` remains unchanged across suspend, expiry and revoke
- use `GroupMembershipEnforcementReadPort` for effective-state truth and raw SQL only for persistence/revision diagnostics
- add a focused handoff and static source guard; the canonical plan already lists expiry/revoke as an open GROUPS-07 evidence gate, so no roadmap status is promoted
- add no dependencies, manifest changes or lockfile changes

## Verification
Static source review only. Cargo commands, tests, Node verifiers, formatters, migration execution, workflows and CI were intentionally not run per maintainer request.