### PR TITLE
refactor(commerce): require Product schema GraphQL idempotency

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -2,34 +2,34 @@
 
 ## Scope
 
-This source-only continuation follows Product schema-write capability publication and rechecks the mounted Commerce GraphQL consumers plus the active Product Admin callers. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open in this slice.
+This source-only continuation follows Product schema-write capability publication and mounted consumer cutover. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open because durable owner replay semantics are still missing.
 
 ## Current source result
 
 - Product publishes `ProductCatalogSchemaWritePort` for every Product schema write used by mounted Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
-- Mounted Commerce GraphQL no longer constructs `ProductCatalogSchemaService` for those writes. Every successful schema-write path resolves the host-selected `ProductCatalogCommandRuntime`, obtains its optional `schema_write_port()`, and fails closed with bounded `PRODUCT_TEMPORARILY_UNAVAILABLE` when an external profile has not supplied the capability.
+- Mounted Commerce GraphQL no longer constructs `ProductCatalogSchemaService` for those writes. Every schema-write path resolves the host-selected `ProductCatalogCommandRuntime`, obtains its optional `schema_write_port()`, and fails closed with bounded `PRODUCT_TEMPORARILY_UNAVAILABLE` when an external profile has not supplied the capability.
 - Schema writes derive tenant/actor/claims/request context from `PortContext`, retain the existing two-second Product command deadline, and scope-hash the caller key with tenant, authenticated actor, operation, and Product id when one exists.
-- The active Product Admin transport no longer re-exports schema-write calls from the legacy GraphQL adapter. It sends `$idempotencyKey: String!` for all eleven schema mutations and retains one caller key across an explicit retry of the same failed operation + intent; success releases the key for a later equal user action.
+- All eleven mounted Product schema-write resolver arguments now use `String`, so the generated GraphQL SDL requires `idempotencyKey: String!` before resolver execution.
+- The foreign-actor regression document supplies an explicit caller key for every Product schema mutation, preserving tenant/actor admission coverage after the SDL becomes non-null.
+- The active Product Admin transport already sends `$idempotencyKey: String!` for all eleven schema mutations and retains one caller key across an explicit retry of the same failed operation + intent; success releases the key for a later equal user action.
 - Product owner schema-write failures continue through stable `PortError` mapping and bounded Commerce public codes rather than exposing owner database/validation details.
 
-## Why the GraphQL SDL is still nullable
+## Mandatory GraphQL caller identity
 
-The mounted schema-write resolver inputs intentionally remain `Option<String>` in this slice. Omission is rejected with `BAD_USER_INPUT` / `Product schema mutation idempotency key is required` after existing module, permission, tenant-actor, and mutation-input admission has run.
+There is no compatibility-generated schema-write identity and no nullable schema-write idempotency argument in mounted Commerce GraphQL. The same caller-key trim and 191-byte validation used by Product lifecycle mutations applies before the schema-write owner port is called.
 
-This preserves the current `admin_graphql_rejects_foreign_actor_for_every_product_mutation` fixture, which intentionally omits schema-write keys while asserting that every Product mutation reaches tenant/actor admission. Making these arguments non-null immediately would move the failure to GraphQL required-argument validation and erase the regression signal. Active Product Admin callers already send non-null keys, so successful mounted schema-write execution has no compatibility-generated identity.
-
-The next narrow SDL step is therefore to add explicit keys to those foreign-actor schema mutation callers and then change all eleven resolver arguments from `Option<String>` to `String`.
+The existing `admin_graphql_rejects_foreign_actor_for_every_product_mutation` fixture now provides explicit schema-write keys. That keeps the regression focused on tenant/actor admission instead of GraphQL missing-argument validation while preserving the mandatory SDL contract for every real caller.
 
 ## Why the canonical item remains open
 
