### PR TITLE
feat(index): add durable locale replay job scope

### DIFF
--- a/crates/rustok-index/docs/m6-locale-replay-job-scope.md
+++ b/crates/rustok-index/docs/m6-locale-replay-job-scope.md
@@ -1,0 +1,102 @@
+# M6 durable locale replay job scope
+
+Status: `job_scope_source_complete_checkpoint_worker_pending`.
+
+## Purpose
+
+The generic source request and current Product PostgreSQL source can now scan one exact canonical locale before pagination. Durable replay identity must match that source scope before checkpoints or GraphQL can safely expose locale replay.
+
+This slice introduces an Index-owned durable **locale job scope** while preserving the existing schema-wide replay job contract byte-for-byte at its public constructor and stored v1 request shape.
+
+## Durable scope model
+
+`index_jobs` gains a permitted `scope_kind = 'locale'` shape:
+
+- tenant, module, entity and schema version are required;
+- `entity_id` remains null;
+- `locale_key` is required, non-empty and bounded to 32 bytes;
+- schema-wide jobs remain `scope_kind = 'schema'` with `locale_key IS NULL`;
+- entity/global job shapes remain unchanged.
+
+The scope index now includes `locale_key` after `schema_version`, so distinct locale jobs do not share one schema-only index prefix.
+
+`partition_key` is not introduced into `index_jobs` and remains outside this slice.
+
+## Migration boundary
+
+`m20260808_000009_add_index_job_locale_scope` follows the existing Index cross-backend constraint-relaxation pattern:
+
+- PostgreSQL discovers and replaces exactly one `index_jobs` scope CHECK, then recreates `idx_index_jobs_scope` with locale dimension;
+- SQLite rebuilds `index_jobs`, copies all existing rows and recreates the claim/scope indexes;
+- down migration restores the previous scope CHECK/index contract.
+
+The migration does not reinterpret existing schema jobs and does not manufacture locale values for old rows.
+
+## Job request/lease identity
+
+`IndexReplayJobLeaseRequest::new(...)` remains schema-wide and keeps the stored exact request contract:
+
+```json
+{"contract":"index_replay_job_v1","source_name":"..."}
+```
+
+The crate-private locale constructor carries an already canonical `LocaleKey`. Locale jobs persist:
+
+```json
+{"contract":"index_replay_job_v2","source_name":"...","locale":"en-US"}
+```
+
+The v2 JSON locale must exactly equal the persisted canonical `locale_key`. Stored jobs fail closed if scope kind, locale column, request version or request locale disagree.
+
+The locale constructor is intentionally crate-private in this slice. No external caller or GraphQL transport can create a locale job until worker/checkpoint semantics are source-complete.
+
+## Schema admission
+
+Before any job lookup/insert, the job store reads the exact active persisted `index_schemas` row. Locale jobs additionally deserialize the persisted `IndexSchema` and reject `LocaleMode::None` with `LocaleScopeUnsupported`.
+
+`LocaleMode::Optional` and `LocaleMode::Required` are eligible for locale job identity. Schema-wide replay remains allowed for all existing schemas, including `LocaleMode::Required`, preserving the current full-rebuild path.
+
+## Lock, lookup and lease semantics
+
+The PostgreSQL advisory scope lock includes explicit scope kind plus canonical locale so schema-wide, `en-US` and `de` are different lock identities.
+
+Active-job lookup is null-safe and exact:
+
+- PostgreSQL uses `locale_key IS NOT DISTINCT FROM $6`;
+- SQLite uses `locale_key IS ?6`;
+- both also require exact `scope_kind`.
+
+A claimed lease retains the optional canonical locale. Existing heartbeat/failure/retry fencing remains based on tenant/job/worker/attempt and therefore needs no locale duplication after the job UUID has been selected.
+
+## Completion fail-closed boundary
+
+`PostgresIndexReplayJobStore::succeed` now looks for a complete checkpoint with the lease's exact locale key (empty string only for schema-wide jobs) and still requires `partition_key = ''`.
+
+This slice deliberately does **not** yet teach `IndexReplayCheckpointKey` or `PostgresIndexReplayCheckpointStore` to write a locale checkpoint. Therefore a locale job cannot accidentally succeed through a schema-wide checkpoint; it remains `CheckpointMissing` until the next source slice adds locale checkpoint identity.
+
+That temporary fail-closed state is intentional and is why the locale job constructor remains crate-private.
+
+## Retained source evidence
+
+`source_replay_locale_job_tests.rs` retains SQLite source that requires:
+
+- independent schema-wide, `en-US` and `de` jobs for one tenant/schema/source;
+- canonical `EN-us` input persisted as `en-US`;
+- a second `en-US` worker to observe `Busy` rather than collide with another locale;
+- exact v1 schema and v2 locale request JSON;
+- a completed schema checkpoint to finish only the schema job, while locale completion remains `CheckpointMissing`;
+- locale job admission against `LocaleMode::None` to fail before creating an `index_jobs` row.
+
+The packet applies the real Index migration chain, including the new cross-backend migration source, but the implementation agent did not execute it.
+
+## Still open
+
+- locale-bearing `IndexReplayCheckpointKey` and checkpoint PostgreSQL adapter;
+- locale-aware one-page replay request/worker admission and exact source scan construction;
+- locale-bearing multi-page run request and cancellation/runner scope;
+- optional GraphQL `locale` input with canonicalization after authorization;
+- retained end-to-end locale replay/restart evidence;
+- `partition_key` source/job/checkpoint semantics;
+- explicit targeted/full/shadow rebuild modes.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/mod.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/mod.rs
@@ -54,6 +54,8 @@ mod source_reconciliation_runner_tests;
 #[cfg(test)]
 mod source_replay_job_tests;
 #[cfg(test)]
+mod source_replay_locale_job_tests;
+#[cfg(test)]
 mod source_replay_runner_tests;
 #[cfg(test)]
 mod source_replay_graceful_shutdown_tests;

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs
@@ -8,9 +8,10 @@ use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::SchemaRef;
+use crate::{IndexSchema, LocaleKey, LocaleMode, SchemaRef};
 
-const REPLAY_JOB_REQUEST_CONTRACT: &str = "index_replay_job_v1";
+const REPLAY_JOB_REQUEST_CONTRACT_V1: &str = "index_replay_job_v1";
+const REPLAY_JOB_REQUEST_CONTRACT_V2: &str = "index_replay_job_v2";
 const MAX_SOURCE_NAME_BYTES: usize = 128;
 const MAX_WORKER_ID_BYTES: usize = 191;
 const MAX_ERROR_CODE_BYTES: usize = 128;
@@ -20,6 +21,7 @@ const MAX_LEASE_SECONDS: u64 = 86_400;
 pub struct IndexReplayJobLeaseRequest {
     tenant_id: Uuid,
     schema: SchemaRef,
+    locale: Option<LocaleKey>,
     source_name: String,
     worker_id: String,
     lease_seconds: u64,
@@ -29,6 +31,42 @@ impl IndexReplayJobLeaseRequest {
     pub fn new(
         tenant_id: Uuid,
         schema: SchemaRef,
+        source_name: impl Into<String>,
+        worker_id: impl Into<String>,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReplayJobError> {
+        Self::new_scoped(
+            tenant_id,
+            schema,
+            None,
+            source_name,
+            worker_id,
+            lease_duration,
+        )
+    }
+
+    pub(crate) fn for_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: LocaleKey,
+        source_name: impl Into<String>,
+        worker_id: impl Into<String>,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReplayJobError> {
+        Self::new_scoped(
+            tenant_id,
+            schema,
+            Some(locale),
+            source_name,
+            worker_id,
+            lease_duration,
+        )
+    }
+
+    fn new_scoped(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: Option<LocaleKey>,
         source_name: impl Into<String>,
         worker_id: impl Into<String>,
         lease_duration: Duration,
@@ -44,6 +82,7 @@ impl IndexReplayJobLeaseRequest {
         Ok(Self {
             tenant_id,
             schema,
+            locale,
             source_name,
             worker_id,
             lease_seconds,
@@ -58,6 +97,10 @@ impl IndexReplayJobLeaseRequest {
         &self.schema
     }
 
+    pub(crate) fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
+    }
+
     pub fn source_name(&self) -> &str {
         &self.source_name
     }
@@ -69,6 +112,10 @@ impl IndexReplayJobLeaseRequest {
     pub fn lease_duration(&self) -> Duration {
         Duration::from_secs(self.lease_seconds)
     }
+
+    fn scope_kind(&self) -> &'static str {
+        if self.locale.is_some() { "locale" } else { "schema" }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +123,7 @@ pub struct IndexReplayJobLease {
     tenant_id: Uuid,
     job_id: Uuid,
     schema: SchemaRef,
+    locale: Option<LocaleKey>,
     source_name: String,
     worker_id: String,
     attempt_count: u32,
@@ -92,6 +140,10 @@ impl IndexReplayJobLease {
 
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
+    }
+
+    pub(crate) fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
     }
 
     pub fn source_name(&self) -> &str {
@@ -130,6 +182,8 @@ pub enum IndexReplayJobError {
     SchemaNotRegistered(SchemaRef),
     #[error("Index replay schema is retired: {0}")]
     SchemaRetired(SchemaRef),
+    #[error("Index replay schema does not support locale-scoped jobs: {0}")]
+    LocaleScopeUnsupported(SchemaRef),
     #[error(
         "Index replay scope is blocked by failed job {job_id} after attempt {attempt_count}"
     )]
@@ -291,6 +345,11 @@ impl PostgresIndexReplayJobStore {
                     "request.source_name does not match the replay scope owner".to_owned(),
                 ));
             }
+            if stored.locale != request.locale {
+                return Err(IndexReplayJobError::InvalidStoredJob(
+                    "stored replay locale does not match the durable scope".to_owned(),
+                ));
+            }
             match stored.state.as_str() {
                 "succeeded" => {
                     return Ok(IndexReplayJobAcquireOutcome::AlreadyComplete {
@@ -351,10 +410,7 @@ impl PostgresIndexReplayJobStore {
         } else {
             job_id = Uuid::new_v4();
             attempt_count = 1;
-            let job_request = json!({
-                "contract": REPLAY_JOB_REQUEST_CONTRACT,
-                "source_name": request.source_name.clone(),
-            });
+            let job_request = replay_job_request(request);
             transaction
                 .execute(Statement::from_sql_and_values(
                     backend,
@@ -362,9 +418,15 @@ impl PostgresIndexReplayJobStore {
                     vec![
                         uuid_value(request.tenant_id, backend),
                         uuid_value(job_id, backend),
+                        request.scope_kind().to_owned().into(),
                         request.schema.module.as_str().to_owned().into(),
                         request.schema.entity.as_str().to_owned().into(),
                         i64::from(request.schema.version.get()).into(),
+                        request
+                            .locale
+                            .as_ref()
+                            .map(|locale| locale.as_str().to_owned())
+                            .into(),
                         SqlValue::Json(Some(Box::new(job_request))),
                         request.worker_id.clone().into(),
                         i64::try_from(request.lease_seconds)
@@ -380,6 +442,7 @@ impl PostgresIndexReplayJobStore {
             tenant_id: request.tenant_id,
             job_id,
             schema: request.schema.clone(),
+            locale: request.locale.clone(),
             source_name: request.source_name.clone(),
             worker_id: request.worker_id.clone(),
             attempt_count,
@@ -392,24 +455,61 @@ struct StoredJob {
     job_id: Uuid,
     state: String,
     source_name: String,
+    locale: Option<LocaleKey>,
     attempt_count: u32,
     claimable: bool,
     last_error_code: Option<String>,
 }
 
+fn replay_job_request(request: &IndexReplayJobLeaseRequest) -> JsonValue {
+    match request.locale.as_ref() {
+        Some(locale) => json!({
+            "contract": REPLAY_JOB_REQUEST_CONTRACT_V2,
+            "source_name": request.source_name.clone(),
+            "locale": locale.as_str(),
+        }),
+        None => json!({
+            "contract": REPLAY_JOB_REQUEST_CONTRACT_V1,
+            "source_name": request.source_name.clone(),
+        }),
+    }
+}
+
 fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexReplayJobError> {
+    let scope_kind: String = row.try_get("", "scope_kind").map_err(storage_error)?;
+    let locale_key: Option<String> = row.try_get("", "locale_key").map_err(storage_error)?;
+    let locale = match (scope_kind.as_str(), locale_key) {
+        ("schema", None) => None,
+        ("locale", Some(raw)) => {
+            let locale = LocaleKey::new(&raw).map_err(|_| {
+                IndexReplayJobError::InvalidStoredJob(
+                    "locale_key is outside the canonical locale contract".to_owned(),
+                )
+            })?;
+            if locale.as_str() != raw {
+                return Err(IndexReplayJobError::InvalidStoredJob(
+                    "locale_key is not canonical".to_owned(),
+                ));
+            }
+            Some(locale)
+        }
+        _ => {
+            return Err(IndexReplayJobError::InvalidStoredJob(
+                "scope_kind and locale_key do not form a replay schema/locale scope".to_owned(),
+            ));
+        }
+    };
+
     let request: JsonValue = row.try_get("", "request").map_err(storage_error)?;
     let object = request.as_object().ok_or_else(|| {
         IndexReplayJobError::InvalidStoredJob("request must be a JSON object".to_owned())
     })?;
-    if object.len() != 2
-        || object.get("contract").and_then(JsonValue::as_str)
-            != Some(REPLAY_JOB_REQUEST_CONTRACT)
-    {
-        return Err(IndexReplayJobError::InvalidStoredJob(
-            "request must use the exact index_replay_job_v1 contract".to_owned(),
-        ));
-    }
+    let contract = object
+        .get("contract")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| {
+            IndexReplayJobError::InvalidStoredJob("request.contract must be a string".to_owned())
+        })?;
     let source_name = object
         .get("source_name")
         .and_then(JsonValue::as_str)
@@ -424,6 +524,31 @@ fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexR
             "request.source_name is outside the replay source contract".to_owned(),
         )
     })?;
+
+    match locale.as_ref() {
+        None => {
+            if object.len() != 2 || contract != REPLAY_JOB_REQUEST_CONTRACT_V1 {
+                return Err(IndexReplayJobError::InvalidStoredJob(
+                    "schema replay request must use the exact index_replay_job_v1 contract"
+                        .to_owned(),
+                ));
+            }
+        }
+        Some(locale) => {
+            if object.len() != 3 || contract != REPLAY_JOB_REQUEST_CONTRACT_V2 {
+                return Err(IndexReplayJobError::InvalidStoredJob(
+                    "locale replay request must use the exact index_replay_job_v2 contract"
+                        .to_owned(),
+                ));
+            }
+            if object.get("locale").and_then(JsonValue::as_str) != Some(locale.as_str()) {
+                return Err(IndexReplayJobError::InvalidStoredJob(
+                    "request.locale does not match locale_key".to_owned(),
+                ));
+            }
+        }
+    }
+
     let attempt_count: i64 = row
         .try_get("", "attempt_count_value")
         .map_err(storage_error)?;
@@ -444,6 +569,7 @@ fn stored_job(row: &QueryResult, backend: DbBackend) -> Result<StoredJob, IndexR
         job_id: stored_uuid(row, "job_id", backend)?,
         state: row.try_get("", "state").map_err(storage_error)?,
         source_name,
+        locale,
         attempt_count,
         claimable: row.try_get("", "claimable").map_err(storage_error)?,
         last_error_code,
@@ -494,6 +620,12 @@ async fn require_complete_checkpoint(
                 lease.schema.module.as_str().to_owned().into(),
                 lease.schema.entity.as_str().to_owned().into(),
                 i64::from(lease.schema.version.get()).into(),
+                lease
+                    .locale
+                    .as_ref()
+                    .map(|locale| locale.as_str().to_owned())
+                    .unwrap_or_default()
+                    .into(),
             ],
         ))
         .await
@@ -544,12 +676,19 @@ async fn lock_replay_scope(
     if backend == DbBackend::Sqlite {
         return Ok(());
     }
+    let locale = request
+        .locale
+        .as_ref()
+        .map(LocaleKey::as_str)
+        .unwrap_or("");
     let lock_key = format!(
-        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
         request.tenant_id,
         request.schema.module.as_str(),
         request.schema.entity.as_str(),
         request.schema.version.get(),
+        request.scope_kind(),
+        locale,
     );
     transaction
         .execute(Statement::from_sql_and_values(
@@ -571,7 +710,7 @@ async fn verify_schema_registration(
         .query_one(Statement::from_sql_and_values(
             backend,
             select_schema_sql(backend),
-            replay_scope_values(request, backend),
+            schema_scope_values(request, backend),
         ))
         .await
         .map_err(storage_error)?
@@ -579,6 +718,20 @@ async fn verify_schema_registration(
     let status: String = row.try_get("", "status").map_err(storage_error)?;
     if status != "active" {
         return Err(IndexReplayJobError::SchemaRetired(request.schema.clone()));
+    }
+    if request.locale.is_some() {
+        let schema_json: JsonValue = row.try_get("", "schema_json").map_err(storage_error)?;
+        let schema: IndexSchema = serde_json::from_value(schema_json).map_err(storage_error)?;
+        if schema.reference != request.schema {
+            return Err(IndexReplayJobError::Storage(
+                "persisted Index schema identity does not match replay scope".to_owned(),
+            ));
+        }
+        if schema.locale_mode == LocaleMode::None {
+            return Err(IndexReplayJobError::LocaleScopeUnsupported(
+                request.schema.clone(),
+            ));
+        }
     }
     Ok(())
 }
@@ -688,7 +841,7 @@ fn stored_uuid(
     }
 }
 
-fn replay_scope_values(
+fn schema_scope_values(
     request: &IndexReplayJobLeaseRequest,
     backend: DbBackend,
 ) -> Vec<SqlValue> {
@@ -700,36 +853,54 @@ fn replay_scope_values(
     ]
 }
 
+fn replay_scope_values(
+    request: &IndexReplayJobLeaseRequest,
+    backend: DbBackend,
+) -> Vec<SqlValue> {
+    let mut values = schema_scope_values(request, backend);
+    values.push(request.scope_kind().to_owned().into());
+    values.push(
+        request
+            .locale
+            .as_ref()
+            .map(|locale| locale.as_str().to_owned())
+            .into(),
+    );
+    values
+}
+
 fn select_schema_sql(backend: DbBackend) -> String {
     let prefix = placeholder_prefix(backend);
     format!(
-        "SELECT status FROM index_schemas WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 LIMIT 1"
+        "SELECT status, schema_json FROM index_schemas WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 LIMIT 1"
     )
 }
 
 fn select_replay_jobs_sql(backend: DbBackend) -> String {
     let prefix = placeholder_prefix(backend);
-    let (attempt_count, claimable) = match backend {
+    let (attempt_count, claimable, locale_match) = match backend {
         DbBackend::Postgres => (
             "CAST(attempt_count AS BIGINT)",
             "((state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP))",
+            format!("locale_key IS NOT DISTINCT FROM {prefix}6"),
         ),
         DbBackend::Sqlite => (
             "CAST(attempt_count AS INTEGER)",
             "CASE WHEN (state = 'pending' AND available_at <= CURRENT_TIMESTAMP) OR (state = 'running' AND lease_expires_at <= CURRENT_TIMESTAMP) THEN TRUE ELSE FALSE END",
+            format!("locale_key IS {prefix}6"),
         ),
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT job_id, state, request, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = 'schema' AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
+        "SELECT job_id, state, scope_kind, locale_key, request, last_error_code, {attempt_count} AS attempt_count_value, {claimable} AS claimable FROM index_jobs WHERE tenant_id = {prefix}1 AND module_name = {prefix}2 AND entity_name = {prefix}3 AND schema_version = {prefix}4 AND kind = 'rebuild' AND scope_kind = {prefix}5 AND {locale_match} AND state IN ('pending', 'running', 'succeeded', 'failed') ORDER BY CASE state WHEN 'succeeded' THEN 0 WHEN 'running' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END, created_at DESC"
     )
 }
 
 fn insert_job_sql(backend: DbBackend) -> String {
     let prefix = placeholder_prefix(backend);
-    let lease_expires = lease_expires_expression(backend, 8);
+    let lease_expires = lease_expires_expression(backend, 10);
     format!(
-        "INSERT INTO index_jobs (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, request, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at) VALUES ({prefix}1, {prefix}2, 'rebuild', 'running', 'schema', {prefix}3, {prefix}4, {prefix}5, {prefix}6, 1, CURRENT_TIMESTAMP, {prefix}7, {lease_expires}, CURRENT_TIMESTAMP)"
+        "INSERT INTO index_jobs (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, locale_key, request, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at) VALUES ({prefix}1, {prefix}2, 'rebuild', 'running', {prefix}3, {prefix}4, {prefix}5, {prefix}6, {prefix}7, {prefix}8, 1, CURRENT_TIMESTAMP, {prefix}9, {lease_expires}, CURRENT_TIMESTAMP)"
     )
 }
 
@@ -776,7 +947,7 @@ fn complete_checkpoint_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "SELECT cursor FROM index_checkpoints WHERE tenant_id = {prefix}1 AND checkpoint_kind = 'rebuild' AND source_name = {prefix}2 AND module_name = {prefix}3 AND entity_name = {prefix}4 AND schema_version = {prefix}5 AND locale_key = '' AND partition_key = '' LIMIT 1{lock}"
+        "SELECT cursor FROM index_checkpoints WHERE tenant_id = {prefix}1 AND checkpoint_kind = 'rebuild' AND source_name = {prefix}2 AND module_name = {prefix}3 AND entity_name = {prefix}4 AND schema_version = {prefix}5 AND locale_key = {prefix}6 AND partition_key = '' LIMIT 1{lock}"
     )
 }
 

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_locale_job_tests.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_locale_job_tests.rs
@@ -1,0 +1,232 @@
+use std::time::Duration;
+
+use rustok_core::MigrationSource;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement, Value as SqlValue,
+};
+use sea_orm_migration::SchemaManager;
+use serde_json::{json, Value as JsonValue};
+use uuid::Uuid;
+
+use super::{
+    IndexReplayJobAcquireOutcome, IndexReplayJobError, IndexReplayJobLease,
+    IndexReplayJobLeaseRequest, PostgresIndexReplayCheckpointStore, PostgresIndexReplayJobStore,
+};
+use crate::{
+    EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexReplayCheckpoint,
+    IndexReplayCheckpointKey, IndexReplayCheckpointStore, IndexSchema, IndexValueType, LocaleKey,
+    LocaleMode, ModuleName, SchemaRef, SchemaVersion,
+};
+
+const TENANT: &str = "22222222-2222-2222-2222-222222222222";
+const SOURCE: &str = "product-primary";
+
+struct Fixture {
+    db: DatabaseConnection,
+    jobs: PostgresIndexReplayJobStore,
+    schema: IndexSchema,
+}
+
+impl Fixture {
+    async fn new(locale_mode: LocaleMode) -> Self {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should connect");
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("foreign keys should be enabled");
+        db.execute_unprepared("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
+            .await
+            .expect("tenant fixture should be created");
+        db.execute_unprepared(&format!("INSERT INTO tenants (id) VALUES ('{TENANT}')"))
+            .await
+            .expect("tenant fixture should be inserted");
+        let manager = SchemaManager::new(&db);
+        for migration in IndexModule.migrations() {
+            migration
+                .up(&manager)
+                .await
+                .unwrap_or_else(|error| panic!("{} should apply: {error}", migration.name()));
+        }
+
+        let schema = schema(locale_mode);
+        let fingerprint = schema.fingerprint().unwrap().to_string();
+        let schema_json = serde_json::to_value(&schema).unwrap();
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO index_schemas (tenant_id, module_name, entity_name, schema_version, schema_fingerprint, schema_json, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active')",
+            vec![
+                TENANT.to_owned().into(),
+                schema.reference.module.as_str().to_owned().into(),
+                schema.reference.entity.as_str().to_owned().into(),
+                i64::from(schema.reference.version.get()).into(),
+                fingerprint.into(),
+                SqlValue::Json(Some(Box::new(schema_json))),
+            ],
+        ))
+        .await
+        .expect("schema fixture should persist");
+
+        let jobs = PostgresIndexReplayJobStore::new(db.clone());
+        Self { db, jobs, schema }
+    }
+
+    fn schema_request(&self, worker: &str) -> IndexReplayJobLeaseRequest {
+        IndexReplayJobLeaseRequest::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            self.schema.reference.clone(),
+            SOURCE,
+            worker,
+            Duration::from_secs(60),
+        )
+        .unwrap()
+    }
+
+    fn locale_request(&self, locale: &str, worker: &str) -> IndexReplayJobLeaseRequest {
+        IndexReplayJobLeaseRequest::for_locale(
+            Uuid::parse_str(TENANT).unwrap(),
+            self.schema.reference.clone(),
+            LocaleKey::new(locale).unwrap(),
+            SOURCE,
+            worker,
+            Duration::from_secs(60),
+        )
+        .unwrap()
+    }
+
+    async fn acquire(&self, request: &IndexReplayJobLeaseRequest) -> IndexReplayJobLease {
+        match self.jobs.acquire(request).await.unwrap() {
+            IndexReplayJobAcquireOutcome::Acquired(lease) => lease,
+            outcome => panic!("replay job should be acquired, got {outcome:?}"),
+        }
+    }
+}
+
+fn schema(locale_mode: LocaleMode) -> IndexSchema {
+    IndexSchema {
+        reference: SchemaRef {
+            module: ModuleName::new("catalog").unwrap(),
+            entity: EntityName::new("product").unwrap(),
+            version: SchemaVersion::INITIAL,
+        },
+        locale_mode,
+        fields: vec![IndexField {
+            name: FieldName::new("id").unwrap(),
+            value_type: IndexValueType::Uuid,
+            cardinality: FieldCardinality::One,
+            nullable: false,
+            selectable: true,
+            filterable: true,
+            sortable: false,
+        }],
+        links: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn locale_jobs_are_distinct_from_schema_and_other_locales() {
+    let fixture = Fixture::new(LocaleMode::Required).await;
+    let schema_lease = fixture.acquire(&fixture.schema_request("schema-worker")).await;
+    let en_lease = fixture.acquire(&fixture.locale_request("EN-us", "en-worker")).await;
+    let de_lease = fixture.acquire(&fixture.locale_request("de", "de-worker")).await;
+
+    assert!(schema_lease.locale().is_none());
+    assert_eq!(en_lease.locale().unwrap().as_str(), "en-US");
+    assert_eq!(de_lease.locale().unwrap().as_str(), "de");
+    assert_ne!(schema_lease.job_id(), en_lease.job_id());
+    assert_ne!(en_lease.job_id(), de_lease.job_id());
+
+    assert_eq!(
+        fixture
+            .jobs
+            .acquire(&fixture.locale_request("en-US", "other-en-worker"))
+            .await
+            .unwrap(),
+        IndexReplayJobAcquireOutcome::Busy
+    );
+
+    let rows = fixture
+        .db
+        .query_all(Statement::from_string(
+            DbBackend::Sqlite,
+            "SELECT scope_kind, locale_key, request FROM index_jobs WHERE tenant_id = '22222222-2222-2222-2222-222222222222' AND kind = 'rebuild' ORDER BY scope_kind, locale_key"
+                .to_owned(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+    let mut observed = Vec::new();
+    for row in rows {
+        let scope_kind: String = row.try_get("", "scope_kind").unwrap();
+        let locale_key: Option<String> = row.try_get("", "locale_key").unwrap();
+        let request: JsonValue = row.try_get("", "request").unwrap();
+        observed.push((scope_kind, locale_key, request));
+    }
+    assert!(observed.iter().any(|(scope, locale, request)| {
+        scope == "schema"
+            && locale.is_none()
+            && request == &json!({"contract": "index_replay_job_v1", "source_name": SOURCE})
+    }));
+    assert!(observed.iter().any(|(scope, locale, request)| {
+        scope == "locale"
+            && locale.as_deref() == Some("en-US")
+            && request
+                == &json!({"contract": "index_replay_job_v2", "source_name": SOURCE, "locale": "en-US"})
+    }));
+    assert!(observed.iter().any(|(scope, locale, request)| {
+        scope == "locale"
+            && locale.as_deref() == Some("de")
+            && request
+                == &json!({"contract": "index_replay_job_v2", "source_name": SOURCE, "locale": "de"})
+    }));
+
+    // A complete schema-wide checkpoint must not satisfy a locale-scoped job.
+    let schema_checkpoint = IndexReplayCheckpoint::new(
+        IndexReplayCheckpointKey::new(
+            Uuid::parse_str(TENANT).unwrap(),
+            SOURCE,
+            fixture.schema.reference.clone(),
+        )
+        .unwrap(),
+        None,
+        Some(1),
+        Some(Uuid::from_u128(1).to_string()),
+    )
+    .unwrap();
+    PostgresIndexReplayCheckpointStore::new(fixture.db.clone(), schema_lease.clone())
+        .commit_replay_checkpoint(&schema_checkpoint)
+        .await
+        .unwrap();
+    fixture.jobs.succeed(&schema_lease).await.unwrap();
+    assert_eq!(
+        fixture.jobs.succeed(&en_lease).await,
+        Err(IndexReplayJobError::CheckpointMissing)
+    );
+}
+
+#[tokio::test]
+async fn locale_job_scope_rejects_nonlocalized_schema() {
+    let fixture = Fixture::new(LocaleMode::None).await;
+    assert_eq!(
+        fixture
+            .jobs
+            .acquire(&fixture.locale_request("en", "locale-worker"))
+            .await,
+        Err(IndexReplayJobError::LocaleScopeUnsupported(
+            fixture.schema.reference.clone()
+        ))
+    );
+
+    let count: i64 = fixture
+        .db
+        .query_one(Statement::from_string(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) AS value FROM index_jobs".to_owned(),
+        ))
+        .await
+        .unwrap()
+        .unwrap()
+        .try_get("", "value")
+        .unwrap();
+    assert_eq!(count, 0);
+}

--- a/crates/rustok-index/src/migrations/m20260808_000009_add_index_job_locale_scope.rs
+++ b/crates/rustok-index/src/migrations/m20260808_000009_add_index_job_locale_scope.rs
@@ -1,0 +1,155 @@
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ConnectionTrait, DbBackend, Statement},
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const TABLE_NAME: &str = "index_jobs";
+const TEMP_TABLE_NAME: &str = "index_jobs_locale_scope_v2";
+const LOCALE_SCOPE_CONSTRAINT_NAME: &str = "ck_index_jobs_scope_v2";
+const STRICT_SCOPE_CONSTRAINT_NAME: &str = "ck_index_jobs_scope_v1";
+
+const LOCALE_SCOPE_CHECK: &str = "(scope_kind = 'global' AND module_name IS NULL AND entity_name IS NULL AND schema_version IS NULL AND entity_id IS NULL AND locale_key IS NULL) OR (scope_kind = 'schema' AND module_name IS NOT NULL AND entity_name IS NOT NULL AND schema_version IS NOT NULL AND entity_id IS NULL AND locale_key IS NULL) OR (scope_kind = 'locale' AND module_name IS NOT NULL AND entity_name IS NOT NULL AND schema_version IS NOT NULL AND entity_id IS NULL AND locale_key IS NOT NULL AND length(locale_key) BETWEEN 1 AND 32) OR (scope_kind = 'entity' AND module_name IS NOT NULL AND entity_name IS NOT NULL AND schema_version IS NOT NULL AND entity_id IS NOT NULL AND locale_key IS NOT NULL)";
+const STRICT_SCOPE_CHECK: &str = "(scope_kind = 'global' AND module_name IS NULL AND entity_name IS NULL AND schema_version IS NULL AND entity_id IS NULL AND locale_key IS NULL) OR (scope_kind = 'schema' AND module_name IS NOT NULL AND entity_name IS NOT NULL AND schema_version IS NOT NULL AND entity_id IS NULL AND locale_key IS NULL) OR (scope_kind = 'entity' AND module_name IS NOT NULL AND entity_name IS NOT NULL AND schema_version IS NOT NULL AND entity_id IS NOT NULL AND locale_key IS NOT NULL)";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_connection().get_database_backend() {
+            DbBackend::Postgres => {
+                replace_postgres_scope_constraint(
+                    manager,
+                    LOCALE_SCOPE_CONSTRAINT_NAME,
+                    LOCALE_SCOPE_CHECK,
+                )
+                .await?;
+                replace_postgres_scope_index(manager, true).await
+            }
+            DbBackend::Sqlite => rebuild_sqlite_table(manager, LOCALE_SCOPE_CHECK, true).await,
+            DbBackend::MySql => Err(DbErr::Custom(
+                "rustok-index replay locale job scope migration supports PostgreSQL and SQLite"
+                    .to_owned(),
+            )),
+        }
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_connection().get_database_backend() {
+            DbBackend::Postgres => {
+                replace_postgres_scope_constraint(
+                    manager,
+                    STRICT_SCOPE_CONSTRAINT_NAME,
+                    STRICT_SCOPE_CHECK,
+                )
+                .await?;
+                replace_postgres_scope_index(manager, false).await
+            }
+            DbBackend::Sqlite => rebuild_sqlite_table(manager, STRICT_SCOPE_CHECK, false).await,
+            DbBackend::MySql => Err(DbErr::Custom(
+                "rustok-index replay locale job scope migration supports PostgreSQL and SQLite"
+                    .to_owned(),
+            )),
+        }
+    }
+}
+
+async fn replace_postgres_scope_constraint(
+    manager: &SchemaManager<'_>,
+    replacement_name: &str,
+    replacement_check: &str,
+) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    let rows = connection
+        .query_all(Statement::from_string(
+            DbBackend::Postgres,
+            format!(
+                "SELECT c.conname FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid JOIN pg_namespace n ON n.oid = t.relnamespace WHERE c.contype = 'c' AND n.nspname = current_schema() AND t.relname = '{TABLE_NAME}' AND pg_get_constraintdef(c.oid) LIKE '%scope_kind%' AND pg_get_constraintdef(c.oid) LIKE '%entity_id%' AND pg_get_constraintdef(c.oid) LIKE '%locale_key%' ORDER BY c.conname"
+            ),
+        ))
+        .await?;
+    if rows.len() != 1 {
+        return Err(DbErr::Custom(format!(
+            "expected exactly one {TABLE_NAME} scope constraint, found {}",
+            rows.len()
+        )));
+    }
+    let constraint_name: String = rows[0].try_get("", "conname")?;
+    let quoted_constraint = quote_postgres_identifier(&constraint_name);
+    let quoted_replacement = quote_postgres_identifier(replacement_name);
+    connection
+        .execute_unprepared(&format!(
+            "ALTER TABLE {TABLE_NAME} DROP CONSTRAINT {quoted_constraint}"
+        ))
+        .await?;
+    connection
+        .execute_unprepared(&format!(
+            "ALTER TABLE {TABLE_NAME} ADD CONSTRAINT {quoted_replacement} CHECK ({replacement_check})"
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn replace_postgres_scope_index(
+    manager: &SchemaManager<'_>,
+    include_locale: bool,
+) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    connection
+        .execute_unprepared("DROP INDEX IF EXISTS idx_index_jobs_scope")
+        .await?;
+    let locale = if include_locale { ", locale_key" } else { "" };
+    connection
+        .execute_unprepared(&format!(
+            "CREATE INDEX idx_index_jobs_scope ON index_jobs (tenant_id, scope_kind, module_name, entity_name, schema_version{locale}, state)"
+        ))
+        .await?;
+    Ok(())
+}
+
+fn quote_postgres_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+async fn rebuild_sqlite_table(
+    manager: &SchemaManager<'_>,
+    scope_check: &str,
+    include_locale_in_scope_index: bool,
+) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    connection
+        .execute_unprepared(&format!(
+            "CREATE TABLE {TEMP_TABLE_NAME} (tenant_id TEXT NOT NULL, job_id TEXT NOT NULL, kind VARCHAR(32) NOT NULL, state VARCHAR(16) NOT NULL DEFAULT 'pending', scope_kind VARCHAR(16) NOT NULL, module_name VARCHAR(128), entity_name VARCHAR(128), schema_version INTEGER, entity_id TEXT, locale_key VARCHAR(32), request JSON NOT NULL, cursor JSON, attempt_count INTEGER NOT NULL DEFAULT 0, available_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, lease_owner VARCHAR(191), lease_expires_at TEXT, heartbeat_at TEXT, cancel_requested BOOLEAN NOT NULL DEFAULT FALSE, last_error_code VARCHAR(128), last_error_details JSON, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, completed_at TEXT, PRIMARY KEY (tenant_id, job_id), FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON UPDATE CASCADE ON DELETE CASCADE, CHECK (kind IN ('schema_apply', 'secondary_index', 'rebuild', 'reconcile', 'consistency_check')), CHECK (state IN ('pending', 'running', 'succeeded', 'failed', 'cancelled')), CHECK (attempt_count >= 0), CHECK (schema_version IS NULL OR schema_version > 0), CHECK (locale_key IS NULL OR (length(locale_key) <= 32 AND locale_key = trim(locale_key))), CHECK ({scope_check}), CHECK ((state = 'running' AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL) OR (state <> 'running' AND lease_owner IS NULL AND lease_expires_at IS NULL)), CHECK ((state IN ('succeeded', 'failed', 'cancelled') AND completed_at IS NOT NULL) OR (state IN ('pending', 'running') AND completed_at IS NULL)))"
+        ))
+        .await?;
+    connection
+        .execute_unprepared(&format!(
+            "INSERT INTO {TEMP_TABLE_NAME} (tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, entity_id, locale_key, request, cursor, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at, cancel_requested, last_error_code, last_error_details, created_at, updated_at, completed_at) SELECT tenant_id, job_id, kind, state, scope_kind, module_name, entity_name, schema_version, entity_id, locale_key, request, cursor, attempt_count, available_at, lease_owner, lease_expires_at, heartbeat_at, cancel_requested, last_error_code, last_error_details, created_at, updated_at, completed_at FROM {TABLE_NAME}"
+        ))
+        .await?;
+    connection
+        .execute_unprepared(&format!("DROP TABLE {TABLE_NAME}"))
+        .await?;
+    connection
+        .execute_unprepared(&format!(
+            "ALTER TABLE {TEMP_TABLE_NAME} RENAME TO {TABLE_NAME}"
+        ))
+        .await?;
+    connection
+        .execute_unprepared(
+            "CREATE INDEX idx_index_jobs_claim ON index_jobs (tenant_id, state, available_at, lease_expires_at)",
+        )
+        .await?;
+    let locale = if include_locale_in_scope_index {
+        ", locale_key"
+    } else {
+        ""
+    };
+    connection
+        .execute_unprepared(&format!(
+            "CREATE INDEX idx_index_jobs_scope ON index_jobs (tenant_id, scope_kind, module_name, entity_name, schema_version{locale}, state)"
+        ))
+        .await?;
+    Ok(())
+}

--- a/crates/rustok-index/src/migrations/mod.rs
+++ b/crates/rustok-index/src/migrations/mod.rs
@@ -6,6 +6,7 @@ mod m20260804_000005_relax_index_finding_locale_scope;
 mod m20260806_000006_add_index_finding_lifecycle_audit;
 mod m20260806_000007_add_index_finding_repair_commands;
 mod m20260806_000008_add_index_finding_repair_recovery;
+mod m20260808_000009_add_index_job_locale_scope;
 
 use rustok_core::MigrationDependencyDescriptor;
 use sea_orm_migration::sea_orm::DbBackend;
@@ -42,6 +43,7 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260806_000006_add_index_finding_lifecycle_audit::Migration),
         Box::new(m20260806_000007_add_index_finding_repair_commands::Migration),
         Box::new(m20260806_000008_add_index_finding_repair_recovery::Migration),
+        Box::new(m20260808_000009_add_index_job_locale_scope::Migration),
     ]
 }
 
@@ -78,6 +80,10 @@ pub fn migration_dependencies() -> Vec<MigrationDependencyDescriptor> {
         MigrationDependencyDescriptor::new(
             "m20260806_000008_add_index_finding_repair_recovery",
             vec!["m20260806_000007_add_index_finding_repair_commands"],
+        ),
+        MigrationDependencyDescriptor::new(
+            "m20260808_000009_add_index_job_locale_scope",
+            vec!["m20260806_000008_add_index_finding_repair_recovery"],
         ),
     ]
 }

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -22,6 +22,7 @@ const scripts = [
   'verify-index-schema-scoped-source-event-id.mjs',
   'verify-index-source-replay-contract.mjs',
   'verify-index-locale-source-scan.mjs',
+  'verify-index-replay-locale-job-scope.mjs',
   'verify-index-source-refresh-event.mjs',
   'verify-index-source-absence-watermark.mjs',
   'verify-index-source-continuation.mjs',

--- a/scripts/verify/verify-index-replay-locale-job-scope.mjs
+++ b/scripts/verify/verify-index-replay-locale-job-scope.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-locale-job-scope] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const migrationPath = 'crates/rustok-index/src/migrations/m20260808_000009_add_index_job_locale_scope.rs';
+const migration = requireMarkers(migrationPath, [
+  "scope_kind = 'locale'",
+  "locale_key IS NOT NULL",
+  "length(locale_key) BETWEEN 1 AND 32",
+  'replace_postgres_scope_constraint',
+  'rebuild_sqlite_table',
+  'DROP INDEX IF EXISTS idx_index_jobs_scope',
+  'schema_version{locale}, state',
+  'STRICT_SCOPE_CHECK',
+]);
+if (migration.includes('partition_key')) {
+  fail(`${migrationPath} must not add partition scope to index_jobs`);
+}
+
+requireMarkers('crates/rustok-index/src/migrations/mod.rs', [
+  'mod m20260808_000009_add_index_job_locale_scope;',
+  'Box::new(m20260808_000009_add_index_job_locale_scope::Migration)',
+  '"m20260808_000009_add_index_job_locale_scope"',
+  '"m20260806_000008_add_index_finding_repair_recovery"',
+]);
+
+const jobPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_job.rs';
+const job = requireMarkers(jobPath, [
+  'REPLAY_JOB_REQUEST_CONTRACT_V1: &str = "index_replay_job_v1"',
+  'REPLAY_JOB_REQUEST_CONTRACT_V2: &str = "index_replay_job_v2"',
+  'locale: Option<LocaleKey>',
+  'pub(crate) fn for_locale(',
+  'fn scope_kind(&self) ->',
+  'if self.locale.is_some() { "locale" } else { "schema" }',
+  'LocaleScopeUnsupported(SchemaRef)',
+  '"locale": locale.as_str()',
+  'request.locale does not match locale_key',
+  'schema.locale_mode == LocaleMode::None',
+  'request.scope_kind().to_owned().into()',
+  'locale_key IS NOT DISTINCT FROM',
+  'locale_key IS {prefix}6',
+  'lease.locale',
+  "partition_key = ''",
+]);
+for (const forbidden of ['partition_key: Option', 'scope_kind = \'partition\'', 'targeted_rebuild', 'shadow_rebuild']) {
+  if (job.includes(forbidden)) fail(`${jobPath} must not absorb partition/rebuild-mode semantics: ${forbidden}`);
+}
+
+const packetPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_locale_job_tests.rs';
+requireMarkers(packetPath, [
+  'locale_jobs_are_distinct_from_schema_and_other_locales',
+  'LocaleKey::new(locale)',
+  '"EN-us"',
+  'Some("en-US")',
+  '"index_replay_job_v1"',
+  '"index_replay_job_v2"',
+  'IndexReplayJobAcquireOutcome::Busy',
+  'Err(IndexReplayJobError::CheckpointMissing)',
+  'locale_job_scope_rejects_nonlocalized_schema',
+  'LocaleMode::None',
+  'LocaleScopeUnsupported',
+  'assert_eq!(count, 0);',
+]);
+
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
+  '#[cfg(test)]\nmod source_replay_locale_job_tests;'.replace('\\n', '\n'),
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-locale-replay-job-scope.md', [
+  'Status: `job_scope_source_complete_checkpoint_worker_pending`.',
+  '`scope_kind = \'locale\'`',
+  '`index_replay_job_v1`',
+  '`index_replay_job_v2`',
+  '`LocaleMode::None`',
+  '`CheckpointMissing`',
+  'constructor remains crate-private',
+  '`partition_key` source/job/checkpoint semantics',
+]);
+
+console.log('[verify-index-replay-locale-job-scope] durable schema/locale replay jobs are isolated and locale completion remains fail-closed until checkpoint/worker support lands');


### PR DESCRIPTION
## Summary

- add a cross-backend Index migration that permits `scope_kind='locale'` for durable replay jobs only when schema identity and a non-empty bounded `locale_key` are present;
- preserve existing global/schema/entity job shapes and keep schema replay jobs on `locale_key IS NULL`;
- extend `idx_index_jobs_scope` with `locale_key` so per-locale jobs have an explicit scope index dimension;
- keep `IndexReplayJobLeaseRequest::new(...)` schema-wide and preserve exact `index_replay_job_v1` persisted JSON;
- add a crate-private canonical-locale constructor for future worker use, persisting exact `index_replay_job_v2` with the same locale as `index_jobs.locale_key`;
- make advisory locking and active-job lookup distinguish schema-wide and each canonical locale scope;
- deserialize the persisted active `IndexSchema` before locale job creation and reject `LocaleMode::None` fail-closed;
- retain the optional locale on the acquired lease and make job completion require a checkpoint with the same locale key while keeping `partition_key=''`;
- intentionally leave locale checkpoint writing and worker/runner/GraphQL exposure for the next slice, so a locale job cannot yet succeed and the locale constructor remains crate-private;
- retain SQLite source evidence for schema/en-US/de scope isolation, v1/v2 request shapes, same-locale Busy behavior, schema-checkpoint isolation, and LocaleMode::None rejection.

## Boundary

This PR does not change `IndexReplayCheckpointKey`, one-page replay request, multi-page run request, GraphQL input, partition scope, or rebuild modes. It does not make locale replay externally callable. It establishes the durable job identity needed for the next checkpoint/worker slice.

## Migration semantics

PostgreSQL discovers/replaces the one existing `index_jobs` scope CHECK and recreates the scope index. SQLite rebuilds `index_jobs`, copies all rows, and recreates claim/scope indexes following the existing Index constraint-relaxation pattern. Existing schema jobs are not rewritten to locale jobs.

## Validation

Static source review only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.