### PR TITLE
test(groups): retain governance suspension expiry PostgreSQL evidence

### DIFF
--- a/apps/server/tests/groups_governance_suspension_expiry_postgres.rs
+++ b/apps/server/tests/groups_governance_suspension_expiry_postgres.rs
@@ -1,0 +1,266 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use chrono::Utc;
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    ChangeGroupRoleRequest, GroupGovernanceCommandPort, GroupGovernanceService,
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService, GroupRole,
+    SuspendGroupMembershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const POSTGRES_URL_ENV: &str = "RUSTOK_GROUPS_TEST_POSTGRES_URL";
+
+fn schema_url(base: &str, schema: &str) -> String {
+    let separator = if base.contains('?') { '&' } else { '?' };
+    format!("{base}{separator}options=-csearch_path%3D{schema}%2Cpublic")
+}
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups governance expiry PostgreSQL connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for PostgreSQL governance expiry evidence");
+    }
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+    first_target_id: Uuid,
+    second_target_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', 'governance-postgres-suspension-expiry', 4);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{first_target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{second_target_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups PostgreSQL governance expiry fixture should seed");
+}
+
+fn write_context(tenant_id: Uuid, actor_id: Uuid, operation: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-governance-postgres-expiry-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(format!("{operation}-{}", Uuid::new_v4()))
+}
+
+async fn membership_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> (String, String, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT role, status, revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("PostgreSQL membership snapshot query should succeed")
+        .expect("membership should exist");
+    (
+        row.try_get("", "role").expect("membership role should decode"),
+        row.try_get("", "status")
+            .expect("membership status should decode"),
+        row.try_get("", "revision")
+            .expect("membership revision should decode"),
+    )
+}
+
+async fn group_member_count(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT member_count FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("PostgreSQL group member_count query should succeed")
+        .expect("group should exist");
+    row.try_get("", "member_count")
+        .expect("group member_count should decode")
+}
+
+#[tokio::test]
+#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]
+async fn governance_authority_follows_temporary_suspension_and_owner_clock_expiry_postgres() {
+    let base_url = std::env::var(POSTGRES_URL_ENV)
+        .expect("RUSTOK_GROUPS_TEST_POSTGRES_URL must be configured");
+    let schema = format!("groups_governance_expiry_{}", Uuid::new_v4().simple());
+    let admin_db = connect(&base_url).await;
+    admin_db
+        .execute_unprepared(&format!("CREATE SCHEMA {schema}"))
+        .await
+        .expect("isolated Groups governance expiry schema should create");
+    let scoped_url = schema_url(&base_url, &schema);
+    let db = connect(&scoped_url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    let first_target_id = Uuid::new_v4();
+    let second_target_id = Uuid::new_v4();
+    seed_group_fixture(
+        &db,
+        tenant_id,
+        group_id,
+        owner_id,
+        admin_id,
+        first_target_id,
+        second_target_id,
+    )
+    .await;
+
+    let governance = GroupGovernanceService::new(db.clone());
+    let baseline = GroupGovernanceCommandPort::change_group_role(
+        &governance,
+        write_context(tenant_id, admin_id, "postgres-admin-baseline-role-change"),
+        ChangeGroupRoleRequest {
+            group_id,
+            target_user_id: first_target_id,
+            role: GroupRole::Moderator,
+        },
+    )
+    .await
+    .expect("active administrator should change a member role before PostgreSQL suspension");
+    assert_eq!(baseline.previous_role, GroupRole::Member);
+    assert_eq!(baseline.current_role, GroupRole::Moderator);
+    assert!(!baseline.replayed);
+
+    let (admin_role_before, admin_status_before, admin_revision_before) =
+        membership_snapshot(&db, tenant_id, group_id, admin_id).await;
+    assert_eq!(admin_role_before, "admin");
+    assert_eq!(admin_status_before, "active");
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 4);
+
+    let enforcement = GroupMembershipEnforcementCommandService::new(db.clone());
+    let effective_until = Utc::now() + chrono::Duration::seconds(2);
+    let suspended = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &enforcement,
+        write_context(tenant_id, owner_id, "postgres-owner-suspend-admin"),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: admin_id,
+            expected_membership_revision: admin_revision_before,
+            reason_code: "temporary_governance_review".to_string(),
+            effective_until: Some(effective_until),
+        },
+    )
+    .await
+    .expect("owner should temporarily suspend the administrator on PostgreSQL");
+    assert_eq!(suspended.membership_revision, admin_revision_before + 1);
+    assert_eq!(suspended.member_count, 4);
+    assert!(suspended.group_version > baseline.group_version as i64);
+
+    let (admin_role_during, admin_status_during, admin_revision_during) =
+        membership_snapshot(&db, tenant_id, group_id, admin_id).await;
+    assert_eq!(admin_role_during, "admin");
+    assert_eq!(admin_status_during, "active");
+    assert_eq!(admin_revision_during, suspended.membership_revision);
+
+    let denied = GroupGovernanceCommandPort::change_group_role(
+        &governance,
+        write_context(tenant_id, admin_id, "postgres-suspended-admin-role-change"),
+        ChangeGroupRoleRequest {
+            group_id,
+            target_user_id: second_target_id,
+            role: GroupRole::Moderator,
+        },
+    )
+    .await
+    .expect_err("suspended administrator must not retain PostgreSQL governance authority");
+    assert_eq!(denied.code, "groups.membership_suspended");
+    assert!(!denied.retryable);
+
+    let (blocked_target_role, blocked_target_status, blocked_target_revision) =
+        membership_snapshot(&db, tenant_id, group_id, second_target_id).await;
+    assert_eq!(blocked_target_role, "member");
+    assert_eq!(blocked_target_status, "active");
+    assert_eq!(blocked_target_revision, 1);
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 4);
+
+    tokio::time::sleep(Duration::from_millis(2300)).await;
+
+    let restored = GroupGovernanceCommandPort::change_group_role(
+        &governance,
+        write_context(tenant_id, admin_id, "postgres-restored-admin-role-change"),
+        ChangeGroupRoleRequest {
+            group_id,
+            target_user_id: second_target_id,
+            role: GroupRole::Moderator,
+        },
+    )
+    .await
+    .expect("expired suspension should restore PostgreSQL administrator governance authority without cleanup");
+    assert_eq!(restored.previous_role, GroupRole::Member);
+    assert_eq!(restored.current_role, GroupRole::Moderator);
+    assert!(!restored.replayed);
+    assert_eq!(restored.group_version, suspended.group_version as u64 + 1);
+
+    let (admin_role_after, admin_status_after, admin_revision_after) =
+        membership_snapshot(&db, tenant_id, group_id, admin_id).await;
+    assert_eq!(admin_role_after, "admin");
+    assert_eq!(admin_status_after, "active");
+    assert_eq!(admin_revision_after, suspended.membership_revision);
+
+    let (restored_target_role, restored_target_status, restored_target_revision) =
+        membership_snapshot(&db, tenant_id, group_id, second_target_id).await;
+    assert_eq!(restored_target_role, "moderator");
+    assert_eq!(restored_target_status, "active");
+    assert_eq!(restored_target_revision, blocked_target_revision + 1);
+    assert_eq!(group_member_count(&db, tenant_id, group_id).await, 4);
+
+    drop(enforcement);
+    drop(governance);
+    drop(db);
+    admin_db
+        .execute_unprepared(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .expect("isolated Groups governance expiry schema should drop");
+}

--- a/crates/rustok-groups/docs/governance-suspension-expiry-postgres-contract.md
+++ b/crates/rustok-groups/docs/governance-suspension-expiry-postgres-contract.md
@@ -1,0 +1,56 @@
+# Groups governance suspension/expiry PostgreSQL evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_governance_suspension_expiry_postgres.rs` is the PostgreSQL counterpart to the SQLite governance suspension/expiry packet. It retains executable source evidence that local governance authority follows Groups owner-clock effective membership rather than raw stored role/status.
+
+The packet uses a unique PostgreSQL schema, every production Groups migration, `GroupGovernanceService`, and `GroupMembershipEnforcementCommandService`. It introduces no cleanup worker, alternate governance authorization path, dependency, manifest, or lockfile change.
+
+## PostgreSQL isolation
+
+Every pooled connection receives the isolated schema through PostgreSQL startup options:
+
+```text
+options=-csearch_path=<schema>,public
+```
+
+The packet intentionally does not rely on session-local `SET search_path`.
+
+## Contract
+
+The fixture contains one owner, one administrator, and two ordinary active members. Before enforcement, the administrator proves real local governance authority by changing the first member from `member` to `moderator` through `GroupGovernanceCommandPort`.
+
+The owner then applies a short production suspension to the administrator. While effective, the evidence requires:
+
+- stored administrator role remains `admin`;
+- stored membership status remains `active`;
+- administrator membership revision advances exactly for suspension;
+- stored lifecycle `member_count` remains unchanged;
+- a fresh administrator role-change command for the second member fails with `groups.membership_suspended` and `retryable=false`;
+- the denied command leaves the target role/status/revision unchanged.
+
+After `effective_until`, the test performs **no revoke or cleanup mutation**. The same administrator must regain governance authority with a fresh role command. The restored command must advance group version exactly once after the suspension version; the target membership revision advances exactly once; the administrator remains stored `admin/active` at the exact suspension revision; lifecycle `member_count` remains unchanged.
+
+This source complements the existing PostgreSQL governance/enforcement replay, role-versus-suspension race, and platform ownership recovery packet. It does not duplicate those contracts and does not claim native/GraphQL governance parity.
+
+## Execution status
+
+The test is ignored unless `RUSTOK_GROUPS_TEST_POSTGRES_URL` is configured and was not executed while preparing this slice. Governance runtime evidence remains **maintainer execution pending**.
+
+Maintainer command:
+
+```bash
+RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' \
+  cargo test -p rustok-server --features mod-groups \
+  --test groups_governance_suspension_expiry_postgres -- --ignored --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-governance-suspension-expiry-postgres.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-governance-suspension-expiry-postgres.mjs
+++ b/scripts/verify/verify-groups-governance-suspension-expiry-postgres.mjs
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_governance_suspension_expiry_postgres.rs";
+const docsPath = "crates/rustok-groups/docs/governance-suspension-expiry-postgres-contract.md";
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  '#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]',
+  "RUSTOK_GROUPS_TEST_POSTGRES_URL",
+  "options=-csearch_path%3D",
+  "CREATE SCHEMA",
+  "DROP SCHEMA",
+  "rustok_groups::migrations::migrations()",
+  "GroupGovernanceService::new",
+  "GroupGovernanceCommandPort::change_group_role",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "postgres-admin-baseline-role-change",
+  "temporary_governance_review",
+  'assert_eq!(admin_role_during, "admin")',
+  'assert_eq!(admin_status_during, "active")',
+  'assert_eq!(denied.code, "groups.membership_suspended")',
+  "blocked_target_revision, 1",
+  "tokio::time::sleep",
+  "expired suspension should restore PostgreSQL administrator governance authority without cleanup",
+  "restored.group_version, suspended.group_version as u64 + 1",
+  "admin_revision_after, suspended.membership_revision",
+  "restored_target_revision, blocked_target_revision + 1",
+  "group_member_count",
+]) {
+  requireText(test, marker, `Groups governance suspension/expiry PostgreSQL source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "SET search_path",
+  "groups:manage",
+  "rustok_moderation::",
+  "MembershipEnforcementProvenance",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups governance suspension/expiry PostgreSQL source contains shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "executable source added / maintainer execution pending",
+  "PostgreSQL isolation",
+  "stored administrator role remains `admin`",
+  "stored membership status remains `active`",
+  "groups.membership_suspended",
+  "no revoke or cleanup mutation",
+  "exact suspension revision",
+  "role-versus-suspension race",
+  "native/GraphQL governance parity",
+]) {
+  requireText(docs, marker, `Groups governance suspension/expiry PostgreSQL handoff is missing ${marker}`);
+}
+
+console.log("Groups governance PostgreSQL suspension/expiry source guard passed");


### PR DESCRIPTION
## Summary
- add schema-isolated PostgreSQL executable source for Groups governance authority under temporary membership suspension and owner-clock expiry
- use all production Groups migrations, `GroupGovernanceService`, and the production membership enforcement command service
- provide pooled connections with the isolated schema through startup `search_path`; no session-local `SET search_path`
- prove an active local administrator can change a member role before enforcement
- suspend that administrator through the owner command while stored role remains `admin` and stored status remains `active`
- prove a fresh governance command fails closed with stable `groups.membership_suspended` and leaves the target role/revision unchanged
- after expiry, perform no revoke or cleanup and prove the same administrator regains governance authority with exact group-version/revision progression and unchanged lifecycle member count
- complement existing PostgreSQL replay/race/platform-recovery evidence without duplicating it
- add no dependency, manifest, lockfile, production-owner, GraphQL, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, and CI were intentionally not run per maintainer instruction.