### PR TITLE
docs(index): actualize Product key4 promotion contract

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Storefront budgeted execution merge
-`dd57844c52d05e624710eda6174b43c246173886` and continued on
-`agent/product-storefront-budgeted-execution-evidence-20260808`.
+Status overlay rechecked after Storefront budgeted timeout evidence merge
+`e0bbcc885d7670990fdf0c21d5f2ef01f5015a99` and continued on
+`agent/product-key4-promotion-contract-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -36,6 +36,8 @@ Source-complete:
   enforces outer Tokio timeouts for raw Index/EAV execution and Product tag hydration;
 - deterministic storage-free timeout evidence source for that real budgeted adapter through a crate-private
   post-owner phase seam implemented in production by `ProductStorefrontIndexShadowExecutor`;
+- explicit current Product key-4 tenant promotion contract: ordinary-register/stage, schema-scoped rebuild,
+  evidence admission, `register_current`, lower-key retirement and old-key fail-closed readiness/query behavior;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
@@ -78,6 +80,26 @@ packet is source-complete but has **not** been executed or admitted by the imple
 Mounted Storefront still uses only Product owner reads and does not call either serving-budget classification or
 budgeted execution.
 
+## Product key-4 tenant promotion
+
+Current Product code has already completed the source-code replacement from lower historical keys to one current
+key `4`. `product-postgres-primary` uses `derive_index_schema_source_event_id`; Product source, absence and query
+admission do not select key `3`.
+
+Persisted tenant authority remains a separate execution boundary. For a tenant with a lower Product key still
+active, the required sequence is:
+
+1. ordinary-register the exact current Product key `4` immutable contract;
+2. rebuild key `4` while lower persisted Product keys remain historical/staging state;
+3. execute/admit exact key-4 readiness, freshness, parity, inbox-isolation and restart evidence;
+4. call `PostgresSchemaRegistrationStore::register_current` with that already-staged key `4` contract;
+5. require all lower active Product schemas for that tenant to retire atomically;
+6. require lower-key readiness/query execution to fail closed as inactive;
+7. only then admit an authoritative Product Index consumer.
+
+No runtime dual-read compatibility branch is allowed. Historical lower-key rows are retained storage history,
+not a Product v3/v4 compatibility surface.
+
 ## Remaining Storefront parity/evidence blockers
 
 - execute/admit the deterministic budgeted timeout packet and retain acceptable runtime latency/cancellation
@@ -85,7 +107,7 @@ budgeted execution.
 - execute/review current-key Storefront core/EAV/collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the deployment default-vs-`C` packet agrees;
 - complete maintainer-executed stale locale/readiness/admission/restart evidence;
-- execute/admit current Product replacement evidence and stage/rebuild/promote key `4`;
+- execute/admit Product key-4 staged promotion evidence and perform tenant stage/rebuild/`register_current`;
 - move only eligible Storefront traffic after every evidence/latency gate; channel-less/deep pages stay owner-native.
 
 ## M5 incremental ingestion
@@ -125,19 +147,20 @@ budgeted execution.
 - [x] Define host-measured post-owner serving-budget eligibility.
 - [x] Enforce admitted Index/tag phase timeouts in a separate non-serving post-owner adapter.
 - [x] Retain deterministic timeout/error/deadline/fast-path evidence source for the budgeted adapter.
+- [x] Define/guard the current Product key-4 tenant staging/rebuild/final-supersession contract.
 - [ ] Execute/admit the retained budgeted timeout evidence.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Execute/admit current replacement Product PostgreSQL evidence.
-- [ ] Stage/rebuild/promote Product key `4` for a tenant.
+- [ ] Execute/admit Product key-4 promotion evidence and stage/rebuild/promote a tenant.
 - [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes.
 
 ## Next source-code boundary
 
-The Storefront request-shape, post-page projection, tag hydration, budget policy, timeout enforcement and
-retained timeout packet are source-complete. Do not add a traffic-switch adapter from source inspection alone.
-Further source work should stay on an independent retained evidence boundary (replacement/readiness/restart) and
-must not claim runtime admission. Maintainer execution of the timeout and PostgreSQL packets remains required.
+The Storefront request-shape, projection/hydration, timeout and current-key promotion contracts are source-complete.
+Do not add a traffic-switch adapter from source inspection alone. The next useful source-only slice is retained
+Product key-4 promotion/restart PostgreSQL evidence if no such packet exists; otherwise maintainer execution is
+the blocking action. Any new packet must use production schema registration/readiness/query/replay paths and
+must not manufacture a second Product compatibility implementation.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m4-single-current-schema-supersession.md
+++ b/crates/rustok-index/docs/m4-single-current-schema-supersession.md
@@ -112,7 +112,7 @@ materialization is ready:
 
 A rolling deployment can temporarily have old and new process generations, and staging can temporarily
 leave two persisted keys `active`, but source code still contains only one replacement implementation.
-There is no Product v4/v5 compatibility branch or dual query path in the new runtime.
+There is no compatibility branch or dual query path in the new runtime.
 
 If fail-closed downtime is acceptable, callers may invoke `register_current` before rebuild; the old
 contract then becomes non-authoritative immediately. The staged sequence above is preferred for
@@ -121,34 +121,40 @@ production replacement.
 Historical rows may be purged later through a separately admitted maintenance policy, but purge is not
 required for correctness and is intentionally not coupled to source-module migrations.
 
-## Product Storefront relevance
+## Current Product key-4 application
 
-The current Product Index contract cannot be expanded under its existing persisted routing key because
-that would change the fingerprint. The Storefront parity gate also rejects introducing parallel Product
-v4/v5 compatibility branches.
+Product has already crossed the **source-code** replacement boundary described above. Current runtime code
+publishes exactly one 15-field Product contract on routing key `4`; lower Product keys are historical storage
+identities only. The selected Product source uses `derive_index_schema_source_event_id` and explicitly rejects
+reintroduction of the old key `3` compatibility path.
 
-This generic supersession path provides the persistence/replay identity mechanisms for a future
-**single-current** Product replacement:
+This does **not** mean every tenant has completed persisted promotion. For a tenant that still has a lower
+Product contract active, the current key-4 rollout must follow the staged sequence:
 
-- one monotonically higher internal routing key;
-- only that replacement contract published by new Product runtime code;
-- schema-scoped deterministic Product replay delivery IDs;
-- staged new-key replay/rebuild before authority transition;
-- all lower persisted Product keys retired atomically per tenant at final supersession;
-- no old Product source/query compatibility branch selected in the replacement runtime.
+1. ordinary-register the exact current Product key `4` contract while any lower persisted Product key remains
+   active;
+2. rebuild key `4` with schema-scoped delivery UUIDs so historical inbox rows cannot suppress replacement
+   deliveries;
+3. retain and execute current-key readiness/freshness/parity/restart evidence;
+4. call `register_current` with the same already-staged Product key `4` contract;
+5. require all lower active Product schema rows for that tenant to become `retired` atomically;
+6. require old-key readiness/query execution to fail closed as inactive;
+7. only then admit an authoritative Product Index consumer for that tenant.
 
-This slice does not change the Product routing key or Product schema yet. The future replacement Product
-source must switch from `derive_index_source_event_id` to `derive_index_schema_source_event_id` in the
-same PR that changes its current routing key.
+The runtime must not stage or select a Product key `3` implementation merely because persisted key `3` rows may
+still exist. Historical rows remain valid storage history; they are not a compatibility surface.
+
+The focused M7 Product promotion contract is retained in
+`m7-product-current-schema-promotion.md` and guarded by
+`verify-index-product-current-schema-promotion.mjs`.
 
 ## Deliberate limits
 
 This primitive does not:
 
-- choose a Product replacement key;
-- alter Product fields;
-- register schemas automatically for every tenant;
-- run replay/rebuild jobs;
+- automatically stage Product key `4` for every tenant;
+- run Product replay/rebuild jobs;
+- execute or admit Product current-key PostgreSQL evidence;
 - delete old Index materialization;
 - change public event contracts;
 - authorize Storefront cutover.
@@ -164,6 +170,7 @@ cargo test -p rustok-index source_event_id --lib -- --nocapture
 cargo test -p rustok-index schema_registration --lib -- --nocapture
 node scripts/verify/verify-index-schema-scoped-source-event-id.mjs
 node scripts/verify/verify-index-schema-supersession.mjs
+node scripts/verify/verify-index-product-current-schema-promotion.mjs
 node scripts/verify/verify-index-schema-readiness.mjs
 node scripts/verify/verify-index-product-storefront-parity-gate.mjs
 node scripts/verify/verify-index-query-contract.mjs

--- a/crates/rustok-index/docs/m7-product-current-schema-promotion.md
+++ b/crates/rustok-index/docs/m7-product-current-schema-promotion.md
@@ -1,0 +1,64 @@
+# M7 Product current-schema promotion
+
+Status: `source_contract_complete_execution_pending`.
+
+## Current source identity
+
+Current Product runtime code publishes exactly one Product Index schema on routing key `4` through
+`PRODUCT_SCHEMA_ROUTING_KEY`. The schema contains 15 fields and two links. Lower Product routing keys are
+historical persisted identities only; they are not selected as runtime compatibility implementations.
+
+`product-postgres-primary` derives replay delivery UUIDs with `derive_index_schema_source_event_id` using the
+exact Product `SchemaRef`. The same owner mutation/source-version pair therefore receives a distinct delivery
+identity when replayed under a different Product schema key, while retries of the same key remain stable.
+
+The Product source and its current absence/query-admission consumers reject a hard-coded key `3` path.
+
+## Tenant promotion sequence
+
+Source completeness does not imply that every tenant has already promoted persisted Product authority to key
+`4`. For a tenant with a lower active Product schema, promotion is explicitly staged:
+
+1. ordinary-register the exact Product key `4` immutable contract;
+2. leave lower persisted Product keys untouched while key `4` is rebuilt;
+3. rebuild key `4` using schema-scoped replay delivery IDs;
+4. execute/admit exact key-4 readiness, freshness, parity, inbox-isolation and restart evidence;
+5. call `PostgresSchemaRegistrationStore::register_current` with the already-staged key `4` contract;
+6. require every lower active Product schema for that tenant to become `retired` atomically;
+7. require lower-key readiness/query execution to fail closed because the persisted schema is inactive;
+8. only after promotion may an authoritative Product Index consumer be admitted for that tenant.
+
+Ordinary registration must not retire lower contracts. `register_current` is the authority transition, not the
+staging primitive.
+
+## Historical state
+
+Promotion does not rewrite or delete historical `index_entities`, `index_links`, inbox deliveries or replay
+checkpoints. Their schema key/fingerprint identities remain valid history. Old materialization may be purged
+later only through a separately admitted maintenance policy.
+
+A rolling deployment may temporarily observe more than one persisted active Product schema during staging, but
+current source code still contains one Product implementation. Persisted coexistence is not runtime dual-read
+compatibility.
+
+## Storefront gate
+
+Mounted Storefront remains owner-native. Promotion source completeness does not establish Storefront parity,
+collation admission, timeout/latency admission or tenant readiness. Channel-less and deep-page Storefront
+request shapes remain owner-native under the current key-4 contract.
+
+## Execution still required
+
+Maintainer-owned execution must still prove at least:
+
+- Product key `4` can be staged while the lower persisted key remains active;
+- schema-scoped key-4 replay does not collide with historical inbox delivery identities;
+- exact key-4 readiness/freshness/parity/restart packets pass;
+- `register_current` retires lower active Product keys only after staging/rebuild;
+- an old Product schema reference fails readiness/query admission after retirement;
+- restart after promotion resolves only the current runtime-selected key `4` contract.
+
+This document and its source guard do not claim those runtime results.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -68,6 +68,21 @@ Never-completing phases use `std::future::pending`; timeout cancellation is stil
 `tokio::time::timeout` wrapper. The packet has not been executed by the implementation agent and therefore is
 not admitted runtime/latency evidence yet.
 
+## Current Product key-4 promotion — source contract complete, execution pending
+
+Current Product runtime code publishes one 15-field schema on routing key `4` and derives replay delivery IDs
+with `derive_index_schema_source_event_id`. Lower Product keys are historical persisted identities, not runtime
+compatibility implementations.
+
+Tenant promotion must remain staged: ordinary-register key `4`, rebuild/evidence it while lower persisted keys
+may still be active, then call `PostgresSchemaRegistrationStore::register_current` with the same staged key `4`
+contract. Final supersession retires lower active Product schemas atomically; old-key readiness/query execution
+must then fail closed as inactive.
+
+The focused source contract is retained in `m7-product-current-schema-promotion.md` and
+`verify-index-product-current-schema-promotion.mjs`. It does not claim that any tenant has completed the
+stage/rebuild/promote sequence.
+
 ## Search/collation/EAV source state
 
 Product owns the 1022-byte effective Storefront title-search bound compatible with generic 1024-byte
@@ -84,15 +99,15 @@ bind-free `Never`. Current Product Index remains one 15-field schema on routing 
 2. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
 3. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible cutover closed.
 4. Stale locale/readiness/admission/restart evidence remains maintainer-run.
-5. Stage/rebuild/promote current Product key `4` and admit replacement evidence.
+5. Execute/admit Product key-4 promotion evidence and perform tenant stage/rebuild/`register_current`.
 6. Any serving router must preserve channel-less/deep-page owner-native branches and traffic switch remains last.
 
 ## Next source boundary
 
 Do not move mounted Storefront traffic from source inspection alone. Further serving composition depends on
-maintainer execution/admission of timeout, Storefront parity/collation, stale-readiness and replacement evidence.
-Independent source work may continue only on one of those retained evidence boundaries without weakening this
-gate.
+maintainer execution/admission of timeout, Storefront parity/collation, stale-readiness and key-4 promotion
+evidence. Independent source work may continue only on one of those retained evidence boundaries without
+weakening this gate.
 
 ## Source guards
 
@@ -101,6 +116,7 @@ gate.
 - `verify-index-product-storefront-budgeted-execution.mjs` locks post-owner phase timeout enforcement;
 - `verify-index-product-storefront-budgeted-execution-evidence.mjs` locks the deterministic retained timeout
   packet and test-only phase seam;
+- `verify-index-product-current-schema-promotion.mjs` locks the single-current key-4 staged-promotion contract;
 - `verify-index-product-storefront-shadow-executor.mjs` keeps the ordinary evidence executor separate;
 - request-shape, public-projection, tag-hydration, collation and key-4 guards remain retained;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.

--- a/scripts/verify/verify-index-product-current-schema-promotion.mjs
+++ b/scripts/verify/verify-index-product-current-schema-promotion.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-current-schema-promotion] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const modulePath = 'crates/rustok-distribution/src/product_index/mod.rs';
+const moduleSource = requireMarkers(modulePath, [
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+  'Lower keys are historical storage identities only.',
+]);
+forbidMarkers(modulePath, moduleSource, [
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 3',
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 5',
+  'mod product_v3',
+  'mod product_v4',
+]);
+
+const productPath = 'crates/rustok-distribution/src/product_index/product.rs';
+const product = requireMarkers(productPath, [
+  'PRODUCT_INDEX_SOURCE: &str = "product-postgres-primary"',
+  'derive_index_schema_source_event_id',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  'assert_eq!(schema.fields.len(), 15);',
+  'assert_eq!(schema.links.len(), 2);',
+]);
+forbidMarkers(productPath, product, [
+  'derive_index_source_event_id(',
+  'SchemaVersion::new(3)',
+  'product_v3_schema',
+  'product_v4_schema',
+]);
+
+for (const currentConsumer of [
+  'crates/rustok-distribution/src/product_index/absence.rs',
+  'crates/rustok-distribution/src/product_index/query_admission.rs',
+]) {
+  const consumer = requireMarkers(currentConsumer, [
+    'PRODUCT_SCHEMA_ROUTING_KEY',
+    'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+  ]);
+  forbidMarkers(currentConsumer, consumer, ['SchemaVersion::new(3)']);
+}
+
+const registrationPath = 'crates/rustok-index/src/infrastructure/postgres/schema_registration.rs';
+const registration = requireMarkers(registrationPath, [
+  'pub async fn register_current(',
+  'register_current_in_transaction(',
+  'retire_lower_active_schemas(',
+  "status = 'retired'",
+  'schema_version < $4 AND status = \'active\'',
+  'Historical entity/link/inbox/replay rows are not deleted or rewritten',
+]);
+forbidMarkers(registrationPath, registration, [
+  'DELETE FROM index_schemas',
+  'DELETE FROM index_entities',
+  'DELETE FROM index_links',
+  'UPDATE index_entities SET schema_version',
+]);
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/schema_registration_tests.rs', [
+  'ordinary_registration_does_not_implicitly_retire_older_contracts',
+  'staged_latest_contract_can_be_promoted_without_reinsertion',
+  'explicit_current_supersession_retires_all_lower_active_contracts',
+  'historical_exact_contract_cannot_be_declared_current_after_supersession',
+  'supersession_is_tenant_scoped',
+]);
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/schema_readiness.rs', [
+  'if status != "active"',
+  'IndexSchemaReadinessFailure::Inactive',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/query_port.rs', [
+  'if status != "active"',
+  'PersistedSchemaReadinessFailure::Inactive',
+]);
+requireMarkers('crates/rustok-index/src/application/source_event_id.rs', [
+  'pub fn derive_index_schema_source_event_id(',
+  'rustok-index-schema-source-event-id-v1',
+]);
+
+requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.md', [
+  'Current Product key-4 application',
+  'current Product key `4` contract',
+  'The runtime must not stage or select a Product key `3` implementation',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-current-schema-promotion.md', [
+  'Status: `source_contract_complete_execution_pending`',
+  'Current source identity',
+  'Tenant promotion sequence',
+  'ordinary-register the exact Product key `4` immutable contract',
+  '`PostgresSchemaRegistrationStore::register_current`',
+  'Historical state',
+  'Mounted Storefront remains owner-native',
+  'Execution still required',
+]);
+
+console.log('[verify-index-product-current-schema-promotion] Product key4 is the only current runtime contract; tenant stage/rebuild/register_current promotion remains fail-closed and execution-owned');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -113,14 +113,26 @@ if (budgeted.includes('list_filtered_published_products(')) {
 
 const productIndexPath = 'crates/rustok-distribution/src/product_index/product.rs';
 const productIndex = requireMarkers(productIndexPath, [
+  'derive_index_schema_source_event_id',
   'assert_eq!(schema.fields.len(), 15);',
   'many_field("tag_ids", IndexValueType::Uuid, true, false)',
   'many_field("sales_channel_ids", IndexValueType::Uuid, true, true)',
   'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
 ]);
-for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'localized_tag_names']) {
+for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'localized_tag_names', 'derive_index_source_event_id(']) {
   if (productIndex.includes(forbidden)) fail(`${productIndexPath} contains forbidden Product schema marker ${forbidden}`);
 }
+
+requireMarkers('scripts/verify/verify-index-product-current-schema-promotion.mjs', [
+  'Product key4 is the only current runtime contract',
+  'tenant stage/rebuild/register_current promotion remains fail-closed and execution-owned',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-current-schema-promotion.md', [
+  'Status: `source_contract_complete_execution_pending`',
+  'Tenant promotion sequence',
+  '`PostgresSchemaRegistrationStore::register_current`',
+  'Mounted Storefront remains owner-native',
+]);
 
 requireMarkers('crates/rustok-distribution/src/product_index/storefront_projection.rs', [
   'const UNTITLED_PRODUCT: &str = "Untitled product";',
@@ -161,6 +173,7 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', 
   'Mounted Storefront remains owner-native',
   'Serving-budget policy and timeout enforcement — source complete',
   'Deterministic timeout evidence — source complete, execution pending',
+  'Current Product key-4 promotion — source contract complete, execution pending',
   '`ProductStorefrontIndexBudgetedProjectionExecutor`',
   'The packet has not been executed by the implementation agent',
 ]);
@@ -174,9 +187,10 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-budgeted-executio
   'The retained packet is **source-only** until a maintainer executes it.',
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-product-current-schema-promotion.mjs'",
   "'verify-index-product-storefront-serving-budget-policy.mjs'",
   "'verify-index-product-storefront-budgeted-execution.mjs'",
   "'verify-index-product-storefront-budgeted-execution-evidence.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; budget policy, non-serving phase timeout enforcement and deterministic timeout evidence source are complete while maintainer execution/admission remains pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; current key4 promotion, budget policy, timeout enforcement and deterministic timeout evidence are source-complete while maintainer execution/admission remains pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -62,6 +62,7 @@ const scripts = [
   'verify-index-replay-retry-store.mjs',
   'verify-index-replay-dead-letter-admission.mjs',
   'verify-index-product-source.mjs',
+  'verify-index-product-current-schema-promotion.mjs',
   'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-eav-owner-clock.mjs',
   'verify-index-product-attribute-term-contract.mjs',

--- a/scripts/verify/verify-index-schema-supersession.mjs
+++ b/scripts/verify/verify-index-schema-supersession.mjs
@@ -96,11 +96,17 @@ requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.m
   '`derive_index_schema_source_event_id`',
   'Recommended staged rebuild sequence',
   'use ordinary `register` to stage',
-  'schema-scoped deterministic Product replay delivery IDs',
   'call `register_current` with that already-staged exact contract',
   'Historical rows may be purged later',
-  'single-current',
-  'This slice does not change the Product routing key or Product schema yet.',
+  'Current Product key-4 application',
+  'publishes exactly one 15-field Product contract on routing key `4`',
+  'uses `derive_index_schema_source_event_id`',
+  'must not stage or select a Product key `3` implementation',
+  'm7-product-current-schema-promotion.md',
 ]);
 
-console.log('[verify-index-schema-supersession] explicit single-current staged schema supersession source contract verified');
+requireMarkers('scripts/verify/verify-index-product-current-schema-promotion.mjs', [
+  'Product key4 is the only current runtime contract',
+]);
+
+console.log('[verify-index-schema-supersession] explicit single-current staged schema supersession source contract verified with current Product key4 application');


### PR DESCRIPTION
## Summary

- actualize the generic single-current schema supersession contract to the Product state that already exists in current runtime source;
- record that Product publishes one 15-field current schema on routing key `4`, lower keys are historical storage identities only, and `product-postgres-primary` already uses `derive_index_schema_source_event_id`;
- remove the stale statement that Product routing-key replacement is still a future source-code change;
- add a focused M7 Product key-4 tenant promotion contract: ordinary-register/stage key4, rebuild with schema-scoped delivery IDs, execute/admit readiness/freshness/parity/restart evidence, then call `register_current` and require lower active Product schemas to retire atomically;
- require old-key readiness/query execution to fail closed as inactive after promotion;
- explicitly forbid using persisted key3 history as a runtime Product compatibility implementation;
- add `verify-index-product-current-schema-promotion.mjs`, wire it into the aggregate Index contract, and include the promotion gate in the Storefront parity guard;
- advance the current M7 plan without claiming any tenant has actually completed stage/rebuild/promote.

## Boundary

This PR changes no Product schema, routing key, replay implementation, registration API, query runtime, mounted Storefront path, or traffic policy. It does not execute PostgreSQL promotion/rebuild/readiness evidence and does not claim runtime admission.

Mounted Storefront remains owner-native. Channel-less and deep-page request shapes remain owner-native under the current key4 contract.

## Main recheck

The branch is based directly on `main@e0bbcc885d7670990fdf0c21d5f2ef01f5015a99` and is not behind. Final compare contains 8 documentation/source-guard files only.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.