-The embedded `ProductCatalogSchemaService` still does not persist a command receipt keyed by `PortContext.idempotency_key`. Caller identity is now explicit and retained by Product Admin across failed explicit retries, but durable owner replay/adoption semantics must not be inferred from that boundary contract. A response lost after owner commit can still make a create retry unsafe until Product persists/replays the completed outcome.
+The embedded `ProductCatalogSchemaService` still does not persist a command receipt keyed by `PortContext.idempotency_key`. Caller identity is explicit and Product Admin retains it across failed explicit retries, but durable owner replay/adoption semantics must not be inferred from that boundary contract. A response lost after owner commit can still make a non-idempotent create retry unsafe until Product persists and replays the completed outcome.
 
 Remaining source order:
 
-1. update the foreign-actor regression document with explicit schema-write caller keys and make mounted schema-write `idempotencyKey` non-null;
-2. implement the owner-local durable receipt/replay contract needed for non-idempotent schema creates and define the outcome for update-style writes;
-3. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
-4. update canonical completion only when mounted non-null caller identity and intended owner replay semantics are source-complete.
+1. implement the owner-local durable receipt/replay contract needed for non-idempotent schema creates and define replay behavior for update-style schema writes;
+2. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
+3. update canonical completion only when the intended owner replay semantics are source-complete;
+4. retain static/compile/parity/remote/restart/backend evidence as separate maintainer-run verification.
 
 ## Verification state
 

--- a/crates/rustok-commerce/src/graphql/mutations/catalog.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/catalog.rs
@@ -114,12 +114,9 @@ fn product_schema_write_context(
     tenant_id: Uuid,
     user_id: Uuid,
     product_id: Option<Uuid>,
-    idempotency_key: Option<String>,
+    idempotency_key: String,
     operation: &'static str,
 ) -> Result<PortContext> {
-    let idempotency_key = idempotency_key.ok_or_else(|| {
-        invalid_product_idempotency_key("Product schema mutation idempotency key is required")
-    })?;
     product_command_context(
         ctx,
         tenant_id,
@@ -374,7 +371,7 @@ impl CommerceCatalogMutation {
     async fn create_product_attribute(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         locale: String,
         input: CreateProductAttributeInput,
     ) -> Result<bool> {
@@ -429,7 +426,7 @@ impl CommerceCatalogMutation {
     async fn create_product_attribute_option(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         locale: String,
         input: CreateProductAttributeOptionInput,
     ) -> Result<bool> {
@@ -470,7 +467,7 @@ impl CommerceCatalogMutation {
     async fn create_catalog_category(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         locale: String,
         input: CreateCatalogCategoryInput,
     ) -> Result<bool> {
@@ -515,7 +512,7 @@ impl CommerceCatalogMutation {
     async fn create_product_attribute_schema(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         locale: String,
         input: CreateProductAttributeSchemaInput,
     ) -> Result<bool> {
@@ -553,7 +550,7 @@ impl CommerceCatalogMutation {
     async fn create_product_attribute_schema_group(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         locale: String,
         input: CreateProductAttributeSchemaGroupInput,
     ) -> Result<bool> {
@@ -594,7 +591,7 @@ impl CommerceCatalogMutation {
     async fn create_catalog_category_attribute_group(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         locale: String,
         input: CreateCategoryAttributeGroupInput,
     ) -> Result<bool> {
@@ -635,7 +632,7 @@ impl CommerceCatalogMutation {
     async fn set_catalog_category_schema_mode(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         input: SetCategorySchemaModeInput,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -671,7 +668,7 @@ impl CommerceCatalogMutation {
     async fn bind_product_attribute_schema_attribute(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         input: BindSchemaAttributeInput,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -712,7 +709,7 @@ impl CommerceCatalogMutation {
     async fn bind_catalog_category_attribute(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         input: BindCategoryAttributeInput,
     ) -> Result<bool> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
@@ -754,7 +751,7 @@ impl CommerceCatalogMutation {
     async fn save_product_attribute_values(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         product_id: Uuid,
         locale: String,
         patches: Vec<ProductAttributeValuePatchInput>,
@@ -795,7 +792,7 @@ impl CommerceCatalogMutation {
     async fn clear_detached_product_attribute_values(
         &self,
         ctx: &Context<'_>,
-        idempotency_key: Option<String>,
+        idempotency_key: String,
         product_id: Uuid,
         locale: String,
         attribute_ids: Vec<Uuid>,

--- a/crates/rustok-commerce/tests/graphql_runtime_parity_test/catalog.rs
+++ b/crates/rustok-commerce/tests/graphql_runtime_parity_test/catalog.rs
@@ -122,7 +122,7 @@ async fn admin_graphql_rejects_foreign_actor_for_every_product_mutation() {
               update: updateProduct(idempotencyKey: "foreign-actor-update-all", id: "{id}", input: {{}}) {{ id }}
               publish: publishProduct(idempotencyKey: "foreign-actor-publish-all", id: "{id}") {{ id }}
               delete: deleteProduct(idempotencyKey: "foreign-actor-delete-all", id: "{id}")
-              createAttribute: createProductAttribute(locale: "en", input: {{
+              createAttribute: createProductAttribute(idempotencyKey: "foreign-actor-create-attribute-all", locale: "en", input: {{
                 code: "blocked"
                 valueType: "text"
                 label: "Blocked"
@@ -132,57 +132,59 @@ async fn admin_graphql_rejects_foreign_actor_for_every_product_mutation() {
                 isSortable: false
                 showOnStorefront: false
               }})
-              createOption: createProductAttributeOption(locale: "en", input: {{
+              createOption: createProductAttributeOption(idempotencyKey: "foreign-actor-create-option-all", locale: "en", input: {{
                 attributeId: "{id}"
                 code: "blocked"
                 label: "Blocked"
                 position: 0
               }})
-              createCategory: createCatalogCategory(locale: "en", input: {{
+              createCategory: createCatalogCategory(idempotencyKey: "foreign-actor-create-category-all", locale: "en", input: {{
                 code: "blocked"
                 slug: "blocked"
                 kind: "structural"
                 name: "Blocked"
               }})
-              createSchema: createProductAttributeSchema(locale: "en", input: {{
+              createSchema: createProductAttributeSchema(idempotencyKey: "foreign-actor-create-schema-all", locale: "en", input: {{
                 code: "blocked"
                 name: "Blocked"
               }})
-              createSchemaGroup: createProductAttributeSchemaGroup(locale: "en", input: {{
+              createSchemaGroup: createProductAttributeSchemaGroup(idempotencyKey: "foreign-actor-create-schema-group-all", locale: "en", input: {{
                 schemaId: "{id}"
                 code: "blocked"
                 label: "Blocked"
                 position: 0
               }})
-              createCategoryGroup: createCatalogCategoryAttributeGroup(locale: "en", input: {{
+              createCategoryGroup: createCatalogCategoryAttributeGroup(idempotencyKey: "foreign-actor-create-category-group-all", locale: "en", input: {{
                 categoryId: "{id}"
                 code: "blocked"
                 label: "Blocked"
                 position: 0
               }})
-              setSchemaMode: setCatalogCategorySchemaMode(input: {{
+              setSchemaMode: setCatalogCategorySchemaMode(idempotencyKey: "foreign-actor-set-schema-mode-all", input: {{
                 categoryId: "{id}"
                 mode: "inherit"
               }})
-              bindSchemaAttribute: bindProductAttributeSchemaAttribute(input: {{
+              bindSchemaAttribute: bindProductAttributeSchemaAttribute(idempotencyKey: "foreign-actor-bind-schema-attribute-all", input: {{
                 schemaId: "{id}"
                 attributeId: "{id}"
                 isRequired: false
                 isDisabled: false
                 position: 0
               }})
-              bindCategoryAttribute: bindCatalogCategoryAttribute(input: {{
+              bindCategoryAttribute: bindCatalogCategoryAttribute(idempotencyKey: "foreign-actor-bind-category-attribute-all", input: {{
                 categoryId: "{id}"
                 attributeId: "{id}"
                 bindingKind: "addition"
                 isDisabled: false
               }})
               saveValues: saveProductAttributeValues(
+                idempotencyKey: "foreign-actor-save-values-all"
                 productId: "{id}"
                 locale: "en"
                 patches: []
               ) {{ attributeId }}
               clearValues: clearDetachedProductAttributeValues(
+                idempotencyKey: "foreign-actor-clear-values-all"
                 productId: "{id}"
                 locale: "en"
                 attributeIds: []

--- a/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-graphql-lifecycle-command-cutover.mjs
@@ -100,7 +100,6 @@ for (const required of [
 }
 
 for (const forbidden of [
-  "idempotency_key: Option<String>",
   "Product mutation idempotency key is required",
   "one-request compatibility identity",
   'format!("compatibility-{}", Uuid::new_v4())',
@@ -199,11 +198,18 @@ requireText(
   "Product lifecycle shipping-profile fixture",
 );
 
-requireText(
+forbidText(
   mutations,
   "ProductCatalogSchemaService::new",
-  "remaining Product schema-write debt must stay explicit",
+  "mounted Product schema writes must not regress to direct owner-service construction",
 );
+for (const required of [
+  "ProductCatalogSchemaWritePort",
+  ".schema_write_port()",
+  "product.schema_write_port_unavailable",
+]) {
+  requireText(mutations, required, "Product schema-write owner boundary");
+}
 forbidText(
   mutations,
   "use rustok_product::{CatalogService,",
@@ -216,4 +222,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product GraphQL lifecycle SDL requires explicit caller idempotency; retry-aware Product Admin and regression callers supply keys with no compatibility identity");
+console.log("✔ Product GraphQL lifecycle SDL requires explicit caller idempotency; mounted schema writes retain the typed owner boundary with no direct Product schema service construction");

--- a/scripts/verify/verify-commerce-product-schema-write-consumer-cutover.mjs
+++ b/scripts/verify/verify-commerce-product-schema-write-consumer-cutover.mjs
@@ -18,6 +18,7 @@ const forbidText = (source, text, message) => {
 };
 
 const server = read("crates/rustok-commerce/src/graphql/mutations/catalog.rs");
+const catalogFixture = read("crates/rustok-commerce/tests/graphql_runtime_parity_test/catalog.rs");
 const activeTransport = read("crates/rustok-product/admin/src/catalog_transport_retry.rs");
 const schemaTransport = read("crates/rustok-product/admin/src/transport/product_schema_graphql.rs");
 const retryIdentity = read("crates/rustok-product/admin/src/schema_retry_identity.rs");
@@ -31,7 +32,7 @@ forbidText(
 requireText(server, "ProductCatalogSchemaWritePort", "mounted Commerce must depend on the typed Product schema-write port");
 requireText(server, ".schema_write_port()", "mounted Commerce must resolve schema writes from the host-selected Product command runtime");
 requireText(server, "product.schema_write_port_unavailable", "missing external schema-write capability must fail closed");
-requireText(server, "Product schema mutation idempotency key is required", "omitted schema-write caller identity must be rejected before owner execution");
+forbidText(server, "Product schema mutation idempotency key is required", "mounted schema SDL must no longer rely on nullable-key omission handling");
 requireText(server, "with_idempotency_key(scoped_key)", "schema writes must reuse the scoped Product PortContext idempotency identity");
 requireText(server, "with_deadline(PRODUCT_COMMAND_DEADLINE)", "schema writes must retain the Product command deadline");
 
@@ -55,14 +56,27 @@ for (const [resolver, ownerMethod] of schemaResolvers) {
   const next = server.indexOf("\n    async fn ", start + 1);
   const end = next < 0 ? server.length : next;
   const slice = server.slice(start, end);
-  requireText(
-    slice,
-    "idempotency_key: Option<String>",
-    `${resolver} must keep nullable SDL only as the explicit admission-ordering follow-up`,
-  );
-  requireText(slice, "product_schema_write_context(", `${resolver} must reject omitted caller identity before owner execution`);
+  requireText(slice, "idempotency_key: String", `${resolver} must expose required GraphQL caller idempotency`);
+  forbidText(slice, "idempotency_key: Option<String>", `${resolver} must not keep nullable GraphQL caller idempotency`);
+  requireText(slice, "product_schema_write_context(", `${resolver} must build the owner write context from caller identity`);
   requireText(slice, `.${ownerMethod}(`, `${resolver} must call Product owner schema-write method ${ownerMethod}`);
   requireText(slice, "product_schema_write_port(ctx, &port_context)?", `${resolver} must resolve the host-composed schema-write capability`);
+}
+
+for (const required of [
+  'createProductAttribute(idempotencyKey: "foreign-actor-create-attribute-all"',
+  'createProductAttributeOption(idempotencyKey: "foreign-actor-create-option-all"',
+  'createCatalogCategory(idempotencyKey: "foreign-actor-create-category-all"',
+  'createProductAttributeSchema(idempotencyKey: "foreign-actor-create-schema-all"',
+  'createProductAttributeSchemaGroup(idempotencyKey: "foreign-actor-create-schema-group-all"',
+  'createCatalogCategoryAttributeGroup(idempotencyKey: "foreign-actor-create-category-group-all"',
+  'setCatalogCategorySchemaMode(idempotencyKey: "foreign-actor-set-schema-mode-all"',
+  'bindProductAttributeSchemaAttribute(idempotencyKey: "foreign-actor-bind-schema-attribute-all"',
+  'bindCatalogCategoryAttribute(idempotencyKey: "foreign-actor-bind-category-attribute-all"',
+  'idempotencyKey: "foreign-actor-save-values-all"',
+  'idempotencyKey: "foreign-actor-clear-values-all"',
+]) {
+  requireText(catalogFixture, required, "Product schema foreign-actor fixture");
 }
 
 requireText(
@@ -89,5 +103,5 @@ requireText(retryIdentity, "&pending.intent == intent", "schema retry identity m
 requireText(retryIdentity, "product-admin-schema:", "schema retry keys must use the Product Admin schema namespace");
 
 console.log(
-  "Product schema-write consumer cutover source guard passed: mounted Commerce uses the host-selected owner port, successful execution requires caller identity, Product Admin sends retained String! keys, and nullable server SDL remains an explicit admission-ordering follow-up.",
+  "Product schema-write consumer cutover source guard passed: mounted Commerce uses the host-selected owner port, all eleven SDL arguments require caller idempotency, foreign-actor regression callers provide keys, and Product Admin retains explicit retry identity.",
 );


### PR DESCRIPTION
## Summary

- make all eleven mounted Commerce GraphQL Product schema-write `idempotencyKey` arguments non-null by changing resolver inputs from `Option<String>` to `String`
- remove the nullable schema missing-key compatibility branch while preserving the existing Product caller-key trim, 191-byte validation, scope hashing, two-second deadline, claims, request channel, typed owner-port execution, and bounded public error mapping
- update the foreign-actor Product mutation regression document with explicit schema-write caller keys so tenant/actor admission remains the asserted failure after GraphQL required-argument validation becomes mandatory
- normalize the Product schema-write source guard to require non-null resolver inputs and explicit fixture callers
- repair the previously stale Product lifecycle source guard left after #3288: it now forbids direct `ProductCatalogSchemaService` construction and requires the typed `ProductCatalogSchemaWritePort` boundary instead of requiring removed debt
- update the Product schema-write recheck packet to record that mounted caller identity is now mandatory

## Intentionally still open

- Product owner durable receipt/replay semantics for non-idempotent schema creates and defined replay behavior for update-style schema writes
- compatibility-source cleanup only after compile/source evidence confirms it is unmounted
- canonical combined Product schema-write/idempotency item remains `[ ]` until owner replay semantics are source-complete
- broad ecommerce typed-owner/FBA invariant remains open

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction. No FBA/FFA promotion.