### PR TITLE
feat(product): add durable attribute schema receipts

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -270,9 +270,10 @@ These are source-contract defects, not verification-only tasks.
 - [x] Teach Product Admin FFA lifecycle commands to retain one GraphQL caller
   idempotency key across explicit retries, then make mounted GraphQL `idempotencyKey`
   non-null/mandatory after updating current regression callers to supply explicit keys.
-- [ ] Cut remaining Product schema writes away from direct
-  `ProductCatalogSchemaService` construction through typed Product owner write
-  capabilities with explicit write idempotency semantics.
+- [ ] Complete Product schema-write durable idempotency: mounted consumers already use
+  typed Product owner write capabilities with mandatory caller identity; durable owner
+  receipts cover attribute and attribute-option creates, while category/schema/group
+  creates and update-style schema writes still need explicit owner replay semantics.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.

--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -2,34 +2,41 @@
 
 ## Scope
 
-This source-only continuation follows Product schema-write capability publication and mounted consumer cutover. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open because durable owner replay semantics are still missing.
+This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, and mandatory GraphQL caller identity. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open while durable owner replay is completed operation by operation.
 
 ## Current source result
 
 - Product publishes `ProductCatalogSchemaWritePort` for every Product schema write used by mounted Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
 - Mounted Commerce GraphQL no longer constructs `ProductCatalogSchemaService` for those writes. Every schema-write path resolves the host-selected `ProductCatalogCommandRuntime`, obtains its optional `schema_write_port()`, and fails closed with bounded `PRODUCT_TEMPORARILY_UNAVAILABLE` when an external profile has not supplied the capability.
 - Schema writes derive tenant/actor/claims/request context from `PortContext`, retain the existing two-second Product command deadline, and scope-hash the caller key with tenant, authenticated actor, operation, and Product id when one exists.
-- All eleven mounted Product schema-write resolver arguments now use `String`, so the generated GraphQL SDL requires `idempotencyKey: String!` before resolver execution.
-- The foreign-actor regression document supplies an explicit caller key for every Product schema mutation, preserving tenant/actor admission coverage after the SDL becomes non-null.
-- The active Product Admin transport already sends `$idempotencyKey: String!` for all eleven schema mutations and retains one caller key across an explicit retry of the same failed operation + intent; success releases the key for a later equal user action.
+- All eleven mounted Product schema-write resolver arguments use `String`, so the generated GraphQL SDL requires `idempotencyKey: String!` before resolver execution.
+- The active Product Admin transport sends `$idempotencyKey: String!` for all eleven schema mutations and retains one caller key across an explicit retry of the same failed operation + intent; success releases the key for a later equal user action.
 - Product owner schema-write failures continue through stable `PortError` mapping and bounded Commerce public codes rather than exposing owner database/validation details.
 
-## Mandatory GraphQL caller identity
+## Durable attribute-create receipts
 
-There is no compatibility-generated schema-write identity and no nullable schema-write idempotency argument in mounted Commerce GraphQL. The same caller-key trim and 191-byte validation used by Product lifecycle mutations applies before the schema-write owner port is called.
+Product attribute and attribute-option creates now use the shared `rustok-outbox::idempotency` owner-operation ledger under `owner_slug = product`.
 
