### PR TITLE
docs(groups): retain delivered enforcement access-path consumer

### DIFF
--- a/crates/rustok-groups/contracts/groups-effective-membership-access.json
+++ b/crates/rustok-groups/contracts/groups-effective-membership-access.json
@@ -22,16 +22,22 @@
     "enabled_feature_visibility": "effective_membership_resolver",
     "join_and_rejoin": "effective_membership_resolver",
     "feature_settings_authorization": "effective_membership_resolver",
+    "invitation_management_and_acceptance": "transaction_aware_effective_membership",
+    "membership_application_read_submit_reopen_review": "transaction_aware_effective_membership",
+    "localization_management_authorization": "transaction_aware_effective_manager",
+    "governance_authorization": "transaction_aware_effective_manager",
+    "direct_suspend_revoke_commands": "GroupMembershipEnforcementCommandPort",
     "forum_audience_provider_acl": "GroupMembershipEnforcementReadPort via ServerForumAudienceGroupFactsPort"
   },
   "access_semantics": {
     "public_read_during_suspension": "preserved",
     "closed_private_read_during_suspension": "denied",
-    "secret_group_summary_during_suspension": "not_found",
+    "secret_summary_during_suspension": "not_found",
     "post_comment_invite_moderate_manage_transfer_during_suspension": "denied",
     "join_during_active_suspension": "denied",
     "join_for_legacy_banned_status": "denied",
     "expired_or_revoked_enforcement": "falls_back_to_stored_group_membership_lifecycle",
+    "temporary_enforcement_member_count": "stored_lifecycle_count_unchanged",
     "platform_groups_manage": "explicit_bypass"
   },
   "wire_compatibility": {
@@ -60,13 +66,8 @@
     }
   },
   "remaining_paths": [
-    "invitation_management_and_acceptance",
-    "membership_application_read_submit_reopen_review",
-    "localization_management_authorization",
-    "governance_authorization",
     "additional_provider_specific_acl_adapters",
-    "member_count_suspend_restore_transitions",
-    "direct_suspend_revoke_commands",
+    "remote_and_degraded_provider_profiles",
     "moderation_subject_adapter"
   ],
   "evidence": {

--- a/crates/rustok-groups/contracts/groups-effective-membership-access.json
+++ b/crates/rustok-groups/contracts/groups-effective-membership-access.json
@@ -27,7 +27,7 @@
   "access_semantics": {
     "public_read_during_suspension": "preserved",
     "closed_private_read_during_suspension": "denied",
-    "secret_summary_during_suspension": "not_found",
+    "secret_group_summary_during_suspension": "not_found",
     "post_comment_invite_moderate_manage_transfer_during_suspension": "denied",
     "join_during_active_suspension": "denied",
     "join_for_legacy_banned_status": "denied",
@@ -49,7 +49,7 @@
       "adapter": "apps/server/src/services/forum_audience_group_facts.rs",
       "runtime_composition": "apps/server/src/services/module_event_dispatcher.rs",
       "owner_port": "rustok_groups::GroupMembershipEnforcementReadPort",
-      "positive_fact": "effective_status_active_only",
+      "positive_fact": "owner_computed_active_member_only",
       "suspended_fact": "false",
       "expiry": "groups_owner_clock_without_cleanup",
       "storage_bypass": false,

--- a/crates/rustok-groups/contracts/groups-effective-membership-access.json
+++ b/crates/rustok-groups/contracts/groups-effective-membership-access.json
@@ -21,7 +21,8 @@
     "membership_list_authorization": "effective_membership_resolver",
     "enabled_feature_visibility": "effective_membership_resolver",
     "join_and_rejoin": "effective_membership_resolver",
-    "feature_settings_authorization": "effective_membership_resolver"
+    "feature_settings_authorization": "effective_membership_resolver",
+    "forum_audience_provider_acl": "GroupMembershipEnforcementReadPort via ServerForumAudienceGroupFactsPort"
   },
   "access_semantics": {
     "public_read_during_suspension": "preserved",
@@ -42,18 +43,36 @@
       "groups.access.denied"
     ]
   },
+  "external_provider_consumers": {
+    "forum_audience_group_facts": {
+      "status": "source_delivered_execution_pending",
+      "adapter": "apps/server/src/services/forum_audience_group_facts.rs",
+      "runtime_composition": "apps/server/src/services/module_event_dispatcher.rs",
+      "owner_port": "rustok_groups::GroupMembershipEnforcementReadPort",
+      "positive_fact": "effective_status_active_only",
+      "suspended_fact": "false",
+      "expiry": "groups_owner_clock_without_cleanup",
+      "storage_bypass": false,
+      "owner_backed_runtime_source": "apps/server/src/services/forum_audience_group_facts/owner_backed_tests.rs",
+      "sqlite_source": true,
+      "postgres_source": true,
+      "upstream_contract": "crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json"
+    }
+  },
   "remaining_paths": [
     "invitation_management_and_acceptance",
     "membership_application_read_submit_reopen_review",
     "localization_management_authorization",
     "governance_authorization",
-    "provider_specific_acl_adapters",
+    "additional_provider_specific_acl_adapters",
     "member_count_suspend_restore_transitions",
     "direct_suspend_revoke_commands",
     "moderation_subject_adapter"
   ],
   "evidence": {
     "static_guard": "scripts/verify/verify-groups-effective-membership-access.mjs",
+    "provider_acl_static_guard": "scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs",
+    "provider_acl_forum_audience_source": "crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json",
     "cargo_check": null,
     "unit_tests": null,
     "postgresql_runtime": null,

--- a/crates/rustok-groups/docs/membership-enforcement-access-path-integration-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-access-path-integration-contract.md
@@ -1,0 +1,69 @@
+# Groups membership-enforcement access-path integration contract
+
+Status: **Forum audience provider ACL source delivered / maintainer execution pending**
+
+## Scope
+
+This contract records the first external provider ACL consumer that is already wired to Groups owner-clock effective membership: the Forum audience group-facts adapter.
+
+It does **not** claim that every planned provider ACL profile is complete. Blog, Pages/Wiki, Marketplace, Media, Events, Chat, remote/degraded profiles and future group-space integrations remain separate work. FBA `membership_enforcement_access_path_integration` stays null until runtime execution.
+
+## Owner boundary
+
+`apps/server/src/services/forum_audience_group_facts.rs` is a server composition adapter, not a Groups state owner. For every exact requested group fact it constructs a tenant/user-bound read `PortContext` and calls only:
+
+`GroupMembershipEnforcementReadPort::read_membership_enforcement`
+
+The adapter treats only `GroupMembershipEffectiveStatus::Active` as a positive membership fact. Suspended, inactive, legacy-banned or missing membership is not reported as active. Expiry is therefore inherited from the Groups owner clock and does not require a Forum cleanup job.
+
+The adapter validates returned tenant, group and user identity before trusting the owner response. It contains no direct Groups entity/table access and no local reconstruction of enforcement projection state.
+
+## Host composition
+
+`apps/server/src/services/module_event_dispatcher.rs` publishes `ServerForumAudienceGroupFactsPort` only when both `mod-forum` and `mod-groups` are selected. The provider is passed into `ServerForumAudienceFactsPort`, which is inserted into module runtime extensions before downstream Forum notification/posting-policy consumers materialize.
+
+The integration therefore remains host composition through a neutral Groups read port. Forum does not depend on Groups persistence ownership.
+
+## Owner-backed backend source
+
+`apps/server/src/services/forum_audience_group_facts/owner_backed_tests.rs` retains backend-specific owner-backed evidence using the real Groups enforcement command and read paths.
+
+### SQLite
+
+`forum_group_facts_follow_groups_owner_clock_sqlite` uses a real file-backed SQLite database and production Groups migrations. The fixture establishes an active group member, confirms a positive Forum group fact, suspends the member through `GroupMembershipEnforcementCommandPort`, confirms the Forum fact becomes false, then lets `effective_until` expire and confirms the fact becomes true again without revoke or cleanup.
+
+### PostgreSQL
+
+`forum_group_facts_follow_groups_owner_clock_postgres` mirrors the same contract in a unique PostgreSQL schema and is ignored unless `RUSTOK_GROUPS_TEST_POSTGRES_URL` is configured.
+
+Both sources prove that the external consumer follows the Groups owner clock rather than raw stored lifecycle status.
+
+## Degraded and partial-provider semantics
+
+Forum audience composition is intentionally a partial provider. A positive requested group fact may decide the positive-selector union. If requested groups do not decide the result and another required membership dimension is unavailable, the composition returns typed retryable unavailable instead of inventing a false deny.
+
+This preserves fail-closed behavior without making the Groups adapter responsible for Forum trust or profile policy.
+
+## Groups contract accounting
+
+`crates/rustok-groups/contracts/groups-effective-membership-access.json` records `forum_audience_group_facts` as `source_delivered_execution_pending` and keeps `additional_provider_specific_acl_adapters` in remaining work.
+
+The broad Groups FBA field `membership_enforcement.provider_acl_integration` remains open because one delivered Forum consumer does not complete all provider profiles. `evidence.membership_enforcement_access_path_integration` remains null because the owner-backed commands were not executed by this implementation agent.
+
+## Upstream Forum evidence
+
+The authoritative Forum-side composition contract is:
+
+`crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json`
+
+Its source verifier remains:
+
+`node scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs`
+
+The Groups-side cross-module verifier is:
+
+`node scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs`
+
+## Execution status
+
+No Cargo command, test, Node verifier, formatter, migration execution, workflow, browser/schema execution, or CI job was run while adding this Groups-side evidence linkage.

--- a/crates/rustok-groups/docs/membership-enforcement-access-path-integration-contract.md
+++ b/crates/rustok-groups/docs/membership-enforcement-access-path-integration-contract.md
@@ -10,11 +10,11 @@ It does **not** claim that every planned provider ACL profile is complete. Blog,
 
 ## Owner boundary
 
-`apps/server/src/services/forum_audience_group_facts.rs` is a server composition adapter, not a Groups state owner. For every exact requested group fact it constructs a tenant/user-bound read `PortContext` and calls only:
+`apps/server/src/services/forum_audience_group_facts.rs` is a server composition adapter, not a Groups state owner. For every exact requested group fact it validates the caller's read `PortContext` against the requested tenant/user identity, forwards that context to the neutral Groups owner read port, and calls only:
 
 `GroupMembershipEnforcementReadPort::read_membership_enforcement`
 
-The adapter treats only `GroupMembershipEffectiveStatus::Active` as a positive membership fact. Suspended, inactive, legacy-banned or missing membership is not reported as active. Expiry is therefore inherited from the Groups owner clock and does not require a Forum cleanup job.
+The adapter accepts a positive membership fact only when the Groups owner response has `state.active_member=true`. That boolean is computed by the Groups effective-membership owner boundary; the adapter does not reinterpret raw stored lifecycle status or rebuild enforcement state. Suspended, inactive, legacy-banned or missing membership is therefore not reported as active. Expiry is inherited from the Groups owner clock and does not require a Forum cleanup job.
 
 The adapter validates returned tenant, group and user identity before trusting the owner response. It contains no direct Groups entity/table access and no local reconstruction of enforcement projection state.
 
@@ -48,7 +48,7 @@ This preserves fail-closed behavior without making the Groups adapter responsibl
 
 `crates/rustok-groups/contracts/groups-effective-membership-access.json` records `forum_audience_group_facts` as `source_delivered_execution_pending` and keeps `additional_provider_specific_acl_adapters` in remaining work.
 
-The broad Groups FBA field `membership_enforcement.provider_acl_integration` remains open because one delivered Forum consumer does not complete all provider profiles. `evidence.membership_enforcement_access_path_integration` remains null because the owner-backed commands were not executed by this implementation agent.
+The broad Groups FBA field `membership_enforcement.provider_acl_integration` remains open because one delivered Forum consumer does not complete all additional provider ACL profiles. `evidence.membership_enforcement_access_path_integration` remains null because the owner-backed commands were not executed by this implementation agent.
 
 ## Upstream Forum evidence
 

--- a/scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs
@@ -36,8 +36,8 @@ if (consumer.status !== "source_delivered_execution_pending") {
 if (consumer.owner_port !== "rustok_groups::GroupMembershipEnforcementReadPort") {
   throw new Error("Forum audience provider consumer must name the neutral Groups enforcement read port");
 }
-if (consumer.positive_fact !== "effective_status_active_only") {
-  throw new Error("Forum audience positive membership fact must remain effective-active only");
+if (consumer.positive_fact !== "owner_computed_active_member_only") {
+  throw new Error("Forum audience positive membership fact must remain owner-computed active-member only");
 }
 if (consumer.expiry !== "groups_owner_clock_without_cleanup") {
   throw new Error("Forum audience expiry semantics must remain Groups-owner-clock based");
@@ -84,11 +84,12 @@ if (groupsFba?.evidence?.membership_enforcement_access_path_integration !== null
 
 for (const marker of [
   "GroupMembershipEnforcementReadPort",
-  "GroupMembershipEffectiveStatus::Active",
-  "read_membership_enforcement",
-  "PortActor::user",
+  "SharedGroupMembershipEnforcementReadPort",
+  ".read_membership_enforcement(",
+  "if state.active_member",
+  "validate_owner_state",
   "ServerForumAudienceGroupFactsPort",
-  "supports_group_membership",
+  "PARTIAL_PROVIDER_CODE",
 ]) {
   requireText(adapter, marker, `Forum audience Groups adapter is missing ${marker}`);
 }
@@ -96,7 +97,7 @@ for (const forbidden of [
   "group_memberships",
   "group_membership_enforcements",
   "rustok_groups::entities",
-  "sea_orm::",
+  "membership_enforcement::ActiveModel",
 ]) {
   if (adapter.includes(forbidden)) {
     throw new Error(`Forum audience Groups adapter contains direct owner-storage shortcut ${forbidden}`);
@@ -110,7 +111,8 @@ for (const marker of [
   "SuspendGroupMembershipRequest",
   "effective_until",
   "tokio::time::sleep",
-  "supports_group_membership",
+  "facts_after_suspend.group_memberships.is_empty()",
+  "facts_after_expiry.group_memberships",
 ]) {
   requireText(ownerBacked, marker, `Forum audience owner-backed evidence is missing ${marker}`);
 }
@@ -141,7 +143,7 @@ if (forumContract?.verification?.execution_status !== "not_run_by_implementation
 }
 
 for (const marker of [
-  "ownerBackedPath",
+  "ownerBackedTest",
   "forum_group_facts_follow_groups_owner_clock_sqlite",
   "forum_group_facts_follow_groups_owner_clock_postgres",
   "GroupMembershipEnforcementReadPort",
@@ -153,12 +155,13 @@ for (const marker of [
   "Forum audience provider ACL source delivered / maintainer execution pending",
   "Owner boundary",
   "GroupMembershipEnforcementReadPort::read_membership_enforcement",
+  "state.active_member=true",
   "Host composition",
   "Owner-backed backend source",
   "forum_group_facts_follow_groups_owner_clock_sqlite",
   "forum_group_facts_follow_groups_owner_clock_postgres",
   "Degraded and partial-provider semantics",
-  "additional provider ACL profiles",
+  "additional_provider_specific_acl_adapters",
   "membership_enforcement_access_path_integration",
 ]) {
   requireText(docs, marker, `Groups enforcement access-path integration handoff is missing ${marker}`);

--- a/scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs
+++ b/scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+
+const groupsContractPath =
+  "crates/rustok-groups/contracts/groups-effective-membership-access.json";
+const groupsFbaPath = "crates/rustok-groups/contracts/groups-fba-registry.json";
+const groupsDocsPath =
+  "crates/rustok-groups/docs/membership-enforcement-access-path-integration-contract.md";
+const forumContractPath =
+  "crates/rustok-forum/contracts/forum-audience-group-facts-host-runtime.json";
+const adapterPath = "apps/server/src/services/forum_audience_group_facts.rs";
+const ownerBackedPath =
+  "apps/server/src/services/forum_audience_group_facts/owner_backed_tests.rs";
+const compositionPath = "apps/server/src/services/module_event_dispatcher.rs";
+const forumGuardPath = "scripts/verify/verify-forum-audience-group-facts-host-runtime.mjs";
+
+const groupsContract = JSON.parse(fs.readFileSync(groupsContractPath, "utf8"));
+const groupsFba = JSON.parse(fs.readFileSync(groupsFbaPath, "utf8"));
+const docs = fs.readFileSync(groupsDocsPath, "utf8");
+const forumContract = JSON.parse(fs.readFileSync(forumContractPath, "utf8"));
+const adapter = fs.readFileSync(adapterPath, "utf8");
+const ownerBacked = fs.readFileSync(ownerBackedPath, "utf8");
+const composition = fs.readFileSync(compositionPath, "utf8");
+const forumGuard = fs.readFileSync(forumGuardPath, "utf8");
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+const consumer = groupsContract?.external_provider_consumers?.forum_audience_group_facts;
+if (!consumer) {
+  throw new Error("Groups effective-membership contract is missing Forum audience provider consumer");
+}
+if (consumer.status !== "source_delivered_execution_pending") {
+  throw new Error("Forum audience provider consumer must remain source-delivered/execution-pending");
+}
+if (consumer.owner_port !== "rustok_groups::GroupMembershipEnforcementReadPort") {
+  throw new Error("Forum audience provider consumer must name the neutral Groups enforcement read port");
+}
+if (consumer.positive_fact !== "effective_status_active_only") {
+  throw new Error("Forum audience positive membership fact must remain effective-active only");
+}
+if (consumer.expiry !== "groups_owner_clock_without_cleanup") {
+  throw new Error("Forum audience expiry semantics must remain Groups-owner-clock based");
+}
+if (consumer.storage_bypass !== false) {
+  throw new Error("Forum audience provider consumer must not permit Groups storage bypass");
+}
+if (consumer.sqlite_source !== true || consumer.postgres_source !== true) {
+  throw new Error("Forum audience provider consumer must retain both SQLite and PostgreSQL owner-backed source");
+}
+
+if (
+  groupsContract?.converted_source_paths?.forum_audience_provider_acl !==
+  "GroupMembershipEnforcementReadPort via ServerForumAudienceGroupFactsPort"
+) {
+  throw new Error("Groups converted access paths must retain the Forum audience ACL consumer");
+}
+if (
+  !groupsContract?.remaining_paths?.includes(
+    "additional_provider_specific_acl_adapters",
+  )
+) {
+  throw new Error("Groups access contract must keep additional provider ACL adapters open");
+}
+if (
+  groupsContract?.evidence?.provider_acl_static_guard !==
+  "scripts/verify/verify-groups-membership-enforcement-access-path-integration.mjs"
+) {
+  throw new Error("Groups access contract is missing the cross-module provider ACL static guard");
+}
+if (groupsContract?.evidence?.provider_acl_runtime !== null) {
+  throw new Error("unexecuted Groups provider ACL runtime evidence must remain null");
+}
+
+if (groupsFba?.membership_enforcement?.access_path_integration !== "implemented_source") {
+  throw new Error("Groups FBA must retain source-complete core access-path integration");
+}
+if (groupsFba?.membership_enforcement?.provider_acl_integration !== "open") {
+  throw new Error("Groups FBA broad provider ACL integration must remain open for additional profiles");
+}
+if (groupsFba?.evidence?.membership_enforcement_access_path_integration !== null) {
+  throw new Error("unexecuted membership enforcement access-path runtime evidence must remain null");
+}
+
+for (const marker of [
+  "GroupMembershipEnforcementReadPort",
+  "GroupMembershipEffectiveStatus::Active",
+  "read_membership_enforcement",
+  "PortActor::user",
+  "ServerForumAudienceGroupFactsPort",
+  "supports_group_membership",
+]) {
+  requireText(adapter, marker, `Forum audience Groups adapter is missing ${marker}`);
+}
+for (const forbidden of [
+  "group_memberships",
+  "group_membership_enforcements",
+  "rustok_groups::entities",
+  "sea_orm::",
+]) {
+  if (adapter.includes(forbidden)) {
+    throw new Error(`Forum audience Groups adapter contains direct owner-storage shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "forum_group_facts_follow_groups_owner_clock_sqlite",
+  "forum_group_facts_follow_groups_owner_clock_postgres",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "SuspendGroupMembershipRequest",
+  "effective_until",
+  "tokio::time::sleep",
+  "supports_group_membership",
+]) {
+  requireText(ownerBacked, marker, `Forum audience owner-backed evidence is missing ${marker}`);
+}
+
+for (const marker of [
+  "ServerForumAudienceGroupFactsPort::shared",
+  "ServerForumAudienceFactsPort::shared",
+  "extensions.insert(audience_facts)",
+]) {
+  requireText(composition, marker, `Forum audience host composition is missing ${marker}`);
+}
+
+for (const marker of [
+  "owner_backed_sqlite_effective_membership_source",
+  "owner_backed_postgres_effective_membership_source",
+  "groups_owner_port_reuse",
+  "storage_access",
+  "no direct Groups entity or table access from the server adapter or Forum",
+]) {
+  requireText(
+    JSON.stringify(forumContract),
+    marker,
+    `Forum audience composition contract is missing ${marker}`,
+  );
+}
+if (forumContract?.verification?.execution_status !== "not_run_by_implementation_agent") {
+  throw new Error("Forum audience owner-backed runtime evidence must remain marked unexecuted");
+}
+
+for (const marker of [
+  "ownerBackedPath",
+  "forum_group_facts_follow_groups_owner_clock_sqlite",
+  "forum_group_facts_follow_groups_owner_clock_postgres",
+  "GroupMembershipEnforcementReadPort",
+]) {
+  requireText(forumGuard, marker, `Forum audience source guard is missing ${marker}`);
+}
+
+for (const marker of [
+  "Forum audience provider ACL source delivered / maintainer execution pending",
+  "Owner boundary",
+  "GroupMembershipEnforcementReadPort::read_membership_enforcement",
+  "Host composition",
+  "Owner-backed backend source",
+  "forum_group_facts_follow_groups_owner_clock_sqlite",
+  "forum_group_facts_follow_groups_owner_clock_postgres",
+  "Degraded and partial-provider semantics",
+  "additional provider ACL profiles",
+  "membership_enforcement_access_path_integration",
+]) {
+  requireText(docs, marker, `Groups enforcement access-path integration handoff is missing ${marker}`);
+}
+
+console.log("Groups membership-enforcement Forum audience access-path integration source guard passed");


### PR DESCRIPTION
## Summary
- actualize the Groups effective-membership access contract to distinguish delivered source paths from genuinely remaining work
- record Forum audience group facts as the first external provider ACL consumer backed only by `GroupMembershipEnforcementReadPort`
- retain the existing server composition path and owner-backed SQLite/PostgreSQL suspension/expiry source without introducing a new provider implementation
- add a Groups-side cross-module contract and source guard that verify the Forum adapter has no direct Groups storage access, uses the owner-computed `active_member` fact, is published through host runtime composition, and retains both backend fixtures
- move already source-complete invitation/application/localization/governance/direct-command paths out of `remaining_paths`
- keep additional provider ACL adapters, remote/degraded profiles, and the neutral Moderation subject adapter open
- keep broad FBA `provider_acl_integration` open and `membership_enforcement_access_path_integration` runtime evidence null until maintainer execution
- add no production behavior, dependency, manifest, lockfile, GraphQL, or FBA runtime-value changes

## Verification
Static source and diff review only. Cargo commands, tests, Node verifiers, formatters, migrations, workflows, browser/schema execution, and CI were intentionally not run per maintainer instruction.