### PR TITLE
feat(index): make replay runner gracefully interruptible

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after Product graph-source actualization merge
-`832f4946245ef6bc82b7eb50e202b47d0426a569` and continued on
-`agent/index-replay-graphql-transport-20260808`.
+Status overlay rechecked after guarded replay GraphQL transport merge
+`6672c8b15f7b3ebd53a75147262b3d74020e4a16` and continued on
+`agent/index-replay-graceful-shutdown-v2-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -89,7 +89,7 @@ Current Product code has already completed the source-code replacement from lowe
 key `4`. `product-postgres-primary` uses `derive_index_schema_source_event_id`; Product source, absence and query
 admission do not select key `3`.
 
-The retained PostgreSQL packet now covers the staged authority-transition path in source:
+The retained PostgreSQL packet covers the staged authority-transition path in source:
 
 1. obtain the exact current Product schema from `SharedIndexSchemaRegistry` and assert key `4`;
 2. ordinary-register a storage-only lower-key fixture plus the actual current runtime schemas, leaving both
@@ -113,7 +113,7 @@ register a key3 Product source/factory. Runtime dual-read compatibility remains 
 request-bound tenant/actor context and effective `modules:manage`, rejects cross-tenant run requests and derives
 cancel tenant from that context.
 
-The GraphQL layer now exposes source-complete schema-wide `runIndexReplay` / `cancelIndexReplay` commands without
+The GraphQL layer exposes source-complete schema-wide `runIndexReplay` / `cancelIndexReplay` commands without
 calling `SharedIndexReplayRuntime`, source adapters or PostgreSQL directly. Authorization occurs before parsing
 untrusted schema/job input.
 
@@ -122,8 +122,27 @@ resource budget. Each run creates a server-owned worker identity and applies fix
 per page, at most 8 pages, heartbeat every page and a 60-second lease. Yielded work remains resumable through the
 existing durable job/checkpoint mechanism.
 
-This source slice does not establish GraphQL runtime execution evidence and does not solve graceful host shutdown
-inside an active replay page. Those remain separate boundaries.
+GraphQL runtime execution/cancellation evidence remains maintainer-owned.
+
+## M6 replay graceful interruption
+
+`PostgresIndexReplayRunner::run_interruptible` now carries one host-owned synchronous probe into the existing
+one-page safe points: before source scan, before each mutation, and before checkpoint commit. Ordinary `run` and
+persisted operator cancellation semantics remain unchanged.
+
+An `IndexReplayError::Interrupted` first preserves any persisted cancellation race. Otherwise the same fenced
+job is yielded back to `pending`, lease ownership is cleared, no failure payload is recorded, and the last
+committed checkpoint is preserved.
+
+A retained deterministic SQLite packet covers both important restart windows:
+
+- host stop before scan: zero source calls/checkpoint changes, then attempt 2 completes normally;
+- host stop after one mutation is durable but before checkpoint commit: the first attempt yields with no
+  checkpoint, then attempt 2 scans the same page, records the stable delivery as `Duplicate`, commits the
+  checkpoint and succeeds.
+
+This is runner-level source completeness only. The server `StopHandle` is not yet wired through
+`SharedIndexReplayRuntime` / `IndexReplayOperatorRuntime` into the interruptible path.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -153,9 +172,11 @@ inside an active replay page. Those remain separate boundaries.
 - [x] Reconciliation, drift diagnosis and targeted repair source.
 - [x] Real-migration repair PostgreSQL harness and retained-evidence admission tooling.
 - [x] Guarded schema-wide replay run/cancel GraphQL command transport with server-owned bounded run policy.
+- [x] Carry a host-owned interruption probe through replay runner safe points and retain duplicate-safe restart evidence source.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
-- [ ] Bind graceful host shutdown to in-page replay interruption safe points and retain restart/redelivery evidence.
+- [ ] Execute/admit retained graceful interruption/restart evidence.
+- [ ] Bind server `StopHandle` to interruptible replay execution through guarded runtime/operator composition.
 - [ ] Complete remaining multi-host/restart evidence beyond existing convergence/replay packets.
 - [ ] Add locale/partition replay checkpoint dimensions and explicit rebuild modes under separate contracts.
 
@@ -190,13 +211,12 @@ inside an active replay page. Those remain separate boundaries.
 ## Next source-code boundary
 
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
-The next independent M6 source slice is graceful replay shutdown: bind a host-owned stop probe to the existing
-`IndexReplayWorker::run_next_page_interruptible` safe points, yield the active job back to durable `pending`
-without marking it failed/cancelled, and retain restart evidence that stable deliveries become duplicates when a
-shutdown occurs after mutation durability but before checkpoint commit.
+The next independent M6 source slice is server binding: surface only a server-owned `StopHandle::is_stopping`
+probe through `SharedIndexReplayRuntime` and `IndexReplayOperatorRuntime` so authorized replay commands use
+`run_interruptible` without accepting any shutdown control from GraphQL input.
 
-Do not conflate that shutdown contract with user-requested cancellation. Locale/partition checkpoint scope and
-explicit rebuild modes remain later, separate contracts.
+Do not change user-requested cancellation semantics while adding host-stop composition. Locale/partition replay
+checkpoint scope and explicit rebuild modes remain later, separate contracts.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-bounded-multipage-runner.md
+++ b/crates/rustok-index/docs/m6-bounded-multipage-runner.md
@@ -4,9 +4,9 @@ Status: `source_complete_owner_execution_pending`
 
 This slice composes the existing one-page replay worker, fenced rebuild jobs, mutation
 store, and lease-bound checkpoint store into one bounded PostgreSQL runner. It includes
-durable cancellation requests and between-page terminal cancellation. It does not add a
-scheduler, background task, automatic retry/backoff, in-page interruption, dry-run, or
-production source adapter.
+durable cancellation requests, between-page terminal cancellation, and a separate
+host-probed in-page interruption path. It does not add a scheduler, background task,
+automatic retry/backoff, dry-run, or production source adapter.
 
 ## Request bounds
 
@@ -22,9 +22,9 @@ The source name is never caller supplied. `PostgresIndexReplayRunner` resolves t
 owner from `SharedIndexSourceRegistry` before acquiring the durable job. The job request
 therefore uses the same source identity as page execution and checkpoint persistence.
 
-## Execution order
+## Ordinary execution order
 
-For an acquired `IndexReplayJobLease`, the runner:
+For an acquired `IndexReplayJobLease`, ordinary `PostgresIndexReplayRunner::run`:
 
 1. constructs `PostgresIndexReplayCheckpointStore` from that exact lease;
 2. observes and terminalizes a previously requested cancellation before each page;
@@ -38,10 +38,36 @@ For an acquired `IndexReplayJobLease`, the runner:
 8. when the page budget ends with continuation, atomically returns the same job to
    `pending`, clears lease ownership, and makes it immediately claimable for resume.
 
-A page itself is not interrupted by a heartbeat or cancellation task. Operators must
-choose a lease longer than the maximum admitted source-page and mutation/checkpoint
-commit duration. A cancellation requested during a page is observed after that page's
-idempotent mutations and checkpoint are durable.
+A persisted cancellation requested during ordinary execution is still observed after the
+current page's idempotent mutations and checkpoint are durable. This existing user-cancel
+contract is intentionally unchanged by host interruption work.
+
+## Host-probed in-page interruption
+
+`PostgresIndexReplayRunner::run_interruptible` is a separate execution entry point over the
+same job/checkpoint/mutation stores. It adapts a host-owned probe to
+`IndexReplayWorker::run_next_page_interruptible`, whose safe points are before source scan,
+before every mutation, and before checkpoint commit.
+
+If the worker returns `IndexReplayError::Interrupted`, the runner first preserves any
+persisted cancellation race. Otherwise it uses the ordinary fenced pending-yield transition:
+
+- the job keeps the same UUID;
+- state returns to `pending`;
+- lease ownership is cleared;
+- no failure payload is recorded;
+- the last committed checkpoint is preserved;
+- the next claim increments `attempt_count`.
+
+Host interruption does not set `cancel_requested` and is not a terminal cancellation.
+
+If interruption occurs after one or more mutations are already durable but before checkpoint
+commit, the next attempt replays the same page. Stable delivery IDs make those durable
+mutations `Duplicate`; the resumed page can then advance its checkpoint safely. No synthetic
+checkpoint advance or mutation rollback is introduced.
+
+The retained SQLite packet is documented in `m6-replay-graceful-shutdown.md`. It is
+source-only until maintainer execution/admission.
 
 ## Cancellation contract
 
@@ -86,22 +112,28 @@ classified as `checkpoint_lease_lost`, heartbeat loss, terminal completion loss,
 loss, and cancellation ownership loss return explicit `IndexReplayRunError::LeaseLost`
 instead of attempting a stale state write.
 
+Host interruption is not a page failure and does not enter this failure path.
+
 ## Still open
 
-- interruption or timeout of one currently executing source page;
+- bind the server-owned `StopHandle` to the interruptible runner path without exposing a
+  shutdown control to GraphQL callers;
+- execute/admit retained interruption/restart evidence;
 - automatic bounded retry/backoff and dead-letter scheduling;
-- a host scheduler, command/transport authorization, and graceful process shutdown;
-- direct server-composition publication of the runner;
-- dry-run and targeted/full/shadow rebuild modes;
+- operator-visible scheduler health and metrics;
+- explicit targeted/full/shadow rebuild modes;
 - locale and partition checkpoint dimensions;
-- Product and later source adapters;
 - retained PostgreSQL cancellation, crash, lease-expiry, restart, timing, and
-  multi-instance evidence.
+  multi-instance evidence beyond current focused packets.
+
+The guarded schema-wide GraphQL run/cancel command transport is now source-complete through
+`IndexReplayOperatorRuntime`; its execution evidence remains maintainer-owned.
 
 ## Owner validation
 
 ```bash
 node scripts/verify/verify-index-replay-multipage-runner.mjs
