### PR TITLE
fix(groups): preserve enforcement owner error identity in GraphQL

### DIFF
--- a/crates/rustok-groups/docs/membership-enforcement-graphql-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-graphql-contract.md
@@ -76,15 +76,23 @@ The result does not expose Moderation case/decision/report data or internal rece
 
 ## Errors
 
-Neutral `PortError` kinds map consistently with existing Groups transports:
+Neutral `PortError` kinds retain the common GraphQL transport classification:
 
-- validation/conflict -> GraphQL bad user input;
-- not found -> not found;
-- forbidden -> permission denied;
-- unavailable/timeout -> generic temporary-unavailable internal error;
-- invariant violation -> generic requires-review internal error.
+- validation/conflict -> GraphQL `BAD_USER_INPUT`;
+- not found -> `NOT_FOUND`;
+- forbidden -> `PERMISSION_DENIED`;
+- unavailable/timeout -> generic `INTERNAL_ERROR` with the public temporary-unavailable message;
+- invariant violation -> generic `INTERNAL_ERROR` with the public requires-review message.
 
-Owner stable error codes remain authoritative internally. Runtime schema/error-extension parity still requires executable evidence; source presence alone does not promote that gate.
+The enforcement transport additionally preserves the stable owner error identity in GraphQL extensions:
+
+- `code` remains the platform-wide GraphQL transport classification;
+- `domainCode` is the exact stable `PortError.code` returned by the Groups owner;
+- `retryable` is the exact neutral `PortError.retryable` flag.
+
+This avoids forcing clients to parse messages or collapse distinct owner conflicts such as `groups.membership_enforcement_revision_conflict`, while keeping unavailable/invariant diagnostics sanitized by the neutral port contract. The transport does not replace the common GraphQL `code` field with a domain-specific value.
+
+Source-level tests retain conflict and unavailable extension mapping. Runtime schema/error-extension parity still requires executable evidence; source presence alone does not promote that gate.
 
 ## No fallback
 
@@ -96,7 +104,8 @@ Intentionally not run while preparing this slice:
 
 ```bash
 cargo check -p rustok-groups --features graphql
-cargo test -p rustok-groups
+cargo test -p rustok-groups --features graphql graphql_conflict_preserves_transport_and_owner_codes
+cargo test -p rustok-groups --features graphql graphql_unavailable_keeps_owner_code_and_retryability
 node scripts/verify/verify-groups-membership-enforcement-graphql.mjs
 ```
 

--- a/crates/rustok-groups/src/graphql_membership_enforcement.rs
+++ b/crates/rustok-groups/src/graphql_membership_enforcement.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use async_graphql::{Context, ErrorExtensions, FieldError, Object, Result, SimpleObject};
 use chrono::{DateTime, Utc};
 use rustok_api::graphql::GraphQLError;
 use rustok_api::request::RequestContext;
@@ -17,6 +17,8 @@ use crate::{
 };
 
 const PORT_DEADLINE: Duration = Duration::from_secs(5);
+const DOMAIN_CODE_EXTENSION: &str = "domainCode";
+const RETRYABLE_EXTENSION: &str = "retryable";
 
 #[derive(Default)]
 pub struct GroupsMembershipEnforcementMutation;
@@ -189,7 +191,9 @@ fn port_context(
 }
 
 fn map_port_error(error: PortError) -> FieldError {
-    match error.kind {
+    let domain_code = error.code.clone();
+    let retryable = error.retryable;
+    let transport_error = match error.kind {
         PortErrorKind::Validation | PortErrorKind::Conflict => {
             <FieldError as GraphQLError>::bad_user_input(&error.message)
         }
@@ -203,5 +207,72 @@ fn map_port_error(error: PortError) -> FieldError {
         PortErrorKind::InvariantViolation => <FieldError as GraphQLError>::internal_error(
             "Groups membership enforcement requires review",
         ),
+    };
+
+    // Keep the common GraphQL `code` extension as the transport classification while preserving
+    // the stable owner PortError identity separately. Clients can branch on the domain code without
+    // losing the platform-wide BAD_USER_INPUT/PERMISSION_DENIED/etc. contract.
+    transport_error.extend_with(move |_, extensions| {
+        extensions.set(DOMAIN_CODE_EXTENSION, domain_code);
+        extensions.set(RETRYABLE_EXTENSION, retryable);
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use async_graphql::ErrorExtensions;
+
+    use super::*;
+
+    fn extension_json(error: FieldError, key: &str) -> Option<serde_json::Value> {
+        error
+            .extend()
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.get(key))
+            .cloned()
+            .and_then(|value| value.into_json().ok())
+    }
+
+    #[test]
+    fn graphql_conflict_preserves_transport_and_owner_codes() {
+        let error = map_port_error(PortError::conflict(
+            "groups.membership_enforcement_revision_conflict",
+            "stale membership revision",
+        ));
+        assert_eq!(
+            extension_json(error.clone(), "code").and_then(|value| value.as_str().map(str::to_owned)),
+            Some("BAD_USER_INPUT".to_string())
+        );
+        assert_eq!(
+            extension_json(error.clone(), DOMAIN_CODE_EXTENSION)
+                .and_then(|value| value.as_str().map(str::to_owned)),
+            Some("groups.membership_enforcement_revision_conflict".to_string())
+        );
+        assert_eq!(
+            extension_json(error, RETRYABLE_EXTENSION).and_then(|value| value.as_bool()),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn graphql_unavailable_keeps_safe_message_and_retryability() {
+        let error = map_port_error(PortError::unavailable(
+            "groups.persistence_unavailable",
+            "private database diagnostic",
+        ));
+        assert_eq!(
+            extension_json(error.clone(), "code").and_then(|value| value.as_str().map(str::to_owned)),
+            Some("INTERNAL_ERROR".to_string())
+        );
+        assert_eq!(
+            extension_json(error.clone(), DOMAIN_CODE_EXTENSION)
+                .and_then(|value| value.as_str().map(str::to_owned)),
+            Some("groups.persistence_unavailable".to_string())
+        );
+        assert_eq!(
+            extension_json(error, RETRYABLE_EXTENSION).and_then(|value| value.as_bool()),
+            Some(true)
+        );
     }
 }

--- a/crates/rustok-groups/src/graphql_membership_enforcement.rs
+++ b/crates/rustok-groups/src/graphql_membership_enforcement.rs
@@ -224,54 +224,58 @@ mod tests {
 
     use super::*;
 
-    fn extension_json(error: FieldError, key: &str) -> Option<serde_json::Value> {
-        error
-            .extend()
-            .extensions
-            .as_ref()
-            .and_then(|extensions| extensions.get(key))
-            .cloned()
-            .and_then(|value| value.into_json().ok())
-    }
-
     #[test]
     fn graphql_conflict_preserves_transport_and_owner_codes() {
         let error = map_port_error(PortError::conflict(
             "groups.membership_enforcement_revision_conflict",
             "stale membership revision",
-        ));
+        ))
+        .extend();
+        let extensions = error.extensions.expect("mapped GraphQL error should carry extensions");
+        let json = |key: &str| {
+            extensions
+                .get(key)
+                .cloned()
+                .and_then(|value| value.into_json().ok())
+        };
         assert_eq!(
-            extension_json(error.clone(), "code").and_then(|value| value.as_str().map(str::to_owned)),
+            json("code").and_then(|value| value.as_str().map(str::to_owned)),
             Some("BAD_USER_INPUT".to_string())
         );
         assert_eq!(
-            extension_json(error.clone(), DOMAIN_CODE_EXTENSION)
-                .and_then(|value| value.as_str().map(str::to_owned)),
+            json(DOMAIN_CODE_EXTENSION).and_then(|value| value.as_str().map(str::to_owned)),
             Some("groups.membership_enforcement_revision_conflict".to_string())
         );
         assert_eq!(
-            extension_json(error, RETRYABLE_EXTENSION).and_then(|value| value.as_bool()),
+            json(RETRYABLE_EXTENSION).and_then(|value| value.as_bool()),
             Some(false)
         );
     }
 
     #[test]
-    fn graphql_unavailable_keeps_safe_message_and_retryability() {
+    fn graphql_unavailable_keeps_owner_code_and_retryability() {
         let error = map_port_error(PortError::unavailable(
             "groups.persistence_unavailable",
             "private database diagnostic",
-        ));
+        ))
+        .extend();
+        let extensions = error.extensions.expect("mapped GraphQL error should carry extensions");
+        let json = |key: &str| {
+            extensions
+                .get(key)
+                .cloned()
+                .and_then(|value| value.into_json().ok())
+        };
         assert_eq!(
-            extension_json(error.clone(), "code").and_then(|value| value.as_str().map(str::to_owned)),
+            json("code").and_then(|value| value.as_str().map(str::to_owned)),
             Some("INTERNAL_ERROR".to_string())
         );
         assert_eq!(
-            extension_json(error.clone(), DOMAIN_CODE_EXTENSION)
-                .and_then(|value| value.as_str().map(str::to_owned)),
+            json(DOMAIN_CODE_EXTENSION).and_then(|value| value.as_str().map(str::to_owned)),
             Some("groups.persistence_unavailable".to_string())
         );
         assert_eq!(
-            extension_json(error, RETRYABLE_EXTENSION).and_then(|value| value.as_bool()),
+            json(RETRYABLE_EXTENSION).and_then(|value| value.as_bool()),
             Some(true)
         );
     }

--- a/scripts/verify/verify-groups-membership-enforcement-graphql.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-graphql.mjs
@@ -48,6 +48,19 @@ for (const marker of [
   "member_count",
   "enforcement_revision",
   "replayed",
+  'const DOMAIN_CODE_EXTENSION: &str = "domainCode"',
+  'const RETRYABLE_EXTENSION: &str = "retryable"',
+  "let domain_code = error.code.clone()",
+  "let retryable = error.retryable",
+  "transport_error.extend_with",
+  "extensions.set(DOMAIN_CODE_EXTENSION, domain_code)",
+  "extensions.set(RETRYABLE_EXTENSION, retryable)",
+  "graphql_conflict_preserves_transport_and_owner_codes",
+  "graphql_unavailable_keeps_owner_code_and_retryability",
+  'Some("BAD_USER_INPUT".to_string())',
+  'Some("INTERNAL_ERROR".to_string())',
+  'Some("groups.membership_enforcement_revision_conflict".to_string())',
+  'Some("groups.persistence_unavailable".to_string())',
 ]) {
   requireText(graphql, marker, `Groups enforcement GraphQL source is missing ${marker}`);
 }
@@ -121,6 +134,10 @@ for (const marker of [
   "No fallback",
   "graphql_application_cas::GroupsMutationRoot",
   "GroupMembershipEnforcementCommandPort",
+  "domainCode",
+  "retryable",
+  "platform-wide GraphQL transport classification",
+  "Runtime schema/error-extension parity",
   "cargo check -p rustok-groups --features graphql",
 ]) {
   requireText(docs, marker, `Groups enforcement GraphQL handoff is missing ${marker}`);


### PR DESCRIPTION
## Summary
- preserve stable Groups owner `PortError.code` across direct enforcement GraphQL mutations as `extensions.domainCode`
- preserve exact neutral `PortError.retryable` as `extensions.retryable`
- keep the existing platform-wide GraphQL `extensions.code` classification unchanged (`BAD_USER_INPUT`, `PERMISSION_DENIED`, `INTERNAL_ERROR`, etc.)
- retain sanitized unavailable/invariant public messages while exposing only the already-public machine-readable domain code
- add source-level tests for revision conflict and unavailable mappings
- update the direct enforcement GraphQL handoff and source guard without promoting runtime parity evidence
- add no dependency, manifest, lockfile, schema, owner-state, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.