### PR TITLE
feat(index): carry locale through replay checkpoints

### DIFF
--- a/crates/rustok-index/docs/m6-locale-replay-checkpoint-worker.md
+++ b/crates/rustok-index/docs/m6-locale-replay-checkpoint-worker.md
@@ -1,0 +1,82 @@
+# M6 locale replay checkpoint and one-page worker contract
+
+Status: `checkpoint_worker_source_complete_runner_pending`.
+
+## Purpose
+
+Locale-aware source scans and durable locale replay jobs now exist. This slice connects the one-page application worker and PostgreSQL checkpoint store to the same canonical locale identity, without exposing locale replay through the multi-page runner or GraphQL yet.
+
+## One-page request
+
+`IndexReplayPageRequest` now carries `locale: Option<LocaleKey>`.
+
+The existing public `IndexReplayPageRequest::new(...)` remains schema-wide. The crate-private locale constructor accepts an already canonical `LocaleKey`; it is reserved for the multi-page runner follow-up and retained crate tests.
+
+Before any checkpoint read or source scan, `IndexReplayWorker` resolves the exact `SchemaRegistry` entry:
+
+- a missing schema fails closed as `SchemaNotRegistered`;
+- a locale request against `LocaleMode::None` fails closed as `LocaleScopeUnsupported`;
+- locale requests against `Optional` or `Required` are admitted;
+- schema-wide requests remain admitted for every existing locale mode, including `Required`, so the current full rebuild path is preserved.
+
+## Checkpoint identity
+
+`IndexReplayCheckpointKey` now carries the same optional canonical locale. Its existing `new(...)` constructor remains schema-wide; the locale constructor builds an exact locale key.
+
+The worker derives the checkpoint key and source scan request from the same `IndexReplayPageRequest.locale` value. It does not infer locale from a cursor or returned mutation.
+
+For locale pages the worker calls `IndexSourceScanRequest::for_locale(...)`; schema-wide pages continue to call `IndexSourceScanRequest::new(...)`.
+
+The already-retained source-page validator remains the second fail-closed layer: a locale source cannot return a mutation outside the requested locale.
+
+## PostgreSQL checkpoint adapter
+
+`PostgresIndexReplayCheckpointStore` now requires checkpoint key locale equality with `IndexReplayJobLease.locale` in addition to tenant/source/schema equality.
+
+Checkpoint SQL continues to use the existing composite key:
+
+`tenant + kind + source + module + entity + version + locale_key + partition_key`.
+
+The adapter now binds the canonical locale string when the key is locale-scoped and preserves the historical empty-string locale for schema-wide replay. `partition_key` remains the empty string in both paths.
+
+A schema lease therefore cannot read or commit an `en-US` checkpoint, an `en-US` lease cannot read or commit the schema-wide checkpoint, and `de` remains distinct from both.
+
+## Durable completion
+
+The job-store completion probe introduced with durable locale job scope already looks up the lease's exact locale checkpoint. Once this slice writes locale checkpoints, a locale job can complete honestly.
+
+Retained SQLite source now proves:
+
+1. a schema-wide checkpoint completes only the schema job;
+2. the same schema checkpoint leaves `en-US` with `CheckpointMissing`;
+3. an `en-US` checkpoint is stored under locale key `en-US` and completes only the `en-US` job;
+4. the `de` job remains `CheckpointMissing`;
+5. stored checkpoint rows contain separate empty-string and `en-US` locale identities.
+
+## Boundary
+
+This slice does not change:
+
+- `IndexReplayRunRequest` or multi-page runner scope;
+- replay cancellation GraphQL transport;
+- public GraphQL input;
+- `partition_key` behavior;
+- targeted/full/shadow rebuild modes;
+- Product source SQL (already locale-aware from the previous slice);
+- Storefront serving behavior.
+
+Locale page/checkpoint constructors remain internal until the runner uses the same durable locale job identity. External callers therefore cannot create a partial locale replay through the production command transport in this intermediate state.
+
+## Next source slice
+
+The next PR should carry optional locale through `IndexReplayRunRequest` and `PostgresIndexReplayRunner`:
+
+- acquire schema or locale job lease from the same request;
+- build schema-wide or exact-locale page requests consistently;
+- preserve cancellation, heartbeat, graceful-stop and retry semantics;
+- add optional GraphQL `locale` only after authorization, canonicalize through `LocaleKey`, and keep omission exactly schema-wide;
+- retain end-to-end locale replay/restart evidence.
+
+`partition_key` and rebuild modes remain separate later contracts.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/application/source_replay.rs
+++ b/crates/rustok-index/src/application/source_replay.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::{IndexMutation, SchemaRef, SchemaRegistry};
+use crate::{IndexMutation, LocaleKey, LocaleMode, SchemaRef, SchemaRegistry};
 
 use super::{
     IndexSourceCursor, IndexSourceError, IndexSourceScanRequest, SharedIndexSourceRegistry,
@@ -73,6 +73,7 @@ impl IndexReplayFailure {
 pub struct IndexReplayPageRequest {
     tenant_id: Uuid,
     schema: SchemaRef,
+    locale: Option<LocaleKey>,
     limit: usize,
 }
 
@@ -87,6 +88,23 @@ impl IndexReplayPageRequest {
         Ok(Self {
             tenant_id,
             schema,
+            locale: None,
+            limit,
+        })
+    }
+
+    pub(crate) fn for_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: LocaleKey,
+        limit: usize,
+    ) -> Result<Self, IndexReplayError> {
+        IndexSourceScanRequest::for_locale(tenant_id, schema.clone(), locale.clone(), None, limit)
+            .map_err(IndexReplayError::SourceContract)?;
+        Ok(Self {
+            tenant_id,
+            schema,
+            locale: Some(locale),
             limit,
         })
     }
@@ -99,6 +117,10 @@ impl IndexReplayPageRequest {
         &self.schema
     }
 
+    pub(crate) fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
+    }
+
     pub fn limit(&self) -> usize {
         self.limit
     }
@@ -109,6 +131,7 @@ pub struct IndexReplayCheckpointKey {
     tenant_id: Uuid,
     source_name: String,
     schema: SchemaRef,
+    locale: Option<LocaleKey>,
 }
 
 impl IndexReplayCheckpointKey {
@@ -116,6 +139,24 @@ impl IndexReplayCheckpointKey {
         tenant_id: Uuid,
         source_name: impl Into<String>,
         schema: SchemaRef,
+    ) -> Result<Self, IndexReplayError> {
+        Self::new_scoped(tenant_id, source_name, schema, None)
+    }
+
+    pub(crate) fn for_locale(
+        tenant_id: Uuid,
+        source_name: impl Into<String>,
+        schema: SchemaRef,
+        locale: LocaleKey,
+    ) -> Result<Self, IndexReplayError> {
+        Self::new_scoped(tenant_id, source_name, schema, Some(locale))
+    }
+
+    fn new_scoped(
+        tenant_id: Uuid,
+        source_name: impl Into<String>,
+        schema: SchemaRef,
+        locale: Option<LocaleKey>,
     ) -> Result<Self, IndexReplayError> {
         if tenant_id.is_nil() {
             return Err(IndexReplayError::NilTenantId);
@@ -128,6 +169,7 @@ impl IndexReplayCheckpointKey {
             tenant_id,
             source_name,
             schema,
+            locale,
         })
     }
 
@@ -141,6 +183,10 @@ impl IndexReplayCheckpointKey {
 
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
+    }
+
+    pub(crate) fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
     }
 }
 
@@ -343,11 +389,29 @@ where
             .sources
             .source_for_schema(request.schema())
             .ok_or_else(|| IndexReplayError::UnknownSchemaSource(request.schema().clone()))?;
