### PR TITLE
refactor(product-admin): retain lifecycle retry identity

### DIFF
--- a/crates/rustok-product/admin/src/catalog_transport_retry.rs
+++ b/crates/rustok-product/admin/src/catalog_transport_retry.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use rustok_graphql::GraphqlHttpError;
+
+use crate::lifecycle_retry_identity::{
+    ProductAdminLifecycleOperation, ProductAdminLifecycleRetryIdentity,
+};
+use crate::model::{ProductDetail, ProductDraft};
+
+pub use crate::legacy_transport::fetch_catalog_search_options;
+pub(crate) use crate::legacy_transport::{
+    bind_category_attribute, bind_schema_attribute, clear_detached_product_attribute_values,
+    create_attribute_schema, create_catalog_category, create_category_attribute_group,
+    create_product_attribute, create_product_attribute_option,
+    create_product_attribute_schema_group, fetch_attribute_schemas, fetch_bootstrap,
+    fetch_catalog_categories, fetch_effective_product_form, fetch_product,
+    fetch_product_attribute_values, fetch_product_attributes, fetch_product_pricing, fetch_products,
+    fetch_shipping_profiles, save_product_attribute_values, set_category_schema_mode,
+};
+
+type RetryIdentity = ProductAdminLifecycleRetryIdentity<String>;
+
+fn retry_registry() -> &'static Mutex<HashMap<String, RetryIdentity>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, RetryIdentity>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lifecycle_operation_segment(operation: ProductAdminLifecycleOperation) -> &'static str {
+    match operation {
+        ProductAdminLifecycleOperation::CreateProduct => "create-product",
+        ProductAdminLifecycleOperation::UpdateProduct => "update-product",
+        ProductAdminLifecycleOperation::ChangeStatus => "change-status",
+        ProductAdminLifecycleOperation::DeleteProduct => "delete-product",
+    }
+}
+
+fn lifecycle_slot(
+    operation: ProductAdminLifecycleOperation,
+    tenant_id: &str,
+    actor_id: &str,
+    product_id: Option<&str>,
+) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        lifecycle_operation_segment(operation),
+        tenant_id,
+        actor_id,
+        product_id.unwrap_or("new")
+    )
+}
+
+fn retained_caller_key(
+    slot: &str,
+    operation: ProductAdminLifecycleOperation,
+    intent: String,
+) -> String {
+    let mut registry = retry_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry
+        .entry(slot.to_string())
+        .or_default()
+        .idempotency_key_for(operation, &intent)
+}
+
+fn mark_lifecycle_succeeded(slot: &str) {
+    let mut registry = retry_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(identity) = registry.get_mut(slot) {
+        identity.mark_succeeded();
+    }
+    registry.remove(slot);
+}
+
+fn draft_intent(
+    operation: ProductAdminLifecycleOperation,
+    tenant_id: &str,
+    actor_id: &str,
+    product_id: Option<&str>,
+    draft: &ProductDraft,
+) -> String {
+    format!(
+        "operation={};tenant={tenant_id:?};actor={actor_id:?};product={product_id:?};draft={draft:?}",
+        lifecycle_operation_segment(operation),
+    )
+}
+
+fn status_intent(tenant_id: &str, actor_id: &str, product_id: &str, status: &str) -> String {
+    format!(
+        "operation=change-status;tenant={tenant_id:?};actor={actor_id:?};product={product_id:?};status={status:?}"
+    )
+}
+
+fn delete_intent(tenant_id: &str, actor_id: &str, product_id: &str) -> String {
+    format!(
+        "operation=delete-product;tenant={tenant_id:?};actor={actor_id:?};product={product_id:?}"
+    )
+}
+
+pub(crate) async fn create_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    draft: ProductDraft,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let operation = ProductAdminLifecycleOperation::CreateProduct;
+    let slot = lifecycle_slot(operation, &tenant_id, &user_id, None);
+    let intent = draft_intent(operation, &tenant_id, &user_id, None, &draft);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result = crate::product_lifecycle_graphql::create_product(
+        token,
+        tenant_slug,
+        tenant_id,
+        user_id,
+        idempotency_key,
+        draft,
+    )
+    .await;
+    if result.is_ok() {
+        mark_lifecycle_succeeded(&slot);
+    }
+    result
+}
+
+pub(crate) async fn update_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    id: String,
+    draft: ProductDraft,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let operation = ProductAdminLifecycleOperation::UpdateProduct;
+    let slot = lifecycle_slot(operation, &tenant_id, &user_id, Some(&id));
+    let intent = draft_intent(operation, &tenant_id, &user_id, Some(&id), &draft);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result = crate::product_lifecycle_graphql::update_product(
+        token,
+        tenant_slug,
+        tenant_id,
+        user_id,
+        id,
+        idempotency_key,
+        draft,
+    )
+    .await;
+    if result.is_ok() {
+        mark_lifecycle_succeeded(&slot);
+    }
+    result
+}
+
+pub(crate) async fn change_product_status(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    id: String,
+    status: &str,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let operation = ProductAdminLifecycleOperation::ChangeStatus;
+    let slot = lifecycle_slot(operation, &tenant_id, &user_id, Some(&id));
+    let intent = status_intent(&tenant_id, &user_id, &id, status);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result = crate::product_lifecycle_graphql::change_product_status(
+        token,
+        tenant_slug,
+        tenant_id,
+        user_id,
+        id,
+        status,
+        idempotency_key,
+    )
+    .await;
+    if result.is_ok() {
+        mark_lifecycle_succeeded(&slot);
+    }
+    result
+}
+
+pub(crate) async fn delete_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    id: String,
+) -> Result<bool, GraphqlHttpError> {
+    let operation = ProductAdminLifecycleOperation::DeleteProduct;
+    let slot = lifecycle_slot(operation, &tenant_id, &user_id, Some(&id));
+    let intent = delete_intent(&tenant_id, &user_id, &id);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result = crate::product_lifecycle_graphql::delete_product(
+        token,
+        tenant_slug,
+        tenant_id,
+        user_id,
+        id,
+        idempotency_key,
+    )
+    .await;
+    if result.is_ok() {
+        mark_lifecycle_succeeded(&slot);
+    }
+    result
+}

