### PR TITLE
test(parity): retain Forum Page Builder runtime authorization evidence

### DIFF
--- a/crates/rustok-api/src/runtime.rs
+++ b/crates/rustok-api/src/runtime.rs
@@ -113,3 +113,60 @@ impl HostRuntimeContext {
             .cloned()
     }
 }
+
+#[cfg(all(test, feature = "runtime"))]
+mod tests {
+    use super::*;
+    use sea_orm::Database;
+
+    #[tokio::test]
+    async fn tenant_module_enablement_is_exact_and_fail_closed() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("runtime module evidence SQLite should connect");
+        db.execute_unprepared(
+            r#"
+CREATE TABLE tenant_modules (
+    tenant_id TEXT NOT NULL,
+    module_slug TEXT NOT NULL,
+    enabled INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, module_slug)
+);
+"#,
+        )
+        .await
+        .expect("tenant_modules evidence table should create");
+
+        let tenant_id = Uuid::new_v4();
+        let foreign_tenant_id = Uuid::new_v4();
+        db.execute_unprepared(&format!(
+            "INSERT INTO tenant_modules (tenant_id, module_slug, enabled) VALUES \
+             ('{tenant_id}', 'forum', 1), \
+             ('{tenant_id}', 'pages', 0), \
+             ('{foreign_tenant_id}', 'forum', 1)"
+        ))
+        .await
+        .expect("tenant module evidence rows should insert");
+
+        assert!(
+            is_tenant_module_enabled(&db, tenant_id, "forum")
+                .await
+                .expect("enabled Forum lookup should succeed")
+        );
+        assert!(
+            !is_tenant_module_enabled(&db, tenant_id, "pages")
+                .await
+                .expect("disabled module lookup should succeed")
+        );
+        assert!(
+            !is_tenant_module_enabled(&db, Uuid::new_v4(), "forum")
+                .await
+                .expect("foreign tenant lookup should succeed")
+        );
+        assert!(
+            !is_tenant_module_enabled(&db, tenant_id, "missing")
+                .await
+                .expect("missing module lookup should succeed")
+        );
+    }
+}

--- a/crates/rustok-forum/admin/src/widget_preview_transport.rs
+++ b/crates/rustok-forum/admin/src/widget_preview_transport.rs
@@ -22,17 +22,42 @@ pub(crate) fn require_tenant_scope(
 }
 
 #[cfg(feature = "ssr")]
