### PR TITLE
test(groups): retain localization suspension expiry PostgreSQL evidence

### DIFF
--- a/apps/server/tests/groups_localization_enforcement_expiry_postgres.rs
+++ b/apps/server/tests/groups_localization_enforcement_expiry_postgres.rs
@@ -1,0 +1,285 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    GroupLocalizationCommandPort, GroupLocalizationReadPort, GroupLocalizationService,
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService,
+    ListGroupTranslationsRequest, SuspendGroupMembershipRequest, UpsertGroupTranslationRequest,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const POSTGRES_URL_ENV: &str = "RUSTOK_GROUPS_TEST_POSTGRES_URL";
+
+fn schema_url(base: &str, schema: &str) -> String {
+    let separator = if base.contains('?') { '&' } else { '?' };
+    format!("{base}{separator}options=-csearch_path%3D{schema}%2Cpublic")
+}
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups localization expiry PostgreSQL connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for PostgreSQL localization expiry evidence");
+    }
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'localization-postgres-expiry', 2);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups PostgreSQL localization expiry fixture should seed");
+}
+
+fn read_context(tenant_id: Uuid, actor_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-localization-postgres-expiry-read-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+}
+
+fn write_context(tenant_id: Uuid, actor_id: Uuid, operation: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-localization-postgres-expiry-write-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(format!("{operation}-{}", Uuid::new_v4()))
+}
+
+async fn membership_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_id: Uuid,
+) -> (String, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT status, revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership snapshot query should succeed")
+        .expect("membership should exist");
+    (
+        row.try_get("", "status")
+            .expect("membership status should decode"),
+        row.try_get("", "revision")
+            .expect("membership revision should decode"),
+    )
+}
+
+async fn group_member_count(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT member_count FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group member_count query should succeed")
+        .expect("group should exist");
+    row.try_get("", "member_count")
+        .expect("group member_count should decode")
+}
+
+#[tokio::test]
+#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]
+async fn localization_management_follows_effective_suspension_and_owner_clock_expiry_postgres() {
+    let base_url = std::env::var(POSTGRES_URL_ENV)
+        .expect("RUSTOK_GROUPS_TEST_POSTGRES_URL must be configured");
+    let schema = format!("groups_localization_expiry_{}", Uuid::new_v4().simple());
+    let admin_db = connect(&base_url).await;
+    admin_db
+        .execute_unprepared(&format!("CREATE SCHEMA {schema}"))
+        .await
+        .expect("isolated Groups localization expiry schema should create");
+    let scoped_url = schema_url(&base_url, &schema);
+    let db = connect(&scoped_url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    seed_group_fixture(&db, tenant_id, group_id, owner_id, admin_id).await;
+
+    let localization = GroupLocalizationService::new(db.clone());
+    let initial = GroupLocalizationCommandPort::upsert_group_translation(
+        &localization,
+        write_context(tenant_id, owner_id, "owner-initial-translation"),
+        UpsertGroupTranslationRequest {
+            group_id,
+            locale: "en".to_string(),
+            title: "Initial title".to_string(),
+            summary: None,
+            body: None,
+        },
+    )
+    .await
+    .expect("active owner should create the initial translation");
+    assert!(initial.created);
+
+    let admin_before = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("active administrator should read management translations");
+    assert_eq!(admin_before.len(), 1);
+
+    let (_, admin_initial_revision) = membership_snapshot(&db, tenant_id, admin_id).await;
+    let enforcement = GroupMembershipEnforcementCommandService::new(db.clone());
+    let effective_until = Utc::now() + chrono::Duration::seconds(2);
+    let suspended = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &enforcement,
+        write_context(tenant_id, owner_id, "owner-suspend-admin"),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: admin_id,
+            expected_membership_revision: admin_initial_revision,
+            reason_code: "temporary_settings_review".to_string(),
+            effective_until: Some(effective_until),
+        },
+    )
+    .await
+    .expect("owner should temporarily suspend the administrator on PostgreSQL");
+    assert_eq!(suspended.membership_revision, admin_initial_revision + 1);
+    assert_eq!(suspended.member_count, 2);
+    assert!(suspended.group_version > initial.group_version as i64);
+
+    let (stored_status_during_suspension, stored_revision_during_suspension) =
+        membership_snapshot(&db, tenant_id, admin_id).await;
+    assert_eq!(stored_status_during_suspension, "active");
+    assert_eq!(stored_revision_during_suspension, suspended.membership_revision);
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 2);
+
+    let read_error = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect_err("suspended administrator must not read management translations");
+    assert_eq!(read_error.code, "groups.membership_suspended");
+    assert!(!read_error.retryable);
+
+    let write_error = GroupLocalizationCommandPort::upsert_group_translation(
+        &localization,
+        write_context(tenant_id, admin_id, "suspended-admin-write"),
+        UpsertGroupTranslationRequest {
+            group_id,
+            locale: "fr".to_string(),
+            title: "Blocked title".to_string(),
+            summary: None,
+            body: None,
+        },
+    )
+    .await
+    .expect_err("suspended administrator must not mutate translations");
+    assert_eq!(write_error.code, "groups.membership_suspended");
+    assert!(!write_error.retryable);
+
+    let owner_during = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, owner_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("owner should retain management access while administrator is suspended");
+    assert_eq!(owner_during.len(), 1, "failed suspended write must not create French translation");
+
+    tokio::time::sleep(Duration::from_millis(2300)).await;
+
+    let admin_after_expiry = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("expired suspension should restore administrator reads without cleanup");
+    assert_eq!(admin_after_expiry.len(), 1);
+
+    let restored = GroupLocalizationCommandPort::upsert_group_translation(
+        &localization,
+        write_context(tenant_id, admin_id, "restored-admin-write"),
+        UpsertGroupTranslationRequest {
+            group_id,
+            locale: "fr".to_string(),
+            title: "Restored title".to_string(),
+            summary: Some("PostgreSQL owner-clock access restored".to_string()),
+            body: None,
+        },
+    )
+    .await
+    .expect("expired suspension should restore administrator writes without cleanup");
+    assert!(restored.created);
+    assert_eq!(restored.group_version, suspended.group_version as u64 + 1);
+
+    let final_translations = GroupLocalizationReadPort::list_group_translations(
+        &localization,
+        read_context(tenant_id, admin_id),
+        ListGroupTranslationsRequest { group_id },
+    )
+    .await
+    .expect("restored administrator should read both translations");
+    assert_eq!(final_translations.len(), 2);
+    assert!(final_translations.iter().any(|translation| translation.locale == "fr"));
+
+    let (stored_status_after_expiry, stored_revision_after_expiry) =
+        membership_snapshot(&db, tenant_id, admin_id).await;
+    assert_eq!(stored_status_after_expiry, "active");
+    assert_eq!(stored_revision_after_expiry, suspended.membership_revision);
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 2);
+
+    drop(enforcement);
+    drop(localization);
+    drop(db);
+    admin_db
+        .execute_unprepared(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .expect("isolated Groups localization expiry schema should drop");
+}

