### PR TITLE
test(groups): retain localization GraphQL SQLite parity

### DIFF
--- a/apps/server/tests/groups_localization_graphql_sqlite_parity.rs
+++ b/apps/server/tests/groups_localization_graphql_sqlite_parity.rs
@@ -1,0 +1,444 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use async_graphql::{EmptySubscription, Request, Response, Schema};
+use rustok_api::{AuthContext, HostRuntimeContext, PortActor, PortContext, TenantContext};
+use rustok_groups::graphql_application_cas::{GroupsMutationRoot, GroupsQueryRoot};
+use rustok_groups::{
+    DeleteGroupTranslationRequest, GroupLocalizationCommandPort, GroupLocalizationReadPort,
+    GroupLocalizationService, ListGroupTranslationsRequest, UpsertGroupTranslationRequest,
+};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups localization GraphQL parity SQLite connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for localization GraphQL parity evidence");
+    }
+}
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp
+        .path()
+        .join("groups-localization-graphql-parity.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    native_group_id: Uuid,
+    graphql_group_id: Uuid,
+    owner_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES
+    ('{native_group_id}', '{tenant_id}', '{owner_id}', 'localization-native-parity', 1),
+    ('{graphql_group_id}', '{tenant_id}', '{owner_id}', 'localization-graphql-parity', 1);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{native_group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{graphql_group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups localization GraphQL parity fixture should seed");
+}
+
+fn tenant_context(tenant_id: Uuid) -> TenantContext {
+    TenantContext {
+        id: tenant_id,
+        name: "Groups localization GraphQL parity".to_string(),
+        slug: "groups-localization-graphql-parity".to_string(),
+        domain: None,
+        settings: serde_json::json!({}),
+        default_locale: "en".to_string(),
+        is_active: true,
+    }
+}
+
+fn auth_context(tenant_id: Uuid, owner_id: Uuid) -> AuthContext {
+    AuthContext {
+        user_id: owner_id,
+        session_id: Uuid::new_v4(),
+        tenant_id,
+        permissions: Vec::new(),
+        client_id: None,
+        scopes: Vec::new(),
+        grant_type: "direct".to_string(),
+    }
+}
+
+fn native_read_context(tenant_id: Uuid, owner_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(owner_id.to_string()),
+        "en",
+        format!("groups-localization-native-read-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(5))
+}
+
+fn native_write_context(tenant_id: Uuid, owner_id: Uuid, operation: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(owner_id.to_string()),
+        "en",
+        format!("groups-localization-native-write-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(5))
+    .with_idempotency_key(format!("{operation}-{}", Uuid::new_v4()))
+}
+
+fn graphql_schema(
+    db: DatabaseConnection,
+) -> Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription> {
+    Schema::build(
+        GroupsQueryRoot::default(),
+        GroupsMutationRoot::default(),
+        EmptySubscription,
+    )
+    .data(HostRuntimeContext::new(db))
+    .finish()
+}
+
+async fn execute_graphql(
+    schema: &Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription>,
+    tenant_id: Uuid,
+    owner_id: Uuid,
+    document: String,
+) -> Response {
+    schema
+        .execute(
+            Request::new(document)
+                .data(tenant_context(tenant_id))
+                .data(auth_context(tenant_id, owner_id)),
+        )
+        .await
+}
+
+fn response_json(response: Response) -> serde_json::Value {
+    assert!(
+        response.errors.is_empty(),
+        "Groups localization GraphQL parity request should succeed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .into_json()
+        .expect("Groups localization GraphQL parity data should convert to JSON")
+}
+
+fn extension_json(error: &async_graphql::ServerError, key: &str) -> Option<serde_json::Value> {
+    error
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get(key))
+        .cloned()
+        .and_then(|value| value.into_json().ok())
+}
+
+#[tokio::test]
+async fn localization_native_and_final_graphql_share_owner_semantics_sqlite() {
+    let temp = tempfile::tempdir()
+        .expect("temporary Groups localization GraphQL parity directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let db = connect(&url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let native_group_id = Uuid::new_v4();
+    let graphql_group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    seed_group_fixture(
+        &db,
+        tenant_id,
+        native_group_id,
+        graphql_group_id,
+        owner_id,
+    )
+    .await;
+
+    let native = GroupLocalizationService::new(db.clone());
+    let schema = graphql_schema(db.clone());
+
+    let native_en = GroupLocalizationCommandPort::upsert_group_translation(
+        &native,
+        native_write_context(tenant_id, owner_id, "native-en"),
+        UpsertGroupTranslationRequest {
+            group_id: native_group_id,
+            locale: "en".to_string(),
+            title: "English title".to_string(),
+            summary: Some("English summary".to_string()),
+            body: Some("English body".to_string()),
+        },
+    )
+    .await
+    .expect("native English localization should succeed");
+
+    let graphql_en = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  upsertGroupTranslation(
+    idempotencyKey: "graphql-en",
+    groupId: "{graphql_group_id}",
+    input: {{
+      locale: "en",
+      title: "English title",
+      summary: "English summary",
+      body: "English body"
+    }}
+  ) {{
+    translation {{ groupId locale title summary body }}
+    groupVersion
+    created
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    let graphql_en = &graphql_en["upsertGroupTranslation"];
+    assert_eq!(graphql_en["created"].as_bool(), Some(native_en.created));
+    assert_eq!(graphql_en["groupVersion"].as_u64(), Some(native_en.group_version));
+    assert_eq!(graphql_en["translation"]["locale"], native_en.translation.locale);
+    assert_eq!(graphql_en["translation"]["title"], native_en.translation.title);
+    assert_eq!(
+        graphql_en["translation"]["summary"],
+        native_en.translation.summary.as_deref()
+    );
+    assert_eq!(
+        graphql_en["translation"]["body"],
+        native_en.translation.body.as_deref()
+    );
+    assert_eq!(
+        graphql_en["translation"]["groupId"],
+        graphql_group_id.to_string()
+    );
+
+    let native_fr = GroupLocalizationCommandPort::upsert_group_translation(
+        &native,
+        native_write_context(tenant_id, owner_id, "native-fr"),
+        UpsertGroupTranslationRequest {
+            group_id: native_group_id,
+            locale: "fr".to_string(),
+            title: "Titre français".to_string(),
+            summary: None,
+            body: Some("Corps français".to_string()),
+        },
+    )
+    .await
+    .expect("native French localization should succeed");
+
+    let graphql_fr = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  upsertGroupTranslation(
+    idempotencyKey: "graphql-fr",
+    groupId: "{graphql_group_id}",
+    input: {{ locale: "fr", title: "Titre français", body: "Corps français" }}
+  ) {{
+    translation {{ locale title summary body }}
+    groupVersion
+    created
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    let graphql_fr = &graphql_fr["upsertGroupTranslation"];
+    assert_eq!(graphql_fr["created"].as_bool(), Some(native_fr.created));
+    assert_eq!(graphql_fr["groupVersion"].as_u64(), Some(native_fr.group_version));
+    assert_eq!(graphql_fr["translation"]["locale"], native_fr.translation.locale);
+    assert_eq!(graphql_fr["translation"]["title"], native_fr.translation.title);
+    assert!(graphql_fr["translation"]["summary"].is_null());
+    assert_eq!(
+        graphql_fr["translation"]["body"],
+        native_fr.translation.body.as_deref()
+    );
+
+    let native_list = GroupLocalizationReadPort::list_group_translations(
+        &native,
+        native_read_context(tenant_id, owner_id),
+        ListGroupTranslationsRequest {
+            group_id: native_group_id,
+        },
+    )
+    .await
+    .expect("native localization read should succeed");
+    let graphql_list = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+query {{
+  groupTranslations(groupId: "{graphql_group_id}") {{ locale title summary body }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    let graphql_list = graphql_list["groupTranslations"]
+        .as_array()
+        .expect("GraphQL localization list should be an array");
+    assert_eq!(graphql_list.len(), native_list.len());
+    for (graphql_item, native_item) in graphql_list.iter().zip(native_list.iter()) {
+        assert_eq!(graphql_item["locale"], native_item.locale);
+        assert_eq!(graphql_item["title"], native_item.title);
+        assert_eq!(graphql_item["summary"], native_item.summary.as_deref());
+        assert_eq!(graphql_item["body"], native_item.body.as_deref());
+    }
+
+    let native_delete = GroupLocalizationCommandPort::delete_group_translation(
+        &native,
+        native_write_context(tenant_id, owner_id, "native-delete-fr"),
+        DeleteGroupTranslationRequest {
+            group_id: native_group_id,
+            locale: "fr".to_string(),
+        },
+    )
+    .await
+    .expect("native French localization delete should succeed");
+    let graphql_delete = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  deleteGroupTranslation(
+    idempotencyKey: "graphql-delete-fr",
+    groupId: "{graphql_group_id}",
+    locale: "fr"
+  ) {{ groupId locale groupVersion }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    let graphql_delete = &graphql_delete["deleteGroupTranslation"];
+    assert_eq!(graphql_delete["groupId"], graphql_group_id.to_string());
+    assert_eq!(graphql_delete["locale"], native_delete.locale);
+    assert_eq!(
+        graphql_delete["groupVersion"].as_u64(),
+        Some(native_delete.group_version)
+    );
+
+    let native_last_error = GroupLocalizationCommandPort::delete_group_translation(
+        &native,
+        native_write_context(tenant_id, owner_id, "native-delete-last"),
+        DeleteGroupTranslationRequest {
+            group_id: native_group_id,
+            locale: "en".to_string(),
+        },
+    )
+    .await
+    .expect_err("native last translation delete must fail closed");
+    assert_eq!(native_last_error.code, "groups.conflict");
+    assert!(!native_last_error.retryable);
+
+    let graphql_last = execute_graphql(
+        &schema,
+        tenant_id,
+        owner_id,
+        format!(
+            r#"
+mutation {{
+  deleteGroupTranslation(
+    idempotencyKey: "graphql-delete-last",
+    groupId: "{graphql_group_id}",
+    locale: "en"
+  ) {{ groupVersion }}
+}}
+"#
+        ),
+    )
+    .await;
+    assert_eq!(graphql_last.errors.len(), 1);
+    let graphql_last_error = &graphql_last.errors[0];
+    assert_eq!(graphql_last_error.message, native_last_error.message);
+    assert_eq!(
+        extension_json(graphql_last_error, "code")
+            .and_then(|value| value.as_str().map(str::to_owned)),
+        Some("BAD_USER_INPUT".to_string())
+    );
+
+    let native_final = GroupLocalizationReadPort::list_group_translations(
+        &native,
+        native_read_context(tenant_id, owner_id),
+        ListGroupTranslationsRequest {
+            group_id: native_group_id,
+        },
+    )
+    .await
+    .expect("native final localization read should succeed");
+    let graphql_final = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+query {{
+  groupTranslations(groupId: "{graphql_group_id}") {{ locale title }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    assert_eq!(native_final.len(), 1);
+    assert_eq!(native_final[0].locale, "en");
+    let graphql_final = graphql_final["groupTranslations"]
+        .as_array()
+        .expect("final GraphQL localization list should be an array");
+    assert_eq!(graphql_final.len(), 1);
+    assert_eq!(graphql_final[0]["locale"], "en");
+
+    drop(schema);
+    drop(native);
+    drop(db);
+    drop(temp);
+}

--- a/apps/server/tests/groups_localization_graphql_sqlite_parity.rs
+++ b/apps/server/tests/groups_localization_graphql_sqlite_parity.rs
@@ -231,19 +231,27 @@ mutation {{
     let graphql_en = &graphql_en["upsertGroupTranslation"];
     assert_eq!(graphql_en["created"].as_bool(), Some(native_en.created));
     assert_eq!(graphql_en["groupVersion"].as_u64(), Some(native_en.group_version));
-    assert_eq!(graphql_en["translation"]["locale"], native_en.translation.locale);
-    assert_eq!(graphql_en["translation"]["title"], native_en.translation.title);
     assert_eq!(
-        graphql_en["translation"]["summary"],
+        graphql_en["translation"]["locale"].as_str(),
+        Some(native_en.translation.locale.as_str())
+    );
+    assert_eq!(
+        graphql_en["translation"]["title"].as_str(),
+        Some(native_en.translation.title.as_str())
+    );
+    assert_eq!(
+        graphql_en["translation"]["summary"].as_str(),
         native_en.translation.summary.as_deref()
     );
     assert_eq!(
-        graphql_en["translation"]["body"],
+        graphql_en["translation"]["body"].as_str(),
         native_en.translation.body.as_deref()
     );
     assert_eq!(
-        graphql_en["translation"]["groupId"],
-        graphql_group_id.to_string()
+        graphql_en["translation"]["groupId"]
+            .as_str()
+            .map(str::to_owned),
+        Some(graphql_group_id.to_string())
     );
 
     let native_fr = GroupLocalizationCommandPort::upsert_group_translation(
@@ -286,11 +294,17 @@ mutation {{
     let graphql_fr = &graphql_fr["upsertGroupTranslation"];
     assert_eq!(graphql_fr["created"].as_bool(), Some(native_fr.created));
     assert_eq!(graphql_fr["groupVersion"].as_u64(), Some(native_fr.group_version));
-    assert_eq!(graphql_fr["translation"]["locale"], native_fr.translation.locale);
-    assert_eq!(graphql_fr["translation"]["title"], native_fr.translation.title);
+    assert_eq!(
+        graphql_fr["translation"]["locale"].as_str(),
+        Some(native_fr.translation.locale.as_str())
+    );
+    assert_eq!(
+        graphql_fr["translation"]["title"].as_str(),
+        Some(native_fr.translation.title.as_str())
+    );
     assert!(graphql_fr["translation"]["summary"].is_null());
     assert_eq!(
-        graphql_fr["translation"]["body"],
+        graphql_fr["translation"]["body"].as_str(),
         native_fr.translation.body.as_deref()
     );
 
@@ -323,10 +337,10 @@ query {{
         .expect("GraphQL localization list should be an array");
     assert_eq!(graphql_list.len(), native_list.len());
     for (graphql_item, native_item) in graphql_list.iter().zip(native_list.iter()) {
-        assert_eq!(graphql_item["locale"], native_item.locale);
-        assert_eq!(graphql_item["title"], native_item.title);
-        assert_eq!(graphql_item["summary"], native_item.summary.as_deref());
-        assert_eq!(graphql_item["body"], native_item.body.as_deref());
+        assert_eq!(graphql_item["locale"].as_str(), Some(native_item.locale.as_str()));
+        assert_eq!(graphql_item["title"].as_str(), Some(native_item.title.as_str()));
+        assert_eq!(graphql_item["summary"].as_str(), native_item.summary.as_deref());
+        assert_eq!(graphql_item["body"].as_str(), native_item.body.as_deref());
     }
 
     let native_delete = GroupLocalizationCommandPort::delete_group_translation(
@@ -359,8 +373,14 @@ mutation {{
         .await,
     );
     let graphql_delete = &graphql_delete["deleteGroupTranslation"];
-    assert_eq!(graphql_delete["groupId"], graphql_group_id.to_string());
-    assert_eq!(graphql_delete["locale"], native_delete.locale);
+    assert_eq!(
+        graphql_delete["groupId"].as_str().map(str::to_owned),
+        Some(graphql_group_id.to_string())
+    );
+    assert_eq!(
+        graphql_delete["locale"].as_str(),
+        Some(native_delete.locale.as_str())
+    );
     assert_eq!(
         graphql_delete["groupVersion"].as_u64(),
         Some(native_delete.group_version)
@@ -435,7 +455,7 @@ query {{
         .as_array()
         .expect("final GraphQL localization list should be an array");
     assert_eq!(graphql_final.len(), 1);
-    assert_eq!(graphql_final[0]["locale"], "en");
+    assert_eq!(graphql_final[0]["locale"].as_str(), Some("en"));
 
     drop(schema);
     drop(native);

--- a/crates/rustok-groups/docs/localization-graphql-sqlite-parity-contract.md
+++ b/crates/rustok-groups/docs/localization-graphql-sqlite-parity-contract.md
@@ -1,0 +1,54 @@
+# Groups localization native/GraphQL SQLite parity contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_localization_graphql_sqlite_parity.rs` retains executable source evidence that the stable final Groups GraphQL root and the native localization ports expose the same Groups-owned localization semantics on SQLite.
+
+The packet uses one real temporary file-backed SQLite database, all production Groups migrations, `GroupLocalizationService`, and `graphql_application_cas::{GroupsQueryRoot, GroupsMutationRoot}`. It adds no alternate GraphQL mutation path, direct localization-table mutation, fallback, dependency, or manifest change.
+
+## Equivalent owner fixtures
+
+The test creates two equivalent public Groups owned by the same authenticated user with no platform `groups:manage` permission:
+
+- one group is exercised through `GroupLocalizationReadPort` / `GroupLocalizationCommandPort`;
+- the other is exercised through the stable final GraphQL root.
+
+Because each group starts with the same aggregate version and equivalent owner membership, matching mutations must return matching owner versions and localization payload semantics without pretending that two transports mutate one aggregate concurrently.
+
+## Parity contract
+
+The packet requires parity for:
+
+- English translation creation, including normalized locale, title, summary, body, `created`, and group version;
+- French translation creation with nullable summary and matching group version;
+- exact-locale ordered management reads through native `list_group_translations` and GraphQL `groupTranslations`;
+- French translation deletion with matching locale and group version;
+- last-translation deletion denial: native stable `groups.conflict`, non-retryable owner failure, GraphQL `BAD_USER_INPUT`, and the exact same owner-safe message;
+- final state containing only the English translation on both equivalent groups.
+
+The GraphQL request carries the exact tenant-bound owner principal and an empty permission list. Local owner authority therefore remains a Groups owner-domain decision rather than a transport-side platform permission shortcut.
+
+## Final-root composition
+
+The test builds the same stable `graphql_application_cas::GroupsQueryRoot` / `GroupsMutationRoot` entrypoints published by the module manifest. Localization reaches that root through the existing merged chain; the evidence does not instantiate `GroupsLocalizationMutation` as a private alternate schema.
+
+## Execution status
+
+The packet was not executed while preparing this slice. FBA `localization_transport_parity` therefore remains null until maintainer execution.
+
+Maintainer command:
+
+```bash
+cargo test -p rustok-server --features mod-groups \
+  --test groups_localization_graphql_sqlite_parity -- --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-localization-graphql-sqlite-parity.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, browser/schema execution, workflow, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-localization-graphql-sqlite-parity.mjs
+++ b/scripts/verify/verify-groups-localization-graphql-sqlite-parity.mjs
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_localization_graphql_sqlite_parity.rs";
+const docsPath = "crates/rustok-groups/docs/localization-graphql-sqlite-parity-contract.md";
+const registryPath = "crates/rustok-groups/contracts/groups-fba-registry.json";
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "rustok_groups::migrations::migrations()",
+  "GroupsQueryRoot::default()",
+  "GroupsMutationRoot::default()",
+  "HostRuntimeContext::new(db)",
+  "AuthContext",
+  "TenantContext",
+  "permissions: Vec::new()",
+  "GroupLocalizationService::new",
+  "GroupLocalizationCommandPort::upsert_group_translation",
+  "GroupLocalizationReadPort::list_group_translations",
+  "GroupLocalizationCommandPort::delete_group_translation",
+  "upsertGroupTranslation",
+  "groupTranslations",
+  "deleteGroupTranslation",
+  'assert_eq!(native_last_error.code, "groups.conflict")',
+  'Some("BAD_USER_INPUT".to_string())',
+  "graphql_last_error.message, native_last_error.message",
+  "graphql_en[\"groupVersion\"].as_u64(), Some(native_en.group_version)",
+  "graphql_fr[\"groupVersion\"].as_u64(), Some(native_fr.group_version)",
+  "Some(native_delete.group_version)",
+  "graphql_final.len(), 1",
+]) {
+  requireText(test, marker, `Groups localization GraphQL SQLite parity source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "translation::ActiveModel",
+  "GroupsLocalizationMutation::default()",
+  "rustok_moderation::",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups localization GraphQL SQLite parity source contains shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "executable source added / maintainer execution pending",
+  "Equivalent owner fixtures",
+  "Parity contract",
+  "groups.conflict",
+  "BAD_USER_INPUT",
+  "Final-root composition",
+  "localization_transport_parity",
+  "empty permission list",
+]) {
+  requireText(docs, marker, `Groups localization GraphQL SQLite parity handoff is missing ${marker}`);
+}
+
+if (registry?.evidence?.localization_transport_parity !== null) {
+  throw new Error("unexecuted localization transport parity evidence must remain null");
+}
+
+console.log("Groups localization native/GraphQL SQLite parity source guard passed");


### PR DESCRIPTION
## Summary
- add file-backed SQLite executable source for native versus final-GraphQL Groups localization parity
- use two equivalent owner-controlled groups, all production Groups migrations, `GroupLocalizationService`, and the stable `graphql_application_cas` final query/mutation roots
- retain matching English/French upsert payloads and aggregate versions across native and GraphQL paths
- compare ordered exact-locale management reads
- retain matching French deletion semantics and group versions
- prove last-translation delete fails natively with stable `groups.conflict` and through GraphQL as `BAD_USER_INPUT` with the same owner-safe message
- use an authenticated local owner with no platform `groups:manage` permission so authorization remains owner-domain behavior
- add a focused handoff/guard while keeping FBA `localization_transport_parity` null until maintainer execution
- add no dependency, manifest, lockfile, registry, production-owner, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, browser/schema execution, workflows, and CI were intentionally not run per maintainer instruction.