### PR TITLE
refactor(commerce): cut Product schema writes to owner port

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -2,28 +2,34 @@
 
 ## Scope
 
-This source-only continuation follows the completed Product read/lifecycle cutovers and rechecks the remaining mounted Commerce GraphQL schema-write boundary. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write cutover item remains open in this slice.
+This source-only continuation follows Product schema-write capability publication and rechecks the mounted Commerce GraphQL consumers plus the active Product Admin callers. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open in this slice.
 
 ## Current source result
 
-- Product now publishes `ProductCatalogSchemaWritePort` as a transport-neutral owner capability for every Product schema write currently used by mounted Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
-- The embedded `ProductCatalogSchemaService` implements the port and derives tenant/actor only from validated `PortContext`.
-- Every call requires `PortCallPolicy::write()`, so caller context must carry write policy requirements including idempotency identity and deadline before owner execution is admitted.
-- Product schema-write failures are mapped to stable `PortError` codes/messages while internal database/validation/core causes remain in owner logs rather than public messages.
-- `ProductCatalogCommandRuntime` now carries an optional `ProductCatalogSchemaWritePort`. `in_process` composes the embedded owner provider; external command profiles remain fail-closed until a host explicitly supplies a schema-write provider.
+- Product publishes `ProductCatalogSchemaWritePort` for every Product schema write used by mounted Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
+- Mounted Commerce GraphQL no longer constructs `ProductCatalogSchemaService` for those writes. Every successful schema-write path resolves the host-selected `ProductCatalogCommandRuntime`, obtains its optional `schema_write_port()`, and fails closed with bounded `PRODUCT_TEMPORARILY_UNAVAILABLE` when an external profile has not supplied the capability.
+- Schema writes derive tenant/actor/claims/request context from `PortContext`, retain the existing two-second Product command deadline, and scope-hash the caller key with tenant, authenticated actor, operation, and Product id when one exists.
+- The active Product Admin transport no longer re-exports schema-write calls from the legacy GraphQL adapter. It sends `$idempotencyKey: String!` for all eleven schema mutations and retains one caller key across an explicit retry of the same failed operation + intent; success releases the key for a later equal user action.
+- Product owner schema-write failures continue through stable `PortError` mapping and bounded Commerce public codes rather than exposing owner database/validation details.
+
+## Why the GraphQL SDL is still nullable
+
+The mounted schema-write resolver inputs intentionally remain `Option<String>` in this slice. Omission is rejected with `BAD_USER_INPUT` / `Product schema mutation idempotency key is required` after existing module, permission, tenant-actor, and mutation-input admission has run.
+
+This preserves the current `admin_graphql_rejects_foreign_actor_for_every_product_mutation` fixture, which intentionally omits schema-write keys while asserting that every Product mutation reaches tenant/actor admission. Making these arguments non-null immediately would move the failure to GraphQL required-argument validation and erase the regression signal. Active Product Admin callers already send non-null keys, so successful mounted schema-write execution has no compatibility-generated identity.
+
+The next narrow SDL step is therefore to add explicit keys to those foreign-actor schema mutation callers and then change all eleven resolver arguments from `Option<String>` to `String`.
 
 ## Why the canonical item remains open
 
-Mounted Commerce GraphQL still constructs `ProductCatalogSchemaService` directly for schema writes. This PR only publishes and composes the owner capability; it does not yet cut those consumers over.
+The embedded `ProductCatalogSchemaService` still does not persist a command receipt keyed by `PortContext.idempotency_key`. Caller identity is now explicit and retained by Product Admin across failed explicit retries, but durable owner replay/adoption semantics must not be inferred from that boundary contract. A response lost after owner commit can still make a create retry unsafe until Product persists/replays the completed outcome.
 
-The embedded schema service also does not currently persist a command receipt keyed by `PortContext.idempotency_key`. `PortCallPolicy::write()` makes caller identity mandatory at the boundary, but durable replay/adoption semantics must not be inferred from that validation alone.
+Remaining source order:
 
-The next source slice therefore remains:
-
-1. define mounted GraphQL caller idempotency input/identity for the schema-write mutations without breaking Product Admin callers;
-2. replace every direct `ProductCatalogSchemaService` construction in mounted Commerce schema writes with the host-selected `ProductCatalogSchemaWritePort`;
-3. decide and implement the owner-local durable replay/receipt contract needed for non-idempotent create operations before claiming retry-safe write semantics;
-4. update canonical completion only when both consumer cutover and the intended idempotency semantics are source-complete.
+1. update the foreign-actor regression document with explicit schema-write caller keys and make mounted schema-write `idempotencyKey` non-null;
+2. implement the owner-local durable receipt/replay contract needed for non-idempotent schema creates and define the outcome for update-style writes;
+3. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
+4. update canonical completion only when mounted non-null caller identity and intended owner replay semantics are source-complete.
 
 ## Verification state
 

--- a/crates/rustok-commerce/src/graphql/mutations/catalog.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/catalog.rs
@@ -8,11 +8,11 @@ use sha2::{Digest, Sha256};
 use std::time::Duration;
 use uuid::Uuid;
 
-use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogSchemaService};
+use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogSchemaWritePort};
 
 use super::super::{
-    PRODUCT_MODULE_SLUG as MODULE_SLUG, map_product_service_error, product_mutation_actor,
-    require_commerce_permission, types::*,
+    PRODUCT_MODULE_SLUG as MODULE_SLUG, product_mutation_actor, require_commerce_permission,
+    types::*,
 };
 use super::helpers::*;
 
@@ -109,6 +109,27 @@ fn product_command_context(
     Ok(context)
 }
 
+fn product_schema_write_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    product_id: Option<Uuid>,
+    idempotency_key: Option<String>,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let idempotency_key = idempotency_key.ok_or_else(|| {
+        invalid_product_idempotency_key("Product schema mutation idempotency key is required")
+    })?;
+    product_command_context(
+        ctx,
+        tenant_id,
+        user_id,
+        product_id,
+        idempotency_key,
+        operation,
+    )
+}
+
 fn product_command_port_error(
     context: &PortContext,
     error: PortError,
@@ -158,6 +179,29 @@ fn product_command_port_error(
         extensions.set("code", code);
         extensions.set("retryable", error.retryable);
         extensions.set("correlation_id", context.correlation_id.clone());
+    })
+}
+
+fn product_schema_write_port(
+    ctx: &Context<'_>,
+    context: &PortContext,
+) -> Result<std::sync::Arc<dyn ProductCatalogSchemaWritePort>> {
+    let runtime = product_command_runtime(ctx)?;
+    runtime.schema_write_port().ok_or_else(|| {
+        tracing::error!(
+            profile = runtime.profile().as_str(),
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            code = "product.schema_write_port_unavailable",
+            "Product GraphQL schema-write capability is unavailable"
+        );
+        async_graphql::Error::new("Product data is temporarily unavailable").extend_with(
+            |_, extensions| {
+                extensions.set("code", "PRODUCT_TEMPORARILY_UNAVAILABLE");
+                extensions.set("retryable", true);
+                extensions.set("correlation_id", context.correlation_id.clone());
+            },
+        )
     })
 }
 
