### PR TITLE
test(groups): retain direct enforcement GraphQL PostgreSQL parity

### DIFF
--- a/apps/server/tests/groups_membership_enforcement_graphql_postgres.rs
+++ b/apps/server/tests/groups_membership_enforcement_graphql_postgres.rs
@@ -1,0 +1,371 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use async_graphql::{EmptySubscription, Request, Response, Schema};
+use rustok_api::{AuthContext, HostRuntimeContext, PortActor, PortContext, TenantContext};
+use rustok_groups::graphql_application_cas::{GroupsMutationRoot, GroupsQueryRoot};
+use rustok_groups::{
+    GroupMembershipEffectiveStatus, GroupMembershipEnforcementCommandPort,
+    GroupMembershipEnforcementCommandService, RevokeGroupMembershipSuspensionRequest,
+    SuspendGroupMembershipRequest,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const POSTGRES_URL_ENV: &str = "RUSTOK_GROUPS_TEST_POSTGRES_URL";
+
+fn schema_url(base: &str, schema: &str) -> String {
+    let separator = if base.contains('?') { '&' } else { '?' };
+    format!("{base}{separator}options=-csearch_path%3D{schema}%2Cpublic")
+}
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups GraphQL parity PostgreSQL connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for PostgreSQL GraphQL parity evidence");
+    }
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    native_target_id: Uuid,
+    graphql_target_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'enforcement-graphql-postgres-parity', 3);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{native_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{graphql_target_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups PostgreSQL GraphQL parity fixture should seed");
+}
+
+fn tenant_context(tenant_id: Uuid) -> TenantContext {
+    TenantContext {
+        id: tenant_id,
+        name: "Groups PostgreSQL GraphQL parity".to_string(),
+        slug: "groups-postgres-graphql-parity".to_string(),
+        domain: None,
+        settings: serde_json::json!({}),
+        default_locale: "en".to_string(),
+        is_active: true,
+    }
+}
+
+fn auth_context(tenant_id: Uuid, owner_id: Uuid) -> AuthContext {
+    AuthContext {
+        user_id: owner_id,
+        session_id: Uuid::new_v4(),
+        tenant_id,
+        permissions: Vec::new(),
+        client_id: None,
+        scopes: Vec::new(),
+        grant_type: "direct".to_string(),
+    }
+}
+
+fn native_context(tenant_id: Uuid, owner_id: Uuid, idempotency_key: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(owner_id.to_string()),
+        "en",
+        format!("groups-enforcement-postgres-native-parity-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(5))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn graphql_schema(
+    db: DatabaseConnection,
+) -> Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription> {
+    Schema::build(
+        GroupsQueryRoot::default(),
+        GroupsMutationRoot::default(),
+        EmptySubscription,
+    )
+    .data(HostRuntimeContext::new(db))
+    .finish()
+}
+
+async fn execute_graphql(
+    schema: &Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription>,
+    tenant_id: Uuid,
+    owner_id: Uuid,
+    document: String,
+) -> Response {
+    schema
+        .execute(
+            Request::new(document)
+                .data(tenant_context(tenant_id))
+                .data(auth_context(tenant_id, owner_id)),
+        )
+        .await
+}
+
+fn response_json(response: Response) -> serde_json::Value {
+    assert!(
+        response.errors.is_empty(),
+        "PostgreSQL GraphQL parity request should succeed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .into_json()
+        .expect("PostgreSQL GraphQL parity response data should convert to JSON")
+}
+
+fn extension_json(error: &async_graphql::ServerError, key: &str) -> Option<serde_json::Value> {
+    error
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get(key))
+        .cloned()
+        .and_then(|value| value.into_json().ok())
+}
+
+#[tokio::test]
+#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]
+async fn direct_enforcement_native_and_graphql_share_owner_semantics_postgres() {
+    let base_url = std::env::var(POSTGRES_URL_ENV)
+        .expect("RUSTOK_GROUPS_TEST_POSTGRES_URL must be configured");
+    let schema_name = format!("groups_graphql_parity_{}", Uuid::new_v4().simple());
+    let admin = connect(&base_url).await;
+    admin
+        .execute_unprepared(&format!("CREATE SCHEMA {schema_name}"))
+        .await
+        .expect("isolated Groups GraphQL parity schema should create");
+    let scoped_url = schema_url(&base_url, &schema_name);
+    let db = connect(&scoped_url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let native_target_id = Uuid::new_v4();
+    let graphql_target_id = Uuid::new_v4();
+    seed_group_fixture(
+        &db,
+        tenant_id,
+        group_id,
+        owner_id,
+        native_target_id,
+        graphql_target_id,
+    )
+    .await;
+
+    let native_service = GroupMembershipEnforcementCommandService::new(db.clone());
+    let native_suspend = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &native_service,
+        native_context(tenant_id, owner_id, "postgres-native-suspend"),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: native_target_id,
+            expected_membership_revision: 1,
+            reason_code: "parity_review".to_string(),
+            effective_until: None,
+        },
+    )
+    .await
+    .expect("native PostgreSQL owner suspend should succeed");
+    assert_eq!(native_suspend.effective_status, GroupMembershipEffectiveStatus::Suspended);
+    assert_eq!(native_suspend.membership_revision, 2);
+    assert_eq!(native_suspend.enforcement_revision, 1);
+    assert_eq!(native_suspend.member_count, 3);
+    assert!(!native_suspend.replayed);
+
+    let schema = graphql_schema(db.clone());
+    let suspend_document = format!(
+        r#"
+mutation {{
+  suspendGroupMembership(
+    idempotencyKey: "postgres-graphql-suspend",
+    groupId: "{group_id}",
+    targetUserId: "{graphql_target_id}",
+    expectedMembershipRevision: 1,
+    reasonCode: "parity_review"
+  ) {{
+    membershipId
+    membershipRevision
+    groupVersion
+    memberCount
+    effectiveStatus
+    enforcementRevision
+    effectiveUntil
+    revokedAt
+    replayed
+  }}
+}}
+"#
+    );
+    let graphql_suspend = response_json(
+        execute_graphql(&schema, tenant_id, owner_id, suspend_document.clone()).await,
+    );
+    let graphql_suspend = &graphql_suspend["suspendGroupMembership"];
+    assert_eq!(graphql_suspend["membershipRevision"].as_i64(), Some(2));
+    assert_eq!(graphql_suspend["memberCount"].as_i64(), Some(native_suspend.member_count));
+    assert_eq!(
+        graphql_suspend["effectiveStatus"].as_str(),
+        Some(native_suspend.effective_status.as_str())
+    );
+    assert_eq!(
+        graphql_suspend["enforcementRevision"].as_i64(),
+        Some(native_suspend.enforcement_revision)
+    );
+    assert!(graphql_suspend["effectiveUntil"].is_null());
+    assert!(graphql_suspend["revokedAt"].is_null());
+    assert_eq!(graphql_suspend["replayed"].as_bool(), Some(false));
+    assert!(
+        graphql_suspend["groupVersion"].as_i64().is_some_and(|version| version > native_suspend.group_version)
+    );
+
+    let replay = response_json(
+        execute_graphql(&schema, tenant_id, owner_id, suspend_document).await,
+    );
+    let replay = &replay["suspendGroupMembership"];
+    assert_eq!(replay["membershipId"], graphql_suspend["membershipId"]);
+    assert_eq!(replay["membershipRevision"], graphql_suspend["membershipRevision"]);
+    assert_eq!(replay["groupVersion"], graphql_suspend["groupVersion"]);
+    assert_eq!(replay["memberCount"], graphql_suspend["memberCount"]);
+    assert_eq!(replay["effectiveStatus"], graphql_suspend["effectiveStatus"]);
+    assert_eq!(replay["enforcementRevision"], graphql_suspend["enforcementRevision"]);
+    assert_eq!(replay["replayed"].as_bool(), Some(true));
+
+    let stale = execute_graphql(
+        &schema,
+        tenant_id,
+        owner_id,
+        format!(
+            r#"
+mutation {{
+  suspendGroupMembership(
+    idempotencyKey: "postgres-graphql-stale",
+    groupId: "{group_id}",
+    targetUserId: "{graphql_target_id}",
+    expectedMembershipRevision: 1,
+    reasonCode: "stale_review"
+  ) {{ membershipRevision }}
+}}
+"#
+        ),
+    )
+    .await;
+    assert_eq!(stale.errors.len(), 1);
+    let stale_error = &stale.errors[0];
+    assert_eq!(
+        extension_json(stale_error, "code").and_then(|value| value.as_str().map(str::to_owned)),
+        Some("BAD_USER_INPUT".to_string())
+    );
+    assert_eq!(
+        extension_json(stale_error, "domainCode")
+            .and_then(|value| value.as_str().map(str::to_owned)),
+        Some("groups.membership_enforcement_revision_conflict".to_string())
+    );
+    assert_eq!(
+        extension_json(stale_error, "retryable").and_then(|value| value.as_bool()),
+        Some(false)
+    );
+
+    let native_revoke = GroupMembershipEnforcementCommandPort::revoke_membership_suspension(
+        &native_service,
+        native_context(tenant_id, owner_id, "postgres-native-revoke"),
+        RevokeGroupMembershipSuspensionRequest {
+            group_id,
+            target_user_id: native_target_id,
+            expected_membership_revision: native_suspend.membership_revision,
+            reason_code: "parity_complete".to_string(),
+        },
+    )
+    .await
+    .expect("native PostgreSQL owner revoke should succeed");
+    assert_eq!(native_revoke.effective_status, GroupMembershipEffectiveStatus::Active);
+    assert_eq!(native_revoke.membership_revision, 3);
+    assert_eq!(native_revoke.enforcement_revision, 2);
+    assert_eq!(native_revoke.member_count, 3);
+    assert!(native_revoke.revoked_at.is_some());
+
+    let graphql_revoke = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  revokeGroupMembershipSuspension(
+    idempotencyKey: "postgres-graphql-revoke",
+    groupId: "{group_id}",
+    targetUserId: "{graphql_target_id}",
+    expectedMembershipRevision: 2,
+    reasonCode: "parity_complete"
+  ) {{
+    membershipRevision
+    groupVersion
+    memberCount
+    effectiveStatus
+    enforcementRevision
+    effectiveUntil
+    revokedAt
+    replayed
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    let graphql_revoke = &graphql_revoke["revokeGroupMembershipSuspension"];
+    assert_eq!(graphql_revoke["membershipRevision"].as_i64(), Some(3));
+    assert_eq!(graphql_revoke["memberCount"].as_i64(), Some(native_revoke.member_count));
+    assert_eq!(
+        graphql_revoke["effectiveStatus"].as_str(),
+        Some(native_revoke.effective_status.as_str())
+    );
+    assert_eq!(
+        graphql_revoke["enforcementRevision"].as_i64(),
+        Some(native_revoke.enforcement_revision)
+    );
+    assert!(graphql_revoke["effectiveUntil"].is_null());
+    assert!(graphql_revoke["revokedAt"].is_string());
+    assert_eq!(graphql_revoke["replayed"].as_bool(), Some(false));
+    assert!(
+        graphql_revoke["groupVersion"].as_i64().is_some_and(|version| version > native_revoke.group_version)
+    );
+
+    drop(native_service);
+    drop(schema);
+    drop(db);
+    admin
+        .execute_unprepared(&format!("DROP SCHEMA {schema_name} CASCADE"))
+        .await
+        .expect("isolated Groups GraphQL parity schema should drop");
+}

--- a/crates/rustok-groups/docs/membership-enforcement-graphql-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-graphql-contract.md
@@ -1,6 +1,6 @@
 # Groups membership enforcement GraphQL contract
 
-Status: **source-ready with executable SQLite parity source / maintainer execution pending**
+Status: **source-ready with executable SQLite/PostgreSQL parity sources / maintainer execution pending**
 
 ## Scope
 
@@ -110,6 +110,18 @@ No synthetic owner result or direct enforcement-table mutation is used. The Grap
 
 This packet is **execution pending**. Its source does not populate `membership_enforcement_command_transport_parity` or promote any runtime gate until a maintainer runs it.
 
+## Executable PostgreSQL native/GraphQL parity source
+
+`apps/server/tests/groups_membership_enforcement_graphql_postgres.rs` mirrors the SQLite packet against PostgreSQL using a unique schema per execution. Every SeaORM pool connection receives the schema through startup options:
+
+```text
+options=-csearch_path=<schema>,public
+```
+
+The packet intentionally does not rely on session-local `SET search_path`. It applies the same production Groups migrations and repeats native-vs-final-GraphQL suspend, immutable replay, stale revision error extensions and revoke semantics for a local owner with no platform moderation permission.
+
+The PostgreSQL test is ignored unless `RUSTOK_GROUPS_TEST_POSTGRES_URL` is configured. Its source is **execution pending** and does not populate transport parity evidence before a maintainer runs it.
+
 ## No fallback
 
 The stable module manifest entrypoint remains `graphql_application_cas::GroupsMutationRoot`; the new enforcement mutation is composed inside that root. There is no implicit GraphQL-to-native, native-to-GraphQL, admin, remote, or legacy fallback path.
@@ -123,7 +135,8 @@ cargo check -p rustok-groups --features graphql
 cargo test -p rustok-groups --features graphql graphql_conflict_preserves_transport_and_owner_codes
 cargo test -p rustok-groups --features graphql graphql_unavailable_keeps_owner_code_and_retryability
 cargo test -p rustok-server --features mod-groups --test groups_membership_enforcement_graphql_sqlite -- --nocapture
+RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' cargo test -p rustok-server --features mod-groups --test groups_membership_enforcement_graphql_postgres -- --ignored --nocapture
 node scripts/verify/verify-groups-membership-enforcement-graphql.mjs
 ```
 
-No Cargo command, test, Node verifier, browser/schema execution, formatter, workflow or CI job was executed. PostgreSQL/native-GraphQL parity and executed SQLite replay/CAS/authorization/schema/error parity remain open.
+No Cargo command, test, Node verifier, browser/schema execution, formatter, workflow or CI job was executed. Executed SQLite/PostgreSQL replay/CAS/authorization/schema/error parity remains open.

--- a/scripts/verify/verify-groups-membership-enforcement-graphql.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-graphql.mjs
@@ -22,8 +22,12 @@ const docs = fs.readFileSync(
   "crates/rustok-groups/docs/membership-enforcement-graphql-contract.md",
   "utf8",
 );
-const parity = fs.readFileSync(
+const sqliteParity = fs.readFileSync(
   "apps/server/tests/groups_membership_enforcement_graphql_sqlite.rs",
+  "utf8",
+);
+const postgresParity = fs.readFileSync(
+  "apps/server/tests/groups_membership_enforcement_graphql_postgres.rs",
   "utf8",
 );
 
@@ -136,6 +140,7 @@ for (const marker of [
   "Transport boundary",
   "Owner-only business semantics",
   "Executable SQLite native/GraphQL parity source",
+  "Executable PostgreSQL native/GraphQL parity source",
   "No fallback",
   "graphql_application_cas::GroupsMutationRoot",
   "GroupMembershipEnforcementCommandPort",
@@ -144,8 +149,10 @@ for (const marker of [
   "platform-wide GraphQL transport classification",
   "membership_enforcement_command_transport_parity",
   "execution pending",
+  "options=-csearch_path=<schema>,public",
   "cargo check -p rustok-groups --features graphql",
   "groups_membership_enforcement_graphql_sqlite",
+  "groups_membership_enforcement_graphql_postgres",
 ]) {
   requireText(docs, marker, `Groups enforcement GraphQL handoff is missing ${marker}`);
 }
@@ -168,7 +175,7 @@ for (const marker of [
   "graphql-suspend",
   "graphql-stale",
   "graphql-revoke",
-  "replayed" ,
+  "replayed",
   'Some("BAD_USER_INPUT".to_string())',
   'Some("groups.membership_enforcement_revision_conflict".to_string())',
   "domainCode",
@@ -178,7 +185,7 @@ for (const marker of [
   "version > native_suspend.group_version",
   "version > native_revoke.group_version",
 ]) {
-  requireText(parity, marker, `Groups enforcement GraphQL SQLite parity source is missing ${marker}`);
+  requireText(sqliteParity, marker, `Groups enforcement GraphQL SQLite parity source is missing ${marker}`);
 }
 
 for (const forbidden of [
@@ -187,9 +194,50 @@ for (const forbidden of [
   "GroupMembershipEffectiveState {",
   "rustok_moderation::",
 ]) {
-  if (parity.includes(forbidden)) {
+  if (sqliteParity.includes(forbidden)) {
     throw new Error(`Groups enforcement GraphQL SQLite parity source contains shortcut ${forbidden}`);
   }
 }
 
-console.log("Groups membership enforcement GraphQL source and SQLite parity guard passed");
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  '#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]',
+  "RUSTOK_GROUPS_TEST_POSTGRES_URL",
+  "options=-csearch_path%3D",
+  "CREATE SCHEMA",
+  "DROP SCHEMA",
+  "rustok_groups::migrations::migrations()",
+  "GroupsQueryRoot::default()",
+  "GroupsMutationRoot::default()",
+  "HostRuntimeContext::new(db)",
+  "permissions: Vec::new()",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "GroupMembershipEnforcementCommandPort::revoke_membership_suspension",
+  "suspendGroupMembership",
+  "revokeGroupMembershipSuspension",
+  "postgres-graphql-suspend",
+  "postgres-graphql-stale",
+  "postgres-graphql-revoke",
+  'Some("BAD_USER_INPUT".to_string())',
+  'Some("groups.membership_enforcement_revision_conflict".to_string())',
+  "domainCode",
+  "retryable",
+  "native_suspend.member_count",
+  "native_revoke.member_count",
+]) {
+  requireText(postgresParity, marker, `Groups enforcement GraphQL PostgreSQL parity source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "SET search_path",
+  "UPDATE group_membership_enforcements",
+  "INSERT INTO group_membership_enforcements",
+  "GroupMembershipEffectiveState {",
+  "rustok_moderation::",
+]) {
+  if (postgresParity.includes(forbidden)) {
+    throw new Error(`Groups enforcement GraphQL PostgreSQL parity source contains shortcut ${forbidden}`);
+  }
+}
+
+console.log("Groups membership enforcement GraphQL source and SQLite/PostgreSQL parity guard passed");


### PR DESCRIPTION
## Summary
- add schema-isolated PostgreSQL executable source for native vs final-GraphQL direct membership enforcement parity
- use PostgreSQL startup `search_path` options on every pooled connection; no session-local `SET search_path`
- apply production Groups migrations and use the production native command service plus `graphql_application_cas::GroupsMutationRoot`
- retain suspend semantic parity, immutable GraphQL replay, stale revision `BAD_USER_INPUT + domainCode + retryable=false`, and revoke parity
- use a local owner principal without platform moderation permission so hierarchy remains an owner-domain decision
- update the existing GraphQL contract/guard to record SQLite/PostgreSQL parity source while leaving transport parity runtime evidence unpromoted
- add no dependency, manifest, lockfile, schema definition, production-owner, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.