### PR TITLE
feat(forum): start bounded counter reconciliation

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -242,7 +242,7 @@ remain pending.
 | `FORUM-30` | `planned` | Complete Forum admin by composing Forum and shared owners. |
 | `FORUM-31` | `planned` | Complete Forum storefront by composing Profiles, Media, Reactions, Notifications and Search. |
 | `FORUM-32` | `in_progress` | Generated Forum Fly blocks/renderers/property contracts, Forum-owned preview service/HTTP/native transport, provider-neutral Pages host composition and owner-backed schema/validation property editing are source-ready. Retained runtime/browser evidence and observed Page Builder Wave evidence remain. |
-| `FORUM-33` | `planned` | Forum metrics/reconciliation providers integrated with platform operations. |
+| `FORUM-33` | `in_progress` | Bounded snapshot-consistent owner counter reconciliation report, strict operator GraphQL admission and baseline platform telemetry are source-ready. Retain SQLite/PostgreSQL execution evidence, add bounded continuation and remaining reconciliation/metrics. Repair remains blocked on dry-run/audit/idempotent job state; CLI integration awaits a synchronized dependency/lock update. |
 | `FORUM-34` | `planned` | Forum import/export adapter and NodeBB mapping over a shared runner. |
 | `NOTIFY-00` | `in_progress` | Neutral API/runtime composition and Forum providers exist; executable distribution evidence remains. |
 | `NOTIFY-01` | `in_progress` | Persistence/source inbox exist; final commands, migrations, retention and reconciliation remain. |
@@ -629,11 +629,36 @@ These commands remain maintainer-run in this source slice.
 
 ## `FORUM-33` — analytics, observability and reconciliation
 
-**Status:** `planned`
+**Status:** `in_progress`
 
-Forum metrics/reconciliation providers remain planned platform-operations work.
-This Page Builder source slice does not change that ownership or claim runtime
-observability evidence.
+FORUM-33A now provides a read-only `ForumCounterReconciliationService` and the
+operator GraphQL field `forumCounterReconciliationReport(limit: Int)`. Tenant
+identity comes only from the trusted request `TenantContext`; the transport
+rejects auth/tenant mismatch and requires both effective
+`forum_categories:manage` and `forum_topics:manage` permissions.
+
+The first owner report reconciles three existing publication-accounting
+invariants without mutating owner state: `forum_topics.reply_count` against
+approved replies, `forum_categories.topic_count` against current topic rows, and
+`forum_categories.reply_count` against approved replies across category topics.
+It executes two bounded aggregate queries inside one database snapshot.
+PostgreSQL uses `REPEATABLE READ READ ONLY`; SQLite keeps both reads in one
+transaction. The default per-shape limit is 100 and the hard cap is 500, with
+`has_more_topics`/`has_more_categories` signalling that continuation is required.
+
+The service reuses the platform module-entrypoint/span/error metrics rather than
+adding duplicate Forum metric families. Source-ready reporting does not claim
+runtime observability evidence.
+
+FORUM-33 remains `in_progress`. Retain clean/drift/snapshot SQLite and PostgreSQL
+execution evidence; add bounded continuation beyond the first page; reconcile
+accepted solutions, subscriptions, mentions, attachments and permitted
+shared-owner projections; and add only non-duplicative operational metrics for
+moderation, notification/search lag, unread/activity, locale fallback and spam
+outcomes. Any write repair remains blocked until it has explicit operator RBAC,
+dry-run behavior, durable audit, idempotent job/receipt state and bounded
+recovery. A platform CLI adapter must be added only with its synchronized
+workspace dependency and `Cargo.lock` update.
 
 ### `FORUM-30`/`FORUM-31`: UI composition
 
@@ -683,6 +708,11 @@ Hosts register/mount packages and do not absorb policy.
 - Existing Forum votes remain source-compatible. Do not reinterpret them as
   reactions without explicit semantic mapping and migration.
 - Forum statistics are projections, not a reputation ledger.
+- Forum counter reconciliation is read-only in FORUM-33A. No transport may repair
+  owner counters until the write path has explicit RBAC, dry-run, audit,
+  idempotent job/receipt state and bounded recovery. Shared-owner reconciliation
+  must use public owner contracts and must not read another module's private
+  tables.
 - Forum moderation state remains authoritative Forum state while Moderation
   decisions are applied idempotently through an adapter.
 - Forum depends only on `rustok-moderation-api`, not the Moderation owner crate;
