### PR TITLE
docs(index): actualize Product graph source state

### DIFF
--- a/crates/rustok-index/docs/m7-product-graph-source.md
+++ b/crates/rustok-index/docs/m7-product-graph-source.md
@@ -1,13 +1,13 @@
 # M7 canonical Product graph source
 
-Status: `single_current_product_source_complete_storefront_locale_query_gap_open`.
+Status: `single_current_product_and_storefront_query_source_complete_execution_admission_pending`.
 
 The selected distribution publishes one current Product Index contract and one current ProductVariant
 contract. Parallel Product compatibility implementations remain removed.
 
 The generic Index `SchemaRef` still contains a positive numeric routing key because it participates in
 persisted schema/entity/link/inbox/replay identities. Current Product runtime code owns exactly one such
-key; lower keys are historical storage identities only.
+Product key, `4`; lower keys are historical storage identities only.
 
 ## Canonical Product graph
 
@@ -31,92 +31,147 @@ Localized tag names remain Taxonomy-owned; Product Index stores only stable tag 
 Physical Product/translation deletes remain represented by Product-owned tombstones and canonical
 `IndexMutation::Delete` mutations.
 
-## Localized identity boundary
+## Localized identity and Storefront query boundary
 
-One Product Index entity corresponds to one **physically stored** `product_translations.locale` row.
-The source does not fabricate requested-locale records from a fallback translation. The absence provider
-correctly treats a missing exact locale as absent.
+One physical Product Index entity still corresponds to one stored `product_translations.locale` row. The source
+does not fabricate a requested-locale record from a fallback translation, and exact-locale absence remains a
+source/readiness fact.
 
-That generic source rule is not yet Storefront-equivalent. Owner Storefront list search currently
-matches title through any Product translation, and owner result localization can return a fallback
-translation when the requested locale is absent. A current-locale scalar title filter or a second
-independent fallback query cannot by itself preserve the same global admission, de-duplication, ordering,
-page boundary, and exact count.
+Storefront parity no longer tries to force requested/fallback semantics into that physical source shape. The
+generic localized query path folds physical rows by logical identity `(tenant_id, schema_ref, entity_id)` and
+projects requested locale -> fallback locale -> no localized row **after** matching/grouping semantics are
+fixed. Logical identity is established before ordering, pagination and exact count, and entity-ID tie breaking
+matches owner ascending/descending ordering.
 
-This is now an explicit Storefront query/source gap. Do not add another Product routing key or parallel
-Product schema merely to work around it. The effective localized Storefront identity/search architecture
-must be resolved at the generic query/owner-contract layer first.
+Owner Storefront title search remains across **all Product translations**, not only the requested locale. The
+localized Index contract represents that as an any-locale identity predicate while projecting only the
+requested/fallback localized row. Generic scalar String `TextLike` is source-complete, and Product owns the
+1022-byte effective Storefront search bound required to fit the Index 1024-byte `%...%` pattern budget.
+
+The retained PostgreSQL localized fold/runtime and Storefront core packets cover this architecture in source.
+Deployment/default collation parity remains an execution/admission gate because the Index PostgreSQL compiler
+uses deterministic `COLLATE "C"` while the Product owner query uses its deployment/default collation.
+
+## Product public projection after the fixed page
+
+Generic Index results remain Product-neutral. When neither requested nor fallback Product translation exists,
+raw `title`/`handle` stay `IndexValue::Null`.
+
+The Product-specific public projection is derived only **after** raw page identity/order/count boundaries are
+fixed:
+
+- `title: Null` -> `"Untitled product"`;
+- `handle: Null` -> `""`.
+
+Product tags are also resolved after page selection through `ProductStorefrontTagReadPort`, keyed by the
+already-selected Product IDs rather than only `tag_ids`. That preserves Taxonomy requested->fallback/canonical
+name resolution and Product's legacy normalized `metadata.tags` fallback without adding localized tag names to
+the Product Index schema.
+
+## Storefront request-shape policy
+
+Current key `4` has explicit fail-closed request-shape limits:
+
+- trusted non-empty public channel slug + non-nil Channel UUID is Index-eligible;
+- channel-less owner requests remain owner-native because `sales_channel_ids` cannot distinguish metadata-
+  unrestricted Products from restricted Products that resolve to every current Channel;
+- owner-valid offsets through `10_000` are Index-eligible;
+- deeper owner-valid pages remain owner-native without clamp or cursor rewriting.
+
+No visibility sentinel, Product key5 approximation, or compatibility schema is used to bypass those semantic
+limits.
 
 ## Single-current immutable replacement
 
-The previous Product schema fingerprint was not changed in place. Current runtime code uses one
-monotonically higher internal routing key and derives deterministic Product replay UUIDs with
-`derive_index_schema_source_event_id`, so rebuild deliveries cannot collide with lower-key historical
-`index_inbox` rows.
+The previous Product schema fingerprint was not changed in place. Current runtime code uses one monotonically
+higher internal routing key (`4`) and derives deterministic Product replay UUIDs with
+`derive_index_schema_source_event_id`, so current-key rebuild deliveries cannot collide with lower-key delivery
+identities for the same owner mutation coordinates.
 
-The replacement source does not register or select the lower Product runtime contract. Production
-promotion remains staged:
+The replacement source does not register or select a lower Product runtime contract. Tenant promotion remains
+staged:
 
-1. ordinary-register the current immutable key;
-2. replay/rebuild it completely;
+1. ordinary-register the exact current key4 immutable contract;
+2. replay/rebuild key4 completely;
 3. prove exact readiness/freshness/parity/restart evidence;
 4. call `register_current` to retire lower active persisted Product keys;
-5. only then select an authoritative consumer.
+5. require lower-key readiness/query execution to fail closed as inactive;
+6. only then admit an authoritative Product Index consumer for that tenant.
 
-This is one current contract, not a Product version matrix.
+A retained PostgreSQL promotion/restart packet now exists in source and uses production Product/Index
+migrations, current distribution composition, current Product source, mutation storage, schema registration,
+readiness/query verification and fresh runtime composition. Its lower key3 contract is storage/probe-only; it
+does not reconstruct or select a historical key3 Product implementation. The packet remains unexecuted by the
+implementation agent.
 
 ## Complete mutation ordering
 
-Product scalar/translation/Variant-membership/EAV/tag state advances under the Product owner revision
-boundary. Resolved SalesChannel membership advances under `relation_epoch`.
+Product scalar/translation/Variant-membership/EAV/tag state advances under the Product owner revision boundary.
+Resolved SalesChannel membership advances under `relation_epoch`.
 
-`product_index_graph_projection_snapshots.projection_epoch` remains the only complete Product mutation
-`source_version`. Live replay requires the projection Product watermark to equal the current Product
-revision and joins the exact retained relation epoch referenced by projection state.
+`product_index_graph_projection_snapshots.projection_epoch` remains the complete Product mutation
+`source_version`. Live replay requires the projection Product watermark to equal the current Product revision
+and joins the exact retained relation epoch referenced by projection state.
 
-The current source additionally materializes Product-owned tag UUIDs and canonical typed EAV terms in
-the same PostgreSQL source read. EAV commands advance Product `index_revision` and graph projection
-before their refresh ledger is captured.
+The current source additionally materializes Product-owned tag UUIDs and canonical typed EAV terms in the same
+PostgreSQL source read. EAV commands advance Product `index_revision` and graph projection before their refresh
+ledger is captured.
 
-Product hard-delete replay also uses projection epoch but does not decode live Storefront fields or
-require a live relation freshness witness because the mutation removes the Product graph.
+Product hard-delete replay also uses projection epoch but does not decode live Storefront fields or require a
+live relation freshness witness because the mutation removes the Product graph.
 
 ## Relation freshness gate
 
