### PR TITLE
refactor(groups): add revisioned membership target lock primitive

### DIFF
--- a/crates/rustok-groups/docs/membership-enforcement-target-lock-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-target-lock-contract.md
@@ -1,0 +1,41 @@
+# Groups membership-subject owner-lock contract
+
+Status: **source-complete / execution evidence pending**
+
+## Purpose
+
+`lock_membership_enforcement_target_by_id_for_update` is the Groups-owned lock primitive for trusted producer paths that receive a revisioned `group_memberships.id` instead of a `(group_id, user_id)` tuple.
+
+It is intentionally crate-private. It does not authorize moderation, create receipts, interpret external decisions, or expose Groups persistence outside the owner crate.
+
+## Lock protocol
+
+A membership UUID cannot reveal its owning group without a lookup, so the primitive uses this sequence:
+
+1. perform a tenant-scoped membership **locator read** by `group_memberships.id`;
+2. treat only `group_id` and `user_id` from that row as aggregate-location facts;
+3. acquire the canonical Groups group writer reservation;
+4. read the group under that retained reservation;
+5. re-read the membership under owner lock and require the same group/user identity;
+6. lock the current `group_membership_enforcements` row when present;
+7. return only the locked owner rows to the caller.
+
+The canonical mutation order therefore remains:
+
+```text
+Group -> GroupMembership -> GroupMembershipEnforcement
+```
+
+The locator row is never sufficient for authorization, revision validation, provenance validation, or mutation. If the subject disappears between lookup and owner locking, the primitive returns `None`. If immutable aggregate identity disagrees after locking, it fails with an owner invariant instead of silently retargeting the subject.
+
+PostgreSQL/MySQL use row locks. SQLite first reserves the writer with the existing no-op `groups.version` update before the membership/enforcement re-reads.
+
+## Moderation handoff
+
+The future neutral Groups moderation adapter must perform its durable producer receipt admission **before** calling this primitive. After admission, it can lock the membership subject by immutable UUID, validate exact reviewed revision/effect/provenance against the returned rows, and invoke the existing shared Groups enforcement mutation.
+
+This source slice does not add `rustok-moderation-api`, `rustok-outbox`, a moderation factory, or any alternate state path. Those dependencies still require a synchronized `Cargo.toml` + `Cargo.lock` update.
+
+## Execution status
+
+No Cargo command, test, Node verifier, formatter, migration, workflow, or CI job was run while adding this primitive. Runtime contention evidence remains pending.

--- a/crates/rustok-groups/src/membership_enforcement_transaction.rs
+++ b/crates/rustok-groups/src/membership_enforcement_transaction.rs
@@ -7,9 +7,20 @@ use uuid::Uuid;
 
 use crate::dto::GroupMembershipEffectiveState;
 use crate::entities::group;
-use crate::error::GroupsResult;
+use crate::error::{GroupsError, GroupsResult};
 use crate::membership_enforcement::resolve_group_membership_enforcement;
 use crate::membership_enforcement_entities::{membership_enforcement, membership_state};
+
+/// One membership subject locked under the canonical Groups owner aggregate order.
+///
+/// The initial unlocked membership lookup used by `lock_membership_enforcement_target_by_id_for_update`
+/// is only an aggregate locator. Callers must make every authorization, revision, provenance, and
+/// mutation decision from these locked rows.
+pub(crate) struct LockedMembershipEnforcementTarget {
+    pub(crate) group: group::Model,
+    pub(crate) membership: membership_state::Model,
+    pub(crate) enforcement: Option<membership_enforcement::Model>,
+}
 
 /// Acquire the Groups owner aggregate writer reservation before reading mutable group state.
 ///
@@ -42,6 +53,93 @@ pub(crate) async fn reserve_group_write_for_update(
         }
     }
     Ok(())
+}
+
+/// Lock one revisioned membership subject addressed by `group_memberships.id`.
+///
+/// A membership UUID does not itself carry the owning `group_id`, so the function first performs a
+/// tenant-scoped locator read. That row is never trusted as mutable state. It then acquires the
+/// canonical `Group -> GroupMembership -> GroupMembershipEnforcement` owner locks, re-reads the
+/// membership under lock, and verifies that its immutable aggregate identity still matches the
+/// locator. This makes the primitive suitable for receipt-first producer adapters that receive a
+/// membership subject UUID rather than a `(group_id, user_id)` pair.
+///
+/// Missing subjects return `Ok(None)`. Corrupt identity movement fails closed instead of silently
+/// retargeting the caller to another group or user.
+pub(crate) async fn lock_membership_enforcement_target_by_id_for_update(
+    transaction: &DatabaseTransaction,
+    tenant_id: Uuid,
+    membership_id: Uuid,
+) -> GroupsResult<Option<LockedMembershipEnforcementTarget>> {
+    let Some(locator) = membership_state::Entity::find_by_id(membership_id)
+        .filter(membership_state::Column::TenantId.eq(tenant_id))
+        .one(transaction)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    reserve_group_write_for_update(transaction, tenant_id, locator.group_id).await?;
+
+    let group_model = group::Entity::find()
+        .filter(group::Column::TenantId.eq(tenant_id))
+        .filter(group::Column::Id.eq(locator.group_id))
+        .one(transaction)
+        .await?
+        .ok_or_else(|| {
+            GroupsError::Invariant(
+                "membership subject points to a missing group after owner reservation".to_string(),
+            )
+        })?;
+
+    let locked_membership = match transaction.get_database_backend() {
+        DbBackend::Sqlite => {
+            membership_state::Entity::find_by_id(membership_id)
+                .filter(membership_state::Column::TenantId.eq(tenant_id))
+                .filter(membership_state::Column::GroupId.eq(locator.group_id))
+                .one(transaction)
+                .await?
+        }
+        DbBackend::Postgres | DbBackend::MySql => {
+            membership_state::Entity::find_by_id(membership_id)
+                .filter(membership_state::Column::TenantId.eq(tenant_id))
+                .filter(membership_state::Column::GroupId.eq(locator.group_id))
+                .lock_exclusive()
+                .one(transaction)
+                .await?
+        }
+    };
+    let Some(locked_membership) = locked_membership else {
+        return Ok(None);
+    };
+    if locked_membership.group_id != locator.group_id || locked_membership.user_id != locator.user_id {
+        return Err(GroupsError::Invariant(
+            "membership subject aggregate identity changed while owner locks were acquired"
+                .to_string(),
+        ));
+    }
+
+    let enforcement = match transaction.get_database_backend() {
+        DbBackend::Sqlite => {
+            membership_enforcement::Entity::find_by_id(locked_membership.id)
+                .filter(membership_enforcement::Column::TenantId.eq(tenant_id))
+                .one(transaction)
+                .await?
+        }
+        DbBackend::Postgres | DbBackend::MySql => {
+            membership_enforcement::Entity::find_by_id(locked_membership.id)
+                .filter(membership_enforcement::Column::TenantId.eq(tenant_id))
+                .lock_exclusive()
+                .one(transaction)
+                .await?
+        }
+    };
+
+    Ok(Some(LockedMembershipEnforcementTarget {
+        group: group_model,
+        membership: locked_membership,
+        enforcement,
+    }))
 }
 
 /// Resolve effective membership under the Groups owner write-lock protocol.

