### PR TITLE
feat(product): receipt all schema creates

### DIFF
--- a/crates/rustok-commerce/docs/implementation-plan.md
+++ b/crates/rustok-commerce/docs/implementation-plan.md
@@ -271,9 +271,8 @@ These are source-contract defects, not verification-only tasks.
   idempotency key across explicit retries, then make mounted GraphQL `idempotencyKey`
   non-null/mandatory after updating current regression callers to supply explicit keys.
 - [ ] Complete Product schema-write durable idempotency: mounted consumers already use
-  typed Product owner write capabilities with mandatory caller identity; durable owner
-  receipts cover attribute and attribute-option creates, while category/schema/group
-  creates and update-style schema writes still need explicit owner replay semantics.
+  typed Product owner write capabilities with mandatory caller identity. Source-complete
+  durable owner receipts cover all six schema create operations; update-style schema writes still need explicit owner replay semantics.
 - [x] Publish the order-owned `OrderReadPort` for complete order, return, and
   order-change detail/list projections with canonical read context/deadline policy,
   stable typed errors, filters, ordering, totals, and explicit unvalidated evidence.
@@ -290,7 +289,7 @@ These are source-contract defects, not verification-only tasks.
 - [x] Cut GraphQL return/order-change detail and list reads to the scoped host-selected
   runtime with validated actor, resolved channel/effective-locale context, typed
   not-found compatibility errors, and no concrete owner service storage.
-- [x] Cut mounted admin return/order-change detail and list reads to the host-selected
+- [x] Cut mounted admin return/order-change detail/list reads to the host-selected
   runtime while preserving `ORDERS_READ`, filters, clamped pagination, totals, public
   envelopes, actor/channel/effective-locale/deadline context, and unchanged mutation,
   payment, and fulfillment ownership.

--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, and mandatory GraphQL caller identity. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open while durable owner replay is completed operation by operation.
+This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, mandatory GraphQL caller identity, and the first durable attribute-create receipt slice. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open while update-style owner replay semantics are defined and implemented.
 
 ## Current source result
 
@@ -13,28 +13,45 @@ This source-only continuation follows Product schema-write capability publicatio
 - The active Product Admin transport sends `$idempotencyKey: String!` for all eleven schema mutations and retains one caller key across an explicit retry of the same failed operation + intent; success releases the key for a later equal user action.
 - Product owner schema-write failures continue through stable `PortError` mapping and bounded Commerce public codes rather than exposing owner database/validation details.
 
-## Durable attribute-create receipts
+## Durable schema-create receipts
 
-Product attribute and attribute-option creates now use the shared `rustok-outbox::idempotency` owner-operation ledger under `owner_slug = product`.
+All six Product schema create operations now use the shared `rustok-outbox::idempotency` owner-operation ledger under `owner_slug = product`:
 
-For each admitted create, the receipt binds tenant, Product owner namespace, caller idempotency key, operation, actor, and canonical request input. The receipt operation UUID is reused as the Product-owned attribute or option ID while the receipt scope is active. This gives a reclaimed attempt the same resource identity instead of allocating a second row.
+1. attribute create;
+2. attribute-option create;
+3. catalog-category create;
+4. attribute-schema create;
+5. schema-group create;
+6. category-group create.
 
-`ProductWriteTransaction` captures the explicitly scoped receipt lease. On success it calls `idempotency::complete` inside the same database transaction as the Product schema rows and transactional outbox publication, then commits that transaction. A response lost after commit is therefore replayed from the completed owner receipt without rerunning the create or publishing a duplicate event.
+For each admitted create, the receipt binds tenant, Product owner namespace, caller idempotency key, operation, authenticated actor, and canonical request input. The receipt operation UUID is reused as the Product-owned resource ID while the receipt scope is active. A stale lease reclaim therefore reuses the same attribute, option, category, schema, or group identity instead of allocating a second row.
 
