### PR TITLE
feat(index): bound replay storage futures

### DIFF
--- a/crates/rustok-index/docs/.timeout-pr-sentinel
+++ b/crates/rustok-index/docs/.timeout-pr-sentinel
@@ -1,1 +1,0 @@
-timeout-pr-sentinel

--- a/crates/rustok-index/docs/.timeout-pr-sentinel
+++ b/crates/rustok-index/docs/.timeout-pr-sentinel
@@ -1,0 +1,1 @@
+timeout-pr-sentinel

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,8 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked after replay graceful-runner merge
-`9b1bd76ba264939566e66158e35cefab7419ce4c` and continued on
-`agent/index-replay-stop-handle-binding-20260808`.
+Status overlay rechecked at `main@232aeb8c936964c0f76d1a7661379619199f1d49` and continued on
+`agent/index-replay-pending-future-timeouts-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -114,8 +113,7 @@ request-bound tenant/actor context and effective `modules:manage`, rejects cross
 cancel tenant from that context.
 
 The GraphQL layer exposes source-complete schema-wide `runIndexReplay` / `cancelIndexReplay` commands without
-calling `SharedIndexReplayRuntime`, source adapters or PostgreSQL directly. Authorization occurs before parsing
-untrusted schema/job input.
+calling source adapters or PostgreSQL directly. Authorization occurs before parsing untrusted schema/job input.
 
 Caller input contains no tenant, actor, worker ID, source name, locale/partition, scheduler handle, replay
 resource budget, stop handle or shutdown flag. Each run creates a server-owned worker identity and applies fixed
@@ -133,25 +131,47 @@ An `IndexReplayError::Interrupted` first preserves any persisted cancellation ra
 job is yielded back to `pending`, lease ownership is cleared, no failure payload is recorded, and the last
 committed checkpoint is preserved.
 
-A retained deterministic SQLite packet covers both important restart windows:
+Retained source evidence now covers both runner and command boundaries:
 
-- host stop before scan: zero source calls/checkpoint changes, then attempt 2 completes normally;
-- host stop after one mutation is durable but before checkpoint commit: the first attempt yields with no
-  checkpoint, then attempt 2 scans the same page, records the stable delivery as `Duplicate`, commits the
-  checkpoint and succeeds.
+- runner-level SQLite evidence covers stop before scan and the harder durable-mutation-before-checkpoint window,
+  where attempt 2 replays the stable delivery as `Duplicate` before checkpoint/job completion;
+- GraphQL schema-data evidence runs the real `IndexReplayMutation` with request-scoped RBAC, coordinates source
+  scan through `Notify`, invokes the shared `StopHandle::stop()`, requires GraphQL `YIELDED` plus an uncancelled
+  lease-free pending attempt-1 job with no checkpoint/mutation, then constructs fresh runtime/operator/GraphQL
+  state over the same SQLite database and requires the same job to complete as attempt 2.
 
-The host binding is also source-complete:
+The GraphQL packet uses no wall-clock sleeps or polling and intentionally does **not** claim full HTTP/process
+bootstrap execution. Production schema lifecycle reservation/keepalive remains separately source-guarded.
 
-1. `SharedIndexReplayRuntime::run_interruptible` forwards only a lifecycle-neutral boolean probe;
-2. `IndexReplayOperatorRuntime::run_interruptible` preserves exact tenant/actor + `modules:manage` authorization;
-3. GraphQL schema initialization resolves or atomically publishes the one shared server `StopHandle`;
-4. API-only hosts retain a private watch receiver so the existing `StopHandle::stop()` can publish the terminal
-   value even when no background worker subscribed;
-5. `runIndexReplay` samples only `StopHandle::is_stopping` through the guarded operator/runtime chain;
-6. GraphQL never receives a shutdown field and never calls `.stop()`;
-7. `cancelIndexReplay` remains the separate persisted cancellation state machine.
+Neither retained shutdown packet nor a full process-shutdown replay scenario has been executed or admitted by
+the implementation agent.
 
-Actual process-shutdown execution evidence has **not** been run or admitted.
+## M6 replay pending storage-future timeout boundary
+
+The PostgreSQL replay adapter now bounds the two storage futures that could remain pending after a page has
+already entered a durable phase:
+
+- one replay mutation persistence call;
+- one replay checkpoint commit transaction.
+
+`source_replay_timeout.rs` applies a canonical 30-second outer bound and stable retryable dependency identities:
+`index_replay_mutation_timeout` and `index_replay_checkpoint_commit_timeout`.
+
+The one-page worker and multi-page runner error/state surfaces are unchanged. Mutation timeout still appears as
+`IndexReplayError::MutationFailed`; checkpoint timeout still appears as `IndexReplayError::CheckpointCommitFailed`.
+The existing runner records the dependency code plus `retryable: true`, but first rechecks persisted cancellation,
+so a user cancellation that won the race remains `Cancelled`.
+
+These are observation bounds, not rollback guarantees. Dropping the timed-out future does not prove that the
+underlying database operation was cancelled. No synthetic checkpoint is created after mutation timeout. A timed
+checkpoint commit is treated as storage-state-unknown: the next admitted attempt must read the durable checkpoint
+normally under the existing lease fence.
+
+The timeout helper contains no `StopHandle`, `request_cancel`, `cancel_requested` or yield semantics. Graceful
+shutdown remains safe-point-only, while replay retry/recovery policy remains the owner of later retry admission.
+
+Retained timeout unit source and source guard are complete but have **not** been executed or admitted by the
+implementation agent. See `m6-replay-pending-future-timeouts.md`.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -183,9 +203,13 @@ Actual process-shutdown execution evidence has **not** been run or admitted.
 - [x] Guarded schema-wide replay run/cancel GraphQL command transport with server-owned bounded run policy.
 - [x] Carry a host-owned interruption probe through replay runner safe points and retain duplicate-safe restart evidence source.
 - [x] Bind the shared server `StopHandle::is_stopping` signal through guarded replay runtime/operator composition without caller shutdown controls.
+- [x] Retain deterministic GraphQL StopHandle -> pending -> fresh-runtime attempt-2 completion evidence source without sleeps/polling.
+- [x] Bound replay mutation/checkpoint-commit pending futures with retryable timeout identities and preserve cancel/lease precedence.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
-- [ ] Execute/admit retained graceful interruption/restart evidence and process-shutdown binding.
+- [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
+- [ ] Execute/admit retained mutation/checkpoint pending-future timeout evidence.
+- [ ] Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds.
 - [ ] Complete remaining multi-host/restart evidence beyond existing convergence/replay packets.
 - [ ] Add locale/partition replay checkpoint dimensions and explicit rebuild modes under separate contracts.
 
@@ -220,13 +244,15 @@ Actual process-shutdown execution evidence has **not** been run or admitted.
 ## Next source-code boundary
 
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
-The next independent M6 source slice is retained end-to-end shutdown command evidence: drive an authorized replay
-command through the real GraphQL/schema/operator chain, flip the shared `StopHandle` deterministically without
-sleep/timing polling, and prove the job yields `pending` and resumes with duplicate-safe semantics.
 
-If that cannot be retained deterministically without inventing a test-only lifecycle path, move instead to the
-separate pending-future timeout boundary. Locale/partition checkpoint scope and explicit rebuild modes remain
-later contracts.
+After this timeout slice, the next independent M6 source boundary is replay checkpoint scope. The persistence table
+already reserves `locale_key` and `partition_key`, but the current replay request/source-scan contract is
+schema-wide and the runtime key still writes empty values. Do not merely populate those columns. First define a
+real locale-scoped replay request/scan identity end-to-end; only then let checkpoint/job identity carry that scope.
+Partition scope must remain separate until the source contract can actually scan a partition.
+
+Explicit targeted/full/shadow rebuild modes remain a later separate contract and must not be smuggled into locale
+checkpoint work.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-pending-future-timeouts.md
+++ b/crates/rustok-index/docs/m6-replay-pending-future-timeouts.md
@@ -1,0 +1,83 @@
+# M6 replay pending-future timeout boundary
+
+Status: `source_complete_execution_pending`.
+
+## Purpose
+
+Replay already had bounded owner-source calls and cooperative safe-point interruption, but those controls did not bound a storage future after mutation persistence or checkpoint commit had already started.
+
+This slice adds an outer timeout to the two PostgreSQL replay storage phases that can otherwise remain pending inside one page:
+
+- `PostgresMutationStore` when used through `IndexReplayMutationSink`;
+- `PostgresIndexReplayCheckpointStore::commit_replay_checkpoint`.
+
+The one-page worker and multi-page runner state machines are unchanged.
+
+## Timeout contract
+
+`source_replay_timeout.rs` owns one canonical 30-second outer bound for each storage future and two stable retryable dependency codes:
+
+- `index_replay_mutation_timeout`;
+- `index_replay_checkpoint_commit_timeout`.
+
+The bound applies only after replay-specific contract preparation has succeeded. A normal dependency failure still passes through with its existing permanent/retryable classification.
+
+Source scan/load calls remain independently bounded by the existing canonical Index source timeout wrapper. This slice does not merge source and storage timeouts into one page deadline.
+
+## Mutation timeout semantics
+
+The replay adapter creates the stable `MutationDelivery` first and then wraps `PostgresMutationStore::apply` in the outer timeout.
+
+If the future completes, the existing `Applied` / `Duplicate` / `StaleIgnored` mapping is unchanged. If the outer timeout expires, the adapter returns retryable `index_replay_mutation_timeout`, which the worker preserves as `IndexReplayError::MutationFailed` at the current mutation position.
+
+A timeout does **not** prove that the database operation was rolled back or cancelled. The future is dropped, but an underlying driver/database operation may have crossed a durable boundary before the caller stopped observing it. Therefore replay correctness continues to rely on the pre-existing stable event/delivery ID, inbox deduplication and monotonic source-version checks.
+
+The worker does not synthesize a checkpoint for a timed-out mutation. If storage did commit before the timeout was observed, a later replay of the same page must safely resolve that delivery through the existing duplicate/stale rules.
+
+## Checkpoint commit timeout semantics
+
+Checkpoint identity validation remains outside the timeout so invalid lease/scope input fails immediately as the existing permanent contract error.
+
+The database transaction, active lease check, checkpoint upsert and transaction commit are then wrapped as one bounded checkpoint-commit future. Timeout returns retryable `index_replay_checkpoint_commit_timeout`, preserved by the worker as `IndexReplayError::CheckpointCommitFailed`.
+
+The timeout path does not execute a synthetic rollback, rewind or checkpoint write after the outer future has expired. It also does not claim that the underlying database commit could not have completed. The next attempt must read the durable checkpoint normally and continue from whatever state storage actually committed under the existing lease fence.
+
+## Runner failure and cancellation precedence
+
+No new runner terminal state is introduced. Existing `replay_failure_details` already maps mutation/checkpoint dependency failures to their machine code and `IndexReplayFailureKind` retryability.
+
+For either timeout, the multi-page runner still checks persisted cancellation after the page error and before writing terminal failure. Therefore:
+
+1. a user cancellation that won the race remains `Cancelled`;
+2. otherwise an active fenced attempt records the existing `index.replay_page_failed` terminal job failure with timeout dependency code and `retryable: true` in details;
+3. lease loss still fails closed through the existing lease path;
+4. `StopHandle` interruption remains a separate safe-point-only `Yielded -> pending` path and is not used as a storage deadline.
+
+This slice does not automatically requeue a failed replay job. Existing replay retry/recovery policy remains the owner of later retry admission.
+
+## Lease boundary
+
+The 30-second value is an upper bound for one storage dependency future, not a guarantee that a whole page fits inside a job lease. Existing heartbeat and lease fencing remain authoritative. A future page-budget/lease policy may tighten these per-phase values, but must not weaken the timeout error semantics retained here.
+
+## Retained source evidence
+
+`source_replay_timeout.rs` retains unit source for:
+
+- a never-completing mutation future becoming retryable `index_replay_mutation_timeout`;
+- a never-completing checkpoint commit future becoming retryable `index_replay_checkpoint_commit_timeout`;
+- an immediate dependency failure passing through unchanged instead of being rewritten as timeout.
+
+`verify-index-replay-pending-future-timeout.mjs` additionally locks the production adapter wiring, timeout codes, runner retryability mapping, cancellation precedence and the deliberate absence of `StopHandle` / `request_cancel` from the timeout helper.
+
+The retained tests and verifier were not executed by the implementation agent.
+
+## Still open
+
+- maintainer execution/admission of the retained timeout source evidence;
+- broader page-duration versus lease/heartbeat budgeting under multi-mutation pages;
+- checkpoint-read pending-future policy if later evidence shows it needs a separate bound;
+- locale/partition replay checkpoint dimensions;
+- explicit targeted/full/shadow rebuild modes;
+- broader multi-host/restart execution evidence.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -29,6 +29,7 @@ mod source_reconciliation_scheduler;
 mod source_replay;
 mod source_replay_job;
 mod source_replay_retry;
+mod source_replay_timeout;
 mod source_replay_runner {
     include!("source_replay_runner.rs");
     mod graceful_shutdown;

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
@@ -18,6 +18,7 @@ use super::{
     source_replay_job::{
         assert_active_replay_job_lease, IndexReplayJobError, IndexReplayJobLease,
     },
+    source_replay_timeout::{bounded_replay_checkpoint_commit, bounded_replay_mutation},
 };
 
 #[async_trait]
@@ -30,16 +31,19 @@ impl IndexReplayMutationSink for PostgresMutationStore {
     ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
         let delivery = MutationDelivery::from_event(source_name, mutation.clone())
             .map_err(classify_mutation_failure)?;
-        self.apply(registry, &delivery)
-            .await
-            .map(|outcome| match outcome {
-                MutationApplyOutcome::Applied { .. } => IndexReplayMutationOutcome::Applied,
-                MutationApplyOutcome::Duplicate { .. } => IndexReplayMutationOutcome::Duplicate,
-                MutationApplyOutcome::StaleIgnored { .. } => {
-                    IndexReplayMutationOutcome::StaleIgnored
-                }
-            })
-            .map_err(classify_mutation_failure)
+        bounded_replay_mutation(async {
+            self.apply(registry, &delivery)
+                .await
+                .map(|outcome| match outcome {
+                    MutationApplyOutcome::Applied { .. } => IndexReplayMutationOutcome::Applied,
+                    MutationApplyOutcome::Duplicate { .. } => IndexReplayMutationOutcome::Duplicate,
+                    MutationApplyOutcome::StaleIgnored { .. } => {
+                        IndexReplayMutationOutcome::StaleIgnored
+                    }
+                })
+                .map_err(classify_mutation_failure)
+        })
+        .await
     }
 }
 
@@ -144,60 +148,63 @@ impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore {
         checkpoint: &IndexReplayCheckpoint,
     ) -> Result<(), IndexReplayFailure> {
         validate_checkpoint_identity(&self.lease, checkpoint.key())?;
-        let transaction = self
-            .db
-            .begin()
-            .await
-            .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error))?;
-        let result = async {
-            let backend = transaction.get_database_backend();
-            ensure_supported_backend(backend)?;
-            assert_active_replay_job_lease(&transaction, &self.lease, backend)
-                .await
-                .map_err(classify_job_lease_failure)?;
-            let cursor = serde_json::to_value(checkpoint.cursor()).map_err(|error| {
-                checkpoint_contract_failure("checkpoint_cursor_invalid", error)
-            })?;
-            let mut values = checkpoint_key_values(checkpoint.key(), backend);
-            values.push(SqlValue::Json(Some(Box::new(cursor))));
-            values.push(optional_source_version_value(
-                checkpoint.source_version(),
-                backend,
-            )?);
-            values.push(
-                checkpoint
-                    .last_delivery_id()
-                    .map(str::to_owned)
-                    .into(),
-            );
-
-            transaction
-                .execute(Statement::from_sql_and_values(
-                    backend,
-                    upsert_checkpoint_sql(backend),
-                    values,
-                ))
+        bounded_replay_checkpoint_commit(async {
+            let transaction = self
+                .db
+                .begin()
                 .await
                 .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error))?;
-            Ok(())
-        }
-        .await;
-
-        match result {
-            Ok(()) => transaction
-                .commit()
-                .await
-                .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error)),
-            Err(error) => {
-                transaction
-                    .rollback()
+            let result = async {
+                let backend = transaction.get_database_backend();
+                ensure_supported_backend(backend)?;
+                assert_active_replay_job_lease(&transaction, &self.lease, backend)
                     .await
-                    .map_err(|rollback| {
-                        checkpoint_storage_failure("checkpoint_commit_rollback_failed", rollback)
-                    })?;
-                Err(error)
+                    .map_err(classify_job_lease_failure)?;
+                let cursor = serde_json::to_value(checkpoint.cursor()).map_err(|error| {
+                    checkpoint_contract_failure("checkpoint_cursor_invalid", error)
+                })?;
+                let mut values = checkpoint_key_values(checkpoint.key(), backend);
+                values.push(SqlValue::Json(Some(Box::new(cursor))));
+                values.push(optional_source_version_value(
+                    checkpoint.source_version(),
+                    backend,
+                )?);
+                values.push(
+                    checkpoint
+                        .last_delivery_id()
+                        .map(str::to_owned)
+                        .into(),
+                );
+
+                transaction
+                    .execute(Statement::from_sql_and_values(
+                        backend,
+                        upsert_checkpoint_sql(backend),
+                        values,
+                    ))
+                    .await
+                    .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error))?;
+                Ok(())
             }
-        }
+            .await;
+
+            match result {
+                Ok(()) => transaction
+                    .commit()
+                    .await
+                    .map_err(|error| checkpoint_storage_failure("checkpoint_commit_failed", error)),
+                Err(error) => {
+                    transaction
+                        .rollback()
+                        .await
+                        .map_err(|rollback| {
+                            checkpoint_storage_failure("checkpoint_commit_rollback_failed", rollback)
+                        })?;
+                    Err(error)
+                }
+            }
+        })
+        .await
     }
 }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs
@@ -1,0 +1,127 @@
+use std::{future::Future, time::Duration};
+
+use tokio::time::timeout;
+
+use crate::IndexReplayFailure;
+
+/// Canonical upper bound for one replay mutation persistence call or one replay checkpoint commit.
+///
+/// This is an outer future bound, not a claim that the underlying database operation is rolled back
+/// or cancelled after the future is dropped. Replay correctness must therefore continue to rely on
+/// stable delivery identity, monotonic source versions, durable checkpoint reads, and the job lease
+/// fence after any timeout.
+const DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT: Duration = Duration::from_secs(30);
+
+const INDEX_REPLAY_MUTATION_TIMEOUT_CODE: &str = "index_replay_mutation_timeout";
+const INDEX_REPLAY_CHECKPOINT_COMMIT_TIMEOUT_CODE: &str =
+    "index_replay_checkpoint_commit_timeout";
+
+pub(super) async fn bounded_replay_mutation<T, F>(future: F) -> Result<T, IndexReplayFailure>
+where
+    F: Future<Output = Result<T, IndexReplayFailure>>,
+{
+    bounded_replay_storage_future(
+        DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT,
+        INDEX_REPLAY_MUTATION_TIMEOUT_CODE,
+        "mutation",
+        future,
+    )
+    .await
+}
+
+pub(super) async fn bounded_replay_checkpoint_commit<T, F>(
+    future: F,
+) -> Result<T, IndexReplayFailure>
+where
+    F: Future<Output = Result<T, IndexReplayFailure>>,
+{
+    bounded_replay_storage_future(
+        DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT,
+        INDEX_REPLAY_CHECKPOINT_COMMIT_TIMEOUT_CODE,
+        "checkpoint_commit",
+        future,
+    )
+    .await
+}
+
+async fn bounded_replay_storage_future<T, F>(
+    call_timeout: Duration,
+    timeout_code: &'static str,
+    phase: &'static str,
+    future: F,
+) -> Result<T, IndexReplayFailure>
+where
+    F: Future<Output = Result<T, IndexReplayFailure>>,
+{
+    debug_assert!(!call_timeout.is_zero());
+    match timeout(call_timeout, future).await {
+        Ok(result) => result,
+        Err(_) => {
+            tracing::error!(
+                replay_phase = phase,
+                replay_failure_code = timeout_code,
+                replay_failure_retryable = true,
+                timeout_ms = call_timeout.as_millis(),
+                "Index replay storage future exceeded its outer timeout"
+            );
+            Err(IndexReplayFailure::retryable_static(timeout_code))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use super::*;
+    use crate::IndexReplayFailureKind;
+
+    #[tokio::test]
+    async fn pending_mutation_future_times_out_as_retryable() {
+        let failure = bounded_replay_storage_future(
+            Duration::from_millis(1),
+            INDEX_REPLAY_MUTATION_TIMEOUT_CODE,
+            "mutation",
+            pending::<Result<(), IndexReplayFailure>>(),
+        )
+        .await
+        .expect_err("pending replay mutation should hit the outer timeout");
+
+        assert_eq!(failure.kind(), IndexReplayFailureKind::Retryable);
+        assert_eq!(failure.code(), INDEX_REPLAY_MUTATION_TIMEOUT_CODE);
+    }
+
+    #[tokio::test]
+    async fn pending_checkpoint_commit_future_times_out_as_retryable() {
+        let failure = bounded_replay_storage_future(
+            Duration::from_millis(1),
+            INDEX_REPLAY_CHECKPOINT_COMMIT_TIMEOUT_CODE,
+            "checkpoint_commit",
+            pending::<Result<(), IndexReplayFailure>>(),
+        )
+        .await
+        .expect_err("pending replay checkpoint commit should hit the outer timeout");
+
+        assert_eq!(failure.kind(), IndexReplayFailureKind::Retryable);
+        assert_eq!(
+            failure.code(),
+            INDEX_REPLAY_CHECKPOINT_COMMIT_TIMEOUT_CODE
+        );
+    }
+
+    #[tokio::test]
+    async fn dependency_failure_is_preserved_before_timeout() {
+        let expected = IndexReplayFailure::permanent("mutation_rejected")
+            .expect("fixture failure code should be valid");
+        let actual = bounded_replay_storage_future(
+            Duration::from_millis(1),
+            INDEX_REPLAY_MUTATION_TIMEOUT_CODE,
+            "mutation",
+            async { Err::<(), _>(expected.clone()) },
+        )
+        .await
+        .expect_err("dependency failure should pass through unchanged");
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs
@@ -57,11 +57,12 @@ where
     match timeout(call_timeout, future).await {
         Ok(result) => result,
         Err(_) => {
+            let timeout_ms = u64::try_from(call_timeout.as_millis()).unwrap_or(u64::MAX);
             tracing::error!(
                 replay_phase = phase,
                 replay_failure_code = timeout_code,
                 replay_failure_retryable = true,
-                timeout_ms = call_timeout.as_millis(),
+                timeout_ms,
                 "Index replay storage future exceeded its outer timeout"
             );
             Err(IndexReplayFailure::retryable_static(timeout_code))

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -33,6 +33,7 @@ const scripts = [
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-replay-graphql-transport.mjs',
+  'verify-index-replay-graphql-shutdown-evidence.mjs',
   'verify-index-server-reconciliation-guard.mjs',
   'verify-index-drift-diagnosis-graphql-transport.mjs',
   'verify-index-drift-source-page-diagnosis.mjs',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -29,6 +29,7 @@ const scripts = [
   'verify-index-replay-job-leases.mjs',
   'verify-index-replay-multipage-runner.mjs',
   'verify-index-replay-graceful-shutdown.mjs',
+  'verify-index-replay-pending-future-timeout.mjs',
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-replay-graphql-transport.mjs',

--- a/scripts/verify/verify-index-replay-pending-future-timeout.mjs
+++ b/scripts/verify/verify-index-replay-pending-future-timeout.mjs
@@ -59,6 +59,7 @@ if (adapter.includes('bounded_replay_checkpoint_commit(async {\n            vali
 
 const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
 const runner = requireMarkers(runnerPath, [
+  'let page = match worker.run_next_page(request.page_request().clone()).await {',
   'if cancel_if_requested(&self.db, &lease).await? {',
   'let details = replay_failure_details(&error);',
   'finish_failure(&self.db, &lease, details).await?',
@@ -67,10 +68,18 @@ const runner = requireMarkers(runnerPath, [
   'failure.kind() == IndexReplayFailureKind::Retryable',
   '"retryable": retryable',
 ]);
-const pageFailure = runner.indexOf('Err(error) => {');
+const pageMatch = runner.indexOf('let page = match worker.run_next_page(request.page_request().clone()).await {');
+const pageFailure = runner.indexOf('Err(error) => {', pageMatch);
 const cancelCheck = runner.indexOf('if cancel_if_requested(&self.db, &lease).await? {', pageFailure);
 const failureDetails = runner.indexOf('let details = replay_failure_details(&error);', cancelCheck);
-if (pageFailure < 0 || cancelCheck <= pageFailure || failureDetails <= cancelCheck) {
+const finishFailure = runner.indexOf('finish_failure(&self.db, &lease, details).await?', failureDetails);
+if (
+  pageMatch < 0 ||
+  pageFailure <= pageMatch ||
+  cancelCheck <= pageFailure ||
+  failureDetails <= cancelCheck ||
+  finishFailure <= failureDetails
+) {
   fail('persisted cancellation must keep precedence over terminal page failure after a timeout');
 }
 

--- a/scripts/verify/verify-index-replay-pending-future-timeout.mjs
+++ b/scripts/verify/verify-index-replay-pending-future-timeout.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-pending-future-timeout] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const helperPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs';
+const helper = requireMarkers(helperPath, [
+  'DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT: Duration = Duration::from_secs(30)',
+  'INDEX_REPLAY_MUTATION_TIMEOUT_CODE: &str = "index_replay_mutation_timeout"',
+  '"index_replay_checkpoint_commit_timeout"',
+  'tokio::time::timeout',
+  'bounded_replay_mutation',
+  'bounded_replay_checkpoint_commit',
+  'IndexReplayFailure::retryable_static(timeout_code)',
+  'pending::<Result<(), IndexReplayFailure>>()',
+  'IndexReplayFailureKind::Retryable',
+  'dependency_failure_is_preserved_before_timeout',
+]);
+for (const forbidden of ['StopHandle', 'request_cancel', 'cancel_requested', 'yield_for_resume']) {
+  if (helper.includes(forbidden)) {
+    fail(`${helperPath} must stay storage-timeout-only and not absorb lifecycle/cancellation semantics: ${forbidden}`);
+  }
+}
+
+const adapterPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
+const adapter = requireMarkers(adapterPath, [
+  'source_replay_timeout::{bounded_replay_checkpoint_commit, bounded_replay_mutation}',
+  'bounded_replay_mutation(async {',
+  'self.apply(registry, &delivery)',
+  'bounded_replay_checkpoint_commit(async {',
+  'validate_checkpoint_identity(&self.lease, checkpoint.key())?;',
+  'assert_active_replay_job_lease(&transaction, &self.lease, backend)',
+  'upsert_checkpoint_sql(backend)',
+  'transaction\n                    .commit()'.replace('\\n', '\n'),
+]);
+const identityValidation = adapter.indexOf('validate_checkpoint_identity(&self.lease, checkpoint.key())?;');
+const checkpointTimeout = adapter.indexOf('bounded_replay_checkpoint_commit(async {', identityValidation);
+if (identityValidation < 0 || checkpointTimeout <= identityValidation) {
+  fail('checkpoint identity validation must remain outside/before the bounded commit future');
+}
+if (adapter.includes('bounded_replay_checkpoint_commit(async {\n            validate_checkpoint_identity'.replace('\\n', '\n'))) {
+  fail('checkpoint identity validation must not be delayed inside the timeout future');
+}
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = requireMarkers(runnerPath, [
+  'if cancel_if_requested(&self.db, &lease).await? {',
+  'let details = replay_failure_details(&error);',
+  'finish_failure(&self.db, &lease, details).await?',
+  'IndexReplayError::MutationFailed { failure, .. }',
+  '| IndexReplayError::CheckpointCommitFailed(failure)',
+  'failure.kind() == IndexReplayFailureKind::Retryable',
+  '"retryable": retryable',
+]);
+const pageFailure = runner.indexOf('Err(error) => {');
+const cancelCheck = runner.indexOf('if cancel_if_requested(&self.db, &lease).await? {', pageFailure);
+const failureDetails = runner.indexOf('let details = replay_failure_details(&error);', cancelCheck);
+if (pageFailure < 0 || cancelCheck <= pageFailure || failureDetails <= cancelCheck) {
+  fail('persisted cancellation must keep precedence over terminal page failure after a timeout');
+}
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  'mod source_replay_timeout;',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-replay-pending-future-timeouts.md', [
+  'Status: `source_complete_execution_pending`.',
+  '`index_replay_mutation_timeout`',
+  '`index_replay_checkpoint_commit_timeout`',
+  'does **not** prove that the database operation was rolled back or cancelled',
+  'does not execute a synthetic rollback, rewind or checkpoint write',
+  'user cancellation that won the race remains `Cancelled`',
+  '`retryable: true`',
+  '`StopHandle` interruption remains a separate safe-point-only',
+  'not a guarantee that a whole page fits inside a job lease',
+]);
+
+console.log('[verify-index-replay-pending-future-timeout] replay mutation/checkpoint storage futures are bounded with retryable timeout identity while lease, cancel, and graceful-stop semantics stay separate');


### PR DESCRIPTION
## Summary

- bound the two PostgreSQL replay storage futures that could remain pending after a page enters a durable phase: one mutation persistence call and one checkpoint commit transaction;
- add one canonical 30-second outer bound in `source_replay_timeout.rs` with stable retryable dependency identities `index_replay_mutation_timeout` and `index_replay_checkpoint_commit_timeout`;
- keep stable mutation delivery construction outside the mutation timeout and preserve existing Applied/Duplicate/StaleIgnored mapping when the dependency completes;
- keep checkpoint lease/scope identity validation outside the checkpoint timeout, then bound database begin, active-lease validation, checkpoint upsert and transaction commit as one commit future;
- preserve the existing one-page worker and multi-page runner error/state surfaces: mutation timeout remains `MutationFailed`, checkpoint timeout remains `CheckpointCommitFailed`;
- preserve persisted cancellation precedence: the runner still checks `cancel_if_requested` after a page error and before terminal failure, while lease loss and graceful StopHandle interruption remain separate existing paths;
- explicitly avoid claiming that dropping a timed-out future rolled back or cancelled the underlying database operation; mutation timeout creates no synthetic checkpoint, and checkpoint timeout is treated as storage-state-unknown for the next durable checkpoint read;
- retain deterministic pending-future unit source and a focused source guard without running it;
- repair the stale aggregate/cursor regression by restoring the already-retained replay GraphQL shutdown evidence guard to the Index aggregate and marking that evidence source-complete in the current plan.

## Boundary

This PR does not add automatic retry/requeue, change replay job/cancellation SQL, change worker/runner terminal states, change GraphQL input, change StopHandle semantics, add locale/partition scope, add rebuild modes, or touch M7 Storefront traffic.

The 30-second timeout is per storage dependency future, not a whole-page deadline or a guarantee that a page fits inside the current lease. Whole-page duration versus lease/heartbeat policy remains a separate M6 boundary.

## Main recheck

The branch started from `main@232aeb8c936964c0f76d1a7661379619199f1d49`. Current `main@22bfca7b783aa9a1e9d057b26776ff0a7b3f8e81` is three commits ahead. Those commits affect Groups governance evidence and Product/Commerce GraphQL idempotency paths; they do not overlap this seven-file Index timeout/docs/guard diff or `scripts/verify/verify-index-query-contract.mjs`.

## Validation

Static source review only. The review checked current Tokio availability, replay dependency trait signatures, checkpoint transaction ownership, existing runner cancel-before-failure ordering, retryability serialization, aggregate guard membership, and the absence of worker/runner state-machine changes. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.