### PR TITLE
feat(index): make Product replay scans locale-aware

### DIFF
--- a/crates/rustok-distribution/src/product_index/product.rs
+++ b/crates/rustok-distribution/src/product_index/product.rs
@@ -408,8 +408,29 @@ impl ProductPostgresIndexSource {
     ) -> Result<Vec<QueryResult>, IndexSourceFailure> {
         let fetch_limit = i64::try_from(request.limit() + 1)
             .expect("Index source page limit is bounded below i64::MAX");
-        let (sql, values): (String, Vec<Value>) = match cursor {
-            Some(cursor) => (
+        let (sql, values): (String, Vec<Value>) = match (request.locale(), cursor) {
+            (Some(locale), Some(cursor)) => (
+                format!(
+                    "WITH {PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nWHERE row.locale = $2 AND row.product_id > $3\nORDER BY row.product_id ASC\nLIMIT $4"
+                ),
+                vec![
+                    request.tenant_id().into(),
+                    locale.as_str().to_owned().into(),
+                    cursor.product_id.into(),
+                    fetch_limit.into(),
+                ],
+            ),
+            (Some(locale), None) => (
+                format!(
+                    "WITH {PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nWHERE row.locale = $2\nORDER BY row.product_id ASC\nLIMIT $3"
+                ),
+                vec![
+                    request.tenant_id().into(),
+                    locale.as_str().to_owned().into(),
+                    fetch_limit.into(),
+                ],
+            ),
+            (None, Some(cursor)) => (
                 format!(
                     "WITH {PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nWHERE (row.product_id, row.locale) > ($2, $3)\nORDER BY row.product_id ASC, row.locale ASC\nLIMIT $4"
                 ),
@@ -420,7 +441,7 @@ impl ProductPostgresIndexSource {
                     fetch_limit.into(),
                 ],
             ),
-            None => (
+            (None, None) => (
                 format!(
                     "WITH {PRODUCT_ATTRIBUTE_TERMS_CTE},\n{PRODUCT_ROWS_CTE}\n{PRODUCT_ROW_SELECT}\nORDER BY row.product_id ASC, row.locale ASC\nLIMIT $2"
                 ),
@@ -482,6 +503,11 @@ impl IndexSource for ProductPostgresIndexSource {
             .map(ProductCursor::decode)
             .transpose()
             .map_err(|_| permanent("product_index_cursor_invalid"))?;
+        if let (Some(locale), Some(cursor)) = (request.locale(), cursor.as_ref())
+            && cursor.locale != locale.as_str()
+        {
+            return Err(permanent("product_index_cursor_invalid"));
+        }
         let rows = self.scan_rows(&request, cursor.as_ref()).await?;
         let has_more = rows.len() > request.limit();
         let mut mutations = Vec::with_capacity(rows.len().min(request.limit()));

--- a/crates/rustok-index/docs/m6-locale-scoped-source-scan.md
+++ b/crates/rustok-index/docs/m6-locale-scoped-source-scan.md
@@ -1,16 +1,16 @@
 # M6 locale-scoped replay source scan foundation
 
-Status: `generic_source_contract_complete_product_source_pending`.
+Status: `product_source_complete_durable_replay_scope_pending`.
 
 ## Purpose
 
-Replay checkpoints already reserve a `locale_key`, but the generic source scan request was schema-wide. Populating a checkpoint locale without a real locale-aware source request would create false isolation: a supposedly locale-scoped replay could still scan and mutate every locale in the schema.
+Replay checkpoints already reserve a `locale_key`, but the original generic source scan request was schema-wide. Populating a checkpoint locale without a real locale-aware source request would create false isolation: a supposedly locale-scoped replay could still scan and mutate every locale in the schema.
 
-This slice establishes the generic source boundary first. Durable replay job/checkpoint locale identity, Product PostgreSQL locale predicates, GraphQL locale input, partition scope and rebuild modes are intentionally separate follow-up work.
+The generic exact-locale request and one current `LocaleMode::Required` source — Product — now carry that scope end-to-end through the source boundary. Durable replay job/checkpoint locale identity, GraphQL locale input, partition scope and rebuild modes remain separate follow-up work.
 
 ## Generic source request
 
-`IndexSourceScanRequest` now carries `locale: Option<LocaleKey>`.
+`IndexSourceScanRequest` carries `locale: Option<LocaleKey>`.
 
 The existing `IndexSourceScanRequest::new(...)` constructor is unchanged in meaning and constructs a schema-wide scan with no locale scope. Existing source implementations therefore keep their current call shape and behavior.
 
@@ -26,9 +26,30 @@ For a locale-scoped request, every returned mutation key must contain exactly th
 
 This validator is a safety net, not a pagination strategy. A real locale-capable source must constrain its underlying scan before pagination; post-filtering a schema-wide page would be incorrect because it could skip matching rows or return empty continuation pages.
 
+## Product PostgreSQL source
+
+Current Product remains one physical Index entity per Product translation locale and keeps its current schema-wide replay path intact when `request.locale()` is absent:
+
+- first page orders by `(product_id, locale)`;
+- continuation uses `(row.product_id, row.locale) > ($2, $3)`;
+- the existing `ProductCursor { product_id, locale }` wire format is unchanged.
+
+For `request.locale() = Some(locale)`, Product now constrains the underlying PostgreSQL query before pagination:
+
+- first page uses `WHERE row.locale = $2`, orders by `row.product_id`, and limits with `$3`;
+- continuation uses `WHERE row.locale = $2 AND row.product_id > $3`, orders by `row.product_id`, and limits with `$4`;
+- the requested canonical locale is bound as a SQL parameter rather than interpolated;
+- a supplied Product cursor must contain exactly the same canonical locale or the source fails with `product_index_cursor_invalid` before querying storage.
+
+The Product cursor deliberately keeps its locale field even on locale-scoped scans. That preserves one stable cursor wire contract and makes cross-locale cursor reuse explicitly detectable rather than silently reinterpreted.
+
+After row decode, the generic source-page validator supplies a second fail-closed boundary: every emitted Product mutation must still carry exactly the requested `LocaleKey`.
+
 ## Canonical locale identity
 
-The request accepts `LocaleKey`, not a raw string. The retained source fixture uses a BCP-47-compatible mixed-case locale (`EN-us`) and requires canonical `en-US`, so casing/alias normalization cannot create separate replay scan identities.
+The request accepts `LocaleKey`, not a raw string. The retained generic source fixture uses a BCP-47-compatible mixed-case locale (`EN-us`) and requires canonical `en-US`, so casing normalization cannot create separate replay scan identities.
+
+Product cursors already require their serialized locale to be canonical. Locale-scoped replay adds the stronger requirement that the cursor locale equals the request locale.
 
 ## Explicit non-goals in this slice
 
@@ -37,12 +58,11 @@ This slice does not:
 - change `IndexReplayPageRequest`, `IndexReplayRunRequest`, replay jobs, leases or checkpoints;
 - write non-empty `index_jobs.locale_key` or `index_checkpoints.locale_key`;
 - add or change a database migration;
-- add Product SQL locale filtering yet;
 - add GraphQL locale input;
 - add `partition_key` behavior;
 - introduce targeted/full/shadow rebuild modes;
 - change M7 Storefront serving behavior.
 
-The next source slice should make one real `LocaleMode::Required` source — current Product — honor `request.locale()` in SQL before pagination while preserving its current schema-wide scan when locale is absent. Only after that source capability exists should durable replay job/checkpoint locale identity be admitted.
+The next source slice can now introduce honest durable locale replay identity: worker `LocaleMode` admission, a locale replay job scope, locale-bearing lease/request identity and matching `index_checkpoints.locale_key`. It must preserve the existing schema-wide replay contract and leave `partition_key` empty until a real partition-scoped source contract exists.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/scripts/verify/verify-index-locale-source-scan.mjs
+++ b/scripts/verify/verify-index-locale-source-scan.mjs
@@ -51,16 +51,56 @@ for (const forbidden of [
   }
 }
 
+const productPath = 'crates/rustok-distribution/src/product_index/product.rs';
+const product = requireMarkers(productPath, [
+  'locale_mode: LocaleMode::Required',
+  'match (request.locale(), cursor)',
+  '(Some(locale), Some(cursor)) =>',
+  'WHERE row.locale = $2 AND row.product_id > $3',
+  'ORDER BY row.product_id ASC\\nLIMIT $4'.replace('\\\\n', '\\n'),
+  '(Some(locale), None) =>',
+  'WHERE row.locale = $2',
+  'ORDER BY row.product_id ASC\\nLIMIT $3'.replace('\\\\n', '\\n'),
+  '(None, Some(cursor)) =>',
+  'WHERE (row.product_id, row.locale) > ($2, $3)',
+  'ORDER BY row.product_id ASC, row.locale ASC\\nLIMIT $4'.replace('\\\\n', '\\n'),
+  '(None, None) =>',
+  'ORDER BY row.product_id ASC, row.locale ASC\\nLIMIT $2'.replace('\\\\n', '\\n'),
+  'locale.as_str().to_owned().into()',
+  'if let (Some(locale), Some(cursor)) = (request.locale(), cursor.as_ref())',
+  'cursor.locale != locale.as_str()',
+  'return Err(permanent("product_index_cursor_invalid"));',
+  'IndexSourcePage::new(&request, mutations, next_cursor)',
+]);
+
+const localeCursor = product.indexOf('(Some(locale), Some(cursor)) =>');
+const localeFirst = product.indexOf('(Some(locale), None) =>', localeCursor);
+const schemaCursor = product.indexOf('(None, Some(cursor)) =>', localeFirst);
+const schemaFirst = product.indexOf('(None, None) =>', schemaCursor);
+if (localeCursor < 0 || localeFirst <= localeCursor || schemaCursor <= localeFirst || schemaFirst <= schemaCursor) {
+  fail('Product scan must retain four explicit locale/schema-wide cursor branches');
+}
+
+if (product.includes('filter(|row| row.locale')) {
+  fail('Product locale replay must constrain SQL before pagination rather than post-filter rows');
+}
+if (product.includes('partition_key') || product.includes('scope_kind = \'locale\'')) {
+  fail('Product source slice must not absorb durable locale job/checkpoint or partition scope');
+}
+
 requireMarkers('crates/rustok-index/docs/m6-locale-scoped-source-scan.md', [
-  'Status: `generic_source_contract_complete_product_source_pending`.',
+  'Status: `product_source_complete_durable_replay_scope_pending`.',
   '`IndexSourceScanRequest::new(...)`',
   '`IndexSourceScanRequest::for_locale(...)`',
   '`IndexSourceError::ScanMutationLocaleMismatch`',
   'constrain its underlying scan before pagination',
-  'does not:',
-  'add Product SQL locale filtering yet',
+  'Current Product',
+  '`WHERE row.locale = $2`',
+  '`WHERE row.locale = $2 AND row.product_id > $3`',
+  '`product_index_cursor_invalid`',
+  'write non-empty `index_jobs.locale_key` or `index_checkpoints.locale_key`',
   'add `partition_key` behavior',
-  'current Product',
+  'durable locale replay identity',
 ]);
 
-console.log('[verify-index-locale-source-scan] generic exact-locale source scan contract is fail-closed while durable replay scope and Product SQL remain separate');
+console.log('[verify-index-locale-source-scan] generic and Product exact-locale source scans are fail-closed before pagination while durable replay locale identity remains separate');


### PR DESCRIPTION
## Summary

- make current Product PostgreSQL source honor generic `IndexSourceScanRequest::locale()` before pagination;
- preserve the existing schema-wide Product scan unchanged when locale is absent: `(product_id, locale)` cursor predicate and ordering remain intact;
- add exact-locale first-page SQL `WHERE row.locale = $2` with Product-ID ordering and bounded limit;
- add exact-locale continuation SQL `WHERE row.locale = $2 AND row.product_id > $3` with the same Product-ID ordering;
- bind canonical locale as a SQL parameter rather than interpolating it;
- preserve the existing `ProductCursor { product_id, locale }` wire shape and fail closed when a locale-scoped request receives a cursor from another canonical locale;
- keep common `IndexSourcePage` locale validation as a second fail-closed layer after Product row decode;
- update the retained locale source-scan doc/guard to mark Product source support complete and durable replay job/checkpoint locale identity pending.

## Boundary

This PR still does not create locale-scoped replay jobs or checkpoints. It does not write non-empty `index_jobs.locale_key` / `index_checkpoints.locale_key`, add a migration, add GraphQL locale input, add partition scope, or introduce rebuild modes.

The next independent M6 slice is durable locale replay identity: worker `LocaleMode` admission, a durable locale job scope, locale-bearing lease/run/checkpoint identity and a migration that permits that honest scope while preserving existing schema-wide jobs.

## Main recheck

The branch started from #3302 merge `b9d4814b61b6909f64e461959f7b99e5a2cff89f`. Current main advanced through #3304 Product schema-write receipts and #3305 Groups evidence. #3304 changes Product owner schema-write files, not `rustok-distribution/src/product_index/product.rs`; #3305 is Groups-only. The source paths are disjoint.

## Validation

Static source review only. Because `product.rs` required a full-file Contents API replacement, the PR patch will be reviewed before merge and any unrelated diff will be removed. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.