### PR TITLE
test(groups): retain localization suspension expiry SQLite evidence

### DIFF
--- a/apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs
+++ b/apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs
@@ -1,0 +1,272 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    GroupLocalizationCommandPort, GroupLocalizationReadPort, GroupLocalizationService,
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService,
+    ListGroupTranslationsRequest, SuspendGroupMembershipRequest, UpsertGroupTranslationRequest,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups localization expiry SQLite connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for localization expiry evidence");
+    }
+}
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp.path().join("groups-localization-enforcement-expiry.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'localization-enforcement-expiry', 2);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups localization expiry fixture should seed");
+}
+
+fn read_context(tenant_id: Uuid, actor_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-localization-expiry-read-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+}
+
+fn write_context(tenant_id: Uuid, actor_id: Uuid, operation: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-localization-expiry-write-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(format!("{operation}-{}", Uuid::new_v4()))
+}
+
+async fn membership_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> (String, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT status, revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership snapshot query should succeed")
+        .expect("membership should exist");
+    (
+        row.try_get("", "status")
+            .expect("membership status should decode"),
+        row.try_get("", "revision")
+            .expect("membership revision should decode"),
+    )
+}
+
+async fn group_member_count(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT member_count FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group member_count query should succeed")
+        .expect("group should exist");
+    row.try_get("", "member_count")
+        .expect("group member_count should decode")
+}
+
+#[tokio::test]
+async fn localization_management_follows_effective_suspension_and_owner_clock_expiry_sqlite() {
+    let temp = tempfile::tempdir().expect("temporary Groups localization expiry directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let db = connect(&url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    seed_group_fixture(&db, tenant_id, group_id, owner_id, admin_id).await;
+
+    let localization = GroupLocalizationService::new(db.clone());
+    let initial = GroupLocalizationCommandPort::upsert_group_translation(
+        &localization,
+        write_context(tenant_id, owner_id, "owner-initial-translation"),
+        UpsertGroupTranslationRequest {
+            group_id,
+            locale: "en".to_string(),
+            title: "Initial title".to_string(),
+            summary: None,
+            body: None,
+        },
+    )
+    .await
+    .expect("active owner should create the initial translation");
+    assert!(initial.created);
+
+    let admin_before = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("active administrator should read management translations");
+    assert_eq!(admin_before.len(), 1);
+
+    let (_, admin_initial_revision) = membership_snapshot(&db, tenant_id, admin_id).await;
+    let enforcement = GroupMembershipEnforcementCommandService::new(db.clone());
+    let effective_until = Utc::now() + chrono::Duration::seconds(2);
+    let suspended = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &enforcement,
+        write_context(tenant_id, owner_id, "owner-suspend-admin"),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: admin_id,
+            expected_membership_revision: admin_initial_revision,
+            reason_code: "temporary_settings_review".to_string(),
+            effective_until: Some(effective_until),
+        },
+    )
+    .await
+    .expect("owner should temporarily suspend the administrator");
+    assert_eq!(suspended.membership_revision, admin_initial_revision + 1);
+    assert_eq!(suspended.member_count, 2);
+
+    let (stored_status_during_suspension, stored_revision_during_suspension) =
+        membership_snapshot(&db, tenant_id, admin_id).await;
+    assert_eq!(stored_status_during_suspension, "active");
+    assert_eq!(stored_revision_during_suspension, suspended.membership_revision);
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 2);
+
+    let read_error = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect_err("suspended administrator must not read management translations");
+    assert_eq!(read_error.code, "groups.membership_suspended");
+    assert!(!read_error.retryable);
+
+    let write_error = GroupLocalizationCommandPort::upsert_group_translation(
+        &localization,
+        write_context(tenant_id, admin_id, "suspended-admin-write"),
+        UpsertGroupTranslationRequest {
+            group_id,
+            locale: "fr".to_string(),
+            title: "Blocked title".to_string(),
+            summary: None,
+            body: None,
+        },
+    )
+    .await
+    .expect_err("suspended administrator must not mutate translations");
+    assert_eq!(write_error.code, "groups.membership_suspended");
+    assert!(!write_error.retryable);
+
+    let owner_during = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, owner_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("owner should still read translations while administrator is suspended");
+    assert_eq!(owner_during.len(), 1, "failed suspended write must not create French translation");
+
+    tokio::time::sleep(Duration::from_millis(2300)).await;
+
+    let admin_after_expiry = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("expired suspension should restore administrator management reads without cleanup");
+    assert_eq!(admin_after_expiry.len(), 1);
+
+    let restored = GroupLocalizationCommandPort::upsert_group_translation(
+        &localization,
+        write_context(tenant_id, admin_id, "restored-admin-write"),
+        UpsertGroupTranslationRequest {
+            group_id,
+            locale: "fr".to_string(),
+            title: "Restored title".to_string(),
+            summary: Some("Owner-clock access restored".to_string()),
+            body: None,
+        },
+    )
+    .await
+    .expect("expired suspension should restore administrator management writes without cleanup");
+    assert!(restored.created);
+    assert!(restored.group_version > suspended.group_version.max(initial.group_version as i64) as u64);
+
+    let final_translations = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("restored administrator should read both translations");
+    assert_eq!(final_translations.len(), 2);
+    assert!(final_translations.iter().any(|translation| translation.locale == "fr"));
+
+    let (stored_status_after_expiry, stored_revision_after_expiry) =
+        membership_snapshot(&db, tenant_id, admin_id).await;
+    assert_eq!(stored_status_after_expiry, "active");
+    assert_eq!(stored_revision_after_expiry, suspended.membership_revision);
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 2);
+
+    drop(enforcement);
+    drop(localization);
+    drop(db);
+    drop(temp);
+}

