### PR TITLE
test(groups): retain direct enforcement GraphQL SQLite parity

### DIFF
--- a/apps/server/tests/groups_membership_enforcement_graphql_sqlite.rs
+++ b/apps/server/tests/groups_membership_enforcement_graphql_sqlite.rs
@@ -1,0 +1,395 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use async_graphql::{EmptySubscription, Request, Response, Schema};
+use rustok_api::{AuthContext, HostRuntimeContext, PortActor, PortContext, TenantContext};
+use rustok_groups::graphql_application_cas::{GroupsMutationRoot, GroupsQueryRoot};
+use rustok_groups::{
+    GroupMembershipEffectiveStatus, GroupMembershipEnforcementCommandPort,
+    GroupMembershipEnforcementCommandService, RevokeGroupMembershipSuspensionRequest,
+    SuspendGroupMembershipRequest,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups GraphQL parity SQLite connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for GraphQL parity evidence");
+    }
+}
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp.path().join("groups-enforcement-graphql-parity.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    native_target_id: Uuid,
+    graphql_target_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'enforcement-graphql-parity', 3);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{native_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{graphql_target_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups GraphQL parity fixture should seed");
+}
+
+fn tenant_context(tenant_id: Uuid) -> TenantContext {
+    TenantContext {
+        id: tenant_id,
+        name: "Groups GraphQL parity".to_string(),
+        slug: "groups-graphql-parity".to_string(),
+        domain: None,
+        settings: serde_json::json!({}),
+        default_locale: "en".to_string(),
+        is_active: true,
+    }
+}
+
+fn auth_context(tenant_id: Uuid, owner_id: Uuid) -> AuthContext {
+    AuthContext {
+        user_id: owner_id,
+        session_id: Uuid::new_v4(),
+        tenant_id,
+        permissions: Vec::new(),
+        client_id: None,
+        scopes: Vec::new(),
+        grant_type: "direct".to_string(),
+    }
+}
+
+fn native_context(tenant_id: Uuid, owner_id: Uuid, idempotency_key: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(owner_id.to_string()),
+        "en",
+        format!("groups-enforcement-native-parity-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(5))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn graphql_schema(
+    db: DatabaseConnection,
+) -> Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription> {
+    Schema::build(
+        GroupsQueryRoot::default(),
+        GroupsMutationRoot::default(),
+        EmptySubscription,
+    )
+    .data(HostRuntimeContext::new(db))
+    .finish()
+}
+
+async fn execute_graphql(
+    schema: &Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription>,
+    tenant_id: Uuid,
+    owner_id: Uuid,
+    document: String,
+) -> Response {
+    schema
+        .execute(
+            Request::new(document)
+                .data(tenant_context(tenant_id))
+                .data(auth_context(tenant_id, owner_id)),
+        )
+        .await
+}
+
+fn response_json(response: Response) -> serde_json::Value {
+    assert!(
+        response.errors.is_empty(),
+        "GraphQL parity request should succeed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .into_json()
+        .expect("GraphQL parity response data should convert to JSON")
+}
+
+fn extension_json(error: &async_graphql::ServerError, key: &str) -> Option<serde_json::Value> {
+    error
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get(key))
+        .cloned()
+        .and_then(|value| value.into_json().ok())
+}
+
+#[tokio::test]
+async fn direct_enforcement_native_and_graphql_share_owner_semantics_sqlite() {
+    let temp = tempfile::tempdir().expect("temporary Groups GraphQL parity directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let db = connect(&url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let native_target_id = Uuid::new_v4();
+    let graphql_target_id = Uuid::new_v4();
+    seed_group_fixture(
+        &db,
+        tenant_id,
+        group_id,
+        owner_id,
+        native_target_id,
+        graphql_target_id,
+    )
+    .await;
+
+    let native_service = GroupMembershipEnforcementCommandService::new(db.clone());
+    let native_suspend = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &native_service,
+        native_context(tenant_id, owner_id, "native-suspend"),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: native_target_id,
+            expected_membership_revision: 1,
+            reason_code: "parity_review".to_string(),
+            effective_until: None,
+        },
+    )
+    .await
+    .expect("native owner suspend should succeed");
+    assert_eq!(
+        native_suspend.effective_status,
+        GroupMembershipEffectiveStatus::Suspended
+    );
+    assert_eq!(native_suspend.membership_revision, 2);
+    assert_eq!(native_suspend.enforcement_revision, 1);
+    assert_eq!(native_suspend.member_count, 3);
+    assert!(!native_suspend.replayed);
+
+    let schema = graphql_schema(db.clone());
+    let graphql_suspend_document = format!(
+        r#"
+mutation {{
+  suspendGroupMembership(
+    idempotencyKey: "graphql-suspend",
+    groupId: "{group_id}",
+    targetUserId: "{graphql_target_id}",
+    expectedMembershipRevision: 1,
+    reasonCode: "parity_review"
+  ) {{
+    groupId
+    membershipId
+    userId
+    membershipRevision
+    groupVersion
+    memberCount
+    effectiveStatus
+    enforcementRevision
+    effectiveUntil
+    revokedAt
+    replayed
+  }}
+}}
+"#
+    );
+    let graphql_suspend = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            graphql_suspend_document.clone(),
+        )
+        .await,
+    );
+    let graphql_suspend = &graphql_suspend["suspendGroupMembership"];
+    assert_eq!(graphql_suspend["groupId"], group_id.to_string());
+    assert_eq!(graphql_suspend["userId"], graphql_target_id.to_string());
+    assert_eq!(
+        graphql_suspend["membershipRevision"].as_i64(),
+        Some(native_suspend.membership_revision)
+    );
+    assert_eq!(
+        graphql_suspend["memberCount"].as_i64(),
+        Some(native_suspend.member_count)
+    );
+    assert_eq!(
+        graphql_suspend["effectiveStatus"].as_str(),
+        Some(native_suspend.effective_status.as_str())
+    );
+    assert_eq!(
+        graphql_suspend["enforcementRevision"].as_i64(),
+        Some(native_suspend.enforcement_revision)
+    );
+    assert_eq!(graphql_suspend["replayed"].as_bool(), Some(false));
+    assert!(graphql_suspend["effectiveUntil"].is_null());
+    assert!(graphql_suspend["revokedAt"].is_null());
+    assert!(
+        graphql_suspend["groupVersion"].as_i64().is_some_and(|version| version > native_suspend.group_version),
+        "sequential GraphQL mutation should return a later owner group version"
+    );
+
+    let replay = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            graphql_suspend_document,
+        )
+        .await,
+    );
+    let replay = &replay["suspendGroupMembership"];
+    assert_eq!(replay["membershipId"], graphql_suspend["membershipId"]);
+    assert_eq!(
+        replay["membershipRevision"],
+        graphql_suspend["membershipRevision"]
+    );
+    assert_eq!(replay["groupVersion"], graphql_suspend["groupVersion"]);
+    assert_eq!(replay["memberCount"], graphql_suspend["memberCount"]);
+    assert_eq!(replay["effectiveStatus"], graphql_suspend["effectiveStatus"]);
+    assert_eq!(replay["enforcementRevision"], graphql_suspend["enforcementRevision"]);
+    assert_eq!(replay["replayed"].as_bool(), Some(true));
+
+    let stale = execute_graphql(
+        &schema,
+        tenant_id,
+        owner_id,
+        format!(
+            r#"
+mutation {{
+  suspendGroupMembership(
+    idempotencyKey: "graphql-stale",
+    groupId: "{group_id}",
+    targetUserId: "{graphql_target_id}",
+    expectedMembershipRevision: 1,
+    reasonCode: "stale_review"
+  ) {{ membershipRevision }}
+}}
+"#
+        ),
+    )
+    .await;
+    assert_eq!(stale.errors.len(), 1);
+    let stale_error = &stale.errors[0];
+    assert_eq!(
+        extension_json(stale_error, "code").and_then(|value| value.as_str().map(str::to_owned)),
+        Some("BAD_USER_INPUT".to_string())
+    );
+    assert_eq!(
+        extension_json(stale_error, "domainCode")
+            .and_then(|value| value.as_str().map(str::to_owned)),
+        Some("groups.membership_enforcement_revision_conflict".to_string())
+    );
+    assert_eq!(
+        extension_json(stale_error, "retryable").and_then(|value| value.as_bool()),
+        Some(false)
+    );
+
+    let native_revoke = GroupMembershipEnforcementCommandPort::revoke_membership_suspension(
+        &native_service,
+        native_context(tenant_id, owner_id, "native-revoke"),
+        RevokeGroupMembershipSuspensionRequest {
+            group_id,
+            target_user_id: native_target_id,
+            expected_membership_revision: native_suspend.membership_revision,
+            reason_code: "parity_complete".to_string(),
+        },
+    )
+    .await
+    .expect("native owner revoke should succeed");
+    assert_eq!(native_revoke.effective_status, GroupMembershipEffectiveStatus::Active);
+    assert_eq!(native_revoke.membership_revision, 3);
+    assert_eq!(native_revoke.enforcement_revision, 2);
+    assert_eq!(native_revoke.member_count, 3);
+    assert!(native_revoke.revoked_at.is_some());
+
+    let graphql_revoke = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  revokeGroupMembershipSuspension(
+    idempotencyKey: "graphql-revoke",
+    groupId: "{group_id}",
+    targetUserId: "{graphql_target_id}",
+    expectedMembershipRevision: 2,
+    reasonCode: "parity_complete"
+  ) {{
+    membershipRevision
+    groupVersion
+    memberCount
+    effectiveStatus
+    enforcementRevision
+    effectiveUntil
+    revokedAt
+    replayed
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    let graphql_revoke = &graphql_revoke["revokeGroupMembershipSuspension"];
+    assert_eq!(
+        graphql_revoke["membershipRevision"].as_i64(),
+        Some(native_revoke.membership_revision)
+    );
+    assert_eq!(
+        graphql_revoke["memberCount"].as_i64(),
+        Some(native_revoke.member_count)
+    );
+    assert_eq!(
+        graphql_revoke["effectiveStatus"].as_str(),
+        Some(native_revoke.effective_status.as_str())
+    );
+    assert_eq!(
+        graphql_revoke["enforcementRevision"].as_i64(),
+        Some(native_revoke.enforcement_revision)
+    );
+    assert!(graphql_revoke["effectiveUntil"].is_null());
+    assert!(graphql_revoke["revokedAt"].is_string());
+    assert_eq!(graphql_revoke["replayed"].as_bool(), Some(false));
+    assert!(
+        graphql_revoke["groupVersion"].as_i64().is_some_and(|version| version > native_revoke.group_version),
+        "sequential GraphQL revoke should return a later owner group version"
+    );
+
+    drop(native_service);
+    drop(schema);
+    drop(db);
+    drop(temp);
+}

--- a/crates/rustok-groups/docs/membership-enforcement-graphql-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-graphql-contract.md
@@ -1,6 +1,6 @@
 # Groups membership enforcement GraphQL contract
 
-Status: **source-ready / maintainer execution pending**
+Status: **source-ready with executable SQLite parity source / maintainer execution pending**
 
 ## Scope
 
@@ -92,7 +92,23 @@ The enforcement transport additionally preserves the stable owner error identity
 
 This avoids forcing clients to parse messages or collapse distinct owner conflicts such as `groups.membership_enforcement_revision_conflict`, while keeping unavailable/invariant diagnostics sanitized by the neutral port contract. The transport does not replace the common GraphQL `code` field with a domain-specific value.
 
-Source-level tests retain conflict and unavailable extension mapping. Runtime schema/error-extension parity still requires executable evidence; source presence alone does not promote that gate.
+Source-level tests retain conflict and unavailable extension mapping.
+
+## Executable SQLite native/GraphQL parity source
+
+`apps/server/tests/groups_membership_enforcement_graphql_sqlite.rs` retains an executable parity packet over a real temporary SQLite file, all production Groups migrations, the production native command service and the stable final Groups GraphQL root.
+
+The packet seeds one local owner and two equivalent lifecycle-active member targets. One target is mutated through `GroupMembershipEnforcementCommandPort`; the other is mutated through `graphql_application_cas::GroupsMutationRoot`. It requires semantic parity for:
+
+- suspend result membership revision, lifecycle member count, effective status and enforcement revision;
+- GraphQL receipt replay with the same idempotency key and immutable owner result, changing only `replayed=true`;
+- stale expected-revision failure with GraphQL `code=BAD_USER_INPUT`, exact owner `domainCode=groups.membership_enforcement_revision_conflict`, and `retryable=false`;
+- revoke result membership revision, lifecycle member count, effective status, enforcement revision and revocation presence;
+- monotonic owner `groupVersion` across the sequential native/GraphQL commands rather than pretending two sequential mutations share the same aggregate version.
+
+No synthetic owner result or direct enforcement-table mutation is used. The GraphQL request carries the exact tenant-bound local owner principal with no platform moderation permission, proving that local owner hierarchy remains an owner-domain decision.
+
+This packet is **execution pending**. Its source does not populate `membership_enforcement_command_transport_parity` or promote any runtime gate until a maintainer runs it.
 
 ## No fallback
 
@@ -106,7 +122,8 @@ Intentionally not run while preparing this slice:
 cargo check -p rustok-groups --features graphql
 cargo test -p rustok-groups --features graphql graphql_conflict_preserves_transport_and_owner_codes
 cargo test -p rustok-groups --features graphql graphql_unavailable_keeps_owner_code_and_retryability
+cargo test -p rustok-server --features mod-groups --test groups_membership_enforcement_graphql_sqlite -- --nocapture
 node scripts/verify/verify-groups-membership-enforcement-graphql.mjs
 ```
 
-No Cargo command, test, Node verifier, browser/schema execution, formatter, workflow or CI job was executed. Runtime replay/CAS/authorization/schema/error parity remains open.
+No Cargo command, test, Node verifier, browser/schema execution, formatter, workflow or CI job was executed. PostgreSQL/native-GraphQL parity and executed SQLite replay/CAS/authorization/schema/error parity remain open.

--- a/scripts/verify/verify-groups-membership-enforcement-graphql.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-graphql.mjs
@@ -22,6 +22,10 @@ const docs = fs.readFileSync(
   "crates/rustok-groups/docs/membership-enforcement-graphql-contract.md",
   "utf8",
 );
+const parity = fs.readFileSync(
+  "apps/server/tests/groups_membership_enforcement_graphql_sqlite.rs",
+  "utf8",
+);
 
 function requireText(source, needle, message) {
   if (!source.includes(needle)) throw new Error(message);
@@ -131,16 +135,61 @@ for (const marker of [
 for (const marker of [
   "Transport boundary",
   "Owner-only business semantics",
+  "Executable SQLite native/GraphQL parity source",
   "No fallback",
   "graphql_application_cas::GroupsMutationRoot",
   "GroupMembershipEnforcementCommandPort",
   "domainCode",
   "retryable",
   "platform-wide GraphQL transport classification",
-  "Runtime schema/error-extension parity",
+  "membership_enforcement_command_transport_parity",
+  "execution pending",
   "cargo check -p rustok-groups --features graphql",
+  "groups_membership_enforcement_graphql_sqlite",
 ]) {
   requireText(docs, marker, `Groups enforcement GraphQL handoff is missing ${marker}`);
 }
 
-console.log("Groups membership enforcement GraphQL source guard passed");
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "rustok_groups::migrations::migrations()",
+  "GroupsQueryRoot::default()",
+  "GroupsMutationRoot::default()",
+  "HostRuntimeContext::new(db)",
+  "AuthContext",
+  "TenantContext",
+  "permissions: Vec::new()",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "GroupMembershipEnforcementCommandPort::revoke_membership_suspension",
+  "suspendGroupMembership",
+  "revokeGroupMembershipSuspension",
+  "graphql-suspend",
+  "graphql-stale",
+  "graphql-revoke",
+  "replayed" ,
+  'Some("BAD_USER_INPUT".to_string())',
+  'Some("groups.membership_enforcement_revision_conflict".to_string())',
+  "domainCode",
+  "retryable",
+  "native_suspend.member_count",
+  "native_revoke.member_count",
+  "version > native_suspend.group_version",
+  "version > native_revoke.group_version",
+]) {
+  requireText(parity, marker, `Groups enforcement GraphQL SQLite parity source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "UPDATE group_membership_enforcements",
+  "INSERT INTO group_membership_enforcements",
+  "GroupMembershipEffectiveState {",
+  "rustok_moderation::",
+]) {
+  if (parity.includes(forbidden)) {
+    throw new Error(`Groups enforcement GraphQL SQLite parity source contains shortcut ${forbidden}`);
+  }
+}
+
+console.log("Groups membership enforcement GraphQL source and SQLite parity guard passed");


### PR DESCRIPTION
## Summary
- add file-backed SQLite executable source for native vs final-GraphQL direct membership enforcement parity
- apply production Groups migrations and use the production native command service plus `graphql_application_cas::GroupsMutationRoot`
- suspend equivalent member targets through native and GraphQL paths and compare owner-semantic revision/count/status/enforcement fields
- prove GraphQL receipt replay returns the immutable owner result with only `replayed=true`
- prove stale GraphQL CAS returns `BAD_USER_INPUT`, exact owner `domainCode=groups.membership_enforcement_revision_conflict`, and `retryable=false`
- revoke through native and GraphQL paths and retain semantic parity plus monotonic aggregate version evidence
- use a local owner principal with no platform moderation permission, preserving owner-domain hierarchy semantics
- update the existing GraphQL handoff/guard while keeping `membership_enforcement_command_transport_parity` unpromoted until execution
- add no dependency, manifest, lockfile, schema, production-owner, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.