-`product_sales_channel_index_relation_freshness_snapshots` identifies the exact retained relation epoch
-and records observed Product source version, canonical Product visibility key, and tenant Channel
-identity generation.
+`product_sales_channel_index_relation_freshness_snapshots` identifies the exact retained relation epoch and
+records observed Product source version, canonical Product visibility key, and tenant Channel identity
+generation.
 
-For every live Product row, the source fails closed unless the witness matches current visibility and
-Channel identity generation and is not newer than current Product owner revision. Missing/stale
-freshness therefore cannot publish a live Product mutation. Product locale absence uses the same gate.
+For every live Product row, the source fails closed unless the witness matches current visibility and Channel
+identity generation and is not newer than current Product owner revision. Missing/stale freshness therefore
+cannot publish a live Product mutation. Product locale absence uses the same gate.
 
-Freshness-only Channel changes do not fabricate Product relation/projection epochs when resolved UUID
-membership and Product record state are unchanged.
+Freshness-only Channel changes do not fabricate Product relation/projection epochs when resolved UUID membership
+and Product record state are unchanged.
 
-Detailed contracts:
+## Non-serving budget boundary
+
+The owner-first Storefront evidence path has a separate post-owner budget policy and budgeted projection
+executor. Eligibility requires a host-measured remaining request budget, bounded Index/tag phases, safety
+margin and Product tag capability. Eligible projected and tag phases are wrapped with outer Tokio timeouts while
+the already-successful owner result remains authoritative.
+
+A deterministic storage-free timeout packet is retained in source. It remains execution/admission pending and
+does not mount the Index path into Storefront traffic.
+
+## Detailed contracts
 
 - [Product graph projection ledger](../../rustok-product/docs/index-graph-projection-ledger.md)
 - [Product-SalesChannel relation ledger](../../rustok-product/docs/index-sales-channel-relation-ledger.md)
 - [Product-SalesChannel freshness witness](../../rustok-product/docs/index-sales-channel-relation-freshness.md)
 - [Product typed EAV terms](./m7-product-attribute-term-contract.md)
+- [Product current-schema promotion](./m7-product-current-schema-promotion.md)
 - [Storefront parity gate](./m7-product-storefront-parity-gate.md)
+- [Storefront public projection](./m7-product-storefront-public-projection.md)
+- [Storefront tag hydration](./m7-product-storefront-tag-hydration.md)
+- [Storefront serving budget](./m7-product-storefront-serving-budget-policy.md)
 - [Cross-owner resolver](./m7-product-sales-channel-resolver.md)
 
 ## Still open
 
-The Product source contract itself is current, but production/Storefront admission still requires:
+The Product graph/query/Storefront source boundaries above are source-complete. Remaining gates are execution,
+admission, and later serving composition:
 
-- staged current-key rebuild and final persisted supersession;
-- actualization and execution of retained PostgreSQL packets on the current key/15-field contract;
-- an explicit effective localized Product list identity/search/fallback architecture;
-- any generic text-pattern primitive required by that chosen architecture;
-- Storefront query translation and bounded Taxonomy tag-name hydration;
-- full owner-vs-Index Storefront equivalence;
-- Product typed event family/routes after event-contract digest admission;
-- final traffic cutover evidence.
+- maintainer execution/admission of the retained Product key4 promotion/restart packet;
+- maintainer execution/review of current-key Storefront core/EAV/collation and actualized Product PostgreSQL
+  packets;
+- deployment-specific admission of owner/default vs Index `COLLATE "C"` title-search parity;
+- maintainer execution/admission of deterministic timeout/latency evidence;
+- remaining stale-locale/readiness/admission/restart evidence not already covered by focused packets;
+- Product typed event family/routes only after the separate M5 event-contract digest gate;
+- real tenant stage/rebuild/promote only after evidence admission;
+- final eligible Storefront traffic cutover last, while channel-less/deep-page shapes stay owner-native.
 
 ## Validation ownership
 
-Formatting, Cargo checks/tests, JavaScript guards, PostgreSQL execution, migrations, workflows, and CI
-are maintainer-run. The implementation agent did not execute them.
+Formatting, Cargo checks/tests, JavaScript guards, PostgreSQL execution, migrations, workflows, and CI are
+maintainer-run. The implementation agent did not execute them.

--- a/scripts/verify/verify-index-product-source.mjs
+++ b/scripts/verify/verify-index-product-source.mjs
@@ -139,11 +139,40 @@ requireMarkers('crates/rustok-distribution/src/product_index/attribute_terms.rs'
   'localized_present',
 ]);
 
+const graphDocPath = 'crates/rustok-index/docs/m7-product-graph-source.md';
+const graphDoc = requireMarkers(graphDocPath, [
+  'Status: `single_current_product_and_storefront_query_source_complete_execution_admission_pending`',
+  'Current Product runtime code owns exactly one such Product key, `4`',
+  'Localized identity and Storefront query boundary',
+  'folds physical rows by logical identity `(tenant_id, schema_ref, entity_id)`',
+  'Owner Storefront title search remains across **all Product translations**',
+  'Product public projection after the fixed page',
+  '`title: Null` -> `"Untitled product"`',
+  '`ProductStorefrontTagReadPort`',
+  'Storefront request-shape policy',
+  'channel-less owner requests remain owner-native',
+  'deeper owner-valid pages remain owner-native',
+  'A retained PostgreSQL promotion/restart packet now exists in source',
+  'Non-serving budget boundary',
+  'deterministic storage-free timeout packet is retained in source',
+  'The Product graph/query/Storefront source boundaries above are source-complete.',
+]);
+forbidMarkers(graphDocPath, graphDoc, [
+  'single_current_product_source_complete_storefront_locale_query_gap_open',
+  'This is now an explicit Storefront query/source gap.',
+  'effective localized Storefront identity/search architecture must be resolved',
+  'any generic text-pattern primitive required by that chosen architecture',
+  'Storefront query translation and bounded Taxonomy tag-name hydration',
+  'full owner-vs-Index Storefront equivalence',
+]);
+
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-product-source.mjs'",
+  "'verify-index-product-current-schema-promotion-postgres-packet.mjs'",
+  "'verify-index-product-storefront-budgeted-execution-evidence.mjs'",
   "'verify-index-product-attribute-term-contract.mjs'",
   "'verify-index-product-channel-relation-freshness.mjs'",
   "'verify-index-linked-target-query-freshness.mjs'",
 ]);
 
-console.log('[verify-index-product-source] single-current Storefront-capable Product source verified');
+console.log('[verify-index-product-source] single-current key4 Product graph and resolved Storefront query-source boundaries verified; execution/admission remains separate');


### PR DESCRIPTION
## Summary

- actualize `m7-product-graph-source.md`, which still described localized Storefront identity/search, TextLike, tag hydration and owner-vs-Index parity as unresolved source gaps;
- record the current single Product key4/15-field/two-link graph source and schema-scoped replay identity;
- document the source-complete localized logical-identity fold, requested→fallback projection, all-translations title-search identity predicate, Product-owned search bound and entity-ID tie break;
- document post-page public placeholders and Product-owned tag hydration without copying localized names into Index;
- record channel-less/deep-page owner-native request-shape policy;
- link the retained Product key4 promotion/restart PostgreSQL packet and the non-serving serving-budget/timeout evidence boundary;
- narrow the remaining list to maintainer execution/admission, deployment collation admission, M5 typed-event work and final traffic cutover;
- extend `verify-index-product-source.mjs` so the actualized roadmap markers are required and the old stale-gap language is forbidden.

## Boundary

Documentation/source-guard actualization only. No Product runtime, schema, source, query, Storefront, traffic, migration or evidence-execution behavior changes.

## Main recheck

Branch is directly ahead of `main@c2821a6e3cb6e4fd89e6ebf95224f74bbcc78404`; final diff contains exactly the Product graph-source document and its existing source guard.

## Validation

Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.