--- a/crates/rustok-product/admin/src/lib.rs
+++ b/crates/rustok-product/admin/src/lib.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::too_many_arguments)]
 mod catalog_controls;
 #[path = "catalog_transport.rs"]
+mod legacy_transport;
+#[path = "catalog_transport_retry.rs"]
 mod transport;
 mod core;
 mod i18n;
 mod lifecycle_retry_identity;
 mod model;
+#[path = "transport/product_lifecycle_graphql.rs"]
+mod product_lifecycle_graphql;
 mod ui;
 
 pub use model::{ProductCatalogSearchOption, ProductCatalogSearchOptions};

--- a/crates/rustok-product/admin/src/transport/product_lifecycle_graphql.rs
+++ b/crates/rustok-product/admin/src/transport/product_lifecycle_graphql.rs
@@ -1,0 +1,505 @@
+#![allow(dead_code)]
+
+#[cfg(target_arch = "wasm32")]
+use leptos::web_sys;
+use rustok_graphql::{GraphqlHttpError, GraphqlRequest, execute as execute_graphql};
+use rustok_ui_core::normalize_ui_text as optional_text;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::model::{ProductDetail, ProductDraft};
+
+const PRODUCT_ADMIN_GRAPHQL_OWNER: &str = "rustok_product.admin";
+const PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY: &str =
+    "product_admin_primary_graphql_mutations";
+const PRODUCT_ADMIN_HTTP_PUBLIC_MESSAGE: &str =
+    "Product admin service is temporarily unavailable";
+const PRODUCT_ADMIN_GRAPHQL_PUBLIC_MESSAGE: &str =
+    "Product admin request could not be completed";
+
+const CREATE_PRODUCT_MUTATION: &str = "mutation ProductAdminCreateProduct($idempotencyKey: String!, $input: CreateProductInput!) { createProduct(idempotencyKey: $idempotencyKey, input: $input) { id status sellerId vendor productType shippingProfileSlug primaryCategoryId tags createdAt updatedAt publishedAt translations { locale title handle description metaTitle metaDescription } variants { id sku barcode shippingProfileSlug title option1 option2 option3 inventoryQuantity inventoryPolicy inStock prices { currencyCode amount compareAtAmount onSale } } options { id name values position } } }";
+const UPDATE_PRODUCT_MUTATION: &str = "mutation ProductAdminUpdateProduct($idempotencyKey: String!, $id: UUID!, $input: UpdateProductInput!) { updateProduct(idempotencyKey: $idempotencyKey, id: $id, input: $input) { id status sellerId vendor productType shippingProfileSlug primaryCategoryId tags createdAt updatedAt publishedAt translations { locale title handle description metaTitle metaDescription } variants { id sku barcode shippingProfileSlug title option1 option2 option3 inventoryQuantity inventoryPolicy inStock prices { currencyCode amount compareAtAmount onSale } } options { id name values position } } }";
+const DELETE_PRODUCT_MUTATION: &str = "mutation ProductAdminDeleteProduct($idempotencyKey: String!, $id: UUID!) { deleteProduct(idempotencyKey: $idempotencyKey, id: $id) }";
+
+#[derive(Debug, Deserialize)]
+struct CreateProductResponse {
+    #[serde(rename = "createProduct")]
+    create_product: ProductDetail,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateProductResponse {
+    #[serde(rename = "updateProduct")]
+    update_product: ProductDetail,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeleteProductResponse {
+    #[serde(rename = "deleteProduct")]
+    delete_product: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateProductVariables {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    input: CreateProductInput,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateProductVariables {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    id: String,
+    input: UpdateProductInput,
+}
+
+#[derive(Debug, Serialize)]
+struct DeleteProductVariables {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateProductInput {
+    translations: Vec<ProductTranslationInput>,
+    options: Vec<ProductOptionInput>,
+    variants: Vec<CreateVariantInput>,
+    #[serde(rename = "sellerId")]
+    seller_id: Option<String>,
+    vendor: Option<String>,
+    #[serde(rename = "productType")]
+    product_type: Option<String>,
+    #[serde(rename = "shippingProfileSlug")]
+    shipping_profile_slug: Option<String>,
+    #[serde(rename = "primaryCategoryId")]
+    primary_category_id: Option<String>,
+    publish: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateProductInput {
+    translations: Option<Vec<ProductTranslationInput>>,
+    #[serde(rename = "sellerId")]
+    seller_id: Option<String>,
+    vendor: Option<String>,
+    #[serde(rename = "productType")]
+    product_type: Option<String>,
+    #[serde(rename = "shippingProfileSlug")]
+    shipping_profile_slug: Option<String>,
+    #[serde(rename = "primaryCategoryId")]
+    primary_category_id: Option<String>,
+    status: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProductTranslationInput {
+    locale: String,
+    title: String,
+    handle: Option<String>,
+    description: Option<String>,
+    #[serde(rename = "metaTitle")]
+    meta_title: Option<String>,
+    #[serde(rename = "metaDescription")]
+    meta_description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProductOptionInput {
+    translations: Vec<ProductOptionTranslationInput>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProductOptionTranslationInput {
+    locale: String,
+    name: String,
+    values: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateVariantInput {
+    sku: Option<String>,
+    barcode: Option<String>,
+    #[serde(rename = "shippingProfileSlug")]
+    shipping_profile_slug: Option<String>,
+    option1: Option<String>,
+    option2: Option<String>,
+    option3: Option<String>,
+    prices: Vec<PriceInput>,
+    #[serde(rename = "inventoryQuantity")]
+    inventory_quantity: Option<i32>,
+    #[serde(rename = "inventoryPolicy")]
+    inventory_policy: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PriceInput {
+    #[serde(rename = "currencyCode")]
+    currency_code: String,
+    amount: String,
+    #[serde(rename = "compareAtAmount")]
+    compare_at_amount: Option<String>,
+}
+
+struct MutationErrorContext {
+    operation: &'static str,
+    correlation_id: String,
+    token_present: bool,
+    tenant_slug_length: Option<usize>,
+    tenant_id_length: usize,
+    actor_id_length: usize,
+    resource_id_length: Option<usize>,
+    status_length: Option<usize>,
+    draft_present: bool,
+}
+
+impl MutationErrorContext {
+    fn new(
+        operation: &'static str,
+        token: Option<&str>,
+        tenant_slug: Option<&str>,
+        tenant_id: &str,
+        actor_id: &str,
+    ) -> Self {
+        Self {
+            operation,
+            correlation_id: format!("product-admin-mutation:{operation}:{}", Uuid::new_v4()),
+            token_present: token.is_some(),
+            tenant_slug_length: tenant_slug.map(str::chars).map(Iterator::count),
+            tenant_id_length: tenant_id.chars().count(),
+            actor_id_length: actor_id.chars().count(),
+            resource_id_length: None,
+            status_length: None,
+            draft_present: false,
+        }
+    }
+
+    fn with_resource(mut self, resource_id: &str) -> Self {
+        self.resource_id_length = Some(resource_id.chars().count());
+        self
+    }
+
+    fn with_status(mut self, status: &str) -> Self {
+        self.status_length = Some(status.chars().count());
+        self
+    }
+
+    fn with_draft(mut self) -> Self {
+        self.draft_present = true;
+        self
+    }
+
+    fn map_error(&self, error: GraphqlHttpError) -> GraphqlHttpError {
+        let (error_kind, code, public_error, technical_failure) = match &error {
+            GraphqlHttpError::Network => (
+                "network",
+                "product.admin_graphql_network_unavailable",
+                GraphqlHttpError::Network,
+                true,
+            ),
+            GraphqlHttpError::Http(_) => (
+                "http",
+                "product.admin_graphql_http_unavailable",
+                GraphqlHttpError::Http(PRODUCT_ADMIN_HTTP_PUBLIC_MESSAGE.to_string()),
+                true,
+            ),
+            GraphqlHttpError::Unauthorized => (
+                "unauthorized",
+                "product.admin_graphql_authentication_required",
+                GraphqlHttpError::Unauthorized,
+                false,
+            ),
+            GraphqlHttpError::Graphql(_) => (
+                "graphql",
+                "product.admin_graphql_request_rejected",
+                GraphqlHttpError::Graphql(PRODUCT_ADMIN_GRAPHQL_PUBLIC_MESSAGE.to_string()),
+                false,
+            ),
+        };
+        let error_payload_length = match &error {
+            GraphqlHttpError::Http(value) | GraphqlHttpError::Graphql(value) => {
+                Some(value.chars().count())
+            }
+            GraphqlHttpError::Network | GraphqlHttpError::Unauthorized => None,
+        };
+        let error_payload_present = error_payload_length.is_some_and(|length| length > 0);
+
+        if technical_failure {
+            tracing::error!(
+                error_payload_present,
+                error_payload_length = ?error_payload_length,
+                owner = PRODUCT_ADMIN_GRAPHQL_OWNER,
+                owner_operation = self.operation,
+                correlation_id = %self.correlation_id,
+                token_present = self.token_present,
+                tenant_slug_present = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                tenant_id_length = self.tenant_id_length,
+                actor_id_length = self.actor_id_length,
+                resource_id_present = self.resource_id_length.is_some(),
+                resource_id_length = ?self.resource_id_length,
+                status_present = self.status_length.is_some(),
+                status_length = ?self.status_length,
+                draft_present = self.draft_present,
+                error_kind,
+                code,
+                boundary = PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY,
+                "product admin GraphQL lifecycle mutation failed"
+            );
+        } else {
+            tracing::warn!(
+                error_payload_present,
+                error_payload_length = ?error_payload_length,
+                owner = PRODUCT_ADMIN_GRAPHQL_OWNER,
+                owner_operation = self.operation,
+                correlation_id = %self.correlation_id,
+                token_present = self.token_present,
+                tenant_slug_present = self.tenant_slug_length.is_some(),
+                tenant_slug_length = ?self.tenant_slug_length,
+                tenant_id_length = self.tenant_id_length,
+                actor_id_length = self.actor_id_length,
+                resource_id_present = self.resource_id_length.is_some(),
+                resource_id_length = ?self.resource_id_length,
+                status_present = self.status_length.is_some(),
+                status_length = ?self.status_length,
+                draft_present = self.draft_present,
+                error_kind,
+                code,
+                boundary = PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY,
+                "product admin GraphQL lifecycle mutation was rejected"
+            );
+        }
+
+        public_error
+    }
+}
+
+fn graphql_url() -> String {
+    if let Some(url) = option_env!("RUSTOK_GRAPHQL_URL") {
+        return url.to_string();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let origin = web_sys::window()
+            .and_then(|window| window.location().origin().ok())
+            .unwrap_or_else(|| "http://localhost:5150".to_string());
+        format!("{origin}/api/graphql")
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let base =
+            std::env::var("RUSTOK_API_URL").unwrap_or_else(|_| "http://localhost:5150".to_string());
+        format!("{base}/api/graphql")
+    }
+}
+
+async fn request<V, T>(
+    query: &str,
+    variables: V,
+    token: Option<String>,
+    tenant_slug: Option<String>,
+) -> Result<T, GraphqlHttpError>
+where
+    V: Serialize,
+    T: for<'de> Deserialize<'de>,
+{
+    execute_graphql(
+        &graphql_url(),
+        GraphqlRequest::new(query, Some(variables)),
+        token,
+        tenant_slug,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn create_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    actor_id: String,
+    idempotency_key: String,
+    draft: ProductDraft,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let context = MutationErrorContext::new(
+        "create_product",
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        &tenant_id,
+        &actor_id,
+    )
+    .with_draft();
+    let response: CreateProductResponse = request(
+        CREATE_PRODUCT_MUTATION,
+        CreateProductVariables {
+            idempotency_key,
+            input: build_create_product_input(draft),
+        },
+        token,
+        tenant_slug,
+    )
+    .await
+    .map_err(|error| context.map_error(error))?;
+    Ok(response.create_product)
+}
+
+pub(crate) async fn update_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    actor_id: String,
+    id: String,
+    idempotency_key: String,
+    draft: ProductDraft,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let context = MutationErrorContext::new(
+        "update_product",
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        &tenant_id,
+        &actor_id,
+    )
+    .with_resource(&id)
+    .with_draft();
+    let response: UpdateProductResponse = request(
+        UPDATE_PRODUCT_MUTATION,
+        UpdateProductVariables {
+            idempotency_key,
+            id,
+            input: UpdateProductInput {
+                translations: Some(vec![build_translation_input(&draft)]),
+                seller_id: optional_text(draft.seller_id.as_str()),
+                vendor: optional_text(draft.vendor.as_str()),
+                product_type: optional_text(draft.product_type.as_str()),
+                shipping_profile_slug: draft.shipping_profile_slug.clone(),
+                primary_category_id: draft.primary_category_id.clone(),
+                status: None,
+            },
+        },
+        token,
+        tenant_slug,
+    )
+    .await
+    .map_err(|error| context.map_error(error))?;
+    Ok(response.update_product)
+}
+
+pub(crate) async fn change_product_status(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    actor_id: String,
+    id: String,
+    status: &str,
+    idempotency_key: String,
+) -> Result<ProductDetail, GraphqlHttpError> {
+    let context = MutationErrorContext::new(
+        "change_product_status",
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        &tenant_id,
+        &actor_id,
+    )
+    .with_resource(&id)
+    .with_status(status);
+    let response: UpdateProductResponse = request(
+        UPDATE_PRODUCT_MUTATION,
+        UpdateProductVariables {
+            idempotency_key,
+            id,
+            input: UpdateProductInput {
+                translations: None,
+                seller_id: None,
+                vendor: None,
+                product_type: None,
+                shipping_profile_slug: None,
+                primary_category_id: None,
+                status: Some(status.to_string()),
+            },
+        },
+        token,
+        tenant_slug,
+    )
+    .await
+    .map_err(|error| context.map_error(error))?;
+    Ok(response.update_product)
+}
+
+pub(crate) async fn delete_product(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    actor_id: String,
+    id: String,
+    idempotency_key: String,
+) -> Result<bool, GraphqlHttpError> {
+    let context = MutationErrorContext::new(
+        "delete_product",
+        token.as_deref(),
+        tenant_slug.as_deref(),
+        &tenant_id,
+        &actor_id,
+    )
+    .with_resource(&id);
+    let response: DeleteProductResponse = request(
+        DELETE_PRODUCT_MUTATION,
+        DeleteProductVariables {
+            idempotency_key,
+            id,
+        },
+        token,
+        tenant_slug,
+    )
+    .await
+    .map_err(|error| context.map_error(error))?;
+    Ok(response.delete_product)
+}
+
+fn build_create_product_input(draft: ProductDraft) -> CreateProductInput {
+    CreateProductInput {
+        translations: vec![build_translation_input(&draft)],
+        options: Vec::new(),
+        variants: vec![CreateVariantInput {
+            sku: optional_text(draft.sku.as_str()),
+            barcode: optional_text(draft.barcode.as_str()),
+            shipping_profile_slug: None,
+            option1: None,
+            option2: None,
+            option3: None,
+            prices: vec![PriceInput {
+                currency_code: if draft.currency_code.trim().is_empty() {
+                    "USD".to_string()
+                } else {
+                    draft.currency_code.trim().to_uppercase()
+                },
+                amount: if draft.amount.trim().is_empty() {
+                    "0.00".to_string()
+                } else {
+                    draft.amount.trim().to_string()
+                },
+                compare_at_amount: optional_text(draft.compare_at_amount.as_str()),
+            }],
+            inventory_quantity: Some(draft.inventory_quantity),
+            inventory_policy: Some("deny".to_string()),
+        }],
+        seller_id: optional_text(draft.seller_id.as_str()),
+        vendor: optional_text(draft.vendor.as_str()),
+        product_type: optional_text(draft.product_type.as_str()),
+        shipping_profile_slug: draft.shipping_profile_slug,
+        primary_category_id: draft.primary_category_id,
+        publish: Some(draft.publish_now),
+    }
+}
+
+fn build_translation_input(draft: &ProductDraft) -> ProductTranslationInput {
+    ProductTranslationInput {
+        locale: draft.locale.clone(),
+        title: draft.title.trim().to_string(),
+        handle: optional_text(draft.handle.as_str()),
+        description: optional_text(draft.description.as_str()),
+        meta_title: None,
+        meta_description: None,
+    }
+}

--- a/scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs
+++ b/scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const lib = read("crates/rustok-product/admin/src/lib.rs");
+const facade = read("crates/rustok-product/admin/src/catalog_transport_retry.rs");
+const adapter = read("crates/rustok-product/admin/src/transport/product_lifecycle_graphql.rs");
+const identity = read("crates/rustok-product/admin/src/lifecycle_retry_identity.rs");
+const commerce = read("crates/rustok-commerce/src/graphql/mutations/catalog.rs");
+const failures = [];
+
+function requireText(source, text, label) {
+  if (!source.includes(text)) failures.push(`${label}: missing ${text}`);
+}
+
+function forbidText(source, text, label) {
+  if (source.includes(text)) failures.push(`${label}: forbidden ${text}`);
+}
+
+for (const required of [
+  '#[path = "catalog_transport.rs"]\nmod legacy_transport;',
+  '#[path = "catalog_transport_retry.rs"]\nmod transport;',
+  '#[path = "transport/product_lifecycle_graphql.rs"]\nmod product_lifecycle_graphql;',
+]) {
+  requireText(lib, required, "Product Admin active transport wiring");
+}
+
+for (const required of [
+  "ProductAdminLifecycleRetryIdentity",
+  "ProductAdminLifecycleOperation::CreateProduct",
+  "ProductAdminLifecycleOperation::UpdateProduct",
+  "ProductAdminLifecycleOperation::ChangeStatus",
+  "ProductAdminLifecycleOperation::DeleteProduct",
+  "OnceLock<Mutex<HashMap<String, RetryIdentity>>>",
+  ".idempotency_key_for(operation, &intent)",
+  "if result.is_ok()",
+  "mark_lifecycle_succeeded(&slot);",
+  "crate::product_lifecycle_graphql::create_product(",
+  "crate::product_lifecycle_graphql::update_product(",
+  "crate::product_lifecycle_graphql::change_product_status(",
+  "crate::product_lifecycle_graphql::delete_product(",
+]) {
+  requireText(facade, required, "Product Admin lifecycle retry consumer facade");
+}
+
+requireText(identity, "pub(crate) fn mark_succeeded(&mut self)", "published retry identity contract");
+requireText(identity, "pending.operation == operation", "published retry identity operation match");
+requireText(identity, "&pending.intent == intent", "published retry identity exact-intent match");
+
+for (const required of [
+  "$idempotencyKey: String!",
+  "createProduct(idempotencyKey: $idempotencyKey, input: $input)",
+  "updateProduct(idempotencyKey: $idempotencyKey, id: $id, input: $input)",
+  "deleteProduct(idempotencyKey: $idempotencyKey, id: $id)",
+  '#[serde(rename = "idempotencyKey")]\n    idempotency_key: String',
+  "PRODUCT_ADMIN_MUTATION_GRAPHQL_BOUNDARY",
+  "PRODUCT_ADMIN_HTTP_PUBLIC_MESSAGE",
+  "PRODUCT_ADMIN_GRAPHQL_PUBLIC_MESSAGE",
+]) {
+  requireText(adapter, required, "Product Admin retry-aware lifecycle GraphQL adapter");
+}
+
+forbidText(adapter, "compatibility-", "Product Admin explicit retry caller");
+forbidText(adapter, "Option<String>\n    idempotency_key", "Product Admin explicit retry caller");
+
+// This consumer slice deliberately stops before the server schema contract becomes required.
+// Keeping the next debt visible prevents source inspection from over-claiming completion.
+requireText(
+  commerce,
+  "idempotency_key: Option<String>",
+  "mounted GraphQL mandatory-idempotency follow-up remains explicit",
+);
+requireText(
+  commerce,
+  "using one-request compatibility identity",
+  "mounted GraphQL compatibility path remains explicit",
+);
+
+if (failures.length) {
+  console.error("Product Admin lifecycle retry consumer source verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("✔ Product Admin lifecycle callers retain explicit GraphQL retry identity; mandatory server schema remains follow-up debt");


### PR DESCRIPTION
## Summary

- activate a retry-aware Product Admin transport facade while keeping existing UI call signatures unchanged
- retain caller idempotency identity for create, update, status-change, and delete by operation + exact logical intent
- reuse the same caller key after a failed lifecycle request, rotate when intent changes, and release only after lifecycle success
- keep retry state scoped by tenant, actor, operation, and Product identity so independent Product commands do not overwrite each other
- add a dedicated lifecycle GraphQL adapter that sends `idempotencyKey` as a non-null `String!` variable for Product create/update/delete; status changes continue to use the existing `updateProduct` shape with the same explicit key contract
- preserve the existing Product Admin lifecycle payload projection and public GraphQL transport error-safety behavior
- keep reads and Product schema writes on the existing catalog transport; this slice does not touch remaining schema-write owner-boundary debt
- add a source guard that proves active retry-aware wiring and explicitly requires the mounted Commerce GraphQL `Option<String>` compatibility path to remain visible as the next follow-up

## Retry semantics

The pending identity survives failed lifecycle requests. A changed payload/status target rotates the identity. A successful lifecycle response releases it so a later identical user command receives a new identity. The existing create flow is safe with the separate attribute-value write: after create succeeds, Product Admin immediately moves the returned Product into editing state, so a later form retry is an update rather than a second create.

## Remaining Product debt

- make mounted GraphQL Product lifecycle `idempotencyKey` mandatory and remove the one-request compatibility identity now that Product Admin sends an explicit key
- cut remaining Product schema writes from direct `ProductCatalogSchemaService` construction to typed Product owner write capabilities
- execute the plan-listed static/compile/parity/runtime evidence before any FBA/FFA promotion

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction.