### PR TITLE
test(index): retain Storefront budgeted timeout evidence

### DIFF
--- a/crates/rustok-distribution/src/product_index/mod.rs
+++ b/crates/rustok-distribution/src/product_index/mod.rs
@@ -14,8 +14,10 @@ mod storefront_budgeted_execution;
 pub(crate) use storefront_budgeted_execution::{
     ProductStorefrontIndexBudgetedExecution, ProductStorefrontIndexBudgetedProjectionError,
     ProductStorefrontIndexBudgetedProjectionExecutor, ProductStorefrontIndexBudgetedStartError,
-    ProductStorefrontIndexBudgetedTagHydrationError,
+    ProductStorefrontIndexBudgetedTagHydrationError, ProductStorefrontIndexProjectionPhases,
 };
+#[cfg(test)]
+mod storefront_budgeted_execution_tests;
 mod storefront_projection;
 pub(crate) use storefront_projection::{
     ProductStorefrontIndexPublicProjectionError, project_product_storefront_index_page,

--- a/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs
@@ -1,5 +1,6 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
+use async_trait::async_trait;
 use rustok_api::PortContext;
 use rustok_index::IndexQueryPage;
 use rustok_product::{
@@ -53,6 +54,66 @@ pub(crate) enum ProductStorefrontIndexBudgetedTagHydrationError {
     Hydration(#[from] ProductStorefrontIndexTagHydrationError),
 }
 
+/// Post-owner projected phases consumed by the budgeted adapter.
+///
+/// Production uses `ProductStorefrontIndexShadowExecutor`. The trait exists so retained tests can exercise
+/// the real budget/timeout wrapper deterministically without PostgreSQL or a synthetic shared Index runtime.
+#[async_trait]
+pub(crate) trait ProductStorefrontIndexProjectionPhases: Send + Sync {
+    async fn execute_projected(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        public_channel_slug: Option<String>,
+        public_channel_id: Option<Uuid>,
+        query: StorefrontProductListQuery,
+    ) -> Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError>;
+
+    async fn hydrate_projected_tags(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        projected: &IndexQueryPage,
+    ) -> Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError>;
+}
+
+#[async_trait]
+impl ProductStorefrontIndexProjectionPhases for ProductStorefrontIndexShadowExecutor {
+    async fn execute_projected(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        public_channel_slug: Option<String>,
+        public_channel_id: Option<Uuid>,
+        query: StorefrontProductListQuery,
+    ) -> Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError> {
+        ProductStorefrontIndexShadowExecutor::execute_projected(
+            self,
+            context,
+            fallback_locale,
+            public_channel_slug,
+            public_channel_id,
+            query,
+        )
+        .await
+    }
+
+    async fn hydrate_projected_tags(
+        &self,
+        context: PortContext,
+        fallback_locale: String,
+        projected: &IndexQueryPage,
+    ) -> Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError> {
+        ProductStorefrontIndexShadowExecutor::hydrate_projected_tags(
+            self,
+            context,
+            fallback_locale,
+            projected,
+        )
+        .await
+    }
+}
+
 /// Non-serving executor for an already-authoritative Product Storefront page.
 ///
 /// The caller must first produce the authoritative owner result and classify the post-owner remaining budget.
@@ -61,12 +122,19 @@ pub(crate) enum ProductStorefrontIndexBudgetedTagHydrationError {
 /// Mounted Storefront does not call this adapter.
 #[derive(Clone)]
 pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor {
-    shadow: ProductStorefrontIndexShadowExecutor,
+    phases: Arc<dyn ProductStorefrontIndexProjectionPhases>,
 }
 
 impl ProductStorefrontIndexBudgetedProjectionExecutor {
     pub(crate) fn new(shadow: ProductStorefrontIndexShadowExecutor) -> Self {
-        Self { shadow }
+        Self {
+            phases: Arc::new(shadow),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_phases(phases: Arc<dyn ProductStorefrontIndexProjectionPhases>) -> Self {
+        Self { phases }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -93,7 +161,7 @@ impl ProductStorefrontIndexBudgetedProjectionExecutor {
         index_context.deadline_ms = Some(index_execution_budget_ms);
         let projected = match timeout(
             Duration::from_millis(index_execution_budget_ms),
-            self.shadow.execute_projected(
+            self.phases.execute_projected(
                 index_context,
                 fallback_locale.clone(),
                 public_channel_slug,
@@ -122,7 +190,7 @@ impl ProductStorefrontIndexBudgetedProjectionExecutor {
                 Some(
                     match timeout(
                         Duration::from_millis(tag_hydration_budget_ms),
-                        self.shadow
+                        self.phases
                             .hydrate_projected_tags(tag_context, fallback_locale, projected),
                     )
                     .await

--- a/crates/rustok-distribution/src/product_index/storefront_budgeted_execution_tests.rs
+++ b/crates/rustok-distribution/src/product_index/storefront_budgeted_execution_tests.rs
@@ -1,0 +1,342 @@
+use std::{
+    future::pending,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use rustok_api::{PortActor, PortContext};
+use rustok_index::{
+    FieldName, FieldPath, IndexProjectedValue, IndexQueryItem, IndexQueryPage, IndexValue,
+};
+use rustok_product::{
+    ProductStorefrontTagHydration, ProductStorefrontTagHydrationItem, StorefrontProductList,
+    StorefrontProductListItem, StorefrontProductListQuery, entities::product::ProductStatus,
+};
+use uuid::Uuid;
+
+use super::{
+    ProductStorefrontIndexBudgetedProjectionError, ProductStorefrontIndexBudgetedProjectionExecutor,
+    ProductStorefrontIndexBudgetedStartError, ProductStorefrontIndexBudgetedTagHydrationError,
+    ProductStorefrontIndexProjectionPhases, ProductStorefrontIndexServingBudgetDecision,
+    ProductStorefrontIndexShadowProjectionError, ProductStorefrontIndexTagHydrationError,
+};
+
+#[derive(Clone, Copy)]
+enum IndexBehavior {
+    Return,
+    Error,
+    Pending,
+}
+
+#[derive(Clone, Copy)]
+enum TagBehavior {
+    Return,
+    Pending,
+}
+
+#[derive(Default)]
+struct FakeState {
+    index_calls: AtomicUsize,
+    tag_calls: AtomicUsize,
+    index_deadlines: Mutex<Vec<Option<u64>>>,
+    tag_deadlines: Mutex<Vec<Option<u64>>>,
+}
+
+struct FakePhases {
+    state: Arc<FakeState>,
+    index_behavior: IndexBehavior,
+    tag_behavior: TagBehavior,
+    page: IndexQueryPage,
+    hydration: ProductStorefrontTagHydration,
+}
+
+#[async_trait]
+impl ProductStorefrontIndexProjectionPhases for FakePhases {
+    async fn execute_projected(
+        &self,
+        context: PortContext,
+        _fallback_locale: String,
+        _public_channel_slug: Option<String>,
+        _public_channel_id: Option<Uuid>,
+        _query: StorefrontProductListQuery,
+    ) -> Result<IndexQueryPage, ProductStorefrontIndexShadowProjectionError> {
+        self.state.index_calls.fetch_add(1, Ordering::SeqCst);
+        self.state
+            .index_deadlines
+            .lock()
+            .unwrap()
+            .push(context.deadline_ms);
+        match self.index_behavior {
+            IndexBehavior::Return => Ok(self.page.clone()),
+            IndexBehavior::Error => Err(ProductStorefrontIndexShadowProjectionError::InvalidTenant),
+            IndexBehavior::Pending => {
+                pending::<()>().await;
+                unreachable!("pending projected phase is cancelled only by the budget timeout")
+            }
+        }
+    }
+
+    async fn hydrate_projected_tags(
+        &self,
+        context: PortContext,
+        _fallback_locale: String,
+        _projected: &IndexQueryPage,
+    ) -> Result<ProductStorefrontTagHydration, ProductStorefrontIndexTagHydrationError> {
+        self.state.tag_calls.fetch_add(1, Ordering::SeqCst);
+        self.state
+            .tag_deadlines
+            .lock()
+            .unwrap()
+            .push(context.deadline_ms);
+        match self.tag_behavior {
+            TagBehavior::Return => Ok(self.hydration.clone()),
+            TagBehavior::Pending => {
+                pending::<()>().await;
+                unreachable!("pending tag phase is cancelled only by the budget timeout")
+            }
+        }
+    }
+}
+
+fn context() -> PortContext {
+    PortContext::new(
+        Uuid::from_u128(0x9100).to_string(),
+        PortActor::system(),
+        "fi",
+        "budgeted-storefront-evidence",
+    )
+}
+
+fn field(name: &str, value: IndexValue) -> IndexProjectedValue {
+    IndexProjectedValue {
+        path: FieldPath::new(FieldName::new(name).unwrap()),
+        value,
+    }
+}
+
+fn raw_page(product_id: Uuid) -> IndexQueryPage {
+    IndexQueryPage {
+        items: vec![IndexQueryItem {
+            entity_id: product_id,
+            relations: Vec::new(),
+            fields: vec![
+                field("title", IndexValue::Null),
+                field("handle", IndexValue::Null),
+                field("tag_ids", IndexValue::List(Vec::new())),
+            ],
+            nested_relations: Vec::new(),
+        }],
+        exact_count: Some(1),
+        has_more: false,
+        next_cursor: None,
+    }
+}
+
+fn authoritative_page(product_id: Uuid) -> StorefrontProductList {
+    StorefrontProductList {
+        items: vec![StorefrontProductListItem {
+            id: product_id,
+            status: ProductStatus::Active,
+            title: "Untitled product".to_owned(),
+            handle: String::new(),
+            seller_id: None,
+            vendor: None,
+            product_type: None,
+            tags: vec!["Legacy".to_owned()],
+            created_at: chrono::Utc::now(),
+            published_at: None,
+        }],
+        total: 1,
+        page: 1,
+        per_page: 12,
+        has_next: false,
+    }
+}
+
+fn hydration(product_id: Uuid) -> ProductStorefrontTagHydration {
+    ProductStorefrontTagHydration {
+        items: vec![ProductStorefrontTagHydrationItem {
+            product_id,
+            tags: vec!["Legacy".to_owned()],
+        }],
+    }
+}
+
+fn fake_executor(
+    product_id: Uuid,
+    index_behavior: IndexBehavior,
+    tag_behavior: TagBehavior,
+) -> (ProductStorefrontIndexBudgetedProjectionExecutor, Arc<FakeState>) {
+    let state = Arc::new(FakeState::default());
+    let phases = FakePhases {
+        state: state.clone(),
+        index_behavior,
+        tag_behavior,
+        page: raw_page(product_id),
+        hydration: hydration(product_id),
+    };
+    (
+        ProductStorefrontIndexBudgetedProjectionExecutor::from_phases(Arc::new(phases)),
+        state,
+    )
+}
+
+fn eligible(index_execution_ms: u64, tag_hydration_ms: u64) -> ProductStorefrontIndexServingBudgetDecision {
+    ProductStorefrontIndexServingBudgetDecision::Eligible {
+        index_execution_ms,
+        tag_hydration_ms,
+        safety_margin_ms: 1,
+    }
+}
+
+async fn execute(
+    executor: &ProductStorefrontIndexBudgetedProjectionExecutor,
+    authoritative: StorefrontProductList,
+    decision: ProductStorefrontIndexServingBudgetDecision,
+) -> Result<super::ProductStorefrontIndexBudgetedExecution, ProductStorefrontIndexBudgetedStartError> {
+    executor
+        .execute_after_owner(
+            authoritative,
+            context(),
+            "en".to_owned(),
+            Some("online".to_owned()),
+            Some(Uuid::from_u128(0x9200)),
+            StorefrontProductListQuery::default(),
+            decision,
+        )
+        .await
+}
+
+fn projected_string(page: &IndexQueryPage, field_name: &str) -> Option<&str> {
+    let item = page.items.first()?;
+    item.fields.iter().find_map(|projected| {
+        (projected.path.links().is_empty() && projected.path.field().as_str() == field_name)
+            .then_some(&projected.value)
+            .and_then(|value| match value {
+                IndexValue::String(value) => Some(value.as_str()),
+                _ => None,
+            })
+    })
+}
+
+#[tokio::test]
+async fn noneligible_budget_starts_no_projected_work() {
+    let product_id = Uuid::from_u128(0x9301);
+    let (executor, state) = fake_executor(product_id, IndexBehavior::Return, TagBehavior::Return);
+    let outcome = execute(
+        &executor,
+        authoritative_page(product_id),
+        ProductStorefrontIndexServingBudgetDecision::OwnerNativeInsufficientBudget {
+            required_ms: 10,
+            remaining_ms: 9,
+        },
+    )
+    .await;
+
+    assert!(matches!(
+        outcome,
+        Err(ProductStorefrontIndexBudgetedStartError::BudgetNotEligible(
+            ProductStorefrontIndexServingBudgetDecision::OwnerNativeInsufficientBudget { .. }
+        ))
+    ));
+    assert_eq!(state.index_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(state.tag_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn index_timeout_preserves_authoritative_owner_page_and_skips_enrichment() {
+    let product_id = Uuid::from_u128(0x9302);
+    let authoritative = authoritative_page(product_id);
+    let (executor, state) = fake_executor(product_id, IndexBehavior::Pending, TagBehavior::Return);
+    let execution = execute(&executor, authoritative.clone(), eligible(1, 20))
+        .await
+        .unwrap();
+
+    assert_eq!(execution.authoritative.items[0].id, authoritative.items[0].id);
+    assert!(matches!(
+        execution.projected,
+        Err(ProductStorefrontIndexBudgetedProjectionError::TimedOut { budget_ms: 1 })
+    ));
+    assert!(execution.public_projected.is_none());
+    assert!(execution.tag_hydration.is_none());
+    assert!(execution.comparison.is_none());
+    assert_eq!(state.index_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(state.tag_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(*state.index_deadlines.lock().unwrap(), vec![Some(1)]);
+}
+
+#[tokio::test]
+async fn raw_projection_failure_skips_public_projection_and_tag_hydration() {
+    let product_id = Uuid::from_u128(0x9303);
+    let (executor, state) = fake_executor(product_id, IndexBehavior::Error, TagBehavior::Return);
+    let execution = execute(&executor, authoritative_page(product_id), eligible(20, 20))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        execution.projected,
+        Err(ProductStorefrontIndexBudgetedProjectionError::Projection(
+            ProductStorefrontIndexShadowProjectionError::InvalidTenant
+        ))
+    ));
+    assert!(execution.public_projected.is_none());
+    assert!(execution.tag_hydration.is_none());
+    assert!(execution.comparison.is_none());
+    assert_eq!(state.index_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(state.tag_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn tag_timeout_preserves_raw_public_pages_and_phase_deadlines() {
+    let product_id = Uuid::from_u128(0x9304);
+    let authoritative = authoritative_page(product_id);
+    let (executor, state) = fake_executor(product_id, IndexBehavior::Return, TagBehavior::Pending);
+    let execution = execute(&executor, authoritative.clone(), eligible(40, 1))
+        .await
+        .unwrap();
+
+    assert_eq!(execution.authoritative.items[0].id, product_id);
+    assert!(execution.projected.is_ok());
+    let public = execution.public_projected.as_ref().unwrap().as_ref().unwrap();
+    assert_eq!(projected_string(public, "title"), Some("Untitled product"));
+    assert_eq!(projected_string(public, "handle"), Some(""));
+    assert!(matches!(
+        execution.tag_hydration,
+        Some(Err(ProductStorefrontIndexBudgetedTagHydrationError::TimedOut { budget_ms: 1 }))
+    ));
+    assert!(execution.comparison.unwrap().is_match());
+    assert_eq!(*state.index_deadlines.lock().unwrap(), vec![Some(40)]);
+    assert_eq!(*state.tag_deadlines.lock().unwrap(), vec![Some(1)]);
+}
+
+#[tokio::test]
+async fn eligible_fast_path_preserves_identity_count_and_owner_tag_projection() {
+    let product_id = Uuid::from_u128(0x9305);
+    let (executor, state) = fake_executor(product_id, IndexBehavior::Return, TagBehavior::Return);
+    let execution = execute(&executor, authoritative_page(product_id), eligible(50, 30))
+        .await
+        .unwrap();
+
+    let raw = execution.projected.as_ref().unwrap();
+    assert_eq!(raw.items.iter().map(|item| item.entity_id).collect::<Vec<_>>(), vec![product_id]);
+    assert_eq!(raw.exact_count, Some(1));
+    assert!(!raw.has_more);
+    assert!(execution.comparison.unwrap().is_match());
+    assert_eq!(execution.index_execution_budget_ms, 50);
+    assert_eq!(execution.tag_hydration_budget_ms, 30);
+    assert_eq!(execution.safety_margin_ms, 1);
+
+    let public = execution.public_projected.as_ref().unwrap().as_ref().unwrap();
+    assert_eq!(projected_string(public, "title"), Some("Untitled product"));
+    assert_eq!(projected_string(public, "handle"), Some(""));
+
+    let hydrated = execution.tag_hydration.as_ref().unwrap().as_ref().unwrap();
+    assert_eq!(hydrated.items.len(), 1);
+    assert_eq!(hydrated.items[0].product_id, product_id);
+    assert_eq!(hydrated.items[0].tags, vec!["Legacy".to_owned()]);
+    assert_eq!(*state.index_deadlines.lock().unwrap(), vec![Some(50)]);
+    assert_eq!(*state.tag_deadlines.lock().unwrap(), vec![Some(30)]);
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Storefront serving-budget policy merge
-`0c40387d9bb2257f8345448792f9c9ddd6b38480` and continued on
-`agent/product-storefront-budgeted-execution-20260808`.
+Status overlay rechecked after Storefront budgeted execution merge
+`dd57844c52d05e624710eda6174b43c246173886` and continued on
+`agent/product-storefront-budgeted-execution-evidence-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -32,8 +32,10 @@ Source-complete:
 - bounded Product-owned post-page tag hydration keyed by selected Product IDs, including Taxonomy fallback and
   legacy metadata-only tags;
 - host-measured post-owner serving-budget eligibility policy without hard-coded production SLO values;
-- **non-serving post-owner budgeted execution** that accepts only `Eligible`, narrows phase port deadlines and
+- non-serving post-owner budgeted execution that accepts only `Eligible`, narrows phase port deadlines and
   enforces outer Tokio timeouts for raw Index/EAV execution and Product tag hydration;
+- deterministic storage-free timeout evidence source for that real budgeted adapter through a crate-private
+  post-owner phase seam implemented in production by `ProductStorefrontIndexShadowExecutor`;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
@@ -56,7 +58,7 @@ Product relation ordering, Taxonomy requested->fallback/canonical-key resolution
 fallback remain owner semantics. Embedded runtime selects the capability; external profiles have no implicit
 embedded fallback.
 
-## Serving budget and timeout enforcement
+## Serving budget, timeout enforcement and retained evidence
 
 `PortContext.deadline_ms` is the original duration budget. A future host/router must measure `remaining_ms`
 after owner success. `ProductStorefrontIndexServingBudget` carries host-selected positive Index/tag phase
@@ -68,12 +70,18 @@ page, rejects non-`Eligible` decisions before work starts, narrows the projected
 outer timeout, then separately narrows and times Product tag hydration. Public placeholder mapping occurs only
 after successful raw projection. Timeout/error results remain separate and never replace owner success.
 
-The ordinary owner-first shadow executor remains the unbudgeted evidence path. Mounted Storefront still uses
-only Product owner reads and does not call either serving-budget classification or budgeted execution.
+`ProductStorefrontIndexProjectionPhases` isolates only those two post-owner phases. Production uses the real
+shadow executor. The retained packet substitutes deterministic fake phases and covers non-eligible no-work,
+projected timeout/error, tag timeout, exact phase deadlines and the fast identity/count/public/tag path. The
+packet is source-complete but has **not** been executed or admitted by the implementation agent.
+
+Mounted Storefront still uses only Product owner reads and does not call either serving-budget classification or
+budgeted execution.
 
 ## Remaining Storefront parity/evidence blockers
 
-- retain and execute deterministic timeout/latency evidence for budgeted post-owner execution;
+- execute/admit the deterministic budgeted timeout packet and retain acceptable runtime latency/cancellation
+  evidence for the selected deployment profile;
 - execute/review current-key Storefront core/EAV/collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the deployment default-vs-`C` packet agrees;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence;
@@ -116,20 +124,20 @@ only Product owner reads and does not call either serving-budget classification 
 - [x] Batch-hydrate Product tags post-page through Product owner capability, including legacy metadata fallback.
 - [x] Define host-measured post-owner serving-budget eligibility.
 - [x] Enforce admitted Index/tag phase timeouts in a separate non-serving post-owner adapter.
-- [ ] Retain deterministic runtime timeout/latency evidence for the budgeted adapter.
+- [x] Retain deterministic timeout/error/deadline/fast-path evidence source for the budgeted adapter.
+- [ ] Execute/admit the retained budgeted timeout evidence.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
 - [ ] Execute/admit current replacement Product PostgreSQL evidence.
 - [ ] Stage/rebuild/promote Product key `4` for a tenant.
 - [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes.
 
-## Next source-code step
+## Next source-code boundary
 
-Retain deterministic non-serving timeout-behavior evidence for `ProductStorefrontIndexBudgetedProjectionExecutor`.
-The source packet should prove: a non-eligible decision starts no projected work; Index timeout preserves the
-owner page; raw projection failure skips public/tag enrichment; tag timeout preserves raw/public pages; phase
-`deadline_ms` values reach Product capabilities; and an eligible fast path preserves raw identity/count/page
-semantics. Do not run the packet and do not mount Storefront traffic.
+The Storefront request-shape, post-page projection, tag hydration, budget policy, timeout enforcement and
+retained timeout packet are source-complete. Do not add a traffic-switch adapter from source inspection alone.
+Further source work should stay on an independent retained evidence boundary (replacement/readiness/restart) and
+must not claim runtime admission. Maintainer execution of the timeout and PostgreSQL packets remains required.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-budgeted-execution.md
+++ b/crates/rustok-index/docs/m7-product-storefront-budgeted-execution.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront budgeted execution
 
-Status: `source_complete_runtime_latency_evidence_pending`.
+Status: `source_complete_timeout_evidence_execution_pending`.
 
 ## Post-owner only
 
@@ -39,14 +39,34 @@ The result retains:
 A raw Index failure skips public projection and tag hydration. A tag failure/timeout leaves the successful raw
 and public pages intact. None of these outcomes changes the authoritative Product owner result.
 
-## Separation from evidence and serving
+## Retained deterministic timeout evidence — source complete
 
-The existing owner-first shadow executor remains the unbudgeted evidence path. Its post-owner phase methods are
-crate-visible only so this separate adapter can enforce phase budgets around them.
+`ProductStorefrontIndexProjectionPhases` is a crate-private seam around the two post-owner phases. Production
+implements it with `ProductStorefrontIndexShadowExecutor`; the budgeted executor stores only this neutral phase
+capability. The test-only `from_phases` constructor allows retained evidence to exercise the **same timeout
+wrapper** without manufacturing PostgreSQL or `SharedIndexQueryRuntime` setup.
 
-Mounted Storefront does not call the budgeted adapter. Source completeness here does not establish acceptable
-latency, timeout cancellation behavior, external-provider deadline propagation or serving readiness. Those
-require retained runtime evidence and maintainer execution/admission before any traffic switch.
+`storefront_budgeted_execution_tests.rs` retains storage-free scenarios for:
+
+- non-eligible budget decisions starting zero projected/tag calls;
+- a never-completing projected phase timing out while preserving the authoritative owner page;
+- raw projected errors skipping public/tag enrichment;
+- a never-completing Product tag phase timing out while raw/public pages and comparison remain intact;
+- exact narrowed `PortContext.deadline_ms` values reaching both phase boundaries;
+- an eligible fast path retaining Product identity/exact-count/page semantics, public placeholders and Product
+  tag projection.
+
+The timeout cases use `std::future::pending` rather than scheduler-sensitive sleeps inside the fake phases. The
+outer production `tokio::time::timeout` remains the cancellation boundary under evidence.
+
+## Separation from serving and admission
+
+The existing owner-first shadow executor remains the unbudgeted evidence path and production implementation of
+the post-owner phase seam. Mounted Storefront does not call the budgeted adapter.
+
+The retained packet is **source-only** until a maintainer executes it. This source state does not establish a
+passing timeout packet, acceptable production latency, external-provider cancellation/deadline propagation or
+serving readiness. Those remain admission gates before any traffic switch.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -1,6 +1,6 @@
 # M7 Product Storefront Index parity gate
 
-Status: `budgeted_execution_source_complete_latency_evidence_pending`.
+Status: `budgeted_timeout_evidence_source_complete_execution_pending`.
 
 ## Current boundary
 
@@ -48,8 +48,25 @@ For an eligible handoff it:
 6. keeps timeout/error outcomes separate while preserving the authoritative owner page.
 
 The ordinary `ProductStorefrontIndexShadowExecutor::execute` remains the unbudgeted owner-first evidence path.
-Only crate-private post-owner phase methods are reused by the budgeted adapter. Mounted Storefront references
-neither budget policy nor budgeted execution.
+It implements the crate-private `ProductStorefrontIndexProjectionPhases` seam consumed by the budgeted adapter.
+Mounted Storefront references neither budget policy nor budgeted execution.
+
+## Deterministic timeout evidence — source complete, execution pending
+
+The retained storage-free packet exercises the real budgeted executor through fake implementations of only the
+post-owner phase seam. It covers:
+
+- non-eligible decisions starting no projected/tag work;
+- projected timeout preserving the authoritative owner result and skipping enrichment;
+- projected error skipping public/tag enrichment;
+- tag timeout preserving successful raw/public pages and comparison;
+- admitted phase `deadline_ms` values reaching both phase boundaries;
+- a fast eligible path preserving Product identity/exact-count/page semantics, public placeholders and Product
+  tag projection.
+
+Never-completing phases use `std::future::pending`; timeout cancellation is still performed by the production
+`tokio::time::timeout` wrapper. The packet has not been executed by the implementation agent and therefore is
+not admitted runtime/latency evidence yet.
 
 ## Search/collation/EAV source state
 
@@ -62,25 +79,28 @@ bind-free `Never`. Current Product Index remains one 15-field schema on routing 
 
 ## Remaining fail-closed parity/evidence gates
 
-1. Retain and maintainer-execute deterministic runtime timeout/latency evidence for the budgeted adapter.
+1. Maintainer-execute/admit the deterministic budgeted timeout packet and record acceptable latency/cancellation
+   behavior for the selected runtime profile.
 2. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
 3. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible cutover closed.
 4. Stale locale/readiness/admission/restart evidence remains maintainer-run.
 5. Stage/rebuild/promote current Product key `4` and admit replacement evidence.
 6. Any serving router must preserve channel-less/deep-page owner-native branches and traffic switch remains last.
 
-## Next source slice
+## Next source boundary
 
-Retain deterministic **budgeted execution runtime evidence source** without mounting Storefront traffic. Cover:
-non-eligible decisions starting no projected work, Index timeout preserving owner result, raw failure skipping
-enrichment, tag timeout preserving raw/public pages, phase deadlines reaching Product capabilities, and a fast
-eligible path preserving raw identity/count semantics. Maintainer execution/admission remains separate.
+Do not move mounted Storefront traffic from source inspection alone. Further serving composition depends on
+maintainer execution/admission of timeout, Storefront parity/collation, stale-readiness and replacement evidence.
+Independent source work may continue only on one of those retained evidence boundaries without weakening this
+gate.
 
 ## Source guards
 
 - `verify-index-product-storefront-serving-budget-policy.mjs` locks host-measured budget classification and
   separation from enforcement;
 - `verify-index-product-storefront-budgeted-execution.mjs` locks post-owner phase timeout enforcement;
+- `verify-index-product-storefront-budgeted-execution-evidence.mjs` locks the deterministic retained timeout
+  packet and test-only phase seam;
 - `verify-index-product-storefront-shadow-executor.mjs` keeps the ordinary evidence executor separate;
 - request-shape, public-projection, tag-hydration, collation and key-4 guards remain retained;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.

--- a/scripts/verify/verify-index-product-storefront-budgeted-execution-evidence.mjs
+++ b/scripts/verify/verify-index-product-storefront-budgeted-execution-evidence.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-storefront-budgeted-execution-evidence] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const executionPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
+const execution = requireMarkers(executionPath, [
+  'pub(crate) trait ProductStorefrontIndexProjectionPhases',
+  'impl ProductStorefrontIndexProjectionPhases for ProductStorefrontIndexShadowExecutor',
+  'phases: Arc<dyn ProductStorefrontIndexProjectionPhases>',
+  'pub(crate) fn new(shadow: ProductStorefrontIndexShadowExecutor)',
+  'pub(crate) fn from_phases(phases: Arc<dyn ProductStorefrontIndexProjectionPhases>)',
+  'ProductStorefrontIndexServingBudgetDecision::Eligible',
+  'BudgetNotEligible',
+  'use tokio::time::timeout;',
+  'self.phases.execute_projected(',
+  'self.phases',
+  '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
+]);
+if (execution.includes('list_filtered_published_products(')) {
+  fail(`${executionPath} retained budget evidence seam must remain post-owner only`);
+}
+
+const packetPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution_tests.rs';
+const packet = requireMarkers(packetPath, [
+  'future::pending',
+  'AtomicUsize',
+  'index_deadlines: Mutex<Vec<Option<u64>>>',
+  'tag_deadlines: Mutex<Vec<Option<u64>>>',
+  'impl ProductStorefrontIndexProjectionPhases for FakePhases',
+  'pending::<()>().await;',
+  'noneligible_budget_starts_no_projected_work',
+  'state.index_calls.load(Ordering::SeqCst), 0',
+  'state.tag_calls.load(Ordering::SeqCst), 0',
+  'index_timeout_preserves_authoritative_owner_page_and_skips_enrichment',
+  'ProductStorefrontIndexBudgetedProjectionError::TimedOut { budget_ms: 1 }',
+  'execution.public_projected.is_none()',
+  'execution.tag_hydration.is_none()',
+  'raw_projection_failure_skips_public_projection_and_tag_hydration',
+  'ProductStorefrontIndexShadowProjectionError::InvalidTenant',
+  'tag_timeout_preserves_raw_public_pages_and_phase_deadlines',
+  'projected_string(public, "title"), Some("Untitled product")',
+  'ProductStorefrontIndexBudgetedTagHydrationError::TimedOut { budget_ms: 1 }',
+  'vec![Some(40)]',
+  'vec![Some(1)]',
+  'eligible_fast_path_preserves_identity_count_and_owner_tag_projection',
+  'raw.exact_count, Some(1)',
+  'execution.comparison.unwrap().is_match()',
+  'execution.index_execution_budget_ms, 50',
+  'execution.tag_hydration_budget_ms, 30',
+  'hydrated.items[0].tags, vec!["Legacy".to_owned()]',
+  'vec![Some(50)]',
+  'vec![Some(30)]',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'Postgres',
+  'CatalogService::new',
+  'SharedIndexQueryRuntime',
+  'materialize_postgres',
+]) {
+  if (packet.includes(forbidden)) {
+    fail(`${packetPath} must remain deterministic fake-phase timeout evidence without external storage/runtime setup: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'ProductStorefrontIndexProjectionPhases',
+  '#[cfg(test)]\nmod storefront_budgeted_execution_tests;',
+]);
+
+console.log('[verify-index-product-storefront-budgeted-execution-evidence] retained fake-phase packet covers noneligible, Index timeout/error, tag timeout, phase deadlines and fast-path identity/count; execution remains maintainer-owned');

--- a/scripts/verify/verify-index-product-storefront-budgeted-execution.mjs
+++ b/scripts/verify/verify-index-product-storefront-budgeted-execution.mjs
@@ -39,6 +39,9 @@ requireMarkers(budgetPath, [
 const executionPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
 const execution = requireMarkers(executionPath, [
   'use tokio::time::timeout;',
+  'pub(crate) trait ProductStorefrontIndexProjectionPhases',
+  'impl ProductStorefrontIndexProjectionPhases for ProductStorefrontIndexShadowExecutor',
+  'phases: Arc<dyn ProductStorefrontIndexProjectionPhases>',
   'pub(crate) struct ProductStorefrontIndexBudgetedExecution',
   'pub(crate) authoritative: StorefrontProductList',
   'pub(crate) projected: Result<IndexQueryPage, ProductStorefrontIndexBudgetedProjectionError>',
@@ -60,7 +63,7 @@ const execution = requireMarkers(executionPath, [
   'index_context.deadline_ms = Some(index_execution_budget_ms);',
   'timeout(',
   'Duration::from_millis(index_execution_budget_ms)',
-  'self.shadow.execute_projected(',
+  'self.phases.execute_projected(',
   'ProductStorefrontIndexBudgetedProjectionError::TimedOut',
   '.map(project_product_storefront_index_page);',
   'tag_context.deadline_ms = Some(tag_hydration_budget_ms);',
@@ -124,6 +127,8 @@ requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'ProductStorefrontIndexBudgetedStartError',
   'ProductStorefrontIndexBudgetedProjectionError',
   'ProductStorefrontIndexBudgetedTagHydrationError',
+  'ProductStorefrontIndexProjectionPhases',
+  '#[cfg(test)]\nmod storefront_budgeted_execution_tests;',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -139,4 +144,4 @@ for (const forbidden of [
   }
 }
 
-console.log('[verify-index-product-storefront-budgeted-execution] eligible post-owner projection applies bounded Index/tag timeouts while preserving the authoritative owner result; mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-budgeted-execution] eligible post-owner projection applies bounded Index/tag timeouts through the production phase seam while preserving the authoritative owner result; mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -87,6 +87,9 @@ if (policy.split('#[cfg(test)]')[0].includes('tokio::time::timeout')) {
 const budgetedPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
 const budgeted = requireMarkers(budgetedPath, [
   'use tokio::time::timeout;',
+  'pub(crate) trait ProductStorefrontIndexProjectionPhases',
+  'impl ProductStorefrontIndexProjectionPhases for ProductStorefrontIndexShadowExecutor',
+  'phases: Arc<dyn ProductStorefrontIndexProjectionPhases>',
   'pub(crate) struct ProductStorefrontIndexBudgetedExecution',
   'pub(crate) authoritative: StorefrontProductList',
   'pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor',
@@ -95,7 +98,7 @@ const budgeted = requireMarkers(budgetedPath, [
   'BudgetNotEligible',
   'index_context.deadline_ms = Some(index_execution_budget_ms);',
   'Duration::from_millis(index_execution_budget_ms)',
-  'self.shadow.execute_projected(',
+  'self.phases.execute_projected(',
   'ProductStorefrontIndexBudgetedProjectionError::TimedOut',
   '.map(project_product_storefront_index_page);',
   'tag_context.deadline_ms = Some(tag_hydration_budget_ms);',
@@ -135,13 +138,16 @@ requireMarkers('crates/rustok-distribution/tests/product_storefront_search_colla
 ]);
 
 requireMarkers('scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs', [
-  'separate budgeted execution enforces admitted phase timeouts',
+  'production phase seam',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-budgeted-execution.mjs', [
-  'eligible post-owner projection applies bounded Index/tag timeouts',
+  'production phase seam',
+]);
+requireMarkers('scripts/verify/verify-index-product-storefront-budgeted-execution-evidence.mjs', [
+  'retained fake-phase packet covers noneligible, Index timeout/error, tag timeout, phase deadlines and fast-path identity/count',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-shadow-executor.mjs', [
-  'separate budgeted adapter while mounted Storefront remains owner-native',
+  'implements the crate-private post-owner phase seam',
 ]);
 requireMarkers('scripts/verify/verify-index-product-storefront-tag-hydration.mjs', [
   'Product IDs from the fixed raw Index page drive bounded Product-owned tag hydration',
@@ -151,24 +157,26 @@ requireMarkers('scripts/verify/verify-index-product-postgres-key4-fixtures.mjs',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', [
-  'Status: `budgeted_execution_source_complete_latency_evidence_pending`',
+  'Status: `budgeted_timeout_evidence_source_complete_execution_pending`',
   'Mounted Storefront remains owner-native',
   'Serving-budget policy and timeout enforcement — source complete',
+  'Deterministic timeout evidence — source complete, execution pending',
   '`ProductStorefrontIndexBudgetedProjectionExecutor`',
-  'runtime timeout/latency evidence',
+  'The packet has not been executed by the implementation agent',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-serving-budget-policy.md', [
   'Status: `policy_and_timeout_enforcement_source_complete_runtime_evidence_pending`',
   '`tokio::time::timeout`',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-storefront-budgeted-execution.md', [
-  'Status: `source_complete_runtime_latency_evidence_pending`',
-  'Post-owner only',
-  'Failure separation',
+  'Status: `source_complete_timeout_evidence_execution_pending`',
+  'Retained deterministic timeout evidence — source complete',
+  'The retained packet is **source-only** until a maintainer executes it.',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-storefront-serving-budget-policy.mjs'",
   "'verify-index-product-storefront-budgeted-execution.mjs'",
+  "'verify-index-product-storefront-budgeted-execution-evidence.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; budget policy and non-serving phase timeout enforcement are source-complete while runtime latency/evidence admission remains pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; budget policy, non-serving phase timeout enforcement and deterministic timeout evidence source are complete while maintainer execution/admission remains pending');

--- a/scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs
+++ b/scripts/verify/verify-index-product-storefront-serving-budget-policy.mjs
@@ -72,13 +72,15 @@ for (const forbidden of [
 const budgetedPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
 const budgeted = requireMarkers(budgetedPath, [
   'use tokio::time::timeout;',
+  'pub(crate) trait ProductStorefrontIndexProjectionPhases',
+  'phases: Arc<dyn ProductStorefrontIndexProjectionPhases>',
   'pub(crate) struct ProductStorefrontIndexBudgetedProjectionExecutor',
   'pub(crate) async fn execute_after_owner(',
   'ProductStorefrontIndexServingBudgetDecision::Eligible',
   'BudgetNotEligible',
   'index_context.deadline_ms = Some(index_execution_budget_ms);',
   'Duration::from_millis(index_execution_budget_ms)',
-  'self.shadow.execute_projected(',
+  'self.phases.execute_projected(',
   'tag_context.deadline_ms = Some(tag_hydration_budget_ms);',
   'Duration::from_millis(tag_hydration_budget_ms)',
   '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
@@ -130,4 +132,4 @@ for (const forbidden of [
   }
 }
 
-console.log('[verify-index-product-storefront-serving-budget-policy] host-measured eligibility stays pure, separate budgeted execution enforces admitted phase timeouts, and mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-serving-budget-policy] host-measured eligibility stays pure, separate budgeted execution enforces admitted phase timeouts through the production phase seam, and mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
+++ b/scripts/verify/verify-index-product-storefront-shadow-executor.mjs
@@ -95,9 +95,11 @@ for (const forbidden of [
 
 const budgetedPath = 'crates/rustok-distribution/src/product_index/storefront_budgeted_execution.rs';
 requireMarkers(budgetedPath, [
+  'ProductStorefrontIndexProjectionPhases',
+  'impl ProductStorefrontIndexProjectionPhases for ProductStorefrontIndexShadowExecutor',
   'ProductStorefrontIndexBudgetedProjectionExecutor',
   'ProductStorefrontIndexServingBudgetDecision::Eligible',
-  'self.shadow.execute_projected(',
+  'self.phases.execute_projected(',
   '.hydrate_projected_tags(tag_context, fallback_locale, projected)',
   'use tokio::time::timeout;',
 ]);
@@ -114,6 +116,7 @@ requireMarkers('crates/rustok-distribution/src/product_index/storefront_projecti
 requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
   'ProductStorefrontIndexTagHydrationError',
   'ProductStorefrontIndexBudgetedProjectionExecutor',
+  'ProductStorefrontIndexProjectionPhases',
 ]);
 
 const mountedPath = 'crates/rustok-product/storefront/src/transport/catalog_list_native.rs';
@@ -131,4 +134,4 @@ for (const forbidden of [
   if (mounted.includes(forbidden)) fail(`${mountedPath} must remain owner-native; found ${forbidden}`);
 }
 
-console.log('[verify-index-product-storefront-shadow-executor] owner-first evidence executor exposes crate-private post-owner phases to a separate budgeted adapter while mounted Storefront remains owner-native');
+console.log('[verify-index-product-storefront-shadow-executor] owner-first evidence executor implements the crate-private post-owner phase seam for a separate budgeted adapter while mounted Storefront remains owner-native');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -91,6 +91,7 @@ const scripts = [
   'verify-index-product-storefront-tag-hydration.mjs',
   'verify-index-product-storefront-serving-budget-policy.mjs',
   'verify-index-product-storefront-budgeted-execution.mjs',
+  'verify-index-product-storefront-budgeted-execution-evidence.mjs',
   'verify-index-product-storefront-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-eav-equivalence-postgres-packet.mjs',
   'verify-index-product-storefront-collation-postgres-packet.mjs',


### PR DESCRIPTION
## Summary

- retain deterministic timeout/error/fast-path evidence source for the real `ProductStorefrontIndexBudgetedProjectionExecutor`;
- introduce a crate-private `ProductStorefrontIndexProjectionPhases` seam so the production adapter still delegates to `ProductStorefrontIndexShadowExecutor`, while retained tests can exercise the real timeout wrapper without PostgreSQL or a synthetic `SharedIndexQueryRuntime`;
- keep the budgeted adapter post-owner only and preserve the already-successful authoritative Product page;
- retain a non-eligible case proving zero projected/tag phase calls;
- retain a never-completing Index phase using `std::future::pending`, proving the outer Index timeout preserves owner success and skips public/tag enrichment;
- retain a raw projected error case proving enrichment is skipped;
- retain a never-completing tag phase proving tag timeout preserves successful raw/public pages and raw comparison;
- capture and assert narrowed phase `PortContext.deadline_ms` values at both Index and Product-tag phase boundaries;
- retain an eligible fast path proving raw Product identity/exact-count/page semantics, public title/handle placeholders and Product tag projection;
- keep the packet deterministic and storage-free: no PostgreSQL, Product service construction, `SharedIndexQueryRuntime`, or materialization setup;
- update static guards/docs so M7 now marks timeout evidence **source-complete / execution pending** and explicitly keeps traffic switch blocked on maintainer execution/admission.

## Boundary

This PR does not execute the retained packet, claim timeout/latency/cancellation admission, alter Product Index schema/source/routing key, run PostgreSQL evidence, admit collation parity, or switch Storefront traffic.

Mounted Storefront remains owner-native. Channel-less and deep-page shapes remain owner-native under current contracts.

## Main recheck

Current `main` was rechecked immediately before opening this PR. The final branch compare is limited to the budgeted post-owner phase seam, retained timeout packet, source guards and M7 documentation; Product Index schema/source/query builder and mounted Storefront are unchanged.

## Validation

Static source review checked the current typed Product status/DTO shapes, clone requirements, Tokio `time` support and async phase seam shape. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.