--- a/apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs
+++ b/apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs
@@ -180,6 +180,7 @@ async fn localization_management_follows_effective_suspension_and_owner_clock_ex
     .expect("owner should temporarily suspend the administrator");
     assert_eq!(suspended.membership_revision, admin_initial_revision + 1);
     assert_eq!(suspended.member_count, 2);
+    assert!(suspended.group_version > initial.group_version as i64);
 
     let (stored_status_during_suspension, stored_revision_during_suspension) =
         membership_snapshot(&db, tenant_id, admin_id).await;
@@ -247,7 +248,7 @@ async fn localization_management_follows_effective_suspension_and_owner_clock_ex
     .await
     .expect("expired suspension should restore administrator management writes without cleanup");
     assert!(restored.created);
-    assert!(restored.group_version > suspended.group_version.max(initial.group_version as i64) as u64);
+    assert_eq!(restored.group_version, suspended.group_version as u64 + 1);
 
     let final_translations = GroupLocalizationReadPort::list_group_translations(
         &localization,

--- a/crates/rustok-groups/docs/localization-enforcement-expiry-sqlite-contract.md
+++ b/crates/rustok-groups/docs/localization-enforcement-expiry-sqlite-contract.md
@@ -1,0 +1,53 @@
+# Groups localization enforcement expiry SQLite evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs` retains executable evidence that localization management authorization follows the Groups owner-clock effective membership state instead of raw `group_memberships.status`.
+
+The packet uses a real temporary SQLite file, every production Groups migration, `GroupLocalizationService`, and `GroupMembershipEnforcementCommandService`. It adds no alternate authorization path, cleanup worker, dependency, or manifest change.
+
+## Contract
+
+The fixture contains one lifecycle-active owner and one lifecycle-active administrator. The owner first creates the initial English translation through `GroupLocalizationCommandPort`; the administrator can then read the management translation surface normally.
+
+The owner applies a short production membership suspension to the administrator. While that enforcement is effective, the evidence requires:
+
+- stored membership lifecycle status remains `active`;
+- stored lifecycle `member_count` remains unchanged;
+- membership revision reflects the suspension mutation;
+- `GroupLocalizationReadPort::list_group_translations` fails with `groups.membership_suspended`;
+- `GroupLocalizationCommandPort::upsert_group_translation` fails with the same stable owner code;
+- the denied write does not create the requested translation;
+- the unsuspended owner still retains management access.
+
+After the owner clock passes `effective_until`, the test performs **no cleanup mutation**. It then requires:
+
+- the administrator can read management translations again;
+- the administrator can create a new translation through the same production localization command;
+- stored membership status is still `active`;
+- membership revision has not changed since the original suspension;
+- lifecycle `member_count` is still unchanged;
+- the localization write advances the owner group version normally.
+
+This is source evidence for localization suspension/expiry semantics only. It does not claim concurrent enforcement-vs-localization-write evidence or native/GraphQL localization parity.
+
+## Execution status
+
+The packet was not executed while preparing this slice. Runtime evidence remains **maintainer execution pending** and the FBA `localization_transport_parity` / `localization_concurrency` fields remain null.
+
+Maintainer command:
+
+```bash
+cargo test -p rustok-server --features mod-groups \
+  --test groups_localization_enforcement_expiry_sqlite -- --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-localization-boundary.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-localization-boundary.mjs
+++ b/scripts/verify/verify-groups-localization-boundary.mjs
@@ -92,6 +92,42 @@ requireMarkers("crates/rustok-groups/src/graphql_application_cas.rs", [
   "GroupsApplicationCasMutation",
 ]);
 
+requireMarkers("apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs", [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "rustok_groups::migrations::migrations()",
+  "GroupLocalizationService::new",
+  "GroupLocalizationReadPort::list_group_translations",
+  "GroupLocalizationCommandPort::upsert_group_translation",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  'assert_eq!(stored_status_during_suspension, "active")',
+  'assert_eq!(read_error.code, "groups.membership_suspended")',
+  'assert_eq!(write_error.code, "groups.membership_suspended")',
+  "failed suspended write must not create French translation",
+  "tokio::time::sleep",
+  "expired suspension should restore administrator management reads without cleanup",
+  "expired suspension should restore administrator management writes without cleanup",
+  "stored_revision_after_expiry, suspended.membership_revision",
+  "group_member_count",
+]);
+forbidMarkers("apps/server/tests/groups_localization_enforcement_expiry_sqlite.rs", [
+  "UPDATE group_membership_enforcements",
+  "DELETE FROM group_membership_enforcements",
+  "UPDATE group_memberships SET status",
+  "groups:manage",
+]);
+
+requireMarkers("crates/rustok-groups/docs/localization-enforcement-expiry-sqlite-contract.md", [
+  "executable source added / maintainer execution pending",
+  "stored membership lifecycle status remains `active`",
+  "groups.membership_suspended",
+  "no cleanup mutation",
+  "membership revision has not changed since the original suspension",
+  "localization_transport_parity",
+  "localization_concurrency",
+]);
+
 requireMarkers("crates/rustok-groups/admin/src/core.rs", [
   "prepare_group_translation_query",
   "prepare_upsert_group_translation",
@@ -187,4 +223,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Groups exact-locale localization, effective owner-clock authorization, shared writer reservation, stable GraphQL root, FBA, FFA, last-row, and no-fallback boundary checks passed.");
+console.log("Groups exact-locale localization, effective owner-clock authorization, SQLite suspension/expiry source, shared writer reservation, stable GraphQL root, FBA, FFA, last-row, and no-fallback boundary checks passed.");


### PR DESCRIPTION
## Summary
- add file-backed SQLite executable source for Groups localization management under effective membership suspension/expiry
- use production Groups migrations, `GroupLocalizationService`, and the production membership enforcement command service
- prove an active administrator can read management translations before enforcement
- suspend that administrator through the owner command while stored membership lifecycle status remains `active`
- prove both localization management read and upsert fail closed with `groups.membership_suspended`, and the denied write creates no translation
- prove the unsuspended owner retains management access
- after owner-clock expiry, prove the same administrator regains read/write access without cleanup or a synthetic membership revision bump
- retain lifecycle `member_count` invariance and exact owner group-version progression across suspension and restored translation write
- update the existing localization source guard and add a focused execution handoff while keeping localization transport/concurrency evidence null
- add no dependency, manifest, lockfile, schema definition, production-owner, GraphQL, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.