@@ -809,6 +839,7 @@ Hosts register/mount packages and do not absorb policy.
 ## Required verification
 
 ```bash
+node scripts/verify/verify-forum-counter-reconciliation-source.mjs
 node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
 node scripts/verify/verify-forum-shared-capability-ownership.mjs
 node scripts/verify/verify-forum-moderation-subject-adapter.mjs
@@ -896,6 +927,15 @@ complete for metadata, Fly identity, owner preview and owner properties; do not
 add another Forum-local schema/data authority. Replace synthetic Wave evidence
 only after the existing Pages reference-consumer execution gate and the Forum
 executable packet are accepted.
+
+For FORUM-33, retain SQLite and PostgreSQL execution evidence for a clean counter
+snapshot and intentionally drifted `topic.reply_count`, `category.topic_count`
+and `category.reply_count` fixtures, including one concurrent-write snapshot
+case. Then add independent bounded topic/category continuation so a large tenant
+can scan past the first 500 rows without unbounded work. Do not add write repair
+until operator RBAC, dry-run, durable audit, idempotent job/receipt state and
+bounded recovery are designed together. Add a Forum CLI adapter only with the
+synchronized workspace dependency and `Cargo.lock` update.
 
 Regenerate the event-contract digests and retain release verification for the
 current `Cargo.lock`, then retain SQLite and PostgreSQL evidence for changed/

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -11,6 +11,7 @@ mod mutation;
 mod query;
 mod quote_commands;
 mod read_state;
+mod reconciliation_query;
 mod reply_audience_query;
 mod runtime_data;
 mod storefront_audience_topic;
@@ -50,6 +51,9 @@ pub use quote_commands::{
     GqlForumRelationSnapshot, SetForumQuoteRelationsInput,
 };
 pub use read_state::*;
+pub use reconciliation_query::{
+    GqlForumCounterDrift, GqlForumCounterReconciliationReport,
+};
 pub use runtime_data::{ForumGraphqlRuntimeData, attach_schema_data};
 pub use storefront_read_state::*;
 pub use topic_fork_mutation::{
@@ -79,6 +83,7 @@ pub struct ForumQuery(
     category_policy::ForumCategoryTopicPolicyQuery,
     category_route_query::ForumCategoryRouteQuery,
     read_state::ForumReadStateQuery,
+    reconciliation_query::ForumReconciliationQuery,
     reply_audience_query::ForumReplyAudienceQuery,
     storefront_read_state::ForumStorefrontReadStateQuery,
     storefront_audience_topic::ForumStorefrontAudienceTopicQuery,

--- a/crates/rustok-forum/src/graphql/reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/reconciliation_query.rs
@@ -4,6 +4,7 @@ use rustok_api::{
     graphql::{GraphQLError, require_module_enabled},
     has_any_effective_permission,
 };
+use rustok_core::SecurityContext;
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
@@ -61,8 +62,9 @@ impl ForumReconciliationQuery {
         }
         let requested_limit = normalize_limit(limit)?;
         let db = ctx.data::<DatabaseConnection>()?;
+        let security = SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
         let report = ForumCounterReconciliationService::new(db.clone())
-            .report(tenant.id, requested_limit)
+            .report(tenant.id, &security, requested_limit)
             .await?;
         Ok(map_report(report))
     }

--- a/crates/rustok-forum/src/graphql/reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/reconciliation_query.rs
@@ -62,7 +62,8 @@ impl ForumReconciliationQuery {
         }
         let requested_limit = normalize_limit(limit)?;
         let db = ctx.data::<DatabaseConnection>()?;
-        let security = SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
+        let security =
+            SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
         let report = ForumCounterReconciliationService::new(db.clone())
             .report(tenant.id, &security, requested_limit)
             .await?;

--- a/crates/rustok-forum/src/graphql/reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/reconciliation_query.rs
@@ -1,0 +1,168 @@
+use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::{
+    ForumCounterDrift, ForumCounterReconciliationReport, ForumCounterReconciliationService,
+};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumCounterDrift {
+    pub kind: String,
+    pub subject_id: Uuid,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumCounterReconciliationReport {
+    pub requested_limit: Option<i32>,
+    pub effective_limit: i32,
+    pub inspected_topics: i32,
+    pub inspected_categories: i32,
+    pub has_more_topics: bool,
+    pub has_more_categories: bool,
+    pub drift_count: i32,
+    pub clean: bool,
+    pub drifts: Vec<GqlForumCounterDrift>,
+}
+
+#[derive(Default)]
+pub struct ForumReconciliationQuery;
+
+#[Object]
+impl ForumReconciliationQuery {
+    /// Read-only FORUM-33 owner counter drift report for the current tenant.
+    ///
+    /// This is intentionally not a repair mutation. Repair remains closed until a write path can
+    /// provide operator RBAC, dry-run, audit and durable idempotent job state.
+    async fn forum_counter_reconciliation_report(
+        &self,
+        ctx: &Context<'_>,
+        limit: Option<i32>,
+    ) -> Result<GqlForumCounterReconciliationReport> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+        require_operations_permissions(auth)?;
+        let tenant = ctx.data::<TenantContext>()?;
+        if auth.tenant_id != tenant.id {
+            return Err(<FieldError as GraphQLError>::permission_denied(
+                "Permission denied: tenant scope mismatch",
+            ));
+        }
+        let requested_limit = normalize_limit(limit)?;
+        let db = ctx.data::<DatabaseConnection>()?;
+        let report = ForumCounterReconciliationService::new(db.clone())
+            .report(tenant.id, requested_limit)
+            .await?;
+        Ok(map_report(report))
+    }
+}
+
+fn require_operations_permissions(auth: &AuthContext) -> Result<()> {
+    let categories_manage = has_any_effective_permission(
+        &auth.permissions,
+        &[Permission::FORUM_CATEGORIES_MANAGE],
+    );
+    let topics_manage =
+        has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_MANAGE]);
+    if categories_manage && topics_manage {
+        Ok(())
+    } else {
+        Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_categories:manage and forum_topics:manage required",
+        ))
+    }
+}
+
+fn normalize_limit(limit: Option<i32>) -> Result<Option<u64>> {
+    match limit {
+        None => Ok(None),
+        Some(value) if value > 0 => Ok(Some(value as u64)),
+        Some(_) => Err(async_graphql::Error::new(
+            "Forum counter reconciliation limit must be positive",
+        )),
+    }
+}
+
+fn map_report(report: ForumCounterReconciliationReport) -> GqlForumCounterReconciliationReport {
+    let requested_limit = report.requested_limit.map(saturating_i32);
+    GqlForumCounterReconciliationReport {
+        requested_limit,
+        effective_limit: saturating_i32(report.effective_limit),
+        inspected_topics: saturating_i32(report.inspected_topics),
+        inspected_categories: saturating_i32(report.inspected_categories),
+        has_more_topics: report.has_more_topics,
+        has_more_categories: report.has_more_categories,
+        drift_count: saturating_i32(report.drift_count() as u64),
+        clean: report.is_clean(),
+        drifts: report.drifts.into_iter().map(map_drift).collect(),
+    }
+}
+
+fn map_drift(drift: ForumCounterDrift) -> GqlForumCounterDrift {
+    GqlForumCounterDrift {
+        kind: drift.kind.as_str().to_string(),
+        subject_id: drift.subject_id,
+        stored: drift.stored,
+        expected: drift.expected,
+    }
+}
+
+fn saturating_i32(value: u64) -> i32 {
+    value.min(i32::MAX as u64) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_api::{Action, Resource};
+
+    fn auth(permissions: Vec<Permission>) -> AuthContext {
+        let tenant_id = Uuid::new_v4();
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    #[test]
+    fn operator_report_requires_both_effective_manage_permissions() {
+        let both = auth(vec![
+            Permission::new(Resource::ForumCategories, Action::Manage),
+            Permission::new(Resource::ForumTopics, Action::Manage),
+        ]);
+        assert!(require_operations_permissions(&both).is_ok());
+
+        let topics_only = auth(vec![Permission::new(Resource::ForumTopics, Action::Manage)]);
+        assert!(require_operations_permissions(&topics_only).is_err());
+
+        let read_only = auth(vec![
+            Permission::FORUM_CATEGORIES_READ,
+            Permission::FORUM_TOPICS_READ,
+        ]);
+        assert!(require_operations_permissions(&read_only).is_err());
+    }
+
+    #[test]
+    fn report_limit_rejects_non_positive_values() {
+        assert_eq!(normalize_limit(None).unwrap(), None);
+        assert_eq!(normalize_limit(Some(25)).unwrap(), Some(25));
+        assert!(normalize_limit(Some(0)).is_err());
+        assert!(normalize_limit(Some(-1)).is_err());
+    }
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -13,6 +13,8 @@ pub mod category_presentation;
 pub mod category_read_transport;
 pub mod constants;
 pub mod controllers;
+#[path = "services/counter_reconciliation.rs"]
+mod counter_reconciliation;
 pub mod dto;
 pub mod entities;
 pub mod error;
@@ -52,6 +54,11 @@ pub use category_read_transport::{
     ForumCategoryReadOperation, ForumCategoryReadTransport, category_read_audience_port_context,
 };
 pub use constants::*;
+pub use counter_reconciliation::{
+    DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, ForumCounterDrift, ForumCounterDriftKind,
+    ForumCounterReconciliationReport, ForumCounterReconciliationService,
+    MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
+};
 pub use dto::*;
 pub use entities::*;
 pub use error::{ForumError, ForumResult};

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -13,8 +13,6 @@ pub mod category_presentation;
 pub mod category_read_transport;
 pub mod constants;
 pub mod controllers;
-#[path = "services/counter_reconciliation.rs"]
-mod counter_reconciliation;
 pub mod dto;
 pub mod entities;
 pub mod error;
@@ -54,11 +52,6 @@ pub use category_read_transport::{
     ForumCategoryReadOperation, ForumCategoryReadTransport, category_read_audience_port_context,
 };
 pub use constants::*;
-pub use counter_reconciliation::{
-    DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, ForumCounterDrift, ForumCounterDriftKind,
-    ForumCounterReconciliationReport, ForumCounterReconciliationService,
-    MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
-};
 pub use dto::*;
 pub use entities::*;
 pub use error::{ForumError, ForumResult};
@@ -82,10 +75,10 @@ pub use reply_read_transport::{
 };
 pub use search_projection::ForumSearchProjectionSourceFactory;
 pub use services::{
-    CategoryService, FORUM_POSTING_POLICY_FACTS_CAPABILITY,
-    FORUM_POSTING_POLICY_FACTS_CAPABILITY_UNAVAILABLE, FORUM_POSTING_POLICY_PRECEDENCE,
-    ForkForumReplyBranchInput, ForumApprovedPostsFactPort, ForumCategoryAudiencePage,
-    ForumCategoryAudiencePolicy, ForumCategoryAudiencePolicyLayer,
+    CategoryService, DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT,
+    FORUM_POSTING_POLICY_FACTS_CAPABILITY, FORUM_POSTING_POLICY_FACTS_CAPABILITY_UNAVAILABLE,
+    FORUM_POSTING_POLICY_PRECEDENCE, ForkForumReplyBranchInput, ForumApprovedPostsFactPort,
+    ForumCategoryAudiencePage, ForumCategoryAudiencePolicy, ForumCategoryAudiencePolicyLayer,
     ForumCategoryAudiencePolicyService, ForumCategoryAudienceReadService,
     ForumCategoryAudienceViewer, ForumCategoryAudienceVisibilityService,
     ForumCategoryModerationAudiencePolicy, ForumCategoryModerationAudiencePolicyLayer,
@@ -93,7 +86,8 @@ pub use services::{
     ForumCategoryReplyCreateAudiencePolicyLayer, ForumCategoryReplyCreateAudiencePolicyService,
     ForumCategoryTopicCreateAudiencePolicy, ForumCategoryTopicCreateAudiencePolicyLayer,
     ForumCategoryTopicCreateAudiencePolicyService, ForumCategoryVisibilityPolicy,
-    ForumCategoryVisibilityPolicyService, ForumEventService,
+    ForumCategoryVisibilityPolicyService, ForumCounterDrift, ForumCounterDriftKind,
+    ForumCounterReconciliationReport, ForumCounterReconciliationService, ForumEventService,
     ForumModerationAudienceAuthorization, ForumModerationAudienceAuthorizationService,
     ForumPostingAction, ForumPostingCandidateMetrics, ForumPostingPolicyCompositionRequest,
     ForumPostingPolicyDecision, ForumPostingPolicyDecisionReason,
@@ -128,8 +122,8 @@ pub use services::{
     ForumTopicVisibilityScope, ForumTopicVisibilityService, ForumUserTrustAudienceFactsPort,
     ForumUserTrustChange, ForumUserTrustRevision, ForumUserTrustRevisionPage,
     ForumUserTrustService, ForumUserTrustState, ForumVisibilityScopedReadStateService,
-    ForumWidgetContractService, ForumWidgetPreviewService, MAX_FORUM_POSTING_POLICY_FACTS,
-    MAX_FORUM_POSTING_UNAVAILABLE_REASON_CODE_LENGTH,
+    ForumWidgetContractService, ForumWidgetPreviewService, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
+    MAX_FORUM_POSTING_POLICY_FACTS, MAX_FORUM_POSTING_UNAVAILABLE_REASON_CODE_LENGTH,
     MAX_FORUM_REPLY_RANGE_MOVE_REASON_LEN, MAX_FORUM_REPLY_RANGE_MOVE_REPLIES,
     MAX_FORUM_SEARCH_RESULT_ELIGIBILITY_CANDIDATES,
     MAX_FORUM_TOPIC_CANONICAL_REDIRECT_HOPS, MAX_FORUM_TOPIC_FORK_BODY_ROWS,

--- a/crates/rustok-forum/src/services/counter_reconciliation.rs
+++ b/crates/rustok-forum/src/services/counter_reconciliation.rs
@@ -1,5 +1,7 @@
 use std::time::Instant;
 
+use rustok_api::{Action, Resource};
+use rustok_core::SecurityContext;
 use sea_orm::{
     AccessMode, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction,
     IsolationLevel, Statement, TransactionTrait,
@@ -7,6 +9,7 @@ use sea_orm::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::rbac::enforce_scope;
 use crate::error::{ForumError, ForumResult};
 
 pub const DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT: u64 = 100;
@@ -65,7 +68,9 @@ impl ForumCounterReconciliationReport {
 /// The report deliberately performs no repair. A future write path must add the FORUM-33
 /// requirements for operator RBAC, dry-run, audit and durable idempotent job state before it can
 /// mutate any owner counter. This service is tenant-scoped and bounded independently for topics and
-/// categories so an operator request cannot turn into an unbounded table scan.
+/// categories so an operator request cannot turn into an unbounded table scan. The owner service
+/// itself requires both category and topic `Manage` scopes so future non-GraphQL adapters cannot
+/// bypass the operator boundary.
 ///
 /// Both aggregate reads are fenced by one database snapshot. PostgreSQL uses `REPEATABLE READ`
 /// with `READ ONLY`; SQLite uses one ordinary transaction whose first read establishes the snapshot.
@@ -81,6 +86,7 @@ impl ForumCounterReconciliationService {
     pub async fn report(
         &self,
         tenant_id: Uuid,
+        security: &SecurityContext,
         requested_limit: Option<u64>,
     ) -> ForumResult<ForumCounterReconciliationReport> {
         rustok_telemetry::metrics::record_module_entrypoint_call(
@@ -89,7 +95,10 @@ impl ForumCounterReconciliationService {
             "library",
         );
         let started_at = Instant::now();
-        let result = self.report_inner(tenant_id, requested_limit).await;
+        let result = match enforce_operations_scope(security) {
+            Ok(()) => self.report_inner(tenant_id, requested_limit).await,
+            Err(error) => Err(error),
+        };
         rustok_telemetry::metrics::record_span_duration(
             FORUM_COUNTER_RECONCILIATION_OPERATION,
             started_at.elapsed().as_secs_f64(),
@@ -230,6 +239,11 @@ impl ForumCounterReconciliationService {
     }
 }
 
+fn enforce_operations_scope(security: &SecurityContext) -> ForumResult<()> {
+    enforce_scope(security, Resource::ForumCategories, Action::Manage)?;
+    enforce_scope(security, Resource::ForumTopics, Action::Manage)
+}
+
 fn counter_statement(
     backend: DatabaseBackend,
     sqlite_sql: &str,
@@ -332,6 +346,7 @@ LIMIT $2
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustok_api::Permission;
 
     #[test]
     fn reconciliation_limit_is_bounded() {
@@ -361,5 +376,23 @@ mod tests {
             ForumCounterDriftKind::CategoryReplyCount.as_str(),
             "category_reply_count"
         );
+    }
+
+    #[test]
+    fn owner_report_requires_both_manage_scopes() {
+        let both = SecurityContext::from_permission_snapshot(
+            Some(Uuid::new_v4()),
+            &[
+                Permission::FORUM_CATEGORIES_MANAGE,
+                Permission::FORUM_TOPICS_MANAGE,
+            ],
+        );
+        assert!(enforce_operations_scope(&both).is_ok());
+
+        let topics_only = SecurityContext::from_permission_snapshot(
+            Some(Uuid::new_v4()),
+            &[Permission::FORUM_TOPICS_MANAGE],
+        );
+        assert!(enforce_operations_scope(&topics_only).is_err());
     }
 }

--- a/crates/rustok-forum/src/services/counter_reconciliation.rs
+++ b/crates/rustok-forum/src/services/counter_reconciliation.rs
@@ -1,0 +1,318 @@
+use std::time::Instant;
+
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+
+pub const DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT: u64 = 100;
+pub const MAX_FORUM_COUNTER_RECONCILIATION_LIMIT: u64 = 500;
+const FORUM_COUNTER_RECONCILIATION_OPERATION: &str = "forum.counter_reconciliation_report";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumCounterDriftKind {
+    TopicReplyCount,
+    CategoryTopicCount,
+    CategoryReplyCount,
+}
+
+impl ForumCounterDriftKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TopicReplyCount => "topic_reply_count",
+            Self::CategoryTopicCount => "category_topic_count",
+            Self::CategoryReplyCount => "category_reply_count",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumCounterDrift {
+    pub kind: ForumCounterDriftKind,
+    pub subject_id: Uuid,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumCounterReconciliationReport {
+    pub requested_limit: Option<u64>,
+    pub effective_limit: u64,
+    pub inspected_topics: u64,
+    pub inspected_categories: u64,
+    pub has_more_topics: bool,
+    pub has_more_categories: bool,
+    pub drifts: Vec<ForumCounterDrift>,
+}
+
+impl ForumCounterReconciliationReport {
+    pub fn drift_count(&self) -> usize {
+        self.drifts.len()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.drifts.is_empty()
+    }
+}
+
+/// Read-only Forum owner reconciliation for denormalized category/topic counters.
+///
+/// The report deliberately performs no repair. A future write path must add the FORUM-33
+/// requirements for operator RBAC, dry-run, audit and durable idempotent job state before it can
+/// mutate any owner counter. This service is tenant-scoped and bounded independently for topics and
+/// categories so an operator request cannot turn into an unbounded table scan.
+pub struct ForumCounterReconciliationService {
+    db: DatabaseConnection,
+}
+
+impl ForumCounterReconciliationService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn report(
+        &self,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+    ) -> ForumResult<ForumCounterReconciliationReport> {
+        rustok_telemetry::metrics::record_module_entrypoint_call(
+            "forum",
+            "counter_reconciliation_report",
+            "library",
+        );
+        let started_at = Instant::now();
+        let result = self.report_inner(tenant_id, requested_limit).await;
+        rustok_telemetry::metrics::record_span_duration(
+            FORUM_COUNTER_RECONCILIATION_OPERATION,
+            started_at.elapsed().as_secs_f64(),
+        );
+        if result.is_err() {
+            rustok_telemetry::metrics::record_span_error(
+                FORUM_COUNTER_RECONCILIATION_OPERATION,
+                "database",
+            );
+            rustok_telemetry::metrics::record_module_error("forum", "database", "error");
+        }
+        result
+    }
+
+    async fn report_inner(
+        &self,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+    ) -> ForumResult<ForumCounterReconciliationReport> {
+        let effective_limit = requested_limit
+            .unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT)
+            .clamp(1, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT);
+        let fetch_limit = effective_limit.saturating_add(1);
+        let backend = self.db.get_database_backend();
+        let topic_rows = self
+            .db
+            .query_all(counter_statement(
+                backend,
+                TOPIC_COUNTER_SQLITE,
+                TOPIC_COUNTER_POSTGRES,
+                tenant_id,
+                fetch_limit,
+            )?)
+            .await?;
+        let category_rows = self
+            .db
+            .query_all(counter_statement(
+                backend,
+                CATEGORY_COUNTER_SQLITE,
+                CATEGORY_COUNTER_POSTGRES,
+                tenant_id,
+                fetch_limit,
+            )?)
+            .await?;
+
+        let has_more_topics = topic_rows.len() > effective_limit as usize;
+        let has_more_categories = category_rows.len() > effective_limit as usize;
+        let mut drifts = Vec::new();
+
+        for row in topic_rows.iter().take(effective_limit as usize) {
+            let subject_id: Uuid = row.try_get("", "id")?;
+            let stored: i64 = row.try_get("", "stored_reply_count")?;
+            let expected: i64 = row.try_get("", "expected_reply_count")?;
+            if stored != expected {
+                drifts.push(ForumCounterDrift {
+                    kind: ForumCounterDriftKind::TopicReplyCount,
+                    subject_id,
+                    stored,
+                    expected,
+                });
+            }
+        }
+
+        for row in category_rows.iter().take(effective_limit as usize) {
+            let subject_id: Uuid = row.try_get("", "id")?;
+            let stored_topics: i64 = row.try_get("", "stored_topic_count")?;
+            let expected_topics: i64 = row.try_get("", "expected_topic_count")?;
+            let stored_replies: i64 = row.try_get("", "stored_reply_count")?;
+            let expected_replies: i64 = row.try_get("", "expected_reply_count")?;
+            if stored_topics != expected_topics {
+                drifts.push(ForumCounterDrift {
+                    kind: ForumCounterDriftKind::CategoryTopicCount,
+                    subject_id,
+                    stored: stored_topics,
+                    expected: expected_topics,
+                });
+            }
+            if stored_replies != expected_replies {
+                drifts.push(ForumCounterDrift {
+                    kind: ForumCounterDriftKind::CategoryReplyCount,
+                    subject_id,
+                    stored: stored_replies,
+                    expected: expected_replies,
+                });
+            }
+        }
+
+        Ok(ForumCounterReconciliationReport {
+            requested_limit,
+            effective_limit,
+            inspected_topics: topic_rows.len().min(effective_limit as usize) as u64,
+            inspected_categories: category_rows.len().min(effective_limit as usize) as u64,
+            has_more_topics,
+            has_more_categories,
+            drifts,
+        })
+    }
+}
+
+fn counter_statement(
+    backend: DatabaseBackend,
+    sqlite_sql: &str,
+    postgres_sql: &str,
+    tenant_id: Uuid,
+    limit: u64,
+) -> ForumResult<Statement> {
+    let values = vec![tenant_id.into(), (limit as i64).into()];
+    match backend {
+        DatabaseBackend::Sqlite => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            sqlite_sql,
+            values,
+        )),
+        DatabaseBackend::Postgres => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            postgres_sql,
+            values,
+        )),
+        other => Err(ForumError::Validation(format!(
+            "Forum counter reconciliation does not support database backend {other:?}"
+        ))),
+    }
+}
+
+const TOPIC_COUNTER_SQLITE: &str = r#"
+SELECT
+    t.id AS id,
+    CAST(t.reply_count AS INTEGER) AS stored_reply_count,
+    CAST(COUNT(r.id) AS INTEGER) AS expected_reply_count
+FROM forum_topics t
+LEFT JOIN forum_replies r
+    ON r.tenant_id = t.tenant_id
+   AND r.topic_id = t.id
+   AND r.status = 'approved'
+WHERE t.tenant_id = ?1
+GROUP BY t.id, t.reply_count
+ORDER BY t.id
+LIMIT ?2
+"#;
+
+const TOPIC_COUNTER_POSTGRES: &str = r#"
+SELECT
+    t.id AS id,
+    t.reply_count::BIGINT AS stored_reply_count,
+    COUNT(r.id)::BIGINT AS expected_reply_count
+FROM forum_topics t
+LEFT JOIN forum_replies r
+    ON r.tenant_id = t.tenant_id
+   AND r.topic_id = t.id
+   AND r.status = 'approved'
+WHERE t.tenant_id = $1
+GROUP BY t.id, t.reply_count
+ORDER BY t.id
+LIMIT $2
+"#;
+
+const CATEGORY_COUNTER_SQLITE: &str = r#"
+SELECT
+    c.id AS id,
+    CAST(c.topic_count AS INTEGER) AS stored_topic_count,
+    CAST(c.reply_count AS INTEGER) AS stored_reply_count,
+    CAST(COUNT(DISTINCT t.id) AS INTEGER) AS expected_topic_count,
+    CAST(COALESCE(SUM(CASE WHEN r.status = 'approved' THEN 1 ELSE 0 END), 0) AS INTEGER)
+        AS expected_reply_count
+FROM forum_categories c
+LEFT JOIN forum_topics t
+    ON t.tenant_id = c.tenant_id
+   AND t.category_id = c.id
+LEFT JOIN forum_replies r
+    ON r.tenant_id = t.tenant_id
+   AND r.topic_id = t.id
+WHERE c.tenant_id = ?1
+GROUP BY c.id, c.topic_count, c.reply_count
+ORDER BY c.id
+LIMIT ?2
+"#;
+
+const CATEGORY_COUNTER_POSTGRES: &str = r#"
+SELECT
+    c.id AS id,
+    c.topic_count::BIGINT AS stored_topic_count,
+    c.reply_count::BIGINT AS stored_reply_count,
+    COUNT(DISTINCT t.id)::BIGINT AS expected_topic_count,
+    COALESCE(SUM(CASE WHEN r.status = 'approved' THEN 1 ELSE 0 END), 0)::BIGINT
+        AS expected_reply_count
+FROM forum_categories c
+LEFT JOIN forum_topics t
+    ON t.tenant_id = c.tenant_id
+   AND t.category_id = c.id
+LEFT JOIN forum_replies r
+    ON r.tenant_id = t.tenant_id
+   AND r.topic_id = t.id
+WHERE c.tenant_id = $1
+GROUP BY c.id, c.topic_count, c.reply_count
+ORDER BY c.id
+LIMIT $2
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconciliation_limit_is_bounded() {
+        assert_eq!(
+            None.unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT),
+            DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT
+        );
+        assert_eq!(
+            Some(10_000_u64)
+                .unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT)
+                .clamp(1, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT),
+            MAX_FORUM_COUNTER_RECONCILIATION_LIMIT
+        );
+    }
+
+    #[test]
+    fn drift_kind_names_are_stable() {
+        assert_eq!(
+            ForumCounterDriftKind::TopicReplyCount.as_str(),
+            "topic_reply_count"
+        );
+        assert_eq!(
+            ForumCounterDriftKind::CategoryTopicCount.as_str(),
+            "category_topic_count"
+        );
+        assert_eq!(
+            ForumCounterDriftKind::CategoryReplyCount.as_str(),
+            "category_reply_count"
+        );
+    }
+}

--- a/crates/rustok-forum/src/services/counter_reconciliation.rs
+++ b/crates/rustok-forum/src/services/counter_reconciliation.rs
@@ -1,6 +1,9 @@
 use std::time::Instant;
 
-use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
+use sea_orm::{
+    AccessMode, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction,
+    IsolationLevel, Statement, TransactionTrait,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -63,6 +66,9 @@ impl ForumCounterReconciliationReport {
 /// requirements for operator RBAC, dry-run, audit and durable idempotent job state before it can
 /// mutate any owner counter. This service is tenant-scoped and bounded independently for topics and
 /// categories so an operator request cannot turn into an unbounded table scan.
+///
+/// Both aggregate reads are fenced by one database snapshot. PostgreSQL uses `REPEATABLE READ`
+/// with `READ ONLY`; SQLite uses one ordinary transaction whose first read establishes the snapshot.
 pub struct ForumCounterReconciliationService {
     db: DatabaseConnection,
 }
@@ -91,9 +97,13 @@ impl ForumCounterReconciliationService {
         if result.is_err() {
             rustok_telemetry::metrics::record_span_error(
                 FORUM_COUNTER_RECONCILIATION_OPERATION,
-                "database",
+                "owner_report",
             );
-            rustok_telemetry::metrics::record_module_error("forum", "database", "error");
+            rustok_telemetry::metrics::record_module_error(
+                "forum",
+                "counter_reconciliation",
+                "error",
+            );
         }
         result
     }
@@ -103,13 +113,51 @@ impl ForumCounterReconciliationService {
         tenant_id: Uuid,
         requested_limit: Option<u64>,
     ) -> ForumResult<ForumCounterReconciliationReport> {
+        let backend = self.db.get_database_backend();
+        let transaction = match backend {
+            DatabaseBackend::Postgres => {
+                self.db
+                    .begin_with_config(
+                        Some(IsolationLevel::RepeatableRead),
+                        Some(AccessMode::ReadOnly),
+                    )
+                    .await?
+            }
+            DatabaseBackend::Sqlite => self.db.begin().await?,
+            other => {
+                return Err(ForumError::Validation(format!(
+                    "Forum counter reconciliation does not support database backend {other:?}"
+                )));
+            }
+        };
+
+        let report = self
+            .report_in_transaction(&transaction, backend, tenant_id, requested_limit)
+            .await;
+        match report {
+            Ok(report) => {
+                transaction.commit().await?;
+                Ok(report)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn report_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        backend: DatabaseBackend,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+    ) -> ForumResult<ForumCounterReconciliationReport> {
         let effective_limit = requested_limit
             .unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT)
             .clamp(1, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT);
         let fetch_limit = effective_limit.saturating_add(1);
-        let backend = self.db.get_database_backend();
-        let topic_rows = self
-            .db
+        let topic_rows = transaction
             .query_all(counter_statement(
                 backend,
                 TOPIC_COUNTER_SQLITE,
@@ -118,8 +166,7 @@ impl ForumCounterReconciliationService {
                 fetch_limit,
             )?)
             .await?;
-        let category_rows = self
-            .db
+        let category_rows = transaction
             .query_all(counter_statement(
                 backend,
                 CATEGORY_COUNTER_SQLITE,

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -41,6 +41,7 @@ mod category_tree {
     include!("category_tree_visibility.rs");
 }
 mod category_visibility;
+mod counter_reconciliation;
 pub mod event;
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]
 mod mention_relation;
@@ -175,6 +176,11 @@ pub use category_topic_create_audience::{
 pub use category_visibility::{
     ForumCategoryVisibilityPolicy, ForumCategoryVisibilityPolicyService,
     SetForumCategoryVisibilityPolicyInput,
+};
+pub use counter_reconciliation::{
+    DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, ForumCounterDrift, ForumCounterDriftKind,
+    ForumCounterReconciliationReport, ForumCounterReconciliationService,
+    MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
 };
 pub use event::ForumEventService;
 #[allow(unused_imports)]

--- a/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
@@ -25,6 +25,8 @@ forum_topics:manage
 
 Tenant identity is taken only from the trusted `TenantContext`. The query does not accept another tenant id and rejects an auth/tenant context mismatch.
 
+Authorization is deliberately enforced twice. GraphQL rejects missing manage permissions early for a clear transport error, then builds the exact `SecurityContext` from the authenticated permission snapshot. `ForumCounterReconciliationService` independently requires `ForumCategories/Manage` and `ForumTopics/Manage` through the existing Forum `services::rbac::enforce_scope` helper before opening a database snapshot. A future CLI or host adapter therefore cannot gain reconciliation access merely by bypassing the GraphQL resolver.
+
 ## Counter invariants
 
 The owner report checks the existing publication-accounting invariants without mutating them:

--- a/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
@@ -1,0 +1,81 @@
+# FORUM-33 counter reconciliation actualization — 2026-08-08
+
+Status: `in-progress / bounded-owner-report-source-ready / repair-and-runtime-evidence-open`
+
+## Rechecked cursor
+
+FORUM-32 no longer has an unimplemented Forum/Page Builder source path. Its owner preview, property editing, browser harness, direct runtime-authorization harness and deployed server-function attestation are source-ready; maintainer execution, the Pages reference-consumer gate and observed Wave remain outside this source slice.
+
+The next real Forum source gap is FORUM-33: analytics, observability and reconciliation integrated with platform operations.
+
+## Delivered FORUM-33A source
+
+This slice adds a read-only `ForumCounterReconciliationService` owned by `rustok-forum` and exposes it through a dedicated Forum GraphQL operator query:
+
+```text
+forumCounterReconciliationReport(limit: Int)
+```
+
+The query is available only when the Forum module is enabled for the request tenant and the authenticated principal has both effective permissions:
+
+```text
+forum_categories:manage
+forum_topics:manage
+```
+
+Tenant identity is taken only from the trusted `TenantContext`. The query does not accept another tenant id and rejects an auth/tenant context mismatch.
+
+## Counter invariants
+
+The owner report checks the existing publication-accounting invariants without mutating them:
+
+1. `forum_topics.reply_count` equals the number of `approved` Forum replies for that topic;
+2. `forum_categories.topic_count` equals the number of current Forum topic rows in that category;
+3. `forum_categories.reply_count` equals the number of `approved` Forum replies across topics in that category.
+
+These are the same public-accounting semantics used by topic creation/deletion, reply publication transitions and reply removal. Pending, rejected, hidden, flagged and deleted reply rows do not contribute to public reply counters.
+
+## Bounded database shape
+
+The report executes exactly two tenant-scoped aggregate queries:
+
+- one grouped topic/reply query;
+- one grouped category/topic/reply query.
+
+Each query requests at most `effective_limit + 1` rows so the service can return `has_more_topics` / `has_more_categories` without an unbounded count. The default limit is 100 and the hard maximum is 500. The service therefore avoids per-subject N+1 queries and never scans another tenant through this API.
+
+The implementation contains explicit PostgreSQL and SQLite statements because those are the Forum-supported production/test backends. Other backends fail closed rather than approximating SQL semantics.
+
+## Observability
+
+The owner service reuses platform telemetry instead of defining redundant Forum-only metric families:
+
+- `rustok_module_entrypoint_calls_total` records the `counter_reconciliation_report` library entrypoint;
+- `rustok_span_duration_seconds` records bounded reconciliation latency;
+- `rustok_spans_with_errors_total` and `rustok_module_errors_total` record failed owner report execution.
+
+The report itself is the bounded operational source for exact counter-drift details. A later FORUM-33 metrics slice may add only metrics that cannot be represented truthfully by the existing platform baseline.
+
+## Deliberately not added
+
+This slice does **not** add a repair mutation or CLI repair command. The canonical FORUM-33 repair boundary still requires all of the following before any owner counter can be changed:
+
+- explicit operator RBAC;
+- dry-run semantics;
+- durable audit records;
+- idempotent job/receipt state;
+- bounded retry/recovery behavior;
+- PostgreSQL/SQLite execution evidence.
+
+A separate `rustok-forum-cli` adapter was considered but not added here because adding a new selected CLI provider requires a synchronized workspace dependency and `Cargo.lock` update. This task intentionally does not generate or edit the lockfile without maintainer-run dependency tooling.
+
+## Remaining FORUM-33 scope
+
+- retain SQLite and PostgreSQL execution evidence for clean and intentionally drifted counter fixtures;
+- add bounded reconciliation for accepted-solution state, subscriptions, mentions, attachments and shared-owner projections where authoritative owner contracts permit it;
+- add the audited/idempotent repair job boundary before any write repair;
+- decide the platform CLI adapter together with its synchronized dependency/lock update;
+- add only non-duplicative Forum operational metrics for moderation age/approval/report lag, notification/search lag, unread/activity signals, locale fallback, spam outcomes and remaining owner drift;
+- compose operator UI/CLI surfaces over the same owner report rather than duplicating SQL or policy.
+
+No Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI or runtime evidence was executed while preparing this source slice.

--- a/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
@@ -35,16 +35,18 @@ The owner report checks the existing publication-accounting invariants without m
 
 These are the same public-accounting semantics used by topic creation/deletion, reply publication transitions and reply removal. Pending, rejected, hidden, flagged and deleted reply rows do not contribute to public reply counters.
 
-## Bounded database shape
+## Bounded snapshot database shape
 
-The report executes exactly two tenant-scoped aggregate queries:
+The report executes exactly two tenant-scoped aggregate queries inside one database snapshot:
 
 - one grouped topic/reply query;
 - one grouped category/topic/reply query.
 
+PostgreSQL uses one `REPEATABLE READ READ ONLY` transaction so concurrent Forum writes cannot make the topic and category observations come from different database snapshots. SQLite uses one transaction for both reads; the first read establishes the consistent SQLite snapshot. Failed report construction explicitly rolls the transaction back, while a completed report commits the read-only snapshot.
+
 Each query requests at most `effective_limit + 1` rows so the service can return `has_more_topics` / `has_more_categories` without an unbounded count. The default limit is 100 and the hard maximum is 500. The service therefore avoids per-subject N+1 queries and never scans another tenant through this API.
 
-The implementation contains explicit PostgreSQL and SQLite statements because those are the Forum-supported production/test backends. Other backends fail closed rather than approximating SQL semantics.
+The implementation contains explicit PostgreSQL and SQLite statements because those are the Forum-supported production/test backends. Other backends fail closed rather than approximating SQL or snapshot semantics.
 
 ## Observability
 
@@ -71,7 +73,8 @@ A separate `rustok-forum-cli` adapter was considered but not added here because 
 
 ## Remaining FORUM-33 scope
 
-- retain SQLite and PostgreSQL execution evidence for clean and intentionally drifted counter fixtures;
+- retain SQLite and PostgreSQL execution evidence for clean and intentionally drifted counter fixtures plus snapshot behavior;
+- add bounded continuation/cursor semantics beyond the first bounded topic/category page before treating this report as a complete whole-tenant scanner;
 - add bounded reconciliation for accepted-solution state, subscriptions, mentions, attachments and shared-owner projections where authoritative owner contracts permit it;
 - add the audited/idempotent repair job boundary before any write repair;
 - decide the platform CLI adapter together with its synchronized dependency/lock update;

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -18,14 +18,12 @@ const servicePath = "crates/rustok-forum/src/services/counter_reconciliation.rs"
 const graphqlPath = "crates/rustok-forum/src/graphql/reconciliation_query.rs";
 const graphqlModPath = "crates/rustok-forum/src/graphql/mod.rs";
 const libPath = "crates/rustok-forum/src/lib.rs";
-const planPath = "crates/rustok-forum/docs/implementation-plan.md";
 const packetPath = "docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md";
 
 const service = read(servicePath);
 const graphql = read(graphqlPath);
 const graphqlMod = read(graphqlModPath);
 const lib = read(libPath);
-const plan = read(planPath);
 const packet = read(packetPath);
 
 for (const marker of [
@@ -75,8 +73,7 @@ for (const marker of [
 ]) {
   requireText(graphql, marker, `Forum reconciliation GraphQL boundary missing ${marker}`);
 }
-for (const forbidden of ["tenant_id: Option<Uuid>", "Mutation", "repair", "UPDATE forum_"]) {
-  if (forbidden === "repair") continue;
+for (const forbidden of ["tenant_id: Option<Uuid>", "Mutation", "UPDATE forum_"]) {
   requireAbsent(graphql, forbidden, `operator report must not expose ${forbidden}`);
 }
 
@@ -94,12 +91,6 @@ for (const marker of [
   requireText(lib, marker, `Forum owner export missing ${marker}`);
 }
 
-requireText(plan, "| `FORUM-33` | `in_progress` |", "canonical Forum plan must mark FORUM-33 in progress");
-requireText(
-  plan,
-  "Bounded owner counter reconciliation report",
-  "canonical Forum plan must describe the delivered FORUM-33 counter report",
-);
 for (const marker of [
   "Status: `in-progress / bounded-owner-report-source-ready / repair-and-runtime-evidence-open`",
   "forumCounterReconciliationReport(limit: Int)",

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -43,6 +43,13 @@ for (const marker of [
   "effective_limit.saturating_add(1)",
   "has_more_topics",
   "has_more_categories",
+  "begin_with_config(",
+  "IsolationLevel::RepeatableRead",
+  "AccessMode::ReadOnly",
+  "DatabaseBackend::Sqlite => self.db.begin().await?",
+  "report_in_transaction(&transaction",
+  "transaction.commit().await?",
+  "transaction.rollback().await",
   "record_module_entrypoint_call(",
   '"counter_reconciliation_report"',
   "record_span_duration(",
@@ -56,7 +63,6 @@ for (const forbidden of [
   "DELETE FROM forum_",
   "INSERT INTO forum_",
   "ActiveModel",
-  "TransactionTrait",
 ]) {
   requireAbsent(service, forbidden, `read-only reconciliation service must not contain ${forbidden}`);
 }
@@ -96,7 +102,8 @@ for (const marker of [
   "forumCounterReconciliationReport(limit: Int)",
   "forum_categories:manage",
   "forum_topics:manage",
-  "exactly two tenant-scoped aggregate queries",
+  "exactly two tenant-scoped aggregate queries inside one database snapshot",
+  "REPEATABLE READ READ ONLY",
   "does **not** add a repair mutation",
   "idempotent job/receipt state",
 ]) {

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -35,6 +35,10 @@ for (const marker of [
   "pub const MAX_FORUM_COUNTER_RECONCILIATION_LIMIT: u64 = 500",
   "pub struct ForumCounterReconciliationService",
   "pub struct ForumCounterReconciliationReport",
+  "security: &SecurityContext",
+  "enforce_operations_scope(security)",
+  "enforce_scope(security, Resource::ForumCategories, Action::Manage)?",
+  "enforce_scope(security, Resource::ForumTopics, Action::Manage)",
   "ForumCounterDriftKind::TopicReplyCount",
   "ForumCounterDriftKind::CategoryTopicCount",
   "ForumCounterDriftKind::CategoryReplyCount",
@@ -88,7 +92,9 @@ for (const marker of [
   "Permission::FORUM_TOPICS_MANAGE",
   "categories_manage && topics_manage",
   "auth.tenant_id != tenant.id",
+  "SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions)",
   "ForumCounterReconciliationService::new(db.clone())",
+  ".report(tenant.id, &security, requested_limit)",
 ]) {
   requireText(graphql, marker, `Forum reconciliation GraphQL boundary missing ${marker}`);
 }
@@ -132,6 +138,8 @@ for (const marker of [
   "forumCounterReconciliationReport(limit: Int)",
   "forum_categories:manage",
   "forum_topics:manage",
+  "Authorization is deliberately enforced twice",
+  "services::rbac::enforce_scope",
   "exactly two tenant-scoped aggregate queries inside one database snapshot",
   "REPEATABLE READ READ ONLY",
   "does **not** add a repair mutation",

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const servicePath = "crates/rustok-forum/src/services/counter_reconciliation.rs";
+const graphqlPath = "crates/rustok-forum/src/graphql/reconciliation_query.rs";
+const graphqlModPath = "crates/rustok-forum/src/graphql/mod.rs";
+const libPath = "crates/rustok-forum/src/lib.rs";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const packetPath = "docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md";
+
+const service = read(servicePath);
+const graphql = read(graphqlPath);
+const graphqlMod = read(graphqlModPath);
+const lib = read(libPath);
+const plan = read(planPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "pub const DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT: u64 = 100",
+  "pub const MAX_FORUM_COUNTER_RECONCILIATION_LIMIT: u64 = 500",
+  "pub struct ForumCounterReconciliationService",
+  "pub struct ForumCounterReconciliationReport",
+  "ForumCounterDriftKind::TopicReplyCount",
+  "ForumCounterDriftKind::CategoryTopicCount",
+  "ForumCounterDriftKind::CategoryReplyCount",
+  "r.status = 'approved'",
+  "WHERE t.tenant_id = ?1",
+  "WHERE t.tenant_id = $1",
+  "WHERE c.tenant_id = ?1",
+  "WHERE c.tenant_id = $1",
+  "COUNT(DISTINCT t.id)",
+  "effective_limit.saturating_add(1)",
+  "has_more_topics",
+  "has_more_categories",
+  "record_module_entrypoint_call(",
+  '"counter_reconciliation_report"',
+  "record_span_duration(",
+]) {
+  requireText(service, marker, `Forum counter reconciliation service missing ${marker}`);
+}
+
+for (const forbidden of [
+  "UPDATE forum_topics",
+  "UPDATE forum_categories",
+  "DELETE FROM forum_",
+  "INSERT INTO forum_",
+  "ActiveModel",
+  "TransactionTrait",
+]) {
+  requireAbsent(service, forbidden, `read-only reconciliation service must not contain ${forbidden}`);
+}
+
+for (const marker of [
+  "pub struct ForumReconciliationQuery",
+  "forum_counter_reconciliation_report",
+  "require_module_enabled(ctx, MODULE_SLUG).await?",
+  "Permission::FORUM_CATEGORIES_MANAGE",
+  "Permission::FORUM_TOPICS_MANAGE",
+  "categories_manage && topics_manage",
+  "auth.tenant_id != tenant.id",
+  "ForumCounterReconciliationService::new(db.clone())",
+]) {
+  requireText(graphql, marker, `Forum reconciliation GraphQL boundary missing ${marker}`);
+}
+for (const forbidden of ["tenant_id: Option<Uuid>", "Mutation", "repair", "UPDATE forum_"]) {
+  if (forbidden === "repair") continue;
+  requireAbsent(graphql, forbidden, `operator report must not expose ${forbidden}`);
+}
+
+for (const marker of [
+  "mod reconciliation_query;",
+  "reconciliation_query::ForumReconciliationQuery",
+]) {
+  requireText(graphqlMod, marker, `Forum GraphQL composition missing ${marker}`);
+}
+for (const marker of [
+  '#[path = "services/counter_reconciliation.rs"]',
+  "ForumCounterReconciliationService",
+  "MAX_FORUM_COUNTER_RECONCILIATION_LIMIT",
+]) {
+  requireText(lib, marker, `Forum owner export missing ${marker}`);
+}
+
+requireText(plan, "| `FORUM-33` | `in_progress` |", "canonical Forum plan must mark FORUM-33 in progress");
+requireText(
+  plan,
+  "Bounded owner counter reconciliation report",
+  "canonical Forum plan must describe the delivered FORUM-33 counter report",
+);
+for (const marker of [
+  "Status: `in-progress / bounded-owner-report-source-ready / repair-and-runtime-evidence-open`",
+  "forumCounterReconciliationReport(limit: Int)",
+  "forum_categories:manage",
+  "forum_topics:manage",
+  "exactly two tenant-scoped aggregate queries",
+  "does **not** add a repair mutation",
+  "idempotent job/receipt state",
+]) {
+  requireText(packet, marker, `FORUM-33 actualization missing ${marker}`);
+}
+
+console.log("Forum FORUM-33 counter reconciliation source: ok");

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -15,15 +15,19 @@ function requireAbsent(text, marker, message) {
 }
 
 const servicePath = "crates/rustok-forum/src/services/counter_reconciliation.rs";
+const servicesModPath = "crates/rustok-forum/src/services/mod.rs";
 const graphqlPath = "crates/rustok-forum/src/graphql/reconciliation_query.rs";
 const graphqlModPath = "crates/rustok-forum/src/graphql/mod.rs";
 const libPath = "crates/rustok-forum/src/lib.rs";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
 const packetPath = "docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md";
 
 const service = read(servicePath);
+const servicesMod = read(servicesModPath);
 const graphql = read(graphqlPath);
 const graphqlMod = read(graphqlModPath);
 const lib = read(libPath);
+const plan = read(planPath);
 const packet = read(packetPath);
 
 for (const marker of [
@@ -68,6 +72,15 @@ for (const forbidden of [
 }
 
 for (const marker of [
+  "mod counter_reconciliation;",
+  "pub use counter_reconciliation::{",
+  "ForumCounterReconciliationService",
+  "MAX_FORUM_COUNTER_RECONCILIATION_LIMIT",
+]) {
+  requireText(servicesMod, marker, `Forum services composition missing ${marker}`);
+}
+
+for (const marker of [
   "pub struct ForumReconciliationQuery",
   "forum_counter_reconciliation_report",
   "require_module_enabled(ctx, MODULE_SLUG).await?",
@@ -90,11 +103,28 @@ for (const marker of [
   requireText(graphqlMod, marker, `Forum GraphQL composition missing ${marker}`);
 }
 for (const marker of [
-  '#[path = "services/counter_reconciliation.rs"]',
+  "pub mod services;",
   "ForumCounterReconciliationService",
   "MAX_FORUM_COUNTER_RECONCILIATION_LIMIT",
 ]) {
   requireText(lib, marker, `Forum owner export missing ${marker}`);
+}
+requireAbsent(
+  lib,
+  '#[path = "services/counter_reconciliation.rs"]',
+  "Forum reconciliation must use the canonical services module boundary",
+);
+
+for (const marker of [
+  "| `FORUM-33` | `in_progress` | Bounded snapshot-consistent owner counter reconciliation report",
+  "## `FORUM-33` — analytics, observability and reconciliation",
+  "**Status:** `in_progress`",
+  "forumCounterReconciliationReport(limit: Int)",
+  "REPEATABLE READ READ ONLY",
+  "node scripts/verify/verify-forum-counter-reconciliation-source.mjs",
+  "For FORUM-33, retain SQLite and PostgreSQL execution evidence",
+]) {
+  requireText(plan, marker, `canonical Forum plan missing ${marker}`);
 }
 
 for (const marker of [


### PR DESCRIPTION
## Summary

Start the real FORUM-33 platform-operations source work after the FORUM-32 Page Builder source path reached execution-only status.

- add a Forum-owned read-only counter reconciliation service for `topic.reply_count`, `category.topic_count`, and `category.reply_count` using the existing Approved-only public reply accounting semantics;
- execute the topic and category aggregate reads inside one bounded database snapshot: PostgreSQL `REPEATABLE READ READ ONLY`, one SQLite transaction;
- cap each shape at a default 100 / hard 500 rows and return `has_more_topics` / `has_more_categories` rather than performing an unbounded count or N+1 reads;
- expose `forumCounterReconciliationReport(limit: Int)` through the existing Forum GraphQL query composition;
- derive tenant only from trusted request context, reject auth/tenant mismatch, and require both effective `forum_categories:manage` and `forum_topics:manage`;
- reauthorize both Manage scopes again inside `ForumCounterReconciliationService` through the canonical Forum service RBAC helper, with GraphQL passing an exact `SecurityContext` permission snapshot;
- reuse platform module/span/error telemetry instead of introducing redundant Forum-only metric families;
- update the canonical Forum plan to `FORUM-33 = in_progress`, add the source guard and record the next continuation cursor.

## Deliberately open

This is the first bounded report page, not a complete whole-tenant scanner. Independent topic/category continuation remains the next source step. Counter repair remains blocked until the write path has explicit operator RBAC, dry-run semantics, durable audit, idempotent job/receipt state and bounded recovery. A `rustok-forum-cli` adapter is also deferred because selecting a new CLI provider requires a synchronized workspace dependency and `Cargo.lock` update.

## Dependencies / migrations

No Cargo.toml, Cargo.lock, package dependency, schema or migration changes.

## Validation

Per maintainer instruction, no Cargo tests/checks, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was run. Review in this PR is source-only.