@@ -330,6 +374,7 @@ impl CommerceCatalogMutation {
     async fn create_product_attribute(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         locale: String,
         input: CreateProductAttributeInput,
     ) -> Result<bool> {
@@ -340,50 +385,51 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        service
-            .create_attribute(
-                tenant_id,
-                user_id,
-                rustok_product::services::CreateProductAttributeInput {
-                    code: input.code,
-                    value_type: parse_attribute_value_type(&input.value_type)?,
-                    scope: "product".to_string(),
-                    is_localized: input.is_localized,
-                    is_filterable: input.is_filterable,
-                    is_searchable: input.is_searchable,
-                    is_sortable: input.is_sortable,
-                    is_comparable: false,
-                    show_on_storefront: input.show_on_storefront,
-                    show_in_admin_grid: true,
-                    search_weight: 0,
-                    filter_display: None,
-                    facet_mode: None,
-                    position: 0,
-                    validation: serde_json::Value::Object(Default::default()),
-                    default_value: None,
-                    metadata: serde_json::Value::Object(Default::default()),
-                    translations: vec![rustok_product::services::AttributeTranslationInput {
-                        locale,
-                        label: input.label,
-                        help_text: input.help_text,
-                        facet_label: None,
-                        seo_label: None,
-                    }],
-                },
-            )
+        let domain_input = rustok_product::services::CreateProductAttributeInput {
+            code: input.code,
+            value_type: parse_attribute_value_type(&input.value_type)?,
+            scope: "product".to_string(),
+            is_localized: input.is_localized,
+            is_filterable: input.is_filterable,
+            is_searchable: input.is_searchable,
+            is_sortable: input.is_sortable,
+            is_comparable: false,
+            show_on_storefront: input.show_on_storefront,
+            show_in_admin_grid: true,
+            search_weight: 0,
+            filter_display: None,
+            facet_mode: None,
+            position: 0,
+            validation: serde_json::Value::Object(Default::default()),
+            default_value: None,
+            metadata: serde_json::Value::Object(Default::default()),
+            translations: vec![rustok_product::services::AttributeTranslationInput {
+                locale,
+                label: input.label,
+                help_text: input.help_text,
+                facet_label: None,
+                seo_label: None,
+            }],
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_attribute",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .create_attribute(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
-
+            .map_err(|error| product_command_port_error(&port_context, error, "create_attribute"))?;
         Ok(true)
     }
 
     async fn create_product_attribute_option(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         locale: String,
         input: CreateProductAttributeOptionInput,
     ) -> Result<bool> {
@@ -394,31 +440,37 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        ProductCatalogSchemaService::new(db.clone(), event_bus.clone())
-            .create_attribute_option(
-                tenant_id,
-                user_id,
-                rustok_product::services::CreateProductAttributeOptionInput {
-                    attribute_id: input.attribute_id,
-                    code: input.code,
-                    position: input.position,
-                    metadata: serde_json::Value::Object(Default::default()),
-                    translations: vec![rustok_product::services::AttributeOptionTranslationInput {
-                        locale,
-                        label: input.label,
-                    }],
-                },
-            )
+        let domain_input = rustok_product::services::CreateProductAttributeOptionInput {
+            attribute_id: input.attribute_id,
+            code: input.code,
+            position: input.position,
+            metadata: serde_json::Value::Object(Default::default()),
+            translations: vec![rustok_product::services::AttributeOptionTranslationInput {
+                locale,
+                label: input.label,
+            }],
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_attribute_option",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .create_attribute_option(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "create_attribute_option")
+            })?;
         Ok(true)
     }
 
     async fn create_catalog_category(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         locale: String,
         input: CreateCatalogCategoryInput,
     ) -> Result<bool> {
@@ -429,40 +481,41 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        service
-            .create_category(
-                tenant_id,
-                user_id,
-                rustok_product::services::CreateCatalogCategoryInput {
-                    parent_id: input.parent_id,
-                    code: input.code,
-                    slug: input.slug,
-                    kind: parse_catalog_category_kind(&input.kind)?,
-                    position: 0,
-                    rule_config: serde_json::Value::Object(Default::default()),
-                    metadata: serde_json::Value::Object(Default::default()),
-                    translations: vec![rustok_product::services::CategoryTranslationInput {
-                        locale,
-                        name: input.name,
-                        description: input.description,
-                        meta_title: None,
-                        meta_description: None,
-                    }],
-                },
-            )
+        let domain_input = rustok_product::services::CreateCatalogCategoryInput {
+            parent_id: input.parent_id,
+            code: input.code,
+            slug: input.slug,
+            kind: parse_catalog_category_kind(&input.kind)?,
+            position: 0,
+            rule_config: serde_json::Value::Object(Default::default()),
+            metadata: serde_json::Value::Object(Default::default()),
+            translations: vec![rustok_product::services::CategoryTranslationInput {
+                locale,
+                name: input.name,
+                description: input.description,
+                meta_title: None,
+                meta_description: None,
+            }],
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_category",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .create_category(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
-
+            .map_err(|error| product_command_port_error(&port_context, error, "create_category"))?;
         Ok(true)
     }
 
     async fn create_product_attribute_schema(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         locale: String,
         input: CreateProductAttributeSchemaInput,
     ) -> Result<bool> {
@@ -473,33 +526,34 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        service
-            .create_schema(
-                tenant_id,
-                user_id,
-                rustok_product::services::CreateProductAttributeSchemaInput {
-                    code: input.code,
-                    metadata: serde_json::Value::Object(Default::default()),
-                    translations: vec![rustok_product::services::SchemaTranslationInput {
-                        locale,
-                        name: input.name,
-                        description: input.description,
-                    }],
-                },
-            )
+        let domain_input = rustok_product::services::CreateProductAttributeSchemaInput {
+            code: input.code,
+            metadata: serde_json::Value::Object(Default::default()),
+            translations: vec![rustok_product::services::SchemaTranslationInput {
+                locale,
+                name: input.name,
+                description: input.description,
+            }],
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_schema",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .create_schema(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
-
+            .map_err(|error| product_command_port_error(&port_context, error, "create_schema"))?;
         Ok(true)
     }
 
     async fn create_product_attribute_schema_group(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         locale: String,
         input: CreateProductAttributeSchemaGroupInput,
     ) -> Result<bool> {
@@ -510,32 +564,37 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        ProductCatalogSchemaService::new(db.clone(), event_bus.clone())
-            .create_schema_group(
-                tenant_id,
-                user_id,
-                rustok_product::services::CreateProductAttributeSchemaGroupInput {
-                    schema_id: input.schema_id,
-                    code: input.code,
-                    position: input.position,
-                    metadata: serde_json::Value::Object(Default::default()),
-                    translations: vec![rustok_product::services::AttributeGroupTranslationInput {
-                        locale,
-                        label: input.label,
-                    }],
-                },
-            )
+        let domain_input = rustok_product::services::CreateProductAttributeSchemaGroupInput {
+            schema_id: input.schema_id,
+            code: input.code,
+            position: input.position,
+            metadata: serde_json::Value::Object(Default::default()),
+            translations: vec![rustok_product::services::AttributeGroupTranslationInput {
+                locale,
+                label: input.label,
+            }],
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_schema_group",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .create_schema_group(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "create_schema_group")
+            })?;
         Ok(true)
     }
 
     async fn create_catalog_category_attribute_group(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         locale: String,
         input: CreateCategoryAttributeGroupInput,
     ) -> Result<bool> {
@@ -546,32 +605,37 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        ProductCatalogSchemaService::new(db.clone(), event_bus.clone())
-            .create_category_group(
-                tenant_id,
-                user_id,
-                rustok_product::services::CreateCategoryAttributeGroupInput {
-                    category_id: input.category_id,
-                    code: input.code,
-                    position: input.position,
-                    metadata: serde_json::Value::Object(Default::default()),
-                    translations: vec![rustok_product::services::AttributeGroupTranslationInput {
-                        locale,
-                        label: input.label,
-                    }],
-                },
-            )
+        let domain_input = rustok_product::services::CreateCategoryAttributeGroupInput {
+            category_id: input.category_id,
+            code: input.code,
+            position: input.position,
+            metadata: serde_json::Value::Object(Default::default()),
+            translations: vec![rustok_product::services::AttributeGroupTranslationInput {
+                locale,
+                label: input.label,
+            }],
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "create_category_group",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .create_category_group(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "create_category_group")
+            })?;
         Ok(true)
     }
 
     async fn set_catalog_category_schema_mode(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         input: SetCategorySchemaModeInput,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -581,30 +645,33 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        service
-            .set_category_schema_mode(
-                tenant_id,
-                user_id,
-                rustok_product::services::SetCategorySchemaModeInput {
-                    category_id: input.category_id,
-                    mode: parse_category_schema_mode(&input.mode)?,
-                    schema_id: input.schema_id,
-                    clone_from_category_id: input.clone_from_category_id,
-                },
-            )
+        let domain_input = rustok_product::services::SetCategorySchemaModeInput {
+            category_id: input.category_id,
+            mode: parse_category_schema_mode(&input.mode)?,
+            schema_id: input.schema_id,
+            clone_from_category_id: input.clone_from_category_id,
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "set_category_schema_mode",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .set_category_schema_mode(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
-
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "set_category_schema_mode")
+            })?;
         Ok(true)
     }
 
     async fn bind_product_attribute_schema_attribute(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         input: BindSchemaAttributeInput,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -614,35 +681,38 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        service
-            .bind_schema_attribute(
-                tenant_id,
-                user_id,
-                rustok_product::services::BindSchemaAttributeInput {
-                    schema_id: input.schema_id,
-                    attribute_id: input.attribute_id,
-                    group_code: input.group_code,
-                    is_required: input.is_required,
-                    is_disabled: input.is_disabled,
-                    position: input.position,
-                    visibility_overrides: serde_json::Value::Object(Default::default()),
-                    validation_overrides: serde_json::Value::Object(Default::default()),
-                    metadata: serde_json::Value::Object(Default::default()),
-                },
-            )
+        let domain_input = rustok_product::services::BindSchemaAttributeInput {
+            schema_id: input.schema_id,
+            attribute_id: input.attribute_id,
+            group_code: input.group_code,
+            is_required: input.is_required,
+            is_disabled: input.is_disabled,
+            position: input.position,
+            visibility_overrides: serde_json::Value::Object(Default::default()),
+            validation_overrides: serde_json::Value::Object(Default::default()),
+            metadata: serde_json::Value::Object(Default::default()),
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "bind_schema_attribute",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .bind_schema_attribute(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
-
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "bind_schema_attribute")
+            })?;
         Ok(true)
     }
 
     async fn bind_catalog_category_attribute(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         input: BindCategoryAttributeInput,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -652,36 +722,39 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let service = ProductCatalogSchemaService::new(db.clone(), event_bus.clone());
-        service
-            .bind_category_attribute(
-                tenant_id,
-                user_id,
-                rustok_product::services::BindCategoryAttributeInput {
-                    category_id: input.category_id,
-                    attribute_id: input.attribute_id,
-                    group_code: input.group_code,
-                    binding_kind: parse_category_attribute_binding_kind(&input.binding_kind)?,
-                    is_required: input.is_required,
-                    is_disabled: input.is_disabled,
-                    position: input.position,
-                    visibility_overrides: serde_json::Value::Object(Default::default()),
-                    validation_overrides: serde_json::Value::Object(Default::default()),
-                    metadata: serde_json::Value::Object(Default::default()),
-                },
-            )
+        let domain_input = rustok_product::services::BindCategoryAttributeInput {
+            category_id: input.category_id,
+            attribute_id: input.attribute_id,
+            group_code: input.group_code,
+            binding_kind: parse_category_attribute_binding_kind(&input.binding_kind)?,
+            is_required: input.is_required,
+            is_disabled: input.is_disabled,
+            position: input.position,
+            visibility_overrides: serde_json::Value::Object(Default::default()),
+            validation_overrides: serde_json::Value::Object(Default::default()),
+            metadata: serde_json::Value::Object(Default::default()),
+        };
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            None,
+            idempotency_key,
+            "bind_category_attribute",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .bind_category_attribute(port_context.clone(), domain_input)
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))?;
-
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "bind_category_attribute")
+            })?;
         Ok(true)
     }
 
     async fn save_product_attribute_values(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         product_id: Uuid,
         locale: String,
         patches: Vec<ProductAttributeValuePatchInput>,
@@ -693,23 +766,36 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
         let patches = patches
             .into_iter()
             .map(parse_product_attribute_value_patch)
             .collect::<Result<Vec<_>>>()?;
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        ProductCatalogSchemaService::new(db.clone(), event_bus.clone())
-            .save_product_attribute_values(tenant_id, user_id, product_id, locale.trim(), patches)
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            Some(product_id),
+            idempotency_key,
+            "save_product_attribute_values",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
+            .save_product_attribute_values(
+                port_context.clone(),
+                product_id,
+                locale.trim().to_string(),
+                patches,
+            )
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))
+            .map_err(|error| {
+                product_command_port_error(&port_context, error, "save_product_attribute_values")
+            })
             .map(|items| items.into_iter().map(Into::into).collect())
     }
 
     async fn clear_detached_product_attribute_values(
         &self,
         ctx: &Context<'_>,
+        idempotency_key: Option<String>,
         product_id: Uuid,
         locale: String,
         attribute_ids: Vec<Uuid>,
@@ -721,19 +807,29 @@ impl CommerceCatalogMutation {
             "Permission denied: products:manage required",
         )?;
         let (tenant_id, user_id) = product_mutation_actor(ctx)?;
-
-        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        ProductCatalogSchemaService::new(db.clone(), event_bus.clone())
+        let port_context = product_schema_write_context(
+            ctx,
+            tenant_id,
+            user_id,
+            Some(product_id),
+            idempotency_key,
+            "clear_detached_product_attribute_values",
+        )?;
+        product_schema_write_port(ctx, &port_context)?
             .clear_detached_product_attribute_values(
-                tenant_id,
-                user_id,
+                port_context.clone(),
                 product_id,
-                locale.trim(),
+                locale.trim().to_string(),
                 attribute_ids,
             )
             .await
-            .map_err(|error| map_product_service_error(error, "product_catalog_mutation"))
+            .map_err(|error| {
+                product_command_port_error(
+                    &port_context,
+                    error,
+                    "clear_detached_product_attribute_values",
+                )
+            })
             .map(|items| items.into_iter().map(Into::into).collect())
     }
 }

--- a/crates/rustok-product/admin/src/catalog_transport_retry.rs
+++ b/crates/rustok-product/admin/src/catalog_transport_retry.rs
@@ -10,9 +10,14 @@ use crate::model::{ProductDetail, ProductDraft};
 
 pub use crate::legacy_transport::fetch_catalog_search_options;
 pub(crate) use crate::legacy_transport::{
-    clear_detached_product_attribute_values, fetch_bootstrap, fetch_catalog_categories,
-    fetch_effective_product_form, fetch_product, fetch_product_attribute_values,
-    fetch_product_pricing, fetch_products, fetch_shipping_profiles, save_product_attribute_values,
+    fetch_bootstrap, fetch_catalog_categories, fetch_effective_product_form, fetch_product,
+    fetch_product_attribute_values, fetch_product_pricing, fetch_products, fetch_shipping_profiles,
+};
+pub(crate) use crate::product_schema_graphql::{
+    bind_category_attribute, bind_schema_attribute, clear_detached_product_attribute_values,
+    create_attribute_schema, create_catalog_category, create_category_attribute_group,
+    create_product_attribute, create_product_attribute_option,
+    create_product_attribute_schema_group, save_product_attribute_values, set_category_schema_mode,
 };
 
 type RetryIdentity = ProductAdminLifecycleRetryIdentity<String>;

