### PR TITLE
refactor(commerce): make Product GraphQL idempotency non-null

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -264,12 +264,12 @@ These are source-contract defects, not verification-only tasks.
   errors.
 - [x] Cut mounted GraphQL Product create/update/publish/delete lifecycle execution to
   the host-selected `ProductCatalogCommandRuntime` / `ProductCatalogCommandPort`, keep
-  create/update compatibility validation and public error identities, and publish an
-  optional explicit `idempotencyKey`; omitted keys use a logged one-request compatibility
-  identity and do not claim replay semantics.
-- [ ] Teach Product Admin FFA lifecycle commands to retain one GraphQL caller
+  create/update compatibility validation and public error identities, and require an
+  explicit caller `idempotencyKey` for every lifecycle execution with scoped command
+  identity and no compatibility-generated caller identity.
+- [x] Teach Product Admin FFA lifecycle commands to retain one GraphQL caller
   idempotency key across explicit retries, then make mounted GraphQL `idempotencyKey`
-  mandatory without breaking current UI callers.
+  non-null/mandatory after updating current regression callers to supply explicit keys.
 - [ ] Cut remaining Product schema writes away from direct
   `ProductCatalogSchemaService` construction through typed Product owner write
   capabilities with explicit write idempotency semantics.
@@ -672,6 +672,7 @@ Source inspection is not execution evidence.
 - [ ] `node scripts/verify/verify-commerce-product-command-port.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-rest-lifecycle-command-cutover.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs`
+- [ ] `node scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-detail-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-list-read.mjs`
 - [ ] `node scripts/verify/verify-commerce-product-admin-graphql-read.mjs`
@@ -923,8 +924,8 @@ Source inspection is not execution evidence.
   host-composed Product command runtime with required caller idempotency identity.
 - [x] Cut mounted GraphQL Product create/update/publish/delete execution to the
   host-selected Product command runtime, preserve lifecycle public-error identities,
-  and expose optional explicit caller idempotency while retaining a logged one-request
-  compatibility path for current callers; mandatory FFA retry identity remains open.
+  complete Product Admin retry identity retention, and require non-null explicit caller
+  idempotency with no compatibility-generated lifecycle identity.
 
 ## Change rules
 

--- a/crates/rustok-commerce/docs/product-graphql-idempotency-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-graphql-idempotency-recheck-2026-08-08.md
@@ -2,33 +2,30 @@
 
 ## Scope
 
-This source-only continuation rechecks mounted Product lifecycle caller identity after Product Admin FFA PRs #3263 and #3269. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; this packet does not promote FBA/FFA or verification state.
+This source-only continuation rechecks mounted Product lifecycle caller identity after Product Admin FFA PRs #3263 and #3269 plus Commerce hardening PR #3272. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; this packet does not promote FBA/FFA or verification state.
 
 ## Recheck result
 
-- Product Admin FFA now retains one lifecycle caller idempotency key across a failed explicit retry and sends it as a non-null `String!` GraphQL variable on the active create/update/status/delete transport.
-- Mounted Commerce GraphQL no longer manufactures a one-request `compatibility-*` identity when a lifecycle caller omits `idempotencyKey`.
-- `product_command_context` now rejects omission with public `BAD_USER_INPUT` / `Product mutation idempotency key is required` after existing module, permission, tenant-actor, and create/update shipping-profile admission has run.
-- Non-empty caller keys remain capped at 191 bytes and scope-hashed with tenant, authenticated actor, lifecycle operation, and Product id when one exists before they become `PortContext.idempotency_key` and correlation identity.
-- The lifecycle resolver arguments intentionally remain `Option<String>` in this slice. This preserves the current ordering of foreign-actor and shipping-profile regression fixtures while removing the unsafe compatibility execution path.
+- Product Admin FFA retains one lifecycle caller idempotency key across a failed explicit retry and sends it as a non-null `String!` GraphQL variable on the active create/update/status/delete transport.
+- Mounted Commerce GraphQL no longer manufactures a one-request `compatibility-*` identity for Product lifecycle commands.
+- Mounted `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct` now expose non-null caller `idempotencyKey` arguments because the resolver inputs are `String`, not `Option<String>`.
+- Empty caller keys are still rejected with `BAD_USER_INPUT`; non-empty keys remain capped at 191 bytes and scope-hashed with tenant, authenticated actor, lifecycle operation, and Product id when one exists before they become `PortContext.idempotency_key` and correlation identity.
+- Foreign-actor regression callers now supply explicit lifecycle keys, so GraphQL required-argument validation does not replace the tenant/actor admission assertions those fixtures are meant to retain.
+- The unknown-shipping-profile Product create fixture also supplies an explicit key, preserving the shipping-profile validation assertion under the non-null SDL.
 
