### PR TITLE
refactor(commerce): require Product GraphQL caller idempotency

### DIFF
--- a/crates/rustok-commerce/docs/product-graphql-idempotency-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-graphql-idempotency-recheck-2026-08-08.md
@@ -1,0 +1,35 @@
+# Product GraphQL lifecycle idempotency recheck — 2026-08-08
+
+## Scope
+
+This source-only continuation rechecks mounted Product lifecycle caller identity after Product Admin FFA PRs #3263 and #3269. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; this packet does not promote FBA/FFA or verification state.
+
+## Recheck result
+
+- Product Admin FFA now retains one lifecycle caller idempotency key across a failed explicit retry and sends it as a non-null `String!` GraphQL variable on the active create/update/status/delete transport.
+- Mounted Commerce GraphQL no longer manufactures a one-request `compatibility-*` identity when a lifecycle caller omits `idempotencyKey`.
+- `product_command_context` now rejects omission with public `BAD_USER_INPUT` / `Product mutation idempotency key is required` after existing module, permission, tenant-actor, and create/update shipping-profile admission has run.
+- Non-empty caller keys remain capped at 191 bytes and scope-hashed with tenant, authenticated actor, lifecycle operation, and Product id when one exists before they become `PortContext.idempotency_key` and correlation identity.
+- The lifecycle resolver arguments intentionally remain `Option<String>` in this slice. This preserves the current ordering of foreign-actor and shipping-profile regression fixtures while removing the unsafe compatibility execution path.
+
+## Why the canonical item remains open
+
+The ecommerce plan item that says Product Admin FFA must retain one key and mounted GraphQL `idempotencyKey` must become mandatory remains `[ ]` because the GraphQL SDL is still nullable. The remaining source step is narrow and explicit:
+
+1. update the foreign-actor and unknown-shipping-profile GraphQL fixtures to supply caller idempotency keys while preserving the admission assertions they actually test;
+2. change `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct` resolver arguments from `Option<String>` to `String`, producing non-null GraphQL arguments;
+3. update both Product lifecycle source guards to forbid nullable lifecycle idempotency arguments;
+4. only then mark the canonical FFA/server-idempotency item complete.
+
+The old Product Admin `transport/graphql_adapter.rs` lifecycle query strings remain unmounted compatibility source. The active Product Admin transport is `catalog_transport_retry.rs` plus `transport/product_lifecycle_graphql.rs`; cleanup of the superseded adapter should follow compile/source evidence rather than be mixed into this server hardening slice.
+
+## Remaining Product execution order
+
+1. Complete the non-null GraphQL SDL cutover and regression-fixture caller update described above.
+2. Cut remaining Product schema writes away from direct `ProductCatalogSchemaService` construction through typed Product owner write capabilities with explicit write idempotency semantics.
+3. Remove superseded private Product compatibility helpers only after compile/source evidence confirms no remaining consumers.
+4. Execute the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before any FBA/FFA promotion.
+
+## Verification state
+
+No tests, checks, formatters, workflows, or runtime verification were executed in this slice per maintainer instruction. Source and GitHub diff inspection only.