-        let checkpoint_key = IndexReplayCheckpointKey::new(
-            request.tenant_id(),
-            descriptor.source_name(),
-            request.schema().clone(),
-        )?;
+        let registered = self
+            .schema_registry
+            .get(request.schema())
+            .ok_or_else(|| IndexReplayError::SchemaNotRegistered(request.schema().clone()))?;
+        if request.locale().is_some() && registered.schema.locale_mode == LocaleMode::None {
+            return Err(IndexReplayError::LocaleScopeUnsupported(
+                request.schema().clone(),
+            ));
+        }
+
+        let checkpoint_key = match request.locale() {
+            Some(locale) => IndexReplayCheckpointKey::for_locale(
+                request.tenant_id(),
+                descriptor.source_name(),
+                request.schema().clone(),
+                locale.clone(),
+            )?,
+            None => IndexReplayCheckpointKey::new(
+                request.tenant_id(),
+                descriptor.source_name(),
+                request.schema().clone(),
+            )?,
+        };
         let current = self
             .checkpoint_store
             .load_replay_checkpoint(&checkpoint_key)
@@ -374,14 +438,24 @@ where
         }
 
         check_replay_interruption(&mut should_interrupt).await?;
-        let scan_request = IndexSourceScanRequest::new(
-            request.tenant_id(),
-            request.schema().clone(),
-            current
-                .as_ref()
-                .and_then(|checkpoint| checkpoint.cursor().cloned()),
-            request.limit(),
-        )
+        let cursor = current
+            .as_ref()
+            .and_then(|checkpoint| checkpoint.cursor().cloned());
+        let scan_request = match request.locale() {
+            Some(locale) => IndexSourceScanRequest::for_locale(
+                request.tenant_id(),
+                request.schema().clone(),
+                locale.clone(),
+                cursor,
+                request.limit(),
+            ),
+            None => IndexSourceScanRequest::new(
+                request.tenant_id(),
+                request.schema().clone(),
+                cursor,
+                request.limit(),
+            ),
+        }
         .map_err(IndexReplayError::SourceContract)?;
         let page = self
             .sources
