### PR TITLE
feat(index): expose locale-scoped replay commands

### DIFF
--- a/apps/server/docs/index-replay-graphql-transport.md
+++ b/apps/server/docs/index-replay-graphql-transport.md
@@ -1,22 +1,27 @@
 # Index replay GraphQL transport
 
-Status: `source_complete_shutdown_bound_execution_pending`.
+Status: `locale_source_complete_execution_pending`.
 
 ## Boundary
 
 The server exposes two bounded GraphQL mutations over the guarded `IndexReplayOperatorRuntime`:
 
-- `runIndexReplay(input: ...)` runs one bounded schema-wide replay chunk and samples the server-owned graceful-shutdown signal at replay durable safe points;
+- `runIndexReplay(input: ...)` runs one bounded schema-wide or exact-locale replay chunk and samples the server-owned graceful-shutdown signal at replay durable safe points;
 - `cancelIndexReplay(input: ...)` requests cancellation of one replay job in the authenticated tenant.
 
 This remains a command transport. It does not add automatic replay scheduling, background worker ownership, a
-new replay algorithm, locale/partition checkpoint dimensions, or a traffic cutover.
+new replay algorithm, partition checkpoint scope, explicit targeted/full/shadow rebuild modes, or a traffic
+cutover.
 
 ## Authority before input parsing
 
 Tenant and actor identities are never accepted from GraphQL input. The transport derives both from
 `TenantContext` / `AuthContext`, requires the request-bound effective permission snapshot, and requires
-`modules:manage` before parsing untrusted schema identifiers, schema version, or job UUID.
+`modules:manage` before parsing untrusted schema identifiers, schema version, optional locale, or job UUID.
+
+Only after authorization does the run path canonicalize a supplied locale through `rustok_index::LocaleKey`.
+Locale input is bounded to 32 bytes before parsing. Omission is not inferred from schema metadata and preserves
+the historical schema-wide replay identity exactly.
 
 The server-owned `IndexReplayOperatorRuntime` performs the same authorization again before delegating to the
 canonical shared replay runtime. A cross-tenant job UUID is therefore only looked up in the authenticated
@@ -28,10 +33,11 @@ tenant and cannot widen authority.
 
 - module name;
 - entity name;
-- positive schema routing key.
+- positive schema routing key;
+- optional canonicalizable locale.
 
 It does not accept tenant, actor, worker identity, page limit, page count, heartbeat cadence, lease duration,
-locale, partition, source name, database handle, scheduler controls, shutdown state, or a stop handle.
+partition, source name, database handle, scheduler controls, shutdown state, or a stop handle.
 
 Each GraphQL invocation constructs a fresh server-owned worker identity and uses one fixed bounded chunk:
 
@@ -42,6 +48,24 @@ Each GraphQL invocation constructs a fresh server-owned worker identity and uses
 
 Those transport caps are intentionally narrower than the generic replay runner bounds. A yielded job remains
 resumable by a later authorized invocation through the existing durable job/checkpoint contract.
+
+## Locale identity
+
+A supplied locale is canonicalized once at the transport boundary and carried by `IndexReplayRunRequest` into
+the multi-page runner. The runner derives both durable job lease scope and every page request from that same
+`LocaleKey`:
+
+- schema-wide request -> schema job + schema checkpoint (`locale_key = ''`);
+- exact-locale request -> locale job + same canonical locale checkpoint.
+
+The terminal success fence checks the checkpoint using the leased locale rather than a hard-coded empty locale.
+This keeps acquisition, page scan, checkpoint writes and final success on one exact scope. `partition_key`
+remains empty in both cases.
+
+The one-page worker still resolves the registered runtime schema before checkpoint/source work and rejects a
+locale run for `LocaleMode::None`. Product is the currently retained production source that filters exact locale
+before pagination. Schema-wide replay remains valid, including for `LocaleMode::Required`, so omission does not
+silently become one locale.
 
 ## Graceful shutdown binding
 
@@ -60,6 +84,10 @@ published. The retained receiver is not exposed through GraphQL.
 `IndexReplayOperatorRuntime::run_interruptible` -> `SharedIndexReplayRuntime::run_interruptible` ->
 `PostgresIndexReplayRunner::run_interruptible`.
 
+The interruptible runner uses the same locale-aware lease helper as ordinary replay. A yielded locale job
+therefore keeps the same durable locale identity on the next authorized attempt instead of falling back to a
+schema job.
+
 The Index runtime and server operator remain lifecycle-type neutral; neither imports `StopHandle`. They accept
 only the boolean probe and keep authorization ahead of replay execution.
 
@@ -73,7 +101,8 @@ separate state machines.
 ## Result surface
 
 The run payload exposes only bounded operational counters plus status and job UUID. It does not expose source
-payloads, SQL, database errors, request authority, lease owner identity, shutdown state, or raw dependency causes.
+payloads, SQL, database errors, request authority, lease owner identity, locale internals, shutdown state, or raw
+dependency causes.
 
 The cancellation payload exposes only the normalized outcome: requested, cancelled, already terminal, or not
 found. Operational runner failures are mapped to a generic GraphQL error; an unknown source-owned schema is
@@ -83,8 +112,11 @@ reported as bad user input.
 
 Source guards retain:
 
-- authorization-before-parsing ordering;
-- absence of caller authority/worker/resource-budget/shutdown fields;
+- authorization-before-schema/locale parsing ordering;
+- absence of caller authority/worker/resource-budget/shutdown/partition fields;
+- optional locale canonicalization and schema-wide omission compatibility;
+- exact runner page/job/checkpoint locale coupling;
+- locale-aware interruptible runner acquisition and terminal success fencing;
 - fixed server-owned bounds;
 - delegation only through `IndexReplayOperatorRuntime`;
 - merged GraphQL schema registration;
@@ -92,8 +124,9 @@ Source guards retain:
 - `StopHandle::is_stopping` as the only replay shutdown observation;
 - no direct database/source/scheduler access and no `.stop()` call from the transport.
 
-GraphQL execution, actual process-shutdown replay interruption, database replay execution, cancellation races,
-CI, and retained runtime evidence remain maintainer-owned and are not claimed by this source slice.
+GraphQL execution, actual locale replay/restart execution, actual process-shutdown replay interruption, database
+replay execution, cancellation races, CI, and retained runtime evidence remain maintainer-owned and are not
+claimed by this source slice.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_replay.rs
+++ b/apps/server/src/graphql/index_replay.rs
@@ -19,19 +19,22 @@ use crate::services::rbac_request_scope::permissions_for;
 
 const MAX_SCHEMA_IDENTIFIER_BYTES: usize = 128;
 const MAX_SCHEMA_VERSION_BYTES: usize = 10;
+const MAX_LOCALE_BYTES: usize = 32;
 const GRAPHQL_REPLAY_PAGE_LIMIT: usize = 100;
 const GRAPHQL_REPLAY_MAX_PAGES: usize = 8;
 const GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES: usize = 1;
 const GRAPHQL_REPLAY_LEASE_SECONDS: u64 = 60;
 
-/// Untrusted GraphQL input for one bounded schema-wide replay run.
+/// Untrusted GraphQL input for one bounded schema-wide or exact-locale replay run.
 ///
 /// Tenant, actor, worker identity and replay resource budgets are server-owned and never caller supplied.
+/// Omitting locale preserves the historical schema-wide replay identity.
 #[derive(Debug, Clone, InputObject)]
 pub struct IndexReplayRunInput {
     pub module_name: String,
     pub entity_name: String,
     pub schema_version: String,
+    pub locale: Option<String>,
 }
 
 #[derive(Debug, Clone, InputObject)]
@@ -146,7 +149,7 @@ pub struct IndexReplayMutation;
 
 #[Object]
 impl IndexReplayMutation {
-    /// Run one server-bounded chunk of the exact schema-wide replay job.
+    /// Run one server-bounded chunk of the exact schema-wide or locale replay job.
     async fn run_index_replay(
         &self,
         ctx: &Context<'_>,
@@ -210,16 +213,30 @@ fn prepare_authorized_run(
 > {
     let context = authorize(tenant_id, actor_id)?;
     let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;
+    let locale = parse_locale(input.locale)?;
     let worker_id = format!("graphql-replay-{}", Uuid::new_v4().simple());
-    let request = rustok_index::IndexReplayRunRequest::new(
-        tenant_id,
-        schema,
-        worker_id,
-        GRAPHQL_REPLAY_PAGE_LIMIT,
-        GRAPHQL_REPLAY_MAX_PAGES,
-        GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES,
-        Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS),
-    )
+    let request = if let Some(locale) = locale {
+        rustok_index::IndexReplayRunRequest::for_locale(
+            tenant_id,
+            schema,
+            locale,
+            worker_id,
+            GRAPHQL_REPLAY_PAGE_LIMIT,
+            GRAPHQL_REPLAY_MAX_PAGES,
+            GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES,
+            Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS),
+        )
+    } else {
+        rustok_index::IndexReplayRunRequest::new(
+            tenant_id,
+            schema,
+            worker_id,
+            GRAPHQL_REPLAY_PAGE_LIMIT,
+            GRAPHQL_REPLAY_MAX_PAGES,
+            GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES,
+            Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS),
+        )
+    }
     .map_err(|_| IndexReplayTransportPreparationError::InvalidInput {
         field: "schema_version",
     })?;
@@ -285,6 +302,19 @@ fn parse_schema(
         })?,
         version: rustok_index::SchemaVersion::new(schema_version),
     })
+}
+
+fn parse_locale(
+    locale: Option<String>,
+) -> std::result::Result<Option<rustok_index::LocaleKey>, IndexReplayTransportPreparationError> {
+    locale
+        .map(|locale| {
+            let locale = bounded_text("locale", &locale, MAX_LOCALE_BYTES)?;
+            rustok_index::LocaleKey::new(locale).map_err(|_| {
+                IndexReplayTransportPreparationError::InvalidInput { field: "locale" }
+            })
+        })
+        .transpose()
 }
 
 fn bounded_text<'a>(
@@ -362,6 +392,7 @@ mod tests {
             module_name: "Rustok Product".to_owned(),
             entity_name: "product".to_owned(),
             schema_version: "zero".to_owned(),
+            locale: Some("not a locale!!!".to_owned()),
         }
     }
 
@@ -413,6 +444,7 @@ mod tests {
                         module_name: "rustok-product".to_owned(),
                         entity_name: "product".to_owned(),
                         schema_version: "4".to_owned(),
+                        locale: None,
                     },
                 )
             },
@@ -424,6 +456,7 @@ mod tests {
         assert_eq!(request.page_request().schema().module.as_str(), "rustok-product");
         assert_eq!(request.page_request().schema().entity.as_str(), "product");
         assert_eq!(request.page_request().schema().version.get(), 4);
+        assert!(request.locale().is_none());
         assert!(request.worker_id().starts_with("graphql-replay-"));
         assert_eq!(request.page_request().limit(), GRAPHQL_REPLAY_PAGE_LIMIT);
         assert_eq!(request.max_pages(), GRAPHQL_REPLAY_MAX_PAGES);
@@ -435,6 +468,36 @@ mod tests {
             request.lease_duration(),
             std::time::Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS)
         );
+    }
+
+    #[tokio::test]
+    async fn replay_transport_canonicalizes_optional_locale_after_authorization() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let (_, request) = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                prepare_authorized_run(
+                    tenant_id,
+                    actor_id,
+                    IndexReplayRunInput {
+                        module_name: "rustok-product".to_owned(),
+                        entity_name: "product".to_owned(),
+                        schema_version: "4".to_owned(),
+                        locale: Some("EN-us".to_owned()),
+                    },
+                )
+            },
+        )
+        .await
+        .expect("authorized locale replay request should parse");
+
+        assert_eq!(request.locale().map(|locale| locale.as_str()), Some("en-US"));
     }
 
     #[tokio::test]

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@232aeb8c936964c0f76d1a7661379619199f1d49` and continued on
-`agent/index-replay-pending-future-timeouts-20260808`.
+Status overlay rechecked at `main@ec9ff9e8303d0d42fd937eba4458b9c644c3fc73` and continued on
+`agent/index-replay-locale-runner-graphql-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -112,12 +112,16 @@ register a key3 Product source/factory. Runtime dual-read compatibility remains 
 request-bound tenant/actor context and effective `modules:manage`, rejects cross-tenant run requests and derives
 cancel tenant from that context.
 
-The GraphQL layer exposes source-complete schema-wide `runIndexReplay` / `cancelIndexReplay` commands without
-calling source adapters or PostgreSQL directly. Authorization occurs before parsing untrusted schema/job input.
+The GraphQL layer exposes source-complete schema-wide or exact-locale `runIndexReplay` plus `cancelIndexReplay`
+without calling source adapters or PostgreSQL directly. Authorization occurs before parsing untrusted schema,
+locale or job input.
 
-Caller input contains no tenant, actor, worker ID, source name, locale/partition, scheduler handle, replay
-resource budget, stop handle or shutdown flag. Each run creates a server-owned worker identity and applies fixed
-transport caps: 100 mutations per page, at most 8 pages, heartbeat every page and a 60-second lease.
+Caller run input contains only module/entity/schema key plus one optional bounded locale. Tenant, actor, worker
+ID, source name, partition, scheduler handle, replay resource budget, stop handle and shutdown flag remain
+server-owned or unavailable. Locale is canonicalized through `LocaleKey` after authorization. Omission remains
+exactly schema-wide; it is not rewritten from schema locale defaults. Each run creates a server-owned worker
+identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page and a
+60-second lease.
 
 GraphQL runtime execution/cancellation evidence remains maintainer-owned.
 
@@ -173,6 +177,35 @@ shutdown remains safe-point-only, while replay retry/recovery policy remains the
 Retained timeout unit source and source guard are complete but have **not** been executed or admitted by the
 implementation agent. See `m6-replay-pending-future-timeouts.md`.
 
+## M6 locale-scoped replay source state
+
+Locale replay is now split from partition/rebuild-mode work and tracked end-to-end instead of as one aggregate
+future item.
+
+Already merged on reviewed `main`:
+
+- generic `IndexSourceScanRequest` accepts optional canonical `LocaleKey` and validates returned mutation scope;
+- current Product PostgreSQL replay scans honor exact locale before pagination while preserving the schema-wide
+  `(product_id, locale)` path;
+- durable replay jobs support explicit locale scope through the locale job migration, canonical locale request
+  contract, lease identity, advisory locking, active-job lookup and locale-specific completion probe;
+- one-page replay requests/checkpoint keys carry the same optional canonical locale;
+- one-page worker resolves the exact runtime schema before checkpoint/source work, rejects locale scope for
+  `LocaleMode::None`, and derives source scan plus checkpoint from the same request locale;
+- PostgreSQL checkpoint storage requires exact lease/checkpoint locale equality and persists canonical locale
+  while schema-wide checkpoints retain the historical empty locale string.
+
+Current branch source-complete work:
+
+- Carry optional locale through the multi-page replay runner and GraphQL command transport;
+- use one runner helper for ordinary and graceful execution so durable job lease and page request share scope;
+- bind the terminal success checkpoint probe to `IndexReplayJobLease.locale` instead of hard-coding empty locale;
+- preserve schema-wide omission exactly and canonicalize GraphQL locale only after authorization;
+- retain partition as empty and keep targeted/full/shadow rebuild modes outside this contract.
+
+Runtime execution/admission is still pending. In particular, no claim is made that the retained locale
+replay/restart command path has been executed against SQLite/PostgreSQL or admitted for deployment.
+
 ## Remaining Storefront parity/evidence blockers
 
 - execute/admit the deterministic budgeted timeout packet and retain acceptable runtime latency/cancellation
@@ -200,18 +233,24 @@ implementation agent. See `m6-replay-pending-future-timeouts.md`.
 - [x] Bounded replay, durable jobs/leases/checkpoints and cancellation.
 - [x] Reconciliation, drift diagnosis and targeted repair source.
 - [x] Real-migration repair PostgreSQL harness and retained-evidence admission tooling.
-- [x] Guarded schema-wide replay run/cancel GraphQL command transport with server-owned bounded run policy.
+- [x] Guarded replay run/cancel GraphQL command transport with server-owned bounded run policy.
 - [x] Carry a host-owned interruption probe through replay runner safe points and retain duplicate-safe restart evidence source.
 - [x] Bind the shared server `StopHandle::is_stopping` signal through guarded replay runtime/operator composition without caller shutdown controls.
 - [x] Retain deterministic GraphQL StopHandle -> pending -> fresh-runtime attempt-2 completion evidence source without sleeps/polling.
 - [x] Bound replay mutation/checkpoint-commit pending futures with retryable timeout identities and preserve cancel/lease precedence.
