### PR TITLE
test(groups): retain governance GraphQL SQLite parity

### DIFF
--- a/apps/server/tests/groups_governance_graphql_sqlite_parity.rs
+++ b/apps/server/tests/groups_governance_graphql_sqlite_parity.rs
@@ -1,0 +1,539 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use async_graphql::{EmptySubscription, Request, Response, Schema};
+use rustok_api::{
+    AuthContext, HostRuntimeContext, PortActor, PortContext, PortErrorKind, TenantContext,
+};
+use rustok_groups::graphql_application_cas::{GroupsMutationRoot, GroupsQueryRoot};
+use rustok_groups::{
+    ChangeGroupRoleRequest, GroupGovernanceCommandPort, GroupGovernanceService, GroupRole,
+    TransferGroupOwnershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups governance GraphQL parity SQLite connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for governance GraphQL parity evidence");
+    }
+}
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp.path().join("groups-governance-graphql-parity.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    native_group_id: Uuid,
+    graphql_group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+    target_id: Uuid,
+    replacement_id: Uuid,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES
+    ('{native_group_id}', '{tenant_id}', '{owner_id}', 'governance-native-parity', 4),
+    ('{graphql_group_id}', '{tenant_id}', '{owner_id}', 'governance-graphql-parity', 4);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{native_group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{native_group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{native_group_id}', '{target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{native_group_id}', '{replacement_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{graphql_group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{graphql_group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{graphql_group_id}', '{target_id}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{graphql_group_id}', '{replacement_id}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups governance GraphQL parity fixture should seed");
+}
+
+fn tenant_context(tenant_id: Uuid) -> TenantContext {
+    TenantContext {
+        id: tenant_id,
+        name: "Groups governance GraphQL parity".to_string(),
+        slug: "groups-governance-graphql-parity".to_string(),
+        domain: None,
+        settings: serde_json::json!({}),
+        default_locale: "en".to_string(),
+        is_active: true,
+    }
+}
+
+fn auth_context(tenant_id: Uuid, user_id: Uuid) -> AuthContext {
+    AuthContext {
+        user_id,
+        session_id: Uuid::new_v4(),
+        tenant_id,
+        permissions: Vec::new(),
+        client_id: None,
+        scopes: Vec::new(),
+        grant_type: "direct".to_string(),
+    }
+}
+
+fn native_write_context(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    idempotency_key: &str,
+) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-governance-native-parity-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(5))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn graphql_schema(
+    db: DatabaseConnection,
+) -> Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription> {
+    Schema::build(
+        GroupsQueryRoot::default(),
+        GroupsMutationRoot::default(),
+        EmptySubscription,
+    )
+    .data(HostRuntimeContext::new(db))
+    .finish()
+}
+
+async fn execute_graphql(
+    schema: &Schema<GroupsQueryRoot, GroupsMutationRoot, EmptySubscription>,
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    document: String,
+) -> Response {
+    schema
+        .execute(
+            Request::new(document)
+                .data(tenant_context(tenant_id))
+                .data(auth_context(tenant_id, actor_id)),
+        )
+        .await
+}
+
+fn response_json(response: Response) -> serde_json::Value {
+    assert!(
+        response.errors.is_empty(),
+        "Groups governance GraphQL parity request should succeed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .into_json()
+        .expect("Groups governance GraphQL parity data should convert to JSON")
+}
+
+fn extension_json(error: &async_graphql::ServerError, key: &str) -> Option<serde_json::Value> {
+    error
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get(key))
+        .cloned()
+        .and_then(|value| value.into_json().ok())
+}
+
+async fn group_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+) -> (String, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT owner_user_id, version FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group snapshot query should succeed")
+        .expect("group should exist");
+    (
+        row.try_get("", "owner_user_id")
+            .expect("group owner should decode"),
+        row.try_get("", "version")
+            .expect("group version should decode"),
+    )
+}
+
+async fn membership_role(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> String {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT role FROM group_memberships WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership role query should succeed")
+        .expect("membership should exist");
+    row.try_get("", "role")
+        .expect("membership role should decode")
+}
+
+fn assert_graphql_governance_result(
+    graphql: &serde_json::Value,
+    expected_group_id: Uuid,
+    expected_actor_id: Uuid,
+    expected_target_id: Uuid,
+    expected_previous_role: &str,
+    expected_current_role: &str,
+    expected_group_version: u64,
+    expected_replayed: bool,
+) {
+    assert_eq!(
+        graphql["groupId"].as_str().map(str::to_owned),
+        Some(expected_group_id.to_string())
+    );
+    assert_eq!(
+        graphql["actorUserId"].as_str().map(str::to_owned),
+        Some(expected_actor_id.to_string())
+    );
+    assert_eq!(
+        graphql["targetUserId"].as_str().map(str::to_owned),
+        Some(expected_target_id.to_string())
+    );
+    assert_eq!(graphql["previousRole"].as_str(), Some(expected_previous_role));
+    assert_eq!(graphql["currentRole"].as_str(), Some(expected_current_role));
+    assert_eq!(graphql["groupVersion"].as_u64(), Some(expected_group_version));
+    assert_eq!(graphql["replayed"].as_bool(), Some(expected_replayed));
+}
+
+#[tokio::test]
+async fn governance_native_and_final_graphql_share_owner_semantics_sqlite() {
+    let temp = tempfile::tempdir()
+        .expect("temporary Groups governance GraphQL parity directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let db = connect(&url).await;
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let native_group_id = Uuid::new_v4();
+    let graphql_group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    let target_id = Uuid::new_v4();
+    let replacement_id = Uuid::new_v4();
+    seed_group_fixture(
+        &db,
+        tenant_id,
+        native_group_id,
+        graphql_group_id,
+        owner_id,
+        admin_id,
+        target_id,
+        replacement_id,
+    )
+    .await;
+
+    let native = GroupGovernanceService::new(db.clone());
+    let schema = graphql_schema(db.clone());
+
+    let native_role = GroupGovernanceCommandPort::change_group_role(
+        &native,
+        native_write_context(tenant_id, admin_id, "native-change-role"),
+        ChangeGroupRoleRequest {
+            group_id: native_group_id,
+            target_user_id: target_id,
+            role: GroupRole::Moderator,
+        },
+    )
+    .await
+    .expect("native administrator role change should succeed");
+    assert_eq!(native_role.previous_role, GroupRole::Member);
+    assert_eq!(native_role.current_role, GroupRole::Moderator);
+    assert!(!native_role.replayed);
+
+    let graphql_role = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            admin_id,
+            format!(
+                r#"
+mutation {{
+  changeGroupRole(
+    idempotencyKey: "graphql-change-role",
+    groupId: "{graphql_group_id}",
+    targetUserId: "{target_id}",
+    role: MODERATOR
+  ) {{
+    groupId actorUserId targetUserId previousRole currentRole groupVersion replayed
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    assert_graphql_governance_result(
+        &graphql_role["changeGroupRole"],
+        graphql_group_id,
+        admin_id,
+        target_id,
+        "MEMBER",
+        "MODERATOR",
+        native_role.group_version,
+        false,
+    );
+
+    let native_role_replay = GroupGovernanceCommandPort::change_group_role(
+        &native,
+        native_write_context(tenant_id, admin_id, "native-change-role"),
+        ChangeGroupRoleRequest {
+            group_id: native_group_id,
+            target_user_id: target_id,
+            role: GroupRole::Moderator,
+        },
+    )
+    .await
+    .expect("native role change replay should succeed");
+    assert!(native_role_replay.replayed);
+    assert_eq!(native_role_replay.group_version, native_role.group_version);
+
+    let graphql_role_replay = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            admin_id,
+            format!(
+                r#"
+mutation {{
+  changeGroupRole(
+    idempotencyKey: "graphql-change-role",
+    groupId: "{graphql_group_id}",
+    targetUserId: "{target_id}",
+    role: MODERATOR
+  ) {{
+    groupId actorUserId targetUserId previousRole currentRole groupVersion replayed
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    assert_graphql_governance_result(
+        &graphql_role_replay["changeGroupRole"],
+        graphql_group_id,
+        admin_id,
+        target_id,
+        "MEMBER",
+        "MODERATOR",
+        native_role.group_version,
+        true,
+    );
+
+    let native_forbidden = GroupGovernanceCommandPort::transfer_group_ownership(
+        &native,
+        native_write_context(tenant_id, admin_id, "native-forbidden-transfer"),
+        TransferGroupOwnershipRequest {
+            group_id: native_group_id,
+            new_owner_user_id: replacement_id,
+        },
+    )
+    .await
+    .expect_err("non-owner administrator must not transfer ownership");
+    assert_eq!(native_forbidden.kind, PortErrorKind::Forbidden);
+    assert_eq!(native_forbidden.code, "groups.forbidden");
+    assert!(!native_forbidden.retryable);
+
+    let graphql_forbidden = execute_graphql(
+        &schema,
+        tenant_id,
+        admin_id,
+        format!(
+            r#"
+mutation {{
+  transferGroupOwnership(
+    idempotencyKey: "graphql-forbidden-transfer",
+    groupId: "{graphql_group_id}",
+    newOwnerUserId: "{replacement_id}"
+  ) {{ groupVersion }}
+}}
+"#
+        ),
+    )
+    .await;
+    assert_eq!(graphql_forbidden.errors.len(), 1);
+    let graphql_forbidden_error = &graphql_forbidden.errors[0];
+    assert_eq!(graphql_forbidden_error.message, native_forbidden.message);
+    assert_eq!(
+        extension_json(graphql_forbidden_error, "code")
+            .and_then(|value| value.as_str().map(str::to_owned)),
+        Some("PERMISSION_DENIED".to_string())
+    );
+
+    let (native_owner_before_transfer, native_version_before_transfer) =
+        group_snapshot(&db, tenant_id, native_group_id).await;
+    let (graphql_owner_before_transfer, graphql_version_before_transfer) =
+        group_snapshot(&db, tenant_id, graphql_group_id).await;
+    assert_eq!(native_owner_before_transfer, owner_id.to_string());
+    assert_eq!(graphql_owner_before_transfer, owner_id.to_string());
+    assert_eq!(native_version_before_transfer as u64, native_role.group_version);
+    assert_eq!(graphql_version_before_transfer as u64, native_role.group_version);
+
+    let native_transfer = GroupGovernanceCommandPort::transfer_group_ownership(
+        &native,
+        native_write_context(tenant_id, owner_id, "native-transfer-owner"),
+        TransferGroupOwnershipRequest {
+            group_id: native_group_id,
+            new_owner_user_id: replacement_id,
+        },
+    )
+    .await
+    .expect("native owner transfer should succeed");
+    assert_eq!(native_transfer.previous_role, GroupRole::Member);
+    assert_eq!(native_transfer.current_role, GroupRole::Owner);
+    assert_eq!(native_transfer.group_version, native_role.group_version + 1);
+    assert!(!native_transfer.replayed);
+
+    let graphql_transfer = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  transferGroupOwnership(
+    idempotencyKey: "graphql-transfer-owner",
+    groupId: "{graphql_group_id}",
+    newOwnerUserId: "{replacement_id}"
+  ) {{
+    groupId actorUserId targetUserId previousRole currentRole groupVersion replayed
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    assert_graphql_governance_result(
+        &graphql_transfer["transferGroupOwnership"],
+        graphql_group_id,
+        owner_id,
+        replacement_id,
+        "MEMBER",
+        "OWNER",
+        native_transfer.group_version,
+        false,
+    );
+
+    let native_transfer_replay = GroupGovernanceCommandPort::transfer_group_ownership(
+        &native,
+        native_write_context(tenant_id, owner_id, "native-transfer-owner"),
+        TransferGroupOwnershipRequest {
+            group_id: native_group_id,
+            new_owner_user_id: replacement_id,
+        },
+    )
+    .await
+    .expect("native ownership transfer replay should succeed");
+    assert!(native_transfer_replay.replayed);
+    assert_eq!(native_transfer_replay.group_version, native_transfer.group_version);
+
+    let graphql_transfer_replay = response_json(
+        execute_graphql(
+            &schema,
+            tenant_id,
+            owner_id,
+            format!(
+                r#"
+mutation {{
+  transferGroupOwnership(
+    idempotencyKey: "graphql-transfer-owner",
+    groupId: "{graphql_group_id}",
+    newOwnerUserId: "{replacement_id}"
+  ) {{
+    groupId actorUserId targetUserId previousRole currentRole groupVersion replayed
+  }}
+}}
+"#
+            ),
+        )
+        .await,
+    );
+    assert_graphql_governance_result(
+        &graphql_transfer_replay["transferGroupOwnership"],
+        graphql_group_id,
+        owner_id,
+        replacement_id,
+        "MEMBER",
+        "OWNER",
+        native_transfer.group_version,
+        true,
+    );
+
+    let (native_owner_after, native_version_after) =
+        group_snapshot(&db, tenant_id, native_group_id).await;
+    let (graphql_owner_after, graphql_version_after) =
+        group_snapshot(&db, tenant_id, graphql_group_id).await;
+    assert_eq!(native_owner_after, replacement_id.to_string());
+    assert_eq!(graphql_owner_after, replacement_id.to_string());
+    assert_eq!(native_version_after as u64, native_transfer.group_version);
+    assert_eq!(graphql_version_after as u64, native_transfer.group_version);
+
+    for group_id in [native_group_id, graphql_group_id] {
+        assert_eq!(membership_role(&db, tenant_id, group_id, owner_id).await, "admin");
+        assert_eq!(
+            membership_role(&db, tenant_id, group_id, replacement_id).await,
+            "owner"
+        );
+        assert_eq!(
+            membership_role(&db, tenant_id, group_id, target_id).await,
+            "moderator"
+        );
+        assert_eq!(membership_role(&db, tenant_id, group_id, admin_id).await, "admin");
+    }
+
+    drop(schema);
+    drop(native);
+    drop(db);
+    drop(temp);
+}

--- a/crates/rustok-groups/docs/governance-graphql-sqlite-parity-contract.md
+++ b/crates/rustok-groups/docs/governance-graphql-sqlite-parity-contract.md
@@ -1,0 +1,74 @@
+# Groups governance native/GraphQL SQLite parity contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_governance_graphql_sqlite_parity.rs` retains executable source evidence that the native `GroupGovernanceCommandPort` and the stable final Groups GraphQL root expose the same owner-domain governance semantics on SQLite.
+
+The packet uses a real temporary file-backed SQLite database, every production Groups migration, `GroupGovernanceService`, and `graphql_application_cas::{GroupsQueryRoot, GroupsMutationRoot}`. It adds no alternate governance owner, private GraphQL schema, fallback, dependency, manifest, lockfile, or production behavior change.
+
+## Equivalent owner fixtures
+
+Two equivalent Groups start with the same aggregate version and the same local principals:
+
+- current owner;
+- active administrator;
+- ordinary role-change target;
+- ordinary ownership-replacement target.
+
+One group is mutated through native governance ports and the other through the stable final GraphQL mutation root. GraphQL receives authenticated tenant-bound users with an empty effective permission list, so local governance remains a Groups owner-domain decision rather than a transport-side platform permission shortcut.
+
+## Parity contract
+
+The packet retains parity for both governance commands.
+
+### Role change
+
+An active administrator changes an ordinary member from `member` to `moderator` through native `change_group_role` and GraphQL `changeGroupRole`. The evidence requires matching previous/current roles, actor/target identity, group version and `replayed=false`.
+
+The exact same native and GraphQL requests are then repeated with the same idempotency keys. Both surfaces must return the stored result with `replayed=true` and no extra aggregate version advance.
+
+### Ownership transfer
+
+Before the successful transfer, the administrator attempts to transfer ownership. Native must return non-retryable `groups.forbidden` with `PortErrorKind::Forbidden`; GraphQL must return the same owner-safe message classified as `PERMISSION_DENIED`. The denied request must leave both equivalent aggregates at the post-role-change version and original owner.
+
+The current owner then transfers ownership to the ordinary replacement member through native `transfer_group_ownership` and GraphQL `transferGroupOwnership`. Both surfaces must return matching owner result semantics and the same next aggregate version.
+
+The exact transfer is replayed after the owner reference has already moved. Both native and GraphQL must still return the stored result with `replayed=true`, proving transport parity for the governance receipt-first contract rather than re-authorizing the former owner against current state.
+
+## Final owner state
+
+The packet reads final owner rows only as evidence after all mutations have gone through production owner surfaces. Both equivalent groups must have:
+
+- `groups.owner_user_id` set to the replacement;
+- former owner role `admin`;
+- replacement role `owner`;
+- role-change target `moderator`;
+- original administrator still `admin`;
+- the final group version equal to the ownership-transfer result.
+
+No direct table write is used to stand in for governance behavior.
+
+## Final-root composition
+
+The schema is built with the module's stable `graphql_application_cas::GroupsQueryRoot` and `GroupsMutationRoot`. The evidence does not instantiate `GroupsGovernanceMutation` as a private alternate schema.
+
+## Execution status
+
+The packet was not executed while preparing this slice. FBA `governance_transport_parity` therefore remains null until maintainer execution.
+
+Maintainer command:
+
+```bash
+cargo test -p rustok-server --features mod-groups \
+  --test groups_governance_graphql_sqlite_parity -- --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-governance-graphql-sqlite-parity.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, browser/schema execution, workflow, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-governance-graphql-sqlite-parity.mjs
+++ b/scripts/verify/verify-groups-governance-graphql-sqlite-parity.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_governance_graphql_sqlite_parity.rs";
+const docsPath = "crates/rustok-groups/docs/governance-graphql-sqlite-parity-contract.md";
+const registryPath = "crates/rustok-groups/contracts/groups-fba-registry.json";
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "rustok_groups::migrations::migrations()",
+  "GroupsQueryRoot::default()",
+  "GroupsMutationRoot::default()",
+  "HostRuntimeContext::new(db)",
+  "permissions: Vec::new()",
+  "GroupGovernanceService::new",
+  "GroupGovernanceCommandPort::change_group_role",
+  "GroupGovernanceCommandPort::transfer_group_ownership",
+  "changeGroupRole",
+  "transferGroupOwnership",
+  'assert_eq!(native_forbidden.kind, PortErrorKind::Forbidden)',
+  'assert_eq!(native_forbidden.code, "groups.forbidden")',
+  'Some("PERMISSION_DENIED".to_string())',
+  "graphql_forbidden_error.message, native_forbidden.message",
+  "native_role_replay.replayed",
+  "native_transfer_replay.replayed",
+  '"MEMBER",\n        "MODERATOR"',
+  '"MEMBER",\n        "OWNER"',
+  "native_transfer.group_version, native_role.group_version + 1",
+  'membership_role(&db, tenant_id, group_id, replacement_id).await,\n            "owner"',
+]) {
+  requireText(test, marker, `Groups governance GraphQL SQLite parity source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "GroupsGovernanceMutation::default()",
+  "groups:manage",
+  "rustok_moderation::",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups governance GraphQL SQLite parity source contains shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "executable source added / maintainer execution pending",
+  "Equivalent owner fixtures",
+  "Role change",
+  "Ownership transfer",
+  "groups.forbidden",
+  "PERMISSION_DENIED",
+  "receipt-first contract",
+  "Final owner state",
+  "Final-root composition",
+  "governance_transport_parity",
+  "empty effective permission list",
+]) {
+  requireText(docs, marker, `Groups governance GraphQL SQLite parity handoff is missing ${marker}`);
+}
+
+if (registry?.evidence?.governance_transport_parity !== null) {
+  throw new Error("unexecuted governance transport parity evidence must remain null");
+}
+
+console.log("Groups governance native/GraphQL SQLite parity source guard passed");


### PR DESCRIPTION
## Summary
- add file-backed SQLite executable source for native versus final-GraphQL Groups governance parity
- exercise both `change_group_role` / `changeGroupRole` and `transfer_group_ownership` / `transferGroupOwnership`
- use equivalent owner-controlled groups, all production Groups migrations, `GroupGovernanceService`, and the stable `graphql_application_cas` final roots
- retain role-change result parity and exact idempotent replay without extra version advance
- retain forbidden ownership-transfer parity: native non-retryable `groups.forbidden` / `PortErrorKind::Forbidden` maps to GraphQL `PERMISSION_DENIED` with the same owner-safe message
- retain successful ownership-transfer result parity and replay after the owner reference has already moved
- verify final owner reference and local roles match on the equivalent groups
- use authenticated local principals with no platform permissions so authority remains Groups-owned
- keep FBA `governance_transport_parity` null until maintainer execution
- add no dependency, manifest, lockfile, registry, production-owner, or fallback changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, browser/schema execution, workflows, and CI were intentionally not run per maintainer instruction.