--- a/crates/rustok-commerce/src/graphql/mutations/catalog.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/catalog.rs
@@ -56,32 +56,20 @@ fn product_command_context(
     idempotency_key: Option<String>,
     operation: &'static str,
 ) -> Result<PortContext> {
-    let caller_key = match idempotency_key {
-        Some(value) => {
-            let value = value.trim();
-            if value.is_empty() {
-                return Err(invalid_product_idempotency_key(
-                    "Product mutation idempotency key must not be empty",
-                ));
-            }
-            if value.len() > MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH {
-                return Err(invalid_product_idempotency_key(format!(
-                    "Product mutation idempotency key must contain at most {MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH} bytes"
-                )));
-            }
-            value.to_string()
-        }
-        None => {
-            tracing::warn!(
-                tenant_id = %tenant_id,
-                actor_id = %user_id,
-                product_id = ?product_id,
-                operation,
-                "Product GraphQL lifecycle caller omitted idempotency key; using one-request compatibility identity"
-            );
-            format!("compatibility-{}", Uuid::new_v4())
-        }
-    };
+    let caller_key = idempotency_key.ok_or_else(|| {
+        invalid_product_idempotency_key("Product mutation idempotency key is required")
+    })?;
+    let caller_key = caller_key.trim();
+    if caller_key.is_empty() {
+        return Err(invalid_product_idempotency_key(
+            "Product mutation idempotency key must not be empty",
+        ));
+    }
+    if caller_key.len() > MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH {
+        return Err(invalid_product_idempotency_key(format!(
+            "Product mutation idempotency key must contain at most {MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH} bytes"
+        )));
+    }
 
     let tenant = ctx.data::<TenantContext>()?;
     let auth = ctx.data::<AuthContext>()?;

--- a/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
@@ -80,10 +80,10 @@ for (const required of [
   "MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH: usize = 191",
   "PRODUCT_COMMAND_DEADLINE: Duration = Duration::from_secs(2)",
   "idempotency_key: Option<String>",
+  "Product mutation idempotency key is required",
   "Product mutation idempotency key must not be empty",
   "BAD_USER_INPUT",
-  "one-request compatibility identity",
-  'format!("compatibility-{}", Uuid::new_v4())',
+  "let caller_key = idempotency_key.ok_or_else(||",
   "digest.update(tenant_id.as_bytes())",
   "digest.update(user_id.as_bytes())",
   "digest.update(operation.as_bytes())",
@@ -96,6 +96,14 @@ for (const required of [
   "context = context.with_channel(channel)",
 ]) {
   requireText(mutations, required, "GraphQL Product command context");
+}
+
+for (const forbidden of [
+  "one-request compatibility identity",
+  'format!("compatibility-{}", Uuid::new_v4())',
+  "Product GraphQL lifecycle caller omitted idempotency key",
+]) {
+  forbidText(mutations, forbidden, "GraphQL Product lifecycle compatibility identity");
 }
 
 forbidText(
@@ -189,4 +197,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product GraphQL lifecycle mutations use scoped host-composed owner commands with explicit optional caller idempotency and compatibility fallback");
+console.log("✔ Product GraphQL lifecycle execution requires explicit caller idempotency with no compatibility identity; non-null SDL remains explicit follow-up debt");

--- a/scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs
+++ b/scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs
@@ -69,18 +69,27 @@ for (const required of [
 forbidText(adapter, "compatibility-", "Product Admin explicit retry caller");
 forbidText(adapter, "Option<String>\n    idempotency_key", "Product Admin explicit retry caller");
 
-// This consumer slice deliberately stops before the server schema contract becomes required.
-// Keeping the next debt visible prevents source inspection from over-claiming completion.
+// Product Admin already sends a non-null caller key. Mounted Commerce now rejects an omitted key
+// instead of manufacturing a compatibility identity, but the resolver argument remains nullable so
+// tenant/profile admission regression fixtures preserve their existing ordering until the dedicated
+// non-null SDL cutover updates those callers explicitly.
 requireText(
   commerce,
   "idempotency_key: Option<String>",
-  "mounted GraphQL mandatory-idempotency follow-up remains explicit",
+  "mounted GraphQL non-null SDL follow-up remains explicit",
 );
 requireText(
   commerce,
-  "using one-request compatibility identity",
-  "mounted GraphQL compatibility path remains explicit",
+  "Product mutation idempotency key is required",
+  "mounted GraphQL execution requires caller identity",
 );
+for (const forbidden of [
+  "using one-request compatibility identity",
+  "compatibility-{}",
+  "Product GraphQL lifecycle caller omitted idempotency key",
+]) {
+  forbidText(commerce, forbidden, "mounted GraphQL compatibility identity must stay removed");
+}
 
 if (failures.length) {
   console.error("Product Admin lifecycle retry consumer source verification failed:");
@@ -88,4 +97,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product Admin lifecycle callers retain explicit GraphQL retry identity; mandatory server schema remains follow-up debt");
+console.log("✔ Product Admin lifecycle callers retain explicit retry identity and mounted Commerce rejects omission; non-null server SDL remains follow-up debt");


### PR DESCRIPTION
## Summary

- remove the mounted Product GraphQL lifecycle one-request `compatibility-*` identity path
- reject an omitted lifecycle `idempotencyKey` with stable `BAD_USER_INPUT` instead of inventing caller identity
- preserve the existing non-empty / 191-byte validation and tenant+actor+operation+Product scope hashing before `PortContext`
- preserve existing module, permission, tenant-actor, shipping-profile admission, owner command runtime, typed owner calls, and public lifecycle error identities
- update the Commerce lifecycle and Product Admin retry source guards so compatibility identity is forbidden
- retain `Option<String>` resolver arguments in this narrow slice so the canonical non-null GraphQL SDL task remains explicitly open rather than changing foreign-actor/shipping-profile regression ordering implicitly
- add a source recheck packet documenting the remaining `String!` + fixture-caller cutover

## Canonical status

`crates/rustok-commerce/docs/implementation-plan.md` intentionally remains unchanged. Its Product Admin FFA / mandatory GraphQL idempotency item stays `[ ]`: Product Admin retry identity and mandatory successful execution are now source-complete, but the mounted resolver SDL is still nullable and needs a dedicated caller-fixture update before it can be marked complete.

## Remaining Product work

1. update the foreign-actor and unknown-shipping-profile GraphQL fixtures with explicit caller keys, then change create/update/publish/delete resolver args to non-null `String`
2. cut remaining Product schema writes behind typed Product owner write capabilities with explicit write idempotency
3. remove superseded compatibility helpers only after compile/source evidence
4. run the plan-listed static/compile/parity/runtime evidence before any FBA/FFA promotion

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction.