### PR TITLE
test(parity): retain Forum deployed server-function attestation

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -69,7 +69,8 @@ LABEL org.opencontainers.image.title="RusToK Server" \
       org.opencontainers.image.revision="${OCI_REVISION}" \
       org.opencontainers.image.licenses="BUSL-1.1"
 
-ENV RUST_BACKTRACE=1
+ENV RUST_BACKTRACE=1 \
+    RUSTOK_SOURCE_COMMIT=${OCI_REVISION}
 WORKDIR /app
 
 RUN apt-get update \

--- a/apps/server/Dockerfile.release
+++ b/apps/server/Dockerfile.release
@@ -14,7 +14,8 @@ LABEL org.opencontainers.image.title="RusToK Server" \
       org.opencontainers.image.base.name="docker.io/library/debian:bookworm-20260713-slim" \
       org.opencontainers.image.base.digest="sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818"
 
-ENV RUST_BACKTRACE=1
+ENV RUST_BACKTRACE=1 \
+    RUSTOK_SOURCE_COMMIT=${OCI_REVISION}
 WORKDIR /app
 
 # Keep runtime packages reproducible and independent from moving Debian mirrors.

--- a/crates/rustok-forum/admin/src/lib.rs
+++ b/crates/rustok-forum/admin/src/lib.rs
@@ -22,7 +22,8 @@ pub use page_builder::{
 };
 pub use ui::root::ForumAdmin;
 pub use widget_preview_transport::{
-    ForumWidgetPreviewTransportRequest, preview_forum_page_builder_widget,
+    ForumPageBuilderTransportAttestationResponse, ForumWidgetPreviewTransportRequest,
+    attest_forum_page_builder_transport, preview_forum_page_builder_widget,
 };
 pub use widget_property_transport::{
     ForumWidgetPropertySchemaTransportRequest, ForumWidgetPropertySchemaTransportResponse,

--- a/crates/rustok-forum/admin/src/widget_preview_transport.rs
+++ b/crates/rustok-forum/admin/src/widget_preview_transport.rs
@@ -2,11 +2,35 @@ use leptos::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+const MAX_FORUM_PAGE_BUILDER_ATTESTATION_CHALLENGE_BYTES: usize = 128;
+const FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT: &str =
+    "forum_page_builder_server_fn_attestation_v1";
+const FORUM_PAGE_BUILDER_PREVIEW_ENDPOINT: &str = "/api/fn/forum/page-builder-widget-preview";
+const FORUM_PAGE_BUILDER_PROPERTY_SCHEMA_ENDPOINT: &str =
+    "/api/fn/forum/page-builder-widget-property-schema";
+const FORUM_PAGE_BUILDER_PROPERTY_VALIDATE_ENDPOINT: &str =
+    "/api/fn/forum/page-builder-widget-property-validate";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ForumWidgetPreviewTransportRequest {
     pub widget_type: String,
     #[serde(default)]
     pub props: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumPageBuilderTransportAttestationResponse {
+    pub challenge: String,
+    pub contract: String,
+    pub module_id: String,
+    pub owner_provider: String,
+    pub owner_version: String,
+    pub catalog_version: String,
+    pub builder_contract_version: String,
+    pub widget_types: Vec<String>,
+    pub preview_endpoint: String,
+    pub property_schema_endpoint: String,
+    pub property_validate_endpoint: String,
 }
 
 #[cfg(feature = "ssr")]
@@ -79,6 +103,88 @@ fn runtime() -> Result<
             )
         })?;
     Ok((host, event_bus))
+}
+
+#[cfg(feature = "ssr")]
+fn validate_attestation_challenge(challenge: &str) -> Result<(), ServerFnError> {
+    let bytes = challenge.as_bytes();
+    if bytes.is_empty() || bytes.len() > MAX_FORUM_PAGE_BUILDER_ATTESTATION_CHALLENGE_BYTES {
+        return Err(ServerFnError::new(
+            "Forum Page Builder attestation challenge is outside the bounded size",
+        ));
+    }
+    if !bytes
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    {
+        return Err(ServerFnError::new(
+            "Forum Page Builder attestation challenge contains unsupported characters",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "ssr")]
+fn build_transport_attestation(
+    challenge: String,
+) -> ForumPageBuilderTransportAttestationResponse {
+    let manifest = crate::forum_contribution_manifest();
+    let catalog = rustok_forum::ForumWidgetContractService::catalog();
+    let mut widget_types = catalog
+        .items
+        .iter()
+        .map(|item| item.widget_type.clone())
+        .collect::<Vec<_>>();
+    widget_types.sort();
+
+    ForumPageBuilderTransportAttestationResponse {
+        challenge,
+        contract: FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT.to_string(),
+        module_id: manifest.module_id,
+        owner_provider: manifest.owner_provider,
+        owner_version: manifest.owner_version,
+        catalog_version: catalog.catalog_version,
+        builder_contract_version: catalog.builder_contract_version,
+        widget_types,
+        preview_endpoint: FORUM_PAGE_BUILDER_PREVIEW_ENDPOINT.to_string(),
+        property_schema_endpoint: FORUM_PAGE_BUILDER_PROPERTY_SCHEMA_ENDPOINT.to_string(),
+        property_validate_endpoint: FORUM_PAGE_BUILDER_PROPERTY_VALIDATE_ENDPOINT.to_string(),
+    }
+}
+
+/// Read-only deployed-transport probe for Page Builder evidence.
+///
+/// A successful response proves that the request crossed the real Leptos `/api/fn` dispatcher,
+/// tenant/auth middleware, the shared effective `forum_topics:read` gate, exact tenant-module
+/// enablement, the Forum admin host runtime (including its transactional event bus), and the
+/// Forum-owned widget contract catalog. It returns only stable contract identity plus the caller's
+/// bounded challenge; it never reads or returns Forum topic/reply data.
+#[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]
+pub async fn attest_forum_page_builder_transport(
+    challenge: String,
+) -> Result<ForumPageBuilderTransportAttestationResponse, ServerFnError> {
+    #[cfg(feature = "ssr")]
+    {
+        validate_attestation_challenge(&challenge)?;
+        let auth = leptos_axum::extract::<rustok_api::AuthContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let tenant = leptos_axum::extract::<rustok_api::TenantContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        require_forum_transport_authorization(&auth, &tenant)?;
+
+        let (host, _event_bus) = runtime()?;
+        require_forum_module_enabled(&host, tenant.id).await?;
+        Ok(build_transport_attestation(challenge))
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = challenge;
+        Err(ServerFnError::new(
+            "forum/page-builder-transport-attestation requires the `ssr` feature",
+        ))
+    }
 }
 
 /// Native Leptos transport used by the admin composition root. The transport returns the owner
@@ -217,6 +323,41 @@ mod tests {
                 .expect_err("module lookup failure must fail closed")
                 .to_string()
                 .contains("Forum module state is unavailable")
+        );
+    }
+
+    #[test]
+    fn attestation_challenge_is_bounded_and_transport_identity_is_owner_derived() {
+        assert!(validate_attestation_challenge("forum-attest_01.alpha:beta").is_ok());
+        assert!(validate_attestation_challenge("").is_err());
+        assert!(validate_attestation_challenge("contains space").is_err());
+        assert!(
+            validate_attestation_challenge(
+                &"x".repeat(MAX_FORUM_PAGE_BUILDER_ATTESTATION_CHALLENGE_BYTES + 1)
+            )
+            .is_err()
+        );
+
+        let response = build_transport_attestation("forum-attest_01".to_string());
+        assert_eq!(response.contract, FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT);
+        assert_eq!(response.module_id, "forum");
+        assert_eq!(response.owner_provider, "rustok.forum");
+        assert_eq!(
+            response.widget_types,
+            vec![
+                "forum.reply_stream".to_string(),
+                "forum.topic_detail".to_string(),
+                "forum.topic_list".to_string(),
+            ]
+        );
+        assert_eq!(response.preview_endpoint, FORUM_PAGE_BUILDER_PREVIEW_ENDPOINT);
+        assert_eq!(
+            response.property_schema_endpoint,
+            FORUM_PAGE_BUILDER_PROPERTY_SCHEMA_ENDPOINT
+        );
+        assert_eq!(
+            response.property_validate_endpoint,
+            FORUM_PAGE_BUILDER_PROPERTY_VALIDATE_ENDPOINT
         );
     }
 }

