### PR TITLE
feat(index): expose guarded replay GraphQL commands

### DIFF
--- a/apps/server/docs/index-replay-graphql-transport.md
+++ b/apps/server/docs/index-replay-graphql-transport.md
@@ -1,0 +1,70 @@
+# Index replay GraphQL transport
+
+Status: `source_complete_owner_execution_pending`.
+
+## Boundary
+
+The server now exposes two bounded GraphQL mutations over the existing guarded `IndexReplayOperatorRuntime`:
+
+- `runIndexReplay(input: ...)` runs one bounded schema-wide replay chunk;
+- `cancelIndexReplay(input: ...)` requests cancellation of one replay job in the authenticated tenant.
+
+This is a command transport only. It does not add automatic replay scheduling, background worker ownership, a
+new replay algorithm, locale/partition checkpoint dimensions, or a traffic cutover.
+
+## Authority before input parsing
+
+Tenant and actor identities are never accepted from GraphQL input. The transport derives both from
+`TenantContext` / `AuthContext`, requires the request-bound effective permission snapshot, and requires
+`modules:manage` before parsing untrusted schema identifiers, schema version, or job UUID.
+
+The server-owned `IndexReplayOperatorRuntime` performs the same authorization again before delegating to the
+canonical shared replay runtime. A cross-tenant job UUID is therefore only looked up in the authenticated
+tenant and cannot widen authority.
+
+## Server-owned replay budget
+
+`IndexReplayRunInput` contains only:
+
+- module name;
+- entity name;
+- positive schema routing key.
+
+It does not accept tenant, actor, worker identity, page limit, page count, heartbeat cadence, lease duration,
+locale, partition, source name, database handle, or scheduler controls.
+
+Each GraphQL invocation constructs a fresh server-owned worker identity and uses one fixed bounded chunk:
+
+- page limit: `100` mutations;
+- maximum pages: `8`;
+- heartbeat cadence: every page;
+- lease duration: `60` seconds.
+
+Those transport caps are intentionally narrower than the generic replay runner bounds. A yielded job remains
+resumable by a later authorized invocation through the existing durable job/checkpoint contract.
+
+## Result surface
+
+The run payload exposes only bounded operational counters plus status and job UUID. It does not expose source
+payloads, SQL, database errors, request authority, lease owner identity, or raw dependency causes.
+
+The cancellation payload exposes only the normalized outcome: requested, cancelled, already terminal, or not
+found. Operational runner failures are mapped to a generic GraphQL error; an unknown source-owned schema is
+reported as bad user input.
+
+## Evidence state
+
+Source guards retain:
+
+- authorization-before-parsing ordering;
+- absence of caller authority/worker/resource-budget fields;
+- fixed server-owned bounds;
+- delegation only through `IndexReplayOperatorRuntime`;
+- merged GraphQL schema registration;
+- no direct database/source/scheduler access from the transport.
+
+GraphQL execution, database replay execution, cancellation races, CI, and retained runtime evidence remain
+maintainer-owned and are not claimed by this source slice.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_replay.rs
+++ b/apps/server/src/graphql/index_replay.rs
@@ -1,0 +1,480 @@
+use std::{sync::Arc, time::Duration};
+
+use async_graphql::{
+    Context, Enum, ErrorExtensions, FieldError, InputObject, Object, Result as GraphqlResult,
+    SimpleObject,
+};
+use rustok_api::graphql::GraphQLError;
+use rustok_api::{Permission, has_effective_permission};
+use rustok_core::ModuleRuntimeExtensions;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::context::{AuthContext, TenantContext};
+use crate::services::index_replay_runtime_composition::{
+    IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
+};
+use crate::services::rbac_request_scope::permissions_for;
+
+const MAX_SCHEMA_IDENTIFIER_BYTES: usize = 128;
+const MAX_SCHEMA_VERSION_BYTES: usize = 10;
+const GRAPHQL_REPLAY_PAGE_LIMIT: usize = 100;
+const GRAPHQL_REPLAY_MAX_PAGES: usize = 8;
+const GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES: usize = 1;
+const GRAPHQL_REPLAY_LEASE_SECONDS: u64 = 60;
+
+/// Untrusted GraphQL input for one bounded schema-wide replay run.
+///
+/// Tenant, actor, worker identity and replay resource budgets are server-owned and never caller supplied.
+#[derive(Debug, Clone, InputObject)]
+pub struct IndexReplayRunInput {
+    pub module_name: String,
+    pub entity_name: String,
+    pub schema_version: String,
+}
+
+#[derive(Debug, Clone, InputObject)]
+pub struct IndexReplayCancelInput {
+    pub job_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+#[graphql(rename_items = "SCREAMING_SNAKE_CASE")]
+pub enum IndexReplayGraphqlRunStatus {
+    Busy,
+    AlreadyComplete,
+    Complete,
+    Cancelled,
+    Yielded,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct IndexReplayRunPayload {
+    pub status: IndexReplayGraphqlRunStatus,
+    pub job_id: Option<Uuid>,
+    pub pages_processed: i32,
+    pub mutations_processed: i32,
+    pub applied_count: i32,
+    pub duplicate_count: i32,
+    pub stale_count: i32,
+}
+
+impl TryFrom<rustok_index::IndexReplayRunOutcome> for IndexReplayRunPayload {
+    type Error = FieldError;
+
+    fn try_from(outcome: rustok_index::IndexReplayRunOutcome) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: match outcome.status() {
+                rustok_index::IndexReplayRunStatus::Busy => IndexReplayGraphqlRunStatus::Busy,
+                rustok_index::IndexReplayRunStatus::AlreadyComplete => {
+                    IndexReplayGraphqlRunStatus::AlreadyComplete
+                }
+                rustok_index::IndexReplayRunStatus::Complete => IndexReplayGraphqlRunStatus::Complete,
+                rustok_index::IndexReplayRunStatus::Cancelled => {
+                    IndexReplayGraphqlRunStatus::Cancelled
+                }
+                rustok_index::IndexReplayRunStatus::Yielded => IndexReplayGraphqlRunStatus::Yielded,
+            },
+            job_id: outcome.job_id(),
+            pages_processed: bounded_count(outcome.pages_processed())?,
+            mutations_processed: bounded_count(outcome.mutation_count())?,
+            applied_count: bounded_count(outcome.applied_count())?,
+            duplicate_count: bounded_count(outcome.duplicate_count())?,
+            stale_count: bounded_count(outcome.stale_count())?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+#[graphql(rename_items = "SCREAMING_SNAKE_CASE")]
+pub enum IndexReplayGraphqlCancelStatus {
+    Requested,
+    Cancelled,
+    AlreadySucceeded,
+    AlreadyFailed,
+    AlreadyCancelled,
+    NotFound,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct IndexReplayCancelPayload {
+    pub status: IndexReplayGraphqlCancelStatus,
+}
+
+impl From<rustok_index::IndexReplayCancelOutcome> for IndexReplayCancelPayload {
+    fn from(outcome: rustok_index::IndexReplayCancelOutcome) -> Self {
+        Self {
+            status: match outcome {
+                rustok_index::IndexReplayCancelOutcome::Requested => {
+                    IndexReplayGraphqlCancelStatus::Requested
+                }
+                rustok_index::IndexReplayCancelOutcome::Cancelled => {
+                    IndexReplayGraphqlCancelStatus::Cancelled
+                }
+                rustok_index::IndexReplayCancelOutcome::AlreadyTerminal(
+                    rustok_index::IndexReplayTerminalState::Succeeded,
+                ) => IndexReplayGraphqlCancelStatus::AlreadySucceeded,
+                rustok_index::IndexReplayCancelOutcome::AlreadyTerminal(
+                    rustok_index::IndexReplayTerminalState::Failed,
+                ) => IndexReplayGraphqlCancelStatus::AlreadyFailed,
+                rustok_index::IndexReplayCancelOutcome::AlreadyTerminal(
+                    rustok_index::IndexReplayTerminalState::Cancelled,
+                ) => IndexReplayGraphqlCancelStatus::AlreadyCancelled,
+                rustok_index::IndexReplayCancelOutcome::NotFound => {
+                    IndexReplayGraphqlCancelStatus::NotFound
+                }
+            },
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+enum IndexReplayTransportPreparationError {
+    #[error("Index replay request context is invalid")]
+    InvalidContext,
+    #[error("Index replay requires a request-bound effective permission snapshot")]
+    MissingRequestAuthority,
+    #[error("modules:manage is required for Index replay operations")]
+    Forbidden,
+    #[error("Index replay input field is invalid: {field}")]
+    InvalidInput { field: &'static str },
+}
+
+#[derive(Default)]
+pub struct IndexReplayMutation;
+
+#[Object]
+impl IndexReplayMutation {
+    /// Run one server-bounded chunk of the exact schema-wide replay job.
+    async fn run_index_replay(
+        &self,
+        ctx: &Context<'_>,
+        input: IndexReplayRunInput,
+    ) -> GraphqlResult<IndexReplayRunPayload> {
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+        let tenant = ctx.data::<TenantContext>()?;
+
+        let (operator_context, request) =
+            prepare_authorized_run(tenant.id, auth.user_id, input).map_err(map_preparation_error)?;
+        let runtime = replay_runtime(ctx)?;
+        runtime
+            .run(operator_context, request)
+            .await
+            .map_err(map_operator_error)?
+            .try_into()
+    }
+
+    /// Request cancellation of one replay job in the authenticated tenant.
+    async fn cancel_index_replay(
+        &self,
+        ctx: &Context<'_>,
+        input: IndexReplayCancelInput,
+    ) -> GraphqlResult<IndexReplayCancelPayload> {
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+        let tenant = ctx.data::<TenantContext>()?;
+
+        let (operator_context, job_id) =
+            prepare_authorized_cancel(tenant.id, auth.user_id, input)
+                .map_err(map_preparation_error)?;
+        let runtime = replay_runtime(ctx)?;
+        runtime
+            .request_cancel(operator_context, job_id)
+            .await
+            .map(IndexReplayCancelPayload::from)
+            .map_err(map_operator_error)
+    }
+}
+
+fn replay_runtime(ctx: &Context<'_>) -> GraphqlResult<IndexReplayOperatorRuntime> {
+    ctx.data::<Arc<ModuleRuntimeExtensions>>()?
+        .get::<IndexReplayOperatorRuntime>()
+        .cloned()
+        .ok_or_else(|| {
+            <FieldError as GraphQLError>::internal_error("Index replay runtime is not available")
+        })
+}
+
+fn prepare_authorized_run(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    input: IndexReplayRunInput,
+) -> std::result::Result<
+    (IndexReplayOperatorContext, rustok_index::IndexReplayRunRequest),
+    IndexReplayTransportPreparationError,
+> {
+    let context = authorize(tenant_id, actor_id)?;
+    let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;
+    let worker_id = format!("graphql-replay-{}", Uuid::new_v4().simple());
+    let request = rustok_index::IndexReplayRunRequest::new(
+        tenant_id,
+        schema,
+        worker_id,
+        GRAPHQL_REPLAY_PAGE_LIMIT,
+        GRAPHQL_REPLAY_MAX_PAGES,
+        GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES,
+        Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS),
+    )
+    .map_err(|_| IndexReplayTransportPreparationError::InvalidInput {
+        field: "schema_version",
+    })?;
+    Ok((context, request))
+}
+
+fn prepare_authorized_cancel(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    input: IndexReplayCancelInput,
+) -> std::result::Result<(IndexReplayOperatorContext, Uuid), IndexReplayTransportPreparationError> {
+    let context = authorize(tenant_id, actor_id)?;
+    let job_id = Uuid::parse_str(bounded_text("job_id", &input.job_id, 64)?)
+        .ok()
+        .filter(|value| !value.is_nil())
+        .ok_or(IndexReplayTransportPreparationError::InvalidInput { field: "job_id" })?;
+    Ok((context, job_id))
+}
+
+fn authorize(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+) -> std::result::Result<IndexReplayOperatorContext, IndexReplayTransportPreparationError> {
+    let context = IndexReplayOperatorContext::new(tenant_id, actor_id)
+        .map_err(|_| IndexReplayTransportPreparationError::InvalidContext)?;
+    let permissions = permissions_for(&tenant_id, &actor_id)
+        .ok_or(IndexReplayTransportPreparationError::MissingRequestAuthority)?;
+    if !has_effective_permission(&permissions, &Permission::MODULES_MANAGE) {
+        return Err(IndexReplayTransportPreparationError::Forbidden);
+    }
+    Ok(context)
+}
+
+fn parse_schema(
+    module_name: String,
+    entity_name: String,
+    schema_version: String,
+) -> std::result::Result<rustok_index::SchemaRef, IndexReplayTransportPreparationError> {
+    let module_name = bounded_text("module_name", &module_name, MAX_SCHEMA_IDENTIFIER_BYTES)?;
+    let entity_name = bounded_text("entity_name", &entity_name, MAX_SCHEMA_IDENTIFIER_BYTES)?;
+    let schema_version = bounded_text(
+        "schema_version",
+        &schema_version,
+        MAX_SCHEMA_VERSION_BYTES,
+    )?
+    .parse::<u32>()
+    .ok()
+    .filter(|value| *value > 0)
+    .ok_or(IndexReplayTransportPreparationError::InvalidInput {
+        field: "schema_version",
+    })?;
+
+    Ok(rustok_index::SchemaRef {
+        module: rustok_index::ModuleName::new(module_name).map_err(|_| {
+            IndexReplayTransportPreparationError::InvalidInput {
+                field: "module_name",
+            }
+        })?,
+        entity: rustok_index::EntityName::new(entity_name).map_err(|_| {
+            IndexReplayTransportPreparationError::InvalidInput {
+                field: "entity_name",
+            }
+        })?,
+        version: rustok_index::SchemaVersion::new(schema_version),
+    })
+}
+
+fn bounded_text<'a>(
+    field: &'static str,
+    value: &'a str,
+    max_bytes: usize,
+) -> std::result::Result<&'a str, IndexReplayTransportPreparationError> {
+    if value.is_empty() || value.len() > max_bytes {
+        return Err(IndexReplayTransportPreparationError::InvalidInput { field });
+    }
+    Ok(value)
+}
+
+fn bounded_count(value: usize) -> GraphqlResult<i32> {
+    i32::try_from(value)
+        .map_err(|_| <FieldError as GraphQLError>::internal_error("Index replay count overflow"))
+}
+
+fn map_preparation_error(error: IndexReplayTransportPreparationError) -> FieldError {
+    match error {
+        IndexReplayTransportPreparationError::InvalidContext
+        | IndexReplayTransportPreparationError::MissingRequestAuthority => {
+            <FieldError as GraphQLError>::unauthenticated()
+        }
+        IndexReplayTransportPreparationError::Forbidden => {
+            <FieldError as GraphQLError>::permission_denied(
+                "Permission denied: modules:manage required",
+            )
+        }
+        IndexReplayTransportPreparationError::InvalidInput { field } => {
+            FieldError::new("Invalid Index replay input").extend_with(|_, extensions| {
+                extensions.set("code", "BAD_USER_INPUT");
+                extensions.set("input_field", field);
+            })
+        }
+    }
+}
+
+fn map_operator_error(error: IndexReplayOperatorError) -> FieldError {
+    match error {
+        IndexReplayOperatorError::InvalidContext
+        | IndexReplayOperatorError::MissingRequestAuthority => {
+            <FieldError as GraphQLError>::unauthenticated()
+        }
+        IndexReplayOperatorError::TenantMismatch | IndexReplayOperatorError::Forbidden => {
+            <FieldError as GraphQLError>::permission_denied(
+                "Permission denied: modules:manage required",
+            )
+        }
+        IndexReplayOperatorError::Replay(rustok_index::IndexReplayRunError::UnknownSchemaSource(_)) => {
+            <FieldError as GraphQLError>::bad_user_input("Unknown Index replay schema")
+        }
+        IndexReplayOperatorError::Replay(_) => {
+            <FieldError as GraphQLError>::internal_error("Index replay command failed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustok_api::Permission;
+    use rustok_core::UserRole;
+    use uuid::Uuid;
+
+    use super::{
+        GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES, GRAPHQL_REPLAY_LEASE_SECONDS,
+        GRAPHQL_REPLAY_MAX_PAGES, GRAPHQL_REPLAY_PAGE_LIMIT, IndexReplayCancelInput,
+        IndexReplayRunInput, IndexReplayTransportPreparationError, prepare_authorized_cancel,
+        prepare_authorized_run,
+    };
+    use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+    fn malformed_run() -> IndexReplayRunInput {
+        IndexReplayRunInput {
+            module_name: "Rustok Product".to_owned(),
+            entity_name: "product".to_owned(),
+            schema_version: "zero".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_transport_authorizes_before_parsing_untrusted_run_input() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+
+        let missing = with_rbac_request_scope(None, async {
+            prepare_authorized_run(tenant_id, actor_id, malformed_run())
+        })
+        .await
+        .expect_err("missing authority must win over malformed input");
+        assert_eq!(
+            missing,
+            IndexReplayTransportPreparationError::MissingRequestAuthority
+        );
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async { prepare_authorized_run(tenant_id, actor_id, malformed_run()) },
+        )
+        .await
+        .expect_err("modules:read must fail before replay input parsing");
+        assert_eq!(forbidden, IndexReplayTransportPreparationError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn replay_transport_derives_authority_worker_and_server_owned_budgets() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let (_, request) = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                prepare_authorized_run(
+                    tenant_id,
+                    actor_id,
+                    IndexReplayRunInput {
+                        module_name: "rustok-product".to_owned(),
+                        entity_name: "product".to_owned(),
+                        schema_version: "4".to_owned(),
+                    },
+                )
+            },
+        )
+        .await
+        .expect("authorized replay request should parse");
+
+        assert_eq!(request.page_request().tenant_id(), tenant_id);
+        assert_eq!(request.page_request().schema().module.as_str(), "rustok-product");
+        assert_eq!(request.page_request().schema().entity.as_str(), "product");
+        assert_eq!(request.page_request().schema().version.get(), 4);
+        assert!(request.worker_id().starts_with("graphql-replay-"));
+        assert_eq!(request.page_request().limit(), GRAPHQL_REPLAY_PAGE_LIMIT);
+        assert_eq!(request.max_pages(), GRAPHQL_REPLAY_MAX_PAGES);
+        assert_eq!(
+            request.heartbeat_every_pages(),
+            GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES
+        );
+        assert_eq!(
+            request.lease_duration(),
+            std::time::Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS)
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_cancel_authorizes_before_job_id_parsing_and_derives_tenant() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let malformed = IndexReplayCancelInput {
+            job_id: "not-a-uuid".to_owned(),
+        };
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async { prepare_authorized_cancel(tenant_id, actor_id, malformed) },
+        )
+        .await
+        .expect_err("authorization must precede job id parsing");
+        assert_eq!(forbidden, IndexReplayTransportPreparationError::Forbidden);
+
+        let job_id = Uuid::new_v4();
+        let (_, parsed) = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                prepare_authorized_cancel(
+                    tenant_id,
+                    actor_id,
+                    IndexReplayCancelInput {
+                        job_id: job_id.to_string(),
+                    },
+                )
+            },
+        )
+        .await
+        .expect("authorized job id should parse");
+        assert_eq!(parsed, job_id);
+    }
+}

--- a/apps/server/src/graphql/mod.rs
+++ b/apps/server/src/graphql/mod.rs
@@ -4,6 +4,7 @@ pub mod dashboard_security;
 pub mod forum_principal_security;
 pub mod index_drift_diagnosis;
 pub mod index_drift_source_page_diagnosis;
+pub mod index_replay;
 pub mod legacy_disable_user;
 pub mod loaders;
 #[cfg(feature = "mod-moderation")]

--- a/apps/server/src/graphql/schema.rs
+++ b/apps/server/src/graphql/schema.rs
@@ -21,6 +21,7 @@ use super::dashboard_security::GraphqlDashboardSecurityPolicy;
 use super::forum_principal_security::ForumPrincipalPolicy;
 use super::index_drift_diagnosis::IndexDriftDiagnosisMutation;
 use super::index_drift_source_page_diagnosis::IndexDriftSourcePageDiagnosisMutation;
+use super::index_replay::IndexReplayMutation;
 use super::legacy_disable_user::LegacyDisableUserPolicy;
 use super::loaders::TenantNameLoader;
 #[cfg(feature = "mod-moderation")]
@@ -88,6 +89,7 @@ pub struct Mutation(
     RootMutation,
     IndexDriftDiagnosisMutation,
     IndexDriftSourcePageDiagnosisMutation,
+    IndexReplayMutation,
     #[cfg(feature = "mod-moderation")]
     ModerationRecoveryMutation,
     #[cfg(all(

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product key-4 promotion contract merge
-`d905c25a4d0ffd63682bf2aea9779ded190a255e` and continued on
-`agent/product-key4-promotion-postgres-evidence-20260808`.
+Status overlay rechecked after Product graph-source actualization merge
+`832f4946245ef6bc82b7eb50e202b47d0426a569` and continued on
+`agent/index-replay-graphql-transport-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -107,6 +107,24 @@ The lower-key contract is deliberately a test-only storage/probe fixture derived
 contract with a lower routing key. It does not reconstruct the historical key3 Product fingerprint and does not
 register a key3 Product source/factory. Runtime dual-read compatibility remains forbidden.
 
+## M6 replay command transport
+
+`IndexReplayOperatorRuntime` remains the only server-owned replay invocation authority. It requires exact
+request-bound tenant/actor context and effective `modules:manage`, rejects cross-tenant run requests and derives
+cancel tenant from that context.
+
+The GraphQL layer now exposes source-complete schema-wide `runIndexReplay` / `cancelIndexReplay` commands without
+calling `SharedIndexReplayRuntime`, source adapters or PostgreSQL directly. Authorization occurs before parsing
+untrusted schema/job input.
+
+Caller input contains no tenant, actor, worker ID, source name, locale/partition, scheduler handle or replay
+resource budget. Each run creates a server-owned worker identity and applies fixed transport caps: 100 mutations
+per page, at most 8 pages, heartbeat every page and a 60-second lease. Yielded work remains resumable through the
+existing durable job/checkpoint mechanism.
+
+This source slice does not establish GraphQL runtime execution evidence and does not solve graceful host shutdown
+inside an active replay page. Those remain separate boundaries.
+
 ## Remaining Storefront parity/evidence blockers
 
 - execute/admit the deterministic budgeted timeout packet and retain acceptable runtime latency/cancellation
@@ -134,8 +152,12 @@ register a key3 Product source/factory. Runtime dual-read compatibility remains 
 - [x] Bounded replay, durable jobs/leases/checkpoints and cancellation.
 - [x] Reconciliation, drift diagnosis and targeted repair source.
 - [x] Real-migration repair PostgreSQL harness and retained-evidence admission tooling.
+- [x] Guarded schema-wide replay run/cancel GraphQL command transport with server-owned bounded run policy.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
-- [ ] Complete remaining multi-host/restart/shutdown/command-transport evidence.
+- [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
+- [ ] Bind graceful host shutdown to in-page replay interruption safe points and retain restart/redelivery evidence.
+- [ ] Complete remaining multi-host/restart evidence beyond existing convergence/replay packets.
+- [ ] Add locale/partition replay checkpoint dimensions and explicit rebuild modes under separate contracts.
 
 ## M7 Product Storefront graph
 
@@ -167,11 +189,14 @@ register a key3 Product source/factory. Runtime dual-read compatibility remains 
 
 ## Next source-code boundary
 
-The Storefront request-shape, projection/hydration, timeout, promotion contract and focused promotion/restart
-packet are source-complete. Do not add a traffic-switch adapter from source inspection alone. The remaining
-blocking work is maintainer execution/admission plus any source fix revealed by those runs. Independent source
-cleanup may actualize stale documentation/guards, but it must not convert source-only evidence into a serving
-claim.
+M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
+The next independent M6 source slice is graceful replay shutdown: bind a host-owned stop probe to the existing
+`IndexReplayWorker::run_next_page_interruptible` safe points, yield the active job back to durable `pending`
+without marking it failed/cancelled, and retain restart evidence that stable deliveries become duplicates when a
+shutdown occurs after mutation durability but before checkpoint commit.
+
+Do not conflate that shutdown contract with user-requested cancellation. Locale/partition checkpoint scope and
+explicit rebuild modes remain later, separate contracts.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -8,7 +8,7 @@ This composition freezes the complete immutable Index source/schema registries a
 - bounded guarded replay runtime;
 - one module-work registration for due reconciliation execution.
 
-It does not add automatic replay-job scheduling or a command transport.
+It does not add automatic replay-job scheduling. The server now exposes one bounded authorized GraphQL run/cancel command transport over the guarded replay operator; that transport remains separate from runtime materialization and scheduler ownership.
 
 ## Composition order
 
@@ -18,17 +18,20 @@ It does not add automatic replay-job scheduling or a command transport.
 4. it publishes replay dry-run and calls `register_postgres_index_reconciliation_work`;
 5. only complete source/schema composition creates `ModuleWorkRegistrations` for Index;
 6. it publishes `SharedIndexReplayRuntime`;
-7. the server wraps replay and reconciliation capabilities in guarded operator runtimes.
+7. the server wraps replay and reconciliation capabilities in guarded operator runtimes;
+8. GraphQL exposes only the guarded replay operator through bounded schema-wide run/cancel commands.
 
 An absent source registry publishes no replay runtime, no dry-run runtime, and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed.
 
 The materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the shared `StopHandle` lifecycle.
 
-## Replay operator boundary
+## Replay operator and command boundary
 
 `IndexReplayOperatorRuntime` remains the only server-owned replay invocation boundary. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`. Run rejects cross-tenant requests before delegation; cancellation derives tenant only from the authorized context.
 
-Transport adapters must not call `SharedIndexReplayRuntime` directly.
+The GraphQL transport authorizes before parsing caller schema/job input and delegates only to this operator. Tenant, actor, worker identity, source name, database handles, scheduler controls, and replay resource budgets are not caller fields. The run mutation creates a server-owned worker identity and uses a fixed 100-row × 8-page chunk, per-page heartbeat, and 60-second lease.
+
+Transport adapters must not call `SharedIndexReplayRuntime` directly. See the server transport contract in `apps/server/docs/index-replay-graphql-transport.md`.
 
 ## Reconciliation scheduling boundary
 
@@ -38,11 +41,13 @@ It does not schedule replay/rebuild jobs, create a second task, own a database l
 
 ## Explicitly open
 
-- authorized replay GraphQL, HTTP, CLI, or admin command surfaces;
+- GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
 - automatic replay/rebuild job scheduling;
 - retained PostgreSQL replay and reconciliation scheduler execution evidence;
+- graceful host-shutdown binding to in-page replay interruption safe points;
 - operator-visible scheduler health and metrics;
 - in-page mutation/checkpoint timeout completion;
+- locale/partition replay checkpoint dimensions;
 - targeted/full/shadow repair and complete drift diagnosis.
 
 ## Validation ownership

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -30,6 +30,7 @@ const scripts = [
   'verify-index-replay-multipage-runner.mjs',
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
+  'verify-index-replay-graphql-transport.mjs',
   'verify-index-server-reconciliation-guard.mjs',
   'verify-index-drift-diagnosis-graphql-transport.mjs',
   'verify-index-drift-source-page-diagnosis.mjs',

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-graphql-transport] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const transportPath = 'apps/server/src/graphql/index_replay.rs';
+const transport = requireMarkers(transportPath, [
+  'pub struct IndexReplayRunInput',
+  'pub module_name: String',
+  'pub entity_name: String',
+  'pub schema_version: String',
+  'pub struct IndexReplayCancelInput',
+  'pub job_id: String',
+  'const GRAPHQL_REPLAY_PAGE_LIMIT: usize = 100;',
+  'const GRAPHQL_REPLAY_MAX_PAGES: usize = 8;',
+  'const GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES: usize = 1;',
+  'const GRAPHQL_REPLAY_LEASE_SECONDS: u64 = 60;',
+  'async fn run_index_replay(',
+  'async fn cancel_index_replay(',
+  'prepare_authorized_run(tenant.id, auth.user_id, input)',
+  'prepare_authorized_cancel(tenant.id, auth.user_id, input)',
+  'permissions_for(&tenant_id, &actor_id)',
+  'has_effective_permission(&permissions, &Permission::MODULES_MANAGE)',
+  'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
+  'let worker_id = format!("graphql-replay-{}", Uuid::new_v4().simple());',
+  '.get::<IndexReplayOperatorRuntime>()',
+  '.run(operator_context, request)',
+  '.request_cancel(operator_context, job_id)',
+  'replay_transport_authorizes_before_parsing_untrusted_run_input',
+  'replay_transport_derives_authority_worker_and_server_owned_budgets',
+  'replay_cancel_authorizes_before_job_id_parsing_and_derives_tenant',
+]);
+
+const authorizeStart = transport.indexOf('fn authorize(');
+const permissionCheck = transport.indexOf(
+  'let permissions = permissions_for(&tenant_id, &actor_id)',
+  authorizeStart,
+);
+const runPrepare = transport.indexOf('fn prepare_authorized_run(');
+const runAuthorize = transport.indexOf('let context = authorize(tenant_id, actor_id)?;', runPrepare);
+const runParse = transport.indexOf(
+  'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
+  runPrepare,
+);
+if (
+  authorizeStart < 0 ||
+  permissionCheck < authorizeStart ||
+  runPrepare < 0 ||
+  runAuthorize < runPrepare ||
+  runParse <= runAuthorize
+) {
+  fail('run transport must authorize before parsing untrusted schema input');
+}
+
+const cancelPrepare = transport.indexOf('fn prepare_authorized_cancel(');
+const cancelAuthorize = transport.indexOf('let context = authorize(tenant_id, actor_id)?;', cancelPrepare);
+const cancelParse = transport.indexOf('Uuid::parse_str(bounded_text("job_id"', cancelPrepare);
+if (cancelPrepare < 0 || cancelAuthorize < cancelPrepare || cancelParse <= cancelAuthorize) {
+  fail('cancel transport must authorize before parsing untrusted job id');
+}
+
+const runInputStart = transport.indexOf('pub struct IndexReplayRunInput');
+const runInputEnd = transport.indexOf('\n}', runInputStart);
+const runInput = transport.slice(runInputStart, runInputEnd);
+for (const forbidden of [
+  'tenant',
+  'actor',
+  'user_id',
+  'worker',
+  'page_limit',
+  'max_pages',
+  'heartbeat',
+  'lease',
+  'locale',
+  'partition',
+  'source_name',
+  'Uuid',
+]) {
+  if (runInput.includes(forbidden)) fail(`replay run input contains caller-owned field marker ${forbidden}`);
+}
+
+const production = transport.split('\n#[cfg(test)]')[0];
+for (const forbidden of [
+  'DatabaseConnection',
+  'sea_orm',
+  'tokio::spawn',
+  '.scan(',
+  'PostgresIndexReplayRunner',
+  'SharedIndexReplayRuntime',
+  'PostgresMutationStore',
+  'ModuleWorkScheduler',
+]) {
+  if (production.includes(forbidden)) {
+    fail(`${transportPath} bypasses the guarded replay operator: ${forbidden}`);
+  }
+}
+
+requireMarkers('apps/server/src/graphql/mod.rs', ['pub mod index_replay;']);
+requireMarkers('apps/server/src/graphql/schema.rs', [
+  'use super::index_replay::IndexReplayMutation;',
+  'IndexDriftSourcePageDiagnosisMutation,\n    IndexReplayMutation,',
+]);
+requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
+  'pub struct IndexReplayOperatorRuntime',
+  'pub async fn run(',
+  'pub async fn request_cancel(',
+  'Permission::MODULES_MANAGE',
+  'context.authorize_for(request.page_request().tenant_id())?;',
+]);
+requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
+  'Status: `source_complete_owner_execution_pending`.',
+  '`runIndexReplay(input: ...)`',
+  '`cancelIndexReplay(input: ...)`',
+  'Tenant and actor identities are never accepted',
+  'page limit: `100` mutations',
+  'maximum pages: `8`',
+  'lease duration: `60` seconds',
+  'delegation only through `IndexReplayOperatorRuntime`',
+  'maintainer-owned',
+]);
+
+console.log('[verify-index-replay-graphql-transport] guarded schema-wide run/cancel GraphQL commands use request authority and server-owned bounded replay policy');


### PR DESCRIPTION
## Summary

- expose bounded GraphQL `runIndexReplay` and `cancelIndexReplay` commands over the existing server-owned `IndexReplayOperatorRuntime`;
- derive tenant and actor only from authenticated request context and require the request-bound effective `modules:manage` permission before parsing caller schema/job input;
- keep `IndexReplayOperatorRuntime` as the only replay invocation authority; the GraphQL transport never touches `SharedIndexReplayRuntime`, PostgreSQL, source adapters, mutation storage, or scheduler handles directly;
- keep caller input schema-wide and authority-free: module/entity/schema key for run, job UUID for cancel; tenant, actor, source name, worker identity, locale/partition and replay resource budgets are not caller-controlled;
- generate a server-owned worker identity for each run invocation and apply fixed transport caps of 100 mutations/page, at most 8 pages, heartbeat every page, and a 60-second lease;
- normalize bounded run/cancel statuses and counters without exposing source payloads, SQL, raw dependency failures, lease owner identity, or database causes;
- mount the mutation in the merged server GraphQL schema;
- retain a static transport guard, aggregate it into the Index contract, and actualize M6 docs/current cursor.

## Boundary

This PR adds an authorized command transport only. It does not change replay runner/job/checkpoint semantics, add automatic replay scheduling/background ownership, bind graceful host shutdown to in-page interruption, add locale/partition replay scope, introduce explicit rebuild modes, or execute any replay evidence.

The next independent source boundary remains graceful host shutdown: bind a host stop signal to the existing in-page replay interruption safe points while keeping shutdown distinct from user-requested cancellation.

## Main recheck

The branch started from `main@832f4946245ef6bc82b7eb50e202b47d0426a569`. Current `main@4a16d9e1f8d7c197e4232199d8ade571deab99e5` advanced by four commits affecting only Cargo.lock, Forum audience facts, and Product Admin paths; they are disjoint from this GraphQL/Index diff.

## Validation

Static source review confirmed the current GraphQL error helpers, replay operator error variants, run/cancel status variants, and merged-schema wiring. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.