+node scripts/verify/verify-index-replay-graceful-shutdown.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 cargo check -p rustok-index --all-targets

--- a/crates/rustok-index/docs/m6-cooperative-page-interruption.md
+++ b/crates/rustok-index/docs/m6-cooperative-page-interruption.md
@@ -1,24 +1,24 @@
 # M6 cooperative replay-page interruption
 
-Status: `source_complete_runner_probe_pending`
+Status: `worker_and_runner_source_complete_host_binding_pending`
 
 ## Purpose
 
 `IndexReplayWorker` exposes an interruptible one-page execution path without changing the
-existing replay API. The ordinary `run_next_page` method delegates to the same implementation
-with a no-op probe, while a later lease-aware runner can call
-`run_next_page_interruptible`.
+existing ordinary replay API. `run_next_page` delegates to the same implementation with a no-op
+probe, while `PostgresIndexReplayRunner::run_interruptible` now supplies a host-owned probe to
+`run_next_page_interruptible` under the exact active replay lease.
 
-The caller-owned probe returns a machine-bounded result:
+The probe returns a machine-bounded result:
 
 - `Ok(false)` continues execution;
 - `Ok(true)` returns `IndexReplayError::Interrupted`;
 - `Err(IndexReplayFailure)` returns `IndexReplayError::InterruptionCheckFailed` with only the
   existing bounded retryable/permanent dependency code.
 
-The worker does not impose a deadline on the probe future itself. A production caller must keep
-that probe bounded and must not attach raw database, transport, request, tenant, or stack text to
-its result.
+The one-page worker does not impose a deadline on the probe future itself. The runner adapter uses
+a synchronous boolean host probe, so it does not introduce another pending dependency future at
+these safe points.
 
 ## Safe interruption boundaries
 
@@ -35,48 +35,62 @@ An interruption never commits the page checkpoint. If interruption occurs after 
 mutations were already persisted, the next run scans the same page again. Existing inbox
 deduplication and monotonic source-version guards remain the safety owner for that redelivery.
 
+## Runner integration
+
+The original `source_replay_runner.rs` ordinary run/cancel path remains unchanged. A nested runner
+extension adds `PostgresIndexReplayRunner::run_interruptible` and reuses the same source resolution,
+job acquisition, heartbeat, mutation store, checkpoint store, completion and pending-yield helpers.
+
+When a page returns `Interrupted`, the runner checks persisted cancellation first. If no operator
+cancel won the race, the runner uses the fenced pending-yield transition rather than failure or
+terminal cancellation. The job keeps its UUID, clears lease ownership, preserves the last committed
+checkpoint, records no failure details, and can be claimed as a new attempt.
+
+The retained runner-level SQLite packet proves both pre-scan yield/restart and the durable-mutation / missing-checkpoint redelivery window where attempt 2 observes `Duplicate` before completion.
+
 ## Interaction with merged M6 slices
 
-Production Product, ProductVariant, SalesChannel, and future canonical sources are already
-registered through the 30-second source-call timeout wrapper. The pre-scan safe point therefore
-combines with a bounded production source future; this interruption contract does not replace the
-source timeout.
+Production Product, ProductVariant, SalesChannel, and future canonical sources are registered
+through the 30-second source-call timeout wrapper. The pre-scan safe point therefore combines with
+a bounded production source future; interruption does not replace the source timeout.
 
 The bounded replay dry-run remains a separate no-write validation capability. It does not call
 this worker and does not claim cancellation, checkpoint, or mutation interruption semantics.
 
-Mutation-sink and checkpoint-store futures are not preempted by this slice. The worker can observe
-interruption only before starting the next mutation or checkpoint commit, not while one of those
-operations is already pending.
+Mutation-sink and checkpoint-store futures are not preempted. Interruption is observed only before
+starting the next mutation or checkpoint commit, not while one of those operations is already
+pending.
 
 ## Ownership boundaries
 
-This slice is database and runtime neutral. It does not:
+The one-page worker remains database and runtime neutral. It does not:
 
 - read `index_jobs` or interpret `cancel_requested`;
-- bind the probe to an active replay lease;
 - terminalize a replay job as cancelled;
 - create a PostgreSQL cancellation probe;
 - interrupt a source, mutation, checkpoint, or probe future already in progress;
 - add a timer, polling loop, scheduler, task, or graceful-shutdown owner;
 - change source, mutation, checkpoint, cursor, event identity, migration, or table shape.
 
-The PostgreSQL runner must later derive the probe from the exact active
-`(tenant_id, job_id, worker_id, attempt_count)` lease, classify probe storage failures through a
-bounded code, and preserve its existing fenced cancellation transition.
+The PostgreSQL runner extension owns lease-aware state transitions around interruption, but the
+server lifecycle still does not supply its `StopHandle` to this path. `SharedIndexReplayRuntime`,
+`IndexReplayOperatorRuntime`, and GraphQL therefore remain on ordinary replay execution until the
+next host-composition slice.
 
-The canonical combined roadmap item for in-page interruption/timeouts, dry-run, and
-targeted/full/shadow rebuild modes remains open because runner binding, pending-future handling,
-rebuild modes, and retained PostgreSQL evidence are still absent.
+The canonical roadmap item remains partially open for actual server stop binding, pending-future
+timeout handling, explicit rebuild modes, locale/partition scope, and retained execution evidence.
 
 ## Source evidence
 
 Focused source scenarios retain:
 
-- interruption before source scan with no source, mutation, or checkpoint write;
-- interruption immediately before checkpoint commit after one durable mutation, followed by
+- worker interruption before source scan with no source, mutation, or checkpoint write;
+- worker interruption immediately before checkpoint commit after one durable mutation, followed by
   duplicate-safe replay and checkpoint completion;
-- bounded retryable interruption-probe failure before source access.
+- bounded retryable interruption-probe failure before source access;
+- runner interruption before scan yielding the durable job back to `pending`;
+- runner interruption after durable mutation / before checkpoint commit, followed by attempt-2
+  duplicate redelivery and successful completion.
 
 Formatting, Cargo checks/tests, JavaScript verifiers, PostgreSQL cancellation/lease races, restart
 scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-graceful-shutdown.md
+++ b/crates/rustok-index/docs/m6-replay-graceful-shutdown.md
@@ -1,0 +1,75 @@
+# M6 replay graceful interruption and restart
+
+Status: `runner_source_complete_host_binding_execution_pending`.
+
+## Purpose
+
+The one-page replay worker already exposes cooperative interruption safe points around durable boundaries. This
+slice carries that contract through `PostgresIndexReplayRunner` without changing ordinary replay or persisted
+operator cancellation semantics.
+
+`PostgresIndexReplayRunner::run_interruptible` accepts one host-owned synchronous probe. The probe is adapted to
+`IndexReplayWorker::run_next_page_interruptible`, which checks it:
+
+1. after checkpoint readiness and before source scan;
+2. before each mutation application;
+3. after page mutations are durable and before checkpoint commit.
+
+The existing `PostgresIndexReplayRunner::run` remains unchanged and does not manufacture an interruption probe.
+
+## Host interruption is not user cancellation
+
+`IndexReplayError::Interrupted` is handled separately from page failure. The runner:
+
+1. first checks whether a persisted operator cancellation won the race;
+2. if cancellation is present, returns the existing terminal `Cancelled` outcome;
+3. otherwise calls the existing fenced `yield_for_resume` transition;
+4. returns `Yielded` with the same durable job UUID and attempt number;
+5. leaves the job `pending`, clears lease ownership, records no failure payload, and preserves the last committed
+   checkpoint.
+
+Host interruption never sets `cancel_requested` and never publishes `failed`. User-requested cancellation keeps
+its existing contract and continues to be persisted through `request_cancel`.
+
+## Restart and redelivery
+
+An interruption before source scan performs no source work and leaves no checkpoint change. A new worker can
+claim the same pending job, increment the attempt fence, and continue normally.
+
+The important crash-equivalent window is interruption after a mutation has committed but before the page
+checkpoint commits. The durable mutation remains in `index_inbox` / materialization while the replay checkpoint
+still points at the previous page. A later attempt therefore scans the same page again. Stable delivery identity
+causes the already-durable mutation to return `Duplicate`; only then does the resumed page commit its checkpoint
+and complete the job.
+
+This intentionally relies on the existing inbox deduplication and monotonic source-version guarantees rather
+than introducing rollback or an unsafe synthetic checkpoint advance.
+
+## Retained source evidence
+
+`source_replay_graceful_shutdown_tests.rs` retains deterministic SQLite source for two cases:
+
+- interruption at the first safe point proves zero source scans, a pending lease-free job, no checkpoint, and
+  successful attempt-2 restart;
+- interruption at the third safe point of a one-mutation page proves one durable entity/inbox receipt, no
+  checkpoint, pending yield, then attempt-2 duplicate redelivery and successful checkpoint/job completion.
+
+The packet uses production Index migrations, source registry, mutation store, replay jobs, checkpoint store and
+runner state transitions. It has not been executed by the implementation agent.
+
+## Still open
+
+This slice does **not** yet connect a server `StopHandle` to `run_interruptible`. The next server-composition
+boundary must provide a host-owned stop probe without exposing it to GraphQL callers and without bypassing
+`IndexReplayOperatorRuntime` authority.
+
+Also still separate:
+
+- runtime execution/admission of this retained evidence;
+- GraphQL replay command execution/cancellation evidence;
+- locale/partition replay checkpoint scope;
+- explicit rebuild modes;
+- broader multi-host/timing evidence.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -8,7 +8,7 @@ This composition freezes the complete immutable Index source/schema registries a
 - bounded guarded replay runtime;
 - one module-work registration for due reconciliation execution.
 
-It does not add automatic replay-job scheduling. The server now exposes one bounded authorized GraphQL run/cancel command transport over the guarded replay operator; that transport remains separate from runtime materialization and scheduler ownership.
+It does not add automatic replay-job scheduling. The server exposes one bounded authorized GraphQL run/cancel command transport over the guarded replay operator; that transport remains separate from runtime materialization and scheduler ownership.
 
 ## Composition order
 
@@ -33,6 +33,16 @@ The GraphQL transport authorizes before parsing caller schema/job input and dele
 
 Transport adapters must not call `SharedIndexReplayRuntime` directly. See the server transport contract in `apps/server/docs/index-replay-graphql-transport.md`.
 
+## In-page host interruption boundary
+
+`PostgresIndexReplayRunner` now has a separate `run_interruptible` path that delegates one host-owned probe to the existing `IndexReplayWorker::run_next_page_interruptible` safe points.
+
+An interrupted page is not marked failed and does not manufacture a persisted cancellation. After preserving any cancellation race, the runner yields the fenced job back to `pending` with lease ownership cleared and the last committed checkpoint unchanged. A later attempt can replay the same page; already-durable deliveries remain safe through inbox deduplication and source-version ordering.
+
+The retained SQLite packet covers interruption before source scan and interruption after one mutation is durable but before checkpoint commit. The latter resumes as `Duplicate` on attempt 2 before completing the checkpoint/job.
+
+This is runner-level source completeness only. `SharedIndexReplayRuntime`, `IndexReplayOperatorRuntime`, and the GraphQL transport do **not** yet receive the server `StopHandle`; actual host shutdown binding remains the next composition step.
+
 ## Reconciliation scheduling boundary
 
 The work registration added here is reconciliation-only. It discovers due pending or expired-running reconciliation jobs and delegates actual claim/takeover to `PostgresIndexReconciliationRunner`.
@@ -41,10 +51,11 @@ It does not schedule replay/rebuild jobs, create a second task, own a database l
 
 ## Explicitly open
 
+- connect the server-owned `StopHandle` to interruptible replay execution without exposing shutdown control to callers;
+- execute/admit retained replay interruption/restart evidence;
 - GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
 - automatic replay/rebuild job scheduling;
 - retained PostgreSQL replay and reconciliation scheduler execution evidence;
-- graceful host-shutdown binding to in-page replay interruption safe points;
 - operator-visible scheduler health and metrics;
 - in-page mutation/checkpoint timeout completion;
 - locale/partition replay checkpoint dimensions;

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -29,7 +29,10 @@ mod source_reconciliation_scheduler;
 mod source_replay;
 mod source_replay_job;
 mod source_replay_retry;
-mod source_replay_runner;
+mod source_replay_runner {
+    include!("source_replay_runner.rs");
+    mod graceful_shutdown;
+}
 
 #[cfg(test)]
 mod mutation_store_tests;
@@ -51,6 +54,8 @@ mod source_reconciliation_runner_tests;
 mod source_replay_job_tests;
 #[cfg(test)]
 mod source_replay_runner_tests;
+#[cfg(test)]
+mod source_replay_graceful_shutdown_tests;
 
 pub use drift_candidate_observer::{
     IndexDriftCandidateObserverCompositionError,

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_graceful_shutdown_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_graceful_shutdown_tests.rs
@@ -1,0 +1,336 @@
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use rustok_core::MigrationSource;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use uuid::Uuid;
+
+use super::{IndexReplayRunRequest, IndexReplayRunStatus, PostgresIndexReplayRunner};
+use crate::{
+    EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexMutation,
+    IndexRecord, IndexSchema, IndexSchemaSourceCatalog, IndexSource, IndexSourceCatalog,
+    IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
+    IndexSourceScanRequest, IndexValue, IndexValueType, LocaleMode, ModuleName, SchemaRef,
+    SchemaRegistry, SchemaVersion,
+};
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+const ENTITY_ID: Uuid = Uuid::from_u128(101);
+const EVENT_ID: Uuid = Uuid::from_u128(1001);
+
+struct StableSinglePageSource {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl IndexSource for StableSinglePageSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let mutation = IndexMutation::Upsert {
+            event_id: EVENT_ID,
+            record: IndexRecord {
+                key: EntityKey {
+                    tenant_id: request.tenant_id(),
+                    schema: schema_ref(),
+                    entity_id: ENTITY_ID,
+                    locale: None,
+                },
+                source_version: 1,
+                fields: BTreeMap::from([(
+                    FieldName::new("id").expect("field name"),
+                    IndexValue::Uuid(ENTITY_ID),
+                )]),
+                links: Vec::new(),
+            },
+        };
+        IndexSourcePage::new(&request, vec![mutation], None)
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        IndexSourceLoadBatch::new(&request, Vec::new())
+    }
+}
+
+struct Fixture {
+    db: DatabaseConnection,
+    runner: PostgresIndexReplayRunner,
+    source_calls: Arc<AtomicUsize>,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("foreign keys should be enabled");
+        db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+            .await
+            .expect("tenant fixture should be created");
+        db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT}')"))
+            .await
+            .expect("tenant fixture should be inserted");
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration
+                .up(&manager)
+                .await
+                .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+        }
+
+        let schema = schema();
+        let fingerprint = schema.fingerprint().expect("schema fingerprint").to_string();
+        let schema_json = serde_json::to_value(&schema).expect("schema json");
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active')",
+            vec![
+                TENANT.to_owned().into(),
+                schema.reference.module.as_str().to_owned().into(),
+                schema.reference.entity.as_str().to_owned().into(),
+                i64::from(schema.reference.version.get()).into(),
+                fingerprint.into(),
+                SqlValue::Json(Some(Box::new(schema_json))),
+            ],
+        ))
+        .await
+        .expect("schema fixture should persist");
+
+        let mut schema_catalog = IndexSchemaSourceCatalog::new();
+        schema_catalog
+            .register("shutdown-owner", schema.clone())
+            .expect("schema source registration");
+        let source_calls = Arc::new(AtomicUsize::new(0));
+        let mut source_catalog = IndexSourceCatalog::new();
+        source_catalog
+            .register(
+                "shutdown-owner",
+                "shutdown-owner-primary",
+                [schema.reference.clone()],
+                StableSinglePageSource {
+                    calls: source_calls.clone(),
+                },
+            )
+            .expect("source registration");
+        let sources = source_catalog
+            .materialize(&schema_catalog)
+            .expect("source registry");
+        let mut registry = SchemaRegistry::new();
+        registry.register(schema).expect("schema registry");
+        let runner = PostgresIndexReplayRunner::new(db.clone(), sources, Arc::new(registry));
+
+        Self {
+            db,
+            runner,
+            source_calls,
+        }
+    }
+
+    fn request(&self, worker_id: &str) -> IndexReplayRunRequest {
+        IndexReplayRunRequest::new(
+            tenant_id(),
+            schema_ref(),
+            worker_id,
+            10,
+            1,
+            1,
+            Duration::from_secs(60),
+        )
+        .expect("bounded replay request")
+    }
+}
+
+fn tenant_id() -> Uuid {
+    Uuid::parse_str(TENANT).expect("tenant UUID")
+}
+
+fn schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("shutdown-owner").expect("module name"),
+        entity: EntityName::new("item").expect("entity name"),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn schema() -> IndexSchema {
+    IndexSchema {
+        reference: schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").expect("field name"),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: &str) -> i64 {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return one row")
+        .try_get("", "value")
+        .expect("scalar value should be integer")
+}
+
+async fn scalar_string(db: &DatabaseConnection, sql: &str) -> String {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return one row")
+        .try_get("", "value")
+        .expect("scalar value should be text")
+}
+
+#[tokio::test]
+async fn host_stop_before_scan_yields_pending_and_restart_completes_with_new_attempt() {
+    let fixture = Fixture::new().await;
+    let first = fixture
+        .runner
+        .run_interruptible(fixture.request("worker-a"), || true)
+        .await
+        .expect("host stop should yield replay");
+
+    assert_eq!(first.status(), IndexReplayRunStatus::Yielded);
+    assert_eq!(first.attempt_count(), Some(1));
+    assert_eq!(first.pages_processed(), 0);
+    assert_eq!(fixture.source_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'pending' AND cancel_requested = FALSE AND lease_owner IS NULL AND lease_expires_at IS NULL AND completed_at IS NULL",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild'",
+        )
+        .await,
+        0,
+    );
+
+    let resumed = fixture
+        .runner
+        .run(fixture.request("worker-b"))
+        .await
+        .expect("restart should resume pending replay");
+    assert_eq!(resumed.status(), IndexReplayRunStatus::Complete);
+    assert_eq!(resumed.job_id(), first.job_id());
+    assert_eq!(resumed.attempt_count(), Some(2));
+    assert_eq!(resumed.applied_count(), 1);
+    assert_eq!(resumed.duplicate_count(), 0);
+    assert_eq!(fixture.source_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn host_stop_after_durable_mutation_before_checkpoint_replays_as_duplicate_on_restart() {
+    let fixture = Fixture::new().await;
+    let probe_calls = AtomicUsize::new(0);
+    let first = fixture
+        .runner
+        .run_interruptible(fixture.request("worker-a"), || {
+            probe_calls.fetch_add(1, Ordering::SeqCst) + 1 >= 3
+        })
+        .await
+        .expect("host stop before checkpoint commit should yield replay");
+
+    // Safe points for one mutation are: before scan, before mutation, before checkpoint commit.
+    assert_eq!(probe_calls.load(Ordering::SeqCst), 3);
+    assert_eq!(first.status(), IndexReplayRunStatus::Yielded);
+    assert_eq!(first.attempt_count(), Some(1));
+    assert_eq!(first.pages_processed(), 0);
+    assert_eq!(fixture.source_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_entities WHERE tenant_id = '11111111-1111-1111-1111-111111111111' AND module_name = 'shutdown-owner' AND entity_name = 'item' AND schema_version = 1 AND entity_id = '00000000-0000-0000-0000-000000000065' AND is_deleted = 0",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_inbox WHERE tenant_id = '11111111-1111-1111-1111-111111111111' AND source_name = 'shutdown-owner-primary' AND delivery_id = '00000000-0000-0000-0000-0000000003e9' AND state = 'applied'",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild'",
+        )
+        .await,
+        0,
+    );
+    assert_eq!(
+        scalar_string(
+            &fixture.db,
+            "SELECT state AS value FROM index_jobs WHERE kind = 'rebuild'",
+        )
+        .await,
+        "pending",
+    );
+
+    let resumed = fixture
+        .runner
+        .run(fixture.request("worker-b"))
+        .await
+        .expect("restart should replay interrupted page safely");
+    assert_eq!(resumed.status(), IndexReplayRunStatus::Complete);
+    assert_eq!(resumed.job_id(), first.job_id());
+    assert_eq!(resumed.attempt_count(), Some(2));
+    assert_eq!(resumed.applied_count(), 0);
+    assert_eq!(resumed.duplicate_count(), 1);
+    assert_eq!(fixture.source_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_inbox WHERE tenant_id = '11111111-1111-1111-1111-111111111111' AND source_name = 'shutdown-owner-primary' AND delivery_id = '00000000-0000-0000-0000-0000000003e9' AND state = 'applied'",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_i64(
+            &fixture.db,
+            "SELECT COUNT(*) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild' AND json_type(cursor) = 'null'",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_string(
+            &fixture.db,
+            "SELECT state AS value FROM index_jobs WHERE kind = 'rebuild'",
+        )
+        .await,
+        "succeeded",
+    );
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_graceful_shutdown_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_graceful_shutdown_tests.rs
@@ -56,14 +56,16 @@ impl IndexSource for StableSinglePageSource {
                 links: Vec::new(),
             },
         };
-        IndexSourcePage::new(&request, vec![mutation], None)
+        Ok(IndexSourcePage::new(&request, vec![mutation], None)
+            .expect("stable single-page source should satisfy scan contract"))
     }
 
     async fn load(
         &self,
         request: IndexSourceLoadRequest,
     ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
-        IndexSourceLoadBatch::new(&request, Vec::new())
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+            .expect("empty targeted load should satisfy source contract"))
     }
 }
 
@@ -320,7 +322,7 @@ async fn host_stop_after_durable_mutation_before_checkpoint_replays_as_duplicate
     assert_eq!(
         scalar_i64(
             &fixture.db,
-            "SELECT COUNT(*) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild' AND json_type(cursor) = 'null'",
+            "SELECT COUNT(*) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild' AND CAST(cursor AS TEXT) = 'null'",
         )
         .await,
         1,

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
@@ -1,0 +1,182 @@
+use super::*;
+
+impl PostgresIndexReplayRunner {
+    /// Runs replay with a host-owned cooperative interruption probe.
+    ///
+    /// Host interruption is distinct from persisted operator cancellation. The existing worker checks
+    /// the probe only at durable page boundaries: before source scan, before each mutation apply, and
+    /// before checkpoint commit. When the probe interrupts a page, this runner yields its current job
+    /// lease back to `pending` so a fresh attempt can resume from the last committed checkpoint.
+    /// Already-durable mutations from the interrupted page are intentionally replayed and rely on the
+    /// canonical inbox/source-version idempotency contract.
+    pub async fn run_interruptible<Check>(
+        &self,
+        request: IndexReplayRunRequest,
+        mut should_interrupt: Check,
+    ) -> Result<IndexReplayRunOutcome, IndexReplayRunError>
+    where
+        Check: FnMut() -> bool,
+    {
+        let source_name = self
+            .sources
+            .source_for_schema(request.page_request().schema())
+            .ok_or_else(|| {
+                IndexReplayRunError::UnknownSchemaSource(
+                    request.page_request().schema().clone(),
+                )
+            })?
+            .source_name()
+            .to_owned();
+        let lease_request = IndexReplayJobLeaseRequest::new(
+            request.page_request().tenant_id(),
+            request.page_request().schema().clone(),
+            source_name,
+            request.worker_id().to_owned(),
+            request.lease_duration(),
+        )?;
+        let job_store = PostgresIndexReplayJobStore::new(self.db.clone());
+        let lease = match job_store.acquire(&lease_request).await? {
+            IndexReplayJobAcquireOutcome::Busy => {
+                return Ok(empty_outcome(IndexReplayRunStatus::Busy, None, None));
+            }
+            IndexReplayJobAcquireOutcome::AlreadyComplete { job_id } => {
+                return Ok(empty_outcome(
+                    IndexReplayRunStatus::AlreadyComplete,
+                    Some(job_id),
+                    None,
+                ));
+            }
+            IndexReplayJobAcquireOutcome::Acquired(lease) => lease,
+        };
+
+        let checkpoint_store =
+            PostgresIndexReplayCheckpointStore::new(self.db.clone(), lease.clone());
+        let worker = IndexReplayWorker::new(
+            self.sources.clone(),
+            self.schema_registry.clone(),
+            PostgresMutationStore::new(self.db.clone()),
+            checkpoint_store,
+        );
+
+        let mut aggregate = IndexReplayRunOutcome {
+            status: IndexReplayRunStatus::Yielded,
+            job_id: Some(lease.job_id()),
+            attempt_count: Some(lease.attempt_count()),
+            pages_processed: 0,
+            heartbeat_count: 0,
+            mutation_count: 0,
+            applied_count: 0,
+            duplicate_count: 0,
+            stale_count: 0,
+        };
+
+        for page_index in 0..request.max_pages() {
+            if cancel_if_requested(&self.db, &lease).await? {
+                aggregate.status = IndexReplayRunStatus::Cancelled;
+                return Ok(aggregate);
+            }
+
+            if page_index > 0 && page_index % request.heartbeat_every_pages() == 0 {
+                heartbeat(&job_store, &lease, request.lease_duration()).await?;
+                aggregate.heartbeat_count += 1;
+                if cancel_if_requested(&self.db, &lease).await? {
+                    aggregate.status = IndexReplayRunStatus::Cancelled;
+                    return Ok(aggregate);
+                }
+            }
+
+            let page = match worker
+                .run_next_page_interruptible(request.page_request().clone(), || {
+                    let interrupted = should_interrupt();
+                    async move { Ok::<bool, crate::IndexReplayFailure>(interrupted) }
+                })
+                .await
+            {
+                Ok(page) => page,
+                Err(crate::IndexReplayError::Interrupted) => {
+                    return yield_after_host_interruption(&self.db, &lease, aggregate).await;
+                }
+                Err(error) if replay_error_is_lease_lost(&error) => {
+                    return Err(lease_lost(&lease));
+                }
+                Err(error) => {
+                    if cancel_if_requested(&self.db, &lease).await? {
+                        aggregate.status = IndexReplayRunStatus::Cancelled;
+                        return Ok(aggregate);
+                    }
+                    let details = replay_failure_details(&error);
+                    match finish_failure(&self.db, &lease, details).await? {
+                        TerminalWriteOutcome::Written => {
+                            return Err(IndexReplayRunError::PageFailed {
+                                job_id: lease.job_id(),
+                                error: Box::new(error),
+                            });
+                        }
+                        TerminalWriteOutcome::Cancelled => {
+                            aggregate.status = IndexReplayRunStatus::Cancelled;
+                            return Ok(aggregate);
+                        }
+                    }
+                }
+            };
+
+            if page.status() != IndexReplayPageStatus::AlreadyComplete {
+                aggregate.pages_processed += 1;
+            }
+            aggregate.mutation_count += page.mutation_count();
+            aggregate.applied_count += page.applied_count();
+            aggregate.duplicate_count += page.duplicate_count();
+            aggregate.stale_count += page.stale_count();
+
+            if cancel_if_requested(&self.db, &lease).await? {
+                aggregate.status = IndexReplayRunStatus::Cancelled;
+                return Ok(aggregate);
+            }
+
+            if matches!(
+                page.status(),
+                IndexReplayPageStatus::Complete | IndexReplayPageStatus::AlreadyComplete
+            ) {
+                match finish_success(&self.db, &lease).await? {
+                    TerminalWriteOutcome::Written => {
+                        aggregate.status = IndexReplayRunStatus::Complete;
+                        return Ok(aggregate);
+                    }
+                    TerminalWriteOutcome::Cancelled => {
+                        aggregate.status = IndexReplayRunStatus::Cancelled;
+                        return Ok(aggregate);
+                    }
+                }
+            }
+        }
+
+        match yield_for_resume(&self.db, &lease).await? {
+            TerminalWriteOutcome::Written => Ok(aggregate),
+            TerminalWriteOutcome::Cancelled => {
+                aggregate.status = IndexReplayRunStatus::Cancelled;
+                Ok(aggregate)
+            }
+        }
+    }
+}
+
+async fn yield_after_host_interruption(
+    db: &DatabaseConnection,
+    lease: &IndexReplayJobLease,
+    mut aggregate: IndexReplayRunOutcome,
+) -> Result<IndexReplayRunOutcome, IndexReplayRunError> {
+    if cancel_if_requested(db, lease).await? {
+        aggregate.status = IndexReplayRunStatus::Cancelled;
+        return Ok(aggregate);
+    }
+    match yield_for_resume(db, lease).await? {
+        TerminalWriteOutcome::Written => {
+            aggregate.status = IndexReplayRunStatus::Yielded;
+            Ok(aggregate)
+        }
+        TerminalWriteOutcome::Cancelled => {
+            aggregate.status = IndexReplayRunStatus::Cancelled;
+            Ok(aggregate)
+        }
+    }
+}

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -28,6 +28,7 @@ const scripts = [
   'verify-index-product-absence-postgres-harness.mjs',
   'verify-index-replay-job-leases.mjs',
   'verify-index-replay-multipage-runner.mjs',
+  'verify-index-replay-graceful-shutdown.mjs',
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-replay-graphql-transport.mjs',

--- a/scripts/verify/verify-index-replay-graceful-shutdown.mjs
+++ b/scripts/verify/verify-index-replay-graceful-shutdown.mjs
@@ -22,7 +22,7 @@ const workerPath = 'crates/rustok-index/src/application/source_replay.rs';
 const worker = requireMarkers(workerPath, [
   'pub async fn run_next_page_interruptible<Check, CheckFuture>(',
   'check_replay_interruption(&mut should_interrupt).await?;',
-  'before every\n    /// mutation application, and before checkpoint commit',
+  'before every\n    /// mutation application, and before checkpoint commit'.replace('\\n', '\n'),
   'IndexReplayError::Interrupted',
 ]);
 if (worker.includes('cancel_requested')) {
@@ -93,7 +93,14 @@ const packet = requireMarkers(packetPath, [
   'resumed.duplicate_count(), 1',
   'state = \'succeeded\'',
 ]);
-for (const forbidden of ['tokio::time::sleep', 'tokio::spawn', 'Postgres', 'request_cancel(']) {
+for (const forbidden of [
+  'tokio::time::sleep',
+  'tokio::spawn',
+  'DbBackend::Postgres',
+  'postgres://',
+  'postgresql://',
+  'request_cancel(',
+]) {
   if (packet.includes(forbidden)) {
     fail(`${packetPath} must remain deterministic SQLite restart/redelivery source evidence: ${forbidden}`);
   }

--- a/scripts/verify/verify-index-replay-graceful-shutdown.mjs
+++ b/scripts/verify/verify-index-replay-graceful-shutdown.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-graceful-shutdown] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const workerPath = 'crates/rustok-index/src/application/source_replay.rs';
+const worker = requireMarkers(workerPath, [
+  'pub async fn run_next_page_interruptible<Check, CheckFuture>(',
+  'check_replay_interruption(&mut should_interrupt).await?;',
+  'before every\n    /// mutation application, and before checkpoint commit',
+  'IndexReplayError::Interrupted',
+]);
+if (worker.includes('cancel_requested')) {
+  fail(`${workerPath} generic one-page interruption must remain independent of persisted cancellation`);
+}
+
+const extensionPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';
+const extension = requireMarkers(extensionPath, [
+  'pub async fn run_interruptible<Check>(',
+  'Check: FnMut() -> bool',
+  '.run_next_page_interruptible(request.page_request().clone(), || {',
+  'Ok::<bool, crate::IndexReplayFailure>(interrupted)',
+  'Err(crate::IndexReplayError::Interrupted) => {',
+  'yield_after_host_interruption(&self.db, &lease, aggregate).await',
+  'if cancel_if_requested(db, lease).await?',
+  'match yield_for_resume(db, lease).await?',
+  'aggregate.status = IndexReplayRunStatus::Yielded;',
+  'aggregate.status = IndexReplayRunStatus::Cancelled;',
+]);
+for (const forbidden of [
+  'request_cancel(',
+  'cancel_requested = TRUE',
+  'finish_failure(db, lease',
+  'IndexReplayRunStatus::Complete;',
+]) {
+  if (extension.includes(forbidden)) {
+    fail(`${extensionPath} must yield host interruption without manufacturing cancellation/failure: ${forbidden}`);
+  }
+}
+const interrupted = extension.indexOf('Err(crate::IndexReplayError::Interrupted) => {');
+const helper = extension.indexOf('async fn yield_after_host_interruption(');
+const cancel = extension.indexOf('if cancel_if_requested(db, lease).await?', helper);
+const yieldCall = extension.indexOf('match yield_for_resume(db, lease).await?', cancel);
+if (interrupted < 0 || helper < 0 || cancel <= helper || yieldCall <= cancel) {
+  fail('host interruption must preserve a persisted cancel race before yielding the lease to pending');
+}
+
+const ordinaryPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const ordinary = requireMarkers(ordinaryPath, [
+  'pub async fn run(',
+  'worker.run_next_page(request.page_request().clone())',
+  'pub async fn request_cancel(',
+  'yield_for_resume(&self.db, &lease).await?',
+]);
+if (ordinary.includes('run_interruptible<Check>')) {
+  fail(`${ordinaryPath} ordinary runner file must remain unchanged by the host-probe extension`);
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_replay_runner {',
+  'include!("source_replay_runner.rs");',
+  'mod graceful_shutdown;',
+  'mod source_replay_graceful_shutdown_tests;',
+]);
+
+const packetPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_graceful_shutdown_tests.rs';
+const packet = requireMarkers(packetPath, [
+  'host_stop_before_scan_yields_pending_and_restart_completes_with_new_attempt',
+  'host_stop_after_durable_mutation_before_checkpoint_replays_as_duplicate_on_restart',
+  '.run_interruptible(fixture.request("worker-a"), || true)',
+  'probe_calls.fetch_add(1, Ordering::SeqCst) + 1 >= 3',
+  'assert_eq!(probe_calls.load(Ordering::SeqCst), 3);',
+  'IndexReplayRunStatus::Yielded',
+  'state = \'pending\'',
+  'lease_owner IS NULL',
+  'SELECT COUNT(*) AS value FROM index_checkpoints',
+  'resumed.attempt_count(), Some(2)',
+  'resumed.duplicate_count(), 1',
+  'state = \'succeeded\'',
+]);
+for (const forbidden of ['tokio::time::sleep', 'tokio::spawn', 'Postgres', 'request_cancel(']) {
+  if (packet.includes(forbidden)) {
+    fail(`${packetPath} must remain deterministic SQLite restart/redelivery source evidence: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-replay-graceful-shutdown.md', [
+  'Status: `runner_source_complete_host_binding_execution_pending`.',
+  '`PostgresIndexReplayRunner::run_interruptible`',
+  'Host interruption is not user cancellation',
+  'pending',
+  '`Duplicate`',
+  'does **not** yet connect a server `StopHandle`',
+]);
+
+console.log('[verify-index-replay-graceful-shutdown] interruptible runner yields host stops to pending and retains duplicate-safe restart source evidence; server StopHandle binding remains open');

--- a/scripts/verify/verify-index-replay-multipage-runner.mjs
+++ b/scripts/verify/verify-index-replay-multipage-runner.mjs
@@ -57,6 +57,7 @@ for (const forbidden of [
   'rustok_product',
   'rustok_content',
   'rustok_flex',
+  'run_interruptible<Check>',
 ]) {
   if (runner.includes(forbidden)) fail(`${runnerPath} contains forbidden marker ${forbidden}`);
 }
@@ -75,7 +76,7 @@ if (
   || successCall <= postPageCancel
   || yieldCall <= successCall
 ) {
-  fail('runner must observe cancellation before/after pages, complete on null cursor, then yield');
+  fail('ordinary runner must preserve cancellation before/after pages, complete on null cursor, then yield');
 }
 
 for (const terminalSql of ['finish_success_sql', 'finish_failure_sql', 'yield_job_sql']) {
@@ -102,8 +103,11 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_ru
 ]);
 
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
-  'mod source_replay_runner;',
+  'mod source_replay_runner {',
+  'include!("source_replay_runner.rs");',
+  'mod graceful_shutdown;',
   'mod source_replay_runner_tests;',
+  'mod source_replay_graceful_shutdown_tests;',
   'PostgresIndexReplayRunner',
   'IndexReplayRunRequest',
   'IndexReplayRunOutcome',
@@ -124,10 +128,12 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-multipage-runner.md', [
   '1 through 1024 pages per invocation',
   'The source name is never caller supplied.',
   '`PostgresIndexReplayRunner::request_cancel`',
+  '`PostgresIndexReplayRunner::run_interruptible`',
+  'Host interruption does not set `cancel_requested`',
   'a `pending` job becomes terminal `cancelled` immediately',
   'cancel_requested = FALSE',
   'A running cancellation request survives lease expiry and reclaim.',
-  'in-page interruption',
+  'server-owned `StopHandle`',
   'maintainer-run',
 ]);
 
@@ -135,13 +141,13 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
   '- M6 bounded multi-page replay and cancellation: `source_complete_owner_execution_pending`',
   '- [x] Add bounded multi-page execution with heartbeat cadence and immediate pending resume.',
   '- [x] Add durable cancellation requests and fenced between-page terminal cancellation.',
-  'In-page interruption, automatic retry/backoff, dead-letter scheduling, host scheduling,',
 ]);
 
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-job-leases.mjs'",
   "'verify-index-replay-multipage-runner.mjs'",
+  "'verify-index-replay-graceful-shutdown.mjs'",
   "'verify-index-source-replay-contract.mjs'",
 ]);
 
-console.log('[verify-index-replay-multipage-runner] OK');
+console.log('[verify-index-replay-multipage-runner] ordinary replay/cancel semantics remain stable while host-probed interruption is isolated in a separate extension');

--- a/scripts/verify/verify-index-replay-page-interruption.mjs
+++ b/scripts/verify/verify-index-replay-page-interruption.mjs
@@ -106,22 +106,43 @@ requireMarkers('crates/rustok-index/src/replay_dry_run.rs', [
 const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
 const runner = read(runnerPath);
 if (runner.includes('run_next_page_interruptible')) {
-  fail(`${runnerPath} must not claim lease-bound interruption before the runner integration slice`);
+  fail(`${runnerPath} ordinary replay runner file must stay separate from the interruption extension`);
 }
 
+const runnerExtensionPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';
+const runnerExtension = requireMarkers(runnerExtensionPath, [
+  'pub async fn run_interruptible<Check>(',
+  '.run_next_page_interruptible(request.page_request().clone(), || {',
+  'Err(crate::IndexReplayError::Interrupted) => {',
+  'yield_after_host_interruption(&self.db, &lease, aggregate).await',
+  'match yield_for_resume(db, lease).await?',
+]);
+for (const forbidden of ['request_cancel(', 'cancel_requested = TRUE', 'finish_failure(db, lease']) {
+  if (runnerExtension.includes(forbidden)) {
+    fail(`${runnerExtensionPath} must keep host interruption separate from user cancellation/failure: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_replay_runner {',
+  'include!("source_replay_runner.rs");',
+  'mod graceful_shutdown;',
+]);
+
 requireMarkers('crates/rustok-index/docs/m6-cooperative-page-interruption.md', [
-  'Status: `source_complete_runner_probe_pending`',
+  'Status: `worker_and_runner_source_complete_host_binding_pending`',
   '`run_next_page_interruptible`',
+  '`PostgresIndexReplayRunner::run_interruptible`',
   '`IndexReplayError::Interrupted`',
   '`IndexReplayError::InterruptionCheckFailed`',
   'before every mutation',
   'never commits the page checkpoint',
   '30-second source-call timeout wrapper',
   'bounded replay dry-run',
-  '`(tenant_id, job_id, worker_id, attempt_count)`',
   'does not impose a deadline on the probe future itself',
-  'canonical combined roadmap item',
-  'maintainer-run',
+  'server lifecycle still does not supply its `StopHandle`',
+  'runner interruption after durable mutation / before checkpoint commit',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
   '[M6 Cooperative Replay-page Interruption](./m6-cooperative-page-interruption.md)',
@@ -131,6 +152,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-page-interruption.mjs'",
+  "'verify-index-replay-graceful-shutdown.mjs'",
 ]);
 
-console.log('[verify-index-replay-page-interruption] OK');
+console.log('[verify-index-replay-page-interruption] worker safe points remain storage-neutral while the separate runner extension retains lease-aware host interruption; server StopHandle binding remains open');


### PR DESCRIPTION
## Summary

- carry the existing one-page cooperative replay safe points through a separate `PostgresIndexReplayRunner::run_interruptible` path;
- preserve the original `source_replay_runner.rs` ordinary run/cancel implementation unchanged and isolate host-probed behavior in a child module;
- on `IndexReplayError::Interrupted`, preserve a persisted operator-cancel race first, otherwise use the existing fenced `yield_for_resume` transition rather than failure or terminal cancellation;
- return the active job to durable `pending`, clear lease ownership, retain the same job UUID, preserve the last committed checkpoint, and record no failure payload;
- keep user-requested cancellation unchanged: host interruption never calls `request_cancel`, never sets `cancel_requested`, and never manufactures `failed`/`cancelled` state;
- retain deterministic SQLite source evidence for interruption before scan and for interruption after a durable mutation but before checkpoint commit;
- in the latter window, prove the next attempt replays the same stable delivery as `Duplicate`, then commits the checkpoint and completes the same job under attempt 2;
- update the worker/multipage/runtime composition docs and source guards, and aggregate the new graceful-shutdown guard into the Index contract.

## Module boundary

To avoid rewriting the large ordinary runner file, the PostgreSQL module now wraps it with `include!("source_replay_runner.rs")` and declares a `graceful_shutdown` child module. This preserves the existing public re-export surface and lets the child implementation reuse the runner's private fenced job/checkpoint helpers without changing ordinary execution semantics.

The final branch compare does not include `source_replay_runner.rs`; only module wiring, the new extension/evidence packet, docs and guards are changed.

## Boundary

This PR is runner-level source completeness only. It does **not** connect the server `StopHandle` to replay execution, alter `SharedIndexReplayRuntime`/`IndexReplayOperatorRuntime`/GraphQL command behavior, change user cancellation semantics, add automatic replay scheduling, add locale/partition checkpoint dimensions, or introduce targeted/full/shadow rebuild modes.

The next source slice is server composition: provide a server-owned `StopHandle::is_stopping` probe through the guarded replay runtime/operator so GraphQL callers cannot supply or control shutdown state.

## Main recheck

The branch started from replay GraphQL transport merge `6672c8b15f7b3ebd53a75147262b3d74020e4a16`. Current `main@06cf63e90d122b114dc4035c793ea9a6d98f482d` advanced by three unrelated Commerce/Groups/Forum deployment commits; their paths are disjoint from this Index-only diff.

## Validation

Static source review compared the new fixture against the existing SQLite replay-runner fixture, checked the exact `run_next_page_interruptible` probe signature and safe points, verified the existing private fenced runner helper names, and confirmed the ordinary runner file is absent from the branch diff. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.