-pub(crate) async fn require_forum_module_enabled(
-    host: &rustok_api::HostRuntimeContext,
-    tenant_id: uuid::Uuid,
+pub(crate) fn require_forum_transport_authorization(
+    auth: &rustok_api::AuthContext,
+    tenant: &rustok_api::TenantContext,
 ) -> Result<(), ServerFnError> {
-    match rustok_api::is_tenant_module_enabled(host.db(), tenant_id, "forum").await {
+    require_tenant_scope(auth, tenant)?;
+    if rustok_api::has_any_effective_permission(
+        &auth.permissions,
+        &[rustok_api::Permission::FORUM_TOPICS_READ],
+    ) {
+        Ok(())
+    } else {
+        Err(ServerFnError::new("forum_topics:read required"))
+    }
+}
+
+#[cfg(feature = "ssr")]
+pub(crate) fn require_forum_module_state(
+    state: Result<bool, impl std::fmt::Display>,
+) -> Result<(), ServerFnError> {
+    match state {
         Ok(true) => Ok(()),
         Ok(false) => Err(ServerFnError::new("Forum module is not enabled")),
         Err(error) => Err(ServerFnError::new(format!(
             "Forum module state is unavailable: {error}"
         ))),
     }
+}
+
+#[cfg(feature = "ssr")]
+pub(crate) async fn require_forum_module_enabled(
+    host: &rustok_api::HostRuntimeContext,
+    tenant_id: uuid::Uuid,
+) -> Result<(), ServerFnError> {
+    require_forum_module_state(
+        rustok_api::is_tenant_module_enabled(host.db(), tenant_id, "forum").await,
+    )
 }
 
 #[cfg(feature = "ssr")]
@@ -75,13 +100,7 @@ pub async fn preview_forum_page_builder_widget(
             .await
             .map_err(ServerFnError::new)?;
 
-        require_tenant_scope(&auth, &tenant)?;
-        if !rustok_api::has_any_effective_permission(
-            &auth.permissions,
-            &[rustok_api::Permission::FORUM_TOPICS_READ],
-        ) {
-            return Err(ServerFnError::new("forum_topics:read required"));
-        }
+        require_forum_transport_authorization(&auth, &tenant)?;
 
         let (host, event_bus) = runtime()?;
         require_forum_module_enabled(&host, tenant.id).await?;
@@ -102,8 +121,11 @@ pub async fn preview_forum_page_builder_widget(
             .await
             .map_err(|error| ServerFnError::new(error.to_string()))?;
 
-        serde_json::to_value(response)
-            .map_err(|error| ServerFnError::new(format!("Forum widget preview serialization failed: {error}")))
+        serde_json::to_value(response).map_err(|error| {
+            ServerFnError::new(format!(
+                "Forum widget preview serialization failed: {error}"
+            ))
+        })
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -111,5 +133,90 @@ pub async fn preview_forum_page_builder_widget(
         Err(ServerFnError::new(
             "forum/page-builder-widget-preview requires the `ssr` feature",
         ))
+    }
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use super::*;
+    use rustok_api::{Action, Permission, Resource};
+    use uuid::Uuid;
+
+    fn auth(tenant_id: Uuid, permissions: Vec<Permission>) -> rustok_api::AuthContext {
+        rustok_api::AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    fn tenant(id: Uuid) -> rustok_api::TenantContext {
+        rustok_api::TenantContext {
+            id,
+            name: "Forum evidence tenant".to_string(),
+            slug: "forum-evidence".to_string(),
+            domain: None,
+            settings: serde_json::json!({}),
+            default_locale: "en".to_string(),
+            is_active: true,
+        }
+    }
+
+    #[test]
+    fn transport_authorization_accepts_exact_read_and_effective_manage() {
+        let tenant_id = Uuid::new_v4();
+        let tenant = tenant(tenant_id);
+        assert!(require_forum_transport_authorization(
+            &auth(tenant_id, vec![Permission::FORUM_TOPICS_READ]),
+            &tenant,
+        )
+        .is_ok());
+        assert!(require_forum_transport_authorization(
+            &auth(
+                tenant_id,
+                vec![Permission::new(Resource::ForumTopics, Action::Manage)],
+            ),
+            &tenant,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn transport_authorization_rejects_missing_read_and_cross_tenant_context() {
+        let tenant_id = Uuid::new_v4();
+        let tenant = tenant(tenant_id);
+        let missing = require_forum_transport_authorization(&auth(tenant_id, Vec::new()), &tenant)
+            .expect_err("missing forum_topics:read should be rejected")
+            .to_string();
+        assert!(missing.contains("forum_topics:read required"));
+
+        let mismatch = require_forum_transport_authorization(
+            &auth(Uuid::new_v4(), vec![Permission::FORUM_TOPICS_READ]),
+            &tenant,
+        )
+        .expect_err("cross-tenant auth context should be rejected")
+        .to_string();
+        assert!(mismatch.contains("tenant scope mismatch"));
+    }
+
+    #[test]
+    fn module_state_fails_closed_for_disabled_and_unavailable_states() {
+        assert!(require_forum_module_state(Ok::<_, &str>(true)).is_ok());
+        assert!(
+            require_forum_module_state(Ok::<_, &str>(false))
+                .expect_err("disabled Forum must be rejected")
+                .to_string()
+                .contains("Forum module is not enabled")
+        );
+        assert!(
+            require_forum_module_state(Err::<bool, _>("database unavailable"))
+                .expect_err("module lookup failure must fail closed")
+                .to_string()
+                .contains("Forum module state is unavailable")
+        );
     }
 }

--- a/crates/rustok-forum/admin/src/widget_property_transport.rs
+++ b/crates/rustok-forum/admin/src/widget_property_transport.rs
@@ -40,7 +40,7 @@ pub struct ForumWidgetPropertyValidationTransportResponse {
 #[cfg(feature = "ssr")]
 async fn authorize_forum_property_transport() -> Result<(), ServerFnError> {
     use crate::widget_preview_transport::{
-        require_forum_module_enabled, require_tenant_scope,
+        require_forum_module_enabled, require_forum_transport_authorization,
     };
     use leptos::prelude::expect_context;
 
@@ -50,13 +50,7 @@ async fn authorize_forum_property_transport() -> Result<(), ServerFnError> {
     let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
         .await
         .map_err(ServerFnError::new)?;
-    require_tenant_scope(&auth, &tenant)?;
-    if !rustok_api::has_any_effective_permission(
-        &auth.permissions,
-        &[rustok_api::Permission::FORUM_TOPICS_READ],
-    ) {
-        return Err(ServerFnError::new("forum_topics:read required"));
-    }
+    require_forum_transport_authorization(&auth, &tenant)?;
 
     let host = expect_context::<rustok_api::HostRuntimeContext>();
     require_forum_module_enabled(&host, tenant.id).await

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-runtime-authorization-execution-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-runtime-authorization-execution-contract.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "module": "forum",
+  "packet": "page_builder_runtime_authorization_evidence",
+  "status": "source_ready_maintainer_execution_pending",
+  "runner": "scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs",
+  "output": {
+    "environment": "RUSTOK_FORUM_PAGE_BUILDER_RUNTIME_EVIDENCE_OUTPUT",
+    "default_path": "target/forum-page-builder-runtime-authorization-evidence.json",
+    "format": "forum_page_builder_runtime_authorization_execution_v1",
+    "status": "runtime_authorization_execution_passed_wave_pending"
+  },
+  "commands": [
+    {
+      "id": "transport_authorization",
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-forum-admin",
+        "--features",
+        "ssr",
+        "widget_preview_transport::tests"
+      ]
+    },
+    {
+      "id": "tenant_module_state",
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-api",
+        "--features",
+        "runtime",
+        "tenant_module_enablement_is_exact_and_fail_closed"
+      ]
+    },
+    {
+      "id": "owner_moderator_policy",
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-forum",
+        "widget_preview::tests"
+      ]
+    },
+    {
+      "id": "owner_visibility_sqlite",
+      "program": "cargo",
+      "args": [
+        "test",
+        "-p",
+        "rustok-forum",
+        "--test",
+        "page_builder_widget_visibility_sqlite"
+      ]
+    }
+  ],
+  "proofs": [
+    "preview and property transports share exact tenant and effective forum_topics:read authorization",
+    "forum_topics:manage satisfies effective forum_topics:read without a parallel Forum-specific implication rule",
+    "tenant mismatch and missing read permission fail closed",
+    "tenant module lookup admits only the exact enabled forum row and rejects disabled, foreign and missing rows",
+    "reply_stream approved_only=false requires effective forum_replies:moderate",
+    "moderator preview includes pending/approved/rejected/hidden/flagged but excludes deleted tombstones",
+    "anonymous topic visibility excludes authenticated categories and descendants",
+    "authenticated topic visibility admits authenticated categories while retaining tenant and topic-status filtering"
+  ],
+  "required_source_files": [
+    "crates/rustok-forum/contracts/evidence/forum-page-builder-runtime-authorization-execution-contract.json",
+    "scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs",
+    "crates/rustok-forum/admin/src/widget_preview_transport.rs",
+    "crates/rustok-forum/admin/src/widget_property_transport.rs",
+    "crates/rustok-api/src/runtime.rs",
+    "crates/rustok-api/src/context/auth.rs",
+    "crates/rustok-forum/src/services/widget_preview.rs",
+    "crates/rustok-forum/src/services/topic_visibility.rs",
+    "crates/rustok-forum/src/services/category_visibility.rs",
+    "crates/rustok-forum/tests/page_builder_widget_visibility_sqlite.rs"
+  ],
+  "retained_data": [
+    "exact source commit",
+    "source-file SHA-256 hashes",
+    "command ids and argv",
+    "exit status",
+    "stdout/stderr byte lengths and SHA-256 hashes"
+  ],
+  "forbidden_retained_data": [
+    "database contents",
+    "tenant ids",
+    "actor ids",
+    "Forum topic or reply content",
+    "authorization headers",
+    "cookies",
+    "raw stdout or stderr"
+  ],
+  "not_claimed": [
+    "runtime authorization execution",
+    "browser execution",
+    "deployed server-function transport attestation",
+    "observed Page Builder Wave",
+    "provider SLO health"
+  ]
+}

--- a/crates/rustok-forum/src/services/widget_preview.rs
+++ b/crates/rustok-forum/src/services/widget_preview.rs
@@ -21,6 +21,7 @@ use crate::services::{ReplyService, TopicService};
 use crate::state_machine::ReplyStatus;
 
 const TOPIC_DETAIL_PREVIEW_REPLIES: u64 = 20;
+const APPROVED_PREVIEW_REPLY_STATUSES: [ReplyStatus; 1] = [ReplyStatus::Approved];
 const MODERATOR_PREVIEW_REPLY_STATUSES: [ReplyStatus; 5] = [
     ReplyStatus::Pending,
     ReplyStatus::Approved,
@@ -198,7 +199,7 @@ impl ForumWidgetPreviewService {
                         per_page: TOPIC_DETAIL_PREVIEW_REPLIES,
                     },
                     fallback_locale,
-                    Some(&[ReplyStatus::Approved]),
+                    Some(&APPROVED_PREVIEW_REPLY_STATUSES),
                 )
                 .await?
         } else {
@@ -225,19 +226,7 @@ impl ForumWidgetPreviewService {
         let page = required_u64(props, "page")?;
         let per_page = required_u64(props, "per_page")?;
         let approved_only = required_bool(props, "approved_only")?;
-        if !approved_only
-            && security.get_scope(Resource::ForumReplies, Action::Moderate) == PermissionScope::None
-        {
-            return Err(ForumError::forbidden(
-                "Forum widget preview requires forum_replies:moderate when approved_only=false",
-            ));
-        }
-
-        let statuses: &[ReplyStatus] = if approved_only {
-            &[ReplyStatus::Approved]
-        } else {
-            &MODERATOR_PREVIEW_REPLY_STATUSES
-        };
+        let statuses = reply_stream_preview_statuses(approved_only, &security)?;
         let (items, total) = ReplyService::new(self.db.clone(), self.event_bus.clone())
             .list_response_for_topic_by_statuses_with_locale_fallback(
                 tenant_id,
@@ -262,6 +251,21 @@ impl ForumWidgetPreviewService {
             approved_only,
         })
     }
+}
+
+fn reply_stream_preview_statuses(
+    approved_only: bool,
+    security: &SecurityContext,
+) -> ForumResult<&'static [ReplyStatus]> {
+    if approved_only {
+        return Ok(&APPROVED_PREVIEW_REPLY_STATUSES);
+    }
+    if security.get_scope(Resource::ForumReplies, Action::Moderate) == PermissionScope::None {
+        return Err(ForumError::forbidden(
+            "Forum widget preview requires forum_replies:moderate when approved_only=false",
+        ));
+    }
+    Ok(&MODERATOR_PREVIEW_REPLY_STATUSES)
 }
 
 fn required_string<'a>(props: &'a Value, field: &str) -> ForumResult<&'a str> {
@@ -304,4 +308,45 @@ fn optional_uuid(props: &Value, field: &str) -> ForumResult<Option<Uuid>> {
             })
         })
         .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_api::{Action, Permission, Resource};
+
+    fn security(permissions: Vec<Permission>) -> SecurityContext {
+        SecurityContext::from_permission_snapshot(Some(Uuid::new_v4()), &permissions)
+    }
+
+    #[test]
+    fn approved_reply_stream_never_requires_moderation_scope() {
+        let statuses = reply_stream_preview_statuses(
+            true,
+            &security(vec![Permission::FORUM_TOPICS_READ]),
+        )
+        .expect("approved-only widget preview should not require moderation");
+        assert_eq!(statuses, &[ReplyStatus::Approved]);
+    }
+
+    #[test]
+    fn non_approved_reply_stream_requires_effective_moderation_scope() {
+        let denied = reply_stream_preview_statuses(
+            false,
+            &security(vec![Permission::FORUM_TOPICS_READ]),
+        )
+        .expect_err("non-approved preview must require reply moderation");
+        assert!(denied.to_string().contains("forum_replies:moderate"));
+
+        let statuses = reply_stream_preview_statuses(
+            false,
+            &security(vec![Permission::new(Resource::ForumReplies, Action::Manage)]),
+        )
+        .expect("manage should satisfy the effective moderation scope");
+        assert_eq!(statuses, &MODERATOR_PREVIEW_REPLY_STATUSES);
+        assert!(statuses.contains(&ReplyStatus::Pending));
+        assert!(statuses.contains(&ReplyStatus::Hidden));
+        assert!(statuses.contains(&ReplyStatus::Flagged));
+        assert!(!statuses.contains(&ReplyStatus::Deleted));
+    }
 }

--- a/crates/rustok-forum/src/services/widget_preview.rs
+++ b/crates/rustok-forum/src/services/widget_preview.rs
@@ -313,7 +313,7 @@ fn optional_uuid(props: &Value, field: &str) -> ForumResult<Option<Uuid>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustok_api::{Action, Permission, Resource};
+    use rustok_api::Permission;
 
     fn security(permissions: Vec<Permission>) -> SecurityContext {
         SecurityContext::from_permission_snapshot(Some(Uuid::new_v4()), &permissions)

--- a/crates/rustok-forum/tests/page_builder_widget_visibility_sqlite.rs
+++ b/crates/rustok-forum/tests/page_builder_widget_visibility_sqlite.rs
@@ -1,0 +1,138 @@
+use rustok_forum::{ForumTopicVisibilityScope, ForumTopicVisibilityService};
+use sea_orm::{ConnectionTrait, Database};
+use uuid::Uuid;
+
+async fn setup() -> sea_orm::DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Forum Page Builder visibility evidence SQLite should connect");
+    db.execute_unprepared(
+        r#"
+PRAGMA foreign_keys = OFF;
+CREATE TABLE forum_categories (
+    id TEXT PRIMARY KEY NOT NULL,
+    tenant_id TEXT NOT NULL,
+    parent_id TEXT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    icon TEXT NULL,
+    color TEXT NULL,
+    moderated INTEGER NOT NULL DEFAULT 0,
+    topic_count INTEGER NOT NULL DEFAULT 0,
+    reply_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE forum_category_policies (
+    category_id TEXT PRIMARY KEY NOT NULL,
+    tenant_id TEXT NOT NULL,
+    allows_topics INTEGER NOT NULL DEFAULT 1,
+    visibility_override TEXT NULL,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE forum_topics (
+    id TEXT PRIMARY KEY NOT NULL,
+    tenant_id TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    author_id TEXT NULL,
+    status TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    is_locked INTEGER NOT NULL DEFAULT 0,
+    reply_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_reply_at TEXT NULL
+);
+CREATE TABLE forum_topic_channel_access (
+    tenant_id TEXT NOT NULL,
+    topic_id TEXT NOT NULL,
+    channel_slug TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, topic_id, channel_slug)
+);
+"#,
+    )
+    .await
+    .expect("Forum Page Builder visibility evidence tables should create");
+    db
+}
+
+#[tokio::test]
+async fn page_builder_owner_visibility_preserves_category_floor_tenant_and_topic_state() {
+    let db = setup().await;
+    let tenant_id = Uuid::new_v4();
+    let foreign_tenant_id = Uuid::new_v4();
+    let public_category = Uuid::new_v4();
+    let private_category = Uuid::new_v4();
+    let private_child_category = Uuid::new_v4();
+    let foreign_private_category = Uuid::new_v4();
+
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO forum_categories (id, tenant_id, parent_id) VALUES
+    ('{public_category}', '{tenant_id}', NULL),
+    ('{private_category}', '{tenant_id}', NULL),
+    ('{private_child_category}', '{tenant_id}', '{private_category}'),
+    ('{foreign_private_category}', '{foreign_tenant_id}', NULL);
+INSERT INTO forum_category_policies
+    (category_id, tenant_id, allows_topics, visibility_override)
+VALUES
+    ('{private_category}', '{tenant_id}', 1, 'authenticated'),
+    ('{foreign_private_category}', '{foreign_tenant_id}', 1, 'authenticated');
+"#,
+    ))
+    .await
+    .expect("Forum visibility categories should seed");
+
+    let public_topic = Uuid::new_v4();
+    let private_topic = Uuid::new_v4();
+    let private_child_topic = Uuid::new_v4();
+    let closed_public_topic = Uuid::new_v4();
+    let foreign_topic = Uuid::new_v4();
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO forum_topics (id, tenant_id, category_id, status) VALUES
+    ('{public_topic}', '{tenant_id}', '{public_category}', 'open'),
+    ('{private_topic}', '{tenant_id}', '{private_category}', 'open'),
+    ('{private_child_topic}', '{tenant_id}', '{private_child_category}', 'open'),
+    ('{closed_public_topic}', '{tenant_id}', '{public_category}', 'closed'),
+    ('{foreign_topic}', '{foreign_tenant_id}', '{foreign_private_category}', 'open');
+"#,
+    ))
+    .await
+    .expect("Forum visibility topics should seed");
+
+    let candidates = vec![
+        private_topic,
+        public_topic,
+        private_child_topic,
+        closed_public_topic,
+        foreign_topic,
+    ];
+    let service = ForumTopicVisibilityService::new(db);
+
+    let anonymous = service
+        .filter_visible_topic_ids(
+            tenant_id,
+            &candidates,
+            &ForumTopicVisibilityScope::storefront(None)
+                .expect("anonymous Forum visibility scope should construct"),
+        )
+        .await
+        .expect("anonymous Forum visibility should resolve");
+    assert_eq!(anonymous, vec![public_topic]);
+
+    let authenticated = service
+        .filter_visible_topic_ids(
+            tenant_id,
+            &candidates,
+            &ForumTopicVisibilityScope::storefront_for_viewer(None, true)
+                .expect("authenticated Forum visibility scope should construct"),
+        )
+        .await
+        .expect("authenticated Forum visibility should resolve");
+    assert_eq!(
+        authenticated,
+        vec![private_topic, public_topic, private_child_topic],
+        "authenticated viewers may see authenticated category descendants, but not closed or foreign-tenant topics"
+    );
+}