-A completed receipt decodes the stored `ProductAttributeRecord` or `ProductAttributeOptionRecord`. Reusing the same key for a different operation or request is rejected by the shared immutable request binding and mapped to bounded Product idempotency errors. A non-retryable Product failure is persisted only after the owner write future has returned and its transaction has rolled back. Retryable database/receipt failures are not converted into terminal failure receipts; the processing lease remains reclaimable under the shared stale-lease policy.
+The receipt fence now records the **actual result produced inside the owner create method** rather than requiring the port adapter to predict the response before the Product transaction starts. `ProductWriteTransaction` captures an explicitly scoped lease plus an initially empty result slot. Each receipted create records its concrete result after its schema rows and transactional outbox publication are prepared and before commit. Transaction commit fails closed if a receipt scope has no recorded result.
 
-Direct Product service callers are not silently changed into receipt clients: outside the explicitly scoped owner-port execution, `current_product_operation_id()` is absent, create methods retain normal generated IDs, and `ProductWriteTransaction` commits without receipt completion.
+This is material for `create_category`: `CatalogCategoryRecord.path` depends on the parent row read inside the Product transaction. The port does not perform an external parent/path preflight. The actual path computed by the same transaction is stored in the receipt, so lost-response replay returns the exact committed category result.
+
+`ProductWriteTransaction` calls `idempotency::complete` with that recorded result inside the same database transaction as Product schema rows and transactional outbox publication, then commits. A response lost after commit is therefore replayed without rerunning the create or publishing a duplicate event.
+
+A completed receipt decodes the typed create result. Reusing the same key for a different operation, actor, or request is rejected by the shared immutable request binding and mapped to bounded Product idempotency errors. A non-retryable Product failure is persisted only after the owner write future has returned and its transaction has rolled back. Retryable database/receipt failures are not converted into terminal failure receipts; the processing lease remains reclaimable under the shared stale-lease policy.
+
+Direct Product service callers remain outside receipt semantics. Without the explicit task-local owner-port scope, create methods use normal generated resource IDs, result recording is a no-op for receipt state, and `ProductWriteTransaction` commits without receipt completion.
 
 ## Why the canonical item remains open
 
-This is intentionally a partial durable-idempotency slice. Category, schema, schema-group, and category-group creates still need owner receipt/replay semantics. Update-style schema writes (`set_category_schema_mode`, schema/category binding, attribute-value save, and detached-value clear) still need their replay result/state contract defined and implemented.
+Durable owner replay is now source-complete for all six non-idempotent schema create operations. Update-style schema writes remain open:
 
-In short, attribute and attribute-option creates are durably receipted, while category/schema/group creates and update-style schema writes remain open. The combined canonical item must stay `[ ]` until those remaining write semantics are source-complete.
+- `set_category_schema_mode`;
+- `bind_schema_attribute`;
+- `bind_category_attribute`;
+- `save_product_attribute_values`;
+- `clear_detached_product_attribute_values`.
+
+Those operations need an explicit replay result/state contract. In particular, the two attribute-value writes return projections that must replay the exact intended completed outcome rather than merely assuming repeated state mutation is harmless. The combined canonical item therefore remains `[ ]`.
 
 Remaining source order:
 
-1. extend the same owner-transaction receipt fence to category/schema/group creates with stable Product-owned resource identities;
-2. define and implement replay semantics for update-style schema writes, including the returned attribute-value projections;
+1. define owner receipt/replay semantics for update-style schema writes, including exact returned attribute-value projections;
+2. implement those update-style semantics through the same owner transaction fence where appropriate;
 3. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
 4. retain static/compile/parity/lost-response/restart/backend evidence as separate maintainer-run verification before any promotion.
 

--- a/crates/rustok-product/src/catalog_schema_write_port.rs
+++ b/crates/rustok-product/src/catalog_schema_write_port.rs
@@ -22,12 +22,13 @@ use crate::CommerceError;
 /// idempotency identity and deadline. Consumers must receive this capability from host
 /// composition rather than constructing `ProductCatalogSchemaService` directly.
 ///
-/// The embedded adapter durably binds Product attribute and attribute-option creates to
-/// the shared owner-operation receipt ledger. Their receipt completion is committed in
-/// the same Product transaction as the schema rows and outbox event, so a lost response
-/// replays the stored owner result without creating a second resource. The remaining
-/// category/schema/group creates and update-style schema writes still require explicit
-/// owner-local replay semantics before the combined ecommerce task can be closed.
+/// The embedded adapter durably binds all six Product schema create operations to the
+/// shared owner-operation receipt ledger. Receipt completion is committed in the same
+/// Product transaction as schema rows and outbox publication using the actual result
+/// recorded by the owner create method, so transaction-derived fields such as category
+/// path replay exactly without an external preflight read. Update-style schema writes
+/// still require explicit replay result/state semantics before the combined ecommerce
+/// task can be closed.
 #[async_trait]
 pub trait ProductCatalogSchemaWritePort: Send + Sync {
     async fn create_attribute(
@@ -119,15 +120,8 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
             }
             idempotency::Admission::ReplayError(error) => return Err(error),
         };
-        let expected = ProductAttributeRecord {
-            id: lease.operation_id,
-            code: input.code.clone(),
-            value_type: input.value_type.clone(),
-        };
-        let response_json = encode_schema_receipt(&context, operation, &expected)?;
         let result = with_product_operation_receipt(
             lease,
-            response_json,
             self.create_attribute(tenant_id, actor_id, input),
         )
         .await;
@@ -150,15 +144,8 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
             }
             idempotency::Admission::ReplayError(error) => return Err(error),
         };
-        let expected = ProductAttributeOptionRecord {
-            id: lease.operation_id,
-            attribute_id: input.attribute_id,
-            code: input.code.clone(),
-        };
-        let response_json = encode_schema_receipt(&context, operation, &expected)?;
         let result = with_product_operation_receipt(
             lease,
-            response_json,
             self.create_attribute_option(tenant_id, actor_id, input),
         )
         .await;