+- [x] Define canonical locale-scoped source scan and make current Product filter before pagination.
+- [x] Add durable locale replay job scope and exact locale checkpoint identity.
+- [x] Carry locale through one-page replay worker/checkpoint storage with fail-closed `LocaleMode` admission.
+- [x] Carry optional locale through the multi-page replay runner and GraphQL command transport.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
 - [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
 - [ ] Execute/admit retained mutation/checkpoint pending-future timeout evidence.
+- [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
 - [ ] Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds.
 - [ ] Complete remaining multi-host/restart evidence beyond existing convergence/replay packets.
-- [ ] Add locale/partition replay checkpoint dimensions and explicit rebuild modes under separate contracts.
+- [ ] Add partition replay scope only after a real partition-capable source contract exists.
+- [ ] Add explicit targeted/full/shadow rebuild modes under a separate contract.
 
 ## M7 Product Storefront graph
 
@@ -245,14 +284,15 @@ implementation agent. See `m6-replay-pending-future-timeouts.md`.
 
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
 
-After this timeout slice, the next independent M6 source boundary is replay checkpoint scope. The persistence table
-already reserves `locale_key` and `partition_key`, but the current replay request/source-scan contract is
-schema-wide and the runtime key still writes empty values. Do not merely populate those columns. First define a
-real locale-scoped replay request/scan identity end-to-end; only then let checkpoint/job identity carry that scope.
-Partition scope must remain separate until the source contract can actually scan a partition.
+The locale request/source/job/checkpoint/runner/GraphQL identity chain is source-complete after this slice. The
+next M6 evidence boundary is retained end-to-end locale replay/restart execution through the real runner/command
+composition, proving exact locale resume and isolation from schema-wide/other-locale jobs without changing
+cancellation, heartbeat or graceful-stop semantics.
 
-Explicit targeted/full/shadow rebuild modes remain a later separate contract and must not be smuggled into locale
-checkpoint work.
+Partition is no longer grouped with locale. Add partition replay scope only after a real partition-capable source
+contract exists and can filter before pagination; do not merely populate `partition_key`. Explicit
+ targeted/full/shadow rebuild modes remain a later separate contract and must not be smuggled into partition or
+locale evidence work.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-locale-replay-runner-graphql.md
+++ b/crates/rustok-index/docs/m6-locale-replay-runner-graphql.md
@@ -1,0 +1,99 @@
+# M6 locale replay runner and GraphQL command scope
+
+Status: `runner_graphql_source_complete_execution_pending`.
+
+## Purpose
+
+This slice completes the source-code path that began with the generic locale source-scan contract and now carries one optional canonical locale through the public replay command boundary, multi-page runner, durable job lease, one-page worker, checkpoint identity and terminal success fence.
+
+The retained sequence is:
+
+1. generic `IndexSourceScanRequest` gained optional canonical locale scope;
+2. current Product PostgreSQL replay scans filter that locale before pagination;
+3. durable replay jobs gained an explicit `locale` scope and canonical `locale_key` identity;
+4. one-page replay requests/checkpoints gained the same locale identity and fail-closed `LocaleMode` admission;
+5. this slice carries that identity through `IndexReplayRunRequest`, both runner paths and the authorized GraphQL command.
+
+## Multi-page run request
+
+`IndexReplayRunRequest::new(...)` remains schema-wide and preserves the historical public call shape.
+
+`IndexReplayRunRequest::for_locale(...)` accepts an already canonical `LocaleKey`. Both constructors delegate to one scoped initializer and therefore retain the same page limit, maximum-page, heartbeat and lease-duration validation.
+
+The request exposes its optional locale read-only. It does not gain partition or rebuild-mode state.
+
+## Durable job and page identity
+
+Both ordinary `PostgresIndexReplayRunner::run` and graceful `run_interruptible` call the same `lease_request_for_run(...)` helper:
+
+- no locale -> `IndexReplayJobLeaseRequest::new(...)`;
+- locale -> `IndexReplayJobLeaseRequest::for_locale(...)` with the exact request locale.
+
+The page request stored inside `IndexReplayRunRequest` was built from that same locale. The worker therefore scans and checkpoints the same scope as the durable job lease.
+
+The runner never reconstructs locale from source cursor contents, returned mutations, schema defaults, or checkpoint rows.
+
+## Terminal success fence
+
+Before this slice, multi-page `finish_success` required `checkpoint.locale_key = ''` unconditionally. That was correct for schema-wide replay but would make a durable locale job unable to finish honestly after writing a locale checkpoint.
+
+The terminal write now binds one ninth value from `IndexReplayJobLease.locale`:
+
+- schema lease binds the historical empty string;
+- locale lease binds the exact canonical locale string.
+
+The completion `EXISTS` probe requires `checkpoint.locale_key` to equal that value. `partition_key` remains the empty string.
+
+Job acquisition, page source scan, checkpoint read/write and final success therefore share one locale identity.
+
+## GraphQL command
+
+`runIndexReplay` now accepts one optional `locale` string in addition to module, entity and schema routing key.
+
+Authority ordering is unchanged and explicit:
+
+1. derive tenant and actor from authenticated request context;
+2. require the request-bound effective `modules:manage` permission;
+3. only then parse schema input and optional locale;
+4. bound locale to 32 bytes and canonicalize through `LocaleKey`;
+5. build a schema-wide or exact-locale `IndexReplayRunRequest` with server-owned worker identity and fixed transport budgets.
+
+Omitting locale remains exactly schema-wide. A schema's `LocaleMode::Required` does not cause omission to be rewritten into a default locale. A supplied locale reaches the existing worker/job admission, where `LocaleMode::None` fails closed.
+
+GraphQL still accepts no tenant, actor, worker identity, source name, partition, scheduler handle, replay budget, stop handle or shutdown flag.
+
+## Graceful shutdown and cancellation
+
+The interruptible runner uses the same locale-aware lease helper as ordinary replay. Yield-to-pending, heartbeat, persisted cancellation precedence and duplicate-safe restart semantics are otherwise unchanged.
+
+User cancellation remains job-UUID based inside the authenticated tenant. Locale is not accepted on the cancellation mutation and is not needed to widen or reconstruct cancellation scope.
+
+## Compatibility
+
+Schema-wide callers continue to use `IndexReplayRunRequest::new(...)` and bind the same empty checkpoint locale as before.
+
+The existing Product schema-wide replay path remains available even for locale-required schemas, preserving full rebuild behavior. Locale-scoped commands are additive.
+
+No migration is introduced in this slice because the durable locale job/checkpoint storage shapes were already established by the preceding locale job/checkpoint slices.
+
+## Boundary
+
+This slice does not add:
+
+- partition-scoped source scans, jobs or checkpoints;
+- targeted/full/shadow rebuild modes;
+- automatic scheduling or retry policy changes;
+- Storefront serving changes;
+- a new source implementation;
+- new cancellation semantics;
+- production evidence admission.
+
+Partition replay must remain blocked until a real source contract can scan exactly one partition before pagination. Explicit rebuild modes remain a separate later contract.
+
+## Evidence state and next source boundary
+
+Retained source assertions cover schema-wide omission, canonical locale request construction, common runner lease selection, locale-aware terminal checkpoint SQL and GraphQL authorization-before-locale-parsing.
+
+The next M6 evidence boundary is end-to-end retained locale replay/restart execution through the real runner/command composition, including yielded/restarted locale identity and isolation from the schema-wide and other-locale jobs. Execution/admission remains maintainer-owned.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
@@ -10,8 +10,8 @@ use uuid::Uuid;
 
 use crate::{
     IndexReplayError, IndexReplayFailureKind, IndexReplayPageRequest, IndexReplayPageStatus,
-    IndexReplayWorker, IndexSourceError, IndexSourceFailureKind, SchemaRef, SchemaRegistry,
-    SharedIndexSourceRegistry,
+    IndexReplayWorker, IndexSourceError, IndexSourceFailureKind, LocaleKey, SchemaRef,
+    SchemaRegistry, SharedIndexSourceRegistry,
 };
 
 use super::{
@@ -42,6 +42,50 @@ impl IndexReplayRunRequest {
         heartbeat_every_pages: usize,
         lease_duration: Duration,
     ) -> Result<Self, IndexReplayRunError> {
+        Self::new_scoped(
+            tenant_id,
+            schema,
+            None,
+            worker_id,
+            page_limit,
+            max_pages,
+            heartbeat_every_pages,
+            lease_duration,
+        )
+    }
+
+    pub fn for_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: LocaleKey,
+        worker_id: impl Into<String>,
+        page_limit: usize,
+        max_pages: usize,
+        heartbeat_every_pages: usize,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReplayRunError> {
+        Self::new_scoped(
+            tenant_id,
+            schema,
+            Some(locale),
+            worker_id,
+            page_limit,
+            max_pages,
+            heartbeat_every_pages,
+            lease_duration,
+        )
+    }
+
+    fn new_scoped(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: Option<LocaleKey>,
+        worker_id: impl Into<String>,
+        page_limit: usize,
+        max_pages: usize,
+        heartbeat_every_pages: usize,
+        lease_duration: Duration,
+    ) -> Result<Self, IndexReplayRunError> {
         if !(1..=MAX_PAGES_PER_RUN).contains(&max_pages) {
             return Err(IndexReplayRunError::InvalidMaxPages {
                 actual: max_pages,
@@ -54,8 +98,11 @@ impl IndexReplayRunRequest {
                 max: max_pages,
             });
         }
-        let page_request = IndexReplayPageRequest::new(tenant_id, schema, page_limit)
-            .map_err(IndexReplayRunError::InvalidPageRequest)?;
+        let page_request = match locale {
+            Some(locale) => IndexReplayPageRequest::for_locale(tenant_id, schema, locale, page_limit),
+            None => IndexReplayPageRequest::new(tenant_id, schema, page_limit),
+        }
+        .map_err(IndexReplayRunError::InvalidPageRequest)?;
         Ok(Self {
             page_request,
             worker_id: worker_id.into(),
@@ -67,6 +114,10 @@ impl IndexReplayRunRequest {
 
     pub fn page_request(&self) -> &IndexReplayPageRequest {
         &self.page_request
+    }
+
+    pub fn locale(&self) -> Option<&LocaleKey> {
+        self.page_request.locale()
     }
 
     pub fn worker_id(&self) -> &str {
@@ -220,13 +271,7 @@ impl PostgresIndexReplayRunner {
             })?
             .source_name()
             .to_owned();
-        let lease_request = IndexReplayJobLeaseRequest::new(
-            request.page_request().tenant_id(),
-            request.page_request().schema().clone(),
-            source_name,
-            request.worker_id().to_owned(),
-            request.lease_duration(),
-        )?;
+        let lease_request = lease_request_for_run(&request, source_name)?;
         let job_store = PostgresIndexReplayJobStore::new(self.db.clone());
         let lease = match job_store.acquire(&lease_request).await? {
             IndexReplayJobAcquireOutcome::Busy => {
@@ -350,6 +395,29 @@ enum TerminalWriteOutcome {
     Cancelled,
 }
 
+fn lease_request_for_run(
+    request: &IndexReplayRunRequest,
+    source_name: String,
+) -> Result<IndexReplayJobLeaseRequest, IndexReplayRunError> {
+    match request.locale() {
+        Some(locale) => Ok(IndexReplayJobLeaseRequest::for_locale(
+            request.page_request().tenant_id(),
+            request.page_request().schema().clone(),
+            locale.clone(),
+            source_name,
+            request.worker_id().to_owned(),
+            request.lease_duration(),
+        )?),
+        None => Ok(IndexReplayJobLeaseRequest::new(
+            request.page_request().tenant_id(),
+            request.page_request().schema().clone(),
+            source_name,
+            request.worker_id().to_owned(),
+            request.lease_duration(),
+        )?),
+    }
+}
+
 fn empty_outcome(
     status: IndexReplayRunStatus,
     job_id: Option<Uuid>,
@@ -469,6 +537,13 @@ async fn finish_success(
     values.push(lease.schema().module.as_str().to_owned().into());
     values.push(lease.schema().entity.as_str().to_owned().into());
     values.push(i64::from(lease.schema().version.get()).into());
+    values.push(
+        lease
+            .locale()
+            .map(|locale| locale.as_str().to_owned())
+            .unwrap_or_default()
+            .into(),
+    );
     let updated = db
         .execute(Statement::from_sql_and_values(
             backend,
@@ -640,7 +715,7 @@ fn finish_success_sql(backend: DbBackend) -> String {
         _ => unreachable!("unsupported database backend was validated"),
     };
     format!(
-        "UPDATE index_jobs SET state = 'succeeded', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE AND EXISTS (SELECT 1 FROM index_checkpoints AS checkpoint WHERE checkpoint.tenant_id = {prefix}1 AND checkpoint.checkpoint_kind = 'rebuild' AND checkpoint.source_name = {prefix}5 AND checkpoint.module_name = {prefix}6 AND checkpoint.entity_name = {prefix}7 AND checkpoint.schema_version = {prefix}8 AND checkpoint.locale_key = '' AND checkpoint.partition_key = '' AND {complete_cursor})"
+        "UPDATE index_jobs SET state = 'succeeded', lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error_code = NULL, last_error_details = NULL WHERE tenant_id = {prefix}1 AND job_id = {prefix}2 AND kind = 'rebuild' AND state = 'running' AND lease_owner = {prefix}3 AND attempt_count = {prefix}4 AND lease_expires_at > CURRENT_TIMESTAMP AND cancel_requested = FALSE AND EXISTS (SELECT 1 FROM index_checkpoints AS checkpoint WHERE checkpoint.tenant_id = {prefix}1 AND checkpoint.checkpoint_kind = 'rebuild' AND checkpoint.source_name = {prefix}5 AND checkpoint.module_name = {prefix}6 AND checkpoint.entity_name = {prefix}7 AND checkpoint.schema_version = {prefix}8 AND checkpoint.locale_key = {prefix}9 AND checkpoint.partition_key = '' AND {complete_cursor})"
     )
 }
 
@@ -697,4 +772,62 @@ pub enum IndexReplayRunError {
         #[source]
         error: Box<IndexReplayError>,
     },
+}
+
+#[cfg(test)]
+mod locale_scope_tests {
+    use super::*;
+
+    fn product_schema() -> SchemaRef {
+        SchemaRef {
+            module: crate::ModuleName::new("rustok-product").unwrap(),
+            entity: crate::EntityName::new("product").unwrap(),
+            version: crate::SchemaVersion::new(4),
+        }
+    }
+
+    #[test]
+    fn locale_run_request_keeps_page_job_and_terminal_checkpoint_scope_identical() {
+        let request = IndexReplayRunRequest::for_locale(
+            Uuid::new_v4(),
+            product_schema(),
+            LocaleKey::new("EN-us").unwrap(),
+            "locale-runner-test",
+            100,
+            8,
+            1,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+
+        assert_eq!(request.locale().map(LocaleKey::as_str), Some("en-US"));
+        let lease_request = lease_request_for_run(&request, "product-postgres-primary".to_owned())
+            .unwrap();
+        assert_eq!(lease_request.locale().map(LocaleKey::as_str), Some("en-US"));
+
+        let postgres = finish_success_sql(DbBackend::Postgres);
+        assert!(postgres.contains("checkpoint.locale_key = $9"));
+        assert!(postgres.contains("checkpoint.partition_key = ''"));
+        let sqlite = finish_success_sql(DbBackend::Sqlite);
+        assert!(sqlite.contains("checkpoint.locale_key = ?9"));
+        assert!(sqlite.contains("checkpoint.partition_key = ''"));
+    }
+
+    #[test]
+    fn schema_run_request_preserves_empty_locale_identity() {
+        let request = IndexReplayRunRequest::new(
+            Uuid::new_v4(),
+            product_schema(),
+            "schema-runner-test",
+            100,
+            8,
+            1,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        assert!(request.locale().is_none());
+        let lease_request = lease_request_for_run(&request, "product-postgres-primary".to_owned())
+            .unwrap();
+        assert!(lease_request.locale().is_none());
+    }
 }

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
@@ -27,13 +27,7 @@ impl PostgresIndexReplayRunner {
             })?
             .source_name()
             .to_owned();
-        let lease_request = IndexReplayJobLeaseRequest::new(
-            request.page_request().tenant_id(),
-            request.page_request().schema().clone(),
-            source_name,
-            request.worker_id().to_owned(),
-            request.lease_duration(),
-        )?;
+        let lease_request = lease_request_for_run(&request, source_name)?;
         let job_store = PostgresIndexReplayJobStore::new(self.db.clone());
         let lease = match job_store.acquire(&lease_request).await? {
             IndexReplayJobAcquireOutcome::Busy => {

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -44,6 +44,7 @@ const scripts = [
   'verify-index-drift-source-page-graphql-transport.mjs',
   'verify-index-drift-candidate-contract.mjs',
   'verify-index-postgres-drift-candidate-reader.mjs',
+  'verify-index-query-equivalence-admission.mjs',
   'verify-index-drift-candidate-confirmation.mjs',
   'verify-index-confirmed-candidate-persistence.mjs',
   'verify-index-drift-finding-lifecycle.mjs',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -23,6 +23,7 @@ const scripts = [
   'verify-index-source-replay-contract.mjs',
   'verify-index-locale-source-scan.mjs',
   'verify-index-replay-locale-job-scope.mjs',
+  'verify-index-replay-locale-runner-graphql.mjs',
   'verify-index-source-refresh-event.mjs',
   'verify-index-source-absence-watermark.mjs',
   'verify-index-source-continuation.mjs',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -23,6 +23,7 @@ const scripts = [
   'verify-index-source-replay-contract.mjs',
   'verify-index-locale-source-scan.mjs',
   'verify-index-replay-locale-job-scope.mjs',
+  'verify-index-replay-locale-checkpoint-worker.mjs',
   'verify-index-replay-locale-runner-graphql.mjs',
   'verify-index-source-refresh-event.mjs',
   'verify-index-source-absence-watermark.mjs',

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -44,7 +44,6 @@ const scripts = [
   'verify-index-drift-source-page-graphql-transport.mjs',
   'verify-index-drift-candidate-contract.mjs',
   'verify-index-postgres-drift-candidate-reader.mjs',
-  'verify-index-query-equivalence-admission.mjs',
   'verify-index-drift-candidate-confirmation.mjs',
   'verify-index-confirmed-candidate-persistence.mjs',
   'verify-index-drift-finding-lifecycle.mjs',

--- a/scripts/verify/verify-index-replay-graphql-shutdown-evidence.mjs
+++ b/scripts/verify/verify-index-replay-graphql-shutdown-evidence.mjs
@@ -23,7 +23,7 @@ const packet = requireMarkers(packetPath, [
   'use super::index_replay::IndexReplayMutation;',
   'materialize_index_replay_runtime',
   'PostgresSchemaRegistrationStore',
-  'Schema<ReplayTestQuery, IndexReplayMutation, EmptySubscription>',
+  'type ReplayTestSchema = Schema<EmptyQuery, IndexReplayMutation, EmptySubscription>;',
   '.data(extensions)',
   '.data(stop_handle.clone())',
   'with_rbac_request_scope(',
@@ -32,7 +32,7 @@ const packet = requireMarkers(packetPath, [
   'gate.started.notified().await;',
   'first.stop_handle.stop().await;',
   'gate.release.notify_one();',
-  'first_run["status"].as_str(), Some("YIELDED")',
+  'assert_eq!(first_run["status"], "YIELDED");',
   'job_state(&db).await, "pending"',
   'job_attempt_count(&db).await, 1',
   'pending_uncancelled_lease_free_jobs(&db).await, 1',
@@ -40,7 +40,7 @@ const packet = requireMarkers(packetPath, [
   'materialized_entity_count(&db).await, 0',
   'applied_inbox_count(&db).await, 0',
   'let restarted = graphql_runtime(&db, None).await;',
-  'second_run["status"].as_str(), Some("COMPLETE")',
+  'assert_eq!(second_run["status"], "COMPLETE");',
   'job_attempt_count(&db).await, 2',
   'job_state(&db).await, "succeeded"',
   'checkpoint_count(&db).await, 1',
@@ -79,11 +79,11 @@ if (spawn < 0 || scope <= spawn || execute <= scope || started <= execute || sto
   fail('first GraphQL request must install request authority inside its task, enter source scan, publish stop, then release scan deterministically');
 }
 
-const firstYield = packet.indexOf('Some("YIELDED")', release);
+const firstYield = packet.indexOf('assert_eq!(first_run["status"], "YIELDED");', release);
 const pending = packet.indexOf('job_state(&db).await, "pending"', firstYield);
 const restart = packet.indexOf('let restarted = graphql_runtime(&db, None).await;', pending);
 const secondExecute = packet.indexOf('restarted.schema.execute(replay_request())', restart);
-const complete = packet.indexOf('Some("COMPLETE")', secondExecute);
+const complete = packet.indexOf('assert_eq!(second_run["status"], "COMPLETE");', secondExecute);
 const attemptTwo = packet.indexOf('job_attempt_count(&db).await, 2', complete);
 if (firstYield < 0 || pending <= firstYield || restart <= pending || secondExecute <= restart || complete <= secondExecute || attemptTwo <= complete) {
   fail('packet must retain yielded pending state before fresh GraphQL/runtime composition resumes and completes attempt 2');
@@ -106,6 +106,7 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.r
   '.run_interruptible(request, should_interrupt)',
 ]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs', [
+  'let lease_request = lease_request_for_run(&request, source_name)?;',
   'Err(crate::IndexReplayError::Interrupted) => {',
   'yield_after_host_interruption(&self.db, &lease, aggregate).await',
   'match yield_for_resume(db, lease).await?',
@@ -129,4 +130,4 @@ requireMarkers('apps/server/docs/index-replay-graphql-shutdown-evidence.md', [
   'does not claim full HTTP/process bootstrap execution',
 ]);
 
-console.log('[verify-index-replay-graphql-shutdown-evidence] deterministic schema-data GraphQL shutdown packet retains authorized stop-to-pending and fresh-runtime attempt-2 completion without sleeps or polling');
+console.log('[verify-index-replay-graphql-shutdown-evidence] deterministic schema-data GraphQL shutdown packet matches current assertions and retains authorized stop-to-pending plus fresh-runtime attempt-2 completion');

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -24,8 +24,10 @@ const transport = requireMarkers(transportPath, [
   'pub module_name: String',
   'pub entity_name: String',
   'pub schema_version: String',
+  'pub locale: Option<String>',
   'pub struct IndexReplayCancelInput',
   'pub job_id: String',
+  'const MAX_LOCALE_BYTES: usize = 32;',
   'const GRAPHQL_REPLAY_PAGE_LIMIT: usize = 100;',
   'const GRAPHQL_REPLAY_MAX_PAGES: usize = 8;',
   'const GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES: usize = 1;',
@@ -37,6 +39,10 @@ const transport = requireMarkers(transportPath, [
   'permissions_for(&tenant_id, &actor_id)',
   'has_effective_permission(&permissions, &Permission::MODULES_MANAGE)',
   'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
+  'let locale = parse_locale(input.locale)?;',
+  'rustok_index::LocaleKey::new(locale)',
+  'rustok_index::IndexReplayRunRequest::for_locale(',
+  'rustok_index::IndexReplayRunRequest::new(',
   'let worker_id = format!("graphql-replay-{}", Uuid::new_v4().simple());',
   '.get::<IndexReplayOperatorRuntime>()',
   'let stop_handle = ctx.data::<StopHandle>()?.clone();',
@@ -44,6 +50,7 @@ const transport = requireMarkers(transportPath, [
   '.request_cancel(operator_context, job_id)',
   'replay_transport_authorizes_before_parsing_untrusted_run_input',
   'replay_transport_derives_authority_worker_and_server_owned_budgets',
+  'replay_transport_canonicalizes_optional_locale_after_authorization',
   'replay_cancel_authorizes_before_job_id_parsing_and_derives_tenant',
 ]);
 
@@ -54,18 +61,20 @@ const permissionCheck = transport.indexOf(
 );
 const runPrepare = transport.indexOf('fn prepare_authorized_run(');
 const runAuthorize = transport.indexOf('let context = authorize(tenant_id, actor_id)?;', runPrepare);
-const runParse = transport.indexOf(
+const runSchemaParse = transport.indexOf(
   'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
   runPrepare,
 );
+const runLocaleParse = transport.indexOf('let locale = parse_locale(input.locale)?;', runPrepare);
 if (
   authorizeStart < 0 ||
   permissionCheck < authorizeStart ||
   runPrepare < 0 ||
   runAuthorize < runPrepare ||
-  runParse <= runAuthorize
+  runSchemaParse <= runAuthorize ||
+  runLocaleParse <= runAuthorize
 ) {
-  fail('run transport must authorize before parsing untrusted schema input');
+  fail('run transport must authorize before parsing untrusted schema/locale input');
 }
 
 const cancelPrepare = transport.indexOf('fn prepare_authorized_cancel(');
@@ -87,7 +96,6 @@ for (const forbidden of [
   'max_pages',
   'heartbeat',
   'lease',
-  'locale',
   'partition',
   'source_name',
   'StopHandle',
@@ -95,6 +103,9 @@ for (const forbidden of [
   'Uuid',
 ]) {
   if (runInput.includes(forbidden)) fail(`replay run input contains caller-owned field marker ${forbidden}`);
+}
+if (!runInput.includes('locale: Option<String>')) {
+  fail('replay run input must expose only one optional locale scope extension');
 }
 
 const production = transport.split('\n#[cfg(test)]')[0];
@@ -145,10 +156,11 @@ requireMarkers('apps/server/src/services/app_lifecycle.rs', [
   'pub fn is_stopping(&self) -> bool',
 ]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `source_complete_shutdown_bound_execution_pending`.',
+  'Status: `locale_source_complete_execution_pending`.',
   '`runIndexReplay(input: ...)`',
   '`cancelIndexReplay(input: ...)`',
   'Tenant and actor identities are never accepted',
+  'optional canonicalizable locale',
   'page limit: `100` mutations',
   'maximum pages: `8`',
   'lease duration: `60` seconds',
@@ -157,4 +169,4 @@ requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
   'maintainer-owned',
 ]);
 
-console.log('[verify-index-replay-graphql-transport] guarded schema-wide replay run is bound to the server-owned StopHandle probe; cancel and caller input remain independent of shutdown control');
+console.log('[verify-index-replay-graphql-transport] guarded schema/locale replay run is authorized before optional locale parsing, bounded by server policy and bound to the server-owned StopHandle probe');

--- a/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
+++ b/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
@@ -72,8 +72,9 @@ for (const forbidden of ['pub partition', 'partition_key', 'targeted_rebuild', '
 
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
   'optional canonicalizable locale',
-  'Omitting locale remains exactly schema-wide',
-  '`partition_key` remains empty',
+  'Omission is not inferred from schema metadata',
+  'The terminal success fence checks the checkpoint using the leased locale',
+  '`partition_key`',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-locale-replay-runner-graphql.md', [
   'runner_graphql_source_complete_execution_pending',

--- a/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
+++ b/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-locale-runner-graphql] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = requireMarkers(runnerPath, [
+  'pub fn for_locale(',
+  'pub fn locale(&self) -> Option<&LocaleKey>',
+  'fn lease_request_for_run(',
+  'IndexReplayJobLeaseRequest::for_locale(',
+  'IndexReplayJobLeaseRequest::new(',
+  'lease.locale()',
+  'checkpoint.locale_key = {prefix}9',
+  "checkpoint.partition_key = ''",
+]);
+if (runner.includes("checkpoint.locale_key = ''")) {
+  fail(`${runnerPath} must not hard-code schema locale in the terminal success fence`);
+}
+for (const forbidden of ['partition_key()', 'partition: Option', 'targeted_rebuild', 'shadow_rebuild']) {
+  if (runner.includes(forbidden)) fail(`${runnerPath} absorbed forbidden later scope: ${forbidden}`);
+}
+
+const gracefulPath =
+  'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';
+const graceful = requireMarkers(gracefulPath, [
+  'let lease_request = lease_request_for_run(&request, source_name)?;',
+  'run_next_page_interruptible(request.page_request().clone()',
+  'yield_after_host_interruption',
+]);
+if (graceful.includes('IndexReplayJobLeaseRequest::new(')) {
+  fail(`${gracefulPath} must use the common scoped lease helper`);
+}
+
+const graphqlPath = 'apps/server/src/graphql/index_replay.rs';
+const graphql = requireMarkers(graphqlPath, [
+  'const MAX_LOCALE_BYTES: usize = 32;',
+  'pub locale: Option<String>',
+  'let context = authorize(tenant_id, actor_id)?;',
+  'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
+  'let locale = parse_locale(input.locale)?;',
+  'rustok_index::LocaleKey::new(locale)',
+  'rustok_index::IndexReplayRunRequest::for_locale(',
+  'rustok_index::IndexReplayRunRequest::new(',
+  'locale: Some("EN-us".to_owned())',
+  'Some("en-US")',
+]);
+const authorization = graphql.indexOf('let context = authorize(tenant_id, actor_id)?;');
+const schemaParse = graphql.indexOf('let schema = parse_schema(', authorization);
+const localeParse = graphql.indexOf('let locale = parse_locale(input.locale)?;', authorization);
+if (authorization < 0 || schemaParse <= authorization || localeParse <= authorization) {
+  fail(`${graphqlPath} must authorize before parsing schema or locale input`);
+}
+for (const forbidden of ['pub partition', 'partition_key', 'targeted_rebuild', 'shadow_rebuild']) {
+  if (graphql.includes(forbidden)) fail(`${graphqlPath} exposed forbidden later scope: ${forbidden}`);
+}
+
+requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
+  'optional canonicalizable locale',
+  'Omitting locale remains exactly schema-wide',
+  '`partition_key` remains empty',
+]);
+requireMarkers('crates/rustok-index/docs/m6-locale-replay-runner-graphql.md', [
+  'runner_graphql_source_complete_execution_pending',
+  'checkpoint.locale_key',
+  'Partition replay must remain blocked',
+  'end-to-end retained locale replay/restart execution',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  'Carry optional locale through the multi-page replay runner and GraphQL command transport',
+  'Add partition replay scope only after a real partition-capable source contract exists',
+  'Add explicit targeted/full/shadow rebuild modes under a separate contract',
+]);
+
+console.log('[verify-index-replay-locale-runner-graphql] source contract markers present');


### PR DESCRIPTION
## Summary

- carry optional canonical `LocaleKey` through `IndexReplayRunRequest` while preserving the existing schema-wide constructor and omission behavior;
- make ordinary and interruptible multi-page runners derive durable job lease scope from the same page request locale identity;
- fix terminal replay success so completion checks the leased locale checkpoint instead of hard-coding `locale_key = ''`, while keeping `partition_key = ''`;
- expose optional bounded GraphQL `locale` only after request authority is established and canonicalize through `LocaleKey`;
- preserve server-owned worker identity, page/heartbeat/lease budgets, cancellation and graceful-shutdown semantics;
- actualize the current `rustok-index` execution plan so merged locale source/Product/job/checkpoint work is recorded separately from pending execution evidence, partition scope and targeted/full/shadow rebuild modes;
- add a focused locale runner/GraphQL source guard, register the previously omitted #3311 checkpoint-worker guard in the aggregate, and actualize stale GraphQL/shutdown guards found during recheck.

## Recheck findings

- #3311 intentionally stopped before multi-page runner/GraphQL locale exposure;
- `finish_success` still required an empty locale checkpoint, so a future locale runner could not honestly terminalize;
- `verify-index-query-contract.mjs` did not include `verify-index-replay-locale-checkpoint-worker.mjs` from #3311;
- the existing GraphQL transport guard still prohibited `locale` and the shutdown evidence guard contained stale source markers even on reviewed `main`.

## Boundary

This PR does not add partition-scoped replay, targeted/full/shadow rebuild modes, scheduling/retry-policy changes, serving changes, or new cancellation semantics. Locale omission remains schema-wide. Runtime execution/admission remains maintainer-owned.

`main` advanced after branch creation through Product-only #3314; its changed paths are disjoint from this PR.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.