--- a/crates/rustok-forum/tests/page_builder_widget_visibility_sqlite.rs
+++ b/crates/rustok-forum/tests/page_builder_widget_visibility_sqlite.rs
@@ -1,58 +1,48 @@
-use rustok_forum::{ForumTopicVisibilityScope, ForumTopicVisibilityService};
-use sea_orm::{ConnectionTrait, Database};
+use rustok_core::MigrationSource;
+use rustok_forum::{ForumModule, ForumTopicVisibilityScope, ForumTopicVisibilityService};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::SchemaManager;
 use uuid::Uuid;
 
-async fn setup() -> sea_orm::DatabaseConnection {
-    let db = Database::connect("sqlite::memory:")
+async fn setup() -> DatabaseConnection {
+    let url = format!(
+        "sqlite:file:forum_page_builder_visibility_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(url);
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    let db = Database::connect(options)
         .await
         .expect("Forum Page Builder visibility evidence SQLite should connect");
+
     db.execute_unprepared(
         r#"
-PRAGMA foreign_keys = OFF;
-CREATE TABLE forum_categories (
+CREATE TABLE taxonomy_terms (
     id TEXT PRIMARY KEY NOT NULL,
     tenant_id TEXT NOT NULL,
-    parent_id TEXT NULL,
-    position INTEGER NOT NULL DEFAULT 0,
-    icon TEXT NULL,
-    color TEXT NULL,
-    moderated INTEGER NOT NULL DEFAULT 0,
-    topic_count INTEGER NOT NULL DEFAULT 0,
-    reply_count INTEGER NOT NULL DEFAULT 0,
+    kind TEXT NOT NULL,
+    scope_type TEXT NOT NULL,
+    scope_value TEXT NOT NULL DEFAULT '',
+    canonical_key TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE forum_category_policies (
-    category_id TEXT PRIMARY KEY NOT NULL,
-    tenant_id TEXT NOT NULL,
-    allows_topics INTEGER NOT NULL DEFAULT 1,
-    visibility_override TEXT NULL,
-    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE TABLE forum_topics (
-    id TEXT PRIMARY KEY NOT NULL,
-    tenant_id TEXT NOT NULL,
-    category_id TEXT NOT NULL,
-    author_id TEXT NULL,
-    status TEXT NOT NULL,
-    metadata TEXT NOT NULL DEFAULT '{}',
-    is_pinned INTEGER NOT NULL DEFAULT 0,
-    is_locked INTEGER NOT NULL DEFAULT 0,
-    reply_count INTEGER NOT NULL DEFAULT 0,
-    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_reply_at TEXT NULL
-);
-CREATE TABLE forum_topic_channel_access (
-    tenant_id TEXT NOT NULL,
-    topic_id TEXT NOT NULL,
-    channel_slug TEXT NOT NULL,
-    PRIMARY KEY (tenant_id, topic_id, channel_slug)
-);
+)
 "#,
     )
     .await
-    .expect("Forum Page Builder visibility evidence tables should create");
+    .expect("Forum Page Builder visibility taxonomy prerequisite should create");
+
+    let manager = SchemaManager::new(&db);
+    for migration in ForumModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Forum migration should apply to visibility evidence SQLite");
+    }
     db
 }
 
@@ -68,11 +58,13 @@ async fn page_builder_owner_visibility_preserves_category_floor_tenant_and_topic
 
     db.execute_unprepared(&format!(
         r#"
-INSERT INTO forum_categories (id, tenant_id, parent_id) VALUES
-    ('{public_category}', '{tenant_id}', NULL),
-    ('{private_category}', '{tenant_id}', NULL),
-    ('{private_child_category}', '{tenant_id}', '{private_category}'),
-    ('{foreign_private_category}', '{foreign_tenant_id}', NULL);
+INSERT INTO forum_categories
+    (id, tenant_id, parent_id, position, moderated, topic_count, reply_count)
+VALUES
+    ('{public_category}', '{tenant_id}', NULL, 0, 0, 0, 0),
+    ('{private_category}', '{tenant_id}', NULL, 1, 0, 0, 0),
+    ('{private_child_category}', '{tenant_id}', '{private_category}', 2, 0, 0, 0),
+    ('{foreign_private_category}', '{foreign_tenant_id}', NULL, 0, 0, 0, 0);
 INSERT INTO forum_category_policies
     (category_id, tenant_id, allows_topics, visibility_override)
 VALUES
@@ -90,12 +82,14 @@ VALUES
     let foreign_topic = Uuid::new_v4();
     db.execute_unprepared(&format!(
         r#"
-INSERT INTO forum_topics (id, tenant_id, category_id, status) VALUES
-    ('{public_topic}', '{tenant_id}', '{public_category}', 'open'),
-    ('{private_topic}', '{tenant_id}', '{private_category}', 'open'),
-    ('{private_child_topic}', '{tenant_id}', '{private_child_category}', 'open'),
-    ('{closed_public_topic}', '{tenant_id}', '{public_category}', 'closed'),
-    ('{foreign_topic}', '{foreign_tenant_id}', '{foreign_private_category}', 'open');
+INSERT INTO forum_topics
+    (id, tenant_id, category_id, status, metadata, is_pinned, is_locked, reply_count)
+VALUES
+    ('{public_topic}', '{tenant_id}', '{public_category}', 'open', '{{}}', 0, 0, 0),
+    ('{private_topic}', '{tenant_id}', '{private_category}', 'open', '{{}}', 0, 0, 0),
+    ('{private_child_topic}', '{tenant_id}', '{private_child_category}', 'open', '{{}}', 0, 0, 0),
+    ('{closed_public_topic}', '{tenant_id}', '{public_category}', 'closed', '{{}}', 0, 0, 0),
+    ('{foreign_topic}', '{foreign_tenant_id}', '{foreign_private_category}', 'open', '{{}}', 0, 0, 0);
 "#,
     ))
     .await

--- a/docs/modules/forum-page-builder-runtime-authorization-evidence-actualization-2026-08-08.md
+++ b/docs/modules/forum-page-builder-runtime-authorization-evidence-actualization-2026-08-08.md
@@ -1,0 +1,154 @@
+# Forum / Page Builder runtime authorization evidence actualization — 2026-08-08
+
+Status: `source-ready / maintainer-runtime-execution-pending / browser-execution-pending / wave-pending`
+
+## Rechecked cursor
+
+PR #3264 retained the browser-evidence harness for the real Pages admin contribution flow. Browser execution was deliberately not performed. The next FORUM-32 source cursor was direct runtime authorization evidence for the Forum-owned preview/property boundary.
+
+This slice makes that runtime evidence source-ready without claiming that it has executed.
+
+## Shared transport authorization
+
+Forum preview and property native transports now use one production authorization helper before owner work begins.
+
+The shared gate requires:
+
+1. `AuthContext.tenant_id == TenantContext.id`;
+2. effective `forum_topics:read` through the platform `has_any_effective_permission` helper;
+3. an exact enabled `forum` tenant-module row through `is_tenant_module_enabled`.
+
+The effective permission rule is the platform rule, not a Forum-local implication table. Therefore `forum_topics:manage` satisfies `forum_topics:read` through the ordinary same-resource `manage -> read` behavior, while an empty or unrelated permission set fails closed.
+
+Both owner-property schema/validation server functions and the owner-preview server function cross this same gate. Property transport no longer carries a duplicate effective-permission check.
+
+## Tenant module evidence
+
+`rustok-api::is_tenant_module_enabled` remains the production database query used by GraphQL/native transport adapters.
+
+A retained SQLite test source now exercises its exact scope:
+
+- the current tenant's enabled `forum` row is admitted;
+- a disabled module row is rejected;
+- a `forum` row owned by another tenant does not satisfy the request;
+- a missing module row does not satisfy the request.
+
+The Forum transport maps disabled and lookup-error states to explicit fail-closed server-function errors.
+
+## Owner moderator preview evidence
+
+`ForumWidgetPreviewService` keeps reply preview policy inside Forum.
+
+`approved_only=true` returns only the `Approved` status set and does not require moderation authority.
+
+`approved_only=false` requires effective `forum_replies:moderate`. A same-resource `Manage` permission satisfies that effective scope through the existing security model.
+
+The moderator status set is explicitly:
+
+```text
+Pending
+Approved
+Rejected
+Hidden
+Flagged
+```
+
+`Deleted` is intentionally absent, so soft-delete/tombstone rows cannot become moderator Page Builder preview data.
+
+## Owner visibility evidence
+
+The retained SQLite integration source calls the public production `ForumTopicVisibilityService::filter_visible_topic_ids` path rather than copying visibility decisions into a test helper.
+
+Its fixture contains:
+
+- a public category;
+- an authenticated category;
+- a child inheriting that authenticated visibility floor;
+- a closed current-tenant topic;
+- a foreign-tenant topic.
+
+The anonymous storefront scope sees only the current-tenant open topic in the public category. The authenticated scope may also see the authenticated category and its descendant, while closed and foreign-tenant topics remain excluded.
+
+This is the same category floor consumed by the Forum widget topic-list preview before the bounded owner query executes.
+
+## Retained execution contract
+
+The runtime contract is:
+
+```text
+crates/rustok-forum/contracts/evidence/forum-page-builder-runtime-authorization-execution-contract.json
+```
+
+The runner is:
+
+```text
+scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs
+```
+
+A successful maintainer execution may write only:
+
+```text
+format: forum_page_builder_runtime_authorization_execution_v1
+status: runtime_authorization_execution_passed_wave_pending
+```
+
+The runner executes four bounded `cargo test` commands declared by the contract:
+
+1. Forum admin transport authorization source tests;
+2. exact tenant-module runtime lookup evidence;
+3. Forum owner moderator preview policy tests;
+4. Forum owner topic/category visibility SQLite evidence.
+
+The runner uses `spawnSync` without a shell, removes any prior success packet before execution, hashes required source files at the exact checkout `HEAD`, and writes a success packet only after every command exits successfully.
+
+Raw command output is not retained. The packet stores only command identity/argv, exit status, stdout/stderr byte lengths and SHA-256 hashes, exact source commit and required-source SHA-256 hashes.
+
+## What this packet does not prove
+
+Even after a future successful local/runtime harness execution, the packet does not independently prove deployed server-function transport attestation. It does not send authenticated HTTP requests to a deployed host and does not retain cookies, Authorization headers, tenant ids or actor ids.
+
+That distinction is intentional: the source-level runtime evidence proves the production authorization/owner policy seams under execution, while environment/deployment transport attestation remains a separate reviewed evidence boundary.
+
+The browser packet from #3264 also remains execution-pending. Provider SLO health remains `unobserved`; no source in this slice converts missing health observation into a healthy claim.
+
+## Source-only guard
+
+The source guard is:
+
+```text
+node scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
+```
+
+It checks the command matrix, privacy/retention boundary, shared transport authorization, generic effective-permission source, exact module-state test, moderator `Deleted` exclusion and owner visibility SQLite source.
+
+## Maintainer execution cursor
+
+When reviewed execution inputs/environment are available, maintainers can run:
+
+```text
+node scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs
+```
+
+The browser harness retained by #3264 remains a separate command and packet. Acceptance should correlate the exact source revision used for both retained packets before any Forum Page Builder Wave claim.
+
+## Promotion boundary
+
+FORUM-32 remains `in_progress`.
+
+Source is now ready for:
+
+- contribution metadata/Fly identity;
+- Forum owner preview;
+- Forum owner-backed properties;
+- browser evidence harness;
+- direct runtime authorization/visibility evidence harness.
+
+Still open:
+
+1. execute and retain the Forum browser packet;
+2. execute and retain this runtime authorization packet;
+3. retain any required deployed transport provenance/attestation separately;
+4. satisfy the existing Pages reference-consumer gate;
+5. only then evaluate observed Forum Page Builder Wave evidence.
+
+No runtime, Cargo, browser, database or verifier execution is claimed by this source slice. No tests, Cargo commands, Node verifiers, formatters, builds, workflows, CI, database fixtures or browser/runtime evidence were executed while preparing it.

--- a/scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs
+++ b/scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-runtime-authorization-execution-contract.json",
+);
+const MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
+const MAX_COMMANDS = 16;
+const MAX_ARG_LENGTH = 4096;
+
+function fail(message) {
+  throw new Error(`Forum Page Builder runtime authorization evidence failed: ${message}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function regularFileRecord(relativePath, label) {
+  if (
+    typeof relativePath !== "string" ||
+    relativePath.length === 0 ||
+    relativePath.length > 4096 ||
+    relativePath.includes("\0")
+  ) {
+    fail(`${label} has an invalid path`);
+  }
+  const absolute = path.resolve(repoRoot, relativePath);
+  const relative = path.relative(repoRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail(`${label} must remain inside the repository`);
+  }
+  if (!existsSync(absolute)) fail(`${label} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) {
+    fail(`${label} must be a regular non-symlink file`);
+  }
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > MAX_CAPTURE_BYTES) {
+    fail(`${label} must be a bounded non-empty file`);
+  }
+  const bytes = readFileSync(absolute);
+  return { bytes: stats.size, sha256: sha256(bytes) };
+}
+
+function outputPath(contract) {
+  const environmentName = contract.output?.environment;
+  const defaultPath = contract.output?.default_path;
+  if (typeof environmentName !== "string" || typeof defaultPath !== "string") {
+    fail("contract output path is invalid");
+  }
+  const raw = process.env[environmentName];
+  if (
+    raw !== undefined &&
+    (raw.length === 0 || raw.length > 16_384 || /[\u0000\r\n]/u.test(raw))
+  ) {
+    fail(`${environmentName} is outside the bounded output input`);
+  }
+  const requested = raw ?? defaultPath;
+  const absolute = path.isAbsolute(requested)
+    ? path.resolve(requested)
+    : path.resolve(repoRoot, requested);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail("runtime evidence output must remain inside repository target/");
+  }
+  return absolute;
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell: false,
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) fail(`git HEAD lookup failed: ${result.error.message}`);
+  if (result.status !== 0) fail("git HEAD lookup returned a non-zero status");
+  const value = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(value)) fail("git HEAD is not a full lowercase SHA");
+  return value;
+}
+
+function sourceHashes(contract) {
+  if (
+    !Array.isArray(contract.required_source_files) ||
+    contract.required_source_files.length === 0 ||
+    contract.required_source_files.length > 128
+  ) {
+    fail("required source-file set is outside the bounded contract");
+  }
+  return Object.fromEntries(
+    contract.required_source_files.map((relativePath) => [
+      relativePath,
+      regularFileRecord(relativePath, `source file ${relativePath}`).sha256,
+    ]),
+  );
+}
+
+function validatedCommands(contract) {
+  if (
+    !Array.isArray(contract.commands) ||
+    contract.commands.length === 0 ||
+    contract.commands.length > MAX_COMMANDS
+  ) {
+    fail("runtime command set is outside the bounded contract");
+  }
+  const seen = new Set();
+  return contract.commands.map((command) => {
+    if (
+      command === null ||
+      typeof command !== "object" ||
+      typeof command.id !== "string" ||
+      !/^[a-z0-9_]{1,64}$/u.test(command.id) ||
+      seen.has(command.id)
+    ) {
+      fail("runtime command id is invalid or duplicated");
+    }
+    seen.add(command.id);
+    if (command.program !== "cargo") {
+      fail(`runtime command ${command.id} must use the allowlisted cargo program`);
+    }
+    if (
+      !Array.isArray(command.args) ||
+      command.args.length === 0 ||
+      command.args.length > 32 ||
+      command.args.some(
+        (arg) =>
+          typeof arg !== "string" ||
+          arg.length === 0 ||
+          arg.length > MAX_ARG_LENGTH ||
+          /[\u0000\r\n]/u.test(arg),
+      )
+    ) {
+      fail(`runtime command ${command.id} has invalid argv`);
+    }
+    if (command.args[0] !== "test") {
+      fail(`runtime command ${command.id} must remain a cargo test command`);
+    }
+    return {
+      id: command.id,
+      program: command.program,
+      args: [...command.args],
+    };
+  });
+}
+
+function boundedCapture(value, label) {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value ?? "");
+  if (buffer.byteLength > MAX_CAPTURE_BYTES) {
+    fail(`${label} exceeds ${MAX_CAPTURE_BYTES} bytes`);
+  }
+  return {
+    bytes: buffer.byteLength,
+    sha256: sha256(buffer),
+  };
+}
+
+function executeCommand(command) {
+  const result = spawnSync(command.program, command.args, {
+    cwd: repoRoot,
+    shell: false,
+    encoding: null,
+    maxBuffer: MAX_CAPTURE_BYTES,
+    env: process.env,
+  });
+  if (result.error) {
+    fail(`runtime command ${command.id} could not execute: ${result.error.message}`);
+  }
+  const stdout = boundedCapture(result.stdout, `${command.id} stdout`);
+  const stderr = boundedCapture(result.stderr, `${command.id} stderr`);
+  const status = result.status;
+  if (!Number.isInteger(status)) {
+    fail(`runtime command ${command.id} did not return an integer status`);
+  }
+  const observation = {
+    id: command.id,
+    program: command.program,
+    args: command.args,
+    status,
+    stdout,
+    stderr,
+  };
+  if (status !== 0) {
+    const error = new Error(`runtime command ${command.id} failed with status ${status}`);
+    error.observation = observation;
+    throw error;
+  }
+  return observation;
+}
+
+function writeAtomic(location, document) {
+  mkdirSync(path.dirname(location), { recursive: true });
+  const temporary = `${location}.tmp-${process.pid}`;
+  rmSync(temporary, { force: true });
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+  renameSync(temporary, location);
+}
+
+function main() {
+  const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+  if (contract.status !== "source_ready_maintainer_execution_pending") {
+    fail("runtime evidence contract must not claim execution before the runner starts");
+  }
+  if (
+    contract.output?.format !== "forum_page_builder_runtime_authorization_execution_v1" ||
+    contract.output?.status !== "runtime_authorization_execution_passed_wave_pending"
+  ) {
+    fail("runtime evidence output identity drifted");
+  }
+
+  const output = outputPath(contract);
+  rmSync(output, { force: true });
+  const sourceCommit = currentCommit();
+  const sources = sourceHashes(contract);
+  const commands = validatedCommands(contract);
+  const observations = [];
+
+  for (const command of commands) {
+    observations.push(executeCommand(command));
+  }
+
+  writeAtomic(output, {
+    format: contract.output.format,
+    status: contract.output.status,
+    source_commit: sourceCommit,
+    source_files: sources,
+    commands: observations,
+    retained_raw_command_output: false,
+    runtime_authorization_execution_only: true,
+    deployed_server_fn_attestation_pending: true,
+    browser_execution_pending: true,
+    provider_slo_health_unobserved: true,
+    observed_page_builder_wave_pending: true,
+    executed_at: new Date().toISOString(),
+  });
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs
+++ b/scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs
@@ -199,9 +199,7 @@ function executeCommand(command) {
     stderr,
   };
   if (status !== 0) {
-    const error = new Error(`runtime command ${command.id} failed with status ${status}`);
-    error.observation = observation;
-    throw error;
+    throw new Error(`runtime command ${command.id} failed with status ${status}`);
   }
   return observation;
 }
@@ -245,9 +243,9 @@ function main() {
     commands: observations,
     retained_raw_command_output: false,
     runtime_authorization_execution_only: true,
-    deployed_server_fn_attestation_pending: true,
-    browser_execution_pending: true,
-    provider_slo_health_unobserved: true,
+    deployed_server_fn_attestation_not_claimed: true,
+    browser_execution_not_claimed: true,
+    provider_slo_health_not_claimed: true,
     observed_page_builder_wave_pending: true,
     executed_at: new Date().toISOString(),
   });

--- a/scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
+++ b/scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireContains(text, needle, message) {
+  if (!text.includes(needle)) throw new Error(message);
+}
+
+function requireAbsent(text, needle, message) {
+  if (text.includes(needle)) throw new Error(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-runtime-authorization-execution-contract.json";
+const runnerPath = "scripts/evidence/forum-page-builder-runtime-authorization-evidence.mjs";
+const previewTransportPath = "crates/rustok-forum/admin/src/widget_preview_transport.rs";
+const propertyTransportPath = "crates/rustok-forum/admin/src/widget_property_transport.rs";
+const apiRuntimePath = "crates/rustok-api/src/runtime.rs";
+const authPath = "crates/rustok-api/src/context/auth.rs";
+const widgetPreviewPath = "crates/rustok-forum/src/services/widget_preview.rs";
+const topicVisibilityPath = "crates/rustok-forum/src/services/topic_visibility.rs";
+const categoryVisibilityPath = "crates/rustok-forum/src/services/category_visibility.rs";
+const visibilityTestPath = "crates/rustok-forum/tests/page_builder_widget_visibility_sqlite.rs";
+const packetPath =
+  "docs/modules/forum-page-builder-runtime-authorization-evidence-actualization-2026-08-08.md";
+
+const contractSource = read(contractPath);
+const contract = JSON.parse(contractSource);
+const runner = read(runnerPath);
+const previewTransport = read(previewTransportPath);
+const propertyTransport = read(propertyTransportPath);
+const apiRuntime = read(apiRuntimePath);
+const auth = read(authPath);
+const widgetPreview = read(widgetPreviewPath);
+const topicVisibility = read(topicVisibilityPath);
+const categoryVisibility = read(categoryVisibilityPath);
+const visibilityTest = read(visibilityTestPath);
+const packet = read(packetPath);
+
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  throw new Error("runtime evidence contract must not claim execution");
+}
+if (contract.runner !== runnerPath) {
+  throw new Error("runtime evidence contract must point to the retained runner");
+}
+if (contract.output?.format !== "forum_page_builder_runtime_authorization_execution_v1") {
+  throw new Error("runtime evidence format drifted");
+}
+if (contract.output?.status !== "runtime_authorization_execution_passed_wave_pending") {
+  throw new Error("runtime evidence success status must keep Wave pending");
+}
+const expectedCommandIds = [
+  "transport_authorization",
+  "tenant_module_state",
+  "owner_moderator_policy",
+  "owner_visibility_sqlite",
+];
+if (JSON.stringify(contract.commands?.map((command) => command.id)) !== JSON.stringify(expectedCommandIds)) {
+  throw new Error("runtime evidence command matrix drifted");
+}
+for (const command of contract.commands ?? []) {
+  if (command.program !== "cargo" || command.args?.[0] !== "test") {
+    throw new Error(`runtime evidence command ${command.id} must remain cargo test`);
+  }
+}
+for (const pending of [
+  "runtime authorization execution",
+  "browser execution",
+  "deployed server-function transport attestation",
+  "observed Page Builder Wave",
+  "provider SLO health",
+]) {
+  if (!contract.not_claimed?.includes(pending)) {
+    throw new Error(`runtime evidence contract must keep ${pending} pending`);
+  }
+}
+
+for (const marker of [
+  'spawnSync("git", ["rev-parse", "HEAD"]',
+  'command.program !== "cargo"',
+  'command.args[0] !== "test"',
+  "shell: false",
+  "encoding: null",
+  "MAX_CAPTURE_BYTES",
+  "rmSync(output, { force: true })",
+  "sourceCommit = currentCommit()",
+  "sourceHashes(contract)",
+  "stdout: stdout",
+  "stderr: stderr",
+  "retained_raw_command_output: false",
+  "runtime_authorization_execution_only: true",
+  "deployed_server_fn_attestation_pending: true",
+  "browser_execution_pending: true",
+  "provider_slo_health_unobserved: true",
+  "observed_page_builder_wave_pending: true",
+]) {
+  requireContains(runner, marker, `runtime evidence runner missing ${marker}`);
+}
+for (const forbidden of [
+  "execSync(",
+  "execFileSync(",
+  "shell: true",
+  "stdout.toString",
+  "stderr.toString",
+  "stdout_text",
+  "stderr_text",
+]) {
+  requireAbsent(runner, forbidden, `runtime evidence runner must not retain raw output through ${forbidden}`);
+}
+
+for (const marker of [
+  "pub(crate) fn require_forum_transport_authorization",
+  "require_tenant_scope(auth, tenant)?",
+  "has_any_effective_permission",
+  "Permission::FORUM_TOPICS_READ",
+  "require_forum_transport_authorization(&auth, &tenant)?",
+  'is_tenant_module_enabled(host.db(), tenant_id, "forum")',
+  "transport_authorization_accepts_exact_read_and_effective_manage",
+  "transport_authorization_rejects_missing_read_and_cross_tenant_context",
+  "module_state_fails_closed_for_disabled_and_unavailable_states",
+]) {
+  requireContains(previewTransport, marker, `preview transport missing runtime authorization marker: ${marker}`);
+}
+for (const marker of [
+  "require_forum_transport_authorization",
+  "require_forum_transport_authorization(&auth, &tenant)?",
+  "require_forum_module_enabled(&host, tenant.id).await",
+]) {
+  requireContains(propertyTransport, marker, `property transport missing shared authorization marker: ${marker}`);
+}
+requireAbsent(
+  propertyTransport,
+  "has_any_effective_permission",
+  "property transport must not keep a second effective-permission implementation",
+);
+requireAbsent(
+  propertyTransport,
+  "require_tenant_scope(&auth, &tenant)",
+  "property transport must use the shared tenant/permission gate",
+);
+
+for (const marker of [
+  "permissions.contains(required)",
+  "Action::Manage",
+  "has_any_effective_permission",
+]) {
+  requireContains(auth, marker, `generic effective-permission source missing ${marker}`);
+}
+for (const marker of [
+  "tenant_module_enablement_is_exact_and_fail_closed",
+  'Database::connect("sqlite::memory:")',
+  "CREATE TABLE tenant_modules",
+  "enabled = 1",
+  'is_tenant_module_enabled(&db, tenant_id, "forum")',
+  'is_tenant_module_enabled(&db, tenant_id, "pages")',
+]) {
+  requireContains(apiRuntime, marker, `tenant module runtime evidence missing ${marker}`);
+}
+
+for (const marker of [
+  "fn reply_stream_preview_statuses",
+  "PermissionScope::None",
+  "forum_replies:moderate",
+  "APPROVED_PREVIEW_REPLY_STATUSES",
+  "MODERATOR_PREVIEW_REPLY_STATUSES",
+  "non_approved_reply_stream_requires_effective_moderation_scope",
+  "!statuses.contains(&ReplyStatus::Deleted)",
+]) {
+  requireContains(widgetPreview, marker, `Forum owner moderator evidence missing ${marker}`);
+}
+requireAbsent(
+  widgetPreview.split("const MODERATOR_PREVIEW_REPLY_STATUSES")[1]?.split("];", 1)[0] ?? "",
+  "ReplyStatus::Deleted",
+  "moderator preview status set must not include deleted tombstones",
+);
+
+for (const marker of [
+  "filter_visible_topic_ids",
+  "hidden_category_ids_for_scope",
+  "forum_topic::Column::TenantId.eq(tenant_id)",
+  "forum_topic::Column::Status.eq(TopicStatus::Open)",
+]) {
+  requireContains(topicVisibility, marker, `topic visibility owner path missing ${marker}`);
+}
+for (const marker of [
+  "hidden_category_ids_for_viewer",
+  "ForumCategoryVisibility::Authenticated",
+  "if is_authenticated",
+]) {
+  requireContains(categoryVisibility, marker, `category visibility owner path missing ${marker}`);
+}
+for (const marker of [
+  'Database::connect("sqlite::memory:")',
+  "forum_category_policies",
+  "visibility_override",
+  "authenticated",
+  "ForumTopicVisibilityService::new",
+  "filter_visible_topic_ids",
+  "ForumTopicVisibilityScope::storefront(None)",
+  "ForumTopicVisibilityScope::storefront_for_viewer(None, true)",
+  "closed_public_topic",
+  "foreign_topic",
+]) {
+  requireContains(visibilityTest, marker, `SQLite visibility evidence missing ${marker}`);
+}
+
+for (const marker of [
+  "Status: `source-ready / maintainer-runtime-execution-pending / browser-execution-pending / wave-pending`",
+  "forum_page_builder_runtime_authorization_execution_v1",
+  "runtime_authorization_execution_passed_wave_pending",
+  "manage -> read",
+  "forum_replies:moderate",
+  "Deleted",
+  "deployed server-function transport attestation",
+  "No runtime, Cargo, browser, database or verifier execution is claimed",
+]) {
+  requireContains(packet, marker, `runtime authorization actualization missing ${marker}`);
+}
+
+console.log("Forum Page Builder runtime authorization evidence source: ok");

--- a/scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
+++ b/scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
@@ -89,8 +89,8 @@ for (const marker of [
   "rmSync(output, { force: true })",
   "sourceCommit = currentCommit()",
   "sourceHashes(contract)",
-  "stdout: stdout",
-  "stderr: stderr",
+  "stdout,",
+  "stderr,",
   "retained_raw_command_output: false",
   "runtime_authorization_execution_only: true",
   "deployed_server_fn_attestation_pending: true",
@@ -194,7 +194,8 @@ for (const marker of [
   requireContains(categoryVisibility, marker, `category visibility owner path missing ${marker}`);
 }
 for (const marker of [
-  'Database::connect("sqlite::memory:")',
+  "ForumModule.migrations()",
+  "SchemaManager::new(&db)",
   "forum_category_policies",
   "visibility_override",
   "authenticated",

--- a/scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
+++ b/scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs
@@ -93,9 +93,9 @@ for (const marker of [
   "stderr,",
   "retained_raw_command_output: false",
   "runtime_authorization_execution_only: true",
-  "deployed_server_fn_attestation_pending: true",
-  "browser_execution_pending: true",
-  "provider_slo_health_unobserved: true",
+  "deployed_server_fn_attestation_not_claimed: true",
+  "browser_execution_not_claimed: true",
+  "provider_slo_health_not_claimed: true",
   "observed_page_builder_wave_pending: true",
 ]) {
   requireContains(runner, marker, `runtime evidence runner missing ${marker}`);


### PR DESCRIPTION
## Summary

Continue FORUM-32 after #3264 by retaining direct runtime authorization/visibility evidence source for Forum-owned Page Builder preview/property transports without claiming execution.

- make preview/property native transports share one production tenant + effective `forum_topics:read` gate and retain source tests for exact read, generic `manage -> read`, missing permission and tenant mismatch;
- retain exact tenant-module enablement SQLite evidence on the shared `rustok-api::is_tenant_module_enabled` helper, including disabled/foreign/missing rows;
- extract the existing Forum owner reply-stream preview status policy into a focused seam and retain tests that `approved_only=false` requires effective `forum_replies:moderate` while `Deleted` tombstones remain excluded even for moderators;
- add production-migration SQLite visibility evidence through `ForumTopicVisibilityService::filter_visible_topic_ids` for public/authenticated category floors, descendants, closed topics and foreign tenants;
- add a bounded maintainer runner that executes only contract-declared `cargo test` argv without a shell, clears stale output, hashes required source files and retains only exit status plus stdout/stderr sizes and SHA-256 hashes;
- add a source-only verifier and dated actualization packet. Deployed server-function attestation, actual browser/runtime execution, provider SLO evidence and observed Page Builder Wave remain separate/open.

## Plan status

The canonical Forum/Page Builder plans remain truthful at their existing high-level `in_progress` / retained runtime-browser-Wave evidence-open state. This dated actualization is the more specific source overlay; no execution checkbox is promoted by this PR.

## Dependencies

No Cargo.toml, Cargo.lock, package dependency or new runtime dependency changes.

## Validation

Per maintainer instruction, no Cargo tests, Node verifiers, Playwright/browser execution, formatter, build, workflow, CI, database/runtime evidence, lock generation or `git diff --check` was run.