### PR TITLE
feat(index): bind replay to server graceful shutdown

### DIFF
--- a/apps/server/docs/index-replay-graphql-transport.md
+++ b/apps/server/docs/index-replay-graphql-transport.md
@@ -1,15 +1,15 @@
 # Index replay GraphQL transport
 
-Status: `source_complete_owner_execution_pending`.
+Status: `source_complete_shutdown_bound_execution_pending`.
 
 ## Boundary
 
-The server now exposes two bounded GraphQL mutations over the existing guarded `IndexReplayOperatorRuntime`:
+The server exposes two bounded GraphQL mutations over the guarded `IndexReplayOperatorRuntime`:
 
-- `runIndexReplay(input: ...)` runs one bounded schema-wide replay chunk;
+- `runIndexReplay(input: ...)` runs one bounded schema-wide replay chunk and samples the server-owned graceful-shutdown signal at replay durable safe points;
 - `cancelIndexReplay(input: ...)` requests cancellation of one replay job in the authenticated tenant.
 
-This is a command transport only. It does not add automatic replay scheduling, background worker ownership, a
+This remains a command transport. It does not add automatic replay scheduling, background worker ownership, a
 new replay algorithm, locale/partition checkpoint dimensions, or a traffic cutover.
 
 ## Authority before input parsing
@@ -31,7 +31,7 @@ tenant and cannot widen authority.
 - positive schema routing key.
 
 It does not accept tenant, actor, worker identity, page limit, page count, heartbeat cadence, lease duration,
-locale, partition, source name, database handle, or scheduler controls.
+locale, partition, source name, database handle, scheduler controls, shutdown state, or a stop handle.
 
 Each GraphQL invocation constructs a fresh server-owned worker identity and uses one fixed bounded chunk:
 
@@ -43,10 +43,37 @@ Each GraphQL invocation constructs a fresh server-owned worker identity and uses
 Those transport caps are intentionally narrower than the generic replay runner bounds. A yielded job remains
 resumable by a later authorized invocation through the existing durable job/checkpoint contract.
 
+## Graceful shutdown binding
+
+GraphQL schema initialization resolves one `StopHandle` from `ServerRuntimeContext`. If no worker or module-work
+host has created it yet, schema initialization atomically publishes one. All cloned `ServerRuntimeContext`
+instances share the same typed value map, so later background-worker/module-work initialization reuses that same
+handle instead of creating a separate shutdown domain.
+
+Schema initialization also retains one watch receiver for the lifetime of the server context. This matters for
+API-only hosts: `StopHandle::stop()` uses the watch sender and must have a receiver alive for the stop value to be
+published. The retained receiver is not exposed through GraphQL.
+
+`runIndexReplay` obtains only the server-owned handle from schema data and passes
+`StopHandle::is_stopping` as a synchronous boolean probe through:
+
+`IndexReplayOperatorRuntime::run_interruptible` -> `SharedIndexReplayRuntime::run_interruptible` ->
+`PostgresIndexReplayRunner::run_interruptible`.
+
+The Index runtime and server operator remain lifecycle-type neutral; neither imports `StopHandle`. They accept
+only the boolean probe and keep authorization ahead of replay execution.
+
+If shutdown is observed at a replay safe point, the runner-level contract returns the job to durable `pending`
+without setting `cancel_requested` or publishing failure. A later process/authorized invocation may resume from
+the last committed checkpoint; already-durable deliveries remain duplicate-safe.
+
+The cancellation mutation does not sample or mutate shutdown state. User cancellation and host shutdown remain
+separate state machines.
+
 ## Result surface
 
 The run payload exposes only bounded operational counters plus status and job UUID. It does not expose source
-payloads, SQL, database errors, request authority, lease owner identity, or raw dependency causes.
+payloads, SQL, database errors, request authority, lease owner identity, shutdown state, or raw dependency causes.
 
 The cancellation payload exposes only the normalized outcome: requested, cancelled, already terminal, or not
 found. Operational runner failures are mapped to a generic GraphQL error; an unknown source-owned schema is
@@ -57,14 +84,16 @@ reported as bad user input.
 Source guards retain:
 
 - authorization-before-parsing ordering;
-- absence of caller authority/worker/resource-budget fields;
+- absence of caller authority/worker/resource-budget/shutdown fields;
 - fixed server-owned bounds;
 - delegation only through `IndexReplayOperatorRuntime`;
 - merged GraphQL schema registration;
-- no direct database/source/scheduler access from the transport.
+- one shared lifecycle handle and API-host watch keepalive;
+- `StopHandle::is_stopping` as the only replay shutdown observation;
+- no direct database/source/scheduler access and no `.stop()` call from the transport.
 
-GraphQL execution, database replay execution, cancellation races, CI, and retained runtime evidence remain
-maintainer-owned and are not claimed by this source slice.
+GraphQL execution, actual process-shutdown replay interruption, database replay execution, cancellation races,
+CI, and retained runtime evidence remain maintainer-owned and are not claimed by this source slice.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_replay.rs
+++ b/apps/server/src/graphql/index_replay.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::context::{AuthContext, TenantContext};
+use crate::services::app_lifecycle::StopHandle;
 use crate::services::index_replay_runtime_composition::{
     IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
 };
@@ -159,8 +160,9 @@ impl IndexReplayMutation {
         let (operator_context, request) =
             prepare_authorized_run(tenant.id, auth.user_id, input).map_err(map_preparation_error)?;
         let runtime = replay_runtime(ctx)?;
+        let stop_handle = ctx.data::<StopHandle>()?.clone();
         runtime
-            .run(operator_context, request)
+            .run_interruptible(operator_context, request, || stop_handle.is_stopping())
             .await
             .map_err(map_operator_error)?
             .try_into()

--- a/apps/server/src/graphql/schema.rs
+++ b/apps/server/src/graphql/schema.rs
@@ -39,6 +39,7 @@ use super::storefront_principal_security::StorefrontPrincipalPolicy;
 use super::subscriptions::BuildSubscription;
 use super::system::SystemQuery;
 use super::tenant_security::GraphqlTenantPolicy;
+use crate::services::app_lifecycle::StopHandle;
 use crate::services::build_event_hub::BuildEventHub;
 use crate::services::field_definition_cache::FieldDefinitionCache;
 use crate::services::field_definition_registry_bootstrap::build_field_def_registry;
@@ -127,6 +128,7 @@ pub struct GraphqlSchemaDependencies {
     pub build_event_hub: Arc<BuildEventHub>,
     pub field_definition_cache: FieldDefinitionCache,
     pub runtime_extensions: Arc<ModuleRuntimeExtensions>,
+    pub stop_handle: StopHandle,
     pub rbac_role_writer: RbacGraphqlRoleWriterHandle,
     pub search_rate_limiter: Option<SearchGraphqlRateLimiterHandle>,
     #[cfg(feature = "mod-blog")]
@@ -155,6 +157,7 @@ pub fn build_schema(dependencies: GraphqlSchemaDependencies) -> AppSchema {
         build_event_hub,
         field_definition_cache,
         runtime_extensions,
+        stop_handle,
         rbac_role_writer,
         search_rate_limiter,
         #[cfg(feature = "mod-blog")]
@@ -249,6 +252,7 @@ pub fn build_schema(dependencies: GraphqlSchemaDependencies) -> AppSchema {
         .data(flex_runtime)
         .data(marketplace_catalog)
         .data(runtime_extensions)
+        .data(stop_handle)
         .data(rbac_role_writer);
 
     let builder = if let Some(search_rate_limiter) = search_rate_limiter {

--- a/apps/server/src/services/graphql_schema.rs
+++ b/apps/server/src/services/graphql_schema.rs
@@ -103,14 +103,20 @@ pub fn init_graphql_schema(ctx: &ServerRuntimeContext) -> Arc<AppSchema> {
 }
 
 fn stop_handle_from_context(ctx: &ServerRuntimeContext) -> StopHandle {
-    let handle = if let Some(handle) = ctx.shared_get::<StopHandle>() {
-        handle
-    } else {
-        let (candidate, _initial_receiver) = StopHandle::new();
-        ctx.shared_insert_if_absent(candidate.clone());
-        ctx.shared_get::<StopHandle>()
-            .expect("StopHandle reservation must publish one shared lifecycle handle")
-    };
+    if let Some(handle) = ctx.shared_get::<StopHandle>() {
+        ctx.shared_insert_if_absent(IndexReplayStopKeepalive {
+            _receiver: handle.subscribe(),
+        });
+        return handle;
+    }
+
+    // Keep the candidate's initial receiver alive until a receiver for the actually published
+    // handle has been installed. This avoids a zero-receiver window if shutdown races schema init.
+    let (candidate, _initial_receiver) = StopHandle::new();
+    ctx.shared_insert_if_absent(candidate);
+    let handle = ctx
+        .shared_get::<StopHandle>()
+        .expect("StopHandle reservation must publish one shared lifecycle handle");
     ctx.shared_insert_if_absent(IndexReplayStopKeepalive {
         _receiver: handle.subscribe(),
     });

--- a/apps/server/src/services/graphql_schema.rs
+++ b/apps/server/src/services/graphql_schema.rs
@@ -5,6 +5,7 @@ use crate::graphql::blog_rate_limit::blog_graphql_rate_limiter_from_context;
 use crate::graphql::rbac_runtime::rbac_graphql_role_writer_from_context;
 use crate::graphql::search_rate_limit::search_graphql_rate_limiter_from_context;
 use crate::graphql::{AppSchema, GraphqlSchemaDependencies, SharedGraphqlSchema, build_schema};
+use crate::services::app_lifecycle::StopHandle;
 use crate::services::app_runtime::module_runtime_extensions_from_ctx;
 use crate::services::build_event_hub::build_event_hub_from_context;
 use crate::services::commerce_provider_runtime::attach_commerce_provider_registries;
@@ -14,6 +15,13 @@ use crate::services::profile_media_public_image_runtime::attach_profile_media_pu
 #[cfg(feature = "mod-seo")]
 use crate::services::seo_redirect_cache_reconciliation::start_seo_redirect_cache_reconciliation;
 use crate::services::server_runtime_context::ServerRuntimeContext;
+
+/// Keeps at least one watch receiver alive for API-only hosts so `StopHandle::stop()` can publish
+/// the terminal value even when no background worker has subscribed yet.
+#[derive(Clone)]
+struct IndexReplayStopKeepalive {
+    _receiver: tokio::sync::watch::Receiver<bool>,
+}
 
 pub fn init_graphql_schema(ctx: &ServerRuntimeContext) -> Arc<AppSchema> {
     #[cfg(feature = "mod-seo")]
@@ -30,6 +38,7 @@ pub fn init_graphql_schema(ctx: &ServerRuntimeContext) -> Arc<AppSchema> {
         attach_profile_media_public_image_provider(ctx, module_runtime_extensions_from_ctx(ctx));
     let event_bus = event_bus_from_context(ctx);
     let transactional_event_bus = transactional_event_bus_from_context(ctx);
+    let stop_handle = stop_handle_from_context(ctx);
     let registry = ctx
         .shared_get::<rustok_core::ModuleRegistry>()
         .expect("ModuleRegistry not initialized; bootstrap_app_runtime must run first");
@@ -68,6 +77,7 @@ pub fn init_graphql_schema(ctx: &ServerRuntimeContext) -> Arc<AppSchema> {
         build_event_hub: build_event_hub_from_context(ctx),
         field_definition_cache: field_definition_cache_from_context(ctx, event_bus),
         runtime_extensions,
+        stop_handle,
         rbac_role_writer: rbac_graphql_role_writer_from_context(ctx),
         search_rate_limiter: search_graphql_rate_limiter_from_context(ctx),
         #[cfg(feature = "mod-blog")]
@@ -90,6 +100,21 @@ pub fn init_graphql_schema(ctx: &ServerRuntimeContext) -> Arc<AppSchema> {
     ctx.shared_insert(SharedGraphqlSchema(schema.clone()));
 
     schema
+}
+
+fn stop_handle_from_context(ctx: &ServerRuntimeContext) -> StopHandle {
+    let handle = if let Some(handle) = ctx.shared_get::<StopHandle>() {
+        handle
+    } else {
+        let (candidate, _initial_receiver) = StopHandle::new();
+        ctx.shared_insert_if_absent(candidate.clone());
+        ctx.shared_get::<StopHandle>()
+            .expect("StopHandle reservation must publish one shared lifecycle handle")
+    };
+    ctx.shared_insert_if_absent(IndexReplayStopKeepalive {
+        _receiver: handle.subscribe(),
+    });
+    handle
 }
 
 #[cfg(feature = "mod-alloy")]

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -106,6 +106,24 @@ impl IndexReplayOperatorRuntime {
         self.inner.run(request).await.map_err(Into::into)
     }
 
+    /// Runs replay through the same authorization boundary while sampling one host-owned
+    /// cooperative interruption probe at the Index runner's durable safe points.
+    pub async fn run_interruptible<Check>(
+        &self,
+        context: IndexReplayOperatorContext,
+        request: rustok_index::IndexReplayRunRequest,
+        should_interrupt: Check,
+    ) -> Result<rustok_index::IndexReplayRunOutcome, IndexReplayOperatorError>
+    where
+        Check: FnMut() -> bool,
+    {
+        context.authorize_for(request.page_request().tenant_id())?;
+        self.inner
+            .run_interruptible(request, should_interrupt)
+            .await
+            .map_err(Into::into)
+    }
+
     pub async fn request_cancel(
         &self,
         context: IndexReplayOperatorContext,

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,8 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after guarded replay GraphQL transport merge
-`6672c8b15f7b3ebd53a75147262b3d74020e4a16` and continued on
-`agent/index-replay-graceful-shutdown-v2-20260808`.
+Status overlay rechecked after replay graceful-runner merge
+`9b1bd76ba264939566e66158e35cefab7419ce4c` and continued on
+`agent/index-replay-stop-handle-binding-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -117,16 +117,15 @@ The GraphQL layer exposes source-complete schema-wide `runIndexReplay` / `cancel
 calling `SharedIndexReplayRuntime`, source adapters or PostgreSQL directly. Authorization occurs before parsing
 untrusted schema/job input.
 
-Caller input contains no tenant, actor, worker ID, source name, locale/partition, scheduler handle or replay
-resource budget. Each run creates a server-owned worker identity and applies fixed transport caps: 100 mutations
-per page, at most 8 pages, heartbeat every page and a 60-second lease. Yielded work remains resumable through the
-existing durable job/checkpoint mechanism.
+Caller input contains no tenant, actor, worker ID, source name, locale/partition, scheduler handle, replay
+resource budget, stop handle or shutdown flag. Each run creates a server-owned worker identity and applies fixed
+transport caps: 100 mutations per page, at most 8 pages, heartbeat every page and a 60-second lease.
 
 GraphQL runtime execution/cancellation evidence remains maintainer-owned.
 
-## M6 replay graceful interruption
+## M6 replay graceful interruption and server lifecycle binding
 
-`PostgresIndexReplayRunner::run_interruptible` now carries one host-owned synchronous probe into the existing
+`PostgresIndexReplayRunner::run_interruptible` carries one host-owned synchronous probe into the existing
 one-page safe points: before source scan, before each mutation, and before checkpoint commit. Ordinary `run` and
 persisted operator cancellation semantics remain unchanged.
 
@@ -141,8 +140,18 @@ A retained deterministic SQLite packet covers both important restart windows:
   checkpoint, then attempt 2 scans the same page, records the stable delivery as `Duplicate`, commits the
   checkpoint and succeeds.
 
-This is runner-level source completeness only. The server `StopHandle` is not yet wired through
-`SharedIndexReplayRuntime` / `IndexReplayOperatorRuntime` into the interruptible path.
+The host binding is also source-complete:
+
+1. `SharedIndexReplayRuntime::run_interruptible` forwards only a lifecycle-neutral boolean probe;
+2. `IndexReplayOperatorRuntime::run_interruptible` preserves exact tenant/actor + `modules:manage` authorization;
+3. GraphQL schema initialization resolves or atomically publishes the one shared server `StopHandle`;
+4. API-only hosts retain a private watch receiver so the existing `StopHandle::stop()` can publish the terminal
+   value even when no background worker subscribed;
+5. `runIndexReplay` samples only `StopHandle::is_stopping` through the guarded operator/runtime chain;
+6. GraphQL never receives a shutdown field and never calls `.stop()`;
+7. `cancelIndexReplay` remains the separate persisted cancellation state machine.
+
+Actual process-shutdown execution evidence has **not** been run or admitted.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -173,10 +182,10 @@ This is runner-level source completeness only. The server `StopHandle` is not ye
 - [x] Real-migration repair PostgreSQL harness and retained-evidence admission tooling.
 - [x] Guarded schema-wide replay run/cancel GraphQL command transport with server-owned bounded run policy.
 - [x] Carry a host-owned interruption probe through replay runner safe points and retain duplicate-safe restart evidence source.
+- [x] Bind the shared server `StopHandle::is_stopping` signal through guarded replay runtime/operator composition without caller shutdown controls.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
-- [ ] Execute/admit retained graceful interruption/restart evidence.
-- [ ] Bind server `StopHandle` to interruptible replay execution through guarded runtime/operator composition.
+- [ ] Execute/admit retained graceful interruption/restart evidence and process-shutdown binding.
 - [ ] Complete remaining multi-host/restart evidence beyond existing convergence/replay packets.
 - [ ] Add locale/partition replay checkpoint dimensions and explicit rebuild modes under separate contracts.
 
@@ -211,12 +220,13 @@ This is runner-level source completeness only. The server `StopHandle` is not ye
 ## Next source-code boundary
 
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
-The next independent M6 source slice is server binding: surface only a server-owned `StopHandle::is_stopping`
-probe through `SharedIndexReplayRuntime` and `IndexReplayOperatorRuntime` so authorized replay commands use
-`run_interruptible` without accepting any shutdown control from GraphQL input.
+The next independent M6 source slice is retained end-to-end shutdown command evidence: drive an authorized replay
+command through the real GraphQL/schema/operator chain, flip the shared `StopHandle` deterministically without
+sleep/timing polling, and prove the job yields `pending` and resumes with duplicate-safe semantics.
 
-Do not change user-requested cancellation semantics while adding host-stop composition. Locale/partition replay
-checkpoint scope and explicit rebuild modes remain later, separate contracts.
+If that cannot be retained deterministically without inventing a test-only lifecycle path, move instead to the
+separate pending-future timeout boundary. Locale/partition checkpoint scope and explicit rebuild modes remain
+later contracts.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-bounded-multipage-runner.md
+++ b/crates/rustok-index/docs/m6-bounded-multipage-runner.md
@@ -4,9 +4,10 @@ Status: `source_complete_owner_execution_pending`
 
 This slice composes the existing one-page replay worker, fenced rebuild jobs, mutation
 store, and lease-bound checkpoint store into one bounded PostgreSQL runner. It includes
-durable cancellation requests, between-page terminal cancellation, and a separate
-host-probed in-page interruption path. It does not add a scheduler, background task,
-automatic retry/backoff, dry-run, or production source adapter.
+durable cancellation requests, between-page terminal cancellation, a separate host-probed
+in-page interruption path, and server-owned graceful-shutdown binding through the guarded
+replay command. It does not add a scheduler, background task, automatic retry/backoff,
+dry-run, or production source adapter.
 
 ## Request bounds
 
@@ -69,6 +70,20 @@ checkpoint advance or mutation rollback is introduced.
 The retained SQLite packet is documented in `m6-replay-graceful-shutdown.md`. It is
 source-only until maintainer execution/admission.
 
+## Server shutdown binding
+
+The Index runner and `SharedIndexReplayRuntime` accept only a lifecycle-neutral boolean probe.
+`IndexReplayOperatorRuntime::run_interruptible` preserves exact request authorization before
+passing that probe to Index.
+
+GraphQL schema initialization owns the actual server lifecycle binding. It resolves the one
+shared `StopHandle`, retains a private watch receiver for API-only hosts, and publishes a clone
+in schema data. The authorized `runIndexReplay` command samples only
+`StopHandle::is_stopping`; GraphQL input contains no shutdown state or stop control and the
+transport never calls `StopHandle::stop()`.
+
+`cancelIndexReplay` remains the separate persisted cancellation state machine.
+
 ## Cancellation contract
 
 `PostgresIndexReplayRunner::request_cancel` accepts one non-nil tenant and job UUID. It
@@ -116,9 +131,7 @@ Host interruption is not a page failure and does not enter this failure path.
 
 ## Still open
 
-- bind the server-owned `StopHandle` to the interruptible runner path without exposing a
-  shutdown control to GraphQL callers;
-- execute/admit retained interruption/restart evidence;
+- execute/admit retained interruption/restart and end-to-end server-shutdown evidence;
 - automatic bounded retry/backoff and dead-letter scheduling;
 - operator-visible scheduler health and metrics;
 - explicit targeted/full/shadow rebuild modes;
@@ -126,8 +139,8 @@ Host interruption is not a page failure and does not enter this failure path.
 - retained PostgreSQL cancellation, crash, lease-expiry, restart, timing, and
   multi-instance evidence beyond current focused packets.
 
-The guarded schema-wide GraphQL run/cancel command transport is now source-complete through
-`IndexReplayOperatorRuntime`; its execution evidence remains maintainer-owned.
+The guarded schema-wide GraphQL run/cancel command transport and server `StopHandle` observation
+are source-complete; execution evidence remains maintainer-owned.
 
 ## Owner validation
 

--- a/crates/rustok-index/docs/m6-cooperative-page-interruption.md
+++ b/crates/rustok-index/docs/m6-cooperative-page-interruption.md
@@ -1,13 +1,18 @@
 # M6 cooperative replay-page interruption
 
-Status: `worker_and_runner_source_complete_host_binding_pending`
+Status: `worker_runner_host_binding_source_complete_execution_pending`
 
 ## Purpose
 
 `IndexReplayWorker` exposes an interruptible one-page execution path without changing the
 existing ordinary replay API. `run_next_page` delegates to the same implementation with a no-op
-probe, while `PostgresIndexReplayRunner::run_interruptible` now supplies a host-owned probe to
+probe, while `PostgresIndexReplayRunner::run_interruptible` supplies a host-owned probe to
 `run_next_page_interruptible` under the exact active replay lease.
+
+`SharedIndexReplayRuntime` and `IndexReplayOperatorRuntime` now carry the same lifecycle-neutral
+boolean probe through runtime and authorization boundaries. The server GraphQL replay command binds
+that probe to the shared `StopHandle::is_stopping` signal without exposing shutdown state in caller
+input.
 
 The probe returns a machine-bounded result:
 
@@ -16,9 +21,9 @@ The probe returns a machine-bounded result:
 - `Err(IndexReplayFailure)` returns `IndexReplayError::InterruptionCheckFailed` with only the
   existing bounded retryable/permanent dependency code.
 
-The one-page worker does not impose a deadline on the probe future itself. The runner adapter uses
-a synchronous boolean host probe, so it does not introduce another pending dependency future at
-these safe points.
+The one-page worker does not impose a deadline on the probe future itself. The runner/shared-runtime
+adapter uses a synchronous boolean host probe, so it does not introduce another pending dependency
+future at these safe points.
 
 ## Safe interruption boundaries
 
@@ -46,7 +51,23 @@ cancel won the race, the runner uses the fenced pending-yield transition rather 
 terminal cancellation. The job keeps its UUID, clears lease ownership, preserves the last committed
 checkpoint, records no failure details, and can be claimed as a new attempt.
 
-The retained runner-level SQLite packet proves both pre-scan yield/restart and the durable-mutation / missing-checkpoint redelivery window where attempt 2 observes `Duplicate` before completion.
+The retained runner-level SQLite packet proves both pre-scan yield/restart and the durable-mutation /
+missing-checkpoint redelivery window where attempt 2 observes `Duplicate` before completion.
+
+## Server binding
+
+GraphQL schema initialization resolves one `StopHandle` from shared `ServerRuntimeContext`. API-only
+hosts atomically create the same typed handle when none exists and retain one private watch receiver,
+so the existing `StopHandle::stop()` sender can publish its terminal value even when no background
+worker subscribed.
+
+`runIndexReplay` obtains that server-owned handle only from schema data and calls the guarded
+interruptible operator with `|| stop_handle.is_stopping()`. The transport does not call `.stop()` and
+accepts no stop handle, shutdown flag, or probe from GraphQL input.
+
+The Index crate and `IndexReplayOperatorRuntime` do not import `StopHandle`; only the boolean probe
+crosses those boundaries. User-requested `cancelIndexReplay` remains the separate persisted
+cancellation path.
 
 ## Interaction with merged M6 slices
 
@@ -72,13 +93,12 @@ The one-page worker remains database and runtime neutral. It does not:
 - add a timer, polling loop, scheduler, task, or graceful-shutdown owner;
 - change source, mutation, checkpoint, cursor, event identity, migration, or table shape.
 
-The PostgreSQL runner extension owns lease-aware state transitions around interruption, but the
-server lifecycle still does not supply its `StopHandle` to this path. `SharedIndexReplayRuntime`,
-`IndexReplayOperatorRuntime`, and GraphQL therefore remain on ordinary replay execution until the
-next host-composition slice.
+The PostgreSQL runner extension owns lease-aware state transitions around interruption. The shared
+Index runtime and guarded server operator only forward a boolean probe. Server GraphQL composition
+owns the actual lifecycle signal binding.
 
-The canonical roadmap item remains partially open for actual server stop binding, pending-future
-timeout handling, explicit rebuild modes, locale/partition scope, and retained execution evidence.
+The canonical roadmap item remains open for execution/admission evidence, pending-future timeout
+handling, explicit rebuild modes, locale/partition scope, and broader multi-host timing evidence.
 
 ## Source evidence
 
@@ -90,7 +110,9 @@ Focused source scenarios retain:
 - bounded retryable interruption-probe failure before source access;
 - runner interruption before scan yielding the durable job back to `pending`;
 - runner interruption after durable mutation / before checkpoint commit, followed by attempt-2
-  duplicate redelivery and successful completion.
+  duplicate redelivery and successful completion;
+- server source guards proving the authorized GraphQL run path samples only
+  `StopHandle::is_stopping` and keeps shutdown controls out of caller input.
 
 Formatting, Cargo checks/tests, JavaScript verifiers, PostgreSQL cancellation/lease races, restart
 scenarios, workflows, and CI are maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-graceful-shutdown.md
+++ b/crates/rustok-index/docs/m6-replay-graceful-shutdown.md
@@ -1,14 +1,20 @@
 # M6 replay graceful interruption and restart
 
-Status: `runner_source_complete_host_binding_execution_pending`.
+Status: `host_binding_source_complete_execution_pending`.
 
 ## Purpose
 
-The one-page replay worker already exposes cooperative interruption safe points around durable boundaries. This
-slice carries that contract through `PostgresIndexReplayRunner` without changing ordinary replay or persisted
-operator cancellation semantics.
+The one-page replay worker exposes cooperative interruption safe points around durable boundaries, and
+`PostgresIndexReplayRunner::run_interruptible` carries that contract through the lease/job/checkpoint state
+machine without changing ordinary replay or persisted operator cancellation semantics.
 
-`PostgresIndexReplayRunner::run_interruptible` accepts one host-owned synchronous probe. The probe is adapted to
+The shared Index replay runtime and guarded server operator now expose the same lifecycle-neutral interruptible
+entry point. The server GraphQL transport binds that entry point to the existing server-owned
+`StopHandle::is_stopping` probe; GraphQL input does not contain or control shutdown state.
+
+## Durable safe points
+
+`PostgresIndexReplayRunner::run_interruptible` adapts one synchronous boolean probe to
 `IndexReplayWorker::run_next_page_interruptible`, which checks it:
 
 1. after checkpoint readiness and before source scan;
@@ -31,6 +37,35 @@ The existing `PostgresIndexReplayRunner::run` remains unchanged and does not man
 Host interruption never sets `cancel_requested` and never publishes `failed`. User-requested cancellation keeps
 its existing contract and continues to be persisted through `request_cancel`.
 
+## Server lifecycle binding
+
+`SharedIndexReplayRuntime::run_interruptible` delegates only the boolean probe to the PostgreSQL runner; the
+Index crate does not import the server `StopHandle` type.
+
+`IndexReplayOperatorRuntime::run_interruptible` preserves the existing exact tenant/actor and effective
+`modules:manage` authorization before delegating the request/probe to the shared Index runtime. The operator also
+remains lifecycle-type neutral.
+
+`init_graphql_schema` resolves one shared `StopHandle` from `ServerRuntimeContext`. If no worker/module-work host
+created one yet, schema initialization atomically publishes one. Because all `ServerRuntimeContext` clones share
+the same typed-value map, later worker/module-work initialization reuses the same lifecycle handle.
+
+For API-only hosts schema initialization retains one `watch::Receiver<bool>` keepalive. That guarantees the
+existing `StopHandle::stop()` sender has a receiver and can publish the terminal stop value even when no
+background worker subscribed. The keepalive is private server state.
+
+`runIndexReplay` obtains the server-owned handle from GraphQL schema data only after request authorization/input
+preparation and calls:
+
+`IndexReplayOperatorRuntime::run_interruptible` -> `SharedIndexReplayRuntime::run_interruptible` ->
+`PostgresIndexReplayRunner::run_interruptible`
+
+with `|| stop_handle.is_stopping()` as the probe.
+
+The transport never calls `StopHandle::stop`; callers cannot supply the handle, stop value, probe, worker ID, or
+resource budgets. `cancelIndexReplay` remains on the existing persisted cancellation path and does not read or
+mutate shutdown state.
+
 ## Restart and redelivery
 
 An interruption before source scan performs no source work and leaves no checkpoint change. A new worker can
@@ -47,26 +82,24 @@ than introducing rollback or an unsafe synthetic checkpoint advance.
 
 ## Retained source evidence
 
-`source_replay_graceful_shutdown_tests.rs` retains deterministic SQLite source for two cases:
+`source_replay_graceful_shutdown_tests.rs` retains deterministic SQLite source for two runner-level cases:
 
 - interruption at the first safe point proves zero source scans, a pending lease-free job, no checkpoint, and
   successful attempt-2 restart;
 - interruption at the third safe point of a one-mutation page proves one durable entity/inbox receipt, no
   checkpoint, pending yield, then attempt-2 duplicate redelivery and successful checkpoint/job completion.
 
-The packet uses production Index migrations, source registry, mutation store, replay jobs, checkpoint store and
-runner state transitions. It has not been executed by the implementation agent.
+Source guards additionally retain the server binding chain, shared lifecycle handle reuse, API-host receiver
+keepalive, and the absence of shutdown controls in GraphQL input.
+
+The packet and actual server-shutdown path have not been executed by the implementation agent.
 
 ## Still open
 
-This slice does **not** yet connect a server `StopHandle` to `run_interruptible`. The next server-composition
-boundary must provide a host-owned stop probe without exposing it to GraphQL callers and without bypassing
-`IndexReplayOperatorRuntime` authority.
-
-Also still separate:
-
-- runtime execution/admission of this retained evidence;
-- GraphQL replay command execution/cancellation evidence;
+- execute/admit the retained runner interruption/restart evidence;
+- retain/execute an end-to-end GraphQL request that begins replay, triggers the server lifecycle stop signal, and
+  observes pending yield/restart without relying on timing-sensitive sleeps;
+- execute/admit GraphQL replay command/cancellation evidence;
 - locale/partition replay checkpoint scope;
 - explicit rebuild modes;
 - broader multi-host/timing evidence.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -17,31 +17,34 @@ It does not add automatic replay-job scheduling. The server exposes one bounded 
 3. `materialize_postgres_index_replay_runtime` requires both immutable registries;
 4. it publishes replay dry-run and calls `register_postgres_index_reconciliation_work`;
 5. only complete source/schema composition creates `ModuleWorkRegistrations` for Index;
-6. it publishes `SharedIndexReplayRuntime`;
+6. it publishes `SharedIndexReplayRuntime` with ordinary and lifecycle-neutral interruptible run entry points;
 7. the server wraps replay and reconciliation capabilities in guarded operator runtimes;
-8. GraphQL exposes only the guarded replay operator through bounded schema-wide run/cancel commands.
+8. GraphQL exposes only the guarded replay operator through bounded schema-wide run/cancel commands;
+9. GraphQL schema initialization supplies the server-owned `StopHandle::is_stopping` probe to authorized replay run commands without making shutdown caller-controlled.
 
 An absent source registry publishes no replay runtime, no dry-run runtime, and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed.
 
-The materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the shared `StopHandle` lifecycle.
+The Index materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the same shared `StopHandle` lifecycle used by replay GraphQL execution.
 
 ## Replay operator and command boundary
 
-`IndexReplayOperatorRuntime` remains the only server-owned replay invocation boundary. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`. Run rejects cross-tenant requests before delegation; cancellation derives tenant only from the authorized context.
+`IndexReplayOperatorRuntime` remains the only server-owned replay invocation authority. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`. Both ordinary and interruptible run reject cross-tenant requests before delegation; cancellation derives tenant only from the authorized context.
 
-The GraphQL transport authorizes before parsing caller schema/job input and delegates only to this operator. Tenant, actor, worker identity, source name, database handles, scheduler controls, and replay resource budgets are not caller fields. The run mutation creates a server-owned worker identity and uses a fixed 100-row × 8-page chunk, per-page heartbeat, and 60-second lease.
+The GraphQL transport authorizes before parsing caller schema/job input and delegates only to this operator. Tenant, actor, worker identity, source name, database handles, scheduler controls, replay resource budgets, and shutdown state are not caller fields. The run mutation creates a server-owned worker identity and uses a fixed 100-row × 8-page chunk, per-page heartbeat, and 60-second lease.
 
 Transport adapters must not call `SharedIndexReplayRuntime` directly. See the server transport contract in `apps/server/docs/index-replay-graphql-transport.md`.
 
 ## In-page host interruption boundary
 
-`PostgresIndexReplayRunner` now has a separate `run_interruptible` path that delegates one host-owned probe to the existing `IndexReplayWorker::run_next_page_interruptible` safe points.
+`PostgresIndexReplayRunner` has a separate `run_interruptible` path that delegates one host-owned probe to the existing `IndexReplayWorker::run_next_page_interruptible` safe points.
 
 An interrupted page is not marked failed and does not manufacture a persisted cancellation. After preserving any cancellation race, the runner yields the fenced job back to `pending` with lease ownership cleared and the last committed checkpoint unchanged. A later attempt can replay the same page; already-durable deliveries remain safe through inbox deduplication and source-version ordering.
 
-The retained SQLite packet covers interruption before source scan and interruption after one mutation is durable but before checkpoint commit. The latter resumes as `Duplicate` on attempt 2 before completing the checkpoint/job.
+`SharedIndexReplayRuntime::run_interruptible` and `IndexReplayOperatorRuntime::run_interruptible` now carry that boolean probe through the immutable replay/runtime and authorization boundaries without importing the server lifecycle type into the Index crate or operator composition.
 
-This is runner-level source completeness only. `SharedIndexReplayRuntime`, `IndexReplayOperatorRuntime`, and the GraphQL transport do **not** yet receive the server `StopHandle`; actual host shutdown binding remains the next composition step.
+GraphQL schema initialization resolves or atomically creates one `StopHandle` in shared server runtime state and retains a watch receiver even for API-only hosts. `runIndexReplay` reads only `StopHandle::is_stopping` and invokes the guarded interruptible operator. It never calls `StopHandle::stop`, and no shutdown field is accepted from GraphQL input.
+
+The retained SQLite runner packet covers interruption before source scan and interruption after one mutation is durable but before checkpoint commit. The latter resumes as `Duplicate` on attempt 2 before completing the checkpoint/job. Actual GraphQL/process-shutdown execution remains maintainer-run.
 
 ## Reconciliation scheduling boundary
 
@@ -51,8 +54,7 @@ It does not schedule replay/rebuild jobs, create a second task, own a database l
 
 ## Explicitly open
 
-- connect the server-owned `StopHandle` to interruptible replay execution without exposing shutdown control to callers;
-- execute/admit retained replay interruption/restart evidence;
+- execute/admit retained replay interruption/restart evidence and end-to-end process-shutdown command evidence;
 - GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
 - automatic replay/rebuild job scheduling;
 - retained PostgreSQL replay and reconciliation scheduler execution evidence;

--- a/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
@@ -19,8 +19,8 @@ use super::{
 /// Cloneable operator capability for bounded Index replay execution.
 ///
 /// Construction is Index-owned so executable hosts publish one canonical runner assembled from
-/// the complete immutable schema/source registries. Consumers receive only bounded run and cancel
-/// operations; the database connection and registry internals remain private.
+/// the complete immutable schema/source registries. Consumers receive only bounded run, cooperative
+/// interruptible run, and cancel operations; the database connection and registry internals remain private.
 #[derive(Clone)]
 pub struct SharedIndexReplayRuntime {
     runner: Arc<PostgresIndexReplayRunner>,
@@ -38,6 +38,24 @@ impl SharedIndexReplayRuntime {
         request: IndexReplayRunRequest,
     ) -> Result<IndexReplayRunOutcome, IndexReplayRunError> {
         self.runner.run(request).await
+    }
+
+    /// Runs one bounded replay invocation with a host-owned cooperative stop probe.
+    ///
+    /// The probe is intentionally synchronous and carries no transport or storage failure surface.
+    /// It is sampled only by the runner's existing durable safe points. Callers that do not own a
+    /// host lifecycle should use [`Self::run`] instead.
+    pub async fn run_interruptible<Check>(
+        &self,
+        request: IndexReplayRunRequest,
+        should_interrupt: Check,
+    ) -> Result<IndexReplayRunOutcome, IndexReplayRunError>
+    where
+        Check: FnMut() -> bool,
+    {
+        self.runner
+            .run_interruptible(request, should_interrupt)
+            .await
     }
 
     pub async fn request_cancel(

--- a/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
@@ -51,7 +51,7 @@ impl SharedIndexReplayRuntime {
         should_interrupt: Check,
     ) -> Result<IndexReplayRunOutcome, IndexReplayRunError>
     where
-        Check: FnMut() -> bool + Send,
+        Check: FnMut() -> bool,
     {
         self.runner
             .run_interruptible(request, should_interrupt)

--- a/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs
@@ -51,7 +51,7 @@ impl SharedIndexReplayRuntime {
         should_interrupt: Check,
     ) -> Result<IndexReplayRunOutcome, IndexReplayRunError>
     where
-        Check: FnMut() -> bool,
+        Check: FnMut() -> bool + Send,
     {
         self.runner
             .run_interruptible(request, should_interrupt)

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
@@ -15,7 +15,7 @@ impl PostgresIndexReplayRunner {
         mut should_interrupt: Check,
     ) -> Result<IndexReplayRunOutcome, IndexReplayRunError>
     where
-        Check: FnMut() -> bool + Send,
+        Check: FnMut() -> bool,
     {
         let source_name = self
             .sources

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
@@ -15,7 +15,7 @@ impl PostgresIndexReplayRunner {
         mut should_interrupt: Check,
     ) -> Result<IndexReplayRunOutcome, IndexReplayRunError>
     where
-        Check: FnMut() -> bool,
+        Check: FnMut() -> bool + Send,
     {
         let source_name = self
             .sources

--- a/scripts/verify/verify-index-replay-graceful-shutdown.mjs
+++ b/scripts/verify/verify-index-replay-graceful-shutdown.mjs
@@ -25,8 +25,8 @@ const worker = requireMarkers(workerPath, [
   'before every\n    /// mutation application, and before checkpoint commit'.replace('\\n', '\n'),
   'IndexReplayError::Interrupted',
 ]);
-if (worker.includes('cancel_requested')) {
-  fail(`${workerPath} generic one-page interruption must remain independent of persisted cancellation`);
+if (worker.includes('cancel_requested') || worker.includes('StopHandle')) {
+  fail(`${workerPath} generic one-page interruption must remain independent of persisted cancellation/server lifecycle`);
 }
 
 const extensionPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';
@@ -47,9 +47,10 @@ for (const forbidden of [
   'cancel_requested = TRUE',
   'finish_failure(db, lease',
   'IndexReplayRunStatus::Complete;',
+  'StopHandle',
 ]) {
   if (extension.includes(forbidden)) {
-    fail(`${extensionPath} must yield host interruption without manufacturing cancellation/failure: ${forbidden}`);
+    fail(`${extensionPath} must yield host interruption without manufacturing cancellation/failure/lifecycle ownership: ${forbidden}`);
   }
 }
 const interrupted = extension.indexOf('Err(crate::IndexReplayError::Interrupted) => {');
@@ -69,6 +70,52 @@ const ordinary = requireMarkers(ordinaryPath, [
 ]);
 if (ordinary.includes('run_interruptible<Check>')) {
   fail(`${ordinaryPath} ordinary runner file must remain unchanged by the host-probe extension`);
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
+  'pub async fn run_interruptible<Check>(',
+  '.run_interruptible(request, should_interrupt)',
+]);
+const operatorPath = 'apps/server/src/services/index_replay_runtime_composition.rs';
+const operator = requireMarkers(operatorPath, [
+  'pub async fn run_interruptible<Check>(',
+  'context.authorize_for(request.page_request().tenant_id())?;',
+  '.run_interruptible(request, should_interrupt)',
+]);
+if (operator.includes('StopHandle')) {
+  fail(`${operatorPath} must remain lifecycle-type neutral`);
+}
+
+const schemaInitPath = 'apps/server/src/services/graphql_schema.rs';
+const schemaInit = requireMarkers(schemaInitPath, [
+  'use crate::services::app_lifecycle::StopHandle;',
+  'let stop_handle = stop_handle_from_context(ctx);',
+  'ctx.shared_insert_if_absent(candidate.clone());',
+  'IndexReplayStopKeepalive',
+  '_receiver: handle.subscribe()',
+  'stop_handle,',
+]);
+if (schemaInit.includes('stop_handle.stop()')) {
+  fail(`${schemaInitPath} schema composition must never trigger shutdown`);
+}
+requireMarkers('apps/server/src/graphql/schema.rs', [
+  'pub stop_handle: StopHandle,',
+  '.data(stop_handle)',
+]);
+const transportPath = 'apps/server/src/graphql/index_replay.rs';
+const transport = requireMarkers(transportPath, [
+  'let stop_handle = ctx.data::<StopHandle>()?.clone();',
+  '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
+  '.request_cancel(operator_context, job_id)',
+]);
+if (transport.includes('stop_handle.stop()')) {
+  fail(`${transportPath} transport may observe but must never trigger server shutdown`);
+}
+const runInputStart = transport.indexOf('pub struct IndexReplayRunInput');
+const runInputEnd = transport.indexOf('\n}', runInputStart);
+const runInput = transport.slice(runInputStart, runInputEnd);
+for (const forbidden of ['stop', 'shutdown', 'probe', 'StopHandle']) {
+  if (runInput.includes(forbidden)) fail(`GraphQL replay input exposes lifecycle marker ${forbidden}`);
 }
 
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
@@ -107,12 +154,15 @@ for (const forbidden of [
 }
 
 requireMarkers('crates/rustok-index/docs/m6-replay-graceful-shutdown.md', [
-  'Status: `runner_source_complete_host_binding_execution_pending`.',
+  'Status: `host_binding_source_complete_execution_pending`.',
   '`PostgresIndexReplayRunner::run_interruptible`',
+  '`SharedIndexReplayRuntime::run_interruptible`',
+  '`IndexReplayOperatorRuntime::run_interruptible`',
+  '`StopHandle::is_stopping`',
   'Host interruption is not user cancellation',
   'pending',
   '`Duplicate`',
-  'does **not** yet connect a server `StopHandle`',
+  'actual server-shutdown path have not been executed',
 ]);
 
-console.log('[verify-index-replay-graceful-shutdown] interruptible runner yields host stops to pending and retains duplicate-safe restart source evidence; server StopHandle binding remains open');
+console.log('[verify-index-replay-graceful-shutdown] server-owned StopHandle observation is bound through guarded lifecycle-neutral replay probes while interruption remains pending/duplicate-safe and distinct from user cancellation');

--- a/scripts/verify/verify-index-replay-graceful-shutdown.mjs
+++ b/scripts/verify/verify-index-replay-graceful-shutdown.mjs
@@ -90,9 +90,11 @@ const schemaInitPath = 'apps/server/src/services/graphql_schema.rs';
 const schemaInit = requireMarkers(schemaInitPath, [
   'use crate::services::app_lifecycle::StopHandle;',
   'let stop_handle = stop_handle_from_context(ctx);',
-  'ctx.shared_insert_if_absent(candidate.clone());',
+  'let (candidate, _initial_receiver) = StopHandle::new();',
+  'ctx.shared_insert_if_absent(candidate);',
   'IndexReplayStopKeepalive',
   '_receiver: handle.subscribe()',
+  'avoid a zero-receiver window',
   'stop_handle,',
 ]);
 if (schemaInit.includes('stop_handle.stop()')) {

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -39,7 +39,8 @@ const transport = requireMarkers(transportPath, [
   'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
   'let worker_id = format!("graphql-replay-{}", Uuid::new_v4().simple());',
   '.get::<IndexReplayOperatorRuntime>()',
-  '.run(operator_context, request)',
+  'let stop_handle = ctx.data::<StopHandle>()?.clone();',
+  '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
   '.request_cancel(operator_context, job_id)',
   'replay_transport_authorizes_before_parsing_untrusted_run_input',
   'replay_transport_derives_authority_worker_and_server_owned_budgets',
@@ -89,6 +90,8 @@ for (const forbidden of [
   'locale',
   'partition',
   'source_name',
+  'StopHandle',
+  'is_stopping',
   'Uuid',
 ]) {
   if (runInput.includes(forbidden)) fail(`replay run input contains caller-owned field marker ${forbidden}`);
@@ -104,9 +107,10 @@ for (const forbidden of [
   'SharedIndexReplayRuntime',
   'PostgresMutationStore',
   'ModuleWorkScheduler',
+  '.stop()',
 ]) {
   if (production.includes(forbidden)) {
-    fail(`${transportPath} bypasses the guarded replay operator: ${forbidden}`);
+    fail(`${transportPath} bypasses the guarded replay/lifecycle boundary: ${forbidden}`);
   }
 }
 
@@ -114,24 +118,41 @@ requireMarkers('apps/server/src/graphql/mod.rs', ['pub mod index_replay;']);
 requireMarkers('apps/server/src/graphql/schema.rs', [
   'use super::index_replay::IndexReplayMutation;',
   'IndexDriftSourcePageDiagnosisMutation,\n    IndexReplayMutation,',
+  'pub stop_handle: StopHandle,',
+  '.data(stop_handle)',
+]);
+requireMarkers('apps/server/src/services/graphql_schema.rs', [
+  'let stop_handle = stop_handle_from_context(ctx);',
+  'ctx.shared_insert_if_absent(candidate.clone());',
+  'IndexReplayStopKeepalive',
+  '_receiver: handle.subscribe()',
+  'stop_handle,',
 ]);
 requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'pub struct IndexReplayOperatorRuntime',
-  'pub async fn run(',
+  'pub async fn run_interruptible<Check>(',
+  '.run_interruptible(request, should_interrupt)',
   'pub async fn request_cancel(',
   'Permission::MODULES_MANAGE',
   'context.authorize_for(request.page_request().tenant_id())?;',
 ]);
+requireMarkers('apps/server/src/services/app_lifecycle.rs', [
+  'pub struct StopHandle',
+  'pub fn subscribe(&self)',
+  'pub async fn stop(&self)',
+  'pub fn is_stopping(&self) -> bool',
+]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `source_complete_owner_execution_pending`.',
+  'Status: `source_complete_shutdown_bound_execution_pending`.',
   '`runIndexReplay(input: ...)`',
   '`cancelIndexReplay(input: ...)`',
   'Tenant and actor identities are never accepted',
   'page limit: `100` mutations',
   'maximum pages: `8`',
   'lease duration: `60` seconds',
+  '`StopHandle::is_stopping`',
   'delegation only through `IndexReplayOperatorRuntime`',
   'maintainer-owned',
 ]);
 
-console.log('[verify-index-replay-graphql-transport] guarded schema-wide run/cancel GraphQL commands use request authority and server-owned bounded replay policy');
+console.log('[verify-index-replay-graphql-transport] guarded schema-wide replay run is bound to the server-owned StopHandle probe; cancel and caller input remain independent of shutdown control');

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -123,9 +123,11 @@ requireMarkers('apps/server/src/graphql/schema.rs', [
 ]);
 requireMarkers('apps/server/src/services/graphql_schema.rs', [
   'let stop_handle = stop_handle_from_context(ctx);',
-  'ctx.shared_insert_if_absent(candidate.clone());',
+  'let (candidate, _initial_receiver) = StopHandle::new();',
+  'ctx.shared_insert_if_absent(candidate);',
   'IndexReplayStopKeepalive',
   '_receiver: handle.subscribe()',
+  'avoid a zero-receiver window',
   'stop_handle,',
 ]);
 requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [

--- a/scripts/verify/verify-index-replay-multipage-runner.mjs
+++ b/scripts/verify/verify-index-replay-multipage-runner.mjs
@@ -133,8 +133,9 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-multipage-runner.md', [
   'a `pending` job becomes terminal `cancelled` immediately',
   'cancel_requested = FALSE',
   'A running cancellation request survives lease expiry and reclaim.',
-  'server-owned `StopHandle`',
-  'maintainer-run',
+  'Server shutdown binding',
+  '`StopHandle::is_stopping`',
+  'execution evidence remains maintainer-owned',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
@@ -150,4 +151,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-replay-contract.mjs'",
 ]);
 
-console.log('[verify-index-replay-multipage-runner] ordinary replay/cancel semantics remain stable while host-probed interruption is isolated in a separate extension');
+console.log('[verify-index-replay-multipage-runner] ordinary replay/cancel semantics remain stable while the separate interruptible path is bound to server shutdown through lifecycle-neutral runtime/operator probes');

--- a/scripts/verify/verify-index-replay-page-interruption.mjs
+++ b/scripts/verify/verify-index-replay-page-interruption.mjs
@@ -77,6 +77,7 @@ for (const forbidden of [
   'last_error_details',
   'backtrace',
   'stack_trace',
+  'StopHandle',
 ]) {
   if (replay.includes(forbidden)) {
     fail(`${replayPath} contains forbidden host/storage/scheduler marker ${forbidden}`);
@@ -124,6 +125,20 @@ for (const forbidden of ['request_cancel(', 'cancel_requested = TRUE', 'finish_f
   }
 }
 
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
+  'pub async fn run_interruptible<Check>(',
+  '.run_interruptible(request, should_interrupt)',
+]);
+requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
+  'pub async fn run_interruptible<Check>(',
+  'context.authorize_for(request.page_request().tenant_id())?;',
+  '.run_interruptible(request, should_interrupt)',
+]);
+requireMarkers('apps/server/src/graphql/index_replay.rs', [
+  'let stop_handle = ctx.data::<StopHandle>()?.clone();',
+  '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
+]);
+
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   'mod source_replay_runner {',
   'include!("source_replay_runner.rs");',
@@ -131,9 +146,11 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-cooperative-page-interruption.md', [
-  'Status: `worker_and_runner_source_complete_host_binding_pending`',
+  'Status: `worker_runner_host_binding_source_complete_execution_pending`',
   '`run_next_page_interruptible`',
   '`PostgresIndexReplayRunner::run_interruptible`',
+  '`SharedIndexReplayRuntime` and `IndexReplayOperatorRuntime`',
+  '`StopHandle::is_stopping`',
   '`IndexReplayError::Interrupted`',
   '`IndexReplayError::InterruptionCheckFailed`',
   'before every mutation',
@@ -141,7 +158,7 @@ requireMarkers('crates/rustok-index/docs/m6-cooperative-page-interruption.md', [
   '30-second source-call timeout wrapper',
   'bounded replay dry-run',
   'does not impose a deadline on the probe future itself',
-  'server lifecycle still does not supply its `StopHandle`',
+  'accepts no stop handle, shutdown flag, or probe from GraphQL input',
   'runner interruption after durable mutation / before checkpoint commit',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
@@ -155,4 +172,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-graceful-shutdown.mjs'",
 ]);
 
-console.log('[verify-index-replay-page-interruption] worker safe points remain storage-neutral while the separate runner extension retains lease-aware host interruption; server StopHandle binding remains open');
+console.log('[verify-index-replay-page-interruption] worker safe points remain storage-neutral and the guarded GraphQL replay path binds the shared server stop signal through lifecycle-neutral runtime/operator probes');

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -21,6 +21,9 @@ const requireMarkers = (relative, markers) => {
 const runtimePath = 'crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs';
 const runtime = requireMarkers(runtimePath, [
   'pub struct SharedIndexReplayRuntime',
+  'pub async fn run_interruptible<Check>(',
+  'Check: FnMut() -> bool',
+  '.run_interruptible(request, should_interrupt)',
   'pub enum IndexReplayRuntimeCompositionError',
   'AlreadyMaterialized',
   'MissingSchemaRegistry',
@@ -42,7 +45,7 @@ const runtime = requireMarkers(runtimePath, [
 ]);
 for (const forbidden of [
   'tokio::spawn', 'tokio::time::sleep', 'loop {', '.query_one(',
-  '.query_all(', '.execute(', '.begin()', 'permissions_for(', 'Permission::',
+  '.query_all(', '.execute(', '.begin()', 'permissions_for(', 'Permission::', 'StopHandle',
 ]) {
   if (runtime.includes(forbidden)) fail(`${runtimePath} contains ${forbidden}`);
 }
@@ -57,8 +60,12 @@ const serverPath = 'apps/server/src/services/index_replay_runtime_composition.rs
 const server = requireMarkers(serverPath, [
   'pub struct IndexReplayOperatorContext',
   'pub struct IndexReplayOperatorRuntime',
+  'pub async fn run_interruptible<Check>(',
+  'self.inner',
+  '.run_interruptible(request, should_interrupt)',
   'Permission::MODULES_MANAGE',
   'permissions_for(&self.tenant_id, &self.actor_id)',
+  'context.authorize_for(request.page_request().tenant_id())?;',
   'materialize_postgres_index_sources(extensions, db.clone())',
   'materialize_index_source_registry(extensions)',
   'materialize_postgres_index_replay_runtime(extensions, db.clone())',
@@ -92,6 +99,7 @@ requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
   'publishes no replay runtime, no dry-run runtime, and no empty Index work registration',
   'The materializer performs no SQL',
   'starts the single generic `ModuleWorkScheduler` only when registrations exist',
+  '`SharedIndexReplayRuntime::run_interruptible`',
   'The work registration added here is reconciliation-only',
   'maintainer-run',
 ]);
@@ -104,4 +112,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
-console.log('[verify-index-replay-runtime-composition] OK');
+console.log('[verify-index-replay-runtime-composition] shared replay runtime/operator expose a lifecycle-neutral interruptible path while scheduler composition remains unchanged');


### PR DESCRIPTION
## Summary

- expose lifecycle-neutral `run_interruptible` delegation through `SharedIndexReplayRuntime` and the existing guarded `IndexReplayOperatorRuntime`;
- keep the Index crate and replay operator free of the server `StopHandle` type: only a synchronous boolean probe crosses those boundaries;
- bind authorized GraphQL `runIndexReplay` to the shared server `StopHandle::is_stopping` probe while leaving `cancelIndexReplay` on its existing persisted cancellation path;
- keep shutdown completely server-owned: GraphQL run input still contains only module/entity/schema key and accepts no stop handle, shutdown flag, probe, worker identity, or resource budget;
- extend GraphQL schema dependencies with the shared `StopHandle` and retain one private watch receiver for API-only hosts so the existing `StopHandle::stop()` can publish its terminal value even when no background worker subscribed;
- atomically reuse an existing module-work/background-worker StopHandle when present, or publish one in shared `ServerRuntimeContext` when GraphQL is the first lifecycle consumer;
- keep the initial receiver alive until a receiver for the actually published handle is installed, avoiding a zero-receiver window during concurrent schema initialization/shutdown;
- retain the existing runner behavior from #3276: host interruption yields the fenced replay job to durable `pending`, preserves the last checkpoint, and remains distinct from user cancellation/failure;
- actualize the replay GraphQL/runtime/interruption/multipage guards and M6 roadmap to mark lifecycle binding source-complete / execution pending.

## Authority and lifecycle boundary

The command path is now:

`GraphQL request authority` → `IndexReplayOperatorRuntime::run_interruptible` → `SharedIndexReplayRuntime::run_interruptible` → `PostgresIndexReplayRunner::run_interruptible`

with `|| stop_handle.is_stopping()` supplied only by server GraphQL composition.

The transport never calls `StopHandle::stop()`. The Index runtime and operator do not import `StopHandle`. User-requested `cancelIndexReplay` remains a separate persisted state machine and is unchanged.

## Boundary

This PR does not execute an actual shutdown/replay scenario, change replay jobs/checkpoints/cancellation SQL, add automatic replay scheduling, add locale/partition checkpoint dimensions, introduce explicit rebuild modes, or touch M7 Storefront traffic.

The next independent source slice is retained end-to-end shutdown command evidence: drive an authorized replay through the real GraphQL/schema/operator chain, flip the shared StopHandle deterministically without sleeps/timing polling, and retain pending-yield/restart evidence if that can be done without a test-only lifecycle bypass.

## Main recheck

The branch started from replay graceful-runner merge `9b1bd76ba264939566e66158e35cefab7419ce4c`. Current `main@bc97d19570c18bf1165c87c304d80f550e78e566` is eight commits ahead, affecting only Groups/Commerce/Forum/Page Builder paths; those paths are disjoint from this 16-file server/Index replay lifecycle diff.

## Validation

Static source review confirmed the real bootstrap order and lifecycle reuse: module-work and background-worker initialization only create a `StopHandle` when absent, all `ServerRuntimeContext` clones share the same typed-value map, and server shutdown reads that shared handle and calls `stop().await`. `GraphqlSchemaDependencies` has one construction site. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.