--- a/crates/rustok-product/admin/src/lib.rs
+++ b/crates/rustok-product/admin/src/lib.rs
@@ -10,6 +10,9 @@ mod lifecycle_retry_identity;
 mod model;
 #[path = "transport/product_lifecycle_graphql.rs"]
 mod product_lifecycle_graphql;
+#[path = "transport/product_schema_graphql.rs"]
+mod product_schema_graphql;
+mod schema_retry_identity;
 mod ui;
 
 pub use model::{ProductCatalogSearchOption, ProductCatalogSearchOptions};

--- a/crates/rustok-product/admin/src/schema_retry_identity.rs
+++ b/crates/rustok-product/admin/src/schema_retry_identity.rs
@@ -1,0 +1,160 @@
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProductAdminSchemaOperation {
+    CreateAttribute,
+    CreateAttributeOption,
+    CreateCategory,
+    CreateSchema,
+    CreateSchemaGroup,
+    CreateCategoryGroup,
+    SetCategorySchemaMode,
+    BindSchemaAttribute,
+    BindCategoryAttribute,
+    SaveAttributeValues,
+    ClearDetachedAttributeValues,
+}
+
+impl ProductAdminSchemaOperation {
+    pub(crate) const fn key_segment(self) -> &'static str {
+        match self {
+            Self::CreateAttribute => "create-attribute",
+            Self::CreateAttributeOption => "create-attribute-option",
+            Self::CreateCategory => "create-category",
+            Self::CreateSchema => "create-schema",
+            Self::CreateSchemaGroup => "create-schema-group",
+            Self::CreateCategoryGroup => "create-category-group",
+            Self::SetCategorySchemaMode => "set-category-schema-mode",
+            Self::BindSchemaAttribute => "bind-schema-attribute",
+            Self::BindCategoryAttribute => "bind-category-attribute",
+            Self::SaveAttributeValues => "save-attribute-values",
+            Self::ClearDetachedAttributeValues => "clear-detached-attribute-values",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PendingSchemaInvocation<I> {
+    operation: ProductAdminSchemaOperation,
+    intent: I,
+    idempotency_key: String,
+}
+
+/// Product Admin caller identity retained across one explicit retry of the same schema write.
+///
+/// A failed transport/server call keeps the key. Changing the operation or exact intent rotates
+/// it. A successful response must clear the pending identity so a later identical user action is
+/// a new logical write. Owner-side durable replay is a separate contract and is not implied here.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProductAdminSchemaRetryIdentity<I> {
+    pending: Option<PendingSchemaInvocation<I>>,
+}
+
+impl<I> Default for ProductAdminSchemaRetryIdentity<I> {
+    fn default() -> Self {
+        Self { pending: None }
+    }
+}
+
+impl<I> ProductAdminSchemaRetryIdentity<I>
+where
+    I: Clone + PartialEq,
+{
+    pub(crate) fn idempotency_key_for(
+        &mut self,
+        operation: ProductAdminSchemaOperation,
+        intent: &I,
+    ) -> String {
+        if let Some(pending) = self.pending.as_ref()
+            && pending.operation == operation
+            && &pending.intent == intent
+        {
+            return pending.idempotency_key.clone();
+        }
+
+        let idempotency_key = format!(
+            "product-admin-schema:{}:{}",
+            operation.key_segment(),
+            Uuid::new_v4()
+        );
+        self.pending = Some(PendingSchemaInvocation {
+            operation,
+            intent: intent.clone(),
+            idempotency_key: idempotency_key.clone(),
+        });
+        idempotency_key
+    }
+
+    pub(crate) fn mark_succeeded(&mut self) {
+        self.pending = None;
+    }
+
+    #[cfg(test)]
+    fn pending_key(&self) -> Option<&str> {
+        self.pending
+            .as_ref()
+            .map(|pending| pending.idempotency_key.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_retry_reuses_schema_write_caller_key() {
+        let mut identity = ProductAdminSchemaRetryIdentity::default();
+        let intent = "tenant/user/category:123/mode:inherit".to_string();
+        let first = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::SetCategorySchemaMode,
+            &intent,
+        );
+        let retry = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::SetCategorySchemaMode,
+            &intent,
+        );
+        assert_eq!(first, retry);
+        assert_eq!(identity.pending_key(), Some(first.as_str()));
+    }
+
+    #[test]
+    fn changed_schema_write_intent_rotates_key() {
+        let mut identity = ProductAdminSchemaRetryIdentity::default();
+        let first = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::CreateAttribute,
+            &"code=color".to_string(),
+        );
+        let changed = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::CreateAttribute,
+            &"code=size".to_string(),
+        );
+        assert_ne!(first, changed);
+    }
+
+    #[test]
+    fn success_releases_schema_retry_identity() {
+        let mut identity = ProductAdminSchemaRetryIdentity::default();
+        let intent = "product:123/save-values".to_string();
+        let first = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::SaveAttributeValues,
+            &intent,
+        );
+        identity.mark_succeeded();
+        let later = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::SaveAttributeValues,
+            &intent,
+        );
+        assert_ne!(first, later);
+    }
+
+    #[test]
+    fn generated_schema_keys_fit_graphql_limit() {
+        let mut identity = ProductAdminSchemaRetryIdentity::default();
+        let key = identity.idempotency_key_for(
+            ProductAdminSchemaOperation::ClearDetachedAttributeValues,
+            &"intent".to_string(),
+        );
+        assert!(key.starts_with("product-admin-schema:clear-detached-attribute-values:"));
+        assert!(key.len() <= 191);
+    }
+}