@@ -494,6 +568,10 @@ pub enum IndexReplayError {
     InvalidCheckpointDeliveryId(String),
     #[error("No Index replay source owns schema {0}")]
     UnknownSchemaSource(SchemaRef),
+    #[error("Index replay schema is not registered in the active runtime: {0}")]
+    SchemaNotRegistered(SchemaRef),
+    #[error("Index replay schema does not support locale-scoped pages: {0}")]
+    LocaleScopeUnsupported(SchemaRef),
     #[error(transparent)]
     SourceContract(IndexSourceError),
     #[error("Index replay page was cooperatively interrupted")]

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
@@ -215,6 +215,7 @@ fn validate_checkpoint_identity(
     if key.tenant_id() != lease.tenant_id()
         || key.source_name() != lease.source_name()
         || key.schema() != lease.schema()
+        || key.locale() != lease.locale()
     {
         return Err(IndexReplayFailure::permanent_static(
             "checkpoint_lease_identity_mismatch",
@@ -351,7 +352,10 @@ fn checkpoint_key_values(
         key.schema().module.as_str().to_owned().into(),
         key.schema().entity.as_str().to_owned().into(),
         i64::from(key.schema().version.get()).into(),
-        "".into(),
+        key.locale()
+            .map(|locale| locale.as_str().to_owned())
+            .unwrap_or_default()
+            .into(),
         "".into(),
     ]
 }

--- a/scripts/verify/verify-index-replay-locale-checkpoint-worker.mjs
+++ b/scripts/verify/verify-index-replay-locale-checkpoint-worker.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-locale-checkpoint-worker] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const applicationPath = 'crates/rustok-index/src/application/source_replay.rs';
+const application = requireMarkers(applicationPath, [
+  'locale: Option<LocaleKey>',
+  'pub(crate) fn for_locale(',
+  'IndexSourceScanRequest::for_locale(',
+  'IndexReplayCheckpointKey::for_locale(',
+  'registered.schema.locale_mode == LocaleMode::None',
+  'SchemaNotRegistered(SchemaRef)',
+  'LocaleScopeUnsupported(SchemaRef)',
+  'Some(locale) => IndexSourceScanRequest::for_locale(',
+  'None => IndexSourceScanRequest::new(',
+]);
+const schemaLookup = application.indexOf('.schema_registry\n            .get(request.schema())'.replace('\\n', '\n'));
+const checkpointLoad = application.indexOf('.load_replay_checkpoint(&checkpoint_key)', schemaLookup);
+const sourceScan = application.indexOf('.sources\n            .scan(scan_request)'.replace('\\n', '\n'), checkpointLoad);
+if (schemaLookup < 0 || checkpointLoad <= schemaLookup || sourceScan <= checkpointLoad) {
+  fail('locale schema admission must occur before checkpoint read and source scan');
+}
+for (const forbidden of ['partition_key', 'scope_kind = \'partition\'', 'targeted_rebuild', 'shadow_rebuild']) {
+  if (application.includes(forbidden)) {
+    fail(`${applicationPath} must not absorb partition or rebuild-mode semantics: ${forbidden}`);
+  }
+}
+
+const adapterPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
+const adapter = requireMarkers(adapterPath, [
+  'key.locale() != lease.locale()',
+  'checkpoint_lease_identity_mismatch',
+  'key.locale()\n            .map(|locale| locale.as_str().to_owned())'.replace('\\n', '\n'),
+  '.unwrap_or_default()',
+  '"".into()',
+  'locale_key = {prefix}7',
+  'partition_key = {prefix}8',
+]);
+if (adapter.includes('partition_key()') || adapter.includes('partition: Option')) {
+  fail(`${adapterPath} must keep partition scope empty in this slice`);
+}
+
+const packetPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_locale_job_tests.rs';
+requireMarkers(packetPath, [
+  'locale_jobs_and_checkpoints_are_distinct_from_schema_and_other_locales',
+  'IndexReplayCheckpointKey::new(',
+  'IndexReplayCheckpointKey::for_locale(',
+  'LocaleKey::new("EN-us")',
+  'fixture.jobs.succeed(&schema_lease).await.unwrap();',
+  'Err(IndexReplayJobError::CheckpointMissing)',
+  'fixture.jobs.succeed(&en_lease).await.unwrap();',
+  'fixture.jobs.succeed(&de_lease).await',
+  '"en-US"',
+  'checkpoint_rows.len(), 2',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-locale-replay-checkpoint-worker.md', [
+  'Status: `checkpoint_worker_source_complete_runner_pending`.',
+  '`SchemaNotRegistered`',
+  '`LocaleScopeUnsupported`',
+  '`IndexSourceScanRequest::for_locale(...)`',
+  '`IndexReplayJobLease.locale`',
+  '`partition_key` remains the empty string',
+  '`IndexReplayRunRequest` or multi-page runner scope',
+  'optional GraphQL `locale`',
+]);
+
+console.log('[verify-index-replay-locale-checkpoint-worker] one-page locale admission, source scope, checkpoint identity, and durable completion remain exact while runner/GraphQL/partition modes stay separate');


### PR DESCRIPTION
## Summary

- carry optional canonical `LocaleKey` through `IndexReplayPageRequest` and `IndexReplayCheckpointKey` while preserving existing schema-wide constructors and behavior;
- make one-page locale admission resolve the exact runtime schema before checkpoint/source work and reject missing schemas or `LocaleMode::None` fail closed;
- preserve schema-wide replay for `LocaleMode::Required`, keeping the existing full rebuild path intact;
- derive locale checkpoint identity and locale source scan from the same one-page request scope;
- make `PostgresIndexReplayCheckpointStore` require exact lease/checkpoint locale equality and persist/read canonical locale keys while keeping schema-wide locale key empty and `partition_key` empty;
- extend retained SQLite durable-scope evidence so schema checkpoint, `en-US` checkpoint and `de` job are distinct, with only matching locale completion admitted;
- retain a focused source guard/doc for worker/checkpoint scope while leaving runner/GraphQL locale exposure for the next PR.

## Boundary

This PR does not change `IndexReplayRunRequest`, multi-page runner job acquisition, GraphQL input, cancellation transport, partition scope, or rebuild modes. Locale page/checkpoint constructors remain crate-private, so production command transport remains schema-wide until the next slice.

## Validation

Static source review only. Full-file replacements in `application/source_replay.rs` and PostgreSQL `source_replay.rs` are being reviewed through PR patches before merge. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.