-The existing `admin_graphql_rejects_foreign_actor_for_every_product_mutation` fixture now provides explicit schema-write keys. That keeps the regression focused on tenant/actor admission instead of GraphQL missing-argument validation while preserving the mandatory SDL contract for every real caller.
+For each admitted create, the receipt binds tenant, Product owner namespace, caller idempotency key, operation, actor, and canonical request input. The receipt operation UUID is reused as the Product-owned attribute or option ID while the receipt scope is active. This gives a reclaimed attempt the same resource identity instead of allocating a second row.
+
+`ProductWriteTransaction` captures the explicitly scoped receipt lease. On success it calls `idempotency::complete` inside the same database transaction as the Product schema rows and transactional outbox publication, then commits that transaction. A response lost after commit is therefore replayed from the completed owner receipt without rerunning the create or publishing a duplicate event.
+
+A completed receipt decodes the stored `ProductAttributeRecord` or `ProductAttributeOptionRecord`. Reusing the same key for a different operation or request is rejected by the shared immutable request binding and mapped to bounded Product idempotency errors. A non-retryable Product failure is persisted only after the owner write future has returned and its transaction has rolled back. Retryable database/receipt failures are not converted into terminal failure receipts; the processing lease remains reclaimable under the shared stale-lease policy.
+
+Direct Product service callers are not silently changed into receipt clients: outside the explicitly scoped owner-port execution, `current_product_operation_id()` is absent, create methods retain normal generated IDs, and `ProductWriteTransaction` commits without receipt completion.
 
 ## Why the canonical item remains open
 
-The embedded `ProductCatalogSchemaService` still does not persist a command receipt keyed by `PortContext.idempotency_key`. Caller identity is explicit and Product Admin retains it across failed explicit retries, but durable owner replay/adoption semantics must not be inferred from that boundary contract. A response lost after owner commit can still make a non-idempotent create retry unsafe until Product persists and replays the completed outcome.
+This is intentionally a partial durable-idempotency slice. Category, schema, schema-group, and category-group creates still need owner receipt/replay semantics. Update-style schema writes (`set_category_schema_mode`, schema/category binding, attribute-value save, and detached-value clear) still need their replay result/state contract defined and implemented.
+
+In short, attribute and attribute-option creates are durably receipted, while category/schema/group creates and update-style schema writes remain open. The combined canonical item must stay `[ ]` until those remaining write semantics are source-complete.
 
 Remaining source order:
 
-1. implement the owner-local durable receipt/replay contract needed for non-idempotent schema creates and define replay behavior for update-style schema writes;
-2. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
-3. update canonical completion only when the intended owner replay semantics are source-complete;
-4. retain static/compile/parity/remote/restart/backend evidence as separate maintainer-run verification.
+1. extend the same owner-transaction receipt fence to category/schema/group creates with stable Product-owned resource identities;
+2. define and implement replay semantics for update-style schema writes, including the returned attribute-value projections;
+3. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
+4. retain static/compile/parity/lost-response/restart/backend evidence as separate maintainer-run verification before any promotion.
 
 ## Verification state
 

--- a/crates/rustok-product/src/catalog_schema_write_port.rs
+++ b/crates/rustok-product/src/catalog_schema_write_port.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use rustok_api::{PortCallPolicy, PortContext, PortError};
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use rustok_outbox::idempotency;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use uuid::Uuid;
 
 use crate::services::{
@@ -9,7 +12,7 @@ use crate::services::{
     CreateProductAttributeSchemaGroupInput, CreateProductAttributeSchemaInput,
     ProductAttributeGroupRecord, ProductAttributeOptionRecord, ProductAttributeRecord,
     ProductAttributeSchemaRecord, ProductAttributeValuePatch, ProductAttributeValueRecord,
-    ProductCatalogSchemaService, SetCategorySchemaModeInput,
+    ProductCatalogSchemaService, SetCategorySchemaModeInput, with_product_operation_receipt,
 };
 use crate::CommerceError;
 
@@ -19,10 +22,12 @@ use crate::CommerceError;
 /// idempotency identity and deadline. Consumers must receive this capability from host
 /// composition rather than constructing `ProductCatalogSchemaService` directly.
 ///
-/// The port preserves the caller idempotency identity across embedded and remote
-/// providers. The embedded adapter currently delegates to the existing Product owner
-/// transaction implementation; durable replay evidence remains a separate verification
-/// task and must not be inferred from this source contract alone.
+/// The embedded adapter durably binds Product attribute and attribute-option creates to
+/// the shared owner-operation receipt ledger. Their receipt completion is committed in
+/// the same Product transaction as the schema rows and outbox event, so a lost response
+/// replays the stored owner result without creating a second resource. The remaining
+/// category/schema/group creates and update-style schema writes still require explicit
+/// owner-local replay semantics before the combined ecommerce task can be closed.
 #[async_trait]
 pub trait ProductCatalogSchemaWritePort: Send + Sync {
     async fn create_attribute(
@@ -105,9 +110,28 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<ProductAttributeRecord, PortError> {
         let operation = "create_attribute";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.create_attribute(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let expected = ProductAttributeRecord {
+            id: lease.operation_id,
+            code: input.code.clone(),
+            value_type: input.value_type.clone(),
+        };
+        let response_json = encode_schema_receipt(&context, operation, &expected)?;
+        let result = with_product_operation_receipt(
+            lease,
+            response_json,
+            self.create_attribute(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn create_attribute_option(
@@ -117,9 +141,28 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<ProductAttributeOptionRecord, PortError> {
         let operation = "create_attribute_option";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.create_attribute_option(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let expected = ProductAttributeOptionRecord {
+            id: lease.operation_id,
+            attribute_id: input.attribute_id,
+            code: input.code.clone(),
+        };
+        let response_json = encode_schema_receipt(&context, operation, &expected)?;
+        let result = with_product_operation_receipt(
+            lease,
+            response_json,
+            self.create_attribute_option(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn create_category(
@@ -238,6 +281,131 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
         )
         .await
         .map_err(|error| schema_write_error(&context, operation, error))
+    }
+}
+
+async fn admit_schema_operation<T: Serialize>(
+    service: &ProductCatalogSchemaService,
+    context: &PortContext,
+    tenant_id: Uuid,
+    operation: &'static str,
+    request: &T,
+) -> Result<idempotency::Admission, PortError> {
+    let idempotency_key = context.idempotency_key.as_deref().unwrap_or_default();
+    service
+        .admit_schema_operation_receipt(tenant_id, idempotency_key, operation, request)
+        .await
+        .map_err(|error| schema_receipt_error(context, operation, error))
+}
+
+async fn finish_receipted_schema_write<T>(
+    service: &ProductCatalogSchemaService,
+    context: &PortContext,
+    operation: &'static str,
+    lease: idempotency::Lease,
+    result: std::result::Result<T, CommerceError>,
+) -> Result<T, PortError> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            let port_error = schema_write_error(context, operation, error);
+            if !port_error.retryable {
+                if let Err(receipt_error) = service
+                    .fail_schema_operation_receipt(lease, &port_error)
+                    .await
+                {
+                    tracing::error!(
+                        correlation_id = %context.correlation_id,
+                        tenant_id = %context.tenant_id,
+                        operation,
+                        operation_id = %lease.operation_id,
+                        internal_code = %receipt_error.code,
+                        "failed to persist Product schema terminal failure receipt"
+                    );
+                }
+            }
+            Err(port_error)
+        }
+    }
+}
+
+fn encode_schema_receipt<T: Serialize>(
+    context: &PortContext,
+    operation: &'static str,
+    value: &T,
+) -> Result<serde_json::Value, PortError> {
+    serde_json::to_value(value).map_err(|error| {
+        tracing::error!(
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation,
+            error = %error,
+            "failed to encode Product schema owner receipt"
+        );
+        PortError::invariant_violation(
+            "product.schema_receipt_encode",
+            "product schema operation could not be completed safely",
+        )
+    })
+}
+
+fn decode_schema_receipt<T: DeserializeOwned>(
+    context: &PortContext,
+    operation: &'static str,
+    value: serde_json::Value,
+) -> Result<T, PortError> {
+    serde_json::from_value(value).map_err(|error| {
+        tracing::error!(
+            correlation_id = %context.correlation_id,
+            tenant_id = %context.tenant_id,
+            operation,
+            error = %error,
+            "failed to decode Product schema owner receipt replay"
+        );
+        PortError::invariant_violation(
+            "product.schema_receipt_corrupt",
+            "product schema operation could not be completed safely",
+        )
+    })
+}
+
+fn schema_receipt_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PortError,
+) -> PortError {
+    tracing::error!(
+        correlation_id = %context.correlation_id,
+        tenant_id = %context.tenant_id,
+        operation,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        "Product schema owner receipt admission failed"
+    );
+
+    match error.kind {
+        PortErrorKind::Validation => PortError::validation(
+            "product.schema_idempotency_invalid",
+            "product schema idempotency request is invalid",
+        ),
+        PortErrorKind::Conflict => PortError::conflict(
+            "product.schema_idempotency_conflict",
+            "product schema idempotency key conflicts with an earlier request",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => PortError::unavailable(
+            "product.schema_receipt_unavailable",
+            "product schema receipt storage is temporarily unavailable",
+        ),
+        PortErrorKind::Forbidden => PortError::forbidden(
+            "product.schema_receipt_forbidden",
+            "product schema receipt access is denied",
+        ),
+        PortErrorKind::NotFound | PortErrorKind::InvariantViolation => {
+            PortError::invariant_violation(
+                "product.schema_receipt_invariant",
+                "product schema operation could not be completed safely",
+            )
+        }
     }
 }
 

--- a/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
@@ -5,7 +5,10 @@ use super::{
     ProductCatalogSchemaService, load_attribute_write_definition, map_schema_resolution_error,
     uuid_filter_values, validate_locale,
 };
+use rustok_api::PortError;
+use rustok_outbox::idempotency;
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, FromQueryResult, Statement};
+use serde::Serialize;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -21,9 +24,13 @@ use crate::services::{
     product_attribute_integer_term, product_attribute_localized_text_expr,
     product_attribute_option_term, product_attribute_text_term,
 };
-use crate::services::write_transaction::ProductWriteTransaction;
+use crate::services::write_transaction::{
+    ProductWriteTransaction, current_product_operation_id,
+};
 use rustok_core::generate_id;
 use rustok_events::DomainEvent;
+
+const PRODUCT_SCHEMA_RECEIPT_OWNER: &str = "product";
 
 impl ProductCatalogSchemaService {
     pub async fn create_attribute(
@@ -33,7 +40,7 @@ impl ProductCatalogSchemaService {
         input: CreateProductAttributeInput,
     ) -> CommerceResult<ProductAttributeRecord> {
         input.validate()?;
-        let attribute_id = generate_id();
+        let attribute_id = current_product_operation_id().unwrap_or_else(generate_id);
         let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?;
 
         txn.execute(Statement::from_sql_and_values(
@@ -132,7 +139,7 @@ impl ProductCatalogSchemaService {
             ));
         }
 
-        let option_id = generate_id();
+        let option_id = current_product_operation_id().unwrap_or_else(generate_id);
         txn.execute(Statement::from_sql_and_values(
             txn.get_database_backend(),
             r#"
@@ -182,6 +189,32 @@ impl ProductCatalogSchemaService {
             attribute_id: input.attribute_id,
             code: input.code,
         })
+    }
+
+    pub(crate) async fn admit_schema_operation_receipt<T: Serialize>(
+        &self,
+        tenant_id: Uuid,
+        idempotency_key: &str,
+        operation: &str,
+        request: &T,
+    ) -> Result<idempotency::Admission, PortError> {
+        idempotency::admit(
+            &self.db,
+            tenant_id,
+            PRODUCT_SCHEMA_RECEIPT_OWNER,
+            idempotency_key,
+            operation,
+            request,
+        )
+        .await
+    }
+
+    pub(crate) async fn fail_schema_operation_receipt(
+        &self,
+        lease: idempotency::Lease,
+        error: &PortError,
+    ) -> Result<(), PortError> {
+        idempotency::fail(&self.db, lease, error).await
     }
 
     pub async fn list_attributes(

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -60,3 +60,5 @@ pub use index_refresh_relay::{
     ProductIndexRefreshEventFactory, ProductIndexRefreshRelayError,
     ProductIndexRefreshRelayStep, ProductIndexRefreshRelayStepOutcome,
 };
+
+pub(crate) use write_transaction::with_product_operation_receipt;

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{future::Future, ops::Deref};
 
 use crate::{
     error::{CommerceError, CommerceResult},
@@ -8,21 +8,67 @@ use crate::{
     },
 };
 use rustok_events::DomainEvent;
-use rustok_outbox::TransactionalEventBus;
+use rustok_outbox::{TransactionalEventBus, idempotency};
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, DbErr, ExecResult,
     QueryResult, Statement, TransactionTrait,
 };
+use serde_json::Value;
 use uuid::Uuid;
+
+#[derive(Clone)]
+struct ProductOperationReceipt {
+    lease: idempotency::Lease,
+    response_json: Value,
+}
+
+tokio::task_local! {
+    static PRODUCT_OPERATION_RECEIPT: ProductOperationReceipt;
+}
+
+/// Bind one Product owner receipt to the current async write execution.
+///
+/// The scope is intentionally task-local: the shared `ProductCatalogSchemaService`
+/// stays stateless across concurrent callers, while `ProductWriteTransaction::begin`
+/// captures the receipt only for the explicitly wrapped owner command.
+pub(crate) async fn with_product_operation_receipt<F, T>(
+    lease: idempotency::Lease,
+    response_json: Value,
+    future: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    PRODUCT_OPERATION_RECEIPT
+        .scope(
+            ProductOperationReceipt {
+                lease,
+                response_json,
+            },
+            future,
+        )
+        .await
+}
+
+/// The receipt operation UUID is also a stable Product-owned resource identity
+/// for create operations that opt into durable owner replay.
+pub(crate) fn current_product_operation_id() -> Option<Uuid> {
+    PRODUCT_OPERATION_RECEIPT
+        .try_with(|receipt| receipt.lease.operation_id)
+        .ok()
+}
 
 /// Owns one product write transaction and its transactional outbox publisher.
 ///
 /// Product entity changes and domain events must use the same database
 /// transaction. The wrapper makes publishing through any non-transactional
 /// transport unavailable to product write paths before the transaction commits.
+/// When a Product owner receipt scope is active, terminal success is completed
+/// in this same transaction before commit.
 pub(crate) struct ProductWriteTransaction {
     transaction: DatabaseTransaction,
     event_bus: TransactionalEventBus,
+    operation_receipt: Option<ProductOperationReceipt>,
 }
 
 impl ProductWriteTransaction {
@@ -30,9 +76,11 @@ impl ProductWriteTransaction {
         db: &DatabaseConnection,
         event_bus: TransactionalEventBus,
     ) -> CommerceResult<Self> {
+        let operation_receipt = PRODUCT_OPERATION_RECEIPT.try_with(Clone::clone).ok();
         Ok(Self {
             transaction: db.begin().await?,
             event_bus,
+            operation_receipt,
         })
     }
 
@@ -114,6 +162,22 @@ impl ProductWriteTransaction {
     }
 
     pub(crate) async fn commit(self) -> CommerceResult<()> {
+        if let Some(receipt) = self.operation_receipt.as_ref() {
+            idempotency::complete(&self.transaction, receipt.lease, &receipt.response_json)
+                .await
+                .map_err(|error| {
+                    tracing::error!(
+                        operation_id = %receipt.lease.operation_id,
+                        internal_code = %error.code,
+                        retryable = error.retryable,
+                        "Product owner receipt completion failed inside write transaction"
+                    );
+                    CommerceError::Database(DbErr::Custom(format!(
+                        "product owner receipt completion failed: {}",
+                        error.code
+                    )))
+                })?;
+        }
         self.transaction.commit().await?;
         Ok(())
     }

--- a/scripts/verify/verify-product-catalog-schema-write-port.mjs
+++ b/scripts/verify/verify-product-catalog-schema-write-port.mjs
@@ -71,13 +71,18 @@ for (const required of [
   requireText(lib, required, "Product schema write public export");
 }
 
-// Publication is intentionally separate from the Commerce consumer cutover. Keep the
-// remaining direct construction visible so the canonical task cannot be falsely closed.
-requireText(
+forbidText(
   commerceMutations,
   "ProductCatalogSchemaService::new",
-  "Commerce schema-write consumer debt remains explicit",
+  "mounted Commerce schema writes must not regress to direct Product service construction",
 );
+for (const required of [
+  "ProductCatalogSchemaWritePort",
+  ".schema_write_port()",
+  "product.schema_write_port_unavailable",
+]) {
+  requireText(commerceMutations, required, "mounted Commerce schema-write owner boundary");
+}
 
 if (failures.length) {
   console.error("Product catalog schema write port source verification failed:");
@@ -85,4 +90,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product publishes a typed schema-write capability with write-context policy; Commerce consumer cutover remains explicit debt");
+console.log("✔ Product publishes the typed schema-write capability and mounted Commerce resolves it from host composition without direct Product service construction");

--- a/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
+++ b/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relative) => fs.readFileSync(path.join(root, relative), "utf8");
+const failures = [];
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) failures.push(`${label}: missing ${text}`);
+};
+const forbidText = (source, text, label) => {
+  if (source.includes(text)) failures.push(`${label}: forbidden ${text}`);
+};
+const functionSlice = (source, name, nextName) => {
+  const start = source.indexOf(`async fn ${name}(`);
+  if (start < 0) {
+    failures.push(`missing function ${name}`);
+    return "";
+  }
+  const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
+  return source.slice(start, end < 0 ? source.length : end);
+};
+
+const port = read("crates/rustok-product/src/catalog_schema_write_port.rs");
+const transaction = read("crates/rustok-product/src/services/write_transaction.rs");
+const attributes = read("crates/rustok-product/src/services/catalog_schema_service/attributes.rs");
+const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+const recheck = read("crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md");
+const implStart = port.indexOf("impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService");
+if (implStart < 0) failures.push("missing ProductCatalogSchemaWritePort implementation");
+const portImpl = implStart < 0 ? "" : port.slice(implStart);
+
+for (const required of [
+  "rustok_outbox::idempotency",
+  "admit_schema_operation(",
+  "with_product_operation_receipt(",
+  "decode_schema_receipt(",
+  "finish_receipted_schema_write(",
+  "fail_schema_operation_receipt",
+  '"product.schema_idempotency_conflict"',
+  '"product.schema_receipt_unavailable"',
+]) {
+  requireText(port, required, "Product schema create receipt port");
+}
+
+for (const [name, nextName] of [
+  ["create_attribute", "create_attribute_option"],
+  ["create_attribute_option", "create_category"],
+]) {
+  const slice = functionSlice(portImpl, name, nextName);
+  for (const required of [
+    "admit_schema_operation(",
+    "idempotency::Admission::Replay(value)",
+    "lease.operation_id",
+    "with_product_operation_receipt(",
+    "finish_receipted_schema_write(",
+  ]) {
+    requireText(slice, required, `${name} durable receipt`);
+  }
+}
+
+for (const [name, nextName] of [
+  ["create_category", "create_schema"],
+  ["create_schema", "create_schema_group"],
+  ["create_schema_group", "create_category_group"],
+  ["create_category_group", "set_category_schema_mode"],
+  ["set_category_schema_mode", "bind_schema_attribute"],
+  ["bind_schema_attribute", "bind_category_attribute"],
+  ["bind_category_attribute", "save_product_attribute_values"],
+  ["save_product_attribute_values", "clear_detached_product_attribute_values"],
+  ["clear_detached_product_attribute_values", "admit_schema_operation"],
+]) {
+  const slice = functionSlice(portImpl, name, nextName);
+  forbidText(slice, "admit_schema_operation(", `${name} must remain explicit receipt follow-up debt in this slice`);
+}
+
+for (const required of [
+  "tokio::task_local!",
+  "struct ProductOperationReceipt",
+  "PRODUCT_OPERATION_RECEIPT.try_with(Clone::clone).ok()",
+  "idempotency::complete(&self.transaction, receipt.lease, &receipt.response_json)",
+  "self.transaction.commit().await?",
+  "current_product_operation_id()",
+]) {
+  requireText(transaction, required, "Product write transaction receipt fence");
+}
+const completion = transaction.indexOf("idempotency::complete(&self.transaction");
+const commit = transaction.indexOf("self.transaction.commit().await?");
+if (completion < 0 || commit < 0 || completion > commit) {
+  failures.push("Product receipt completion must occur before owner transaction commit");
+}
+
+const stableIdCount = (attributes.match(/current_product_operation_id\(\)\.unwrap_or_else\(generate_id\)/g) ?? []).length;
+if (stableIdCount !== 2) {
+  failures.push(`attribute and option creates must derive exactly two stable receipt resource IDs (found ${stableIdCount})`);
+}
+for (const required of [
+  'const PRODUCT_SCHEMA_RECEIPT_OWNER: &str = "product"',
+  "idempotency::admit(",
+  "idempotency::fail(",
+]) {
+  requireText(attributes, required, "Product schema receipt owner helpers");
+}
+
+requireText(
+  plan,
+  "receipts cover attribute and attribute-option creates",
+  "canonical Product schema-write debt must record this partial durable slice",
+);
+requireText(
+  plan,
+  "category/schema/group\n  creates and update-style schema writes still need explicit owner replay semantics",
+  "canonical Product schema-write debt must remain open",
+);
+requireText(
+  recheck,
+  "attribute and attribute-option creates",
+  "Product schema write recheck must describe the durable create slice",
+);
+requireText(
+  recheck,
+  "category/schema/group creates and update-style schema writes remain open",
+  "Product schema write recheck must preserve remaining debt",
+);
+
+if (failures.length) {
+  console.error("Product schema attribute-create receipt source verification failed:");
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("✔ Product attribute and attribute-option creates bind durable owner receipts atomically with Product writes; remaining schema replay semantics stay explicit debt");


### PR DESCRIPTION
## Summary

- bind Product schema `create_attribute` and `create_attribute_option` owner-port execution to the shared `owner_operation_receipts` ledger under the Product owner namespace
- bind receipt admission to tenant, operation, authenticated actor and canonical create input while retaining the caller-provided/scoped Product idempotency key
- reuse the receipt operation UUID as the Product-owned attribute/option resource ID on receipted paths so stale lease reclamation preserves resource identity
- capture the receipt lease in an explicitly scoped Product write execution and complete the receipt inside the same `ProductWriteTransaction` as Product schema rows and transactional outbox publication, before the owner transaction commits
- replay a completed stored Product record without rerunning the create; reject immutable request/key rebinding through bounded Product idempotency errors
- preserve direct Product service behavior outside the owner-port receipt scope
- repair the stale Product schema-write publication guard so mounted Commerce is required to use the typed owner capability rather than direct `ProductCatalogSchemaService` construction
- add a focused receipt source guard and update the canonical ecommerce plan/recheck packet without marking the combined schema-write item complete

## Intentionally still open

- durable owner receipts for category, schema, schema-group and category-group creates
- explicit replay result/state semantics for category-schema-mode, schema/category bindings, attribute-value save and detached-value clear
- Product Admin compatibility-source cleanup only after compile/source evidence confirms it is unmounted
- maintainer-run static/compile/lost-response/restart/backend evidence
- broad ecommerce typed-owner/FBA invariant remains open

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction. No FBA/FFA promotion.