### PR TITLE
test(index): retain replay GraphQL shutdown evidence

### DIFF
--- a/apps/server/docs/index-replay-graphql-shutdown-evidence.md
+++ b/apps/server/docs/index-replay-graphql-shutdown-evidence.md
@@ -1,0 +1,94 @@
+# Index replay GraphQL shutdown evidence
+
+Status: `source_complete_execution_pending`.
+
+## Purpose
+
+This retained packet closes the source-level gap between the guarded GraphQL replay command and the shared
+server shutdown signal without relying on sleeps, polling, or a test-only replay runner entry point.
+
+The packet uses the real `IndexReplayMutation`, real `IndexReplayOperatorRuntime`, real
+`SharedIndexReplayRuntime`, real PostgreSQL replay-runner implementation over SQLite, production Index
+migrations, schema registration, replay jobs, checkpoints, mutation store, and inbox/materialization state.
+
+It intentionally builds a minimal async-graphql schema at the same schema-data boundary used by the production
+resolver instead of constructing the full application `AppSchema`. Production `init_graphql_schema` lifecycle
+reservation/keepalive is retained separately by source guards. This packet therefore does not claim full
+HTTP/process bootstrap execution.
+
+## Deterministic shutdown handoff
+
+The first runtime publishes a source whose `scan` method uses two `tokio::sync::Notify` values:
+
+1. the GraphQL request runs in its own task with the real request-scoped RBAC permission snapshot;
+2. source scan records that it has started and then waits for an explicit release notification;
+3. the test waits for that source-start notification, so the replay pre-scan safe point has already passed;
+4. the test calls the real shared `StopHandle::stop()`;
+5. the test releases source scan;
+6. the next replay safe point, immediately before mutation application, observes
+   `StopHandle::is_stopping()` through the real GraphQL -> guarded operator -> shared runtime -> runner chain;
+7. the command returns `YIELDED` and the durable replay job returns to `pending`.
+
+No wall-clock delay or status polling determines ordering.
+
+## First-attempt assertions
+
+After the shutdown-observed GraphQL command:
+
+- the source was scanned exactly once;
+- GraphQL returns `YIELDED` and exposes the durable job UUID;
+- the replay job is `pending`, uncancelled, lease-free, incomplete, and still on attempt `1`;
+- no replay checkpoint exists;
+- no Index entity was materialized;
+- no applied inbox delivery exists.
+
+This proves that server shutdown observation remains distinct from persisted user cancellation and does not
+manufacture a terminal failure.
+
+## Fresh runtime restart
+
+The packet then constructs fresh module/runtime/operator/GraphQL composition over the same SQLite database and a
+new non-stopping `StopHandle`. The source contract and schema identity remain the same, but the scan gate is
+removed.
+
+The same authorized GraphQL command:
+
+- reacquires the same durable replay job;
+- increments the attempt fence to attempt `2`;
+- returns `COMPLETE` with the same job UUID;
+- materializes exactly one Index entity and one applied inbox delivery;
+- commits the rebuild checkpoint;
+- leaves the replay job `succeeded`.
+
+This is restart composition evidence, not an in-memory resume through the first GraphQL schema.
+
+## Duplicate-redelivery boundary
+
+This GraphQL-level packet deliberately stops while source scan is pending, so the first attempt has not yet
+applied a mutation. It therefore does not manufacture a duplicate solely to make the assertion richer.
+
+The retained runner-level graceful-shutdown packet remains the owner of the harder crash-equivalent window:
+mutation durability succeeds, shutdown is observed before checkpoint commit, and attempt 2 safely observes the
+stable delivery as `Duplicate` before completing the checkpoint/job.
+
+Together the packets cover command/lifecycle binding and duplicate-safe durable replay without conflating their
+coordination mechanisms.
+
+## Deliberate limits
+
+This source packet does not:
+
+- execute a real HTTP request;
+- execute full application/bootstrap startup or OS signal handling;
+- invoke production shutdown orchestration beyond the real shared `StopHandle::stop()` primitive;
+- test user-requested cancellation races;
+- add automatic replay scheduling;
+- add locale/partition replay checkpoint scope;
+- add targeted/full/shadow rebuild modes;
+- claim runtime or CI admission.
+
+The production source guards still require `init_graphql_schema` to publish/reuse one shared StopHandle and keep
+an API-host receiver alive, while the transport may only observe `is_stopping()` and may never call `.stop()`.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
+`git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_replay_shutdown_tests.rs
+++ b/apps/server/src/graphql/index_replay_shutdown_tests.rs
@@ -1,0 +1,460 @@
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use async_graphql::{EmptyQuery, EmptySubscription, Request, Schema};
+use async_trait::async_trait;
+use rustok_api::Permission;
+use rustok_core::{
+    MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule, UserRole,
+};
+use rustok_index::{
+    EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexMutation,
+    IndexRecord, IndexSchema, IndexSource, IndexSourceFailure, IndexSourceLoadBatch,
+    IndexSourceLoadRequest, IndexSourcePage, IndexSourceScanRequest, IndexValue, IndexValueType,
+    LocaleMode, ModuleName, PostgresSchemaRegistrationStore, SchemaRef, SchemaVersion,
+    SharedIndexSchemaRegistry, register_index_schema_source, register_index_source,
+};
+use sea_orm::{ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tokio::sync::Notify;
+use uuid::Uuid;
+
+use super::index_replay::IndexReplayMutation;
+use crate::context::{AuthContext, TenantContext};
+use crate::services::app_lifecycle::StopHandle;
+use crate::services::index_replay_runtime_composition::materialize_index_replay_runtime;
+use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
+
+const TENANT_ID: Uuid = Uuid::from_u128(1);
+const ACTOR_ID: Uuid = Uuid::from_u128(2);
+const ENTITY_ID: Uuid = Uuid::from_u128(101);
+const EVENT_ID: Uuid = Uuid::from_u128(1001);
+const SOURCE_NAME: &str = "shutdown-evidence-primary";
+
+#[derive(Clone)]
+struct ScanGate {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+struct ShutdownReplayModule {
+    gate: Option<ScanGate>,
+    source_calls: Arc<AtomicUsize>,
+}
+
+struct ShutdownSource {
+    gate: Option<ScanGate>,
+    source_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl IndexSource for ShutdownSource {
+    async fn scan(
+        &self,
+        request: IndexSourceScanRequest,
+    ) -> Result<IndexSourcePage, IndexSourceFailure> {
+        self.source_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(gate) = &self.gate {
+            gate.started.notify_one();
+            gate.release.notified().await;
+        }
+
+        let mutation = IndexMutation::Upsert {
+            event_id: EVENT_ID,
+            record: IndexRecord {
+                key: EntityKey {
+                    tenant_id: request.tenant_id(),
+                    schema: shutdown_schema_ref(),
+                    entity_id: ENTITY_ID,
+                    locale: None,
+                },
+                source_version: 1,
+                fields: BTreeMap::from([(
+                    FieldName::new("id").expect("field name"),
+                    IndexValue::Uuid(ENTITY_ID),
+                )]),
+                links: Vec::new(),
+            },
+        };
+
+        Ok(IndexSourcePage::new(&request, vec![mutation], None)
+            .expect("shutdown evidence page should satisfy source contract"))
+    }
+
+    async fn load(
+        &self,
+        request: IndexSourceLoadRequest,
+    ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+        Ok(IndexSourceLoadBatch::new(&request, Vec::new())
+            .expect("empty targeted load should satisfy source contract"))
+    }
+}
+
+impl MigrationSource for ShutdownReplayModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        Vec::new()
+    }
+}
+
+#[async_trait]
+impl RusToKModule for ShutdownReplayModule {
+    fn slug(&self) -> &'static str {
+        "shutdown_evidence"
+    }
+
+    fn name(&self) -> &'static str {
+        "Shutdown evidence"
+    }
+
+    fn description(&self) -> &'static str {
+        "Deterministic Index replay GraphQL shutdown evidence source"
+    }
+
+    fn version(&self) -> &'static str {
+        "0.1.0"
+    }
+
+    fn register_runtime_extensions(
+        &self,
+        extensions: &mut ModuleRuntimeExtensions,
+    ) -> rustok_core::Result<()> {
+        let schema = shutdown_schema();
+        register_index_schema_source(extensions, self.slug(), schema.clone()).map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "shutdown evidence schema registration failed: {error}"
+            ))
+        })?;
+        register_index_source(
+            extensions,
+            self.slug(),
+            SOURCE_NAME,
+            [schema.reference],
+            ShutdownSource {
+                gate: self.gate.clone(),
+                source_calls: self.source_calls.clone(),
+            },
+        )
+        .map_err(|error| {
+            rustok_core::Error::Validation(format!(
+                "shutdown evidence source registration failed: {error}"
+            ))
+        })
+    }
+}
+
+type ReplayTestSchema = Schema<EmptyQuery, IndexReplayMutation, EmptySubscription>;
+
+struct ReplayGraphqlRuntime {
+    schema: ReplayTestSchema,
+    stop_handle: StopHandle,
+    _stop_receiver: tokio::sync::watch::Receiver<bool>,
+    source_calls: Arc<AtomicUsize>,
+}
+
+#[tokio::test]
+async fn graphql_replay_observes_shared_stop_and_fresh_runtime_resumes_pending_job() {
+    let db = replay_database().await;
+    let gate = ScanGate {
+        started: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+
+    let first = graphql_runtime(&db, Some(gate.clone())).await;
+    let first_schema = first.schema.clone();
+    let request_task = tokio::spawn(async move {
+        with_rbac_request_scope(
+            Some(operator_scope()),
+            first_schema.execute(replay_request()),
+        )
+        .await
+    });
+
+    // The real source is already inside scan, so the pre-scan safe point has passed. Stop is
+    // published deterministically while scan is pending; once released, the pre-mutation safe point
+    // must observe the same shared StopHandle and yield the job without applying the mutation.
+    gate.started.notified().await;
+    first.stop_handle.stop().await;
+    assert!(first.stop_handle.is_stopping());
+    gate.release.notify_one();
+
+    let first_response = request_task
+        .await
+        .expect("GraphQL replay task should join without panic");
+    assert!(
+        first_response.errors.is_empty(),
+        "shutdown-yield GraphQL response must not contain errors: {:?}",
+        first_response.errors
+    );
+    let first_data = first_response
+        .data
+        .into_json()
+        .expect("GraphQL response data should convert to JSON");
+    let first_run = &first_data["runIndexReplay"];
+    assert_eq!(first_run["status"], "YIELDED");
+    assert_eq!(first_run["pagesProcessed"], 0);
+    assert_eq!(first_run["mutationsProcessed"], 0);
+    assert_eq!(first_run["appliedCount"], 0);
+    assert_eq!(first_run["duplicateCount"], 0);
+    let job_id = Uuid::parse_str(
+        first_run["jobId"]
+            .as_str()
+            .expect("yielded replay should expose job id"),
+    )
+    .expect("GraphQL job id should be a UUID");
+
+    assert_eq!(first.source_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(job_state(&db).await, "pending");
+    assert_eq!(job_attempt_count(&db).await, 1);
+    assert_eq!(pending_uncancelled_lease_free_jobs(&db).await, 1);
+    assert_eq!(checkpoint_count(&db).await, 0);
+    assert_eq!(materialized_entity_count(&db).await, 0);
+    assert_eq!(applied_inbox_count(&db).await, 0);
+
+    // Fresh server/runtime/GraphQL composition gets a fresh non-stopping lifecycle handle while
+    // reusing the same durable database. The same authorized command must reclaim the pending job as
+    // attempt 2 and complete from the last committed checkpoint.
+    let restarted = graphql_runtime(&db, None).await;
+    assert!(!restarted.stop_handle.is_stopping());
+    let second_response = with_rbac_request_scope(
+        Some(operator_scope()),
+        restarted.schema.execute(replay_request()),
+    )
+    .await;
+    assert!(
+        second_response.errors.is_empty(),
+        "restart GraphQL response must not contain errors: {:?}",
+        second_response.errors
+    );
+    let second_data = second_response
+        .data
+        .into_json()
+        .expect("restart GraphQL response data should convert to JSON");
+    let second_run = &second_data["runIndexReplay"];
+    assert_eq!(second_run["status"], "COMPLETE");
+    assert_eq!(second_run["jobId"], job_id.to_string());
+    assert_eq!(second_run["pagesProcessed"], 1);
+    assert_eq!(second_run["mutationsProcessed"], 1);
+    assert_eq!(second_run["appliedCount"], 1);
+    assert_eq!(second_run["duplicateCount"], 0);
+
+    assert_eq!(restarted.source_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(job_state(&db).await, "succeeded");
+    assert_eq!(job_attempt_count(&db).await, 2);
+    assert_eq!(checkpoint_count(&db).await, 1);
+    assert_eq!(materialized_entity_count(&db).await, 1);
+    assert_eq!(applied_inbox_count(&db).await, 1);
+}
+
+async fn replay_database() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("in-memory SQLite should connect");
+    db.execute_unprepared("PRAGMA foreign_keys = ON")
+        .await
+        .expect("foreign keys should be enabled");
+    db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+        .await
+        .expect("tenant fixture should be created");
+    db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT_ID}')"))
+        .await
+        .expect("tenant fixture should be inserted");
+
+    let manager = SchemaManager::new(&db);
+    for migration in IndexModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+    }
+    db
+}
+
+async fn graphql_runtime(
+    db: &DatabaseConnection,
+    gate: Option<ScanGate>,
+) -> ReplayGraphqlRuntime {
+    let source_calls = Arc::new(AtomicUsize::new(0));
+    let registry = ModuleRegistry::new()
+        .register(IndexModule)
+        .register(ShutdownReplayModule {
+            gate,
+            source_calls: source_calls.clone(),
+        });
+    let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+        .expect("shutdown evidence runtime extensions should compose");
+
+    let schemas = extensions
+        .get::<SharedIndexSchemaRegistry>()
+        .cloned()
+        .expect("shutdown evidence schema registry should be present");
+    let schema_store = PostgresSchemaRegistrationStore::new(db.clone());
+    for registered in schemas.registry().iter() {
+        schema_store
+            .register(TENANT_ID, &registered.schema)
+            .await
+            .expect("shutdown evidence schema should persist idempotently");
+    }
+
+    materialize_index_replay_runtime(&mut extensions, db.clone())
+        .expect("guarded replay runtime should materialize");
+    let extensions = Arc::new(extensions);
+    let (stop_handle, stop_receiver) = StopHandle::new();
+    let schema = Schema::build(
+        EmptyQuery,
+        IndexReplayMutation::default(),
+        EmptySubscription,
+    )
+    .data(extensions)
+    .data(stop_handle.clone())
+    .finish();
+
+    ReplayGraphqlRuntime {
+        schema,
+        stop_handle,
+        _stop_receiver: stop_receiver,
+        source_calls,
+    }
+}
+
+fn replay_request() -> Request {
+    Request::new(
+        r#"
+mutation {
+  runIndexReplay(input: {
+    moduleName: "shutdown-evidence"
+    entityName: "item"
+    schemaVersion: "1"
+  }) {
+    status
+    jobId
+    pagesProcessed
+    mutationsProcessed
+    appliedCount
+    duplicateCount
+    staleCount
+  }
+}
+"#,
+    )
+    .data(AuthContext {
+        user_id: ACTOR_ID,
+        email: "operator@example.test".to_owned(),
+        tenant_id: Some(TENANT_ID),
+        is_super_admin: false,
+        is_platform_admin: false,
+        permissions: vec![Permission::MODULES_MANAGE],
+    })
+    .data(TenantContext {
+        id: TENANT_ID,
+        slug: "shutdown-evidence".to_owned(),
+        name: "Shutdown evidence".to_owned(),
+        is_platform: false,
+        default_locale: "en".to_owned(),
+        timezone: "UTC".to_owned(),
+    })
+}
+
+fn operator_scope() -> RbacRequestScope {
+    RbacRequestScope::new(
+        TENANT_ID,
+        ACTOR_ID,
+        vec![Permission::MODULES_MANAGE],
+        UserRole::Admin,
+    )
+}
+
+fn shutdown_schema_ref() -> SchemaRef {
+    SchemaRef {
+        module: ModuleName::new("shutdown-evidence").expect("module name"),
+        entity: EntityName::new("item").expect("entity name"),
+        version: SchemaVersion::INITIAL,
+    }
+}
+
+fn shutdown_schema() -> IndexSchema {
+    IndexSchema {
+        reference: shutdown_schema_ref(),
+        locale_mode: LocaleMode::None,
+        fields: vec![IndexField {
+            name: FieldName::new("id").expect("field name"),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: true,
+        }],
+        links: Vec::new(),
+    }
+}
+
+async fn scalar_i64(db: &DatabaseConnection, sql: &str) -> i64 {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return a row")
+        .try_get("", "value")
+        .expect("scalar value should be integer")
+}
+
+async fn scalar_string(db: &DatabaseConnection, sql: &str) -> String {
+    db.query_one(Statement::from_string(DbBackend::Sqlite, sql.to_owned()))
+        .await
+        .expect("scalar query should execute")
+        .expect("scalar query should return a row")
+        .try_get("", "value")
+        .expect("scalar value should be text")
+}
+
+async fn job_state(db: &DatabaseConnection) -> String {
+    scalar_string(
+        db,
+        "SELECT state AS value FROM index_jobs WHERE kind = 'rebuild'",
+    )
+    .await
+}
+
+async fn job_attempt_count(db: &DatabaseConnection) -> i64 {
+    scalar_i64(
+        db,
+        "SELECT attempt_count AS value FROM index_jobs WHERE kind = 'rebuild'",
+    )
+    .await
+}
+
+async fn pending_uncancelled_lease_free_jobs(db: &DatabaseConnection) -> i64 {
+    scalar_i64(
+        db,
+        "SELECT COUNT(*) AS value FROM index_jobs WHERE kind = 'rebuild' AND state = 'pending' AND cancel_requested = FALSE AND lease_owner IS NULL AND lease_expires_at IS NULL AND completed_at IS NULL",
+    )
+    .await
+}
+
+async fn checkpoint_count(db: &DatabaseConnection) -> i64 {
+    scalar_i64(
+        db,
+        "SELECT COUNT(*) AS value FROM index_checkpoints WHERE checkpoint_kind = 'rebuild'",
+    )
+    .await
+}
+
+async fn materialized_entity_count(db: &DatabaseConnection) -> i64 {
+    scalar_i64(
+        db,
+        "SELECT COUNT(*) AS value FROM index_entities WHERE tenant_id = '00000000-0000-0000-0000-000000000001' AND module_name = 'shutdown-evidence' AND entity_name = 'item' AND schema_version = 1 AND entity_id = '00000000-0000-0000-0000-000000000065' AND is_deleted = 0",
+    )
+    .await
+}
+
+async fn applied_inbox_count(db: &DatabaseConnection) -> i64 {
+    scalar_i64(
+        db,
+        "SELECT COUNT(*) AS value FROM index_inbox WHERE tenant_id = '00000000-0000-0000-0000-000000000001' AND source_name = 'shutdown-evidence-primary' AND delivery_id = '00000000-0000-0000-0000-0000000003e9' AND state = 'applied'",
+    )
+    .await
+}

--- a/apps/server/src/graphql/mod.rs
+++ b/apps/server/src/graphql/mod.rs
@@ -5,6 +5,8 @@ pub mod forum_principal_security;
 pub mod index_drift_diagnosis;
 pub mod index_drift_source_page_diagnosis;
 pub mod index_replay;
+#[cfg(test)]
+mod index_replay_shutdown_tests;
 pub mod legacy_disable_user;
 pub mod loaders;
 #[cfg(feature = "mod-moderation")]

--- a/scripts/verify/verify-index-replay-graphql-shutdown-evidence.mjs
+++ b/scripts/verify/verify-index-replay-graphql-shutdown-evidence.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-graphql-shutdown-evidence] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const packetPath = 'apps/server/src/graphql/index_replay_shutdown_tests.rs';
+const packet = requireMarkers(packetPath, [
+  'use super::index_replay::IndexReplayMutation;',
+  'materialize_index_replay_runtime',
+  'PostgresSchemaRegistrationStore',
+  'Schema<ReplayTestQuery, IndexReplayMutation, EmptySubscription>',
+  '.data(extensions)',
+  '.data(stop_handle.clone())',
+  'with_rbac_request_scope(',
+  'Permission::MODULES_MANAGE',
+  'tokio::spawn(async move {',
+  'gate.started.notified().await;',
+  'first.stop_handle.stop().await;',
+  'gate.release.notify_one();',
+  'first_run["status"].as_str(), Some("YIELDED")',
+  'job_state(&db).await, "pending"',
+  'job_attempt_count(&db).await, 1',
+  'pending_uncancelled_lease_free_jobs(&db).await, 1',
+  'checkpoint_count(&db).await, 0',
+  'materialized_entity_count(&db).await, 0',
+  'applied_inbox_count(&db).await, 0',
+  'let restarted = graphql_runtime(&db, None).await;',
+  'second_run["status"].as_str(), Some("COMPLETE")',
+  'job_attempt_count(&db).await, 2',
+  'job_state(&db).await, "succeeded"',
+  'checkpoint_count(&db).await, 1',
+  'materialized_entity_count(&db).await, 1',
+  'applied_inbox_count(&db).await, 1',
+  'ScanGate',
+  'Arc<Notify>',
+  'gate.started.notify_one();',
+  'gate.release.notified().await;',
+]);
+
+for (const forbidden of [
+  'tokio::time::sleep',
+  'std::thread::sleep',
+  'interval(',
+  'sleep_until(',
+  'while !',
+  'loop {',
+  'request_cancel(',
+  'cancelIndexReplay',
+  'run_interruptible(',
+  'PostgresIndexReplayRunner',
+]) {
+  if (packet.includes(forbidden)) {
+    fail(`${packetPath} must drive shutdown through the real GraphQL command without timing polling or bypassing the guarded operator: ${forbidden}`);
+  }
+}
+
+const spawn = packet.indexOf('tokio::spawn(async move {');
+const scope = packet.indexOf('with_rbac_request_scope(', spawn);
+const execute = packet.indexOf('first_schema.execute(replay_request())', scope);
+const started = packet.indexOf('gate.started.notified().await;', execute);
+const stop = packet.indexOf('first.stop_handle.stop().await;', started);
+const release = packet.indexOf('gate.release.notify_one();', stop);
+if (spawn < 0 || scope <= spawn || execute <= scope || started <= execute || stop <= started || release <= stop) {
+  fail('first GraphQL request must install request authority inside its task, enter source scan, publish stop, then release scan deterministically');
+}
+
+const firstYield = packet.indexOf('Some("YIELDED")', release);
+const pending = packet.indexOf('job_state(&db).await, "pending"', firstYield);
+const restart = packet.indexOf('let restarted = graphql_runtime(&db, None).await;', pending);
+const secondExecute = packet.indexOf('restarted.schema.execute(replay_request())', restart);
+const complete = packet.indexOf('Some("COMPLETE")', secondExecute);
+const attemptTwo = packet.indexOf('job_attempt_count(&db).await, 2', complete);
+if (firstYield < 0 || pending <= firstYield || restart <= pending || secondExecute <= restart || complete <= secondExecute || attemptTwo <= complete) {
+  fail('packet must retain yielded pending state before fresh GraphQL/runtime composition resumes and completes attempt 2');
+}
+
+requireMarkers('apps/server/src/graphql/mod.rs', [
+  '#[cfg(test)]\nmod index_replay_shutdown_tests;'.replace('\\n', '\n'),
+]);
+requireMarkers('apps/server/src/graphql/index_replay.rs', [
+  'let stop_handle = ctx.data::<StopHandle>()?.clone();',
+  '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
+]);
+requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
+  'pub async fn run_interruptible<Check>(',
+  'context.authorize_for(request.page_request().tenant_id())?;',
+  '.run_interruptible(request, should_interrupt)',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
+  'pub async fn run_interruptible<Check>(',
+  '.run_interruptible(request, should_interrupt)',
+]);
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs', [
+  'Err(crate::IndexReplayError::Interrupted) => {',
+  'yield_after_host_interruption(&self.db, &lease, aggregate).await',
+  'match yield_for_resume(db, lease).await?',
+]);
+requireMarkers('apps/server/src/services/graphql_schema.rs', [
+  'let stop_handle = stop_handle_from_context(ctx);',
+  'IndexReplayStopKeepalive',
+  'avoid a zero-receiver window',
+]);
+
+requireMarkers('apps/server/docs/index-replay-graphql-shutdown-evidence.md', [
+  'Status: `source_complete_execution_pending`.',
+  'real `IndexReplayMutation`',
+  '`Notify`',
+  '`StopHandle::stop()`',
+  '`YIELDED`',
+  '`pending`',
+  'fresh runtime/GraphQL composition',
+  'attempt `2`',
+  'runner-level graceful-shutdown packet',
+  'does not claim full HTTP/process bootstrap execution',
+]);
+
+console.log('[verify-index-replay-graphql-shutdown-evidence] deterministic schema-data GraphQL shutdown packet retains authorized stop-to-pending and fresh-runtime attempt-2 completion without sleeps or polling');


### PR DESCRIPTION
## Summary

- retain deterministic GraphQL/schema-data shutdown evidence for the already-bound Index replay command;
- use the real `IndexReplayMutation`, guarded `IndexReplayOperatorRuntime`, `SharedIndexReplayRuntime`, replay runner, schema registration, jobs/checkpoints, mutation store and Index migrations over SQLite;
- run the first authorized GraphQL request in its own request-scoped RBAC task and use `tokio::sync::Notify` to deterministically hold the real source inside `scan` without sleeps or polling;
- call the real shared `StopHandle::stop()` only after source scan has started, release the source, and require the next pre-mutation replay safe point to return GraphQL `YIELDED`;
- require the durable job to be uncancelled, lease-free and `pending` on attempt 1 with no checkpoint, materialized entity or applied inbox delivery;
- build fresh module/runtime/operator/GraphQL composition over the same SQLite database and a new non-stopping StopHandle;
- run the same authorized GraphQL command again and require the same job UUID to complete as attempt 2 with one checkpoint, one materialized entity, one applied inbox delivery and `succeeded` job state;
- keep the harder durable-mutation-before-checkpoint duplicate window owned by the existing runner-level graceful-shutdown packet rather than manufacturing a second coordination mechanism;
- add a focused source guard, aggregate it into the Index contract, and document the exact evidence boundary.

## Evidence boundary

This packet starts at the real GraphQL schema-data boundary used by `IndexReplayMutation`, but intentionally does not construct the full application `AppSchema`, HTTP server, OS signal handler or production bootstrap. Production `init_graphql_schema` StopHandle reservation/reuse/API-host receiver keepalive remains source-guarded separately.

The packet therefore proves the resolver → guarded operator → shared Index runtime → interruptible runner → durable replay storage chain reacts to a real StopHandle transition without timing polling. It does not claim full HTTP/process shutdown execution.

## Determinism

No `tokio::time::sleep`, thread sleep, interval, polling loop or status-spin is used. `Notify` establishes exact ordering: source scan entered → shared StopHandle stopped → source released → next replay safe point observes stop.

## Boundary

No production replay/runtime/GraphQL behavior is changed by this PR. User cancellation, replay SQL, lifecycle binding, M7 Storefront, locale/partition checkpoint scope, automatic scheduling and explicit rebuild modes are unchanged.

## Validation

Static source review checked the async-graphql Query-root requirement, request-scoped RBAC task placement, StopHandle watch semantics, current source/schema registration contracts, response JSON shape and existing runner durable-state semantics. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.