### PR TITLE
feat(index): add locale-scoped source scan contract

### DIFF
--- a/crates/rustok-index/docs/m6-locale-scoped-source-scan.md
+++ b/crates/rustok-index/docs/m6-locale-scoped-source-scan.md
@@ -1,0 +1,48 @@
+# M6 locale-scoped replay source scan foundation
+
+Status: `generic_source_contract_complete_product_source_pending`.
+
+## Purpose
+
+Replay checkpoints already reserve a `locale_key`, but the generic source scan request was schema-wide. Populating a checkpoint locale without a real locale-aware source request would create false isolation: a supposedly locale-scoped replay could still scan and mutate every locale in the schema.
+
+This slice establishes the generic source boundary first. Durable replay job/checkpoint locale identity, Product PostgreSQL locale predicates, GraphQL locale input, partition scope and rebuild modes are intentionally separate follow-up work.
+
+## Generic source request
+
+`IndexSourceScanRequest` now carries `locale: Option<LocaleKey>`.
+
+The existing `IndexSourceScanRequest::new(...)` constructor is unchanged in meaning and constructs a schema-wide scan with no locale scope. Existing source implementations therefore keep their current call shape and behavior.
+
+`IndexSourceScanRequest::for_locale(...)` constructs an exact-locale request from an already canonical `LocaleKey`. The request exposes that scope through `locale()`.
+
+Schema `LocaleMode` admission is deliberately not guessed inside the request constructor. The later replay worker layer owns admission because it has the registered `IndexSchema` contract available. A locale replay against `LocaleMode::None` must fail closed there rather than silently becoming schema-wide.
+
+## Fail-closed page validation
+
+`IndexSourcePage::new` and `SharedIndexSourceRegistry::scan` continue to validate every returned page through the common source contract.
+
+For a locale-scoped request, every returned mutation key must contain exactly the requested locale. A source that ignores the locale request and returns another locale fails with `IndexSourceError::ScanMutationLocaleMismatch`.
+
+This validator is a safety net, not a pagination strategy. A real locale-capable source must constrain its underlying scan before pagination; post-filtering a schema-wide page would be incorrect because it could skip matching rows or return empty continuation pages.
+
+## Canonical locale identity
+
+The request accepts `LocaleKey`, not a raw string. The retained source fixture uses a BCP-47-compatible mixed-case locale (`EN-us`) and requires canonical `en-US`, so casing/alias normalization cannot create separate replay scan identities.
+
+## Explicit non-goals in this slice
+
+This slice does not:
+
+- change `IndexReplayPageRequest`, `IndexReplayRunRequest`, replay jobs, leases or checkpoints;
+- write non-empty `index_jobs.locale_key` or `index_checkpoints.locale_key`;
+- add or change a database migration;
+- add Product SQL locale filtering yet;
+- add GraphQL locale input;
+- add `partition_key` behavior;
+- introduce targeted/full/shadow rebuild modes;
+- change M7 Storefront serving behavior.
+
+The next source slice should make one real `LocaleMode::Required` source — current Product — honor `request.locale()` in SQL before pagination while preserving its current schema-wide scan when locale is absent. Only after that source capability exists should durable replay job/checkpoint locale identity be admitted.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -11,7 +11,7 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::domain::{EntityKey, IndexMutation, SchemaIdentity, SchemaRef};
+use crate::domain::{EntityKey, IndexMutation, LocaleKey, SchemaIdentity, SchemaRef};
 
 use super::IndexSchemaSourceCatalog;
 
@@ -68,14 +68,40 @@ impl<'de> Deserialize<'de> for IndexSourceCursor {
 pub struct IndexSourceScanRequest {
     tenant_id: Uuid,
     schema: SchemaRef,
+    locale: Option<LocaleKey>,
     cursor: Option<IndexSourceCursor>,
     limit: usize,
 }
 
 impl IndexSourceScanRequest {
+    /// Construct the existing schema-wide scan request.
     pub fn new(
         tenant_id: Uuid,
         schema: SchemaRef,
+        cursor: Option<IndexSourceCursor>,
+        limit: usize,
+    ) -> Result<Self, IndexSourceError> {
+        Self::new_scoped(tenant_id, schema, None, cursor, limit)
+    }
+
+    /// Construct an exact-locale scan request.
+    ///
+    /// The caller owns schema `LocaleMode` admission. Once this request reaches a source, the
+    /// returned page is fail-closed: every mutation must carry exactly this canonical locale.
+    pub fn for_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: LocaleKey,
+        cursor: Option<IndexSourceCursor>,
+        limit: usize,
+    ) -> Result<Self, IndexSourceError> {
+        Self::new_scoped(tenant_id, schema, Some(locale), cursor, limit)
+    }
+
+    fn new_scoped(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: Option<LocaleKey>,
         cursor: Option<IndexSourceCursor>,
         limit: usize,
     ) -> Result<Self, IndexSourceError> {
@@ -91,6 +117,7 @@ impl IndexSourceScanRequest {
         Ok(Self {
             tenant_id,
             schema,
+            locale,
             cursor,
             limit,
         })
@@ -102,6 +129,10 @@ impl IndexSourceScanRequest {
 
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
+    }
+
+    pub fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
     }
 
     pub fn cursor(&self) -> Option<&IndexSourceCursor> {
@@ -497,7 +528,7 @@ impl fmt::Debug for SharedIndexSourceRegistry {
         formatter
             .debug_struct("SharedIndexSourceRegistry")
             .field("source_count", &self.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -635,6 +666,8 @@ pub enum IndexSourceError {
     ScanBatchTooLarge { actual: usize, max: usize },
     #[error("Index source scan mutation at position {position} escapes the requested tenant/schema")]
     ScanMutationScopeMismatch { position: usize },
+    #[error("Index source scan mutation at position {position} escapes the requested locale")]
+    ScanMutationLocaleMismatch { position: usize },
     #[error("Index source scan mutation at position {position} duplicates an entity key")]
     DuplicateScanMutationKey { position: usize },
     #[error("Index source scan returned an empty page with a continuation cursor")]
@@ -701,6 +734,11 @@ fn validate_scan_page(
         let key = mutation.key();
         if key.tenant_id != request.tenant_id || key.schema != request.schema {
             return Err(IndexSourceError::ScanMutationScopeMismatch { position });
+        }
+        if let Some(locale) = request.locale.as_ref()
+            && key.locale.as_ref() != Some(locale)
+        {
+            return Err(IndexSourceError::ScanMutationLocaleMismatch { position });
         }
         if !keys.insert(key.clone()) {
             return Err(IndexSourceError::DuplicateScanMutationKey { position });
@@ -817,6 +855,24 @@ mod tests {
     #[test]
     fn source_materialization_requires_exact_schema_owner() {
         let mut schemas = IndexSchemaSourceCatalog::new();
+        schemas.register("catalog", schema(1)).unwrap();
+        let mut sources = IndexSourceCatalog::new();
+        sources
+            .register("product", "product-primary", [schema_ref(1)], NoopSource)
+            .unwrap();
+
+        let error = sources
+            .materialize(&schemas)
+            .expect_err("source owner must equal schema owner");
+        assert!(matches!(
+            error,
+            IndexSourceError::SourceSchemaOwnerMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn source_materialization_builds_runtime_registry() {
+        let mut schemas = IndexSchemaSourceCatalog::new();
         schemas.register("product", schema(1)).unwrap();
 
         let mut sources = IndexSourceCatalog::new();
@@ -868,6 +924,22 @@ mod tests {
             MAX_SCAN_BATCH_SIZE + 1,
         )
         .is_err());
+    }
+
+    #[test]
+    fn locale_scan_request_preserves_exact_canonical_scope() {
+        let locale = LocaleKey::new("EN_us").unwrap();
+        let request = IndexSourceScanRequest::for_locale(
+            Uuid::new_v4(),
+            schema_ref(1),
+            locale.clone(),
+            None,
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(request.locale(), Some(&locale));
+        assert_eq!(request.locale().unwrap().as_str(), "en-US");
     }
 
     #[test]

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -609,14 +609,12 @@ pub enum IndexSourceError {
         schema: SchemaRef,
     },
     #[error(
-        "Index schema {schema} has multiple replay sources: existing={existing_source}/{existing_owner}, incoming={incoming_source}/{incoming_owner}"
+        "Index schema {schema} has multiple replay sources: existing={existing_source}, incoming={incoming_source}"
     )]
     SchemaSourceConflict {
         schema: SchemaRef,
         existing_source: String,
-        existing_owner: String,
         incoming_source: String,
-        incoming_owner: String,
     },
     #[error(
         "Index schema identity {identity} changes replay source: existing={existing_owner}/{existing_source}, incoming={incoming_owner}/{incoming_source}"

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -528,7 +528,7 @@ impl fmt::Debug for SharedIndexSourceRegistry {
         formatter
             .debug_struct("SharedIndexSourceRegistry")
             .field("source_count", &self.len())
-            .finish_non_exhaustive()
+            .finish()
     }
 }
 
@@ -609,12 +609,14 @@ pub enum IndexSourceError {
         schema: SchemaRef,
     },
     #[error(
-        "Index schema {schema} has multiple replay sources: existing={existing_source}, incoming={incoming_source}"
+        "Index schema {schema} has multiple replay sources: existing={existing_source}/{existing_owner}, incoming={incoming_source}/{incoming_owner}"
     )]
     SchemaSourceConflict {
         schema: SchemaRef,
         existing_source: String,
+        existing_owner: String,
         incoming_source: String,
+        incoming_owner: String,
     },
     #[error(
         "Index schema identity {identity} changes replay source: existing={existing_owner}/{existing_source}, incoming={incoming_owner}/{incoming_source}"
@@ -854,24 +856,6 @@ mod tests {
 
     #[test]
     fn source_materialization_requires_exact_schema_owner() {
-        let mut schemas = IndexSchemaSourceCatalog::new();
-        schemas.register("catalog", schema(1)).unwrap();
-        let mut sources = IndexSourceCatalog::new();
-        sources
-            .register("product", "product-primary", [schema_ref(1)], NoopSource)
-            .unwrap();
-
-        let error = sources
-            .materialize(&schemas)
-            .expect_err("source owner must equal schema owner");
-        assert!(matches!(
-            error,
-            IndexSourceError::SourceSchemaOwnerMismatch { .. }
-        ));
-    }
-
-    #[test]
-    fn source_materialization_builds_runtime_registry() {
         let mut schemas = IndexSchemaSourceCatalog::new();
         schemas.register("product", schema(1)).unwrap();
 

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -655,7 +655,7 @@ pub enum IndexSourceError {
     #[error("Index source targeted load requires at least one entity key")]
     EmptyLoadKeys,
     #[error("Index source targeted load has too many keys: actual={actual}, max={max}")]
-    TooManyLoadKeys { actual: usize, max: usize },
+    TooManyLoadKeys { actual: usize, max: MAX_LOAD_KEYS },
     #[error("Index source targeted load key at position {position} has another tenant or schema")]
     MixedLoadScope { position: usize },
     #[error("Index source targeted load key at position {position} is duplicated")]
@@ -928,7 +928,7 @@ mod tests {
 
     #[test]
     fn locale_scan_request_preserves_exact_canonical_scope() {
-        let locale = LocaleKey::new("EN_us").unwrap();
+        let locale = LocaleKey::new("EN-us").unwrap();
         let request = IndexSourceScanRequest::for_locale(
             Uuid::new_v4(),
             schema_ref(1),

--- a/crates/rustok-index/src/application/source_registry.rs
+++ b/crates/rustok-index/src/application/source_registry.rs
@@ -655,7 +655,7 @@ pub enum IndexSourceError {
     #[error("Index source targeted load requires at least one entity key")]
     EmptyLoadKeys,
     #[error("Index source targeted load has too many keys: actual={actual}, max={max}")]
-    TooManyLoadKeys { actual: usize, max: MAX_LOAD_KEYS },
+    TooManyLoadKeys { actual: usize, max: usize },
     #[error("Index source targeted load key at position {position} has another tenant or schema")]
     MixedLoadScope { position: usize },
     #[error("Index source targeted load key at position {position} is duplicated")]

--- a/scripts/verify/verify-index-locale-source-scan.mjs
+++ b/scripts/verify/verify-index-locale-source-scan.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-locale-source-scan] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const sourcePath = 'crates/rustok-index/src/application/source_registry.rs';
+const source = requireMarkers(sourcePath, [
+  'locale: Option<LocaleKey>',
+  'pub fn for_locale(',
+  'Self::new_scoped(tenant_id, schema, Some(locale), cursor, limit)',
+  'Self::new_scoped(tenant_id, schema, None, cursor, limit)',
+  'pub fn locale(&self) -> Option<&LocaleKey>',
+  'ScanMutationLocaleMismatch { position: usize }',
+  'key.locale.as_ref() != Some(locale)',
+  'return Err(IndexSourceError::ScanMutationLocaleMismatch { position });',
+  'LocaleKey::new("EN-us")',
+  '"en-US"',
+]);
+
+const schemaWide = source.indexOf('pub fn new(');
+const localeScoped = source.indexOf('pub fn for_locale(', schemaWide);
+const validator = source.indexOf('fn validate_scan_page(', localeScoped);
+if (schemaWide < 0 || localeScoped <= schemaWide || validator <= localeScoped) {
+  fail('schema-wide constructor, locale constructor and common page validator must remain ordered in the generic source contract');
+}
+
+for (const forbidden of [
+  'partition_key',
+  'scope_kind = \'locale\'',
+  'IndexReplayRunRequest',
+  'IndexReplayCheckpointKey',
+  'IndexReplayJobLeaseRequest',
+]) {
+  if (source.includes(forbidden)) {
+    fail(`${sourcePath} must remain a source-scan contract and not absorb durable replay scope: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-locale-scoped-source-scan.md', [
+  'Status: `generic_source_contract_complete_product_source_pending`.',
+  '`IndexSourceScanRequest::new(...)`',
+  '`IndexSourceScanRequest::for_locale(...)`',
+  '`IndexSourceError::ScanMutationLocaleMismatch`',
+  'constrain its underlying scan before pagination',
+  'does not:',
+  'add Product SQL locale filtering yet',
+  'add `partition_key` behavior',
+  'current Product',
+]);
+
+console.log('[verify-index-locale-source-scan] generic exact-locale source scan contract is fail-closed while durable replay scope and Product SQL remain separate');

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -21,6 +21,7 @@ const scripts = [
   'verify-index-schema-supersession.mjs',
   'verify-index-schema-scoped-source-event-id.mjs',
   'verify-index-source-replay-contract.mjs',
+  'verify-index-locale-source-scan.mjs',
   'verify-index-source-refresh-event.mjs',
   'verify-index-source-absence-watermark.mjs',
   'verify-index-source-continuation.mjs',


### PR DESCRIPTION
## Summary

- extend the generic `IndexSourceScanRequest` with optional canonical `LocaleKey` scope while preserving the existing schema-wide `new(...)` constructor and behavior;
- add `IndexSourceScanRequest::for_locale(...)` plus a read-only `locale()` accessor;
- make common source-page validation fail closed with `ScanMutationLocaleMismatch` when a locale-scoped source returns any mutation outside the requested locale;
- retain a BCP-47-compatible canonicalization fixture (`EN-us` -> `en-US`);
- document why locale filtering must occur before pagination in each capable source rather than through generic post-filtering;
- add and aggregate a focused source guard;
- intentionally stop before Product SQL, durable replay jobs/checkpoints, GraphQL locale input, partition scope, database migration, or rebuild modes.

## Boundary

This is the generic source-scan foundation only. It does not yet make a replay job locale-scoped and it does not write non-empty `index_jobs.locale_key` or `index_checkpoints.locale_key`.

The next source slice is current Product: honor `request.locale()` in its PostgreSQL scan SQL before pagination while preserving the existing schema-wide `(product_id, locale)` cursor path when locale is absent. Durable job/checkpoint locale identity follows only after a real source can scan exactly one locale.

## Main recheck

The branch started from Index timeout merge `63dab08679a94d85945b07aeaa5bed92613cdaed`. Current main has advanced through Groups/Forum changes; those paths are disjoint from this generic Index source-contract/docs/guard slice. PR patch review will be used to verify the manually replaced `source_registry.rs` contains no unrelated changes.

## Validation

Static source review only. ICU4X locale parsing was checked against its documented BCP-47 parsing contract, so the retained mixed-case fixture uses a hyphenated locale. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.