--- a/scripts/verify/verify-groups-membership-enforcement-target-lock.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-target-lock.mjs
@@ -16,7 +16,7 @@ for (const marker of [
   "reserve_group_write_for_update(transaction, tenant_id, locator.group_id).await?",
   "group::Entity::find()",
   ".filter(membership_state::Column::GroupId.eq(locator.group_id))",
-  "query.lock_exclusive()",
+  ".lock_exclusive()",
   "membership_enforcement::Entity::find_by_id(locked_membership.id)",
   "locked_membership.group_id != locator.group_id",
   "locked_membership.user_id != locator.user_id",

--- a/scripts/verify/verify-groups-membership-enforcement-target-lock.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-target-lock.mjs
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+
+const sourcePath = "crates/rustok-groups/src/membership_enforcement_transaction.rs";
+const docsPath = "crates/rustok-groups/docs/membership-enforcement-target-lock-contract.md";
+const source = fs.readFileSync(sourcePath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  "pub(crate) struct LockedMembershipEnforcementTarget",
+  "lock_membership_enforcement_target_by_id_for_update",
+  "membership_state::Entity::find_by_id(membership_id)",
+  "reserve_group_write_for_update(transaction, tenant_id, locator.group_id).await?",
+  "group::Entity::find()",
+  ".filter(membership_state::Column::GroupId.eq(locator.group_id))",
+  "query.lock_exclusive()",
+  "membership_enforcement::Entity::find_by_id(locked_membership.id)",
+  "locked_membership.group_id != locator.group_id",
+  "locked_membership.user_id != locator.user_id",
+  "membership subject aggregate identity changed while owner locks were acquired",
+]) {
+  requireText(source, marker, `Groups membership target-lock source is missing ${marker}`);
+}
+
+const locator = source.indexOf("let Some(locator) = membership_state::Entity::find_by_id(membership_id)");
+const groupReservation = source.indexOf(
+  "reserve_group_write_for_update(transaction, tenant_id, locator.group_id).await?",
+  locator,
+);
+const lockedMembership = source.indexOf("let locked_membership = match", groupReservation);
+const enforcement = source.indexOf("let enforcement = match", lockedMembership);
+if (!(locator >= 0 && locator < groupReservation && groupReservation < lockedMembership && lockedMembership < enforcement)) {
+  throw new Error("Groups membership target-lock source must preserve locator -> Group -> Membership -> Enforcement ordering");
+}
+
+for (const forbidden of [
+  "rustok_moderation",
+  "rustok_outbox",
+  "apply_membership_suspension_in_tx",
+  "group_command_receipts",
+]) {
+  if (source.includes(forbidden)) {
+    throw new Error(`Groups membership target-lock primitive must remain owner-lock-only: ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "locator read",
+  "Group -> GroupMembership -> GroupMembershipEnforcement",
+  "receipt admission **before** calling this primitive",
+  "crate-private",
+  "Runtime contention evidence remains pending",
+]) {
+  requireText(docs, marker, `Groups membership target-lock handoff is missing ${marker}`);
+}
+
+console.log("Groups membership-subject owner-lock source guard passed");


### PR DESCRIPTION
## Summary
- add one crate-private Groups owner lock primitive for producer paths addressed by `group_memberships.id`
- use a tenant-scoped membership lookup only as an aggregate locator, never as authorization or revision truth
- preserve canonical `Group -> GroupMembership -> GroupMembershipEnforcement` mutation locking
- re-read membership under owner lock and fail closed if immutable group/user identity differs
- retain SQLite writer reservation before mutable membership/enforcement reads and PostgreSQL/MySQL row locks
- return the locked group, membership and current enforcement row for a later trusted producer adapter
- document that a future Moderation adapter must perform durable receipt admission before calling this primitive
- add no moderation/outbox dependency, manifest change, lockfile change, mutation path, or runtime-evidence promotion

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.