-## Why the canonical item remains open
+## Canonical source status
 
-The ecommerce plan item that says Product Admin FFA must retain one key and mounted GraphQL `idempotencyKey` must become mandatory remains `[ ]` because the GraphQL SDL is still nullable. The remaining source step is narrow and explicit:
+The ecommerce plan item for Product Admin retry identity plus mandatory mounted GraphQL `idempotencyKey` is now source-complete and can be marked `[x]`. This is a source completion only: the Product lifecycle static guard, compile checks, mounted parity, retry/restart, remote-profile, and runtime evidence remain unexecuted.
 
-1. update the foreign-actor and unknown-shipping-profile GraphQL fixtures to supply caller idempotency keys while preserving the admission assertions they actually test;
-2. change `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct` resolver arguments from `Option<String>` to `String`, producing non-null GraphQL arguments;
-3. update both Product lifecycle source guards to forbid nullable lifecycle idempotency arguments;
-4. only then mark the canonical FFA/server-idempotency item complete.
-
-The old Product Admin `transport/graphql_adapter.rs` lifecycle query strings remain unmounted compatibility source. The active Product Admin transport is `catalog_transport_retry.rs` plus `transport/product_lifecycle_graphql.rs`; cleanup of the superseded adapter should follow compile/source evidence rather than be mixed into this server hardening slice.
+The old Product Admin `transport/graphql_adapter.rs` lifecycle query strings remain unmounted compatibility source. The active Product Admin transport is `catalog_transport_retry.rs` plus `transport/product_lifecycle_graphql.rs`; cleanup of the superseded adapter should follow compile/source evidence rather than be mixed into this server-contract slice.
 
 ## Remaining Product execution order
 
-1. Complete the non-null GraphQL SDL cutover and regression-fixture caller update described above.
-2. Cut remaining Product schema writes away from direct `ProductCatalogSchemaService` construction through typed Product owner write capabilities with explicit write idempotency semantics.
-3. Remove superseded private Product compatibility helpers only after compile/source evidence confirms no remaining consumers.
-4. Execute the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before any FBA/FFA promotion.
+1. Cut remaining Product schema writes away from direct `ProductCatalogSchemaService` construction through typed Product owner write capabilities with explicit write idempotency semantics.
+2. Remove superseded private Product compatibility helpers only after compile/source evidence confirms no remaining consumers.
+3. Execute the plan-listed static, compile, parity, remote-profile, restart, and backend evidence before any FBA/FFA promotion.
+
+The broad ecommerce typed-owner-boundary invariant remains open because Product schema writes still construct `ProductCatalogSchemaService` directly and other ecommerce production-path debt remains separately tracked by the canonical plan.
 
 ## Verification state
 

