### PR TITLE
test(index): retain Product key4 promotion PostgreSQL packet

### DIFF
--- a/crates/rustok-distribution/tests/product_current_schema_promotion_postgres.rs
+++ b/crates/rustok-distribution/tests/product_current_schema_promotion_postgres.rs
@@ -1,0 +1,624 @@
+#![cfg(feature = "mod-product")]
+
+use std::{env, error::Error, sync::Arc};
+
+use rustok_core::{MigrationSource, ModuleRegistry};
+use rustok_index::{
+    EntityKey, FieldName, FieldPath, FilterExpr, IndexModule, IndexMutation, IndexQuery,
+    IndexQueryExecutionError, IndexQueryPort, IndexQueryScope, IndexSchema,
+    IndexSchemaReadinessError, IndexSchemaReadinessRequest, IndexSourceLoadRequest, IndexValue,
+    LocaleKey, MutationApplyOutcome, MutationDelivery, Pagination, PersistedSchemaReadinessFailure,
+    PostgresIndexQueryPort, PostgresIndexSchemaReadinessStore, PostgresMutationStore,
+    PostgresSchemaRegistrationStore, SchemaRef, SchemaRegistry, SchemaVersion,
+    SharedIndexQueryRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
+    derive_index_schema_source_event_id, materialize_index_source_registry,
+    materialize_postgres_index_query_runtime, materialize_postgres_index_sources,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+};
+use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_PRODUCT_KEY4_PROMOTION_DATABASE_URL";
+const PRODUCT_SOURCE: &str = "product-postgres-primary";
+const PRODUCT_EVENT_DOMAIN: &str = "rustok-product.product-replay";
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const PRODUCT_ID: Uuid = Uuid::from_u128(101);
+const TRANSLATION_ID: Uuid = Uuid::from_u128(111);
+const TITLE: &str = "Promoted Product";
+const CURRENT_PRODUCT_SCHEMA_VERSION: u32 = 4;
+const HISTORICAL_PRODUCT_SCHEMA_VERSION: u32 = 3;
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+struct ProductMigrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for ProductMigrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        rustok_product::migrations::migrations()
+    }
+}
+
+struct TestDatabase {
+    control: DatabaseConnection,
+    source: DatabaseConnection,
+    mutation: DatabaseConnection,
+    query: DatabaseConnection,
+    restart_query: DatabaseConnection,
+    schema_name: String,
+}
+
+impl TestDatabase {
+    async fn setup() -> TestResult<Option<Self>> {
+        let Some(database_url) = database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} (or RUSTOK_INDEX_TEST_DATABASE_URL / DATABASE_URL) is not set to a PostgreSQL URL; skipping Product key4 promotion packet"
+            );
+            return Ok(None);
+        };
+
+        let control = connect(&database_url).await?;
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema_name = format!("rustok_index_product_key4_promotion_{suffix}");
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+
+        let migration = scoped_connection(
+            &database_url,
+            &schema_name,
+            &format!("idx_product_key4_promotion_migration_{suffix}"),
+        )
+        .await?;
+        create_product_migration_prerequisites(&migration).await?;
+        ProductMigrator::up(&migration, None).await?;
+        let manager = SchemaManager::new(&migration);
+        for migration_step in IndexModule.migrations() {
+            migration_step.up(&manager).await?;
+        }
+        seed_product(&migration).await?;
+        migration.close().await?;
+
+        Ok(Some(Self {
+            control,
+            source: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_key4_promotion_source_{suffix}"),
+            )
+            .await?,
+            mutation: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_key4_promotion_mutation_{suffix}"),
+            )
+            .await?,
+            query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_key4_promotion_query_{suffix}"),
+            )
+            .await?,
+            restart_query: scoped_connection(
+                &database_url,
+                &schema_name,
+                &format!("idx_product_key4_promotion_restart_{suffix}"),
+            )
+            .await?,
+            schema_name,
+        }))
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.source.close().await?;
+        self.mutation.close().await?;
+        self.query.close().await?;
+        self.restart_query.close().await?;
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        self.control.close().await?;
+        Ok(())
+    }
+}
+
+struct ProductIndexRuntime {
+    sources: SharedIndexSourceRegistry,
+    schemas: SharedIndexSchemaRegistry,
+    query: SharedIndexQueryRuntime,
+    mutations: PostgresMutationStore,
+    current_product_schema: IndexSchema,
+    historical_product_schema: IndexSchema,
+}
+
+#[tokio::test]
+async fn product_key4_stages_rebuilds_promotes_and_restarts_without_key3_runtime_compatibility(
+) -> TestResult<()> {
+    let Some(database) = TestDatabase::setup().await? else {
+        return Ok(());
+    };
+
+    let outcome = run_product_key4_promotion_scenario(&database).await;
+    let cleanup = database.cleanup().await;
+    outcome?;
+    cleanup
+}
+
+async fn run_product_key4_promotion_scenario(database: &TestDatabase) -> TestResult<()> {
+    let runtime = staged_product_runtime(database).await?;
+    let current_ref = runtime.current_product_schema.reference.clone();
+    let historical_ref = runtime.historical_product_schema.reference.clone();
+
+    assert_eq!(
+        current_ref.version,
+        SchemaVersion::new(CURRENT_PRODUCT_SCHEMA_VERSION)
+    );
+    assert_eq!(
+        historical_ref.version,
+        SchemaVersion::new(HISTORICAL_PRODUCT_SCHEMA_VERSION)
+    );
+    assert_eq!(
+        schema_status(&database.query, &historical_ref).await?,
+        "active"
+    );
+    assert_eq!(schema_status(&database.query, &current_ref).await?, "active");
+
+    // Rebuild one real Product row through the selected current Product source and the production mutation
+    // store while both persisted contracts are still active. The runtime itself publishes only key4.
+    let mutation = load_product_mutation(&runtime.sources, &current_ref).await?;
+    let locale = LocaleKey::new("en")?;
+    let source_version = mutation.source_version();
+    let current_event_id = mutation.event_id();
+    assert_eq!(
+        current_event_id,
+        derive_index_schema_source_event_id(
+            PRODUCT_EVENT_DOMAIN,
+            TENANT_ID,
+            &current_ref,
+            PRODUCT_ID,
+            Some(&locale),
+            source_version,
+        )?
+    );
+    let historical_event_id = derive_index_schema_source_event_id(
+        PRODUCT_EVENT_DOMAIN,
+        TENANT_ID,
+        &historical_ref,
+        PRODUCT_ID,
+        Some(&locale),
+        source_version,
+    )?;
+    assert_ne!(current_event_id, historical_event_id);
+
+    apply_product_mutation(&runtime, mutation).await?;
+    assert_current_product_query(&runtime.query, &current_ref).await?;
+
+    // Final authority transition uses the already-staged exact key4 contract. It must not reinsert key4,
+    // rewrite historical materialization, or keep key3 authoritative.
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    let promoted = schema_store
+        .register_current(TENANT_ID, &runtime.current_product_schema)
+        .await?;
+    assert_eq!(promoted.retired_schema_count(), 1);
+    assert_eq!(
+        schema_status(&database.query, &historical_ref).await?,
+        "retired"
+    );
+    assert_eq!(schema_status(&database.query, &current_ref).await?, "active");
+
+    let repeated = schema_store
+        .register_current(TENANT_ID, &runtime.current_product_schema)
+        .await?;
+    assert_eq!(repeated.retired_schema_count(), 0);
+
+    // Build a test-only immutable probe registry containing the persisted historical contract plus every
+    // current runtime schema. No historical Product source/factory is registered or selected.
+    let probe_registry = historical_probe_registry(
+        &runtime.schemas,
+        runtime.historical_product_schema.clone(),
+    )?;
+    assert_historical_readiness_is_inactive(database, &probe_registry, &historical_ref).await?;
+    assert_historical_query_is_inactive(database, probe_registry, &historical_ref).await?;
+
+    // Current key4 remains queryable after lower-key retirement.
+    assert_current_product_query(&runtime.query, &current_ref).await?;
+
+    // Simulate a fresh process composition against the same persisted database. The rebuilt runtime must
+    // publish only current Product key4 and must read the retained key4 materialization successfully.
+    let restart_query = restart_current_product_query_runtime(database).await?;
+    assert_current_product_query(&restart_query, &current_ref).await?;
+
+    Ok(())
+}
+
+async fn staged_product_runtime(database: &TestDatabase) -> TestResult<ProductIndexRuntime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("Product schema registry is missing"))?;
+    let current_product_schema = current_product_schema(&schemas)?;
+    assert_eq!(
+        current_product_schema.reference.version,
+        SchemaVersion::new(CURRENT_PRODUCT_SCHEMA_VERSION)
+    );
+    let mut historical_product_schema = current_product_schema.clone();
+    historical_product_schema.reference.version =
+        SchemaVersion::new(HISTORICAL_PRODUCT_SCHEMA_VERSION);
+
+    let schema_store = PostgresSchemaRegistrationStore::new(database.query.clone());
+    schema_store
+        .register(TENANT_ID, &historical_product_schema)
+        .await?;
+    for registered in schemas.registry().iter() {
+        schema_store.register(TENANT_ID, &registered.schema).await?;
+    }
+
+    assert_eq!(
+        schema_status(&database.query, &historical_product_schema.reference).await?,
+        "active"
+    );
+    assert_eq!(
+        schema_status(&database.query, &current_product_schema.reference).await?,
+        "active"
+    );
+
+    materialize_postgres_index_sources(&mut extensions, database.source.clone())?;
+    let sources = materialize_index_source_registry(&extensions)?
+        .ok_or_else(|| std::io::Error::other("Product source registry is missing"))?;
+    let query = materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?
+        .ok_or_else(|| std::io::Error::other("Product query runtime is missing"))?;
+
+    Ok(ProductIndexRuntime {
+        sources,
+        schemas,
+        query,
+        mutations: PostgresMutationStore::new(database.mutation.clone()),
+        current_product_schema,
+        historical_product_schema,
+    })
+}
+
+async fn restart_current_product_query_runtime(
+    database: &TestDatabase,
+) -> TestResult<SharedIndexQueryRuntime> {
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(rustok_channel::ChannelModule)
+        .register(rustok_product::ProductModule);
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)?;
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .ok_or_else(|| std::io::Error::other("restart Product schema registry is missing"))?;
+
+    let product_schemas = schemas
+        .registry()
+        .iter()
+        .filter(|registered| {
+            registered.schema.reference.module.as_str() == "rustok-product"
+                && registered.schema.reference.entity.as_str() == "product"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(product_schemas.len(), 1);
+    assert_eq!(
+        product_schemas[0].schema.reference.version,
+        SchemaVersion::new(CURRENT_PRODUCT_SCHEMA_VERSION)
+    );
+
+    materialize_postgres_index_query_runtime(&mut extensions, database.restart_query.clone())?
+        .ok_or_else(|| std::io::Error::other("restart Product query runtime is missing").into())
+}
+
+fn current_product_schema(schemas: &SharedIndexSchemaRegistry) -> TestResult<IndexSchema> {
+    let matches = schemas
+        .registry()
+        .iter()
+        .filter(|registered| {
+            registered.schema.reference.module.as_str() == "rustok-product"
+                && registered.schema.reference.entity.as_str() == "product"
+        })
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected exactly one current Product schema, found {}",
+            matches.len()
+        ))
+        .into());
+    }
+    Ok(matches[0].schema.clone())
+}
+
+fn historical_probe_registry(
+    current: &SharedIndexSchemaRegistry,
+    historical_product_schema: IndexSchema,
+) -> TestResult<Arc<SchemaRegistry>> {
+    let mut schemas = current
+        .registry()
+        .iter()
+        .map(|registered| registered.schema.clone())
+        .collect::<Vec<_>>();
+    schemas.push(historical_product_schema);
+    let mut registry = SchemaRegistry::new();
+    registry.register_batch(schemas)?;
+    Ok(Arc::new(registry))
+}
+
+async fn assert_historical_readiness_is_inactive(
+    database: &TestDatabase,
+    probe_registry: &Arc<SchemaRegistry>,
+    historical_ref: &SchemaRef,
+) -> TestResult<()> {
+    let readiness = PostgresIndexSchemaReadinessStore::new(database.query.clone());
+    let request = IndexSchemaReadinessRequest::new(TENANT_ID, [historical_ref.clone()])?;
+    let error = readiness
+        .require(&request, probe_registry.as_ref())
+        .await
+        .expect_err("retired Product key3 must fail persisted readiness");
+    match error {
+        IndexSchemaReadinessError::NotReady { failures }
+            if failures.len() == 1
+                && failures[0].reference == *historical_ref
+                && failures[0].reason == PersistedSchemaReadinessFailure::Inactive => Ok(()),
+        other => Err(std::io::Error::other(format!(
+            "expected inactive Product key3 readiness failure, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn assert_historical_query_is_inactive(
+    database: &TestDatabase,
+    probe_registry: Arc<SchemaRegistry>,
+    historical_ref: &SchemaRef,
+) -> TestResult<()> {
+    let query = PostgresIndexQueryPort::new(database.query.clone(), probe_registry);
+    let error = query
+        .execute_query(product_identity_query(historical_ref)?)
+        .await
+        .expect_err("retired Product key3 must fail query readiness before page SQL");
+    match error {
+        IndexQueryExecutionError::SchemaNotReady { reference, reason }
+            if reference == *historical_ref
+                && reason == PersistedSchemaReadinessFailure::Inactive => Ok(()),
+        other => Err(std::io::Error::other(format!(
+            "expected inactive Product key3 query failure, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn load_product_mutation(
+    sources: &SharedIndexSourceRegistry,
+    current_ref: &SchemaRef,
+) -> TestResult<IndexMutation> {
+    let request = IndexSourceLoadRequest::new(vec![EntityKey {
+        tenant_id: TENANT_ID,
+        schema: current_ref.clone(),
+        entity_id: PRODUCT_ID,
+        locale: Some(LocaleKey::new("en")?),
+    }])?;
+    let mut mutations = sources.load(request).await?.into_mutations();
+    if mutations.len() != 1 {
+        return Err(std::io::Error::other(format!(
+            "expected one current Product mutation, got {}",
+            mutations.len()
+        ))
+        .into());
+    }
+    let mutation = mutations.remove(0);
+    assert_eq!(mutation.key().schema, *current_ref);
+    Ok(mutation)
+}
+
+async fn apply_product_mutation(
+    runtime: &ProductIndexRuntime,
+    mutation: IndexMutation,
+) -> TestResult<()> {
+    let expected_source_version = mutation.source_version();
+    let delivery = MutationDelivery::from_event(PRODUCT_SOURCE, mutation)?;
+    let outcome = runtime
+        .mutations
+        .apply(runtime.schemas.registry(), &delivery)
+        .await?;
+    match outcome {
+        MutationApplyOutcome::Applied { source_version }
+            if source_version == expected_source_version => Ok(()),
+        other => Err(std::io::Error::other(format!(
+            "expected Product key4 mutation version {expected_source_version} to apply, got {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn assert_current_product_query(
+    query: &impl IndexQueryPort,
+    current_ref: &SchemaRef,
+) -> TestResult<()> {
+    let page = query.execute_query(product_identity_query(current_ref)?).await?;
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].entity_id, PRODUCT_ID);
+    assert_eq!(projected_string(&page.items[0], "title")?, TITLE);
+    assert_eq!(page.exact_count, Some(1));
+    assert!(!page.has_more);
+    Ok(())
+}
+
+fn product_identity_query(schema: &SchemaRef) -> TestResult<IndexQuery> {
+    Ok(IndexQuery {
+        scope: IndexQueryScope {
+            tenant_id: TENANT_ID,
+            locale: Some(LocaleKey::new("en")?),
+        },
+        schema: schema.clone(),
+        fields: vec![field_path("title")?],
+        filter: Some(FilterExpr::Eq(
+            field_path("id")?,
+            IndexValue::Uuid(PRODUCT_ID),
+        )),
+        order_by: Vec::new(),
+        pagination: Pagination::Offset {
+            limit: 10,
+            offset: 0,
+        },
+        include_exact_count: true,
+    })
+}
+
+fn field_path(name: &str) -> TestResult<FieldPath> {
+    Ok(FieldPath::new(FieldName::new(name)?))
+}
+
+fn projected_string<'a>(
+    item: &'a rustok_index::IndexQueryItem,
+    field: &str,
+) -> TestResult<&'a str> {
+    let path = field_path(field)?;
+    let projected = item
+        .fields
+        .iter()
+        .find(|projected| projected.path == path)
+        .ok_or_else(|| std::io::Error::other(format!("missing projected field {field}")))?;
+    match &projected.value {
+        IndexValue::String(value) => Ok(value.as_str()),
+        other => Err(std::io::Error::other(format!(
+            "projected field {field} is not a string: {other:?}"
+        ))
+        .into()),
+    }
+}
+
+async fn schema_status(db: &DatabaseConnection, reference: &SchemaRef) -> TestResult<String> {
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"
+SELECT status
+FROM index_schemas
+WHERE tenant_id = $1
+  AND module_name = $2
+  AND entity_name = $3
+  AND schema_version = $4
+"#,
+            vec![
+                TENANT_ID.into(),
+                reference.module.as_str().to_owned().into(),
+                reference.entity.as_str().to_owned().into(),
+                i64::from(reference.version.get()).into(),
+            ],
+        ))
+        .await?
+        .ok_or_else(|| std::io::Error::other(format!("missing persisted schema {reference}")))?;
+    Ok(row.try_get("", "status")?)
+}
+
+async fn create_product_migration_prerequisites(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(
+        r#"
+CREATE TABLE tenants (
+    id UUID PRIMARY KEY
+);
+CREATE TABLE taxonomy_terms (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE (tenant_id, id)
+);
+CREATE TABLE channel_index_identity_generations (
+    tenant_id UUID PRIMARY KEY,
+    generation BIGINT NOT NULL CHECK (generation > 0)
+);
+"#,
+    )
+    .await?;
+    let manager = SchemaManager::new(db);
+    flex::cache_generation::create_field_definition_cache_generation_table(&manager).await?;
+    Ok(())
+}
+
+async fn seed_product(db: &DatabaseConnection) -> TestResult<()> {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO tenants (id) VALUES ('{TENANT_ID}');
+
+INSERT INTO products (id, tenant_id) VALUES ('{PRODUCT_ID}', '{TENANT_ID}');
+
+INSERT INTO product_translations (id, product_id, tenant_id, locale, title, handle) VALUES
+    ('{TRANSLATION_ID}', '{PRODUCT_ID}', '{TENANT_ID}', 'en', '{TITLE}', 'promoted-product');
+
+INSERT INTO product_sales_channel_index_relation_snapshots (
+    tenant_id,
+    product_id,
+    relation_epoch,
+    channel_ids
+) VALUES ('{TENANT_ID}', '{PRODUCT_ID}', 1, '[]'::jsonb);
+
+INSERT INTO product_sales_channel_index_relation_freshness_snapshots (
+    tenant_id,
+    product_id,
+    relation_epoch,
+    product_source_version,
+    visibility_key,
+    channel_identity_generation
+)
+SELECT
+    product.tenant_id,
+    product.id,
+    relation.relation_epoch,
+    product.index_revision,
+    'all',
+    0
+FROM products product
+JOIN LATERAL (
+    SELECT relation_epoch
+    FROM product_sales_channel_index_relation_snapshots relation
+    WHERE relation.tenant_id = product.tenant_id
+      AND relation.product_id = product.id
+    ORDER BY relation.relation_epoch DESC
+    LIMIT 1
+) relation ON TRUE
+WHERE product.tenant_id = '{TENANT_ID}';
+"#
+    ))
+    .await?;
+    Ok(())
+}
+
+fn database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("RUSTOK_INDEX_TEST_DATABASE_URL"))
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+    application_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    db.execute_unprepared(&format!("SET application_name TO '{application_name}'"))
+        .await?;
+    Ok(db)
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Storefront budgeted timeout evidence merge
-`e0bbcc885d7670990fdf0c21d5f2ef01f5015a99` and continued on
-`agent/product-key4-promotion-contract-20260808`.
+Status overlay rechecked after Product key-4 promotion contract merge
+`d905c25a4d0ffd63682bf2aea9779ded190a255e` and continued on
+`agent/product-key4-promotion-postgres-evidence-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -38,6 +38,9 @@ Source-complete:
   post-owner phase seam implemented in production by `ProductStorefrontIndexShadowExecutor`;
 - explicit current Product key-4 tenant promotion contract: ordinary-register/stage, schema-scoped rebuild,
   evidence admission, `register_current`, lower-key retirement and old-key fail-closed readiness/query behavior;
+- retained Product key-4 PostgreSQL promotion/restart packet source using production migrations, current
+  distribution schema/source/query composition, mutation storage, `register_current`, typed inactive probes and
+  fresh restart composition;
 - current-key core/EAV Storefront PostgreSQL packet source;
 - historical retained Product PostgreSQL fixtures actualized to current Product routing key `4`.
 
@@ -86,28 +89,34 @@ Current Product code has already completed the source-code replacement from lowe
 key `4`. `product-postgres-primary` uses `derive_index_schema_source_event_id`; Product source, absence and query
 admission do not select key `3`.
 
-Persisted tenant authority remains a separate execution boundary. For a tenant with a lower Product key still
-active, the required sequence is:
+The retained PostgreSQL packet now covers the staged authority-transition path in source:
 
-1. ordinary-register the exact current Product key `4` immutable contract;
-2. rebuild key `4` while lower persisted Product keys remain historical/staging state;
-3. execute/admit exact key-4 readiness, freshness, parity, inbox-isolation and restart evidence;
-4. call `PostgresSchemaRegistrationStore::register_current` with that already-staged key `4` contract;
-5. require all lower active Product schemas for that tenant to retire atomically;
-6. require lower-key readiness/query execution to fail closed as inactive;
-7. only then admit an authoritative Product Index consumer.
+1. obtain the exact current Product schema from `SharedIndexSchemaRegistry` and assert key `4`;
+2. ordinary-register a storage-only lower-key fixture plus the actual current runtime schemas, leaving both
+   Product keys active during staging;
+3. load one real current Product mutation through `product-postgres-primary` and prove its schema-scoped event ID
+   differs from the same owner coordinates under key `3`;
+4. materialize/query key `4` through production mutation/query paths;
+5. call `PostgresSchemaRegistrationStore::register_current` on the already-staged key `4` contract;
+6. require one lower active Product key to retire and repeated promotion to retire zero more;
+7. require typed `Inactive` from readiness and query verification for the lower storage contract;
+8. rebuild distribution/query composition on a separate connection and require exactly one runtime Product
+   schema, key `4`, to read the retained current materialization.
 
-No runtime dual-read compatibility branch is allowed. Historical lower-key rows are retained storage history,
-not a Product v3/v4 compatibility surface.
+The lower-key contract is deliberately a test-only storage/probe fixture derived from the current immutable
+contract with a lower routing key. It does not reconstruct the historical key3 Product fingerprint and does not
+register a key3 Product source/factory. Runtime dual-read compatibility remains forbidden.
 
 ## Remaining Storefront parity/evidence blockers
 
 - execute/admit the deterministic budgeted timeout packet and retain acceptable runtime latency/cancellation
   evidence for the selected deployment profile;
+- execute/admit the retained Product key-4 promotion/restart PostgreSQL packet;
 - execute/review current-key Storefront core/EAV/collation and actualized retained Product PostgreSQL packets;
 - admit collation parity only where the deployment default-vs-`C` packet agrees;
-- complete maintainer-executed stale locale/readiness/admission/restart evidence;
-- execute/admit Product key-4 staged promotion evidence and perform tenant stage/rebuild/`register_current`;
+- complete maintainer-executed stale locale/readiness/admission/restart evidence beyond the focused promotion
+  packet;
+- perform a real tenant stage/rebuild/`register_current` only after the relevant packets are admitted;
 - move only eligible Storefront traffic after every evidence/latency gate; channel-less/deep pages stay owner-native.
 
 ## M5 incremental ingestion
@@ -148,19 +157,21 @@ not a Product v3/v4 compatibility surface.
 - [x] Enforce admitted Index/tag phase timeouts in a separate non-serving post-owner adapter.
 - [x] Retain deterministic timeout/error/deadline/fast-path evidence source for the budgeted adapter.
 - [x] Define/guard the current Product key-4 tenant staging/rebuild/final-supersession contract.
+- [x] Retain a focused Product key-4 stage/replay/promote/inactive-old-key/restart PostgreSQL packet source.
 - [ ] Execute/admit the retained budgeted timeout evidence.
+- [ ] Execute/admit the Product key-4 promotion/restart PostgreSQL packet.
 - [ ] Execute/review retained Product/Storefront/collation PostgreSQL packets.
 - [ ] Admit owner/default vs Index `COLLATE "C"` title-search parity for a deployment.
-- [ ] Execute/admit Product key-4 promotion evidence and stage/rebuild/promote a tenant.
+- [ ] Stage/rebuild/promote a real Product tenant only after evidence admission.
 - [ ] Move eligible Storefront traffic only after every parity/readiness/freshness/restart/latency gate passes.
 
 ## Next source-code boundary
 
-The Storefront request-shape, projection/hydration, timeout and current-key promotion contracts are source-complete.
-Do not add a traffic-switch adapter from source inspection alone. The next useful source-only slice is retained
-Product key-4 promotion/restart PostgreSQL evidence if no such packet exists; otherwise maintainer execution is
-the blocking action. Any new packet must use production schema registration/readiness/query/replay paths and
-must not manufacture a second Product compatibility implementation.
+The Storefront request-shape, projection/hydration, timeout, promotion contract and focused promotion/restart
+packet are source-complete. Do not add a traffic-switch adapter from source inspection alone. The remaining
+blocking work is maintainer execution/admission plus any source fix revealed by those runs. Independent source
+cleanup may actualize stale documentation/guards, but it must not convert source-only evidence into a serving
+claim.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-current-schema-promotion.md
+++ b/crates/rustok-index/docs/m7-product-current-schema-promotion.md
@@ -1,6 +1,6 @@
 # M7 Product current-schema promotion
 
-Status: `source_contract_complete_execution_pending`.
+Status: `postgres_packet_source_complete_execution_pending`.
 
 ## Current source identity
 
@@ -41,24 +41,59 @@ A rolling deployment may temporarily observe more than one persisted active Prod
 current source code still contains one Product implementation. Persisted coexistence is not runtime dual-read
 compatibility.
 
+## Retained PostgreSQL promotion packet — source complete
+
+`crates/rustok-distribution/tests/product_current_schema_promotion_postgres.rs` retains an isolated PostgreSQL
+scenario using production Product and Index migrations plus the selected distribution runtime.
+
+The packet obtains the exact current Product schema from `SharedIndexSchemaRegistry` and asserts key `4`; it
+does not copy the Product field/link contract into the test. It then creates a **storage-only lower-key
+fixture** by cloning that immutable current contract and changing only the routing key to `3` before ordinary
+registration. This fixture exists solely to exercise lower-active-schema staging, retirement and typed inactive
+checks. It does not reconstruct or select the historical key3 Product implementation and it never registers a
+key3 Product source/factory.
+
+The retained scenario then:
+
+1. ordinary-registers the lower storage fixture and every current runtime schema, proving key3/key4 persisted
+   coexistence during staging;
+2. materializes the real `product-postgres-primary` source and current query runtime;
+3. loads one real key4 Product mutation from Product owner tables;
+4. proves its event ID equals `derive_index_schema_source_event_id` for key4 and differs from the same owner
+   coordinates under key3;
+5. applies that mutation through `PostgresMutationStore` and queries the key4 materialization;
+6. calls `register_current` with the already-staged exact current Product key4 schema and requires exactly one
+   lower active Product schema to retire;
+7. repeats `register_current` and requires zero further retirement;
+8. builds a test-only immutable probe registry containing the lower storage contract plus current schemas, then
+   requires `PostgresIndexSchemaReadinessStore` and `PostgresIndexQueryPort` to return typed `Inactive` for key3;
+9. requires the existing key4 runtime to remain queryable after promotion;
+10. rebuilds distribution/query composition on a separate PostgreSQL connection and requires exactly one
+    runtime Product schema, key4, to read the retained key4 materialization after restart.
+
+The packet uses production `register`, `register_current`, schema readiness, query verification, source
+materialization and mutation storage. The only synthetic element is the lower-key storage/probe contract needed
+to exercise supersession without reviving a deleted compatibility source.
+
 ## Storefront gate
 
 Mounted Storefront remains owner-native. Promotion source completeness does not establish Storefront parity,
 collation admission, timeout/latency admission or tenant readiness. Channel-less and deep-page Storefront
 request shapes remain owner-native under the current key-4 contract.
 
-## Execution still required
+## Maintainer execution still required
 
-Maintainer-owned execution must still prove at least:
+The new PostgreSQL packet is retained source, not an executed result. Maintainer-owned execution must still
+confirm the packet compiles and passes against PostgreSQL, then review it together with current-key
+readiness/freshness/Storefront/collation evidence before any tenant promotion or traffic switch.
 
-- Product key `4` can be staged while the lower persisted key remains active;
-- schema-scoped key-4 replay does not collide with historical inbox delivery identities;
-- exact key-4 readiness/freshness/parity/restart packets pass;
-- `register_current` retires lower active Product keys only after staging/rebuild;
-- an old Product schema reference fails readiness/query admission after retirement;
-- restart after promotion resolves only the current runtime-selected key `4` contract.
+In particular, this source state does not claim:
 
-This document and its source guard do not claim those runtime results.
+- a real tenant has been staged/promoted;
+- the old production key3 fingerprint/JSON was reconstructed;
+- key4 replay/restart evidence has passed;
+- collation or Storefront parity has been admitted;
+- latency/cancellation evidence has been admitted.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
+++ b/crates/rustok-index/docs/m7-product-storefront-parity-gate.md
@@ -68,20 +68,26 @@ Never-completing phases use `std::future::pending`; timeout cancellation is stil
 `tokio::time::timeout` wrapper. The packet has not been executed by the implementation agent and therefore is
 not admitted runtime/latency evidence yet.
 
-## Current Product key-4 promotion — source contract complete, execution pending
+## Current Product key-4 promotion — PostgreSQL packet source complete, execution pending
 
 Current Product runtime code publishes one 15-field schema on routing key `4` and derives replay delivery IDs
 with `derive_index_schema_source_event_id`. Lower Product keys are historical persisted identities, not runtime
 compatibility implementations.
 
-Tenant promotion must remain staged: ordinary-register key `4`, rebuild/evidence it while lower persisted keys
-may still be active, then call `PostgresSchemaRegistrationStore::register_current` with the same staged key `4`
-contract. Final supersession retires lower active Product schemas atomically; old-key readiness/query execution
-must then fail closed as inactive.
+The retained PostgreSQL packet now exercises the staged authority transition with production Product/Index
+migrations and current distribution composition: ordinary-register lower storage fixture plus real key4,
+materialize/query one real key4 Product mutation, call `register_current`, require typed `Inactive` for the
+lower key, and rebuild current runtime composition on a separate connection where only Product key4 is
+published and the existing key4 materialization remains readable.
 
-The focused source contract is retained in `m7-product-current-schema-promotion.md` and
-`verify-index-product-current-schema-promotion.mjs`. It does not claim that any tenant has completed the
-stage/rebuild/promote sequence.
+The lower key3 contract in this packet is explicitly storage/probe-only: it is derived from the current
+immutable Product contract with a lower routing key and does not reconstruct or select the deleted historical
+Product key3 implementation. No key3 source/factory or runtime dual-read path is added.
+
+The focused contract/packet is retained in `m7-product-current-schema-promotion.md`,
+`verify-index-product-current-schema-promotion.mjs`, and
+`verify-index-product-current-schema-promotion-postgres-packet.mjs`. The packet has not been executed by the
+implementation agent and does not claim a real tenant promotion.
 
 ## Search/collation/EAV source state
 
@@ -96,18 +102,18 @@ bind-free `Never`. Current Product Index remains one 15-field schema on routing 
 
 1. Maintainer-execute/admit the deterministic budgeted timeout packet and record acceptable latency/cancellation
    behavior for the selected runtime profile.
-2. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
-3. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible cutover closed.
-4. Stale locale/readiness/admission/restart evidence remains maintainer-run.
-5. Execute/admit Product key-4 promotion evidence and perform tenant stage/rebuild/`register_current`.
+2. Maintainer-execute/admit the Product key4 promotion/restart PostgreSQL packet.
+3. Maintainer execution/review of Storefront core/EAV/collation and actualized retained Product packets.
+4. Collation admission per deployment: any owner/default-vs-`C` mismatch keeps eligible cutover closed.
+5. Stale locale/readiness/admission/restart evidence outside the focused promotion packet remains maintainer-run.
 6. Any serving router must preserve channel-less/deep-page owner-native branches and traffic switch remains last.
 
 ## Next source boundary
 
-Do not move mounted Storefront traffic from source inspection alone. Further serving composition depends on
-maintainer execution/admission of timeout, Storefront parity/collation, stale-readiness and key-4 promotion
-evidence. Independent source work may continue only on one of those retained evidence boundaries without
-weakening this gate.
+Do not move mounted Storefront traffic from source inspection alone. The focused promotion/restart packet is now
+retained in source; further authoritative serving composition depends on maintainer execution/admission of that
+packet, timeout evidence, Storefront parity/collation and stale-readiness evidence. Source fixes should respond
+to those runs rather than weakening the gate.
 
 ## Source guards
 
@@ -116,9 +122,11 @@ weakening this gate.
 - `verify-index-product-storefront-budgeted-execution.mjs` locks post-owner phase timeout enforcement;
 - `verify-index-product-storefront-budgeted-execution-evidence.mjs` locks the deterministic retained timeout
   packet and test-only phase seam;
-- `verify-index-product-current-schema-promotion.mjs` locks the single-current key-4 staged-promotion contract;
+- `verify-index-product-current-schema-promotion.mjs` locks the single-current key4 promotion contract;
+- `verify-index-product-current-schema-promotion-postgres-packet.mjs` locks the staged key4 promotion/restart
+  PostgreSQL packet source;
 - `verify-index-product-storefront-shadow-executor.mjs` keeps the ordinary evidence executor separate;
-- request-shape, public-projection, tag-hydration, collation and key-4 guards remain retained;
+- request-shape, public-projection, tag-hydration, collation and key4 guards remain retained;
 - `verify-index-product-storefront-parity-gate.mjs` keeps mounted Storefront owner-native.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or

--- a/scripts/verify/verify-index-product-current-schema-promotion-postgres-packet.mjs
+++ b/scripts/verify/verify-index-product-current-schema-promotion-postgres-packet.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-product-current-schema-promotion-postgres-packet] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+const forbidMarkers = (relative, source, markers) => {
+  for (const marker of markers) {
+    if (source.includes(marker)) fail(`${relative} contains forbidden marker ${marker}`);
+  }
+};
+
+const packetPath = 'crates/rustok-distribution/tests/product_current_schema_promotion_postgres.rs';
+const packet = requireMarkers(packetPath, [
+  '#![cfg(feature = "mod-product")]',
+  'RUSTOK_PRODUCT_KEY4_PROMOTION_DATABASE_URL',
+  'PRODUCT_SOURCE: &str = "product-postgres-primary"',
+  'PRODUCT_EVENT_DOMAIN: &str = "rustok-product.product-replay"',
+  'CURRENT_PRODUCT_SCHEMA_VERSION: u32 = 4',
+  'HISTORICAL_PRODUCT_SCHEMA_VERSION: u32 = 3',
+  'rustok_product::migrations::migrations()',
+  'for migration_step in IndexModule.migrations()',
+  'rustok_distribution::build_runtime_extensions(&registry)?',
+  '.register(rustok_channel::ChannelModule)',
+  '.register(rustok_product::ProductModule)',
+  'current_product_schema(&schemas)?',
+  'let mut historical_product_schema = current_product_schema.clone();',
+  'historical_product_schema.reference.version =',
+  'schema_store.register(TENANT_ID, &historical_product_schema)',
+  'for registered in schemas.registry().iter()',
+  'materialize_postgres_index_sources(&mut extensions, database.source.clone())?',
+  'materialize_index_source_registry(&extensions)?',
+  'materialize_postgres_index_query_runtime(&mut extensions, database.query.clone())?',
+  'load_product_mutation(&runtime.sources, &current_ref)',
+  'derive_index_schema_source_event_id(',
+  'assert_ne!(current_event_id, historical_event_id);',
+  'MutationDelivery::from_event(PRODUCT_SOURCE, mutation)?',
+  '.apply(runtime.schemas.registry(), &delivery)',
+  '.register_current(TENANT_ID, &runtime.current_product_schema)',
+  'assert_eq!(promoted.retired_schema_count(), 1);',
+  'assert_eq!(repeated.retired_schema_count(), 0);',
+  'PostgresIndexSchemaReadinessStore::new(database.query.clone())',
+  'PersistedSchemaReadinessFailure::Inactive',
+  'PostgresIndexQueryPort::new(database.query.clone(), probe_registry)',
+  'IndexQueryExecutionError::SchemaNotReady { reference, reason }',
+  'restart_current_product_query_runtime(database).await?',
+  'assert_eq!(product_schemas.len(), 1);',
+  'SchemaVersion::new(CURRENT_PRODUCT_SCHEMA_VERSION)',
+  'assert_current_product_query(&restart_query, &current_ref).await?;',
+  'CREATE SCHEMA',
+  'DROP SCHEMA IF EXISTS',
+]);
+
+forbidMarkers(packetPath, packet, [
+  'SchemaVersion::new(5)',
+  'product_v3_schema',
+  'product_v4_schema',
+  'PRODUCT_EVENT_DOMAIN_V3',
+  'PRODUCT_EVENT_DOMAIN_V4',
+  'derive_index_source_event_id(',
+  'mod product_v3',
+  'SharedIndexSourceRegistry::new',
+  'tokio::spawn',
+]);
+
+// The lower-key contract is deliberately a storage/probe fixture. The packet must never register a key3
+// source factory or add key3 to the selected distribution runtime.
+const distributionProductPath = 'crates/rustok-distribution/src/product_index/product.rs';
+const distributionProduct = requireMarkers(distributionProductPath, [
+  'derive_index_schema_source_event_id',
+  'SchemaVersion::new(PRODUCT_SCHEMA_ROUTING_KEY)',
+]);
+forbidMarkers(distributionProductPath, distributionProduct, [
+  'SchemaVersion::new(3)',
+  'product_v3_schema',
+  'derive_index_source_event_id(',
+]);
+
+requireMarkers('crates/rustok-distribution/src/product_index/mod.rs', [
+  'PRODUCT_SCHEMA_ROUTING_KEY: u32 = 4',
+  'Lower keys are historical storage identities only.',
+]);
+requireMarkers('crates/rustok-index/docs/m7-product-current-schema-promotion.md', [
+  'Status: `postgres_packet_source_complete_execution_pending`',
+  'Retained PostgreSQL promotion packet — source complete',
+  'storage-only lower-key fixture',
+  'does not reconstruct or select the historical key3 Product implementation',
+  'Maintainer execution still required',
+]);
+
+console.log('[verify-index-product-current-schema-promotion-postgres-packet] retained Product key4 stage/replay/register_current/inactive-old-key/restart PostgreSQL packet source verified; execution remains maintainer-owned');

--- a/scripts/verify/verify-index-product-current-schema-promotion.mjs
+++ b/scripts/verify/verify-index-product-current-schema-promotion.mjs
@@ -104,14 +104,19 @@ requireMarkers('crates/rustok-index/docs/m4-single-current-schema-supersession.m
   'The runtime must not stage or select a Product key `3` implementation',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-current-schema-promotion.md', [
-  'Status: `source_contract_complete_execution_pending`',
+  'Status: `postgres_packet_source_complete_execution_pending`',
   'Current source identity',
   'Tenant promotion sequence',
   'ordinary-register the exact Product key `4` immutable contract',
   '`PostgresSchemaRegistrationStore::register_current`',
   'Historical state',
+  'Retained PostgreSQL promotion packet — source complete',
+  'storage-only lower-key fixture',
   'Mounted Storefront remains owner-native',
-  'Execution still required',
+  'Maintainer execution still required',
+]);
+requireMarkers('scripts/verify/verify-index-product-current-schema-promotion-postgres-packet.mjs', [
+  'retained Product key4 stage/replay/register_current/inactive-old-key/restart PostgreSQL packet source verified',
 ]);
 
-console.log('[verify-index-product-current-schema-promotion] Product key4 is the only current runtime contract; tenant stage/rebuild/register_current promotion remains fail-closed and execution-owned');
+console.log('[verify-index-product-current-schema-promotion] Product key4 is the only current runtime contract; retained tenant promotion PostgreSQL packet is source-complete and execution remains maintainer-owned');

--- a/scripts/verify/verify-index-product-storefront-parity-gate.mjs
+++ b/scripts/verify/verify-index-product-storefront-parity-gate.mjs
@@ -125,11 +125,16 @@ for (const forbidden of ['SchemaVersion::new(3)', 'SchemaVersion::new(5)', 'loca
 
 requireMarkers('scripts/verify/verify-index-product-current-schema-promotion.mjs', [
   'Product key4 is the only current runtime contract',
-  'tenant stage/rebuild/register_current promotion remains fail-closed and execution-owned',
+  'retained tenant promotion PostgreSQL packet is source-complete',
+]);
+requireMarkers('scripts/verify/verify-index-product-current-schema-promotion-postgres-packet.mjs', [
+  'retained Product key4 stage/replay/register_current/inactive-old-key/restart PostgreSQL packet source verified',
 ]);
 requireMarkers('crates/rustok-index/docs/m7-product-current-schema-promotion.md', [
-  'Status: `source_contract_complete_execution_pending`',
+  'Status: `postgres_packet_source_complete_execution_pending`',
   'Tenant promotion sequence',
+  'Retained PostgreSQL promotion packet — source complete',
+  'storage-only lower-key fixture',
   '`PostgresSchemaRegistrationStore::register_current`',
   'Mounted Storefront remains owner-native',
 ]);
@@ -173,7 +178,7 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-parity-gate.md', 
   'Mounted Storefront remains owner-native',
   'Serving-budget policy and timeout enforcement — source complete',
   'Deterministic timeout evidence — source complete, execution pending',
-  'Current Product key-4 promotion — source contract complete, execution pending',
+  'Current Product key-4 promotion — PostgreSQL packet source complete, execution pending',
   '`ProductStorefrontIndexBudgetedProjectionExecutor`',
   'The packet has not been executed by the implementation agent',
 ]);
@@ -188,9 +193,10 @@ requireMarkers('crates/rustok-index/docs/m7-product-storefront-budgeted-executio
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-current-schema-promotion.mjs'",
+  "'verify-index-product-current-schema-promotion-postgres-packet.mjs'",
   "'verify-index-product-storefront-serving-budget-policy.mjs'",
   "'verify-index-product-storefront-budgeted-execution.mjs'",
   "'verify-index-product-storefront-budgeted-execution-evidence.mjs'",
 ]);
 
-console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; current key4 promotion, budget policy, timeout enforcement and deterministic timeout evidence are source-complete while maintainer execution/admission remains pending');
+console.log('[verify-index-product-storefront-parity-gate] Storefront remains owner-native; key4 promotion PostgreSQL packet, budget policy, timeout enforcement and deterministic timeout evidence are source-complete while maintainer execution/admission remains pending');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -63,6 +63,7 @@ const scripts = [
   'verify-index-replay-dead-letter-admission.mjs',
   'verify-index-product-source.mjs',
   'verify-index-product-current-schema-promotion.mjs',
+  'verify-index-product-current-schema-promotion-postgres-packet.mjs',
   'verify-index-product-locale-refresh-ledger.mjs',
   'verify-index-product-eav-owner-clock.mjs',
   'verify-index-product-attribute-term-contract.mjs',


### PR DESCRIPTION
## Summary

- retain a focused PostgreSQL packet for the current Product key4 staged promotion/restart boundary;
- apply production Product and Index migrations in one isolated PostgreSQL schema;
- build the real selected Index + Channel + Product distribution runtime and obtain the exact current Product schema from `SharedIndexSchemaRegistry` rather than copying its 15-field contract into the test;
- ordinary-register a storage-only lower Product key3 fixture first, then all actual current runtime schemas, proving lower/current persisted coexistence during staging;
- materialize the real `product-postgres-primary` source and current Index query runtime;
- load one real key4 Product mutation from Product owner storage, prove its event ID equals `derive_index_schema_source_event_id` for key4 and differs from the same owner coordinates under key3, then apply it through `PostgresMutationStore`;
- query the current key4 materialization before promotion;
- call `PostgresSchemaRegistrationStore::register_current` with the already-staged exact current key4 contract, require exactly one lower active Product schema to retire, and require repeated promotion to retire zero more;
- use a test-only immutable probe registry plus production readiness/query verification to require typed `Inactive` for retired key3 before page SQL;
- require current key4 to stay queryable after retirement;
- rebuild current distribution/query composition on a separate PostgreSQL connection, require exactly one runtime Product schema (key4), and read the retained key4 materialization after restart;
- add focused packet/source guards, aggregate wiring, current-plan and Storefront parity-gate updates.

## Important fixture boundary

The lower key3 schema used by this packet is deliberately a **storage/probe-only fixture**: it clones the exact current immutable Product contract and changes only the routing key before persistence. This tests staged supersession/inactive behavior without reconstructing or reviving the deleted historical key3 Product implementation. No key3 Product source, factory, runtime branch, or dual-read compatibility path is added.

## Boundary

This PR does not execute the packet, claim a real tenant promotion, reconstruct the old production key3 fingerprint, alter Product schema/source/routing behavior, admit Storefront/collation/latency evidence, or switch mounted Storefront traffic.

## Main recheck

The branch started from Product key4 promotion-contract merge `d905c25a4d0ffd63682bf2aea9779ded190a255e`. Current `main` advanced only through Forum #3266; its changed paths are disjoint from this Product/Index packet. Final compare contains 8 expected integration-test, guard and documentation files with no production runtime changes.

## Validation

Static source review confirmed the required public schema/readiness/query APIs, current Product replay domain, mutable/cloneable `IndexSchema`, and current-only restart composition shape. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.