--- a/crates/rustok-forum/admin/src/widget_preview_transport.rs
+++ b/crates/rustok-forum/admin/src/widget_preview_transport.rs
@@ -22,7 +22,7 @@ pub struct ForumWidgetPreviewTransportRequest {
 pub struct ForumPageBuilderTransportAttestationResponse {
     pub challenge: String,
     pub contract: String,
-    pub source_commit: Option<String>,
+    pub source_commit: String,
     pub module_id: String,
     pub owner_provider: String,
     pub owner_version: String,
@@ -125,16 +125,26 @@ fn validate_attestation_challenge(challenge: &str) -> Result<(), ServerFnError> 
 }
 
 #[cfg(feature = "ssr")]
-fn deployed_source_commit() -> Option<String> {
-    let value = std::env::var("RUSTOK_SOURCE_COMMIT").ok()?;
+fn canonical_source_commit(value: &str) -> Option<String> {
     let value = value.trim();
     (value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
         .then(|| value.to_ascii_lowercase())
 }
 
 #[cfg(feature = "ssr")]
+fn deployed_source_commit() -> Result<String, ServerFnError> {
+    let value = std::env::var("RUSTOK_SOURCE_COMMIT").map_err(|_| {
+        ServerFnError::new("Forum Page Builder deployed source revision is unavailable")
+    })?;
+    canonical_source_commit(&value).ok_or_else(|| {
+        ServerFnError::new("Forum Page Builder deployed source revision is not a canonical Git SHA")
+    })
+}
+
+#[cfg(feature = "ssr")]
 fn build_transport_attestation(
     challenge: String,
+    source_commit: String,
 ) -> ForumPageBuilderTransportAttestationResponse {
     let manifest = crate::forum_contribution_manifest();
     let catalog = rustok_forum::ForumWidgetContractService::catalog();
@@ -148,7 +158,7 @@ fn build_transport_attestation(
     ForumPageBuilderTransportAttestationResponse {
         challenge,
         contract: FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT.to_string(),
-        source_commit: deployed_source_commit(),
+        source_commit,
         module_id: manifest.module_id,
         owner_provider: manifest.owner_provider,
         owner_version: manifest.owner_version,
@@ -167,8 +177,8 @@ fn build_transport_attestation(
 /// tenant/auth middleware, the shared effective `forum_topics:read` gate, exact tenant-module
 /// enablement, the Forum admin host runtime (including its transactional event bus), and the
 /// Forum-owned widget contract catalog. It returns only stable contract identity plus the caller's
-/// bounded challenge and canonical runtime source revision when the production image supplied one;
-/// it never reads or returns Forum topic/reply data.
+/// bounded challenge and canonical runtime source revision; it never reads or returns Forum
+/// topic/reply data. Images without a canonical deployed source revision fail closed.
 #[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]
 pub async fn attest_forum_page_builder_transport(
     challenge: String,
@@ -186,7 +196,8 @@ pub async fn attest_forum_page_builder_transport(
 
         let (host, _event_bus) = runtime()?;
         require_forum_module_enabled(&host, tenant.id).await?;
-        Ok(build_transport_attestation(challenge))
+        let source_commit = deployed_source_commit()?;
+        Ok(build_transport_attestation(challenge, source_commit))
     }
     #[cfg(not(feature = "ssr"))]
     {
@@ -347,9 +358,17 @@ mod tests {
             )
             .is_err()
         );
+        assert_eq!(
+            canonical_source_commit("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(canonical_source_commit("unknown"), None);
 
-        let response = build_transport_attestation("forum-attest_01".to_string());
+        let source_commit = "a".repeat(40);
+        let response =
+            build_transport_attestation("forum-attest_01".to_string(), source_commit.clone());
         assert_eq!(response.contract, FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT);
+        assert_eq!(response.source_commit, source_commit);
         assert_eq!(response.module_id, "forum");
         assert_eq!(response.owner_provider, "rustok.forum");
         assert_eq!(

--- a/crates/rustok-forum/admin/src/widget_preview_transport.rs
+++ b/crates/rustok-forum/admin/src/widget_preview_transport.rs
@@ -22,6 +22,7 @@ pub struct ForumWidgetPreviewTransportRequest {
 pub struct ForumPageBuilderTransportAttestationResponse {
     pub challenge: String,
     pub contract: String,
+    pub source_commit: Option<String>,
     pub module_id: String,
     pub owner_provider: String,
     pub owner_version: String,
@@ -125,6 +126,14 @@ fn validate_attestation_challenge(challenge: &str) -> Result<(), ServerFnError> 
 }
 
 #[cfg(feature = "ssr")]
+fn deployed_source_commit() -> Option<String> {
+    let value = std::env::var("RUSTOK_SOURCE_COMMIT").ok()?;
+    let value = value.trim();
+    (value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| value.to_ascii_lowercase())
+}
+
+#[cfg(feature = "ssr")]
 fn build_transport_attestation(
     challenge: String,
 ) -> ForumPageBuilderTransportAttestationResponse {
@@ -140,6 +149,7 @@ fn build_transport_attestation(
     ForumPageBuilderTransportAttestationResponse {
         challenge,
         contract: FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT.to_string(),
+        source_commit: deployed_source_commit(),
         module_id: manifest.module_id,
         owner_provider: manifest.owner_provider,
         owner_version: manifest.owner_version,
@@ -158,7 +168,8 @@ fn build_transport_attestation(
 /// tenant/auth middleware, the shared effective `forum_topics:read` gate, exact tenant-module
 /// enablement, the Forum admin host runtime (including its transactional event bus), and the
 /// Forum-owned widget contract catalog. It returns only stable contract identity plus the caller's
-/// bounded challenge; it never reads or returns Forum topic/reply data.
+/// bounded challenge and canonical runtime source revision when the production image supplied one;
+/// it never reads or returns Forum topic/reply data.
 #[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]
 pub async fn attest_forum_page_builder_transport(
     challenge: String,

--- a/crates/rustok-forum/admin/src/widget_preview_transport.rs
+++ b/crates/rustok-forum/admin/src/widget_preview_transport.rs
@@ -100,7 +100,7 @@ fn runtime() -> Result<
         .shared_get::<rustok_outbox::TransactionalEventBus>()
         .ok_or_else(|| {
             ServerFnError::new(
-                "Forum widget preview requires TransactionalEventBus in host runtime context",
+                "Forum Page Builder transport requires TransactionalEventBus in host runtime context",
             )
         })?;
     Ok((host, event_bus))
@@ -114,10 +114,9 @@ fn validate_attestation_challenge(challenge: &str) -> Result<(), ServerFnError> 
             "Forum Page Builder attestation challenge is outside the bounded size",
         ));
     }
-    if !bytes
-        .iter()
-        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
-    {
+    if !bytes.iter().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(*byte, b'-' | b'_' | b'.' | b':')
+    }) {
         return Err(ServerFnError::new(
             "Forum Page Builder attestation challenge contains unsupported characters",
         ));

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
@@ -77,7 +77,7 @@
   ],
   "retained_data": [
     "exact checkout source commit",
-    "live server-reported source commit",
+    "boolean verification that the live response contained the exact checkout source commit",
     "maintainer-supplied immutable deployment RepoDigest",
     "target origin SHA-256 and byte length",
     "challenge SHA-256 and byte length",

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "module": "forum",
+  "packet": "page_builder_serverfn_deployment_attestation",
+  "status": "source_ready_maintainer_execution_pending",
+  "runner": "scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs",
+  "endpoint": "/api/fn/forum/page-builder-transport-attestation",
+  "request": {
+    "method": "POST",
+    "content_type": "application/x-www-form-urlencoded",
+    "challenge_field": "challenge",
+    "challenge_format": "forum-attest-<uuid>"
+  },
+  "environment": {
+    "common_headers_json": "RUSTOK_FORUM_PAGE_BUILDER_ATTESTATION_COMMON_HEADERS_JSON",
+    "authorized_authorization": "RUSTOK_FORUM_PAGE_BUILDER_ATTESTATION_AUTHORIZATION",
+    "authorized_cookie": "RUSTOK_FORUM_PAGE_BUILDER_ATTESTATION_COOKIE",
+    "no_read_authorization": "RUSTOK_FORUM_PAGE_BUILDER_ATTESTATION_NO_READ_AUTHORIZATION",
+    "no_read_cookie": "RUSTOK_FORUM_PAGE_BUILDER_ATTESTATION_NO_READ_COOKIE"
+  },
+  "scenarios": [
+    {
+      "id": "anonymous",
+      "credential_profile": "none",
+      "success_forbidden": true
+    },
+    {
+      "id": "authorized",
+      "credential_profile": "authorized",
+      "expected_status": 200
+    },
+    {
+      "id": "no_read",
+      "credential_profile": "no_read",
+      "success_forbidden": true
+    }
+  ],
+  "authorized_response": {
+    "contract": "forum_page_builder_server_fn_attestation_v1",
+    "required_markers": [
+      "forum_page_builder_server_fn_attestation_v1",
+      "rustok.forum",
+      "forum.topic_list",
+      "forum.topic_detail",
+      "forum.reply_stream",
+      "/api/fn/forum/page-builder-widget-preview",
+      "/api/fn/forum/page-builder-widget-property-schema",
+      "/api/fn/forum/page-builder-widget-property-validate"
+    ],
+    "source_commit_must_equal_checkout_head": true,
+    "challenge_must_round_trip": true
+  },
+  "deployment_identity": {
+    "immutable_repo_digest_argument_required": true,
+    "live_transport_source_commit_required": true,
+    "source_commit_is_exported_from_oci_revision": true,
+    "origin_to_repo_digest_binding_is_maintainer_reviewed_external_fact": true,
+    "cryptographic_origin_to_repo_digest_binding_claimed": false
+  },
+  "output": {
+    "format": "forum_page_builder_server_fn_deployment_attestation_v1",
+    "status": "server_fn_deployment_attestation_passed_wave_pending",
+    "default_path": "target/forum-page-builder-serverfn-deployment-attestation.json",
+    "atomic_replace": true
+  },
+  "required_source_files": [
+    "crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json",
+    "scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs",
+    "scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs",
+    "crates/rustok-forum/admin/src/widget_preview_transport.rs",
+    "crates/rustok-forum/admin/src/widget_property_transport.rs",
+    "crates/rustok-forum/admin/src/lib.rs",
+    "apps/server/src/services/app_router.rs",
+    "apps/server/Dockerfile",
+    "apps/server/Dockerfile.release",
+    "docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md"
+  ],
+  "retained_data": [
+    "exact checkout source commit",
+    "live server-reported source commit",
+    "maintainer-supplied immutable deployment RepoDigest",
+    "target origin SHA-256 and byte length",
+    "challenge SHA-256 and byte length",
+    "required-source SHA-256 hashes",
+    "scenario status, selected response headers, response byte length and SHA-256",
+    "credential environment names only"
+  ],
+  "forbidden_retained_data": [
+    "raw target origin or URL",
+    "authorization header values",
+    "cookie header values",
+    "common header values",
+    "raw challenge",
+    "raw response bodies",
+    "tenant ids",
+    "actor ids",
+    "Forum topic or reply content"
+  ],
+  "not_claimed": [
+    "server-function deployment attestation execution",
+    "cryptographic origin-to-RepoDigest binding",
+    "browser execution",
+    "runtime authorization execution",
+    "observed Page Builder Wave",
+    "provider SLO health"
+  ]
+}

--- a/crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
+++ b/crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
@@ -54,6 +54,7 @@
     "immutable_repo_digest_argument_required": true,
     "live_transport_source_commit_required": true,
     "source_commit_is_exported_from_oci_revision": true,
+    "canonical_release_passes_github_sha_as_oci_revision": true,
     "origin_to_repo_digest_binding_is_maintainer_reviewed_external_fact": true,
     "cryptographic_origin_to_repo_digest_binding_claimed": false
   },
@@ -73,6 +74,7 @@
     "apps/server/src/services/app_router.rs",
     "apps/server/Dockerfile",
     "apps/server/Dockerfile.release",
+    ".github/workflows/release.yml",
     "docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md"
   ],
   "retained_data": [

--- a/docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md
+++ b/docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md
@@ -1,0 +1,197 @@
+# Forum / Page Builder deployed server-function attestation actualization — 2026-08-08
+
+Status: `source-ready / maintainer-deployment-attestation-execution-pending / browser-execution-pending / runtime-execution-pending / wave-pending`
+
+## Rechecked cursor
+
+PR #3266 retained direct runtime authorization/visibility evidence source for the Forum Page Builder native transports. Its runner is still maintainer-execution-pending. PR #3264 retained the real browser evidence harness, which is also still execution-pending.
+
+The remaining evidence gap between those packets was deployment provenance: a browser URL plus a maintainer-supplied RepoDigest did not independently prove which source revision the live `/api/fn` transport was serving.
+
+This slice makes a bounded deployed server-function attestation source-ready without running it.
+
+## Read-only transport probe
+
+`rustok-forum-admin` now registers:
+
+```text
+POST /api/fn/forum/page-builder-transport-attestation
+```
+
+The server-function argument is intentionally a single bounded scalar:
+
+```text
+challenge=<bounded token>
+```
+
+This avoids reimplementing Leptos nested `request` serialization in an external evidence runner.
+
+The probe is not a second Forum data API. Before returning anything it crosses the same production seams as Forum Page Builder preview/property transport:
+
+1. authenticated `AuthContext` extraction;
+2. trusted `TenantContext` extraction and exact tenant match;
+3. platform effective `forum_topics:read` authorization;
+4. exact enabled `forum` tenant-module lookup;
+5. `HostRuntimeContext` lookup;
+6. the shared `TransactionalEventBus` runtime dependency;
+7. the Forum-owned widget contract catalog.
+
+The success body contains only:
+
+- the caller challenge;
+- a stable attestation contract id;
+- the deployed source commit when the production image supplies a canonical revision;
+- generated Forum module/provider/version identity;
+- Forum widget catalog/contract versions;
+- the three canonical widget types;
+- the canonical preview/property server-function paths.
+
+It does **not** read or return topics, replies, categories, tenant ids, actor ids, sessions, permissions or Page Builder document content.
+
+## Source revision binding
+
+Both production server image definitions already carry the OCI revision label:
+
+```text
+org.opencontainers.image.revision=${OCI_REVISION}
+```
+
+This slice also exports the same immutable build argument into the production container runtime as:
+
+```text
+RUSTOK_SOURCE_COMMIT=${OCI_REVISION}
+```
+
+The probe returns that value only when it is a canonical 40-character hexadecimal Git commit. Images built with the default `unknown` value therefore cannot produce a successful deployment-attestation packet.
+
+The external runner compares the live response marker to the exact checkout `HEAD`. This gives the live origin an independent source-revision statement instead of merely recording a digest supplied to the browser harness.
+
+## RepoDigest boundary
+
+The capture command also requires a canonical Docker RepoDigest:
+
+```text
+REPOSITORY@sha256:<64 hex>
+```
+
+That RepoDigest remains the immutable deployment identity used to correlate browser/deployment evidence.
+
+However, this source does **not** claim a cryptographic origin-to-RepoDigest proof. The fact that the supplied RepoDigest belongs to the reviewed running deployment remains a maintainer/infrastructure provenance fact. The retained packet says so explicitly.
+
+The live source revision and the reviewed RepoDigest are complementary:
+
+- live source commit answers “which repository revision does this server report?”;
+- RepoDigest answers “which immutable image did deployment review identify?”;
+- infrastructure review still owns “this origin is routed to that immutable image.”
+
+## Capture contract
+
+The machine-readable contract is:
+
+```text
+crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json
+```
+
+The runner is:
+
+```text
+scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs
+```
+
+A successful future capture writes:
+
+```text
+format: forum_page_builder_server_fn_deployment_attestation_v1
+status: server_fn_deployment_attestation_passed_wave_pending
+```
+
+The runner requires:
+
+- a reviewed HTTP(S) origin;
+- the reviewed deployment RepoDigest;
+- authenticated credentials with effective `forum_topics:read`;
+- a separate authenticated no-read credential profile;
+- optional non-secret common routing headers such as a reviewed tenant routing header when the environment requires one.
+
+It sends the same challenge to three profiles:
+
+1. anonymous — must not obtain a valid success attestation;
+2. authorized — must return the attestation contract, round-tripped challenge, exact checkout source commit, Forum owner identity, all three widget identities and all three canonical production transport paths;
+3. no-read — must not obtain a valid success attestation.
+
+The authorized request proves the exact deployed `/api/fn` dispatcher has the Forum attestation server function registered and can cross tenant/RBAC/module/runtime owner gates. The no-read/anonymous checks are deployment smoke evidence only; the exhaustive direct authorization semantics remain owned by the separate #3266 runtime harness.
+
+## Retention and privacy
+
+The retained packet stores only:
+
+- checkout source commit;
+- verification that the live response contained that source commit;
+- reviewed immutable RepoDigest;
+- SHA-256 and byte length of the target origin, never the raw origin;
+- SHA-256 and byte length of the random challenge, never the raw challenge;
+- required-source SHA-256 hashes;
+- scenario status, bounded selected response headers, body size and body SHA-256;
+- credential **environment variable names** only.
+
+It never stores:
+
+- raw URLs/origins;
+- Authorization values;
+- cookies;
+- common header values;
+- response bodies;
+- tenant or actor identifiers;
+- Forum content.
+
+The prior output is removed before any network request so a failed attempt cannot leave a stale success packet.
+
+## Source-only guard
+
+The source guard is:
+
+```text
+node scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
+```
+
+It verifies the probe remains read-only and behind the shared transport gates, the production `/api/fn/{*fn_name}` dispatcher remains mounted through `handle_server_fns_with_context`, both production Docker definitions bind `RUSTOK_SOURCE_COMMIT` to the OCI revision argument, and the runner retains hashes/status only.
+
+## Maintainer capture cursor
+
+After deploying the exact source revision with a real OCI revision and preparing reviewed credentials:
+
+```text
+node scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs \
+  --base-url <reviewed-origin> \
+  --deployment-image-digest <repo@sha256:digest>
+```
+
+Credential and optional routing-header environment variable names are declared by the JSON contract.
+
+The browser and direct runtime runners remain separate packets. Acceptance should correlate all three packets to the same source revision and reviewed RepoDigest/deployment provenance before any Forum Page Builder Wave claim.
+
+## Promotion boundary
+
+FORUM-32 remains `in_progress`.
+
+Source is now ready for:
+
+- contribution/Fly identity;
+- Forum owner preview;
+- Forum owner-backed properties;
+- browser evidence;
+- direct runtime authorization/visibility evidence;
+- deployed native server-function source-revision attestation.
+
+Still open:
+
+1. execute and retain the browser packet;
+2. execute and retain the direct runtime authorization packet;
+3. execute and retain this deployed server-function attestation packet;
+4. retain/approve the external origin-to-RepoDigest infrastructure provenance;
+5. satisfy the existing Pages reference-consumer gate;
+6. only then evaluate observed Forum Page Builder Wave evidence.
+
+Provider SLO health remains `unobserved`; this probe does not convert missing provider-health observation into a healthy claim.
+
+No HTTP request, browser, Cargo command, Node verifier, Docker build/inspect, database fixture, formatter, build, workflow or CI execution is claimed by this source slice.

--- a/scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs
+++ b/scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json",
+);
+const MAX_BODY_BYTES = 1024 * 1024;
+const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function fail(message) {
+  throw new Error(`Forum Page Builder server-function attestation failed: ${message}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      console.log(
+        "usage: capture-forum-page-builder-serverfn-attestation.mjs " +
+          "--base-url URL --deployment-image-digest REPO@sha256:DIGEST " +
+          "[--source-commit SHA] [--output FILE]",
+      );
+      process.exit(0);
+    }
+    if (["--base-url", "--deployment-image-digest", "--source-commit", "--output"].includes(argument)) {
+      const value = argv[index + 1];
+      if (!value) fail(`${argument} requires a value`);
+      const key = argument
+        .slice(2)
+        .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      options[key] = value;
+      index += 1;
+      continue;
+    }
+    fail(`unknown argument ${argument}`);
+  }
+  return options;
+}
+
+function requireCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
+    fail(`${label} must be a lowercase 40-character git commit`);
+  }
+  return value;
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell: false,
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) fail(`git HEAD lookup failed: ${result.error.message}`);
+  if (result.status !== 0) fail("git HEAD lookup returned a non-zero status");
+  return requireCommit(result.stdout.trim(), "git HEAD");
+}
+
+function requireBaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail("--base-url must be an absolute HTTP(S) origin");
+  }
+  if (
+    !["http:", "https:"].includes(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    !["", "/"].includes(parsed.pathname)
+  ) {
+    fail("--base-url must be an HTTP(S) origin without credentials, path, query, or fragment");
+  }
+  return parsed.origin;
+}
+
+function requireDeploymentImageDigest(value) {
+  if (
+    typeof value !== "string" ||
+    value.length > 512 ||
+    /[\s\u0000-\u001f\u007f]/u.test(value) ||
+    value.includes("://")
+  ) {
+    fail("--deployment-image-digest must be a bounded Docker RepoDigest");
+  }
+  const parts = value.split("@");
+  if (
+    parts.length !== 2 ||
+    parts[0].length === 0 ||
+    !/^sha256:[0-9a-f]{64}$/u.test(parts[1])
+  ) {
+    fail("--deployment-image-digest must be REPOSITORY@sha256:DIGEST");
+  }
+  return value;
+}
+
+function boundedSecretEnvironment(name, maximumLength) {
+  const value = process.env[name];
+  if (value === undefined || value === "") return null;
+  if (value.length > maximumLength || /[\r\n\u0000]/u.test(value)) {
+    fail(`${name} is outside the bounded credential input`);
+  }
+  return value;
+}
+
+function commonHeaders(environmentName) {
+  const value = process.env[environmentName];
+  if (!value) return { headers: {}, environment_names: [] };
+  if (value.length > 16_384 || /[\u0000]/u.test(value)) {
+    fail(`${environmentName} is outside the bounded common-header input`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    fail(`${environmentName} must contain a JSON object: ${error.message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    fail(`${environmentName} must contain a JSON object`);
+  }
+  const headers = {};
+  for (const [headerName, headerValue] of Object.entries(parsed)) {
+    const normalized = headerName.toLowerCase();
+    if (!/^[a-z0-9!#$%&'*+.^_`|~-]+$/u.test(normalized)) {
+      fail(`${environmentName} contains an invalid header name`);
+    }
+    if (["authorization", "cookie", "set-cookie", "content-length"].includes(normalized)) {
+      fail(`${environmentName} must not carry credential or framing headers`);
+    }
+    if (Object.hasOwn(headers, normalized)) {
+      fail(`${environmentName} contains a duplicate case-insensitive header ${normalized}`);
+    }
+    if (
+      typeof headerValue !== "string" ||
+      headerValue.length > 4096 ||
+      /[\r\n\u0000]/u.test(headerValue)
+    ) {
+      fail(`${environmentName}.${headerName} is outside the bounded header input`);
+    }
+    headers[normalized] = headerValue;
+  }
+  return { headers, environment_names: [environmentName] };
+}
+
+function credentialHeaders(contract, profile, shared) {
+  if (profile === "none") {
+    return { headers: { ...shared.headers }, environment_names: [...shared.environment_names] };
+  }
+  const prefix = profile === "authorized" ? "authorized" : "no_read";
+  const authorizationName = contract.environment[`${prefix}_authorization`];
+  const cookieName = contract.environment[`${prefix}_cookie`];
+  const authorization = boundedSecretEnvironment(authorizationName, 8192);
+  const cookie = boundedSecretEnvironment(cookieName, 16_384);
+  if (!authorization && !cookie) {
+    fail(`${profile} requires ${authorizationName} or ${cookieName}`);
+  }
+  const headers = { ...shared.headers };
+  const environmentNames = [...shared.environment_names];
+  if (authorization) {
+    headers.authorization = authorization;
+    environmentNames.push(authorizationName);
+  }
+  if (cookie) {
+    headers.cookie = cookie;
+    environmentNames.push(cookieName);
+  }
+  return {
+    headers,
+    environment_names: [...new Set(environmentNames)].sort(),
+  };
+}
+
+function regularSourceHash(relativePath) {
+  const absolute = path.resolve(repoRoot, relativePath);
+  const relative = path.relative(repoRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail(`source file ${relativePath} escapes repository root`);
+  }
+  if (!existsSync(absolute)) fail(`source file ${relativePath} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) {
+    fail(`source file ${relativePath} must be a regular non-symlink file`);
+  }
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > MAX_SOURCE_BYTES) {
+    fail(`source file ${relativePath} is outside the bounded source size`);
+  }
+  return sha256(readFileSync(absolute));
+}
+
+function sourceHashes(contract) {
+  if (
+    !Array.isArray(contract.required_source_files) ||
+    contract.required_source_files.length === 0 ||
+    contract.required_source_files.length > 64
+  ) {
+    fail("required source-file set is outside the bounded contract");
+  }
+  return Object.fromEntries(
+    contract.required_source_files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]),
+  );
+}
+
+function selectedHeaders(headers) {
+  const output = {};
+  for (const name of ["cache-control", "content-type", "x-content-type-options"]) {
+    const value = headers.get(name);
+    if (value !== null) output[name] = value;
+  }
+  return output;
+}
+
+async function requestScenario(baseUrl, endpoint, challenge, scenario, credentials) {
+  const body = new URLSearchParams({ challenge }).toString();
+  let response;
+  try {
+    response = await fetch(new URL(endpoint, baseUrl), {
+      method: "POST",
+      headers: {
+        ...credentials.headers,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body,
+      redirect: "manual",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    fail(`${scenario.id} request failed: ${error.message}`);
+  }
+  const responseBody = Buffer.from(await response.arrayBuffer());
+  if (responseBody.byteLength > MAX_BODY_BYTES) {
+    fail(`${scenario.id} response exceeds ${MAX_BODY_BYTES} bytes`);
+  }
+  if (scenario.expected_status !== undefined && response.status !== scenario.expected_status) {
+    fail(`${scenario.id} expected ${scenario.expected_status}, got ${response.status}`);
+  }
+  if (scenario.success_forbidden && response.status === 200) {
+    fail(`${scenario.id} unexpectedly reached a successful attestation response`);
+  }
+  return {
+    response,
+    responseBody,
+    record: {
+      id: scenario.id,
+      credential_environment_names: credentials.environment_names,
+      credential_values_persisted: false,
+      status: response.status,
+      headers: selectedHeaders(response.headers),
+      body_bytes: responseBody.byteLength,
+      body_sha256: sha256(responseBody),
+      raw_body_persisted: false,
+    },
+  };
+}
+
+function requireAuthorizedBody(contract, body, challenge, sourceCommit) {
+  const text = body.toString("utf8");
+  for (const marker of contract.authorized_response.required_markers) {
+    if (!text.includes(marker)) fail(`authorized response is missing marker ${marker}`);
+  }
+  if (!text.includes(challenge)) {
+    fail("authorized response did not round-trip the current challenge");
+  }
+  if (!text.includes(sourceCommit)) {
+    fail("authorized live transport did not report the exact checkout source commit");
+  }
+}
+
+function outputPath(contract, requested) {
+  const candidate = requested ?? contract.output.default_path;
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
+    fail("output path is invalid");
+  }
+  const absolute = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail("attestation output must remain inside repository target/");
+  }
+  return absolute;
+}
+
+function writeAtomic(location, document) {
+  mkdirSync(path.dirname(location), { recursive: true });
+  const temporary = `${location}.tmp-${process.pid}`;
+  rmSync(temporary, { force: true });
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+  renameSync(temporary, location);
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (!options.baseUrl) fail("--base-url is required");
+  if (!options.deploymentImageDigest) fail("--deployment-image-digest is required");
+
+  const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+  if (contract.status !== "source_ready_maintainer_execution_pending") {
+    fail("attestation contract must not claim execution before capture starts");
+  }
+  const baseUrl = requireBaseUrl(options.baseUrl);
+  const deploymentImageDigest = requireDeploymentImageDigest(options.deploymentImageDigest);
+  const head = currentCommit();
+  const sourceCommit = options.sourceCommit
+    ? requireCommit(options.sourceCommit, "--source-commit")
+    : head;
+  if (sourceCommit !== head) {
+    fail(`source commit ${sourceCommit} does not match git HEAD ${head}`);
+  }
+
+  const output = outputPath(contract, options.output);
+  rmSync(output, { force: true });
+  const sources = sourceHashes(contract);
+  const challenge = `forum-attest-${randomUUID()}`;
+  const shared = commonHeaders(contract.environment.common_headers_json);
+  const scenarioRecords = [];
+
+  for (const scenario of contract.scenarios) {
+    const credentials = credentialHeaders(contract, scenario.credential_profile, shared);
+    const captured = await requestScenario(
+      baseUrl,
+      contract.endpoint,
+      challenge,
+      scenario,
+      credentials,
+    );
+    if (scenario.id === "authorized") {
+      requireAuthorizedBody(contract, captured.responseBody, challenge, sourceCommit);
+    }
+    scenarioRecords.push(captured.record);
+  }
+
+  writeAtomic(output, {
+    format: contract.output.format,
+    status: contract.output.status,
+    source_commit: sourceCommit,
+    live_server_source_commit: sourceCommit,
+    captured_at: new Date().toISOString(),
+    target: {
+      origin_bytes: Buffer.byteLength(baseUrl),
+      origin_sha256: sha256(baseUrl),
+      raw_origin_persisted: false,
+      deployment_image_digest: deploymentImageDigest,
+      origin_to_repo_digest_binding: "maintainer_reviewed_external_fact",
+      cryptographic_origin_to_repo_digest_binding: false,
+    },
+    challenge: {
+      bytes: Buffer.byteLength(challenge),
+      sha256: sha256(challenge),
+      raw_value_persisted: false,
+    },
+    source_files: sources,
+    scenarios: scenarioRecords,
+    privacy: {
+      credential_environment_names_only: true,
+      credential_values_persisted: false,
+      common_header_values_persisted: false,
+      raw_response_bodies_persisted: false,
+      tenant_or_actor_identifiers_persisted: false,
+      forum_content_persisted: false,
+    },
+    browser_execution_not_claimed: true,
+    runtime_authorization_execution_not_claimed: true,
+    provider_slo_health_not_claimed: true,
+    observed_page_builder_wave_pending: true,
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs
+++ b/scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs
@@ -258,9 +258,6 @@ async function requestScenario(baseUrl, endpoint, challenge, scenario, credentia
   if (scenario.expected_status !== undefined && response.status !== scenario.expected_status) {
     fail(`${scenario.id} expected ${scenario.expected_status}, got ${response.status}`);
   }
-  if (scenario.success_forbidden && response.status === 200) {
-    fail(`${scenario.id} unexpectedly reached a successful attestation response`);
-  }
   return {
     response,
     responseBody,
@@ -275,6 +272,11 @@ async function requestScenario(baseUrl, endpoint, challenge, scenario, credentia
       raw_body_persisted: false,
     },
   };
+}
+
+function isValidSuccessAttestation(contract, body, challenge) {
+  const text = body.toString("utf8");
+  return text.includes(contract.authorized_response.contract) && text.includes(challenge);
 }
 
 function requireAuthorizedBody(contract, body, challenge, sourceCommit) {
@@ -349,6 +351,11 @@ async function main() {
     );
     if (scenario.id === "authorized") {
       requireAuthorizedBody(contract, captured.responseBody, challenge, sourceCommit);
+    } else if (
+      scenario.success_forbidden &&
+      isValidSuccessAttestation(contract, captured.responseBody, challenge)
+    ) {
+      fail(`${scenario.id} unexpectedly received a valid success attestation`);
     }
     scenarioRecords.push(captured.record);
   }
@@ -357,7 +364,7 @@ async function main() {
     format: contract.output.format,
     status: contract.output.status,
     source_commit: sourceCommit,
-    live_server_source_commit: sourceCommit,
+    live_server_source_commit_verified_equal_checkout: true,
     captured_at: new Date().toISOString(),
     target: {
       origin_bytes: Buffer.byteLength(baseUrl),

--- a/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
+++ b/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
@@ -101,10 +101,13 @@ for (const marker of [
   'const FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT: &str =',
   '"forum_page_builder_server_fn_attestation_v1"',
   'pub struct ForumPageBuilderTransportAttestationResponse',
-  'pub source_commit: Option<String>',
+  'pub source_commit: String',
+  'fn canonical_source_commit(value: &str) -> Option<String>',
   'std::env::var("RUSTOK_SOURCE_COMMIT")',
   'value.len() == 40',
   'value.bytes().all(|byte| byte.is_ascii_hexdigit())',
+  'Forum Page Builder deployed source revision is unavailable',
+  'Forum Page Builder deployed source revision is not a canonical Git SHA',
   '#[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]',
   'pub async fn attest_forum_page_builder_transport(',
   'challenge: String',
@@ -114,6 +117,8 @@ for (const marker of [
   'require_forum_transport_authorization(&auth, &tenant)?',
   'let (host, _event_bus) = runtime()?;',
   'require_forum_module_enabled(&host, tenant.id).await?',
+  'let source_commit = deployed_source_commit()?;',
+  'Ok(build_transport_attestation(challenge, source_commit))',
   'crate::forum_contribution_manifest()',
   'rustok_forum::ForumWidgetContractService::catalog()',
   'FORUM_PAGE_BUILDER_PREVIEW_ENDPOINT',
@@ -122,6 +127,11 @@ for (const marker of [
 ]) {
   requireContains(previewTransport, marker, `Forum transport attestation source missing ${marker}`);
 }
+requireAbsent(
+  previewTransport,
+  "pub source_commit: Option<String>",
+  "successful Forum transport attestation must require a source revision",
+);
 
 const attestationStart = previewTransport.indexOf(
   '#[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]',

--- a/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
+++ b/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
@@ -58,6 +58,13 @@ if (contract.deployment_identity?.cryptographic_origin_to_repo_digest_binding_cl
 if (contract.deployment_identity?.origin_to_repo_digest_binding_is_maintainer_reviewed_external_fact !== true) {
   throw new Error("origin-to-RepoDigest binding must stay an external reviewed fact");
 }
+if (
+  !contract.retained_data?.includes(
+    "boolean verification that the live response contained the exact checkout source commit",
+  )
+) {
+  throw new Error("retained deployment packet must describe live source revision as a verification");
+}
 
 const scenarioIds = contract.scenarios?.map((scenario) => scenario.id);
 if (JSON.stringify(scenarioIds) !== JSON.stringify(["anonymous", "authorized", "no_read"])) {
@@ -190,9 +197,13 @@ for (const marker of [
   "rmSync(output, { force: true })",
   "sourceHashes(contract)",
   'const challenge = `forum-attest-${randomUUID()}`',
+  "function isValidSuccessAttestation(contract, body, challenge)",
+  "text.includes(contract.authorized_response.contract) && text.includes(challenge)",
   "requireAuthorizedBody(contract, captured.responseBody, challenge, sourceCommit)",
-  "text.includes(challenge)",
+  "scenario.success_forbidden &&",
+  "isValidSuccessAttestation(contract, captured.responseBody, challenge)",
   "text.includes(sourceCommit)",
+  "live_server_source_commit_verified_equal_checkout: true",
   "credential_environment_names: credentials.environment_names",
   "credential_values_persisted: false",
   "origin_sha256: sha256(baseUrl)",
@@ -212,6 +223,7 @@ for (const forbidden of [
   "execSync(",
   "shell: true",
   "raw_origin: baseUrl",
+  "live_server_source_commit: sourceCommit",
   "authorization_value",
   "cookie_value",
   "raw_response_body",

--- a/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
+++ b/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireContains(text, needle, message) {
+  if (!text.includes(needle)) throw new Error(message);
+}
+
+function requireAbsent(text, needle, message) {
+  if (text.includes(needle)) throw new Error(message);
+}
+
+const contractPath =
+  "crates/rustok-forum/contracts/evidence/forum-page-builder-serverfn-deployment-attestation-contract.json";
+const runnerPath = "scripts/evidence/capture-forum-page-builder-serverfn-attestation.mjs";
+const verifierPath = "scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs";
+const previewTransportPath = "crates/rustok-forum/admin/src/widget_preview_transport.rs";
+const propertyTransportPath = "crates/rustok-forum/admin/src/widget_property_transport.rs";
+const adminLibPath = "crates/rustok-forum/admin/src/lib.rs";
+const appRouterPath = "apps/server/src/services/app_router.rs";
+const dockerfilePath = "apps/server/Dockerfile";
+const releaseDockerfilePath = "apps/server/Dockerfile.release";
+const packetPath =
+  "docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md";
+
+const contract = JSON.parse(read(contractPath));
+const runner = read(runnerPath);
+const previewTransport = read(previewTransportPath);
+const propertyTransport = read(propertyTransportPath);
+const adminLib = read(adminLibPath);
+const appRouter = read(appRouterPath);
+const dockerfile = read(dockerfilePath);
+const releaseDockerfile = read(releaseDockerfilePath);
+const packet = read(packetPath);
+
+if (contract.status !== "source_ready_maintainer_execution_pending") {
+  throw new Error("deployment attestation contract must not claim execution");
+}
+if (contract.runner !== runnerPath) {
+  throw new Error("deployment attestation contract must point to the retained runner");
+}
+if (contract.endpoint !== "/api/fn/forum/page-builder-transport-attestation") {
+  throw new Error("Forum deployment attestation endpoint drifted");
+}
+if (contract.output?.format !== "forum_page_builder_server_fn_deployment_attestation_v1") {
+  throw new Error("Forum deployment attestation output format drifted");
+}
+if (contract.output?.status !== "server_fn_deployment_attestation_passed_wave_pending") {
+  throw new Error("Forum deployment attestation output status must keep Wave pending");
+}
+if (contract.deployment_identity?.cryptographic_origin_to_repo_digest_binding_claimed !== false) {
+  throw new Error("source must not claim cryptographic origin-to-RepoDigest binding");
+}
+if (contract.deployment_identity?.origin_to_repo_digest_binding_is_maintainer_reviewed_external_fact !== true) {
+  throw new Error("origin-to-RepoDigest binding must stay an external reviewed fact");
+}
+
+const scenarioIds = contract.scenarios?.map((scenario) => scenario.id);
+if (JSON.stringify(scenarioIds) !== JSON.stringify(["anonymous", "authorized", "no_read"])) {
+  throw new Error("deployment attestation scenario matrix drifted");
+}
+const authorized = contract.scenarios.find((scenario) => scenario.id === "authorized");
+if (authorized?.expected_status !== 200) {
+  throw new Error("authorized deployment attestation must require HTTP 200");
+}
+for (const id of ["anonymous", "no_read"]) {
+  if (!contract.scenarios.find((scenario) => scenario.id === id)?.success_forbidden) {
+    throw new Error(`${id} must be forbidden from a valid success attestation`);
+  }
+}
+for (const pending of [
+  "server-function deployment attestation execution",
+  "cryptographic origin-to-RepoDigest binding",
+  "browser execution",
+  "runtime authorization execution",
+  "observed Page Builder Wave",
+  "provider SLO health",
+]) {
+  if (!contract.not_claimed?.includes(pending)) {
+    throw new Error(`deployment contract must keep ${pending} unclaimed`);
+  }
+}
+for (const source of [runnerPath, verifierPath, previewTransportPath, propertyTransportPath, adminLibPath, appRouterPath, dockerfilePath, releaseDockerfilePath, packetPath]) {
+  if (!contract.required_source_files?.includes(source)) {
+    throw new Error(`deployment contract must hash ${source}`);
+  }
+}
+
+for (const marker of [
+  'const FORUM_PAGE_BUILDER_ATTESTATION_CONTRACT: &str =',
+  '"forum_page_builder_server_fn_attestation_v1"',
+  'pub struct ForumPageBuilderTransportAttestationResponse',
+  'pub source_commit: Option<String>',
+  'std::env::var("RUSTOK_SOURCE_COMMIT")',
+  'value.len() == 40',
+  'value.bytes().all(|byte| byte.is_ascii_hexdigit())',
+  '#[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]',
+  'pub async fn attest_forum_page_builder_transport(',
+  'challenge: String',
+  'validate_attestation_challenge(&challenge)?',
+  'leptos_axum::extract::<rustok_api::AuthContext>()',
+  'leptos_axum::extract::<rustok_api::TenantContext>()',
+  'require_forum_transport_authorization(&auth, &tenant)?',
+  'let (host, _event_bus) = runtime()?;',
+  'require_forum_module_enabled(&host, tenant.id).await?',
+  'crate::forum_contribution_manifest()',
+  'rustok_forum::ForumWidgetContractService::catalog()',
+  'FORUM_PAGE_BUILDER_PREVIEW_ENDPOINT',
+  'FORUM_PAGE_BUILDER_PROPERTY_SCHEMA_ENDPOINT',
+  'FORUM_PAGE_BUILDER_PROPERTY_VALIDATE_ENDPOINT',
+]) {
+  requireContains(previewTransport, marker, `Forum transport attestation source missing ${marker}`);
+}
+
+const attestationStart = previewTransport.indexOf(
+  '#[server(prefix = "/api/fn", endpoint = "forum/page-builder-transport-attestation")]',
+);
+const previewStart = previewTransport.indexOf(
+  '#[server(prefix = "/api/fn", endpoint = "forum/page-builder-widget-preview")]',
+);
+if (attestationStart < 0 || previewStart <= attestationStart) {
+  throw new Error("cannot isolate deployed attestation server-function source");
+}
+const attestationEndpointSource = previewTransport.slice(attestationStart, previewStart);
+for (const forbidden of [
+  "ForumWidgetPreviewService",
+  "TopicService",
+  "ReplyService",
+  "forum_topic::",
+  "forum_reply::",
+  "DatabaseConnection",
+]) {
+  requireAbsent(
+    attestationEndpointSource,
+    forbidden,
+    `deployed attestation endpoint must not become a Forum data read path via ${forbidden}`,
+  );
+}
+
+for (const marker of [
+  'endpoint = "forum/page-builder-widget-property-schema"',
+  'endpoint = "forum/page-builder-widget-property-validate"',
+  'require_forum_transport_authorization(&auth, &tenant)?',
+  'require_forum_module_enabled(&host, tenant.id).await',
+]) {
+  requireContains(propertyTransport, marker, `property transport boundary missing ${marker}`);
+}
+for (const marker of [
+  "ForumPageBuilderTransportAttestationResponse",
+  "attest_forum_page_builder_transport",
+]) {
+  requireContains(adminLib, marker, `Forum admin export missing ${marker}`);
+}
+
+for (const marker of [
+  'router.route(',
+  '"/api/fn/{*fn_name}"',
+  'handle_server_fns_with_context(',
+  'middleware::auth_context::resolve_optional',
+  'middleware::tenant::resolve',
+]) {
+  requireContains(appRouter, marker, `server /api/fn composition missing ${marker}`);
+}
+
+for (const [label, source] of [
+  ["production Dockerfile", dockerfile],
+  ["release Dockerfile", releaseDockerfile],
+]) {
+  for (const marker of [
+    "ARG OCI_REVISION=unknown",
+    'org.opencontainers.image.revision="${OCI_REVISION}"',
+    "RUSTOK_SOURCE_COMMIT=${OCI_REVISION}",
+  ]) {
+    requireContains(source, marker, `${label} missing source-revision binding ${marker}`);
+  }
+}
+
+for (const marker of [
+  'spawnSync("git", ["rev-parse", "HEAD"]',
+  "shell: false",
+  'new URLSearchParams({ challenge }).toString()',
+  'method: "POST"',
+  '"content-type": "application/x-www-form-urlencoded"',
+  "AbortSignal.timeout(REQUEST_TIMEOUT_MS)",
+  "requireDeploymentImageDigest(options.deploymentImageDigest)",
+  "rmSync(output, { force: true })",
+  "sourceHashes(contract)",
+  'const challenge = `forum-attest-${randomUUID()}`',
+  "requireAuthorizedBody(contract, captured.responseBody, challenge, sourceCommit)",
+  "text.includes(challenge)",
+  "text.includes(sourceCommit)",
+  "credential_environment_names: credentials.environment_names",
+  "credential_values_persisted: false",
+  "origin_sha256: sha256(baseUrl)",
+  "raw_origin_persisted: false",
+  "raw_value_persisted: false",
+  "raw_body_persisted: false",
+  'origin_to_repo_digest_binding: "maintainer_reviewed_external_fact"',
+  "cryptographic_origin_to_repo_digest_binding: false",
+  "browser_execution_not_claimed: true",
+  "runtime_authorization_execution_not_claimed: true",
+  "provider_slo_health_not_claimed: true",
+  "observed_page_builder_wave_pending: true",
+]) {
+  requireContains(runner, marker, `deployment attestation runner missing ${marker}`);
+}
+for (const forbidden of [
+  "execSync(",
+  "shell: true",
+  "raw_origin: baseUrl",
+  "authorization_value",
+  "cookie_value",
+  "raw_response_body",
+  "response_body_text:",
+  "tenant_id:",
+  "actor_id:",
+]) {
+  requireAbsent(runner, forbidden, `deployment attestation runner must not persist/execute through ${forbidden}`);
+}
+const staleCleanup = runner.indexOf("rmSync(output, { force: true })");
+const requestLoop = runner.indexOf("for (const scenario of contract.scenarios)");
+if (staleCleanup < 0 || requestLoop < 0 || staleCleanup > requestLoop) {
+  throw new Error("stale deployment attestation output must be removed before network requests");
+}
+
+for (const marker of [
+  "Status: `source-ready / maintainer-deployment-attestation-execution-pending / browser-execution-pending / runtime-execution-pending / wave-pending`",
+  "POST /api/fn/forum/page-builder-transport-attestation",
+  "RUSTOK_SOURCE_COMMIT=${OCI_REVISION}",
+  "forum_page_builder_server_fn_deployment_attestation_v1",
+  "server_fn_deployment_attestation_passed_wave_pending",
+  "cryptographic origin-to-RepoDigest",
+  "maintainer/infrastructure provenance fact",
+  "Provider SLO health remains `unobserved`",
+  "No HTTP request, browser, Cargo command, Node verifier, Docker build/inspect, database fixture, formatter, build, workflow or CI execution is claimed",
+]) {
+  requireContains(packet, marker, `deployment attestation actualization missing ${marker}`);
+}
+
+console.log("Forum Page Builder deployed server-function attestation source: ok");

--- a/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
+++ b/scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs
@@ -24,6 +24,7 @@ const adminLibPath = "crates/rustok-forum/admin/src/lib.rs";
 const appRouterPath = "apps/server/src/services/app_router.rs";
 const dockerfilePath = "apps/server/Dockerfile";
 const releaseDockerfilePath = "apps/server/Dockerfile.release";
+const releaseWorkflowPath = ".github/workflows/release.yml";
 const packetPath =
   "docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md";
 
@@ -35,6 +36,7 @@ const adminLib = read(adminLibPath);
 const appRouter = read(appRouterPath);
 const dockerfile = read(dockerfilePath);
 const releaseDockerfile = read(releaseDockerfilePath);
+const releaseWorkflow = read(releaseWorkflowPath);
 const packet = read(packetPath);
 
 if (contract.status !== "source_ready_maintainer_execution_pending") {
@@ -57,6 +59,9 @@ if (contract.deployment_identity?.cryptographic_origin_to_repo_digest_binding_cl
 }
 if (contract.deployment_identity?.origin_to_repo_digest_binding_is_maintainer_reviewed_external_fact !== true) {
   throw new Error("origin-to-RepoDigest binding must stay an external reviewed fact");
+}
+if (contract.deployment_identity?.canonical_release_passes_github_sha_as_oci_revision !== true) {
+  throw new Error("deployment contract must retain canonical release revision wiring");
 }
 if (
   !contract.retained_data?.includes(
@@ -91,7 +96,18 @@ for (const pending of [
     throw new Error(`deployment contract must keep ${pending} unclaimed`);
   }
 }
-for (const source of [runnerPath, verifierPath, previewTransportPath, propertyTransportPath, adminLibPath, appRouterPath, dockerfilePath, releaseDockerfilePath, packetPath]) {
+for (const source of [
+  runnerPath,
+  verifierPath,
+  previewTransportPath,
+  propertyTransportPath,
+  adminLibPath,
+  appRouterPath,
+  dockerfilePath,
+  releaseDockerfilePath,
+  releaseWorkflowPath,
+  packetPath,
+]) {
   if (!contract.required_source_files?.includes(source)) {
     throw new Error(`deployment contract must hash ${source}`);
   }
@@ -194,6 +210,14 @@ for (const [label, source] of [
   ]) {
     requireContains(source, marker, `${label} missing source-revision binding ${marker}`);
   }
+}
+for (const marker of [
+  '--build-arg "OCI_REVISION=$GITHUB_SHA"',
+  '--metadata-file image-build-metadata.json',
+  '--provenance=mode=max',
+  'subject-digest: ${{ steps.image-metadata.outputs.digest }}',
+]) {
+  requireContains(releaseWorkflow, marker, `canonical release workflow missing ${marker}`);
 }
 
 for (const marker of [


### PR DESCRIPTION
## Summary

Continue FORUM-32 after #3266 by retaining a source-ready deployed native server-function attestation boundary without executing it.

- add a read-only `/api/fn/forum/page-builder-transport-attestation` probe that crosses the same tenant, effective `forum_topics:read`, exact tenant-module and Forum host-runtime gates as Page Builder preview/property transport;
- keep the probe data-free: it returns only bounded challenge echo, generated Forum provider/module identity, owner widget contract identity and canonical Page Builder transport paths;
- fail closed unless the deployed process exposes a canonical 40-hex source revision;
- bind both production server Docker definitions to the existing OCI revision through `RUSTOK_SOURCE_COMMIT=${OCI_REVISION}`;
- retain the canonical release workflow as evidence that release builds already pass `GITHUB_SHA` as `OCI_REVISION` and publish immutable digest/provenance;
- add an external HTTP capture contract/runner with anonymous, authorized and no-read profiles, stale-output cleanup and privacy-bounded retention;
- keep origin-to-RepoDigest routing as an explicit maintainer/infrastructure fact rather than claiming cryptographic binding;
- add a source-only guard and dated actualization packet.

## Promotion boundary

This PR does not execute or admit any evidence. Browser execution (#3264), direct runtime authorization execution (#3266), this deployment attestation execution, external origin-to-RepoDigest provenance, the Pages reference-consumer gate and observed Forum Page Builder Wave all remain open. Provider SLO health remains unobserved.

## Dependencies

No Cargo.toml, Cargo.lock, package dependency or new runtime dependency changes.

## Validation

Per maintainer instruction, no Cargo tests, Node verifiers, HTTP requests, browser/Playwright execution, Docker build/inspect, formatter, build, workflow, CI, database/runtime evidence, lock generation or `git diff --check` was run.