### PR TITLE
feat(product): publish catalog schema write capability

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -1,0 +1,30 @@
+# Product schema write boundary recheck — 2026-08-08
+
+## Scope
+
+This source-only continuation follows the completed Product read/lifecycle cutovers and rechecks the remaining mounted Commerce GraphQL schema-write boundary. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write cutover item remains open in this slice.
+
+## Current source result
+
+- Product now publishes `ProductCatalogSchemaWritePort` as a transport-neutral owner capability for every Product schema write currently used by mounted Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
+- The embedded `ProductCatalogSchemaService` implements the port and derives tenant/actor only from validated `PortContext`.
+- Every call requires `PortCallPolicy::write()`, so caller context must carry write policy requirements including idempotency identity and deadline before owner execution is admitted.
+- Product schema-write failures are mapped to stable `PortError` codes/messages while internal database/validation/core causes remain in owner logs rather than public messages.
+- `ProductCatalogCommandRuntime` now carries an optional `ProductCatalogSchemaWritePort`. `in_process` composes the embedded owner provider; external command profiles remain fail-closed until a host explicitly supplies a schema-write provider.
+
+## Why the canonical item remains open
+
+Mounted Commerce GraphQL still constructs `ProductCatalogSchemaService` directly for schema writes. This PR only publishes and composes the owner capability; it does not yet cut those consumers over.
+
+The embedded schema service also does not currently persist a command receipt keyed by `PortContext.idempotency_key`. `PortCallPolicy::write()` makes caller identity mandatory at the boundary, but durable replay/adoption semantics must not be inferred from that validation alone.
+
+The next source slice therefore remains:
+
+1. define mounted GraphQL caller idempotency input/identity for the schema-write mutations without breaking Product Admin callers;
+2. replace every direct `ProductCatalogSchemaService` construction in mounted Commerce schema writes with the host-selected `ProductCatalogSchemaWritePort`;
+3. decide and implement the owner-local durable replay/receipt contract needed for non-idempotent create operations before claiming retry-safe write semantics;
+4. update canonical completion only when both consumer cutover and the intended idempotency semantics are source-complete.
+
+## Verification state
+
+No tests, checks, formatters, workflows, or runtime verification were executed in this slice per maintainer instruction. Source and GitHub diff inspection only. No FBA/FFA status is promoted.

--- a/crates/rustok-product/src/catalog_schema_write_port.rs
+++ b/crates/rustok-product/src/catalog_schema_write_port.rs
@@ -1,0 +1,371 @@
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use uuid::Uuid;
+
+use crate::services::{
+    BindCategoryAttributeInput, BindSchemaAttributeInput, CatalogCategoryRecord,
+    CreateCatalogCategoryInput, CreateCategoryAttributeGroupInput,
+    CreateProductAttributeInput, CreateProductAttributeOptionInput,
+    CreateProductAttributeSchemaGroupInput, CreateProductAttributeSchemaInput,
+    ProductAttributeGroupRecord, ProductAttributeOptionRecord, ProductAttributeRecord,
+    ProductAttributeSchemaRecord, ProductAttributeValuePatch, ProductAttributeValueRecord,
+    ProductCatalogSchemaService, SetCategorySchemaModeInput,
+};
+use crate::CommerceError;
+
+/// Transport-neutral owner boundary for Product catalog schema writes.
+///
+/// Every call requires `PortCallPolicy::write()`, including a non-empty caller-owned
+/// idempotency identity and deadline. Consumers must receive this capability from host
+/// composition rather than constructing `ProductCatalogSchemaService` directly.
+///
+/// The port preserves the caller idempotency identity across embedded and remote
+/// providers. The embedded adapter currently delegates to the existing Product owner
+/// transaction implementation; durable replay evidence remains a separate verification
+/// task and must not be inferred from this source contract alone.
+#[async_trait]
+pub trait ProductCatalogSchemaWritePort: Send + Sync {
+    async fn create_attribute(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeInput,
+    ) -> Result<ProductAttributeRecord, PortError>;
+
+    async fn create_attribute_option(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeOptionInput,
+    ) -> Result<ProductAttributeOptionRecord, PortError>;
+
+    async fn create_category(
+        &self,
+        context: PortContext,
+        input: CreateCatalogCategoryInput,
+    ) -> Result<CatalogCategoryRecord, PortError>;
+
+    async fn create_schema(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeSchemaInput,
+    ) -> Result<ProductAttributeSchemaRecord, PortError>;
+
+    async fn create_schema_group(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeSchemaGroupInput,
+    ) -> Result<ProductAttributeGroupRecord, PortError>;
+
+    async fn create_category_group(
+        &self,
+        context: PortContext,
+        input: CreateCategoryAttributeGroupInput,
+    ) -> Result<ProductAttributeGroupRecord, PortError>;
+
+    async fn set_category_schema_mode(
+        &self,
+        context: PortContext,
+        input: SetCategorySchemaModeInput,
+    ) -> Result<(), PortError>;
+
+    async fn bind_schema_attribute(
+        &self,
+        context: PortContext,
+        input: BindSchemaAttributeInput,
+    ) -> Result<(), PortError>;
+
+    async fn bind_category_attribute(
+        &self,
+        context: PortContext,
+        input: BindCategoryAttributeInput,
+    ) -> Result<(), PortError>;
+
+    async fn save_product_attribute_values(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+        locale: String,
+        patches: Vec<ProductAttributeValuePatch>,
+    ) -> Result<Vec<ProductAttributeValueRecord>, PortError>;
+
+    async fn clear_detached_product_attribute_values(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+        locale: String,
+        attribute_ids: Vec<Uuid>,
+    ) -> Result<Vec<ProductAttributeValueRecord>, PortError>;
+}
+
+#[async_trait]
+impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
+    async fn create_attribute(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeInput,
+    ) -> Result<ProductAttributeRecord, PortError> {
+        let operation = "create_attribute";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.create_attribute(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn create_attribute_option(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeOptionInput,
+    ) -> Result<ProductAttributeOptionRecord, PortError> {
+        let operation = "create_attribute_option";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.create_attribute_option(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn create_category(
+        &self,
+        context: PortContext,
+        input: CreateCatalogCategoryInput,
+    ) -> Result<CatalogCategoryRecord, PortError> {
+        let operation = "create_category";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.create_category(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn create_schema(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeSchemaInput,
+    ) -> Result<ProductAttributeSchemaRecord, PortError> {
+        let operation = "create_schema";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.create_schema(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn create_schema_group(
+        &self,
+        context: PortContext,
+        input: CreateProductAttributeSchemaGroupInput,
+    ) -> Result<ProductAttributeGroupRecord, PortError> {
+        let operation = "create_schema_group";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.create_schema_group(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn create_category_group(
+        &self,
+        context: PortContext,
+        input: CreateCategoryAttributeGroupInput,
+    ) -> Result<ProductAttributeGroupRecord, PortError> {
+        let operation = "create_category_group";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.create_category_group(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn set_category_schema_mode(
+        &self,
+        context: PortContext,
+        input: SetCategorySchemaModeInput,
+    ) -> Result<(), PortError> {
+        let operation = "set_category_schema_mode";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.set_category_schema_mode(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn bind_schema_attribute(
+        &self,
+        context: PortContext,
+        input: BindSchemaAttributeInput,
+    ) -> Result<(), PortError> {
+        let operation = "bind_schema_attribute";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.bind_schema_attribute(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn bind_category_attribute(
+        &self,
+        context: PortContext,
+        input: BindCategoryAttributeInput,
+    ) -> Result<(), PortError> {
+        let operation = "bind_category_attribute";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.bind_category_attribute(tenant_id, actor_id, input)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn save_product_attribute_values(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+        locale: String,
+        patches: Vec<ProductAttributeValuePatch>,
+    ) -> Result<Vec<ProductAttributeValueRecord>, PortError> {
+        let operation = "save_product_attribute_values";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.save_product_attribute_values(tenant_id, actor_id, product_id, &locale, patches)
+            .await
+            .map_err(|error| schema_write_error(&context, operation, error))
+    }
+
+    async fn clear_detached_product_attribute_values(
+        &self,
+        context: PortContext,
+        product_id: Uuid,
+        locale: String,
+        attribute_ids: Vec<Uuid>,
+    ) -> Result<Vec<ProductAttributeValueRecord>, PortError> {
+        let operation = "clear_detached_product_attribute_values";
+        let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
+        self.clear_detached_product_attribute_values(
+            tenant_id,
+            actor_id,
+            product_id,
+            &locale,
+            attribute_ids,
+        )
+        .await
+        .map_err(|error| schema_write_error(&context, operation, error))
+    }
+}
+
+fn schema_write_scope(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(Uuid, Uuid), PortError> {
+    context
+        .require_policy(PortCallPolicy::write())
+        .map_err(|error| schema_context_error(context, operation, error))?;
+
+    let tenant_id = Uuid::parse_str(context.tenant_id.as_str()).map_err(|_| {
+        tracing::warn!(
+            correlation_id = %context.correlation_id,
+            operation,
+            code = "product.schema_tenant_id_invalid",
+            "product schema write tenant context is invalid"
+        );
+        PortError::validation(
+            "product.schema_tenant_id_invalid",
+            "product request context is invalid",
+        )
+    })?;
+    let actor_id = Uuid::parse_str(context.actor.id.as_str()).map_err(|_| {
+        tracing::warn!(
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation,
+            code = "product.schema_actor_id_invalid",
+            "product schema write actor context is invalid"
+        );
+        PortError::validation(
+            "product.schema_actor_id_invalid",
+            "product request context is invalid",
+        )
+    })?;
+
+    Ok((tenant_id, actor_id))
+}
+
+fn schema_context_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PortError,
+) -> PortError {
+    tracing::warn!(
+        internal_code = %error.code,
+        retryable = error.retryable,
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        code = "product.schema_context_invalid",
+        "product schema write call context was rejected"
+    );
+    error
+}
+
+fn schema_write_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: CommerceError,
+) -> PortError {
+    let error_kind = schema_error_kind(&error);
+    tracing::error!(
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        error_kind,
+        code = schema_error_code(&error),
+        "product catalog owner schema write failed"
+    );
+
+    match error {
+        CommerceError::Database(_) => PortError::unavailable(
+            "product.schema_database_unavailable",
+            "product schema storage is temporarily unavailable",
+        ),
+        CommerceError::ProductNotFound(_) => {
+            PortError::not_found("product.product_not_found", "product was not found")
+        }
+        CommerceError::DuplicateHandle { .. } => PortError::conflict(
+            "product.duplicate_handle",
+            "product handle conflicts with an existing product",
+        ),
+        CommerceError::DuplicateSku(_) => PortError::conflict(
+            "product.duplicate_sku",
+            "product SKU conflicts with an existing variant",
+        ),
+        CommerceError::Validation(_) => {
+            PortError::validation("product.schema_validation", "product schema request is invalid")
+        }
+        CommerceError::NoVariants => PortError::validation(
+            "product.no_variants",
+            "product requires at least one variant",
+        ),
+        CommerceError::CannotDeletePublished => PortError::conflict(
+            "product.lifecycle_conflict",
+            "product operation conflicts with the current state",
+        ),
+        CommerceError::Core(_) => PortError::invariant_violation(
+            "product.schema_invariant_violation",
+            "product schema operation could not be completed safely",
+        ),
+    }
+}
+
+fn schema_error_kind(error: &CommerceError) -> &'static str {
+    match error {
+        CommerceError::Database(_) => "database",
+        CommerceError::ProductNotFound(_) => "not_found",
+        CommerceError::DuplicateHandle { .. } => "duplicate_handle",
+        CommerceError::DuplicateSku(_) => "duplicate_sku",
+        CommerceError::Validation(_) => "validation",
+        CommerceError::NoVariants => "no_variants",
+        CommerceError::CannotDeletePublished => "lifecycle_conflict",
+        CommerceError::Core(_) => "core",
+    }
+}
+
+fn schema_error_code(error: &CommerceError) -> &'static str {
+    match error {
+        CommerceError::Database(_) => "product.schema_database_unavailable",
+        CommerceError::ProductNotFound(_) => "product.product_not_found",
+        CommerceError::DuplicateHandle { .. } => "product.duplicate_handle",
+        CommerceError::DuplicateSku(_) => "product.duplicate_sku",
+        CommerceError::Validation(_) => "product.schema_validation",
+        CommerceError::NoVariants => "product.no_variants",
+        CommerceError::CannotDeletePublished => "product.lifecycle_conflict",
+        CommerceError::Core(_) => "product.schema_invariant_violation",
+    }
+}

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -16,6 +16,7 @@ use sea_orm_migration::MigrationTrait;
 
 mod catalog_command_port;
 mod catalog_schema_read_port;
+mod catalog_schema_write_port;
 pub mod dto;
 pub mod entities;
 pub mod error;
@@ -34,6 +35,7 @@ pub use catalog_schema_read_port::{
     ProductEffectiveFormRequest, ProductEffectiveFormSubject,
     ProductStorefrontAttributeFilterResolutionRequest,
 };
+pub use catalog_schema_write_port::ProductCatalogSchemaWritePort;
 pub use error::{CommerceError, CommerceResult};
 pub use ports::*;
 pub use public_error::{ProductPublicError, map_product_public_error};

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -5,7 +5,7 @@ use sea_orm::DatabaseConnection;
 
 use crate::{
     CatalogService, ProductCatalogCommandPort, ProductCatalogReadPort, ProductCatalogSchemaReadPort,
-    ProductCatalogSchemaService, ProductStorefrontTagReadPort,
+    ProductCatalogSchemaService, ProductCatalogSchemaWritePort, ProductStorefrontTagReadPort,
 };
 
 /// Host-selected execution profile for the Product catalog read boundary.
@@ -111,9 +111,13 @@ impl ProductCatalogCommandProfile {
 }
 
 /// Canonical host-composed Product catalog lifecycle command capability.
+///
+/// Product schema writes are an explicit optional secondary capability. External command profiles
+/// therefore fail closed until a host deliberately composes a schema-write provider.
 #[derive(Clone)]
 pub struct ProductCatalogCommandRuntime {
     command_port: Arc<dyn ProductCatalogCommandPort>,
+    schema_write_port: Option<Arc<dyn ProductCatalogSchemaWritePort>>,
     profile: ProductCatalogCommandProfile,
 }
 
@@ -124,23 +128,37 @@ impl ProductCatalogCommandRuntime {
     ) -> Self {
         Self {
             command_port,
+            schema_write_port: None,
             profile,
         }
     }
 
     pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
         Self::new(
-            Arc::new(CatalogService::new(db, event_bus)),
+            Arc::new(CatalogService::new(db.clone(), event_bus.clone())),
             ProductCatalogCommandProfile::EmbeddedNative,
         )
+        .with_schema_write_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))
     }
 
     pub fn external(command_port: Arc<dyn ProductCatalogCommandPort>) -> Self {
         Self::new(command_port, ProductCatalogCommandProfile::External)
     }
 
+    pub fn with_schema_write_port(
+        mut self,
+        schema_write_port: Arc<dyn ProductCatalogSchemaWritePort>,
+    ) -> Self {
+        self.schema_write_port = Some(schema_write_port);
+        self
+    }
+
     pub fn command_port(&self) -> Arc<dyn ProductCatalogCommandPort> {
         self.command_port.clone()
+    }
+
+    pub fn schema_write_port(&self) -> Option<Arc<dyn ProductCatalogSchemaWritePort>> {
+        self.schema_write_port.clone()
     }
 
     pub const fn profile(&self) -> ProductCatalogCommandProfile {

--- a/scripts/verify/verify-product-catalog-schema-write-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-write-port.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const port = read("crates/rustok-product/src/catalog_schema_write_port.rs");
+const runtime = read("crates/rustok-product/src/runtime.rs");
+const lib = read("crates/rustok-product/src/lib.rs");
+const commerceMutations = read("crates/rustok-commerce/src/graphql/mutations/catalog.rs");
+const failures = [];
+
+function requireText(source, text, label) {
+  if (!source.includes(text)) failures.push(`${label}: missing ${text}`);
+}
+
+function forbidText(source, text, label) {
+  if (source.includes(text)) failures.push(`${label}: forbidden ${text}`);
+}
+
+for (const required of [
+  "pub trait ProductCatalogSchemaWritePort: Send + Sync",
+  "async fn create_attribute(",
+  "async fn create_attribute_option(",
+  "async fn create_category(",
+  "async fn create_schema(",
+  "async fn create_schema_group(",
+  "async fn create_category_group(",
+  "async fn set_category_schema_mode(",
+  "async fn bind_schema_attribute(",
+  "async fn bind_category_attribute(",
+  "async fn save_product_attribute_values(",
+  "async fn clear_detached_product_attribute_values(",
+  "impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService",
+  "require_policy(PortCallPolicy::write())",
+  "Uuid::parse_str(context.tenant_id.as_str())",
+  "Uuid::parse_str(context.actor.id.as_str())",
+  '"product.schema_database_unavailable"',
+  '"product.schema_validation"',
+  '"product.schema_invariant_violation"',
+]) {
+  requireText(port, required, "Product schema write owner port");
+}
+
+for (const forbidden of [
+  "PortError::unavailable(\n            \"product.schema_database_unavailable\",\n            error.to_string()",
+  "PortError::validation(\n            \"product.schema_validation\",\n            error.to_string()",
+]) {
+  forbidText(port, forbidden, "Product schema write public error safety");
+}
+
+for (const required of [
+  "ProductCatalogSchemaWritePort",
+  "schema_write_port: Option<Arc<dyn ProductCatalogSchemaWritePort>>",
+  "schema_write_port: None",
+  ".with_schema_write_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))",
+  "pub fn with_schema_write_port(",
+  "pub fn schema_write_port(&self) -> Option<Arc<dyn ProductCatalogSchemaWritePort>>",
+]) {
+  requireText(runtime, required, "Product command runtime schema-write composition");
+}
+
+for (const required of [
+  "mod catalog_schema_write_port;",
+  "pub use catalog_schema_write_port::ProductCatalogSchemaWritePort;",
+]) {
+  requireText(lib, required, "Product schema write public export");
+}
+
+// Publication is intentionally separate from the Commerce consumer cutover. Keep the
+// remaining direct construction visible so the canonical task cannot be falsely closed.
+requireText(
+  commerceMutations,
+  "ProductCatalogSchemaService::new",
+  "Commerce schema-write consumer debt remains explicit",
+);
+
+if (failures.length) {
+  console.error("Product catalog schema write port source verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("✔ Product publishes a typed schema-write capability with write-context policy; Commerce consumer cutover remains explicit debt");


### PR DESCRIPTION
## Summary

- publish `ProductCatalogSchemaWritePort` as the typed Product-owner boundary for every schema write currently used by Commerce GraphQL
- implement the embedded owner adapter on `ProductCatalogSchemaService`
- require `PortCallPolicy::write()` before owner execution, including caller idempotency/deadline admission
- map Product schema owner failures to stable public `PortError` codes/messages with internal causes logged only inside the owner
- expose schema writes as an optional secondary capability on `ProductCatalogCommandRuntime`
- compose the capability automatically for `in_process`; keep external command runtimes fail-closed until the host explicitly supplies a schema-write provider
- add a source guard and a recheck packet documenting that mounted Commerce still constructs `ProductCatalogSchemaService` directly

## Intentionally still open

- mounted Commerce GraphQL schema-write consumer cutover
- GraphQL caller idempotency contract for those schema-write mutations
- owner-local durable receipt/replay semantics for non-idempotent create operations
- canonical combined Product schema-write item remains `[ ]`
- broad ecommerce typed-owner invariant remains open

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction. No FBA/FFA promotion.