@@ -172,9 +159,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<CatalogCategoryRecord, PortError> {
         let operation = "create_category";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.create_category(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.create_category(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn create_schema(
@@ -184,9 +183,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<ProductAttributeSchemaRecord, PortError> {
         let operation = "create_schema";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.create_schema(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.create_schema(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn create_schema_group(
@@ -196,9 +207,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<ProductAttributeGroupRecord, PortError> {
         let operation = "create_schema_group";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.create_schema_group(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.create_schema_group(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn create_category_group(
@@ -208,9 +231,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<ProductAttributeGroupRecord, PortError> {
         let operation = "create_category_group";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.create_category_group(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.create_category_group(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn set_category_schema_mode(
@@ -327,26 +362,6 @@ async fn finish_receipted_schema_write<T>(
             Err(port_error)
         }
     }
-}
-
-fn encode_schema_receipt<T: Serialize>(
-    context: &PortContext,
-    operation: &'static str,
-    value: &T,
-) -> Result<serde_json::Value, PortError> {
-    serde_json::to_value(value).map_err(|error| {
-        tracing::error!(
-            correlation_id = %context.correlation_id,
-            tenant_id = %context.tenant_id,
-            operation,
-            error = %error,
-            "failed to encode Product schema owner receipt"
-        );
-        PortError::invariant_violation(
-            "product.schema_receipt_encode",
-            "product schema operation could not be completed safely",
-        )
-    })
 }
 
 fn decode_schema_receipt<T: DeserializeOwned>(

--- a/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/attributes.rs
@@ -25,7 +25,7 @@ use crate::services::{
     product_attribute_option_term, product_attribute_text_term,
 };
 use crate::services::write_transaction::{
-    ProductWriteTransaction, current_product_operation_id,
+    ProductWriteTransaction, current_product_operation_id, record_product_operation_result,
 };
 use rustok_core::generate_id;
 use rustok_events::DomainEvent;
@@ -109,13 +109,14 @@ impl ProductCatalogSchemaService {
             DomainEvent::ProductAttributeCreated { attribute_id },
         )
         .await?;
-        txn.commit().await?;
-
-        Ok(ProductAttributeRecord {
+        let result = ProductAttributeRecord {
             id: attribute_id,
             code: input.code,
             value_type: input.value_type,
-        })
+        };
+        record_product_operation_result(&result)?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub async fn create_attribute_option(
@@ -183,12 +184,14 @@ impl ProductCatalogSchemaService {
             },
         )
         .await?;
-        txn.commit().await?;
-        Ok(ProductAttributeOptionRecord {
+        let result = ProductAttributeOptionRecord {
             id: option_id,
             attribute_id: input.attribute_id,
             code: input.code,
-        })
+        };
+        record_product_operation_result(&result)?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub(crate) async fn admit_schema_operation_receipt<T: Serialize>(

--- a/crates/rustok-product/src/services/catalog_schema_service/categories.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/categories.rs
@@ -11,7 +11,9 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::error::{CommerceError, CommerceResult};
-use crate::services::write_transaction::ProductWriteTransaction;
+use crate::services::write_transaction::{
+    ProductWriteTransaction, current_product_operation_id, record_product_operation_result,
+};
 use rustok_core::generate_id;
 use rustok_events::DomainEvent;
 
@@ -23,7 +25,7 @@ impl ProductCatalogSchemaService {
         input: CreateCatalogCategoryInput,
     ) -> CommerceResult<CatalogCategoryRecord> {
         input.validate()?;
-        let category_id = generate_id();
+        let category_id = current_product_operation_id().unwrap_or_else(generate_id);
         let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?;
 
         if input.kind == CatalogCategoryKind::Virtual {
@@ -119,15 +121,16 @@ impl ProductCatalogSchemaService {
             DomainEvent::CatalogCategoryCreated { category_id },
         )
         .await?;
-        txn.commit().await?;
-
-        Ok(CatalogCategoryRecord {
+        let result = CatalogCategoryRecord {
             id: category_id,
             code: input.code,
             slug: input.slug,
             path,
             kind: input.kind,
-        })
+        };
+        record_product_operation_result(&result)?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub async fn list_categories(
@@ -169,7 +172,7 @@ impl ProductCatalogSchemaService {
         input.validate()?;
         let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?;
         ensure_structural_category(&txn, tenant_id, input.category_id).await?;
-        let group_id = generate_id();
+        let group_id = current_product_operation_id().unwrap_or_else(generate_id);
         txn.execute(Statement::from_sql_and_values(
             txn.get_database_backend(),
             r#"
@@ -198,13 +201,14 @@ impl ProductCatalogSchemaService {
             },
         )
         .await?;
-        txn.commit().await?;
-
-        Ok(ProductAttributeGroupRecord {
+        let result = ProductAttributeGroupRecord {
             id: group_id,
             owner_id: input.category_id,
             code: input.code,
-        })
+        };
+        record_product_operation_result(&result)?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub async fn set_category_schema_mode(

--- a/crates/rustok-product/src/services/catalog_schema_service/schemas.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/schemas.rs
@@ -9,7 +9,9 @@ use sea_orm::{ConnectionTrait, FromQueryResult, Statement};
 use uuid::Uuid;
 
 use crate::error::{CommerceError, CommerceResult};
-use crate::services::write_transaction::ProductWriteTransaction;
+use crate::services::write_transaction::{
+    ProductWriteTransaction, current_product_operation_id, record_product_operation_result,
+};
 use rustok_core::generate_id;
 use rustok_events::DomainEvent;
 
@@ -21,7 +23,7 @@ impl ProductCatalogSchemaService {
         input: CreateProductAttributeSchemaInput,
     ) -> CommerceResult<ProductAttributeSchemaRecord> {
         input.validate()?;
-        let schema_id = generate_id();
+        let schema_id = current_product_operation_id().unwrap_or_else(generate_id);
         let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?;
 
         txn.execute(Statement::from_sql_and_values(
@@ -64,12 +66,13 @@ impl ProductCatalogSchemaService {
             DomainEvent::ProductAttributeSchemaCreated { schema_id },
         )
         .await?;
-        txn.commit().await?;
-
-        Ok(ProductAttributeSchemaRecord {
+        let result = ProductAttributeSchemaRecord {
             id: schema_id,
             code: input.code,
-        })
+        };
+        record_product_operation_result(&result)?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub async fn list_schemas(
@@ -107,7 +110,7 @@ impl ProductCatalogSchemaService {
         input.validate()?;
         let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?;
         ensure_schema(&txn, tenant_id, input.schema_id).await?;
-        let group_id = generate_id();
+        let group_id = current_product_operation_id().unwrap_or_else(generate_id);
         txn.execute(Statement::from_sql_and_values(
             txn.get_database_backend(),
             r#"
@@ -136,12 +139,14 @@ impl ProductCatalogSchemaService {
             },
         )
         .await?;
-        txn.commit().await?;
-        Ok(ProductAttributeGroupRecord {
+        let result = ProductAttributeGroupRecord {
             id: group_id,
             owner_id: input.schema_id,
             code: input.code,
-        })
+        };
+        record_product_operation_result(&result)?;
+        txn.commit().await?;
+        Ok(result)
     }
 
     pub async fn bind_schema_attribute(

--- a/crates/rustok-product/src/services/mod.rs
+++ b/crates/rustok-product/src/services/mod.rs
@@ -61,4 +61,6 @@ pub use index_refresh_relay::{
     ProductIndexRefreshRelayStep, ProductIndexRefreshRelayStepOutcome,
 };
 
-pub(crate) use write_transaction::with_product_operation_receipt;
+pub(crate) use write_transaction::{
+    record_product_operation_result, with_product_operation_receipt,
+};

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -1,4 +1,8 @@
-use std::{future::Future, ops::Deref};
+use std::{
+    future::Future,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
     error::{CommerceError, CommerceResult},
@@ -13,13 +17,14 @@ use sea_orm::{
     ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, DbErr, ExecResult,
     QueryResult, Statement, TransactionTrait,
 };
+use serde::Serialize;
 use serde_json::Value;
 use uuid::Uuid;
 
 #[derive(Clone)]
 struct ProductOperationReceipt {
     lease: idempotency::Lease,
-    response_json: Value,
+    response_json: Arc<Mutex<Option<Value>>>,
 }
 
 tokio::task_local! {
@@ -30,10 +35,11 @@ tokio::task_local! {
 ///
 /// The scope is intentionally task-local: the shared `ProductCatalogSchemaService`
 /// stays stateless across concurrent callers, while `ProductWriteTransaction::begin`
-/// captures the receipt only for the explicitly wrapped owner command.
+/// captures the receipt only for the explicitly wrapped owner command. The concrete
+/// owner create method records its actual result before commit, so transaction-derived
+/// fields such as category path never need a preflight read outside the owner transaction.
 pub(crate) async fn with_product_operation_receipt<F, T>(
     lease: idempotency::Lease,
-    response_json: Value,
     future: F,
 ) -> T
 where
@@ -43,7 +49,7 @@ where
         .scope(
             ProductOperationReceipt {
                 lease,
-                response_json,
+                response_json: Arc::new(Mutex::new(None)),
             },
             future,
         )
@@ -58,13 +64,40 @@ pub(crate) fn current_product_operation_id() -> Option<Uuid> {
         .ok()
 }
 
+/// Record the actual owner result that must be committed into the active receipt.
+///
+/// Direct internal Product callers have no receipt scope, so this is intentionally a
+/// no-op for them. Receipt-scoped callers must record one result before transaction
+/// commit; a missing or poisoned result slot fails closed and rolls back the owner write.
+pub(crate) fn record_product_operation_result<T: Serialize>(value: &T) -> CommerceResult<()> {
+    let response_json = serde_json::to_value(value).map_err(|error| {
+        CommerceError::Database(DbErr::Custom(format!(
+            "product owner receipt result encoding failed: {error}"
+        )))
+    })?;
+
+    match PRODUCT_OPERATION_RECEIPT.try_with(|receipt| {
+        let mut slot = receipt.response_json.lock().map_err(|_| {
+            CommerceError::Database(DbErr::Custom(
+                "product owner receipt result slot is unavailable".to_string(),
+            ))
+        })?;
+        *slot = Some(response_json);
+        Ok(())
+    }) {
+        Ok(result) => result,
+        Err(_) => Ok(()),
+    }
+}
+
 /// Owns one product write transaction and its transactional outbox publisher.
 ///
 /// Product entity changes and domain events must use the same database
 /// transaction. The wrapper makes publishing through any non-transactional
 /// transport unavailable to product write paths before the transaction commits.
 /// When a Product owner receipt scope is active, terminal success is completed
-/// in this same transaction before commit.
+/// in this same transaction before commit using the actual result recorded by the
+/// owner create method.
 pub(crate) struct ProductWriteTransaction {
     transaction: DatabaseTransaction,
     event_bus: TransactionalEventBus,
@@ -163,7 +196,21 @@ impl ProductWriteTransaction {
 
     pub(crate) async fn commit(self) -> CommerceResult<()> {
         if let Some(receipt) = self.operation_receipt.as_ref() {
-            idempotency::complete(&self.transaction, receipt.lease, &receipt.response_json)
+            let response_json = receipt
+                .response_json
+                .lock()
+                .map_err(|_| {
+                    CommerceError::Database(DbErr::Custom(
+                        "product owner receipt result slot is unavailable".to_string(),
+                    ))
+                })?
+                .clone()
+                .ok_or_else(|| {
+                    CommerceError::Database(DbErr::Custom(
+                        "product owner receipt result was not recorded before commit".to_string(),
+                    ))
+                })?;
+            idempotency::complete(&self.transaction, receipt.lease, &response_json)
                 .await
                 .map_err(|error| {
                     tracing::error!(

--- a/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
+++ b/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
@@ -26,6 +26,8 @@ const functionSlice = (source, name, nextName) => {
 const port = read("crates/rustok-product/src/catalog_schema_write_port.rs");
 const transaction = read("crates/rustok-product/src/services/write_transaction.rs");
 const attributes = read("crates/rustok-product/src/services/catalog_schema_service/attributes.rs");
+const categories = read("crates/rustok-product/src/services/catalog_schema_service/categories.rs");
+const schemas = read("crates/rustok-product/src/services/catalog_schema_service/schemas.rs");
 const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
 const recheck = read("crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md");
 const implStart = port.indexOf("impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService");
@@ -48,12 +50,15 @@ for (const required of [
 for (const [name, nextName] of [
   ["create_attribute", "create_attribute_option"],
   ["create_attribute_option", "create_category"],
+  ["create_category", "create_schema"],
+  ["create_schema", "create_schema_group"],
+  ["create_schema_group", "create_category_group"],
+  ["create_category_group", "set_category_schema_mode"],
 ]) {
   const slice = functionSlice(portImpl, name, nextName);
   for (const required of [
     "admit_schema_operation(",
     "idempotency::Admission::Replay(value)",
-    "lease.operation_id",
     "with_product_operation_receipt(",
     "finish_receipted_schema_write(",
   ]) {
@@ -62,10 +67,6 @@ for (const [name, nextName] of [
 }
 
 for (const [name, nextName] of [
-  ["create_category", "create_schema"],
-  ["create_schema", "create_schema_group"],
-  ["create_schema_group", "create_category_group"],
-  ["create_category_group", "set_category_schema_mode"],
   ["set_category_schema_mode", "bind_schema_attribute"],
   ["bind_schema_attribute", "bind_category_attribute"],
   ["bind_category_attribute", "save_product_attribute_values"],
@@ -73,14 +74,17 @@ for (const [name, nextName] of [
   ["clear_detached_product_attribute_values", "admit_schema_operation"],
 ]) {
   const slice = functionSlice(portImpl, name, nextName);
-  forbidText(slice, "admit_schema_operation(", `${name} must remain explicit receipt follow-up debt in this slice`);
+  forbidText(slice, "admit_schema_operation(", `${name} must remain explicit update-style receipt follow-up debt`);
 }
 
 for (const required of [
   "tokio::task_local!",
   "struct ProductOperationReceipt",
+  "Arc<Mutex<Option<Value>>>",
   "PRODUCT_OPERATION_RECEIPT.try_with(Clone::clone).ok()",
-  "idempotency::complete(&self.transaction, receipt.lease, &receipt.response_json)",
+  "record_product_operation_result",
+  "product owner receipt result was not recorded before commit",
+  "idempotency::complete(&self.transaction, receipt.lease, &response_json)",
   "self.transaction.commit().await?",
   "current_product_operation_id()",
 ]) {
@@ -92,10 +96,21 @@ if (completion < 0 || commit < 0 || completion > commit) {
   failures.push("Product receipt completion must occur before owner transaction commit");
 }
 
-const stableIdCount = (attributes.match(/current_product_operation_id\(\)\.unwrap_or_else\(generate_id\)/g) ?? []).length;
-if (stableIdCount !== 2) {
-  failures.push(`attribute and option creates must derive exactly two stable receipt resource IDs (found ${stableIdCount})`);
+for (const [source, label, expected] of [
+  [attributes, "attribute creates", 2],
+  [categories, "category creates", 2],
+  [schemas, "schema creates", 2],
+]) {
+  const stableIds = (source.match(/current_product_operation_id\(\)\.unwrap_or_else\(generate_id\)/g) ?? []).length;
+  if (stableIds !== expected) {
+    failures.push(`${label} must derive exactly ${expected} stable receipt resource IDs (found ${stableIds})`);
+  }
+  const recordedResults = (source.match(/record_product_operation_result\(&result\)\?/g) ?? []).length;
+  if (recordedResults !== expected) {
+    failures.push(`${label} must record exactly ${expected} actual receipt results before commit (found ${recordedResults})`);
+  }
 }
+
 for (const required of [
   'const PRODUCT_SCHEMA_RECEIPT_OWNER: &str = "product"',
   "idempotency::admit(",
@@ -104,31 +119,41 @@ for (const required of [
   requireText(attributes, required, "Product schema receipt owner helpers");
 }
 
+const categoryCreate = functionSlice(categories, "create_category", "list_categories");
+for (const required of [
+  "let path = parent",
+  "let result = CatalogCategoryRecord",
+  "path,",
+  "record_product_operation_result(&result)?",
+]) {
+  requireText(categoryCreate, required, "category create actual-result receipt");
+}
+
 requireText(
   plan,
-  "receipts cover attribute and attribute-option creates",
-  "canonical Product schema-write debt must record this partial durable slice",
+  "durable owner receipts cover all six schema create operations",
+  "canonical Product schema-write debt must record complete create receipt coverage",
 );
 requireText(
   plan,
-  "category/schema/group\n  creates and update-style schema writes still need explicit owner replay semantics",
+  "update-style schema writes still need explicit owner replay semantics",
   "canonical Product schema-write debt must remain open",
 );
 requireText(
   recheck,
-  "attribute and attribute-option creates",
-  "Product schema write recheck must describe the durable create slice",
+  "all six Product schema create operations",
+  "Product schema write recheck must describe complete create receipt coverage",
 );
 requireText(
   recheck,
-  "category/schema/group creates and update-style schema writes remain open",
-  "Product schema write recheck must preserve remaining debt",
+  "update-style schema writes remain open",
+  "Product schema write recheck must preserve remaining update-style debt",
 );
 
 if (failures.length) {
-  console.error("Product schema attribute-create receipt source verification failed:");
+  console.error("Product schema create receipt source verification failed:");
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product attribute and attribute-option creates bind durable owner receipts atomically with Product writes; remaining schema replay semantics stay explicit debt");
+console.log("✔ All six Product schema creates bind durable owner receipts to actual transaction results; update-style replay semantics remain explicit debt");


### PR DESCRIPTION
## Summary

- extend durable Product owner-operation receipts from attribute/option creates to all six Product schema create operations: attribute, option, category, schema, schema group and category group
- reuse the receipt operation UUID as the stable Product-owned resource ID on every receipted create, including stale-lease reclamation
- change the Product receipt scope from a precomputed response to an actual-result slot populated by the owner create method before commit
- complete the owner receipt inside the same `ProductWriteTransaction` as Product schema rows and transactional outbox publication
- make category replay store the exact `CatalogCategoryRecord.path` calculated from the parent inside the owner transaction, avoiding any external preflight/path race
- keep direct internal Product service callers outside receipt semantics
- keep all five update-style schema writes explicitly unreceipted until their exact replay result/state contracts are defined
- update the focused source guard plus canonical ecommerce plan/recheck without marking the combined schema-write item complete

## Intentionally still open

- durable replay semantics for `set_category_schema_mode`
- durable replay semantics for schema/category attribute bindings
- exact completed-result replay for Product attribute-value save and detached-value clear
- Product Admin compatibility-source cleanup only after compile/source evidence confirms it is unmounted
- maintainer-run static/compile/lost-response/restart/backend evidence
- broad ecommerce typed-owner/FBA invariant remains open

## Verification

Source and GitHub diff inspection only. No tests, checks, formatter, workflows, or runtime verification were run per maintainer instruction. No FBA/FFA promotion.