--- a/crates/rustok-groups/docs/localization-enforcement-expiry-postgres-contract.md
+++ b/crates/rustok-groups/docs/localization-enforcement-expiry-postgres-contract.md
@@ -51,7 +51,7 @@ RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' \
 Source guard:
 
 ```bash
-node scripts/verify/verify-groups-localization-boundary.mjs
+node scripts/verify/verify-groups-localization-enforcement-expiry-postgres.mjs
 ```
 
 No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this source.

--- a/crates/rustok-groups/docs/localization-enforcement-expiry-postgres-contract.md
+++ b/crates/rustok-groups/docs/localization-enforcement-expiry-postgres-contract.md
@@ -1,0 +1,57 @@
+# Groups localization enforcement expiry PostgreSQL evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_localization_enforcement_expiry_postgres.rs` is the PostgreSQL counterpart to the SQLite localization suspension/expiry packet. It retains executable source evidence that localization management authorization follows Groups owner-clock effective membership rather than stored lifecycle status.
+
+The packet uses a unique PostgreSQL schema, all production Groups migrations, `GroupLocalizationService`, and `GroupMembershipEnforcementCommandService`. No alternate authorization path or cleanup process is introduced.
+
+## PostgreSQL isolation
+
+Every execution creates a unique schema and supplies it to every pooled connection through PostgreSQL startup options:
+
+```text
+options=-csearch_path=<schema>,public
+```
+
+The packet intentionally does not use session-local `SET search_path`.
+
+## Contract
+
+The fixture contains one lifecycle-active owner and one lifecycle-active administrator. The owner creates the initial translation through the production localization command. The administrator can read management translations before enforcement.
+
+The owner then applies a short production suspension to the administrator. While effective, the evidence requires:
+
+- stored membership status remains `active`;
+- membership revision reflects exactly the suspension mutation;
+- stored lifecycle `member_count` remains unchanged;
+- management read fails with `groups.membership_suspended`;
+- management translation upsert fails with the same stable owner code;
+- the denied upsert creates no translation;
+- the unsuspended owner retains management access.
+
+After the owner clock passes `effective_until`, the test performs **no cleanup mutation**. The administrator must regain management read/write access, the restored translation write must advance group version exactly once, membership revision must remain unchanged since suspension, and lifecycle `member_count` must remain unchanged.
+
+This is suspension/expiry backend-parity source only. It does not claim concurrent enforcement-vs-localization-write or native/GraphQL localization parity evidence.
+
+## Execution status
+
+The PostgreSQL packet is ignored unless `RUSTOK_GROUPS_TEST_POSTGRES_URL` is configured and was not executed while preparing this slice. Runtime evidence remains **maintainer execution pending**; FBA localization runtime fields remain null.
+
+Maintainer command:
+
+```bash
+RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' \
+  cargo test -p rustok-server --features mod-groups \
+  --test groups_localization_enforcement_expiry_postgres -- --ignored --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-localization-boundary.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-localization-enforcement-expiry-postgres.mjs
+++ b/scripts/verify/verify-groups-localization-enforcement-expiry-postgres.mjs
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_localization_enforcement_expiry_postgres.rs";
+const docsPath = "crates/rustok-groups/docs/localization-enforcement-expiry-postgres-contract.md";
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  '#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]',
+  "RUSTOK_GROUPS_TEST_POSTGRES_URL",
+  "options=-csearch_path%3D",
+  "CREATE SCHEMA",
+  "DROP SCHEMA",
+  "rustok_groups::migrations::migrations()",
+  "GroupLocalizationService::new",
+  "GroupLocalizationReadPort::list_group_translations",
+  "GroupLocalizationCommandPort::upsert_group_translation",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  'assert_eq!(stored_status_during_suspension, "active")',
+  'assert_eq!(read_error.code, "groups.membership_suspended")',
+  'assert_eq!(write_error.code, "groups.membership_suspended")',
+  "failed suspended write must not create French translation",
+  "tokio::time::sleep",
+  "expired suspension should restore administrator reads without cleanup",
+  "expired suspension should restore administrator writes without cleanup",
+  "stored_revision_after_expiry, suspended.membership_revision",
+  "restored.group_version, suspended.group_version as u64 + 1",
+  "group_member_count",
+]) {
+  requireText(test, marker, `Groups PostgreSQL localization expiry source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "SET search_path",
+  "UPDATE group_membership_enforcements",
+  "DELETE FROM group_membership_enforcements",
+  "UPDATE group_memberships SET status",
+  "groups:manage",
+  "rustok_moderation::",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups PostgreSQL localization expiry source contains shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "executable source added / maintainer execution pending",
+  "PostgreSQL isolation",
+  "stored membership status remains `active`",
+  "groups.membership_suspended",
+  "no cleanup mutation",
+  "membership revision must remain unchanged since suspension",
+  "localization_transport_parity",
+  "localization_concurrency",
+]) {
+  requireText(docs, marker, `Groups PostgreSQL localization expiry handoff is missing ${marker}`);
+}
+
+console.log("Groups localization PostgreSQL suspension/expiry source guard passed");


### PR DESCRIPTION
## Summary
- add schema-isolated PostgreSQL executable source for Groups localization management under effective membership suspension/expiry
- apply all production Groups migrations and use `GroupLocalizationService` plus the production membership enforcement command service
- use PostgreSQL startup `search_path` options on pooled connections; no session-local `SET search_path`
- prove stored membership lifecycle status remains `active` while localization management read/write fail closed with `groups.membership_suspended`
- prove denied translation write is non-mutating and the unsuspended owner retains management access
- prove owner-clock expiry restores administrator read/write access without cleanup or a synthetic membership revision bump
- retain lifecycle `member_count` invariance and exact restored localization group-version advance
- add a focused PostgreSQL handoff/guard while keeping localization transport/concurrency runtime evidence unpromoted
- add no dependency, manifest, lockfile, schema definition, production-owner, GraphQL, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.