### PR TITLE
test(parity): retain Forum Page Builder browser evidence harness

### DIFF
--- a/apps/next-admin/playwright.forum-page-builder.config.ts
+++ b/apps/next-admin/playwright.forum-page-builder.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/forum-page-builder",
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  workers: 1,
+  timeout: 240_000,
+  expect: {
+    timeout: 15_000,
+  },
+  reporter: [["list"]],
+  use: {
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "forum-page-builder-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  outputDir: "test-results-forum-page-builder",
+});

--- a/apps/next-admin/playwright.forum-page-builder.config.ts
+++ b/apps/next-admin/playwright.forum-page-builder.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/forum-page-builder",
+  globalSetup: "./tests/forum-page-builder/global-setup.ts",
   fullyParallel: false,
   forbidOnly: true,
   retries: 0,

--- a/apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts
+++ b/apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts
@@ -1,0 +1,642 @@
+import {
+  expect,
+  test,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const contractPath =
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json";
+const contract = JSON.parse(
+  readFileSync(path.join(repoRoot, contractPath), "utf8"),
+) as BrowserContract;
+
+const rootSelector = "[data-fly-browser-root='true']";
+const topicListBlockSelector = "[data-fly-block-id='forum.topic_list']";
+const propertiesPanelSelector =
+  "[data-page-builder-contribution-properties='true']";
+const previewPanelSelector = "[data-page-builder-contribution-preview='true']";
+const contributionRegistrySelector = "[data-fly-contribution-registry='true']";
+const topicListSchemaSelector =
+  "[data-page-builder-contribution-property-schema='forum.topic_list.v1']";
+const issuesSelector =
+  "[data-page-builder-contribution-property-issues='true']";
+const normalizedStatusText =
+  "Owner-normalized properties applied to the Fly draft";
+const categoryUuid = "550e8400-e29b-41d4-a716-446655440000";
+
+type BrowserContract = {
+  schema_version: number;
+  module: string;
+  packet: string;
+  status: string;
+  runner: string;
+  config: string;
+  output: {
+    environment: string;
+    default_path: string;
+    format: string;
+    status: string;
+  };
+  environment: Record<string, string>;
+  profiles: string[];
+  required_source_files: string[];
+};
+
+type FileRecord = {
+  path: string;
+  bytes: number;
+  sha256: string;
+};
+
+type BrowserFailures = {
+  consoleErrors: number;
+  pageErrors: number;
+  criticalRequestFailures: number;
+};
+
+type EvidenceInputs = {
+  sourceCommit: string;
+  deploymentDigest: string;
+  editorStorage: FileRecord;
+  noReadStorage: FileRecord;
+  urls: Record<string, string>;
+  routeHashes: Record<string, string>;
+  sourceHashes: Record<string, string>;
+};
+
+type ScenarioObservation = {
+  passed: boolean;
+  criticalFailures: number;
+  facts: Record<string, boolean | number>;
+};
+
+const observations: Record<string, ScenarioObservation> = {};
+let inputs: EvidenceInputs | null = null;
+
+function fail(message: string): never {
+  throw new Error(`Forum Page Builder browser evidence failed: ${message}`);
+}
+
+function sha256(value: Buffer | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requiredEnvironment(name: string, maximumLength = 16_384): string {
+  const value = process.env[name];
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    /[\u0000\r\n]/u.test(value)
+  ) {
+    fail(`${name} must be a bounded non-empty environment value`);
+  }
+  return value;
+}
+
+function optionalEnvironment(name: string, maximumLength = 16_384): string | null {
+  const value = process.env[name];
+  if (value === undefined || value === "") return null;
+  if (value.length > maximumLength || /[\u0000]/u.test(value)) {
+    fail(`${name} is outside the bounded environment input`);
+  }
+  return value;
+}
+
+function requireCommit(value: string): string {
+  if (!/^[0-9a-f]{40}$/u.test(value)) {
+    fail("source commit must be a full lowercase Git SHA");
+  }
+  return value;
+}
+
+function requireDeploymentDigest(value: string): string {
+  if (!/^[^@\s]+@sha256:[0-9a-f]{64}$/u.test(value)) {
+    fail("deployment digest must be an immutable image RepoDigest");
+  }
+  return value;
+}
+
+function requireUrl(value: string, label: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail(`${label} must be an absolute HTTP(S) URL`);
+  }
+  if (
+    !["http:", "https:"].includes(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hash ||
+    value.length > 4096
+  ) {
+    fail(`${label} must be a bounded credential-free HTTP(S) URL without a fragment`);
+  }
+  return parsed.toString();
+}
+
+function resolveInput(value: string): string {
+  return path.isAbsolute(value) ? path.resolve(value) : path.resolve(repoRoot, value);
+}
+
+function regularFileRecord(value: string, label: string): FileRecord {
+  const absolute = resolveInput(value);
+  if (!existsSync(absolute)) fail(`${label} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) {
+    fail(`${label} must be a regular non-symlink file`);
+  }
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > 8 * 1024 * 1024) {
+    fail(`${label} must be a bounded non-empty file`);
+  }
+  const bytes = readFileSync(absolute);
+  return { path: absolute, bytes: stats.size, sha256: sha256(bytes) };
+}
+
+function currentCommit(): string {
+  const value = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+  return requireCommit(value);
+}
+
+function sourceHashes(): Record<string, string> {
+  if (
+    !Array.isArray(contract.required_source_files) ||
+    contract.required_source_files.length === 0
+  ) {
+    fail("browser execution contract has no required source files");
+  }
+  return Object.fromEntries(
+    contract.required_source_files.map((relativePath) => {
+      const record = regularFileRecord(
+        relativePath,
+        `source file ${relativePath}`,
+      );
+      return [relativePath, record.sha256];
+    }),
+  );
+}
+
+function outputPath(): string {
+  const raw = optionalEnvironment(contract.output.environment, 16_384);
+  const absolute = resolveInput(raw ?? contract.output.default_path);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail("browser evidence output must remain inside repository target/");
+  }
+  return absolute;
+}
+
+function writeAtomic(location: string, document: Record<string, unknown>): void {
+  mkdirSync(path.dirname(location), { recursive: true });
+  const temporary = `${location}.tmp-${process.pid}`;
+  rmSync(temporary, { force: true });
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+  renameSync(temporary, location);
+}
+
+function playwrightVersion(): string {
+  const packagePath = path.join(
+    repoRoot,
+    "apps/next-admin/node_modules/@playwright/test/package.json",
+  );
+  const document = JSON.parse(readFileSync(packagePath, "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof document.version !== "string" || document.version.length === 0) {
+    fail("installed Playwright version is unavailable");
+  }
+  return document.version;
+}
+
+function loadInputs(): EvidenceInputs {
+  const sourceCommit = requireCommit(
+    requiredEnvironment(contract.environment.source_commit),
+  );
+  const head = currentCommit();
+  if (sourceCommit !== head) {
+    fail(`source commit ${sourceCommit} does not match checkout HEAD ${head}`);
+  }
+
+  const deploymentDigest = requireDeploymentDigest(
+    requiredEnvironment(contract.environment.deployment_digest),
+  );
+  const editorStorage = regularFileRecord(
+    requiredEnvironment(contract.environment.editor_storage_state),
+    "editor storage state",
+  );
+  const noReadStorage = regularFileRecord(
+    requiredEnvironment(contract.environment.no_read_storage_state),
+    "no-read storage state",
+  );
+  const urlEnvironment = {
+    full: contract.environment.full_url,
+    preview_off: contract.environment.preview_off_url,
+    properties_off: contract.environment.properties_off_url,
+    forum_disabled: contract.environment.forum_disabled_url,
+    no_read: contract.environment.no_read_url,
+  };
+  const urls = Object.fromEntries(
+    Object.entries(urlEnvironment).map(([profile, environment]) => [
+      profile,
+      requireUrl(requiredEnvironment(environment), `${profile} profile URL`),
+    ]),
+  );
+  return {
+    sourceCommit,
+    deploymentDigest,
+    editorStorage,
+    noReadStorage,
+    urls,
+    routeHashes: Object.fromEntries(
+      Object.entries(urls).map(([profile, url]) => [profile, sha256(url)]),
+    ),
+    sourceHashes: sourceHashes(),
+  };
+}
+
+async function openProfile(
+  browser: Browser,
+  url: string,
+  storageState: string,
+  label: string,
+): Promise<{
+  context: BrowserContext;
+  page: Page;
+  failures: BrowserFailures;
+}> {
+  const context = await browser.newContext({ storageState });
+  const page = await context.newPage();
+  const failures: BrowserFailures = {
+    consoleErrors: 0,
+    pageErrors: 0,
+    criticalRequestFailures: 0,
+  };
+  page.on("console", (message) => {
+    if (message.type() === "error") failures.consoleErrors += 1;
+  });
+  page.on("pageerror", () => {
+    failures.pageErrors += 1;
+  });
+  page.on("requestfailed", (request) => {
+    if (
+      ["document", "script", "stylesheet", "fetch", "xhr"].includes(
+        request.resourceType(),
+      )
+    ) {
+      failures.criticalRequestFailures += 1;
+    }
+  });
+
+  const response = await page.goto(url, { waitUntil: "domcontentloaded" });
+  expect(response, `${label} navigation response`).not.toBeNull();
+  expect(response?.status(), `${label} status`).toBeLessThan(400);
+  const root = page.locator(rootSelector);
+  await expect(root, `${label} Page Builder root`).toBeVisible();
+  await expect(root).toHaveAttribute("data-fly-runtime", "ssr");
+  return { context, page, failures };
+}
+
+function criticalFailureCount(failures: BrowserFailures): number {
+  return (
+    failures.consoleErrors +
+    failures.pageErrors +
+    failures.criticalRequestFailures
+  );
+}
+
+function assertNoCriticalFailures(
+  failures: BrowserFailures,
+  label: string,
+): void {
+  expect(failures.consoleErrors, `${label} console errors`).toBe(0);
+  expect(failures.pageErrors, `${label} page errors`).toBe(0);
+  expect(
+    failures.criticalRequestFailures,
+    `${label} critical request failures`,
+  ).toBe(0);
+}
+
+async function insertTopicList(page: Page): Promise<void> {
+  const block = page.locator(topicListBlockSelector);
+  await expect(block).toBeVisible();
+  await expect(block).toHaveAttribute("data-fly-can-insert", "true");
+  await block.locator("[data-fly-action='insert-block']").click();
+  const layer = page
+    .locator("[data-fly-action='select-component']")
+    .filter({ hasText: "forum.topic_list" })
+    .last();
+  await expect(layer).toBeVisible();
+  await layer.click();
+}
+
+async function loadTopicListSchema(page: Page): Promise<void> {
+  const panel = page.locator(propertiesPanelSelector);
+  await expect(panel).toBeVisible();
+  const load = panel.getByRole("button", { name: "Load schema" });
+  await expect(load).toBeEnabled();
+  await load.click();
+  await expect(panel.locator(topicListSchemaSelector)).toBeVisible();
+}
+
+async function applyProperties(page: Page): Promise<void> {
+  const panel = page.locator(propertiesPanelSelector);
+  const apply = panel.getByRole("button", {
+    name: "Apply normalized properties",
+  });
+  await expect(apply).toBeEnabled();
+  await apply.click();
+}
+
+test.describe.serial("Forum Page Builder retained browser evidence", () => {
+  test.beforeAll(() => {
+    expect(contract.status).toBe("source_ready_maintainer_execution_pending");
+    expect(contract.profiles).toEqual([
+      "full",
+      "preview_off",
+      "properties_off",
+      "forum_disabled",
+      "no_read",
+    ]);
+    inputs = loadInputs();
+  });
+
+  test.afterAll(() => {
+    if (inputs === null) return;
+    const requiredProfiles = contract.profiles;
+    if (
+      !requiredProfiles.every(
+        (profile) => observations[profile]?.passed === true,
+      )
+    ) {
+      return;
+    }
+    writeAtomic(outputPath(), {
+      format: contract.output.format,
+      status: contract.output.status,
+      source_commit: inputs.sourceCommit,
+      deployment_digest: inputs.deploymentDigest,
+      node_version: process.version,
+      playwright_version: playwrightVersion(),
+      source_files: inputs.sourceHashes,
+      input_records: {
+        editor_storage_state: {
+          bytes: inputs.editorStorage.bytes,
+          sha256: inputs.editorStorage.sha256,
+        },
+        no_read_storage_state: {
+          bytes: inputs.noReadStorage.bytes,
+          sha256: inputs.noReadStorage.sha256,
+        },
+        profile_url_sha256: inputs.routeHashes,
+      },
+      observations,
+      retained_secrets: false,
+      browser_execution_only: true,
+      runtime_authorization_evidence_pending: true,
+      observed_page_builder_wave_pending: true,
+      executed_at: new Date().toISOString(),
+    });
+  });
+
+  test("full profile edits owner-normalized props and preserves Fly history", async ({
+    browser,
+  }) => {
+    if (inputs === null) fail("browser inputs were not initialized");
+    const { context, page, failures } = await openProfile(
+      browser,
+      inputs.urls.full,
+      inputs.editorStorage.path,
+      "full profile",
+    );
+    try {
+      await expect(page.locator(contributionRegistrySelector)).toBeVisible();
+      await insertTopicList(page);
+      await loadTopicListSchema(page);
+
+      const panel = page.locator(propertiesPanelSelector);
+      const perPage = panel.locator("#fly-owner-property-per_page");
+      const categoryId = panel.locator("#fly-owner-property-category_id");
+      await expect(perPage).toHaveValue("20");
+
+      await perPage.fill("101");
+      await applyProperties(page);
+      await expect(panel.locator(issuesSelector)).toContainText("per_page");
+      await expect(
+        panel.getByText("Owner validation rejected the current widget properties"),
+      ).toBeVisible();
+
+      await perPage.fill("10");
+      await categoryId.fill(` ${categoryUuid} `);
+      await applyProperties(page);
+      await expect(panel.getByText(normalizedStatusText)).toBeVisible();
+      await expect(panel.locator(issuesSelector)).toContainText("category_id");
+
+      await loadTopicListSchema(page);
+      await expect(perPage).toHaveValue("10");
+      await expect(categoryId).toHaveValue(categoryUuid);
+
+      const undo = page.locator("[data-fly-action='intent:undo']");
+      const redo = page.locator("[data-fly-action='intent:redo']");
+      await expect(undo).toBeEnabled();
+      await undo.click();
+      await loadTopicListSchema(page);
+      await expect(perPage).toHaveValue("20");
+      await expect(categoryId).toHaveValue("");
+
+      await expect(redo).toBeEnabled();
+      await redo.click();
+      await loadTopicListSchema(page);
+      await expect(perPage).toHaveValue("10");
+      await expect(categoryId).toHaveValue(categoryUuid);
+
+      const preview = page.locator(previewPanelSelector);
+      await expect(preview).toBeVisible();
+      const refresh = preview.getByRole("button", { name: "Refresh" });
+      await expect(refresh).toBeEnabled();
+      await refresh.click();
+      await expect(
+        preview.locator(
+          "[data-page-builder-contribution-preview-result='ready']",
+        ),
+      ).toBeVisible();
+
+      const save = page.locator("[data-fly-action='intent:save']");
+      await expect(save).toBeEnabled();
+      await save.click();
+      await expect(save).toBeDisabled();
+      assertNoCriticalFailures(failures, "full profile");
+      observations.full = {
+        passed: true,
+        criticalFailures: criticalFailureCount(failures),
+        facts: {
+          topic_list_admitted: true,
+          invalid_owner_props_rejected: true,
+          owner_normalization_observed: true,
+          fly_undo_observed: true,
+          fly_redo_observed: true,
+          owner_preview_ready: true,
+          pages_save_completed: true,
+        },
+      };
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("preview_off keeps authoring and owner properties but removes preview admission", async ({
+    browser,
+  }) => {
+    if (inputs === null) fail("browser inputs were not initialized");
+    const { context, page, failures } = await openProfile(
+      browser,
+      inputs.urls.preview_off,
+      inputs.editorStorage.path,
+      "preview_off profile",
+    );
+    try {
+      await insertTopicList(page);
+      await loadTopicListSchema(page);
+      const preview = page.locator(previewPanelSelector);
+      await expect(preview).toBeVisible();
+      await expect(preview.getByRole("button", { name: "Refresh" })).toBeDisabled();
+      await expect(
+        preview.locator(
+          "[data-page-builder-contribution-preview-provider='rustok.forum']",
+        ),
+      ).toHaveCount(0);
+      assertNoCriticalFailures(failures, "preview_off profile");
+      observations.preview_off = {
+        passed: true,
+        criticalFailures: criticalFailureCount(failures),
+        facts: {
+          topic_list_admitted: true,
+          owner_properties_actionable: true,
+          owner_preview_not_admitted: true,
+        },
+      };
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("properties_off removes Forum authoring/property admission", async ({
+    browser,
+  }) => {
+    if (inputs === null) fail("browser inputs were not initialized");
+    const { context, page, failures } = await openProfile(
+      browser,
+      inputs.urls.properties_off,
+      inputs.editorStorage.path,
+      "properties_off profile",
+    );
+    try {
+      await expect(page.locator(topicListBlockSelector)).toHaveCount(0);
+      const panel = page.locator(propertiesPanelSelector);
+      await expect(panel).toBeVisible();
+      await expect(panel.getByRole("button", { name: "Load schema" })).toBeDisabled();
+      await expect(
+        panel.locator(
+          "[data-page-builder-contribution-property-provider='rustok.forum']",
+        ),
+      ).toHaveCount(0);
+      assertNoCriticalFailures(failures, "properties_off profile");
+      observations.properties_off = {
+        passed: true,
+        criticalFailures: criticalFailureCount(failures),
+        facts: {
+          topic_list_not_admitted: true,
+          owner_properties_not_actionable: true,
+        },
+      };
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("Forum-disabled tenant exposes no Forum contribution extension", async ({
+    browser,
+  }) => {
+    if (inputs === null) fail("browser inputs were not initialized");
+    const { context, page, failures } = await openProfile(
+      browser,
+      inputs.urls.forum_disabled,
+      inputs.editorStorage.path,
+      "Forum-disabled profile",
+    );
+    try {
+      await expect(page.locator(topicListBlockSelector)).toHaveCount(0);
+      await expect(page.locator(propertiesPanelSelector)).toHaveCount(0);
+      await expect(page.locator(previewPanelSelector)).toHaveCount(0);
+      assertNoCriticalFailures(failures, "Forum-disabled profile");
+      observations.forum_disabled = {
+        passed: true,
+        criticalFailures: criticalFailureCount(failures),
+        facts: {
+          topic_list_absent: true,
+          owner_property_panel_absent: true,
+          owner_preview_panel_absent: true,
+        },
+      };
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("missing forum_topics:read prevents Forum contribution admission", async ({
+    browser,
+  }) => {
+    if (inputs === null) fail("browser inputs were not initialized");
+    const { context, page, failures } = await openProfile(
+      browser,
+      inputs.urls.no_read,
+      inputs.noReadStorage.path,
+      "no-read profile",
+    );
+    try {
+      await expect(page.locator(topicListBlockSelector)).toHaveCount(0);
+      const panel = page.locator(propertiesPanelSelector);
+      if ((await panel.count()) > 0) {
+        await expect(panel.getByRole("button", { name: "Load schema" })).toBeDisabled();
+        await expect(
+          panel.locator(
+            "[data-page-builder-contribution-property-provider='rustok.forum']",
+          ),
+        ).toHaveCount(0);
+      }
+      assertNoCriticalFailures(failures, "no-read profile");
+      observations.no_read = {
+        passed: true,
+        criticalFailures: criticalFailureCount(failures),
+        facts: {
+          topic_list_not_admitted: true,
+          owner_properties_not_actionable: true,
+        },
+      };
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/apps/next-admin/tests/forum-page-builder/global-setup.ts
+++ b/apps/next-admin/tests/forum-page-builder/global-setup.ts
@@ -1,0 +1,44 @@
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json",
+);
+
+type BrowserContract = {
+  output: {
+    environment: string;
+    default_path: string;
+  };
+};
+
+function fail(message: string): never {
+  throw new Error(`Forum Page Builder browser setup failed: ${message}`);
+}
+
+function resolveOutput(contract: BrowserContract): string {
+  const raw = process.env[contract.output.environment];
+  if (raw !== undefined && (raw.length === 0 || raw.length > 16_384 || /[\u0000]/u.test(raw))) {
+    fail(`${contract.output.environment} is outside the bounded output input`);
+  }
+  const requested = raw || contract.output.default_path;
+  const absolute = path.isAbsolute(requested)
+    ? path.resolve(requested)
+    : path.resolve(repoRoot, requested);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail("browser evidence output must remain inside repository target/");
+  }
+  return absolute;
+}
+
+export default function globalSetup(): void {
+  const contract = JSON.parse(
+    readFileSync(contractPath, "utf8"),
+  ) as BrowserContract;
+  rmSync(resolveOutput(contract), { force: true });
+}

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "module": "forum",
+  "packet": "page_builder_browser_evidence",
+  "status": "source_ready_maintainer_execution_pending",
+  "runner": "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts",
+  "config": "apps/next-admin/playwright.forum-page-builder.config.ts",
+  "output": {
+    "environment": "RUSTOK_FORUM_PAGE_BUILDER_BROWSER_EVIDENCE_OUTPUT",
+    "default_path": "target/forum-page-builder-browser-evidence.json",
+    "format": "forum_page_builder_browser_execution_v1",
+    "status": "browser_execution_passed_runtime_evidence_pending"
+  },
+  "environment": {
+    "source_commit": "RUSTOK_FORUM_PAGE_BUILDER_BROWSER_SOURCE_COMMIT",
+    "deployment_digest": "RUSTOK_FORUM_PAGE_BUILDER_DEPLOYMENT_DIGEST",
+    "editor_storage_state": "RUSTOK_FORUM_PAGE_BUILDER_EDITOR_STORAGE_STATE",
+    "no_read_storage_state": "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_STORAGE_STATE",
+    "full_url": "RUSTOK_FORUM_PAGE_BUILDER_FULL_URL",
+    "preview_off_url": "RUSTOK_FORUM_PAGE_BUILDER_PREVIEW_OFF_URL",
+    "properties_off_url": "RUSTOK_FORUM_PAGE_BUILDER_PROPERTIES_OFF_URL",
+    "forum_disabled_url": "RUSTOK_FORUM_PAGE_BUILDER_FORUM_DISABLED_URL",
+    "no_read_url": "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_URL"
+  },
+  "profiles": [
+    "full",
+    "preview_off",
+    "properties_off",
+    "forum_disabled",
+    "no_read"
+  ],
+  "full_profile_proofs": [
+    "forum.topic_list palette admission",
+    "owner schema load",
+    "owner validation rejection",
+    "owner normalization and sanitize issue",
+    "Fly undo and redo",
+    "owner preview readiness",
+    "Pages facade save"
+  ],
+  "required_source_files": [
+    "crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json",
+    "apps/next-admin/playwright.forum-page-builder.config.ts",
+    "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts",
+    "crates/rustok-forum/rustok-module.toml",
+    "crates/rustok-forum/admin/src/page_builder.rs",
+    "crates/rustok-forum/admin/src/widget_preview_transport.rs",
+    "crates/rustok-forum/admin/src/widget_property_transport.rs",
+    "crates/rustok-page-builder/admin/src/contribution_host.rs",
+    "crates/rustok-page-builder/admin/src/editor/palette_layers.rs",
+    "crates/rustok-page-builder/admin/src/editor/contribution_properties.rs",
+    "crates/rustok-page-builder/admin/src/editor/contribution_preview.rs",
+    "apps/admin/src/app/page_builder_contributions.rs"
+  ],
+  "retained_data": [
+    "exact source commit",
+    "immutable deployment RepoDigest",
+    "source-file SHA-256 hashes",
+    "storage-state file SHA-256 hashes and byte sizes",
+    "profile URL SHA-256 hashes",
+    "bounded boolean/count observations"
+  ],
+  "forbidden_retained_data": [
+    "raw profile URLs",
+    "cookies",
+    "authorization headers",
+    "storage-state contents",
+    "owner preview payload",
+    "raw DOM or HTML",
+    "Forum topic or reply content",
+    "tenant or actor identifiers"
+  ],
+  "not_claimed": [
+    "browser execution",
+    "runtime authorization execution",
+    "observed Page Builder Wave",
+    "provider SLO health"
+  ]
+}

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
@@ -23,6 +23,12 @@
     "forum_disabled_url": "RUSTOK_FORUM_PAGE_BUILDER_FORUM_DISABLED_URL",
     "no_read_url": "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_URL"
   },
+  "deployment_identity": {
+    "source_commit_verified_against_checkout_head": true,
+    "deployment_digest_is_maintainer_supplied_reviewed_identity": true,
+    "browser_independent_digest_to_deployment_attestation": false,
+    "deployment_provenance_must_be_verified_outside_this_browser_packet": true
+  },
   "profiles": [
     "full",
     "preview_off",
@@ -56,7 +62,7 @@
   ],
   "retained_data": [
     "exact source commit",
-    "immutable deployment RepoDigest",
+    "maintainer-supplied reviewed immutable deployment RepoDigest",
     "source-file SHA-256 hashes",
     "storage-state file SHA-256 hashes and byte sizes",
     "profile URL SHA-256 hashes",
@@ -74,6 +80,7 @@
   ],
   "not_claimed": [
     "browser execution",
+    "browser-independent digest-to-deployment attestation",
     "runtime authorization execution",
     "observed Page Builder Wave",
     "provider SLO health"

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
@@ -5,6 +5,7 @@
   "status": "source_ready_maintainer_execution_pending",
   "runner": "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts",
   "config": "apps/next-admin/playwright.forum-page-builder.config.ts",
+  "global_setup": "apps/next-admin/tests/forum-page-builder/global-setup.ts",
   "output": {
     "environment": "RUSTOK_FORUM_PAGE_BUILDER_BROWSER_EVIDENCE_OUTPUT",
     "default_path": "target/forum-page-builder-browser-evidence.json",
@@ -41,6 +42,7 @@
   "required_source_files": [
     "crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json",
     "apps/next-admin/playwright.forum-page-builder.config.ts",
+    "apps/next-admin/tests/forum-page-builder/global-setup.ts",
     "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts",
     "crates/rustok-forum/rustok-module.toml",
     "crates/rustok-forum/admin/src/page_builder.rs",

--- a/docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md
+++ b/docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md
@@ -31,12 +31,13 @@ The runner lives with the repository's existing pinned Playwright dependency:
 
 ```text
 apps/next-admin/playwright.forum-page-builder.config.ts
+apps/next-admin/tests/forum-page-builder/global-setup.ts
 apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts
 ```
 
 `apps/next-admin` is only the evidence runner package. The browser target is the maintainer-supplied real Leptos Pages admin route. The harness does not add a Next-admin Forum/Page Builder serving path.
 
-The configuration fixes Chromium to one worker, disables retries, trace, screenshots and video, and writes no Playwright artifact containing cookies, owner payloads or rendered Forum data.
+The configuration fixes Chromium to one worker, disables retries, trace, screenshots and video, and writes no Playwright artifact containing cookies, owner payloads or rendered Forum data. Global setup removes only the bounded evidence output inside repository `target/` before execution so a failed run cannot leave a stale prior success packet behind.
 
 ## Required maintainer fixtures
 
@@ -47,6 +48,8 @@ Maintainers provide reviewed external storage-state files and five real Pages ad
 - `properties_off`: Forum enabled but the authoring/property contribution is filtered;
 - `Forum-disabled`: Pages remains available but Forum is not tenant-enabled;
 - `no_read`: Forum is enabled but the authenticated user lacks effective `forum_topics:read`.
+
+The full profile must point to a reviewed disposable unpublished draft because the evidence deliberately inserts and saves one Forum block. The remaining profile URLs must also be dedicated evidence fixtures so capability/module state is not inferred from production editorial content.
 
 The harness never seeds tenants, sessions, pages or provider profiles. It observes the reviewed environment only.
 
@@ -91,7 +94,7 @@ The output retains only:
 
 It does not retain raw URLs, cookies, Authorization headers, storage-state contents, owner preview payloads, raw DOM/HTML, tenant/actor identifiers or Forum topic/reply content.
 
-If any profile fails, the success evidence packet is not written.
+The previous output is removed before execution. If any profile fails, a new success evidence packet is not written.
 
 ## Source guard
 
@@ -101,7 +104,7 @@ The source-only guard is:
 node scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
 ```
 
-It verifies the evidence contract, profile matrix, retention boundary, stable production browser selectors, existing Forum host composition and the no-execution status.
+It verifies the evidence contract, profile matrix, retention boundary, stale-output cleanup, stable production browser selectors, existing Forum host composition and the no-execution status.
 
 ## Maintainer browser command
 

--- a/docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md
+++ b/docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md
@@ -1,0 +1,131 @@
+# Forum / Page Builder browser evidence harness actualization — 2026-08-08
+
+Status: `source-ready / maintainer-browser-execution-pending / runtime-evidence-pending`
+
+## Rechecked cursor
+
+PR #3254 completed the FORUM-32 source composition for canonical contribution metadata, Fly component/block identity, owner preview and owner-backed property editing. The next canonical cursor is executable evidence, not another Forum schema/data implementation inside Page Builder.
+
+This slice retains the browser-execution source needed for that next step. It does not execute Chromium, does not promote runtime evidence, and does not claim an observed Page Builder Wave.
+
+## Retained browser contract
+
+The canonical browser contract is:
+
+```text
+crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json
+```
+
+A successful maintainer execution writes only:
+
+```text
+format: forum_page_builder_browser_execution_v1
+status: browser_execution_passed_runtime_evidence_pending
+```
+
+The packet is bound to the exact source commit and immutable deployment RepoDigest. Required production source files are hashed at execution time so browser evidence cannot be replayed against a different Forum/Page Builder implementation.
+
+## Harness owner boundary
+
+The runner lives with the repository's existing pinned Playwright dependency:
+
+```text
+apps/next-admin/playwright.forum-page-builder.config.ts
+apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts
+```
+
+`apps/next-admin` is only the evidence runner package. The browser target is the maintainer-supplied real Leptos Pages admin route. The harness does not add a Next-admin Forum/Page Builder serving path.
+
+The configuration fixes Chromium to one worker, disables retries, trace, screenshots and video, and writes no Playwright artifact containing cookies, owner payloads or rendered Forum data.
+
+## Required maintainer fixtures
+
+Maintainers provide reviewed external storage-state files and five real Pages admin URLs:
+
+- `full`: Forum enabled, Page Builder authoring/preview/properties available, effective `forum_topics:read`;
+- `preview_off`: Forum enabled, `tree + properties` available, preview capability disabled;
+- `properties_off`: Forum enabled but the authoring/property contribution is filtered;
+- `Forum-disabled`: Pages remains available but Forum is not tenant-enabled;
+- `no_read`: Forum is enabled but the authenticated user lacks effective `forum_topics:read`.
+
+The harness never seeds tenants, sessions, pages or provider profiles. It observes the reviewed environment only.
+
+## Full-profile proof
+
+The full profile uses the existing `forum.topic_list` contract because it can prove property normalization without requiring a pre-existing topic/reply fixture.
+
+The browser must observe:
+
+1. `forum.topic_list` is admitted in the real Fly palette and can be inserted;
+2. the selected component can load `forum.topic_list.v1` from the owner property transport;
+3. `per_page=101` is rejected by owner validation;
+4. a valid `per_page=10` plus whitespace-padded UUID is accepted, with sanitize feedback and owner-normalized UUID retained in Fly `props`;
+5. Fly undo restores the pre-property state and schema defaults;
+6. Fly redo restores the owner-normalized state;
+7. owner preview resolves successfully through the admitted Forum preview renderer/transport;
+8. the ordinary Pages facade save completes.
+
+The harness reads owner diagnostics and preview readiness only for assertions. Raw owner preview payloads, DOM/HTML and Forum content are never written to retained evidence.
+
+## Capability-profile proof
+
+`preview_off` must keep `forum.topic_list` and owner property schema loading available while the selected component has no actionable Forum preview renderer.
+
+`properties_off` must expose no `forum.topic_list` palette block and no actionable Forum property editor.
+
+The Forum-disabled route must expose neither Forum palette blocks nor the owner property/preview panels created by the Forum host extension.
+
+The `no_read` session must not receive Forum contribution admission. This proves the browser-facing contribution registry follows the effective permission handshake; direct transport authorization execution remains a separate runtime-evidence gate.
+
+## Retention/privacy boundary
+
+The output retains only:
+
+- exact source commit;
+- immutable deployment RepoDigest;
+- SHA-256 hashes of required source files;
+- SHA-256 hashes and byte sizes of external storage-state files;
+- SHA-256 hashes of the five profile URLs;
+- bounded boolean/count observations;
+- Node and Playwright versions.
+
+It does not retain raw URLs, cookies, Authorization headers, storage-state contents, owner preview payloads, raw DOM/HTML, tenant/actor identifiers or Forum topic/reply content.
+
+If any profile fails, the success evidence packet is not written.
+
+## Source guard
+
+The source-only guard is:
+
+```bash
+node scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
+```
+
+It verifies the evidence contract, profile matrix, retention boundary, stable production browser selectors, existing Forum host composition and the no-execution status.
+
+## Maintainer browser command
+
+After deploying the exact source commit and preparing the reviewed fixture URLs/storage states:
+
+```bash
+cd apps/next-admin
+npx --no-install playwright test \
+  --config playwright.forum-page-builder.config.ts
+```
+
+Required environment values are declared by the JSON contract and include the exact source commit, immutable deployment digest, two external storage-state files and five profile URLs.
+
+## Promotion boundary
+
+A passing browser packet may close only the retained browser portion of FORUM-32 for that exact source/image/environment.
+
+It does not by itself prove:
+
+- direct Forum property/preview transport tenant/module/RBAC rejection paths;
+- server/runtime visibility semantics outside the browser flow;
+- provider SLO health;
+- observed tenant Wave readiness.
+
+Those runtime authorization checks remain the next evidence slice. Observed Forum Wave evidence remains blocked on the existing Pages reference-consumer gate plus accepted Forum browser/runtime packets.
+
+No browser execution is claimed by this source slice. No tests, Node verifiers, Cargo commands, formatters, builds, workflows, CI, database or runtime evidence were executed while preparing it.

--- a/docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md
+++ b/docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md
@@ -23,7 +23,7 @@ format: forum_page_builder_browser_execution_v1
 status: browser_execution_passed_runtime_evidence_pending
 ```
 
-The packet is bound to the exact source commit and immutable deployment RepoDigest. Required production source files are hashed at execution time so browser evidence cannot be replayed against a different Forum/Page Builder implementation.
+The exact source commit is checked against checkout `HEAD`, and required production source files are hashed at execution time so the packet cannot silently describe a different checked-out Forum/Page Builder implementation. The immutable RepoDigest is a maintainer-supplied reviewed deployment identity recorded by the packet; this browser harness does not independently attest that the opened URLs are served by that digest. Deployment provenance must therefore be verified outside this browser packet.
 
 ## Harness owner boundary
 
@@ -84,8 +84,8 @@ The `no_read` session must not receive Forum contribution admission. This proves
 
 The output retains only:
 
-- exact source commit;
-- immutable deployment RepoDigest;
+- exact source commit verified against checkout `HEAD`;
+- maintainer-supplied reviewed deployment identity (immutable RepoDigest);
 - SHA-256 hashes of required source files;
 - SHA-256 hashes and byte sizes of external storage-state files;
 - SHA-256 hashes of the five profile URLs;
@@ -104,7 +104,7 @@ The source-only guard is:
 node scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
 ```
 
-It verifies the evidence contract, profile matrix, retention boundary, stale-output cleanup, stable production browser selectors, existing Forum host composition and the no-execution status.
+It verifies the evidence contract, profile matrix, retention boundary, stale-output cleanup, explicit external deployment-provenance boundary, stable production browser selectors, existing Forum host composition and the no-execution status.
 
 ## Maintainer browser command
 
@@ -116,14 +116,15 @@ npx --no-install playwright test \
   --config playwright.forum-page-builder.config.ts
 ```
 
-Required environment values are declared by the JSON contract and include the exact source commit, immutable deployment digest, two external storage-state files and five profile URLs.
+Required environment values are declared by the JSON contract and include the exact source commit, maintainer-supplied reviewed deployment identity, two external storage-state files and five profile URLs.
 
 ## Promotion boundary
 
-A passing browser packet may close only the retained browser portion of FORUM-32 for that exact source/image/environment.
+A passing browser packet may close only the retained browser portion of FORUM-32 for the reviewed source/environment after external deployment provenance has also been accepted.
 
 It does not by itself prove:
 
+- that the browser independently attested RepoDigest-to-deployment identity;
 - direct Forum property/preview transport tenant/module/RBAC rejection paths;
 - server/runtime visibility semantics outside the browser flow;
 - provider SLO health;

--- a/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
+++ b/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireContains(text, needle, message) {
+  if (!text.includes(needle)) throw new Error(message);
+}
+
+function requireAbsent(text, needle, message) {
+  if (text.includes(needle)) throw new Error(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json";
+const configPath = "apps/next-admin/playwright.forum-page-builder.config.ts";
+const runnerPath = "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts";
+const packetPath =
+  "docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md";
+const contract = JSON.parse(read(contractPath));
+const config = read(configPath);
+const runner = read(runnerPath);
+const packet = read(packetPath);
+const packageJson = JSON.parse(read("apps/next-admin/package.json"));
+const moduleManifest = read("crates/rustok-forum/rustok-module.toml");
+const propertyPanel = read(
+  "crates/rustok-page-builder/admin/src/editor/contribution_properties.rs",
+);
+const previewPanel = read(
+  "crates/rustok-page-builder/admin/src/editor/contribution_preview.rs",
+);
+const palette = read("crates/rustok-page-builder/admin/src/editor/palette_layers.rs");
+const composition = read("apps/admin/src/app/page_builder_contributions.rs");
+
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  throw new Error("browser evidence contract must not claim execution");
+}
+if (contract.runner !== runnerPath || contract.config !== configPath) {
+  throw new Error("browser evidence contract must point to the retained Playwright source");
+}
+if (contract.output?.format !== "forum_page_builder_browser_execution_v1") {
+  throw new Error("browser evidence contract output format drifted");
+}
+if (
+  contract.output?.status !==
+  "browser_execution_passed_runtime_evidence_pending"
+) {
+  throw new Error("browser packet must keep runtime evidence pending");
+}
+const expectedProfiles = [
+  "full",
+  "preview_off",
+  "properties_off",
+  "forum_disabled",
+  "no_read",
+];
+if (JSON.stringify(contract.profiles) !== JSON.stringify(expectedProfiles)) {
+  throw new Error("browser evidence profile matrix drifted");
+}
+for (const pending of [
+  "browser execution",
+  "runtime authorization execution",
+  "observed Page Builder Wave",
+  "provider SLO health",
+]) {
+  if (!contract.not_claimed?.includes(pending)) {
+    throw new Error(`browser evidence contract must keep ${pending} pending`);
+  }
+}
+
+for (const marker of [
+  "fullyParallel: false",
+  "retries: 0",
+  "workers: 1",
+  'trace: "off"',
+  'screenshot: "off"',
+  'video: "off"',
+  'name: "forum-page-builder-chromium"',
+]) {
+  requireContains(config, marker, `Playwright config missing ${marker}`);
+}
+
+for (const marker of [
+  "RUSTOK_FORUM_PAGE_BUILDER_BROWSER_SOURCE_COMMIT",
+  "RUSTOK_FORUM_PAGE_BUILDER_DEPLOYMENT_DIGEST",
+  "RUSTOK_FORUM_PAGE_BUILDER_EDITOR_STORAGE_STATE",
+  "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_STORAGE_STATE",
+  "RUSTOK_FORUM_PAGE_BUILDER_FULL_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_PREVIEW_OFF_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_PROPERTIES_OFF_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_FORUM_DISABLED_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_URL",
+  "forum.topic_list",
+  "forum.topic_list.v1",
+  "fly-owner-property-per_page",
+  "fly-owner-property-category_id",
+  'fill("101")',
+  "Owner validation rejected the current widget properties",
+  "Owner-normalized properties applied to the Fly draft",
+  "intent:undo",
+  "intent:redo",
+  "data-page-builder-contribution-preview-result='ready'",
+  "intent:save",
+  "preview_off",
+  "properties_off",
+  "forum_disabled",
+  "no_read",
+  "source_files: inputs.sourceHashes",
+  "profile_url_sha256: inputs.routeHashes",
+  "retained_secrets: false",
+  "runtime_authorization_evidence_pending: true",
+  "observed_page_builder_wave_pending: true",
+]) {
+  requireContains(runner, marker, `browser harness missing required marker: ${marker}`);
+}
+
+for (const forbidden of [
+  ".content()",
+  ".cookies()",
+  "response.text()",
+  "response.body()",
+  "storageState({ path:",
+  "screenshot(",
+  "tracing.start",
+]) {
+  requireAbsent(
+    runner,
+    forbidden,
+    `browser harness must not retain sensitive browser material through ${forbidden}`,
+  );
+}
+
+if (packageJson.devDependencies?.["@playwright/test"] === undefined) {
+  throw new Error("Forum Page Builder harness must reuse the existing Playwright dependency");
+}
+
+for (const marker of [
+  'required_permissions = ["forum_topics:read"]',
+  'owner_data_state = "owner_property_editor_ready"',
+  'preview_data_state = "owner_preview_transport_ready"',
+]) {
+  requireContains(moduleManifest, marker, `Forum contribution manifest missing ${marker}`);
+}
+for (const marker of [
+  'data-page-builder-contribution-properties="true"',
+  'id=input_id',
+  'set_field("props", normalized_props.clone())',
+]) {
+  requireContains(propertyPanel, marker, `property panel missing browser boundary ${marker}`);
+}
+for (const marker of [
+  'data-page-builder-contribution-preview="true"',
+  'data-page-builder-contribution-preview-result="ready"',
+]) {
+  requireContains(previewPanel, marker, `preview panel missing browser boundary ${marker}`);
+}
+for (const marker of [
+  "data-fly-block-id=browser_block_id",
+  'data-fly-action="insert-block"',
+  'data-fly-action="select-component"',
+]) {
+  requireContains(palette, marker, `palette/layer boundary missing ${marker}`);
+}
+for (const marker of [
+  "with_preview_port(Arc::new(ForumPageBuilderPreviewPort))",
+  "with_property_port(Arc::new(ForumPageBuilderPropertyPort))",
+  'enabled_modules.contains("forum")',
+]) {
+  requireContains(composition, marker, `app composition missing ${marker}`);
+}
+
+for (const marker of [
+  "Status: `source-ready / maintainer-browser-execution-pending / runtime-evidence-pending`",
+  "forum_page_builder_browser_execution_v1",
+  "browser_execution_passed_runtime_evidence_pending",
+  "preview_off",
+  "properties_off",
+  "Forum-disabled",
+  "forum_topics:read",
+  "No browser execution is claimed",
+]) {
+  requireContains(packet, marker, `browser evidence actualization missing ${marker}`);
+}
+
+console.log("Forum Page Builder browser evidence harness source: ok");

--- a/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
+++ b/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
@@ -20,7 +20,8 @@ const configPath = "apps/next-admin/playwright.forum-page-builder.config.ts";
 const runnerPath = "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts";
 const packetPath =
   "docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md";
-const contract = JSON.parse(read(contractPath));
+const contractSource = read(contractPath);
+const contract = JSON.parse(contractSource);
 const config = read(configPath);
 const runner = read(runnerPath);
 const packet = read(packetPath);
@@ -72,6 +73,20 @@ for (const pending of [
 }
 
 for (const marker of [
+  "RUSTOK_FORUM_PAGE_BUILDER_BROWSER_SOURCE_COMMIT",
+  "RUSTOK_FORUM_PAGE_BUILDER_DEPLOYMENT_DIGEST",
+  "RUSTOK_FORUM_PAGE_BUILDER_EDITOR_STORAGE_STATE",
+  "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_STORAGE_STATE",
+  "RUSTOK_FORUM_PAGE_BUILDER_FULL_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_PREVIEW_OFF_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_PROPERTIES_OFF_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_FORUM_DISABLED_URL",
+  "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_URL",
+]) {
+  requireContains(contractSource, marker, `browser contract missing environment: ${marker}`);
+}
+
+for (const marker of [
   "fullyParallel: false",
   "retries: 0",
   "workers: 1",
@@ -84,15 +99,6 @@ for (const marker of [
 }
 
 for (const marker of [
-  "RUSTOK_FORUM_PAGE_BUILDER_BROWSER_SOURCE_COMMIT",
-  "RUSTOK_FORUM_PAGE_BUILDER_DEPLOYMENT_DIGEST",
-  "RUSTOK_FORUM_PAGE_BUILDER_EDITOR_STORAGE_STATE",
-  "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_STORAGE_STATE",
-  "RUSTOK_FORUM_PAGE_BUILDER_FULL_URL",
-  "RUSTOK_FORUM_PAGE_BUILDER_PREVIEW_OFF_URL",
-  "RUSTOK_FORUM_PAGE_BUILDER_PROPERTIES_OFF_URL",
-  "RUSTOK_FORUM_PAGE_BUILDER_FORUM_DISABLED_URL",
-  "RUSTOK_FORUM_PAGE_BUILDER_NO_READ_URL",
   "forum.topic_list",
   "forum.topic_list.v1",
   "fly-owner-property-per_page",

--- a/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
+++ b/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
@@ -17,12 +17,14 @@ function requireAbsent(text, needle, message) {
 const contractPath =
   "crates/rustok-forum/contracts/evidence/forum-page-builder-browser-execution-contract.json";
 const configPath = "apps/next-admin/playwright.forum-page-builder.config.ts";
+const setupPath = "apps/next-admin/tests/forum-page-builder/global-setup.ts";
 const runnerPath = "apps/next-admin/tests/forum-page-builder/browser-evidence.spec.ts";
 const packetPath =
   "docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md";
 const contractSource = read(contractPath);
 const contract = JSON.parse(contractSource);
 const config = read(configPath);
+const setup = read(setupPath);
 const runner = read(runnerPath);
 const packet = read(packetPath);
 const packageJson = JSON.parse(read("apps/next-admin/package.json"));
@@ -39,7 +41,11 @@ const composition = read("apps/admin/src/app/page_builder_contributions.rs");
 if (contract.status !== "source_ready_maintainer_execution_pending") {
   throw new Error("browser evidence contract must not claim execution");
 }
-if (contract.runner !== runnerPath || contract.config !== configPath) {
+if (
+  contract.runner !== runnerPath ||
+  contract.config !== configPath ||
+  contract.global_setup !== setupPath
+) {
   throw new Error("browser evidence contract must point to the retained Playwright source");
 }
 if (contract.output?.format !== "forum_page_builder_browser_execution_v1") {
@@ -87,6 +93,7 @@ for (const marker of [
 }
 
 for (const marker of [
+  'globalSetup: "./tests/forum-page-builder/global-setup.ts"',
   "fullyParallel: false",
   "retries: 0",
   "workers: 1",
@@ -97,6 +104,17 @@ for (const marker of [
 ]) {
   requireContains(config, marker, `Playwright config missing ${marker}`);
 }
+
+for (const marker of [
+  "contract.output.environment",
+  "contract.output.default_path",
+  'path.resolve(repoRoot, "target")',
+  "rmSync(resolveOutput(contract), { force: true })",
+]) {
+  requireContains(setup, marker, `browser global setup missing stale-output guard: ${marker}`);
+}
+for (const forbidden of ["readFileSync(resolveOutput", "writeFileSync", "renameSync"])
+  requireAbsent(setup, forbidden, `global setup must only clear the evidence output: ${forbidden}`);
 
 for (const marker of [
   "forum.topic_list",

--- a/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
+++ b/scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs
@@ -57,6 +57,14 @@ if (
 ) {
   throw new Error("browser packet must keep runtime evidence pending");
 }
+if (
+  contract.deployment_identity?.source_commit_verified_against_checkout_head !== true ||
+  contract.deployment_identity?.deployment_digest_is_maintainer_supplied_reviewed_identity !== true ||
+  contract.deployment_identity?.browser_independent_digest_to_deployment_attestation !== false ||
+  contract.deployment_identity?.deployment_provenance_must_be_verified_outside_this_browser_packet !== true
+) {
+  throw new Error("browser evidence contract must keep deployment provenance explicit and external");
+}
 const expectedProfiles = [
   "full",
   "preview_off",
@@ -69,6 +77,7 @@ if (JSON.stringify(contract.profiles) !== JSON.stringify(expectedProfiles)) {
 }
 for (const pending of [
   "browser execution",
+  "browser-independent digest-to-deployment attestation",
   "runtime authorization execution",
   "observed Page Builder Wave",
   "provider SLO health",
@@ -204,6 +213,7 @@ for (const marker of [
   "properties_off",
   "Forum-disabled",
   "forum_topics:read",
+  "maintainer-supplied reviewed deployment identity",
   "No browser execution is claimed",
 ]) {
   requireContains(packet, marker, `browser evidence actualization missing ${marker}`);


### PR DESCRIPTION
## Summary

Continue FORUM-32 after #3254 by retaining the maintainer-run browser evidence source for the real Pages admin contribution flow without changing Forum/Page Builder production code or claiming execution.

- add an exact-source browser evidence contract with five reviewed profiles: full, `preview_off`, `properties_off`, Forum-disabled, and missing `forum_topics:read`;
- reuse the existing pinned `@playwright/test` dependency with one Chromium worker, no retries, trace, screenshots, or video;
- prove in the full profile that `forum.topic_list` can be inserted, owner schema loads, invalid props are rejected, owner-normalized props are applied, Fly undo/redo works, owner preview resolves, and the existing Pages save path completes;
- prove capability/module/permission admission boundaries without retaining raw URLs, storage state, cookies, DOM/HTML, Forum content, or preview payloads;
- verify the source commit against checkout HEAD and retain required source-file hashes plus a maintainer-supplied reviewed immutable RepoDigest; the browser packet explicitly does **not** claim independent digest-to-deployment attestation, so deployment provenance remains an external reviewed input;
- clear the bounded `target/` evidence output in Playwright global setup so a failed run cannot leave a stale prior success packet;
- add a source-only guard and dated actualization packet; direct runtime transport tenant/module/RBAC evidence remains the next slice.

## Remaining cursor

Run and retain this browser packet on the reviewed deployment with accepted external deployment provenance, then add/retain direct runtime authorization evidence for Forum preview/property transports. Observed Forum Page Builder Wave remains blocked on the existing Pages reference-consumer gate plus accepted Forum browser/runtime packets.

## Dependencies / production source

No Cargo/package dependency declaration and no Forum/Page Builder production Rust source changes are included.

## Validation

Per maintainer instruction, no Playwright/browser execution, Node verifier, Cargo command, formatter, build, workflow, CI, database, runtime evidence, or `git diff --check` was run.