--- a/crates/rustok-product/admin/src/transport/product_schema_graphql.rs
+++ b/crates/rustok-product/admin/src/transport/product_schema_graphql.rs
@@ -1,0 +1,534 @@
+#[cfg(target_arch = "wasm32")]
+use leptos::web_sys;
+use rustok_graphql::{GraphqlHttpError, GraphqlRequest, execute as execute_graphql};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::{Mutex, OnceLock};
+
+use crate::model::{
+    BindCategoryAttributeDraft, BindSchemaAttributeDraft, CatalogCategoryDraft,
+    CategoryAttributeGroupDraft, ProductAttributeDraft, ProductAttributeOptionDraft,
+    ProductAttributeSchemaDraft, ProductAttributeSchemaGroupDraft, ProductAttributeValueItem,
+    ProductAttributeValuePatchDraft, SetCategorySchemaModeDraft,
+};
+use crate::schema_retry_identity::{
+    ProductAdminSchemaOperation, ProductAdminSchemaRetryIdentity,
+};
+
+pub type ApiError = GraphqlHttpError;
+
+type RetryIdentity = ProductAdminSchemaRetryIdentity<String>;
+
+const CREATE_PRODUCT_ATTRIBUTE_MUTATION: &str = "mutation ProductAdminCreateAttribute($idempotencyKey: String!, $locale: String!, $input: CreateProductAttributeInput!) { createProductAttribute(idempotencyKey: $idempotencyKey, locale: $locale, input: $input) }";
+const CREATE_PRODUCT_ATTRIBUTE_OPTION_MUTATION: &str = "mutation ProductAdminCreateAttributeOption($idempotencyKey: String!, $locale: String!, $input: CreateProductAttributeOptionInput!) { createProductAttributeOption(idempotencyKey: $idempotencyKey, locale: $locale, input: $input) }";
+const CREATE_CATALOG_CATEGORY_MUTATION: &str = "mutation ProductAdminCreateCatalogCategory($idempotencyKey: String!, $locale: String!, $input: CreateCatalogCategoryInput!) { createCatalogCategory(idempotencyKey: $idempotencyKey, locale: $locale, input: $input) }";
+const CREATE_ATTRIBUTE_SCHEMA_MUTATION: &str = "mutation ProductAdminCreateAttributeSchema($idempotencyKey: String!, $locale: String!, $input: CreateProductAttributeSchemaInput!) { createProductAttributeSchema(idempotencyKey: $idempotencyKey, locale: $locale, input: $input) }";
+const CREATE_SCHEMA_GROUP_MUTATION: &str = "mutation ProductAdminCreateSchemaGroup($idempotencyKey: String!, $locale: String!, $input: CreateProductAttributeSchemaGroupInput!) { createProductAttributeSchemaGroup(idempotencyKey: $idempotencyKey, locale: $locale, input: $input) }";
+const CREATE_CATEGORY_GROUP_MUTATION: &str = "mutation ProductAdminCreateCategoryGroup($idempotencyKey: String!, $locale: String!, $input: CreateCategoryAttributeGroupInput!) { createCatalogCategoryAttributeGroup(idempotencyKey: $idempotencyKey, locale: $locale, input: $input) }";
+const SET_CATEGORY_SCHEMA_MODE_MUTATION: &str = "mutation ProductAdminSetCategorySchemaMode($idempotencyKey: String!, $input: SetCategorySchemaModeInput!) { setCatalogCategorySchemaMode(idempotencyKey: $idempotencyKey, input: $input) }";
+const BIND_SCHEMA_ATTRIBUTE_MUTATION: &str = "mutation ProductAdminBindSchemaAttribute($idempotencyKey: String!, $input: BindSchemaAttributeInput!) { bindProductAttributeSchemaAttribute(idempotencyKey: $idempotencyKey, input: $input) }";
+const BIND_CATEGORY_ATTRIBUTE_MUTATION: &str = "mutation ProductAdminBindCategoryAttribute($idempotencyKey: String!, $input: BindCategoryAttributeInput!) { bindCatalogCategoryAttribute(idempotencyKey: $idempotencyKey, input: $input) }";
+const SAVE_ATTRIBUTE_VALUES_MUTATION: &str = "mutation ProductAdminSaveAttributeValues($idempotencyKey: String!, $productId: UUID!, $locale: String!, $patches: [ProductAttributeValuePatchInput!]!) { saveProductAttributeValues(idempotencyKey: $idempotencyKey, productId: $productId, locale: $locale, patches: $patches) { attributeId kind text integer decimal boolean date datetime optionId optionIds json detached } }";
+const CLEAR_DETACHED_ATTRIBUTE_VALUES_MUTATION: &str = "mutation ProductAdminClearDetachedAttributeValues($idempotencyKey: String!, $productId: UUID!, $locale: String!, $attributeIds: [UUID!]!) { clearDetachedProductAttributeValues(idempotencyKey: $idempotencyKey, productId: $productId, locale: $locale, attributeIds: $attributeIds) { attributeId kind text integer decimal boolean date datetime optionId optionIds json detached } }";
+
+#[derive(Debug, Deserialize)]
+struct BoolMutationResponse {
+    #[serde(rename = "createProductAttribute")]
+    create_product_attribute: Option<bool>,
+    #[serde(rename = "createProductAttributeOption")]
+    create_product_attribute_option: Option<bool>,
+    #[serde(rename = "createCatalogCategory")]
+    create_catalog_category: Option<bool>,
+    #[serde(rename = "createProductAttributeSchema")]
+    create_product_attribute_schema: Option<bool>,
+    #[serde(rename = "createProductAttributeSchemaGroup")]
+    create_product_attribute_schema_group: Option<bool>,
+    #[serde(rename = "createCatalogCategoryAttributeGroup")]
+    create_catalog_category_attribute_group: Option<bool>,
+    #[serde(rename = "setCatalogCategorySchemaMode")]
+    set_catalog_category_schema_mode: Option<bool>,
+    #[serde(rename = "bindProductAttributeSchemaAttribute")]
+    bind_product_attribute_schema_attribute: Option<bool>,
+    #[serde(rename = "bindCatalogCategoryAttribute")]
+    bind_catalog_category_attribute: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SaveAttributeValuesResponse {
+    #[serde(rename = "saveProductAttributeValues")]
+    save_product_attribute_values: Vec<ProductAttributeValueItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClearDetachedAttributeValuesResponse {
+    #[serde(rename = "clearDetachedProductAttributeValues")]
+    clear_detached_product_attribute_values: Vec<ProductAttributeValueItem>,
+}
+
+#[derive(Debug, Serialize)]
+struct LocaleMutationVariables<T> {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    locale: String,
+    input: T,
+}
+
+#[derive(Debug, Serialize)]
+struct InputVariables<T> {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    input: T,
+}
+
+#[derive(Debug, Serialize)]
+struct SaveAttributeValuesVariables {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    #[serde(rename = "productId")]
+    product_id: String,
+    locale: String,
+    patches: Vec<ProductAttributeValuePatchDraft>,
+}
+
+#[derive(Debug, Serialize)]
+struct ClearDetachedAttributeValuesVariables {
+    #[serde(rename = "idempotencyKey")]
+    idempotency_key: String,
+    #[serde(rename = "productId")]
+    product_id: String,
+    locale: String,
+    #[serde(rename = "attributeIds")]
+    attribute_ids: Vec<String>,
+}
+
+fn graphql_url() -> String {
+    if let Some(url) = option_env!("RUSTOK_GRAPHQL_URL") {
+        return url.to_string();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let origin = web_sys::window()
+            .and_then(|window| window.location().origin().ok())
+            .unwrap_or_else(|| "http://localhost:5150".to_string());
+        format!("{origin}/api/graphql")
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let base =
+            std::env::var("RUSTOK_API_URL").unwrap_or_else(|_| "http://localhost:5150".to_string());
+        format!("{base}/api/graphql")
+    }
+}
+
+async fn request<V, T>(
+    query: &str,
+    variables: Option<V>,
+    token: Option<String>,
+    tenant_slug: Option<String>,
+) -> Result<T, ApiError>
+where
+    V: Serialize,
+    T: for<'de> Deserialize<'de>,
+{
+    execute_graphql(
+        &graphql_url(),
+        GraphqlRequest::new(query, variables),
+        token,
+        tenant_slug,
+        None,
+    )
+    .await
+}
+
+fn retry_registry() -> &'static Mutex<HashMap<String, RetryIdentity>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, RetryIdentity>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn retry_slot(
+    operation: ProductAdminSchemaOperation,
+    tenant_id: &str,
+    actor_id: &str,
+    target: &str,
+) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        operation.key_segment(),
+        tenant_id,
+        actor_id,
+        target
+    )
+}
+
+fn write_intent<T: Debug>(
+    operation: ProductAdminSchemaOperation,
+    tenant_id: &str,
+    actor_id: &str,
+    payload: &T,
+) -> String {
+    format!(
+        "operation={};tenant={tenant_id:?};actor={actor_id:?};payload={payload:?}",
+        operation.key_segment()
+    )
+}
+
+fn retained_caller_key(
+    slot: &str,
+    operation: ProductAdminSchemaOperation,
+    intent: String,
+) -> String {
+    let mut registry = retry_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry
+        .entry(slot.to_string())
+        .or_default()
+        .idempotency_key_for(operation, &intent)
+}
+
+fn mark_succeeded(slot: &str) {
+    let mut registry = retry_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(identity) = registry.get_mut(slot) {
+        identity.mark_succeeded();
+    }
+    registry.remove(slot);
+}
+
+pub(crate) async fn create_product_attribute(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    locale: String,
+    draft: ProductAttributeDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::CreateAttribute;
+    let slot = retry_slot(operation, &tenant_id, &user_id, draft.code.as_str());
+    let intent = write_intent(operation, &tenant_id, &user_id, &(locale.as_str(), &draft));
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        CREATE_PRODUCT_ATTRIBUTE_MUTATION,
+        Some(LocaleMutationVariables {
+            idempotency_key,
+            locale,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.create_product_attribute.unwrap_or(false))
+}
+
+pub(crate) async fn create_product_attribute_option(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    locale: String,
+    draft: ProductAttributeOptionDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::CreateAttributeOption;
+    let target = format!("{}:{}", draft.attribute_id, draft.code);
+    let slot = retry_slot(operation, &tenant_id, &user_id, &target);
+    let intent = write_intent(operation, &tenant_id, &user_id, &(locale.as_str(), &draft));
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        CREATE_PRODUCT_ATTRIBUTE_OPTION_MUTATION,
+        Some(LocaleMutationVariables {
+            idempotency_key,
+            locale,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.create_product_attribute_option.unwrap_or(false))
+}
+
+pub(crate) async fn create_catalog_category(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    locale: String,
+    draft: CatalogCategoryDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::CreateCategory;
+    let slot = retry_slot(operation, &tenant_id, &user_id, draft.code.as_str());
+    let intent = write_intent(operation, &tenant_id, &user_id, &(locale.as_str(), &draft));
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        CREATE_CATALOG_CATEGORY_MUTATION,
+        Some(LocaleMutationVariables {
+            idempotency_key,
+            locale,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.create_catalog_category.unwrap_or(false))
+}
+
+pub(crate) async fn create_attribute_schema(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    locale: String,
+    draft: ProductAttributeSchemaDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::CreateSchema;
+    let slot = retry_slot(operation, &tenant_id, &user_id, draft.code.as_str());
+    let intent = write_intent(operation, &tenant_id, &user_id, &(locale.as_str(), &draft));
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        CREATE_ATTRIBUTE_SCHEMA_MUTATION,
+        Some(LocaleMutationVariables {
+            idempotency_key,
+            locale,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.create_product_attribute_schema.unwrap_or(false))
+}
+
+pub(crate) async fn create_product_attribute_schema_group(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    locale: String,
+    draft: ProductAttributeSchemaGroupDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::CreateSchemaGroup;
+    let target = format!("{}:{}", draft.schema_id, draft.code);
+    let slot = retry_slot(operation, &tenant_id, &user_id, &target);
+    let intent = write_intent(operation, &tenant_id, &user_id, &(locale.as_str(), &draft));
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        CREATE_SCHEMA_GROUP_MUTATION,
+        Some(LocaleMutationVariables {
+            idempotency_key,
+            locale,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.create_product_attribute_schema_group.unwrap_or(false))
+}
+
+pub(crate) async fn create_category_attribute_group(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    locale: String,
+    draft: CategoryAttributeGroupDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::CreateCategoryGroup;
+    let target = format!("{}:{}", draft.category_id, draft.code);
+    let slot = retry_slot(operation, &tenant_id, &user_id, &target);
+    let intent = write_intent(operation, &tenant_id, &user_id, &(locale.as_str(), &draft));
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        CREATE_CATEGORY_GROUP_MUTATION,
+        Some(LocaleMutationVariables {
+            idempotency_key,
+            locale,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.create_catalog_category_attribute_group.unwrap_or(false))
+}
+
+pub(crate) async fn set_category_schema_mode(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    draft: SetCategorySchemaModeDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::SetCategorySchemaMode;
+    let slot = retry_slot(operation, &tenant_id, &user_id, draft.category_id.as_str());
+    let intent = write_intent(operation, &tenant_id, &user_id, &draft);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        SET_CATEGORY_SCHEMA_MODE_MUTATION,
+        Some(InputVariables {
+            idempotency_key,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.set_catalog_category_schema_mode.unwrap_or(false))
+}
+
+pub(crate) async fn bind_schema_attribute(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    draft: BindSchemaAttributeDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::BindSchemaAttribute;
+    let target = format!("{}:{}", draft.schema_id, draft.attribute_id);
+    let slot = retry_slot(operation, &tenant_id, &user_id, &target);
+    let intent = write_intent(operation, &tenant_id, &user_id, &draft);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        BIND_SCHEMA_ATTRIBUTE_MUTATION,
+        Some(InputVariables {
+            idempotency_key,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.bind_product_attribute_schema_attribute.unwrap_or(false))
+}
+
+pub(crate) async fn bind_category_attribute(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    draft: BindCategoryAttributeDraft,
+) -> Result<bool, ApiError> {
+    let operation = ProductAdminSchemaOperation::BindCategoryAttribute;
+    let target = format!("{}:{}", draft.category_id, draft.attribute_id);
+    let slot = retry_slot(operation, &tenant_id, &user_id, &target);
+    let intent = write_intent(operation, &tenant_id, &user_id, &draft);
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<BoolMutationResponse, ApiError> = request(
+        BIND_CATEGORY_ATTRIBUTE_MUTATION,
+        Some(InputVariables {
+            idempotency_key,
+            input: draft,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.bind_catalog_category_attribute.unwrap_or(false))
+}
+
+pub(crate) async fn save_product_attribute_values(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    product_id: String,
+    locale: String,
+    mut patches: Vec<ProductAttributeValuePatchDraft>,
+) -> Result<Vec<ProductAttributeValueItem>, ApiError> {
+    for patch in &mut patches {
+        patch.kind = patch.kind.trim().to_ascii_uppercase();
+    }
+    let operation = ProductAdminSchemaOperation::SaveAttributeValues;
+    let slot = retry_slot(operation, &tenant_id, &user_id, product_id.as_str());
+    let intent = write_intent(
+        operation,
+        &tenant_id,
+        &user_id,
+        &(product_id.as_str(), locale.as_str(), &patches),
+    );
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<SaveAttributeValuesResponse, ApiError> = request(
+        SAVE_ATTRIBUTE_VALUES_MUTATION,
+        Some(SaveAttributeValuesVariables {
+            idempotency_key,
+            product_id,
+            locale,
+            patches,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.save_product_attribute_values)
+}
+
+pub(crate) async fn clear_detached_product_attribute_values(
+    token: Option<String>,
+    tenant_slug: Option<String>,
+    tenant_id: String,
+    user_id: String,
+    product_id: String,
+    locale: String,
+    attribute_ids: Vec<String>,
+) -> Result<Vec<ProductAttributeValueItem>, ApiError> {
+    let operation = ProductAdminSchemaOperation::ClearDetachedAttributeValues;
+    let slot = retry_slot(operation, &tenant_id, &user_id, product_id.as_str());
+    let intent = write_intent(
+        operation,
+        &tenant_id,
+        &user_id,
+        &(product_id.as_str(), locale.as_str(), &attribute_ids),
+    );
+    let idempotency_key = retained_caller_key(&slot, operation, intent);
+    let result: Result<ClearDetachedAttributeValuesResponse, ApiError> = request(
+        CLEAR_DETACHED_ATTRIBUTE_VALUES_MUTATION,
+        Some(ClearDetachedAttributeValuesVariables {
+            idempotency_key,
+            product_id,
+            locale,
+            attribute_ids,
+        }),
+        token,
+        tenant_slug,
+    )
+    .await;
+    if result.is_ok() {
+        mark_succeeded(&slot);
+    }
+    result.map(|response| response.clear_detached_product_attribute_values)
+}

--- a/scripts/verify/verify-commerce-product-schema-write-consumer-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-schema-write-consumer-cutover.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relative) => fs.readFileSync(path.join(root, relative), "utf8");
+const fail = (message) => {
+  console.error(`Product schema-write consumer cutover guard failed: ${message}`);
+  process.exit(1);
+};
+const requireText = (source, text, message) => {
+  if (!source.includes(text)) fail(message ?? `missing ${JSON.stringify(text)}`);
+};
+const forbidText = (source, text, message) => {
+  if (source.includes(text)) fail(message ?? `forbidden ${JSON.stringify(text)}`);
+};
+
+const server = read("crates/rustok-commerce/src/graphql/mutations/catalog.rs");
+const activeTransport = read("crates/rustok-product/admin/src/catalog_transport_retry.rs");
+const schemaTransport = read("crates/rustok-product/admin/src/transport/product_schema_graphql.rs");
+const retryIdentity = read("crates/rustok-product/admin/src/schema_retry_identity.rs");
+const adminLib = read("crates/rustok-product/admin/src/lib.rs");
+
+forbidText(
+  server,
+  "ProductCatalogSchemaService",
+  "mounted Commerce GraphQL must not construct the Product schema service directly",
+);
+requireText(server, "ProductCatalogSchemaWritePort", "mounted Commerce must depend on the typed Product schema-write port");
+requireText(server, ".schema_write_port()", "mounted Commerce must resolve schema writes from the host-selected Product command runtime");
+requireText(server, "product.schema_write_port_unavailable", "missing external schema-write capability must fail closed");
+requireText(server, "Product schema mutation idempotency key is required", "omitted schema-write caller identity must be rejected before owner execution");
+requireText(server, "with_idempotency_key(scoped_key)", "schema writes must reuse the scoped Product PortContext idempotency identity");
+requireText(server, "with_deadline(PRODUCT_COMMAND_DEADLINE)", "schema writes must retain the Product command deadline");
+
+const schemaResolvers = [
+  ["create_product_attribute", "create_attribute"],
+  ["create_product_attribute_option", "create_attribute_option"],
+  ["create_catalog_category", "create_category"],
+  ["create_product_attribute_schema", "create_schema"],
+  ["create_product_attribute_schema_group", "create_schema_group"],
+  ["create_catalog_category_attribute_group", "create_category_group"],
+  ["set_catalog_category_schema_mode", "set_category_schema_mode"],
+  ["bind_product_attribute_schema_attribute", "bind_schema_attribute"],
+  ["bind_catalog_category_attribute", "bind_category_attribute"],
+  ["save_product_attribute_values", "save_product_attribute_values"],
+  ["clear_detached_product_attribute_values", "clear_detached_product_attribute_values"],
+];
+
+for (const [resolver, ownerMethod] of schemaResolvers) {
+  const start = server.indexOf(`async fn ${resolver}(`);
+  if (start < 0) fail(`missing schema resolver ${resolver}`);
+  const next = server.indexOf("\n    async fn ", start + 1);
+  const end = next < 0 ? server.length : next;
+  const slice = server.slice(start, end);
+  requireText(
+    slice,
+    "idempotency_key: Option<String>",
+    `${resolver} must keep nullable SDL only as the explicit admission-ordering follow-up`,
+  );
+  requireText(slice, "product_schema_write_context(", `${resolver} must reject omitted caller identity before owner execution`);
+  requireText(slice, `.${ownerMethod}(`, `${resolver} must call Product owner schema-write method ${ownerMethod}`);
+  requireText(slice, "product_schema_write_port(ctx, &port_context)?", `${resolver} must resolve the host-composed schema-write capability`);
+}
+
+requireText(
+  activeTransport,
+  "pub(crate) use crate::product_schema_graphql::{",
+  "active Product Admin transport must source schema writes from the retry-aware GraphQL module",
+);
+requireText(adminLib, "mod product_schema_graphql;", "Product Admin must mount the schema-write GraphQL transport");
+requireText(adminLib, "mod schema_retry_identity;", "Product Admin must mount schema-write retry identity state");
+
+const requiredVariableCount = (schemaTransport.match(/\$idempotencyKey: String!/g) ?? []).length;
+if (requiredVariableCount !== schemaResolvers.length) {
+  fail(`Product Admin must declare one required idempotency variable for each schema mutation (expected ${schemaResolvers.length}, found ${requiredVariableCount})`);
+}
+const forwardedKeyCount = (schemaTransport.match(/idempotencyKey: \$idempotencyKey/g) ?? []).length;
+if (forwardedKeyCount !== schemaResolvers.length) {
+  fail(`Product Admin must forward idempotencyKey on every schema mutation (expected ${schemaResolvers.length}, found ${forwardedKeyCount})`);
+}
+requireText(schemaTransport, "retained_caller_key", "Product Admin schema transport must retain caller identity across failed explicit retries");
+requireText(schemaTransport, "mark_succeeded", "Product Admin schema transport must release caller identity only after success");
+requireText(retryIdentity, "ProductAdminSchemaRetryIdentity", "Product Admin must own a typed schema retry identity capability");
+requireText(retryIdentity, "pending.operation == operation", "schema retry identity must require the same operation");
+requireText(retryIdentity, "&pending.intent == intent", "schema retry identity must require the exact same intent");
+requireText(retryIdentity, "product-admin-schema:", "schema retry keys must use the Product Admin schema namespace");
+
+console.log(
+  "Product schema-write consumer cutover source guard passed: mounted Commerce uses the host-selected owner port, successful execution requires caller identity, Product Admin sends retained String! keys, and nullable server SDL remains an explicit admission-ordering follow-up.",
+);


### PR DESCRIPTION
## Summary

- cut all eleven mounted Commerce GraphQL Product schema-write consumers from direct `ProductCatalogSchemaService` construction to the host-selected `ProductCatalogSchemaWritePort`
- reuse the Product command `PortContext` contract: tenant/actor/claims/request channel, two-second deadline, caller-key trim/191-byte validation, and scope hashing before owner execution
- fail closed with bounded `PRODUCT_TEMPORARILY_UNAVAILABLE` when an external Product command profile has not composed a schema-write capability
- keep stable bounded Product public error identities instead of exposing owner storage/validation details
- move active Product Admin schema writes off the legacy GraphQL adapter into a retry-aware schema transport
- send `$idempotencyKey: String!` for all eleven Product Admin schema mutations and retain one caller key across an explicit retry of the same failed operation + intent; success releases the key
- intentionally keep mounted schema resolver `idempotencyKey` inputs nullable for this slice so the existing foreign-actor regression document continues to reach tenant/actor admission; omission by an admitted caller is rejected with `BAD_USER_INPUT` before owner execution
- add a source guard and update the Product schema-write recheck packet

## Intentionally still open

- update the foreign-actor schema mutation fixture with explicit caller keys and then make all eleven mounted schema `idempotencyKey` arguments non-null
- implement Product-owner durable command receipt/replay semantics for non-idempotent schema creates and define replay behavior for update-style schema writes
- remove superseded compatibility strings only after compile/source evidence
- keep the canonical combined Product schema-write/idempotency item `[ ]` until those semantics are source-complete
- broad ecommerce typed-owner/FBA invariant remains open

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction. No FBA/FFA promotion.