--- a/crates/rustok-commerce/src/graphql/mutations/catalog.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/catalog.rs
@@ -53,13 +53,10 @@ fn product_command_context(
     tenant_id: Uuid,
     user_id: Uuid,
     product_id: Option<Uuid>,
-    idempotency_key: Option<String>,
+    idempotency_key: String,
     operation: &'static str,
 ) -> Result<PortContext> {
-    let caller_key = idempotency_key.ok_or_else(|| {
-        invalid_product_idempotency_key("Product mutation idempotency key is required")
-    })?;
-    let caller_key = caller_key.trim();
+    let caller_key = idempotency_key.trim();
     if caller_key.is_empty() {
         return Err(invalid_product_idempotency_key(
             "Product mutation idempotency key must not be empty",
@@ -169,7 +166,7 @@ impl CommerceCatalogMutation {
     async fn create_product(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         input: CreateProductInput,
     ) -> Result<GqlProduct> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -208,7 +205,7 @@ impl CommerceCatalogMutation {
     async fn update_product(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         id: Uuid,
         input: UpdateProductInput,
     ) -> Result<GqlProduct> {
@@ -271,7 +268,7 @@ impl CommerceCatalogMutation {
     async fn publish_product(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         id: Uuid,
     ) -> Result<GqlProduct> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -302,7 +299,7 @@ impl CommerceCatalogMutation {
     async fn delete_product(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         id: Uuid,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;

--- a/crates/rustok-commerce/tests/graphql_runtime_parity_test/catalog.rs
+++ b/crates/rustok-commerce/tests/graphql_runtime_parity_test/catalog.rs
@@ -75,7 +75,7 @@ async fn admin_graphql_rejects_product_write_actor_from_another_tenant() {
         .execute(Request::new(
             r#"
             mutation {
-              createProduct(input: {
+              createProduct(idempotencyKey: "foreign-actor-create", input: {
                 translations: [{ locale: "en", title: "Unreachable", handle: "unreachable" }]
                 variants: [{ sku: "UNREACHABLE", prices: [{ currencyCode: "EUR", amount: "1.00" }] }]
               }) { id }
@@ -115,13 +115,13 @@ async fn admin_graphql_rejects_foreign_actor_for_every_product_mutation() {
         .execute(Request::new(format!(
             r#"
             mutation {{
-              create: createProduct(input: {{
+              create: createProduct(idempotencyKey: "foreign-actor-create-all", input: {{
                 translations: [{{ locale: "en", title: "Blocked", handle: "blocked" }}]
                 variants: [{{ sku: "BLOCKED", prices: [{{ currencyCode: "EUR", amount: "1.00" }}] }}]
               }}) {{ id }}
-              update: updateProduct(id: "{id}", input: {{}}) {{ id }}
-              publish: publishProduct(id: "{id}") {{ id }}
-              delete: deleteProduct(id: "{id}")
+              update: updateProduct(idempotencyKey: "foreign-actor-update-all", id: "{id}", input: {{}}) {{ id }}
+              publish: publishProduct(idempotencyKey: "foreign-actor-publish-all", id: "{id}") {{ id }}
+              delete: deleteProduct(idempotencyKey: "foreign-actor-delete-all", id: "{id}")
               createAttribute: createProductAttribute(locale: "en", input: {{
                 code: "blocked"
                 valueType: "text"

--- a/crates/rustok-commerce/tests/graphql_runtime_parity_test/shipping.rs
+++ b/crates/rustok-commerce/tests/graphql_runtime_parity_test/shipping.rs
@@ -574,6 +574,7 @@ async fn admin_graphql_rejects_unknown_shipping_profile_references() {
             r#"
             mutation {{
               createProduct(
+                idempotencyKey: "unknown-shipping-profile-product"
                 input: {{
                   translations: [{{
                     locale: "en"

--- a/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
@@ -12,6 +12,8 @@ const mutations = read("crates/rustok-commerce/src/graphql/mutations/catalog.rs"
 const graphqlRuntime = read("crates/rustok-commerce/src/graphql_runtime.rs");
 const ownerPort = read("crates/rustok-product/src/catalog_command_port.rs");
 const hostComposition = read("apps/server/src/services/commerce_provider_runtime.rs");
+const catalogFixture = read("crates/rustok-commerce/tests/graphql_runtime_parity_test/catalog.rs");
+const shippingFixture = read("crates/rustok-commerce/tests/graphql_runtime_parity_test/shipping.rs");
 const failures = [];
 
 function fail(message) {
@@ -79,11 +81,10 @@ for (const required of [
   "product_catalog_command_runtime_for_current_graphql_scope(",
   "MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH: usize = 191",
   "PRODUCT_COMMAND_DEADLINE: Duration = Duration::from_secs(2)",
-  "idempotency_key: Option<String>",
-  "Product mutation idempotency key is required",
+  "idempotency_key: String",
   "Product mutation idempotency key must not be empty",
   "BAD_USER_INPUT",
-  "let caller_key = idempotency_key.ok_or_else(||",
+  "let caller_key = idempotency_key.trim();",
   "digest.update(tenant_id.as_bytes())",
   "digest.update(user_id.as_bytes())",
   "digest.update(operation.as_bytes())",
@@ -99,11 +100,13 @@ for (const required of [
 }
 
 for (const forbidden of [
+  "idempotency_key: Option<String>",
+  "Product mutation idempotency key is required",
   "one-request compatibility identity",
   'format!("compatibility-{}", Uuid::new_v4())',
   "Product GraphQL lifecycle caller omitted idempotency key",
 ]) {
-  forbidText(mutations, forbidden, "GraphQL Product lifecycle compatibility identity");
+  forbidText(mutations, forbidden, "GraphQL Product lifecycle mandatory caller identity");
 }
 
 forbidText(
@@ -139,7 +142,7 @@ for (const [slice, operation, permission, portCall, productIdentity] of [
   [remove, "delete_product", "Permission::PRODUCTS_DELETE", ".delete_product(port_context.clone(), id)", "Some(id)"],
 ]) {
   for (const required of [
-    "idempotency_key: Option<String>",
+    "idempotency_key: String",
     permission,
     "product_mutation_actor(ctx)?",
     "product_command_context(",
@@ -152,6 +155,7 @@ for (const [slice, operation, permission, portCall, productIdentity] of [
   ]) {
     requireText(slice, required, `${operation} GraphQL mutation`);
   }
+  forbidText(slice, "idempotency_key: Option<String>", `${operation} GraphQL mutation`);
   for (const forbidden of [
     "CatalogService::new",
     `.create_product(tenant_id, user_id`,
@@ -180,6 +184,21 @@ for (const required of [
   requireText(update, required, "update Product compatibility semantics");
 }
 
+for (const required of [
+  'createProduct(idempotencyKey: "foreign-actor-create"',
+  'createProduct(idempotencyKey: "foreign-actor-create-all"',
+  'updateProduct(idempotencyKey: "foreign-actor-update-all"',
+  'publishProduct(idempotencyKey: "foreign-actor-publish-all"',
+  'deleteProduct(idempotencyKey: "foreign-actor-delete-all"',
+]) {
+  requireText(catalogFixture, required, "Product lifecycle foreign-actor fixture");
+}
+requireText(
+  shippingFixture,
+  'idempotencyKey: "unknown-shipping-profile-product"',
+  "Product lifecycle shipping-profile fixture",
+);
+
 requireText(
   mutations,
   "ProductCatalogSchemaService::new",
@@ -197,4 +216,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product GraphQL lifecycle execution requires explicit caller idempotency with no compatibility identity; non-null SDL remains explicit follow-up debt");
+console.log("✔ Product GraphQL lifecycle SDL requires explicit caller idempotency; retry-aware Product Admin and regression callers supply keys with no compatibility identity");

--- a/scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs
+++ b/scripts/verify/verify-product-admin-lifecycle-retry-consumer.mjs
@@ -69,26 +69,22 @@ for (const required of [
 forbidText(adapter, "compatibility-", "Product Admin explicit retry caller");
 forbidText(adapter, "Option<String>\n    idempotency_key", "Product Admin explicit retry caller");
 
-// Product Admin already sends a non-null caller key. Mounted Commerce now rejects an omitted key
-// instead of manufacturing a compatibility identity, but the resolver argument remains nullable so
-// tenant/profile admission regression fixtures preserve their existing ordering until the dedicated
-// non-null SDL cutover updates those callers explicitly.
-requireText(
-  commerce,
-  "idempotency_key: Option<String>",
-  "mounted GraphQL non-null SDL follow-up remains explicit",
-);
-requireText(
-  commerce,
-  "Product mutation idempotency key is required",
-  "mounted GraphQL execution requires caller identity",
-);
+for (const required of [
+  "idempotency_key: String",
+  "Product mutation idempotency key must not be empty",
+  "MAX_PRODUCT_GRAPHQL_IDEMPOTENCY_KEY_LENGTH: usize = 191",
+  ".with_idempotency_key(scoped_key)",
+]) {
+  requireText(commerce, required, "mounted GraphQL mandatory idempotency contract");
+}
 for (const forbidden of [
+  "idempotency_key: Option<String>",
+  "Product mutation idempotency key is required",
   "using one-request compatibility identity",
   "compatibility-{}",
   "Product GraphQL lifecycle caller omitted idempotency key",
 ]) {
-  forbidText(commerce, forbidden, "mounted GraphQL compatibility identity must stay removed");
+  forbidText(commerce, forbidden, "mounted GraphQL mandatory idempotency contract");
 }
 
 if (failures.length) {
@@ -97,4 +93,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product Admin lifecycle callers retain explicit retry identity and mounted Commerce rejects omission; non-null server SDL remains follow-up debt");
+console.log("✔ Product Admin lifecycle callers retain retry identity and mounted Commerce exposes non-null Product lifecycle idempotency with no compatibility path");


### PR DESCRIPTION
## Summary

- make mounted Commerce GraphQL `createProduct`, `updateProduct`, `publishProduct`, and `deleteProduct` caller `idempotencyKey` non-null by changing resolver inputs from `Option<String>` to `String`
- keep existing non-empty / 191-byte caller-key validation plus tenant + actor + operation + Product scope hashing before `PortContext`
- preserve Product command runtime composition, typed owner execution, permissions, shipping-profile compatibility validation, request context, deadline, and public lifecycle error identities
- keep the active Product Admin FFA retry-aware transport unchanged: it already sends one stable `$idempotencyKey: String!` across explicit failed retries
- update foreign-actor lifecycle regression callers with explicit keys so they continue to test tenant/actor admission rather than required-argument validation
- update the unknown-shipping-profile Product create fixture with an explicit key so it continues to test shipping-profile validation
- update both Product lifecycle source guards to require non-null resolver inputs and forbid nullable/compatibility caller identity
- mark the canonical Product Admin retry + mandatory GraphQL idempotency source item complete

## Remaining Product debt

- cut remaining Product schema writes away from direct `ProductCatalogSchemaService` construction through typed Product owner write capabilities with explicit write idempotency semantics
- remove superseded Product compatibility helpers only after compile/source evidence
- execute static, compile, mounted parity, retry/restart, remote-profile, and runtime evidence before any FBA/FFA promotion

The broad ecommerce typed-owner invariant remains open.

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction.