### PR TITLE
test(groups): retain direct enforcement PostgreSQL runtime evidence

### DIFF
--- a/apps/server/tests/groups_membership_enforcement_runtime_postgres.rs
+++ b/apps/server/tests/groups_membership_enforcement_runtime_postgres.rs
@@ -1,0 +1,772 @@
+#![cfg(feature = "mod-groups")]
+
+use std::time::Duration;
+
+use rustok_api::{PortActor, PortContext, PortErrorKind};
+use rustok_groups::{
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService,
+    RevokeGroupMembershipSuspensionRequest, SuspendGroupMembershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+const POSTGRES_URL_ENV: &str = "RUSTOK_GROUPS_TEST_POSTGRES_URL";
+
+#[derive(Clone, Copy)]
+struct GroupFixture {
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+    moderator_id: Uuid,
+    member_a_id: Uuid,
+    member_b_id: Uuid,
+    member_c_id: Uuid,
+    owner_membership_id: Uuid,
+    admin_membership_id: Uuid,
+    moderator_membership_id: Uuid,
+    member_a_membership_id: Uuid,
+    member_b_membership_id: Uuid,
+    member_c_membership_id: Uuid,
+}
+
+fn schema_url(base: &str, schema: &str) -> String {
+    let separator = if base.contains('?') { '&' } else { '?' };
+    format!("{base}{separator}options=-csearch_path%3D{schema}%2Cpublic")
+}
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("Groups direct enforcement runtime PostgreSQL connection should open")
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for PostgreSQL enforcement runtime evidence");
+    }
+}
+
+fn fresh_fixture() -> GroupFixture {
+    GroupFixture {
+        group_id: Uuid::new_v4(),
+        owner_id: Uuid::new_v4(),
+        admin_id: Uuid::new_v4(),
+        moderator_id: Uuid::new_v4(),
+        member_a_id: Uuid::new_v4(),
+        member_b_id: Uuid::new_v4(),
+        member_c_id: Uuid::new_v4(),
+        owner_membership_id: Uuid::new_v4(),
+        admin_membership_id: Uuid::new_v4(),
+        moderator_membership_id: Uuid::new_v4(),
+        member_a_membership_id: Uuid::new_v4(),
+        member_b_membership_id: Uuid::new_v4(),
+        member_c_membership_id: Uuid::new_v4(),
+    }
+}
+
+async fn seed_group(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    fixture: GroupFixture,
+    handle: &str,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, member_count)
+VALUES ('{}', '{tenant_id}', '{}', '{handle}', 6);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{}', '{}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{}', '{}', 'admin', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{}', '{}', 'moderator', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{}', '{}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{}', '{}', 'member', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{}', '{}', 'member', 'active', CURRENT_TIMESTAMP);
+"#,
+        fixture.group_id,
+        fixture.owner_id,
+        fixture.owner_membership_id,
+        fixture.group_id,
+        fixture.owner_id,
+        fixture.admin_membership_id,
+        fixture.group_id,
+        fixture.admin_id,
+        fixture.moderator_membership_id,
+        fixture.group_id,
+        fixture.moderator_id,
+        fixture.member_a_membership_id,
+        fixture.group_id,
+        fixture.member_a_id,
+        fixture.member_b_membership_id,
+        fixture.group_id,
+        fixture.member_b_id,
+        fixture.member_c_membership_id,
+        fixture.group_id,
+        fixture.member_c_id,
+    ))
+    .await
+    .expect("Groups direct enforcement PostgreSQL runtime fixture should seed");
+}
+
+fn write_context(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    idempotency_key: &str,
+) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-enforcement-postgres-runtime-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(5))
+    .with_idempotency_key(idempotency_key)
+}
+
+fn platform_context(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    idempotency_key: &str,
+) -> PortContext {
+    write_context(tenant_id, actor_id, idempotency_key).with_claim("groups:moderate")
+}
+
+async fn group_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+) -> (i64, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT version, member_count FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("PostgreSQL group snapshot query should succeed")
+        .expect("group should exist");
+    (
+        row.try_get("", "version").expect("group version should decode"),
+        row.try_get("", "member_count")
+            .expect("member_count should decode"),
+    )
+}
+
+async fn membership_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> (String, String, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT role, status, revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("PostgreSQL membership snapshot query should succeed")
+        .expect("membership should exist");
+    (
+        row.try_get("", "role").expect("membership role should decode"),
+        row.try_get("", "status")
+            .expect("membership status should decode"),
+        row.try_get("", "revision")
+            .expect("membership revision should decode"),
+    )
+}
+
+async fn scalar_count(db: &DatabaseConnection, sql: String) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await
+        .expect("PostgreSQL count query should succeed")
+        .expect("count row should exist");
+    row.try_get("", "count").expect("count should decode")
+}
+
+async fn enforcement_count(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+) -> i64 {
+    scalar_count(
+        db,
+        format!(
+            "SELECT COUNT(*) AS count FROM group_membership_enforcements WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}'"
+        ),
+    )
+    .await
+}
+
+async fn ledger_counts(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+) -> (i64, i64, i64) {
+    let audit = scalar_count(
+        db,
+        format!(
+            "SELECT COUNT(*) AS count FROM group_audit_entries WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}'"
+        ),
+    )
+    .await;
+    let events = scalar_count(
+        db,
+        format!(
+            "SELECT COUNT(*) AS count FROM group_domain_events WHERE tenant_id = '{tenant_id}'"
+        ),
+    )
+    .await;
+    let receipts = scalar_count(
+        db,
+        format!(
+            "SELECT COUNT(*) AS count FROM group_command_receipts WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}'"
+        ),
+    )
+    .await;
+    (audit, events, receipts)
+}
+
+async fn assert_no_material_change(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    fixture: GroupFixture,
+) {
+    assert_eq!(group_snapshot(db, tenant_id, fixture.group_id).await, (1, 6));
+    for user_id in [
+        fixture.owner_id,
+        fixture.admin_id,
+        fixture.moderator_id,
+        fixture.member_a_id,
+        fixture.member_b_id,
+        fixture.member_c_id,
+    ] {
+        assert_eq!(
+            membership_snapshot(db, tenant_id, fixture.group_id, user_id)
+                .await
+                .2,
+            1
+        );
+    }
+    assert_eq!(enforcement_count(db, tenant_id, fixture.group_id).await, 0);
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (0, 0, 0));
+}
+
+async fn suspend(
+    service: &GroupMembershipEnforcementCommandService,
+    context: PortContext,
+    group_id: Uuid,
+    target_user_id: Uuid,
+    expected_membership_revision: i64,
+    reason_code: &str,
+) -> Result<rustok_groups::GroupMembershipEnforcementMutationResult, rustok_api::PortError> {
+    GroupMembershipEnforcementCommandPort::suspend_membership(
+        service,
+        context,
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id,
+            expected_membership_revision,
+            reason_code: reason_code.to_string(),
+            effective_until: None,
+        },
+    )
+    .await
+}
+
+async fn revoke(
+    service: &GroupMembershipEnforcementCommandService,
+    context: PortContext,
+    group_id: Uuid,
+    target_user_id: Uuid,
+    expected_membership_revision: i64,
+    reason_code: &str,
+) -> Result<rustok_groups::GroupMembershipEnforcementMutationResult, rustok_api::PortError> {
+    GroupMembershipEnforcementCommandPort::revoke_membership_suspension(
+        service,
+        context,
+        RevokeGroupMembershipSuspensionRequest {
+            group_id,
+            target_user_id,
+            expected_membership_revision,
+            reason_code: reason_code.to_string(),
+        },
+    )
+    .await
+}
+
+async fn assert_ledger_fact(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    fixture: GroupFixture,
+    membership_id: Uuid,
+    actor_id: Uuid,
+    idempotency_key: &str,
+    audit_action: &str,
+    event_type: &str,
+    command_type: &str,
+) {
+    assert_eq!(
+        scalar_count(
+            db,
+            format!(
+                "SELECT COUNT(*) AS count FROM group_audit_entries WHERE tenant_id = '{tenant_id}' AND group_id = '{}' AND actor_user_id = '{actor_id}' AND target_user_id IS NOT NULL AND action = '{audit_action}'",
+                fixture.group_id
+            ),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        scalar_count(
+            db,
+            format!(
+                "SELECT COUNT(*) AS count FROM group_domain_events WHERE tenant_id = '{tenant_id}' AND aggregate_type = 'membership' AND aggregate_id = '{membership_id}' AND actor_id = '{actor_id}' AND event_type = '{event_type}'"
+            ),
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        scalar_count(
+            db,
+            format!(
+                "SELECT COUNT(*) AS count FROM group_command_receipts WHERE tenant_id = '{tenant_id}' AND group_id = '{}' AND actor_user_id = '{actor_id}' AND idempotency_key = '{idempotency_key}' AND command_type = '{command_type}'",
+                fixture.group_id
+            ),
+        )
+        .await,
+        1
+    );
+}
+
+async fn run_denials(db: &DatabaseConnection) {
+    let tenant_id = Uuid::new_v4();
+    let fixture = fresh_fixture();
+    seed_group(db, tenant_id, fixture, "enforcement-postgres-runtime-denials").await;
+    let service = GroupMembershipEnforcementCommandService::new(db.clone());
+
+    let self_target = suspend(
+        &service,
+        write_context(tenant_id, fixture.moderator_id, "postgres-self-target"),
+        fixture.group_id,
+        fixture.moderator_id,
+        1,
+        "security_self_target",
+    )
+    .await
+    .expect_err("PostgreSQL direct enforcement must reject self-targeting");
+    assert_eq!(self_target.kind, PortErrorKind::Forbidden);
+    assert_eq!(
+        self_target.code,
+        "groups.membership_enforcement_self_target"
+    );
+    assert!(!self_target.retryable);
+
+    let platform_actor = Uuid::new_v4();
+    let owner_target = suspend(
+        &service,
+        platform_context(tenant_id, platform_actor, "postgres-owner-target"),
+        fixture.group_id,
+        fixture.owner_id,
+        1,
+        "security_owner_target",
+    )
+    .await
+    .expect_err("PostgreSQL platform moderation must not suspend the owner");
+    assert_eq!(owner_target.kind, PortErrorKind::Forbidden);
+    assert_eq!(
+        owner_target.code,
+        "groups.membership_enforcement_owner_protected"
+    );
+    assert!(!owner_target.retryable);
+
+    let hierarchy = suspend(
+        &service,
+        write_context(
+            tenant_id,
+            fixture.moderator_id,
+            "postgres-moderator-vs-admin",
+        ),
+        fixture.group_id,
+        fixture.admin_id,
+        1,
+        "security_hierarchy",
+    )
+    .await
+    .expect_err("PostgreSQL moderator must not enforce an administrator");
+    assert_eq!(hierarchy.kind, PortErrorKind::Forbidden);
+    assert_eq!(hierarchy.code, "groups.manager_required");
+    assert!(!hierarchy.retryable);
+
+    let member_actor = suspend(
+        &service,
+        write_context(
+            tenant_id,
+            fixture.member_a_id,
+            "postgres-member-vs-member",
+        ),
+        fixture.group_id,
+        fixture.member_b_id,
+        1,
+        "security_member_actor",
+    )
+    .await
+    .expect_err("PostgreSQL ordinary member must not enforce another member");
+    assert_eq!(member_actor.kind, PortErrorKind::Forbidden);
+    assert_eq!(member_actor.code, "groups.manager_required");
+    assert!(!member_actor.retryable);
+
+    assert_no_material_change(db, tenant_id, fixture).await;
+}
+
+async fn run_hierarchy(db: &DatabaseConnection) {
+    let tenant_id = Uuid::new_v4();
+    let fixture = fresh_fixture();
+    seed_group(db, tenant_id, fixture, "enforcement-postgres-runtime-hierarchy").await;
+    let service = GroupMembershipEnforcementCommandService::new(db.clone());
+
+    let owner_suspend_admin = suspend(
+        &service,
+        write_context(tenant_id, fixture.owner_id, "postgres-owner-suspend-admin"),
+        fixture.group_id,
+        fixture.admin_id,
+        1,
+        "hierarchy_owner_admin",
+    )
+    .await
+    .expect("PostgreSQL owner should suspend administrator");
+    assert_eq!(owner_suspend_admin.membership_revision, 2);
+    assert_eq!(owner_suspend_admin.group_version, 2);
+    assert_eq!(owner_suspend_admin.member_count, 6);
+    let owner_revoke_admin = revoke(
+        &service,
+        write_context(tenant_id, fixture.owner_id, "postgres-owner-revoke-admin"),
+        fixture.group_id,
+        fixture.admin_id,
+        2,
+        "hierarchy_owner_admin_release",
+    )
+    .await
+    .expect("PostgreSQL owner should revoke administrator suspension");
+    assert_eq!(owner_revoke_admin.membership_revision, 3);
+    assert_eq!(owner_revoke_admin.group_version, 3);
+
+    let admin_suspend_moderator = suspend(
+        &service,
+        write_context(
+            tenant_id,
+            fixture.admin_id,
+            "postgres-admin-suspend-moderator",
+        ),
+        fixture.group_id,
+        fixture.moderator_id,
+        1,
+        "hierarchy_admin_moderator",
+    )
+    .await
+    .expect("PostgreSQL administrator should suspend moderator");
+    assert_eq!(admin_suspend_moderator.membership_revision, 2);
+    assert_eq!(admin_suspend_moderator.group_version, 4);
+    let admin_revoke_moderator = revoke(
+        &service,
+        write_context(
+            tenant_id,
+            fixture.admin_id,
+            "postgres-admin-revoke-moderator",
+        ),
+        fixture.group_id,
+        fixture.moderator_id,
+        2,
+        "hierarchy_admin_moderator_release",
+    )
+    .await
+    .expect("PostgreSQL administrator should revoke moderator suspension");
+    assert_eq!(admin_revoke_moderator.membership_revision, 3);
+    assert_eq!(admin_revoke_moderator.group_version, 5);
+
+    let moderator_suspend_member = suspend(
+        &service,
+        write_context(
+            tenant_id,
+            fixture.moderator_id,
+            "postgres-moderator-suspend-member",
+        ),
+        fixture.group_id,
+        fixture.member_a_id,
+        1,
+        "hierarchy_moderator_member",
+    )
+    .await
+    .expect("PostgreSQL moderator should suspend ordinary member");
+    assert_eq!(moderator_suspend_member.membership_revision, 2);
+    assert_eq!(moderator_suspend_member.group_version, 6);
+    let moderator_revoke_member = revoke(
+        &service,
+        write_context(
+            tenant_id,
+            fixture.moderator_id,
+            "postgres-moderator-revoke-member",
+        ),
+        fixture.group_id,
+        fixture.member_a_id,
+        2,
+        "hierarchy_moderator_member_release",
+    )
+    .await
+    .expect("PostgreSQL moderator should revoke ordinary member suspension");
+    assert_eq!(moderator_revoke_member.membership_revision, 3);
+    assert_eq!(moderator_revoke_member.group_version, 7);
+
+    let platform_actor = Uuid::new_v4();
+    let platform_suspend = suspend(
+        &service,
+        platform_context(
+            tenant_id,
+            platform_actor,
+            "postgres-platform-suspend-member",
+        ),
+        fixture.group_id,
+        fixture.member_b_id,
+        1,
+        "hierarchy_platform_member",
+    )
+    .await
+    .expect("PostgreSQL groups:moderate user may act without local membership");
+    assert_eq!(platform_suspend.membership_revision, 2);
+    assert_eq!(platform_suspend.group_version, 8);
+    let platform_revoke = revoke(
+        &service,
+        platform_context(
+            tenant_id,
+            platform_actor,
+            "postgres-platform-revoke-member",
+        ),
+        fixture.group_id,
+        fixture.member_b_id,
+        2,
+        "hierarchy_platform_member_release",
+    )
+    .await
+    .expect("PostgreSQL groups:moderate user may revoke direct-local suspension");
+    assert_eq!(platform_revoke.membership_revision, 3);
+    assert_eq!(platform_revoke.group_version, 9);
+
+    assert_eq!(group_snapshot(db, tenant_id, fixture.group_id).await, (9, 6));
+    assert_eq!(
+        membership_snapshot(db, tenant_id, fixture.group_id, fixture.admin_id).await,
+        ("admin".to_string(), "active".to_string(), 3)
+    );
+    assert_eq!(
+        membership_snapshot(db, tenant_id, fixture.group_id, fixture.moderator_id).await,
+        ("moderator".to_string(), "active".to_string(), 3)
+    );
+    for user_id in [fixture.member_a_id, fixture.member_b_id] {
+        assert_eq!(
+            membership_snapshot(db, tenant_id, fixture.group_id, user_id).await,
+            ("member".to_string(), "active".to_string(), 3)
+        );
+    }
+    assert_eq!(
+        membership_snapshot(db, tenant_id, fixture.group_id, fixture.member_c_id).await,
+        ("member".to_string(), "active".to_string(), 1)
+    );
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (8, 8, 8));
+}
+
+async fn run_atomicity(db: &DatabaseConnection) {
+    let tenant_id = Uuid::new_v4();
+    let fixture = fresh_fixture();
+    seed_group(db, tenant_id, fixture, "enforcement-postgres-runtime-atomicity").await;
+    let service = GroupMembershipEnforcementCommandService::new(db.clone());
+
+    let suspend_key = "postgres-atomic-suspend";
+    let suspended = suspend(
+        &service,
+        write_context(tenant_id, fixture.owner_id, suspend_key),
+        fixture.group_id,
+        fixture.member_c_id,
+        1,
+        "atomic_runtime",
+    )
+    .await
+    .expect("PostgreSQL owner suspension should commit atomically");
+    assert_eq!(suspended.membership_id, fixture.member_c_membership_id);
+    assert_eq!(suspended.membership_revision, 2);
+    assert_eq!(suspended.group_version, 2);
+    assert_eq!(suspended.member_count, 6);
+    assert!(!suspended.replayed);
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (1, 1, 1));
+    assert_ledger_fact(
+        db,
+        tenant_id,
+        fixture,
+        fixture.member_c_membership_id,
+        fixture.owner_id,
+        suspend_key,
+        "group.membership_suspended",
+        "groups.membership.suspended",
+        "groups.membership.suspend.v1",
+    )
+    .await;
+
+    let replay = suspend(
+        &service,
+        write_context(tenant_id, fixture.owner_id, suspend_key),
+        fixture.group_id,
+        fixture.member_c_id,
+        1,
+        "atomic_runtime",
+    )
+    .await
+    .expect("PostgreSQL exact suspension receipt should replay");
+    assert!(replay.replayed);
+    assert_eq!(replay.group_version, suspended.group_version);
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (1, 1, 1));
+
+    let changed_key = suspend(
+        &service,
+        write_context(tenant_id, fixture.owner_id, suspend_key),
+        fixture.group_id,
+        fixture.member_c_id,
+        1,
+        "changed_atomic_runtime",
+    )
+    .await
+    .expect_err("PostgreSQL same idempotency key with changed request must conflict");
+    assert_eq!(changed_key.kind, PortErrorKind::Conflict);
+    assert_eq!(changed_key.code, "groups.conflict");
+    assert!(!changed_key.retryable);
+    assert_eq!(group_snapshot(db, tenant_id, fixture.group_id).await, (2, 6));
+    assert_eq!(
+        membership_snapshot(db, tenant_id, fixture.group_id, fixture.member_c_id)
+            .await
+            .2,
+        2
+    );
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (1, 1, 1));
+
+    let revoke_key = "postgres-atomic-revoke";
+    let revoked = revoke(
+        &service,
+        write_context(tenant_id, fixture.owner_id, revoke_key),
+        fixture.group_id,
+        fixture.member_c_id,
+        2,
+        "atomic_runtime_release",
+    )
+    .await
+    .expect("PostgreSQL owner revoke should commit atomically");
+    assert_eq!(revoked.membership_revision, 3);
+    assert_eq!(revoked.group_version, 3);
+    assert_eq!(revoked.member_count, 6);
+    assert!(revoked.revoked_at.is_some());
+    assert!(!revoked.replayed);
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (2, 2, 2));
+    assert_ledger_fact(
+        db,
+        tenant_id,
+        fixture,
+        fixture.member_c_membership_id,
+        fixture.owner_id,
+        revoke_key,
+        "group.membership_suspension_revoked",
+        "groups.membership.suspension_revoked",
+        "groups.membership.suspension_revoke.v1",
+    )
+    .await;
+
+    let revoke_replay = revoke(
+        &service,
+        write_context(tenant_id, fixture.owner_id, revoke_key),
+        fixture.group_id,
+        fixture.member_c_id,
+        2,
+        "atomic_runtime_release",
+    )
+    .await
+    .expect("PostgreSQL exact revoke receipt should replay after current enforcement became inactive");
+    assert!(revoke_replay.replayed);
+    assert_eq!(revoke_replay.group_version, revoked.group_version);
+    assert_eq!(ledger_counts(db, tenant_id, fixture.group_id).await, (2, 2, 2));
+
+    let enforcement = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "SELECT source_kind, actor_kind, actor_id, revision, CASE WHEN revoked_at IS NULL THEN 0::BIGINT ELSE 1::BIGINT END AS revoked FROM group_membership_enforcements WHERE tenant_id = '{tenant_id}' AND group_id = '{}' AND user_id = '{}'",
+                fixture.group_id, fixture.member_c_id
+            ),
+        ))
+        .await
+        .expect("final PostgreSQL enforcement query should succeed")
+        .expect("final enforcement row should exist");
+    let source_kind: String = enforcement
+        .try_get("", "source_kind")
+        .expect("source kind should decode");
+    let actor_kind: String = enforcement
+        .try_get("", "actor_kind")
+        .expect("actor kind should decode");
+    let actor_id: String = enforcement
+        .try_get("", "actor_id")
+        .expect("actor id should decode");
+    let enforcement_revision: i64 = enforcement
+        .try_get("", "revision")
+        .expect("enforcement revision should decode");
+    let revoked_marker: i64 = enforcement
+        .try_get("", "revoked")
+        .expect("revoked marker should decode");
+    assert_eq!(source_kind, "direct_local");
+    assert_eq!(actor_kind, "user");
+    assert_eq!(actor_id, fixture.owner_id.to_string());
+    assert_eq!(enforcement_revision, revoked.enforcement_revision);
+    assert_eq!(revoked_marker, 1);
+    assert_eq!(group_snapshot(db, tenant_id, fixture.group_id).await, (3, 6));
+    assert_eq!(
+        membership_snapshot(db, tenant_id, fixture.group_id, fixture.member_c_id).await,
+        ("member".to_string(), "active".to_string(), 3)
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]
+async fn direct_enforcement_runtime_security_and_atomicity_postgres() {
+    let base_url = std::env::var(POSTGRES_URL_ENV)
+        .expect("RUSTOK_GROUPS_TEST_POSTGRES_URL must be configured");
+    let schema_name = format!("groups_enforcement_runtime_{}", Uuid::new_v4().simple());
+    let admin_db = connect(&base_url).await;
+    admin_db
+        .execute_unprepared(&format!("CREATE SCHEMA {schema_name}"))
+        .await
+        .expect("isolated Groups enforcement runtime schema should create");
+    let scoped_url = schema_url(&base_url, &schema_name);
+    let db = connect(&scoped_url).await;
+    install_groups_schema(&db).await;
+
+    run_denials(&db).await;
+    run_hierarchy(&db).await;
+    run_atomicity(&db).await;
+
+    drop(db);
+    admin_db
+        .execute_unprepared(&format!("DROP SCHEMA {schema_name} CASCADE"))
+        .await
+        .expect("isolated Groups enforcement runtime schema should drop");
+}

--- a/crates/rustok-groups/docs/membership-enforcement-runtime-postgres-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-runtime-postgres-contract.md
@@ -1,0 +1,83 @@
+# Groups direct membership-enforcement PostgreSQL runtime contract
+
+Status: **executable source added / maintainer execution pending**
+
+## Purpose
+
+`apps/server/tests/groups_membership_enforcement_runtime_postgres.rs` is the PostgreSQL counterpart to the SQLite direct-command runtime packet. It retains executable source evidence for fail-closed security, exact local hierarchy/platform authority, lifecycle-count invariance, receipt replay, and atomic audit/event/receipt facts through the production `GroupMembershipEnforcementCommandPort`.
+
+The packet adds no alternate owner implementation, Moderation adapter, dependency, manifest, lockfile, registry promotion, GraphQL path, or production behavior change. Direct SQL is limited to fixture setup and post-operation evidence reads.
+
+## PostgreSQL isolation
+
+One unique PostgreSQL schema is created for the ignored runtime packet. Every SeaORM connection used by the production service receives that schema through startup options:
+
+```text
+options=-csearch_path=<schema>,public
+```
+
+The source intentionally does not rely on session-local `SET search_path`. After all three fresh-tenant scenarios complete, the scoped connection is dropped and the schema is removed through the administrative connection.
+
+## Denial and zero-side-effect contract
+
+A fresh six-member group exercises four non-retryable denials:
+
+- moderator self-target -> `groups.membership_enforcement_self_target`;
+- non-member platform `groups:moderate` actor targeting the current owner -> `groups.membership_enforcement_owner_protected`;
+- moderator targeting administrator -> `groups.manager_required`;
+- ordinary member targeting ordinary member -> `groups.manager_required`.
+
+After the denials, evidence requires group version one, lifecycle member count six, every membership revision one, no enforcement row, and no audit/event/receipt row. Platform authority therefore bypasses local-membership admission only and never bypasses hard owner protection or hierarchy/self-target invariants.
+
+## Exact hierarchy and platform bypass
+
+A second fresh group proves all supported direct tiers:
+
+1. owner suspends/revokes administrator;
+2. administrator suspends/revokes moderator;
+3. moderator suspends/revokes ordinary member;
+4. a non-member `groups:moderate` user suspends/revokes another ordinary member.
+
+Each suspend/revoke is a production owner command. Eight material mutations advance group version from one to nine, touched target membership revisions from one to three, and never alter stored role/status or lifecycle member count six. The untouched member remains revision one. Exactly eight audit facts, eight membership semantic events and eight completed receipts exist for that fresh tenant/group.
+
+## Atomic receipt/audit/event lifecycle
+
+A third fresh group isolates one owner/member lifecycle.
+
+The suspension commit at expected membership revision one must atomically produce membership revision two, group version two, unchanged member count six, one `group.membership_suspended` audit fact, one `groups.membership.suspended` event and one `groups.membership.suspend.v1` receipt for the exact actor/group/idempotency identity.
+
+Exact same-key replay returns `replayed=true` without additional version/revision/ledger rows. Reusing the same key with a changed request fails non-retryably with `groups.conflict` and leaves state/ledger counts unchanged.
+
+The revoke at expected membership revision two must atomically produce membership revision three, group version three, non-null revocation, one `group.membership_suspension_revoked` audit fact, one `groups.membership.suspension_revoked` event and one `groups.membership.suspension_revoke.v1` receipt. Exact revoke replay after current enforcement becomes inactive returns the stored result without duplicating ledger facts.
+
+## Final provenance
+
+The final bounded enforcement row must retain:
+
+- `source_kind=direct_local`;
+- `actor_kind=user`;
+- original owner UUID as `actor_id`;
+- the owner-result enforcement revision;
+- non-null revocation marker.
+
+The target remains stored `member/active` at membership revision three, group version three, and lifecycle member count six.
+
+## Execution status
+
+The test is ignored unless `RUSTOK_GROUPS_TEST_POSTGRES_URL` is configured and was not executed while preparing this slice. FBA `membership_enforcement_command_runtime` remains null until maintainer execution.
+
+Maintainer command:
+
+```bash
+RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' \
+  cargo test -p rustok-server --features mod-groups \
+  --test groups_membership_enforcement_runtime_postgres -- --ignored --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-membership-enforcement-runtime-postgres.mjs
+```
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, browser/schema execution, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-membership-enforcement-runtime-postgres.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-runtime-postgres.mjs
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_membership_enforcement_runtime_postgres.rs";
+const docsPath = "crates/rustok-groups/docs/membership-enforcement-runtime-postgres-contract.md";
+const registryPath = "crates/rustok-groups/contracts/groups-fba-registry.json";
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  '#[ignore = "requires RUSTOK_GROUPS_TEST_POSTGRES_URL"]',
+  "RUSTOK_GROUPS_TEST_POSTGRES_URL",
+  "options=-csearch_path%3D",
+  "CREATE SCHEMA",
+  "DROP SCHEMA",
+  "rustok_groups::migrations::migrations()",
+  "run_denials(&db).await",
+  "run_hierarchy(&db).await",
+  "run_atomicity(&db).await",
+  "GroupMembershipEnforcementCommandService::new",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "GroupMembershipEnforcementCommandPort::revoke_membership_suspension",
+  '.with_claim("groups:moderate")',
+  '"groups.membership_enforcement_self_target"',
+  '"groups.membership_enforcement_owner_protected"',
+  '"groups.manager_required"',
+  "assert_no_material_change",
+  "(0, 0, 0)",
+  '"postgres-owner-suspend-admin"',
+  '"postgres-admin-suspend-moderator"',
+  '"postgres-moderator-suspend-member"',
+  '"postgres-platform-suspend-member"',
+  "(9, 6)",
+  "(8, 8, 8)",
+  'let suspend_key = "postgres-atomic-suspend"',
+  'let revoke_key = "postgres-atomic-revoke"',
+  '"groups.conflict"',
+  "replay.replayed",
+  "revoke_replay.replayed",
+  "(1, 1, 1)",
+  "(2, 2, 2)",
+  '"group.membership_suspended"',
+  '"groups.membership.suspended"',
+  '"groups.membership.suspend.v1"',
+  '"group.membership_suspension_revoked"',
+  '"groups.membership.suspension_revoked"',
+  '"groups.membership.suspension_revoke.v1"',
+  'assert_eq!(source_kind, "direct_local")',
+  'assert_eq!(actor_kind, "user")',
+  "0::BIGINT ELSE 1::BIGINT",
+  "revoked_marker, 1",
+]) {
+  requireText(test, marker, `Groups direct enforcement PostgreSQL runtime source is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "SET search_path",
+  "rustok_moderation::",
+  "MembershipEnforcementProvenance",
+  "INSERT INTO group_membership_enforcements",
+  "UPDATE group_membership_enforcements",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups direct enforcement PostgreSQL runtime source contains owner shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "executable source added / maintainer execution pending",
+  "PostgreSQL isolation",
+  "Denial and zero-side-effect contract",
+  "groups.membership_enforcement_self_target",
+  "groups.membership_enforcement_owner_protected",
+  "groups.manager_required",
+  "Exact hierarchy and platform bypass",
+  "Atomic receipt/audit/event lifecycle",
+  "groups.conflict",
+  "Final provenance",
+  "direct_local",
+  "membership_enforcement_command_runtime",
+]) {
+  requireText(docs, marker, `Groups direct enforcement PostgreSQL runtime handoff is missing ${marker}`);
+}
+
+if (registry?.evidence?.membership_enforcement_command_runtime !== null) {
+  throw new Error("unexecuted membership enforcement command runtime evidence must remain null");
+}
+
+console.log("Groups direct membership-enforcement PostgreSQL runtime source guard passed");


### PR DESCRIPTION
## Summary
- add schema-isolated PostgreSQL runtime/security/atomicity source for direct Groups membership enforcement
- mirror the SQLite denial contract: self-target, hard owner protection even with platform `groups:moderate`, moderator-vs-admin denial, and ordinary-member denial with zero owner-side effects
- mirror exact successful hierarchy: owner over admin, admin over moderator, moderator over member, plus non-member platform `groups:moderate` bypass for ordinary targets
- retain exact membership/group revision progression, lifecycle member-count invariance, and eight audit/event/receipt facts across hierarchy mutations
- isolate suspend/revoke atomic ledger lifecycle with exact action/event/command identities, same-key replay, and changed-request conflict
- retain direct-local/user provenance and revoked bounded enforcement state
- use a unique PostgreSQL schema supplied to every pooled connection through startup `search_path`; no session-local `SET search_path`
- keep FBA `membership_enforcement_command_runtime` null until maintainer execution
- add no Moderation adapter, dependency, manifest, lockfile, registry, GraphQL transport, or production-owner changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, browser/schema execution, workflows, and CI were intentionally not run per maintainer instruction.