### PR TITLE
feat(forum): reconcile accepted solution state

### DIFF
--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -242,7 +242,7 @@ remain pending.
 | `FORUM-30` | `planned` | Complete Forum admin by composing Forum and shared owners. |
 | `FORUM-31` | `planned` | Complete Forum storefront by composing Profiles, Media, Reactions, Notifications and Search. |
 | `FORUM-32` | `in_progress` | Generated Forum Fly blocks/renderers/property contracts, Forum-owned preview service/HTTP/native transport, provider-neutral Pages host composition and owner-backed schema/validation property editing are source-ready. Retained runtime/browser evidence and observed Page Builder Wave evidence remain. |
-| `FORUM-33` | `in_progress` | Bounded snapshot-consistent owner counter reconciliation report with independent topic/category keyset cursors, strict operator GraphQL/owner admission and baseline platform telemetry are source-ready. Retain SQLite/PostgreSQL execution evidence and remaining reconciliation/metrics. Multi-page scans use page-local snapshots; repair remains blocked on dry-run/audit/idempotent job state and CLI integration awaits a synchronized dependency/lock update. |
+| `FORUM-33` | `in_progress` | Bounded snapshot-consistent owner counter and accepted-solution reconciliation with independent keyset cursors, strict operator GraphQL/owner admission and baseline platform telemetry are source-ready. Retain SQLite/PostgreSQL execution evidence and add subscriptions/mentions/attachments/permitted shared-owner reconciliation plus remaining metrics. Multi-page scans use page-local snapshots; repair remains blocked on dry-run/audit/idempotent job state and CLI integration awaits a synchronized dependency/lock update. |
 | `FORUM-34` | `planned` | Forum import/export adapter and NodeBB mapping over a shared runner. |
 | `NOTIFY-00` | `in_progress` | Neutral API/runtime composition and Forum providers exist; executable distribution evidence remains. |
 | `NOTIFY-01` | `in_progress` | Persistence/source inbox exist; final commands, migrations, retention and reconciliation remain. |
@@ -303,7 +303,7 @@ optional owner selection and host materialization boundary.
 
 The Reactions-disabled Forum composition remains valid: Forum commands and reads
 continue without owner storage or a materialized reaction registry. Reactions
-without Forum or Blog materializes an empty source registry; Forum with Reactions
+without Forum or Blog materializes an empty registry; Forum with Reactions
 materializes the `forum` source with `topic` and `reply` kinds. Blog is the
 second real producer and materializes the `blog` source with `post` while using
 Blog-owned positive version, `published` lifecycle and typed channel visibility.
@@ -631,8 +631,9 @@ These commands remain maintainer-run in this source slice.
 
 **Status:** `in_progress`
 
-FORUM-33A/B provide a read-only `ForumCounterReconciliationService` and the
-operator GraphQL field:
+FORUM-33A/B provide the read-only `ForumCounterReconciliationService`; FORUM-33C
+adds a sibling read-only `ForumSolutionReconciliationService`. Both are exposed
+through the same operator GraphQL query object:
 
 ```text
 forumCounterReconciliationReport(
@@ -640,50 +641,55 @@ forumCounterReconciliationReport(
   topicAfter: UUID,
   categoryAfter: UUID
 )
+
+forumSolutionReconciliationReport(
+  limit: Int,
+  solutionAfter: UUID,
+  solutionStatAfter: UUID
+)
 ```
 
-Tenant identity comes only from the trusted request `TenantContext`; the
-transport rejects auth/tenant mismatch and requires both effective
-`forum_categories:manage` and `forum_topics:manage` permissions. The owner service
-independently reauthorizes the same two Manage scopes through the canonical Forum
-RBAC helper before opening a database transaction.
+Tenant identity comes only from trusted request `TenantContext`. The transport
+rejects auth/tenant mismatch and requires both effective
+`forum_categories:manage` and `forum_topics:manage` permissions. Both owner
+services independently reauthorize the same two Manage scopes through the
+canonical Forum RBAC helper before opening a database transaction.
 
-The report reconciles three existing publication-accounting invariants without
-mutating owner state: `forum_topics.reply_count` against approved replies,
-`forum_categories.topic_count` against current topic rows, and
+Counter reconciliation checks `forum_topics.reply_count` against approved
+replies, `forum_categories.topic_count` against current topic rows, and
 `forum_categories.reply_count` against approved replies across category topics.
-Every page executes two bounded aggregate queries inside one database snapshot.
-PostgreSQL uses `REPEATABLE READ READ ONLY`; SQLite keeps both reads in one
-transaction. The default per-shape limit is 100 and the hard cap is 500.
+Topic/category continuation is independent and uses strict UUID `id > cursor`
+keysets with default 100 / hard 500 rows per shape.
 
-Topic/category continuation is independent and keyset-based. Each shape orders by
-its owner UUID and uses a strict `id > cursor` predicate, never OFFSET. The
-response returns `topicCursor` / `categoryCursor` plus the existing
-`hasMoreTopics` / `hasMoreCategories` flags. A cursor remains stable when its
-shape returns no rows, so a caller can keep an exhausted category cursor while
-advancing topics, or vice versa, without rescanning the exhausted side. Omitting
-both cursors preserves the original first-page behavior through the compatibility
-`report(...)` wrapper.
+Accepted-solution reconciliation treats `forum_solutions` as authority. The
+selected reply must remain the exact same-tenant/topic reply and must still be
+`approved`; non-public or missing replies produce `accepted_reply_eligibility`
+drift. `forum_user_stats.solution_count` remains only a Forum projection. The
+solution report detects a missing user-stat row for an approved accepted-solution
+author and exact stored-vs-expected `solution_count` drift, including stale
+positive counts when no accepted solution remains. Solution rows and user-stat
+rows have independent strict UUID keyset cursors.
 
-Snapshot consistency is page-local. A multi-page operator scan intentionally does
-not hold one database transaction across requests; rows created or changed behind
-an already-returned cursor are observed by a later full reconciliation scan. This
-is a bounded diagnostic source, not a serializable repair fence.
+Every report call is snapshot-consistent within its page. PostgreSQL uses
+`REPEATABLE READ READ ONLY`; SQLite keeps all report reads in one transaction.
+Multi-page scans are deliberately page-local and are not a cross-request
+serializable repair fence. `clean` is page-local; whole-tenant clean requires
+exhausting every relevant cursor chain with every page clean.
 
-The service reuses the platform module-entrypoint/span/error metrics rather than
+The services reuse platform module-entrypoint/span/error metrics rather than
 adding duplicate Forum metric families. Source-ready reporting does not claim
 runtime observability evidence.
 
-FORUM-33 remains `in_progress`. Retain clean/drift/snapshot SQLite and PostgreSQL
-execution evidence for first-page and multi-page traversal, exhausted-one-side
-continuation and page-local snapshot behavior. The next source reconciliation
-work is accepted-solution state, subscriptions, mentions, attachments and
-permitted shared-owner projections, followed by non-duplicative operational
-metrics for moderation, notification/search lag, unread/activity, locale fallback
-and spam outcomes. Any write repair remains blocked until it has explicit
-operator RBAC, dry-run behavior, durable audit, idempotent job/receipt state and
-bounded recovery. A platform CLI adapter must be added only with its synchronized
-workspace dependency and `Cargo.lock` update.
+FORUM-33 remains `in_progress`. Retain SQLite and PostgreSQL execution evidence
+for counter and accepted-solution clean/drift pages, independent multi-page
+cursor traversal, exhausted-one-side behavior and concurrent page-local snapshot
+semantics. The next source reconciliation slice is subscriptions, followed by
+mentions, attachments and permitted shared-owner projections. Add only
+non-duplicative operational metrics for moderation, notification/search lag,
+unread/activity, locale fallback and spam outcomes. Any write repair remains
+blocked until it has explicit operator RBAC, dry-run behavior, durable audit,
+idempotent job/receipt state and bounded recovery. A platform CLI adapter must be
+added only with its synchronized workspace dependency and `Cargo.lock` update.
 
 ### `FORUM-30`/`FORUM-31`: UI composition
 
@@ -733,13 +739,15 @@ Hosts register/mount packages and do not absorb policy.
 - Existing Forum votes remain source-compatible. Do not reinterpret them as
   reactions without explicit semantic mapping and migration.
 - Forum statistics are projections, not a reputation ledger.
-- Forum counter reconciliation is read-only in FORUM-33A/B. Topic/category
-  continuation uses independent strict UUID keyset cursors and page-local
-  snapshots; it must not be treated as a cross-request serializable repair fence.
-  No transport may repair owner counters until the write path has explicit RBAC,
-  dry-run, audit, idempotent job/receipt state and bounded recovery. Shared-owner
-  reconciliation must use public owner contracts and must not read another
-  module's private tables.
+- Forum reconciliation is read-only in FORUM-33A/B/C. Counter, accepted-solution
+  and solution-stat traversal use independent strict UUID keyset cursors and
+  page-local snapshots; they must not be treated as a cross-request serializable
+  repair fence. `forum_solutions` remains accepted-solution authority while
+  `forum_user_stats.solution_count` remains only a projection. No transport may
+  repair owner counters/solution projections until the write path has explicit
+  RBAC, dry-run, audit, idempotent job/receipt state and bounded recovery.
+  Shared-owner reconciliation must use public owner contracts and must not read
+  another module's private tables.
 - Forum moderation state remains authoritative Forum state while Moderation
   decisions are applied idempotently through an adapter.
 - Forum depends only on `rustok-moderation-api`, not the Moderation owner crate;
@@ -955,14 +963,15 @@ add another Forum-local schema/data authority. Replace synthetic Wave evidence
 only after the existing Pages reference-consumer execution gate and the Forum
 executable packet are accepted.
 
-For FORUM-33, retain SQLite and PostgreSQL execution evidence for clean and
-drifted first pages plus multi-page topic/category keyset traversal,
-exhausted-one-side continuation and one concurrent-write page-local snapshot
-case. The next source reconciliation slice is accepted-solution state, followed
-by subscriptions, mentions, attachments and permitted shared-owner projections.
-Do not add write repair until operator RBAC, dry-run, durable audit, idempotent
-job/receipt state and bounded recovery are designed together. Add a Forum CLI
-adapter only with the synchronized workspace dependency and `Cargo.lock` update.
+For FORUM-33, retain SQLite and PostgreSQL execution evidence for clean/drifted
+counter pages and accepted-solution pages, including relation eligibility,
+missing solution-author stats, stale/mismatched `solution_count`, independent
+multi-page cursor traversal, exhausted-one-side behavior and concurrent
+page-local snapshot cases. The next source reconciliation slice is subscriptions,
+followed by mentions, attachments and permitted shared-owner projections. Do not
+add write repair until operator RBAC, dry-run, durable audit, idempotent job/receipt
+state and bounded recovery are designed together. Add a Forum CLI adapter only
+with the synchronized workspace dependency and `Cargo.lock` update.
 
 Regenerate the event-contract digests and retain release verification for the
 current `Cargo.lock`, then retain SQLite and PostgreSQL evidence for changed/

--- a/crates/rustok-forum/docs/implementation-plan.md
+++ b/crates/rustok-forum/docs/implementation-plan.md
@@ -303,7 +303,7 @@ optional owner selection and host materialization boundary.
 
 The Reactions-disabled Forum composition remains valid: Forum commands and reads
 continue without owner storage or a materialized reaction registry. Reactions
-without Forum or Blog materializes an empty registry; Forum with Reactions
+without Forum or Blog materializes an empty source registry; Forum with Reactions
 materializes the `forum` source with `topic` and `reply` kinds. Blog is the
 second real producer and materializes the `blog` source with `post` while using
 Blog-owned positive version, `published` lifecycle and typed channel visibility.

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -52,7 +52,8 @@ pub use quote_commands::{
 };
 pub use read_state::*;
 pub use reconciliation_query::{
-    GqlForumCounterDrift, GqlForumCounterReconciliationReport,
+    GqlForumCounterDrift, GqlForumCounterReconciliationReport, GqlForumSolutionDrift,
+    GqlForumSolutionReconciliationReport,
 };
 pub use runtime_data::{ForumGraphqlRuntimeData, attach_schema_data};
 pub use storefront_read_state::*;
@@ -103,7 +104,7 @@ pub struct ForumMutation(
     storefront_read_state::ForumStorefrontReadStateMutation,
     topic_fork_mutation::ForumTopicForkMutation,
     topic_merge_mutation::ForumTopicMergeMutation,
-    topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation,
+    topic_reply_range_move_mutation::ForumReplyRangeMoveMutation,
     topic_slug_rename_mutation::ForumTopicSlugRenameMutation,
     topic_split_mutation::ForumTopicSplitMutation,
 );

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -104,7 +104,7 @@ pub struct ForumMutation(
     storefront_read_state::ForumStorefrontReadStateMutation,
     topic_fork_mutation::ForumTopicForkMutation,
     topic_merge_mutation::ForumTopicMergeMutation,
-    topic_reply_range_move_mutation::ForumReplyRangeMoveMutation,
+    topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation,
     topic_slug_rename_mutation::ForumTopicSlugRenameMutation,
     topic_split_mutation::ForumTopicSplitMutation,
 );

--- a/crates/rustok-forum/src/graphql/reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/reconciliation_query.rs
@@ -10,6 +10,10 @@ use uuid::Uuid;
 
 use crate::{
     ForumCounterDrift, ForumCounterReconciliationReport, ForumCounterReconciliationService,
+    services::{
+        ForumSolutionDrift, ForumSolutionReconciliationReport,
+        ForumSolutionReconciliationService,
+    },
 };
 
 const MODULE_SLUG: &str = "forum";
@@ -39,6 +43,31 @@ pub struct GqlForumCounterReconciliationReport {
     pub drifts: Vec<GqlForumCounterDrift>,
 }
 
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumSolutionDrift {
+    pub kind: String,
+    pub subject_id: Uuid,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumSolutionReconciliationReport {
+    pub requested_limit: Option<i32>,
+    pub effective_limit: i32,
+    pub inspected_solutions: i32,
+    pub inspected_solution_stats: i32,
+    pub has_more_solutions: bool,
+    pub has_more_solution_stats: bool,
+    pub solution_cursor: Option<Uuid>,
+    pub solution_stat_cursor: Option<Uuid>,
+    pub drift_count: i32,
+    /// True only when the current bounded accepted-solution/stat page contains no detected drift.
+    /// Whole-tenant clean requires exhausting both cursor chains with every page clean.
+    pub clean: bool,
+    pub drifts: Vec<GqlForumSolutionDrift>,
+}
+
 #[derive(Default)]
 pub struct ForumReconciliationQuery;
 
@@ -60,24 +89,11 @@ impl ForumReconciliationQuery {
         topic_after: Option<Uuid>,
         category_after: Option<Uuid>,
     ) -> Result<GqlForumCounterReconciliationReport> {
-        require_module_enabled(ctx, MODULE_SLUG).await?;
-        let auth = ctx
-            .data::<AuthContext>()
-            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
-        require_operations_permissions(auth)?;
-        let tenant = ctx.data::<TenantContext>()?;
-        if auth.tenant_id != tenant.id {
-            return Err(<FieldError as GraphQLError>::permission_denied(
-                "Permission denied: tenant scope mismatch",
-            ));
-        }
-        let requested_limit = normalize_limit(limit)?;
-        let db = ctx.data::<DatabaseConnection>()?;
-        let security =
-            SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
-        let report = ForumCounterReconciliationService::new(db.clone())
+        let (tenant_id, security, requested_limit, db) =
+            reconciliation_context(ctx, limit).await?;
+        let report = ForumCounterReconciliationService::new(db)
             .report_page(
-                tenant.id,
+                tenant_id,
                 &security,
                 requested_limit,
                 topic_after,
@@ -86,6 +102,55 @@ impl ForumReconciliationQuery {
             .await?;
         Ok(map_report(report))
     }
+
+    /// Read-only FORUM-33 accepted-solution and solution-author-stat drift report.
+    ///
+    /// A solution is authoritative only when the exact same-tenant/topic reply still exists and is
+    /// `approved`. `forum_user_stats.solution_count` is reconciled as a projection of those approved
+    /// solution rows. `solution_after` and `solution_stat_after` are independent UUID keyset cursors.
+    /// `clean` is page-local and is not whole-tenant proof until both cursor chains are exhausted.
+    async fn forum_solution_reconciliation_report(
+        &self,
+        ctx: &Context<'_>,
+        limit: Option<i32>,
+        solution_after: Option<Uuid>,
+        solution_stat_after: Option<Uuid>,
+    ) -> Result<GqlForumSolutionReconciliationReport> {
+        let (tenant_id, security, requested_limit, db) =
+            reconciliation_context(ctx, limit).await?;
+        let report = ForumSolutionReconciliationService::new(db)
+            .report_page(
+                tenant_id,
+                &security,
+                requested_limit,
+                solution_after,
+                solution_stat_after,
+            )
+            .await?;
+        Ok(map_solution_report(report))
+    }
+}
+
+async fn reconciliation_context(
+    ctx: &Context<'_>,
+    limit: Option<i32>,
+) -> Result<(Uuid, SecurityContext, Option<u64>, DatabaseConnection)> {
+    require_module_enabled(ctx, MODULE_SLUG).await?;
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    require_operations_permissions(auth)?;
+    let tenant = ctx.data::<TenantContext>()?;
+    if auth.tenant_id != tenant.id {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: tenant scope mismatch",
+        ));
+    }
+    let requested_limit = normalize_limit(limit)?;
+    let db = ctx.data::<DatabaseConnection>()?.clone();
+    let security =
+        SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
+    Ok((tenant.id, security, requested_limit, db))
 }
 
 fn require_operations_permissions(auth: &AuthContext) -> Result<()> {
@@ -109,7 +174,7 @@ fn normalize_limit(limit: Option<i32>) -> Result<Option<u64>> {
         None => Ok(None),
         Some(value) if value > 0 => Ok(Some(value as u64)),
         Some(_) => Err(async_graphql::Error::new(
-            "Forum counter reconciliation limit must be positive",
+            "Forum reconciliation limit must be positive",
         )),
     }
 }
@@ -133,6 +198,34 @@ fn map_report(report: ForumCounterReconciliationReport) -> GqlForumCounterReconc
 
 fn map_drift(drift: ForumCounterDrift) -> GqlForumCounterDrift {
     GqlForumCounterDrift {
+        kind: drift.kind.as_str().to_string(),
+        subject_id: drift.subject_id,
+        stored: drift.stored,
+        expected: drift.expected,
+    }
+}
+
+fn map_solution_report(
+    report: ForumSolutionReconciliationReport,
+) -> GqlForumSolutionReconciliationReport {
+    let requested_limit = report.requested_limit.map(saturating_i32);
+    GqlForumSolutionReconciliationReport {
+        requested_limit,
+        effective_limit: saturating_i32(report.effective_limit),
+        inspected_solutions: saturating_i32(report.inspected_solutions),
+        inspected_solution_stats: saturating_i32(report.inspected_solution_stats),
+        has_more_solutions: report.has_more_solutions,
+        has_more_solution_stats: report.has_more_solution_stats,
+        solution_cursor: report.solution_cursor,
+        solution_stat_cursor: report.solution_stat_cursor,
+        drift_count: saturating_i32(report.drift_count() as u64),
+        clean: report.is_clean(),
+        drifts: report.drifts.into_iter().map(map_solution_drift).collect(),
+    }
+}
+
+fn map_solution_drift(drift: ForumSolutionDrift) -> GqlForumSolutionDrift {
+    GqlForumSolutionDrift {
         kind: drift.kind.as_str().to_string(),
         subject_id: drift.subject_id,
         stored: drift.stored,
@@ -205,5 +298,24 @@ mod tests {
         });
         assert_eq!(mapped.topic_cursor, Some(topic_cursor));
         assert_eq!(mapped.category_cursor, Some(category_cursor));
+    }
+
+    #[test]
+    fn mapped_solution_report_preserves_independent_cursors() {
+        let solution_cursor = Uuid::new_v4();
+        let solution_stat_cursor = Uuid::new_v4();
+        let mapped = map_solution_report(ForumSolutionReconciliationReport {
+            requested_limit: Some(25),
+            effective_limit: 25,
+            inspected_solutions: 25,
+            inspected_solution_stats: 8,
+            has_more_solutions: true,
+            has_more_solution_stats: false,
+            solution_cursor: Some(solution_cursor),
+            solution_stat_cursor: Some(solution_stat_cursor),
+            drifts: Vec::new(),
+        });
+        assert_eq!(mapped.solution_cursor, Some(solution_cursor));
+        assert_eq!(mapped.solution_stat_cursor, Some(solution_stat_cursor));
     }
 }

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -42,6 +42,7 @@ mod category_tree {
 }
 mod category_visibility;
 mod counter_reconciliation;
+mod solution_reconciliation;
 pub mod event;
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]
 mod mention_relation;
@@ -181,6 +182,10 @@ pub use counter_reconciliation::{
     DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, ForumCounterDrift, ForumCounterDriftKind,
     ForumCounterReconciliationReport, ForumCounterReconciliationService,
     MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
+};
+pub use solution_reconciliation::{
+    ForumSolutionDrift, ForumSolutionDriftKind, ForumSolutionReconciliationReport,
+    ForumSolutionReconciliationService,
 };
 pub use event::ForumEventService;
 #[allow(unused_imports)]

--- a/crates/rustok-forum/src/services/solution_reconciliation.rs
+++ b/crates/rustok-forum/src/services/solution_reconciliation.rs
@@ -231,17 +231,17 @@ impl ForumSolutionReconciliationService {
 
             let author_id: Option<Uuid> = row.try_get("", "author_id")?;
             let author_stat_exists: i64 = row.try_get("", "author_stat_exists")?;
-            if eligible == 1
-                && author_stat_exists == 0
-                && let Some(author_id) = author_id
-                && missing_stat_authors.insert(author_id)
-            {
-                drifts.push(ForumSolutionDrift {
-                    kind: ForumSolutionDriftKind::SolutionAuthorStatMissing,
-                    subject_id: author_id,
-                    stored: 0,
-                    expected: 1,
-                });
+            if eligible == 1 && author_stat_exists == 0 {
+                if let Some(author_id) = author_id {
+                    if missing_stat_authors.insert(author_id) {
+                        drifts.push(ForumSolutionDrift {
+                            kind: ForumSolutionDriftKind::SolutionAuthorStatMissing,
+                            subject_id: author_id,
+                            stored: 0,
+                            expected: 1,
+                        });
+                    }
+                }
             }
         }
 

--- a/crates/rustok-forum/src/services/solution_reconciliation.rs
+++ b/crates/rustok-forum/src/services/solution_reconciliation.rs
@@ -1,0 +1,584 @@
+use std::{collections::HashSet, time::Instant};
+
+use rustok_api::{Action, Resource};
+use rustok_core::SecurityContext;
+use sea_orm::{
+    AccessMode, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction,
+    IsolationLevel, Statement, TransactionTrait,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::{
+    counter_reconciliation::{
+        DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
+    },
+    rbac::enforce_scope,
+};
+use crate::error::{ForumError, ForumResult};
+
+const FORUM_SOLUTION_RECONCILIATION_OPERATION: &str = "forum.solution_reconciliation_report";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumSolutionDriftKind {
+    AcceptedReplyEligibility,
+    SolutionAuthorStatMissing,
+    SolutionAuthorStatCount,
+}
+
+impl ForumSolutionDriftKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AcceptedReplyEligibility => "accepted_reply_eligibility",
+            Self::SolutionAuthorStatMissing => "solution_author_stat_missing",
+            Self::SolutionAuthorStatCount => "solution_author_stat_count",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumSolutionDrift {
+    pub kind: ForumSolutionDriftKind,
+    pub subject_id: Uuid,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumSolutionReconciliationReport {
+    pub requested_limit: Option<u64>,
+    pub effective_limit: u64,
+    pub inspected_solutions: u64,
+    pub inspected_solution_stats: u64,
+    pub has_more_solutions: bool,
+    pub has_more_solution_stats: bool,
+    pub solution_cursor: Option<Uuid>,
+    pub solution_stat_cursor: Option<Uuid>,
+    pub drifts: Vec<ForumSolutionDrift>,
+}
+
+impl ForumSolutionReconciliationReport {
+    pub fn drift_count(&self) -> usize {
+        self.drifts.len()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.drifts.is_empty()
+    }
+}
+
+/// Read-only reconciliation for Forum accepted-solution authority and its user-stat projection.
+///
+/// The source of truth is `forum_solutions` plus the exact same-tenant/topic reply relation. A
+/// solution is operationally eligible only while its reply is `approved`; non-public reply states
+/// are not accepted solutions. `forum_user_stats.solution_count` is treated only as a projection of
+/// approved solution rows authored by that user.
+///
+/// Solution rows and solution-stat rows have independent UUID keyset cursors. Every page is fenced
+/// by one database snapshot, but a multi-page scan intentionally does not keep a transaction open
+/// across requests. This diagnostic service performs no repair.
+pub struct ForumSolutionReconciliationService {
+    db: DatabaseConnection,
+}
+
+impl ForumSolutionReconciliationService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn report_page(
+        &self,
+        tenant_id: Uuid,
+        security: &SecurityContext,
+        requested_limit: Option<u64>,
+        solution_after: Option<Uuid>,
+        solution_stat_after: Option<Uuid>,
+    ) -> ForumResult<ForumSolutionReconciliationReport> {
+        rustok_telemetry::metrics::record_module_entrypoint_call(
+            "forum",
+            "solution_reconciliation_report",
+            "library",
+        );
+        let started_at = Instant::now();
+        let result = match enforce_operations_scope(security) {
+            Ok(()) => {
+                self.report_inner(
+                    tenant_id,
+                    requested_limit,
+                    solution_after,
+                    solution_stat_after,
+                )
+                .await
+            }
+            Err(error) => Err(error),
+        };
+        rustok_telemetry::metrics::record_span_duration(
+            FORUM_SOLUTION_RECONCILIATION_OPERATION,
+            started_at.elapsed().as_secs_f64(),
+        );
+        if result.is_err() {
+            rustok_telemetry::metrics::record_span_error(
+                FORUM_SOLUTION_RECONCILIATION_OPERATION,
+                "owner_report",
+            );
+            rustok_telemetry::metrics::record_module_error(
+                "forum",
+                "solution_reconciliation",
+                "error",
+            );
+        }
+        result
+    }
+
+    async fn report_inner(
+        &self,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+        solution_after: Option<Uuid>,
+        solution_stat_after: Option<Uuid>,
+    ) -> ForumResult<ForumSolutionReconciliationReport> {
+        let backend = self.db.get_database_backend();
+        let transaction = match backend {
+            DatabaseBackend::Postgres => {
+                self.db
+                    .begin_with_config(
+                        Some(IsolationLevel::RepeatableRead),
+                        Some(AccessMode::ReadOnly),
+                    )
+                    .await?
+            }
+            DatabaseBackend::Sqlite => self.db.begin().await?,
+            other => {
+                return Err(ForumError::Validation(format!(
+                    "Forum solution reconciliation does not support database backend {other:?}"
+                )));
+            }
+        };
+
+        let report = self
+            .report_in_transaction(
+                &transaction,
+                backend,
+                tenant_id,
+                requested_limit,
+                solution_after,
+                solution_stat_after,
+            )
+            .await;
+        match report {
+            Ok(report) => {
+                transaction.commit().await?;
+                Ok(report)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn report_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        backend: DatabaseBackend,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+        solution_after: Option<Uuid>,
+        solution_stat_after: Option<Uuid>,
+    ) -> ForumResult<ForumSolutionReconciliationReport> {
+        let effective_limit = requested_limit
+            .unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT)
+            .clamp(1, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT);
+        let fetch_limit = effective_limit.saturating_add(1);
+
+        let solution_rows = transaction
+            .query_all(solution_statement(
+                backend,
+                tenant_id,
+                solution_after,
+                fetch_limit,
+            )?)
+            .await?;
+        let stat_rows = transaction
+            .query_all(solution_stat_statement(
+                backend,
+                tenant_id,
+                solution_stat_after,
+                fetch_limit,
+            )?)
+            .await?;
+
+        let has_more_solutions = solution_rows.len() > effective_limit as usize;
+        let has_more_solution_stats = stat_rows.len() > effective_limit as usize;
+        let mut solution_cursor = solution_after;
+        let mut solution_stat_cursor = solution_stat_after;
+        let mut drifts = Vec::new();
+        let mut missing_stat_authors = HashSet::new();
+
+        for row in solution_rows.iter().take(effective_limit as usize) {
+            let topic_id: Uuid = row.try_get("", "id")?;
+            solution_cursor = Some(topic_id);
+            let eligible: i64 = row.try_get("", "eligible")?;
+            if eligible != 1 {
+                drifts.push(ForumSolutionDrift {
+                    kind: ForumSolutionDriftKind::AcceptedReplyEligibility,
+                    subject_id: topic_id,
+                    stored: 1,
+                    expected: eligible,
+                });
+            }
+
+            let author_id: Option<Uuid> = row.try_get("", "author_id")?;
+            let author_stat_exists: i64 = row.try_get("", "author_stat_exists")?;
+            if eligible == 1
+                && author_stat_exists == 0
+                && let Some(author_id) = author_id
+                && missing_stat_authors.insert(author_id)
+            {
+                drifts.push(ForumSolutionDrift {
+                    kind: ForumSolutionDriftKind::SolutionAuthorStatMissing,
+                    subject_id: author_id,
+                    stored: 0,
+                    expected: 1,
+                });
+            }
+        }
+
+        for row in stat_rows.iter().take(effective_limit as usize) {
+            let user_id: Uuid = row.try_get("", "id")?;
+            solution_stat_cursor = Some(user_id);
+            let stored: i64 = row.try_get("", "stored_solution_count")?;
+            let expected: i64 = row.try_get("", "expected_solution_count")?;
+            if stored != expected {
+                drifts.push(ForumSolutionDrift {
+                    kind: ForumSolutionDriftKind::SolutionAuthorStatCount,
+                    subject_id: user_id,
+                    stored,
+                    expected,
+                });
+            }
+        }
+
+        Ok(ForumSolutionReconciliationReport {
+            requested_limit,
+            effective_limit,
+            inspected_solutions: solution_rows.len().min(effective_limit as usize) as u64,
+            inspected_solution_stats: stat_rows.len().min(effective_limit as usize) as u64,
+            has_more_solutions,
+            has_more_solution_stats,
+            solution_cursor,
+            solution_stat_cursor,
+            drifts,
+        })
+    }
+}
+
+fn enforce_operations_scope(security: &SecurityContext) -> ForumResult<()> {
+    enforce_scope(security, Resource::ForumCategories, Action::Manage)?;
+    enforce_scope(security, Resource::ForumTopics, Action::Manage)
+}
+
+fn solution_statement(
+    backend: DatabaseBackend,
+    tenant_id: Uuid,
+    after: Option<Uuid>,
+    limit: u64,
+) -> ForumResult<Statement> {
+    match (backend, after) {
+        (DatabaseBackend::Sqlite, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            SOLUTION_SQLITE,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Sqlite, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            SOLUTION_AFTER_SQLITE,
+            vec![tenant_id.into(), after.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            SOLUTION_POSTGRES,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            SOLUTION_AFTER_POSTGRES,
+            vec![tenant_id.into(), after.into(), (limit as i64).into()],
+        )),
+        (other, _) => Err(ForumError::Validation(format!(
+            "Forum solution reconciliation does not support database backend {other:?}"
+        ))),
+    }
+}
+
+fn solution_stat_statement(
+    backend: DatabaseBackend,
+    tenant_id: Uuid,
+    after: Option<Uuid>,
+    limit: u64,
+) -> ForumResult<Statement> {
+    match (backend, after) {
+        (DatabaseBackend::Sqlite, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            SOLUTION_STAT_SQLITE,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Sqlite, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            SOLUTION_STAT_AFTER_SQLITE,
+            vec![tenant_id.into(), after.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            SOLUTION_STAT_POSTGRES,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            SOLUTION_STAT_AFTER_POSTGRES,
+            vec![tenant_id.into(), after.into(), (limit as i64).into()],
+        )),
+        (other, _) => Err(ForumError::Validation(format!(
+            "Forum solution reconciliation does not support database backend {other:?}"
+        ))),
+    }
+}
+
+const SOLUTION_SQLITE: &str = r#"
+SELECT
+    s.topic_id AS id,
+    CASE WHEN t.id IS NOT NULL AND r.id IS NOT NULL AND r.status = 'approved' THEN 1 ELSE 0 END
+        AS eligible,
+    r.author_id AS author_id,
+    CASE WHEN r.author_id IS NULL OR us.user_id IS NOT NULL THEN 1 ELSE 0 END AS author_stat_exists
+FROM forum_solutions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+LEFT JOIN forum_replies r
+    ON r.tenant_id = s.tenant_id
+   AND r.topic_id = s.topic_id
+   AND r.id = s.reply_id
+LEFT JOIN forum_user_stats us
+    ON us.tenant_id = s.tenant_id
+   AND us.user_id = r.author_id
+WHERE s.tenant_id = ?1
+ORDER BY s.topic_id
+LIMIT ?2
+"#;
+
+const SOLUTION_AFTER_SQLITE: &str = r#"
+SELECT
+    s.topic_id AS id,
+    CASE WHEN t.id IS NOT NULL AND r.id IS NOT NULL AND r.status = 'approved' THEN 1 ELSE 0 END
+        AS eligible,
+    r.author_id AS author_id,
+    CASE WHEN r.author_id IS NULL OR us.user_id IS NOT NULL THEN 1 ELSE 0 END AS author_stat_exists
+FROM forum_solutions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+LEFT JOIN forum_replies r
+    ON r.tenant_id = s.tenant_id
+   AND r.topic_id = s.topic_id
+   AND r.id = s.reply_id
+LEFT JOIN forum_user_stats us
+    ON us.tenant_id = s.tenant_id
+   AND us.user_id = r.author_id
+WHERE s.tenant_id = ?1
+  AND s.topic_id > ?2
+ORDER BY s.topic_id
+LIMIT ?3
+"#;
+
+const SOLUTION_POSTGRES: &str = r#"
+SELECT
+    s.topic_id AS id,
+    CASE WHEN t.id IS NOT NULL AND r.id IS NOT NULL AND r.status = 'approved' THEN 1::BIGINT ELSE 0::BIGINT END
+        AS eligible,
+    r.author_id AS author_id,
+    CASE WHEN r.author_id IS NULL OR us.user_id IS NOT NULL THEN 1::BIGINT ELSE 0::BIGINT END
+        AS author_stat_exists
+FROM forum_solutions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+LEFT JOIN forum_replies r
+    ON r.tenant_id = s.tenant_id
+   AND r.topic_id = s.topic_id
+   AND r.id = s.reply_id
+LEFT JOIN forum_user_stats us
+    ON us.tenant_id = s.tenant_id
+   AND us.user_id = r.author_id
+WHERE s.tenant_id = $1
+ORDER BY s.topic_id
+LIMIT $2
+"#;
+
+const SOLUTION_AFTER_POSTGRES: &str = r#"
+SELECT
+    s.topic_id AS id,
+    CASE WHEN t.id IS NOT NULL AND r.id IS NOT NULL AND r.status = 'approved' THEN 1::BIGINT ELSE 0::BIGINT END
+        AS eligible,
+    r.author_id AS author_id,
+    CASE WHEN r.author_id IS NULL OR us.user_id IS NOT NULL THEN 1::BIGINT ELSE 0::BIGINT END
+        AS author_stat_exists
+FROM forum_solutions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+LEFT JOIN forum_replies r
+    ON r.tenant_id = s.tenant_id
+   AND r.topic_id = s.topic_id
+   AND r.id = s.reply_id
+LEFT JOIN forum_user_stats us
+    ON us.tenant_id = s.tenant_id
+   AND us.user_id = r.author_id
+WHERE s.tenant_id = $1
+  AND s.topic_id > $2
+ORDER BY s.topic_id
+LIMIT $3
+"#;
+
+const SOLUTION_STAT_SQLITE: &str = r#"
+WITH bounded_stats AS (
+    SELECT user_id, solution_count
+    FROM forum_user_stats
+    WHERE tenant_id = ?1
+    ORDER BY user_id
+    LIMIT ?2
+)
+SELECT
+    stats.user_id AS id,
+    CAST(stats.solution_count AS INTEGER) AS stored_solution_count,
+    CAST(COUNT(s.topic_id) AS INTEGER) AS expected_solution_count
+FROM bounded_stats stats
+LEFT JOIN forum_replies r
+    ON r.tenant_id = ?1
+   AND r.author_id = stats.user_id
+   AND r.status = 'approved'
+LEFT JOIN forum_solutions s
+    ON s.tenant_id = r.tenant_id
+   AND s.topic_id = r.topic_id
+   AND s.reply_id = r.id
+GROUP BY stats.user_id, stats.solution_count
+ORDER BY stats.user_id
+"#;
+
+const SOLUTION_STAT_AFTER_SQLITE: &str = r#"
+WITH bounded_stats AS (
+    SELECT user_id, solution_count
+    FROM forum_user_stats
+    WHERE tenant_id = ?1
+      AND user_id > ?2
+    ORDER BY user_id
+    LIMIT ?3
+)
+SELECT
+    stats.user_id AS id,
+    CAST(stats.solution_count AS INTEGER) AS stored_solution_count,
+    CAST(COUNT(s.topic_id) AS INTEGER) AS expected_solution_count
+FROM bounded_stats stats
+LEFT JOIN forum_replies r
+    ON r.tenant_id = ?1
+   AND r.author_id = stats.user_id
+   AND r.status = 'approved'
+LEFT JOIN forum_solutions s
+    ON s.tenant_id = r.tenant_id
+   AND s.topic_id = r.topic_id
+   AND s.reply_id = r.id
+GROUP BY stats.user_id, stats.solution_count
+ORDER BY stats.user_id
+"#;
+
+const SOLUTION_STAT_POSTGRES: &str = r#"
+WITH bounded_stats AS (
+    SELECT user_id, solution_count
+    FROM forum_user_stats
+    WHERE tenant_id = $1
+    ORDER BY user_id
+    LIMIT $2
+)
+SELECT
+    stats.user_id AS id,
+    stats.solution_count::BIGINT AS stored_solution_count,
+    COUNT(s.topic_id)::BIGINT AS expected_solution_count
+FROM bounded_stats stats
+LEFT JOIN forum_replies r
+    ON r.tenant_id = $1
+   AND r.author_id = stats.user_id
+   AND r.status = 'approved'
+LEFT JOIN forum_solutions s
+    ON s.tenant_id = r.tenant_id
+   AND s.topic_id = r.topic_id
+   AND s.reply_id = r.id
+GROUP BY stats.user_id, stats.solution_count
+ORDER BY stats.user_id
+"#;
+
+const SOLUTION_STAT_AFTER_POSTGRES: &str = r#"
+WITH bounded_stats AS (
+    SELECT user_id, solution_count
+    FROM forum_user_stats
+    WHERE tenant_id = $1
+      AND user_id > $2
+    ORDER BY user_id
+    LIMIT $3
+)
+SELECT
+    stats.user_id AS id,
+    stats.solution_count::BIGINT AS stored_solution_count,
+    COUNT(s.topic_id)::BIGINT AS expected_solution_count
+FROM bounded_stats stats
+LEFT JOIN forum_replies r
+    ON r.tenant_id = $1
+   AND r.author_id = stats.user_id
+   AND r.status = 'approved'
+LEFT JOIN forum_solutions s
+    ON s.tenant_id = r.tenant_id
+   AND s.topic_id = r.topic_id
+   AND s.reply_id = r.id
+GROUP BY stats.user_id, stats.solution_count
+ORDER BY stats.user_id
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_api::Permission;
+
+    #[test]
+    fn solution_reconciliation_requires_both_manage_scopes() {
+        let both = SecurityContext::from_permission_snapshot(
+            Some(Uuid::new_v4()),
+            &[
+                Permission::FORUM_CATEGORIES_MANAGE,
+                Permission::FORUM_TOPICS_MANAGE,
+            ],
+        );
+        assert!(enforce_operations_scope(&both).is_ok());
+
+        let topics_only = SecurityContext::from_permission_snapshot(
+            Some(Uuid::new_v4()),
+            &[Permission::FORUM_TOPICS_MANAGE],
+        );
+        assert!(enforce_operations_scope(&topics_only).is_err());
+    }
+
+    #[test]
+    fn solution_keysets_are_strictly_forward() {
+        assert!(SOLUTION_AFTER_SQLITE.contains("s.topic_id > ?2"));
+        assert!(SOLUTION_AFTER_POSTGRES.contains("s.topic_id > $2"));
+        assert!(SOLUTION_STAT_AFTER_SQLITE.contains("user_id > ?2"));
+        assert!(SOLUTION_STAT_AFTER_POSTGRES.contains("user_id > $2"));
+    }
+
+    #[test]
+    fn accepted_solution_requires_approved_reply() {
+        assert!(SOLUTION_SQLITE.contains("r.status = 'approved'"));
+        assert!(SOLUTION_POSTGRES.contains("r.status = 'approved'"));
+        assert!(SOLUTION_STAT_SQLITE.contains("r.status = 'approved'"));
+        assert!(SOLUTION_STAT_POSTGRES.contains("r.status = 'approved'"));
+    }
+}

--- a/crates/rustok-forum/src/services/solution_reconciliation.rs
+++ b/crates/rustok-forum/src/services/solution_reconciliation.rs
@@ -448,21 +448,24 @@ WITH bounded_stats AS (
     WHERE tenant_id = ?1
     ORDER BY user_id
     LIMIT ?2
+), expected_stats AS (
+    SELECT r.author_id AS user_id, COUNT(s.topic_id) AS expected_solution_count
+    FROM forum_solutions s
+    JOIN forum_replies r
+      ON r.tenant_id = s.tenant_id
+     AND r.topic_id = s.topic_id
+     AND r.id = s.reply_id
+     AND r.status = 'approved'
+    WHERE s.tenant_id = ?1
+      AND r.author_id IN (SELECT user_id FROM bounded_stats)
+    GROUP BY r.author_id
 )
 SELECT
     stats.user_id AS id,
     CAST(stats.solution_count AS INTEGER) AS stored_solution_count,
-    CAST(COUNT(s.topic_id) AS INTEGER) AS expected_solution_count
+    CAST(COALESCE(expected.expected_solution_count, 0) AS INTEGER) AS expected_solution_count
 FROM bounded_stats stats
-LEFT JOIN forum_replies r
-    ON r.tenant_id = ?1
-   AND r.author_id = stats.user_id
-   AND r.status = 'approved'
-LEFT JOIN forum_solutions s
-    ON s.tenant_id = r.tenant_id
-   AND s.topic_id = r.topic_id
-   AND s.reply_id = r.id
-GROUP BY stats.user_id, stats.solution_count
+LEFT JOIN expected_stats expected ON expected.user_id = stats.user_id
 ORDER BY stats.user_id
 "#;
 
@@ -474,21 +477,24 @@ WITH bounded_stats AS (
       AND user_id > ?2
     ORDER BY user_id
     LIMIT ?3
+), expected_stats AS (
+    SELECT r.author_id AS user_id, COUNT(s.topic_id) AS expected_solution_count
+    FROM forum_solutions s
+    JOIN forum_replies r
+      ON r.tenant_id = s.tenant_id
+     AND r.topic_id = s.topic_id
+     AND r.id = s.reply_id
+     AND r.status = 'approved'
+    WHERE s.tenant_id = ?1
+      AND r.author_id IN (SELECT user_id FROM bounded_stats)
+    GROUP BY r.author_id
 )
 SELECT
     stats.user_id AS id,
     CAST(stats.solution_count AS INTEGER) AS stored_solution_count,
-    CAST(COUNT(s.topic_id) AS INTEGER) AS expected_solution_count
+    CAST(COALESCE(expected.expected_solution_count, 0) AS INTEGER) AS expected_solution_count
 FROM bounded_stats stats
-LEFT JOIN forum_replies r
-    ON r.tenant_id = ?1
-   AND r.author_id = stats.user_id
-   AND r.status = 'approved'
-LEFT JOIN forum_solutions s
-    ON s.tenant_id = r.tenant_id
-   AND s.topic_id = r.topic_id
-   AND s.reply_id = r.id
-GROUP BY stats.user_id, stats.solution_count
+LEFT JOIN expected_stats expected ON expected.user_id = stats.user_id
 ORDER BY stats.user_id
 "#;
 
@@ -499,21 +505,24 @@ WITH bounded_stats AS (
     WHERE tenant_id = $1
     ORDER BY user_id
     LIMIT $2
+), expected_stats AS (
+    SELECT r.author_id AS user_id, COUNT(s.topic_id)::BIGINT AS expected_solution_count
+    FROM forum_solutions s
+    JOIN forum_replies r
+      ON r.tenant_id = s.tenant_id
+     AND r.topic_id = s.topic_id
+     AND r.id = s.reply_id
+     AND r.status = 'approved'
+    WHERE s.tenant_id = $1
+      AND r.author_id IN (SELECT user_id FROM bounded_stats)
+    GROUP BY r.author_id
 )
 SELECT
     stats.user_id AS id,
     stats.solution_count::BIGINT AS stored_solution_count,
-    COUNT(s.topic_id)::BIGINT AS expected_solution_count
+    COALESCE(expected.expected_solution_count, 0)::BIGINT AS expected_solution_count
 FROM bounded_stats stats
-LEFT JOIN forum_replies r
-    ON r.tenant_id = $1
-   AND r.author_id = stats.user_id
-   AND r.status = 'approved'
-LEFT JOIN forum_solutions s
-    ON s.tenant_id = r.tenant_id
-   AND s.topic_id = r.topic_id
-   AND s.reply_id = r.id
-GROUP BY stats.user_id, stats.solution_count
+LEFT JOIN expected_stats expected ON expected.user_id = stats.user_id
 ORDER BY stats.user_id
 "#;
 
@@ -525,21 +534,24 @@ WITH bounded_stats AS (
       AND user_id > $2
     ORDER BY user_id
     LIMIT $3
+), expected_stats AS (
+    SELECT r.author_id AS user_id, COUNT(s.topic_id)::BIGINT AS expected_solution_count
+    FROM forum_solutions s
+    JOIN forum_replies r
+      ON r.tenant_id = s.tenant_id
+     AND r.topic_id = s.topic_id
+     AND r.id = s.reply_id
+     AND r.status = 'approved'
+    WHERE s.tenant_id = $1
+      AND r.author_id IN (SELECT user_id FROM bounded_stats)
+    GROUP BY r.author_id
 )
 SELECT
     stats.user_id AS id,
     stats.solution_count::BIGINT AS stored_solution_count,
-    COUNT(s.topic_id)::BIGINT AS expected_solution_count
+    COALESCE(expected.expected_solution_count, 0)::BIGINT AS expected_solution_count
 FROM bounded_stats stats
-LEFT JOIN forum_replies r
-    ON r.tenant_id = $1
-   AND r.author_id = stats.user_id
-   AND r.status = 'approved'
-LEFT JOIN forum_solutions s
-    ON s.tenant_id = r.tenant_id
-   AND s.topic_id = r.topic_id
-   AND s.reply_id = r.id
-GROUP BY stats.user_id, stats.solution_count
+LEFT JOIN expected_stats expected ON expected.user_id = stats.user_id
 ORDER BY stats.user_id
 "#;
 

--- a/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md
@@ -1,16 +1,16 @@
-# FORUM-33 counter reconciliation actualization — 2026-08-08
+# FORUM-33 reconciliation actualization — 2026-08-08
 
-Status: `in-progress / bounded-owner-report-and-cursors-source-ready / repair-and-runtime-evidence-open`
+Status: `in-progress / bounded-counter-and-solution-reconciliation-source-ready / repair-and-runtime-evidence-open`
 
 ## Rechecked cursor
 
 FORUM-32 no longer has an unimplemented Forum/Page Builder source path. Its owner preview, property editing, browser harness, direct runtime-authorization harness and deployed server-function attestation are source-ready; maintainer execution, the Pages reference-consumer gate and observed Wave remain outside this source slice.
 
-FORUM-33A established the first read-only owner counter reconciliation page. FORUM-33B closes the next source gap by adding independent bounded continuation for the topic and category shapes without adding repair authority.
+FORUM-33A established the first read-only counter reconciliation page. FORUM-33B added independent bounded topic/category continuation. FORUM-33C closes the next source gap by adding accepted-solution authority and solution-author-stat reconciliation without adding repair authority.
 
-## Delivered FORUM-33A/B source
+## Delivered counter reconciliation source
 
-`ForumCounterReconciliationService` is owned by `rustok-forum` and is exposed through the Forum GraphQL operator query:
+`ForumCounterReconciliationService` remains the read-only owner for publication-accounting drift and is exposed through:
 
 ```text
 forumCounterReconciliationReport(
@@ -20,71 +20,84 @@ forumCounterReconciliationReport(
 )
 ```
 
-All arguments are optional. Omitting both cursors preserves the original first-page behavior. The existing owner `report(...)` method remains as a compatibility first-page wrapper, while `report_page(...)` is the bounded continuation entrypoint.
+It checks:
 
-The query is available only when the Forum module is enabled for the request tenant and the authenticated principal has both effective permissions:
+1. `forum_topics.reply_count` against `approved` replies;
+2. `forum_categories.topic_count` against current topic rows;
+3. `forum_categories.reply_count` against `approved` replies across category topics.
+
+Topic/category traversal remains independent, bounded to default 100 / hard 500 rows per shape, keyset-based with strict `id > cursor`, and page-local snapshot consistent. `clean` is page-local; whole-tenant clean requires exhausting both cursor chains with every page clean.
+
+## Delivered accepted-solution reconciliation source
+
+`ForumSolutionReconciliationService` is a sibling Forum owner service exposed through the same GraphQL operator query object:
+
+```text
+forumSolutionReconciliationReport(
+  limit: Int,
+  solutionAfter: UUID,
+  solutionStatAfter: UUID
+)
+```
+
+The two shapes are independent because the number of accepted solutions and the number of Forum user-stat rows may differ substantially.
+
+### Accepted-solution authority
+
+`forum_solutions` remains the authoritative accepted-solution relation. Existing production tenant-integrity constraints bind each row to exactly one same-tenant topic and one same-tenant reply in that exact topic, with one solution per `(tenant_id, topic_id)` and a solution reply unique within the tenant.
+
+The reconciliation report adds the runtime-lifecycle invariant that the selected reply must still be `approved`. Pending, rejected, hidden, flagged or deleted/nonexistent replies are not operationally valid accepted solutions. The report therefore emits `accepted_reply_eligibility` drift for an authoritative solution row whose exact topic/reply relation is unavailable or whose reply is no longer approved.
+
+The solution shape is bounded and ordered by `forum_solutions.topic_id`; continuation uses strict `topic_id > solutionAfter`, never OFFSET.
+
+### Solution-author statistic projection
+
+`forum_user_stats.solution_count` is a Forum-owned projection, not solution authority. Its expected value is the number of authoritative solution rows whose exact reply is still `approved` and authored by that user.
+
+The report detects both sides of projection drift:
+
+- `solution_author_stat_missing`: an approved accepted solution has a non-null author but no `forum_user_stats` row for that author;
+- `solution_author_stat_count`: an existing user-stat row has a stored `solution_count` different from the number of approved accepted solutions authored by that user, including stale positive counts when no accepted solutions remain.
+
+The stat shape first bounds the `forum_user_stats` user ids, then aggregates accepted solutions only for that bounded page. It is ordered by user UUID and continues with strict `user_id > solutionStatAfter`; it does not fan out into one query per user.
+
+## Admission and tenant boundary
+
+Both reconciliation fields use the same `ForumReconciliationQuery` admission helper. They are available only when the Forum module is enabled for the request tenant and the authenticated principal has both effective permissions:
 
 ```text
 forum_categories:manage
 forum_topics:manage
 ```
 
-Tenant identity is taken only from the trusted `TenantContext`. The query does not accept another tenant id and rejects an auth/tenant context mismatch.
+Tenant identity is taken only from trusted `TenantContext`. Caller input cannot select another tenant, and auth/tenant mismatch is rejected.
 
-Authorization is deliberately enforced twice. GraphQL rejects missing manage permissions early for a clear transport error, then builds the exact `SecurityContext` from the authenticated permission snapshot. `ForumCounterReconciliationService` independently requires `ForumCategories/Manage` and `ForumTopics/Manage` through the existing Forum `services::rbac::enforce_scope` helper before opening a database snapshot. A future CLI or host adapter therefore cannot gain reconciliation access merely by bypassing the GraphQL resolver.
+Authorization is deliberately enforced twice. GraphQL rejects missing manage permissions early, then constructs an exact `SecurityContext` permission snapshot. Both owner reconciliation services independently require `ForumCategories/Manage` and `ForumTopics/Manage` through the canonical Forum `services::rbac::enforce_scope` helper before database work begins. A later CLI/host adapter therefore cannot bypass owner admission by avoiding GraphQL.
 
-## Counter invariants
+## Snapshot and bounded-work semantics
 
-The owner report checks the existing publication-accounting invariants without mutating them:
+Every counter page and every solution page uses one database snapshot for all shapes in that report call:
 
-1. `forum_topics.reply_count` equals the number of `approved` Forum replies for that topic;
-2. `forum_categories.topic_count` equals the number of current Forum topic rows in that category;
-3. `forum_categories.reply_count` equals the number of `approved` Forum replies across topics in that category.
+- PostgreSQL: `REPEATABLE READ READ ONLY`;
+- SQLite: one transaction whose first read establishes the page snapshot.
 
-These are the same public-accounting semantics used by topic creation/deletion, reply publication transitions and reply removal. Pending, rejected, hidden, flagged and deleted reply rows do not contribute to public reply counters.
+Each independent shape fetches at most `effective_limit + 1` rows. Returned cursors preserve the supplied cursor when a shape returns no new rows, allowing one exhausted side to remain parked while another advances.
 
-## Independent bounded continuation
-
-Topic and category continuation are independent because the two shapes may have very different cardinalities. The owner query accepts:
-
-- `topic_after` / GraphQL `topicAfter`;
-- `category_after` / GraphQL `categoryAfter`.
-
-Each SQL shape remains ordered by its owner UUID and uses a strict keyset predicate (`id > cursor`) rather than OFFSET pagination. Each query still fetches at most `effective_limit + 1` rows. The response returns:
-
-- `has_more_topics` and `topic_cursor`;
-- `has_more_categories` and `category_cursor`.
-
-The returned cursor is the last inspected owner id for that shape. If a shape returns no new rows, its output cursor preserves the supplied input cursor instead of resetting to `None`. An operator can therefore keep echoing an exhausted category cursor while advancing topics, or vice versa, without rescanning the exhausted shape from the beginning.
-
-The `clean` field is page-local: it means only that the current bounded page contains no detected drift. Whole-tenant clean requires traversing both cursor chains to exhaustion and observing `clean = true` on every page. `clean = true` while either `has_more_topics` or `has_more_categories` is true is never whole-tenant proof.
-
-This makes tenants larger than the hard 500-row page cap traversable without unbounded work. It deliberately does not keep a database transaction open across HTTP/GraphQL requests. Snapshot consistency is page-local: writes that occur behind an already-returned cursor are observed by the next full reconciliation scan rather than by a long-lived cross-request snapshot. The report remains diagnostic/read-only, so no repair decision may treat a multi-page scan as a serializable write fence.
-
-## Bounded snapshot database shape
-
-Every page executes exactly two tenant-scoped aggregate queries inside one database snapshot:
-
-- one grouped topic/reply query;
-- one grouped category/topic/reply query.
-
-PostgreSQL uses one `REPEATABLE READ READ ONLY` transaction so concurrent Forum writes cannot make the topic and category observations within a page come from different database snapshots. SQLite uses one transaction for both reads; the first read establishes the consistent SQLite snapshot. Failed report construction explicitly rolls the transaction back, while a completed report commits the read-only snapshot.
-
-The default limit is 100 and the hard maximum is 500. The service avoids per-subject N+1 queries and never scans another tenant through this API. PostgreSQL and SQLite have explicit initial-page and keyset-continuation statements. Other backends fail closed rather than approximating SQL or snapshot semantics.
+Snapshot consistency is deliberately page-local. A multi-page diagnostic scan does not retain a transaction across HTTP/GraphQL requests. Rows created or changed behind an already-returned cursor are observed on the next full scan. Neither `clean=true` on one page nor a multi-page scan is a serializable repair fence.
 
 ## Observability
 
-The owner service reuses platform telemetry instead of defining redundant Forum-only metric families:
+The services reuse platform telemetry instead of introducing duplicate Forum-only metric families:
 
-- `rustok_module_entrypoint_calls_total` records the `counter_reconciliation_report` library entrypoint;
-- `rustok_span_duration_seconds` records bounded reconciliation latency;
-- `rustok_spans_with_errors_total` and `rustok_module_errors_total` record failed owner report execution.
+- module entrypoint calls for `counter_reconciliation_report` and `solution_reconciliation_report`;
+- platform span duration;
+- platform span/module error counters.
 
-The report itself is the bounded operational source for exact counter-drift details. A later FORUM-33 metrics slice may add only metrics that cannot be represented truthfully by the existing platform baseline.
+These source-ready instrumentation calls do not claim observed production metrics or provider SLO health.
 
 ## Deliberately not added
 
-This slice does **not** add a repair mutation or CLI repair command. The canonical FORUM-33 repair boundary still requires all of the following before any owner counter can be changed:
+This slice does **not** add a repair mutation or CLI repair command. The canonical FORUM-33 repair boundary still requires all of the following before any owner counter/relation projection can be changed:
 
 - explicit operator RBAC;
 - dry-run semantics;
@@ -97,11 +110,12 @@ A separate `rustok-forum-cli` adapter remains deferred until its workspace depen
 
 ## Remaining FORUM-33 scope
 
-- retain SQLite and PostgreSQL execution evidence for clean/drifted first pages, multi-page cursor traversal, exhausted-one-side continuation and page-local snapshot behavior;
-- add bounded reconciliation for accepted-solution state, subscriptions, mentions, attachments and shared-owner projections where authoritative owner contracts permit it;
+- retain SQLite and PostgreSQL execution evidence for counter clean/drift pages, multi-page traversal, exhausted-one-side continuation and page-local snapshot behavior;
+- retain SQLite and PostgreSQL execution evidence for accepted solution eligibility, missing solution-author stat, stale/mismatched `solution_count`, multi-page solution/stat cursors and concurrent page-local snapshot behavior;
+- add bounded reconciliation for subscriptions next, then mentions, attachments and shared-owner projections where authoritative owner contracts permit it;
 - add the audited/idempotent repair job boundary before any write repair;
 - decide the platform CLI adapter together with its synchronized dependency/lock update;
 - add only non-duplicative Forum operational metrics for moderation age/approval/report lag, notification/search lag, unread/activity signals, locale fallback, spam outcomes and remaining owner drift;
-- compose operator UI/CLI surfaces over the same owner report rather than duplicating SQL or policy.
+- compose operator UI/CLI surfaces over the same owner services rather than duplicating SQL or policy.
 
 No Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI or runtime evidence was executed while preparing this source slice.

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -15,6 +15,7 @@ function requireAbsent(text, marker, message) {
 }
 
 const servicePath = "crates/rustok-forum/src/services/counter_reconciliation.rs";
+const solutionPath = "crates/rustok-forum/src/services/solution_reconciliation.rs";
 const servicesModPath = "crates/rustok-forum/src/services/mod.rs";
 const graphqlPath = "crates/rustok-forum/src/graphql/reconciliation_query.rs";
 const graphqlModPath = "crates/rustok-forum/src/graphql/mod.rs";
@@ -23,6 +24,7 @@ const planPath = "crates/rustok-forum/docs/implementation-plan.md";
 const packetPath = "docs/modules/forum-33-counter-reconciliation-actualization-2026-08-08.md";
 
 const service = read(servicePath);
+const solution = read(solutionPath);
 const servicesMod = read(servicesModPath);
 const graphql = read(graphqlPath);
 const graphqlMod = read(graphqlModPath);
@@ -88,13 +90,64 @@ for (const forbidden of [
   "ActiveModel",
   " OFFSET ",
 ]) {
-  requireAbsent(service, forbidden, `read-only reconciliation service must not contain ${forbidden}`);
+  requireAbsent(service, forbidden, `read-only counter reconciliation service must not contain ${forbidden}`);
+}
+
+for (const marker of [
+  "pub enum ForumSolutionDriftKind",
+  "AcceptedReplyEligibility",
+  "SolutionAuthorStatMissing",
+  "SolutionAuthorStatCount",
+  "pub struct ForumSolutionReconciliationReport",
+  "pub struct ForumSolutionReconciliationService",
+  "security: &SecurityContext",
+  "enforce_operations_scope(security)",
+  "enforce_scope(security, Resource::ForumCategories, Action::Manage)?",
+  "enforce_scope(security, Resource::ForumTopics, Action::Manage)",
+  "solution_after: Option<Uuid>",
+  "solution_stat_after: Option<Uuid>",
+  "pub solution_cursor: Option<Uuid>",
+  "pub solution_stat_cursor: Option<Uuid>",
+  "FROM forum_solutions s",
+  "LEFT JOIN forum_topics t",
+  "LEFT JOIN forum_replies r",
+  "LEFT JOIN forum_user_stats us",
+  "r.status = 'approved'",
+  "WITH bounded_stats AS (",
+  "FROM forum_user_stats",
+  "AND s.topic_id > ?2",
+  "AND s.topic_id > $2",
+  "AND user_id > ?2",
+  "AND user_id > $2",
+  "COUNT(s.topic_id)",
+  "effective_limit.saturating_add(1)",
+  "IsolationLevel::RepeatableRead",
+  "AccessMode::ReadOnly",
+  "DatabaseBackend::Sqlite => self.db.begin().await?",
+  "transaction.commit().await?",
+  "transaction.rollback().await",
+  '"solution_reconciliation_report"',
+]) {
+  requireText(solution, marker, `Forum solution reconciliation service missing ${marker}`);
+}
+
+for (const forbidden of [
+  "UPDATE forum_",
+  "DELETE FROM forum_",
+  "INSERT INTO forum_",
+  "ActiveModel",
+  " OFFSET ",
+]) {
+  requireAbsent(solution, forbidden, `read-only solution reconciliation service must not contain ${forbidden}`);
 }
 
 for (const marker of [
   "mod counter_reconciliation;",
+  "mod solution_reconciliation;",
   "pub use counter_reconciliation::{",
+  "pub use solution_reconciliation::{",
   "ForumCounterReconciliationService",
+  "ForumSolutionReconciliationService",
   "MAX_FORUM_COUNTER_RECONCILIATION_LIMIT",
 ]) {
   requireText(servicesMod, marker, `Forum services composition missing ${marker}`);
@@ -103,6 +156,8 @@ for (const marker of [
 for (const marker of [
   "pub struct ForumReconciliationQuery",
   "forum_counter_reconciliation_report",
+  "forum_solution_reconciliation_report",
+  "reconciliation_context(ctx, limit).await?",
   "require_module_enabled(ctx, MODULE_SLUG).await?",
   "Permission::FORUM_CATEGORIES_MANAGE",
   "Permission::FORUM_TOPICS_MANAGE",
@@ -111,12 +166,14 @@ for (const marker of [
   "SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions)",
   "topic_after: Option<Uuid>",
   "category_after: Option<Uuid>",
+  "solution_after: Option<Uuid>",
+  "solution_stat_after: Option<Uuid>",
   "pub topic_cursor: Option<Uuid>",
   "pub category_cursor: Option<Uuid>",
-  "ForumCounterReconciliationService::new(db.clone())",
-  ".report_page(",
-  "topic_after,",
-  "category_after,",
+  "pub solution_cursor: Option<Uuid>",
+  "pub solution_stat_cursor: Option<Uuid>",
+  "ForumCounterReconciliationService::new(db)",
+  "ForumSolutionReconciliationService::new(db)",
   "whole-tenant clean requires exhausting both",
 ]) {
   requireText(graphql, marker, `Forum reconciliation GraphQL boundary missing ${marker}`);
@@ -145,32 +202,35 @@ requireAbsent(
 );
 
 for (const marker of [
-  "| `FORUM-33` | `in_progress` | Bounded snapshot-consistent owner counter reconciliation report with independent topic/category keyset cursors",
+  "| `FORUM-33` | `in_progress` | Bounded snapshot-consistent owner counter and accepted-solution reconciliation",
   "## `FORUM-33` — analytics, observability and reconciliation",
   "**Status:** `in_progress`",
-  "topicAfter: UUID",
-  "categoryAfter: UUID",
+  "forumSolutionReconciliationReport",
+  "solutionAfter: UUID",
+  "solutionStatAfter: UUID",
   "page-local snapshot",
   "node scripts/verify/verify-forum-counter-reconciliation-source.mjs",
-  "For FORUM-33, retain SQLite and PostgreSQL execution evidence",
+  "subscriptions",
 ]) {
   requireText(plan, marker, `canonical Forum plan missing ${marker}`);
 }
 
 for (const marker of [
-  "Status: `in-progress / bounded-owner-report-and-cursors-source-ready / repair-and-runtime-evidence-open`",
-  "topicAfter: UUID",
-  "categoryAfter: UUID",
-  "strict keyset predicate (`id > cursor`)",
-  "topic_cursor",
-  "category_cursor",
-  "The `clean` field is page-local",
+  "Status: `in-progress / bounded-counter-and-solution-reconciliation-source-ready / repair-and-runtime-evidence-open`",
+  "forumSolutionReconciliationReport(",
+  "solutionAfter: UUID",
+  "solutionStatAfter: UUID",
+  "accepted_reply_eligibility",
+  "solution_author_stat_missing",
+  "solution_author_stat_count",
+  "forum_user_stats.solution_count",
+  "strict `topic_id > solutionAfter`",
+  "strict `user_id > solutionStatAfter`",
   "page-local",
   "forum_categories:manage",
   "forum_topics:manage",
   "Authorization is deliberately enforced twice",
   "services::rbac::enforce_scope",
-  "Every page executes exactly two tenant-scoped aggregate queries inside one database snapshot",
   "REPEATABLE READ READ ONLY",
   "does **not** add a repair mutation",
   "idempotent job/receipt state",
@@ -178,4 +238,4 @@ for (const marker of [
   requireText(packet, marker, `FORUM-33 actualization missing ${marker}`);
 }
 
-console.log("Forum FORUM-33 counter reconciliation source: ok");
+console.log("Forum FORUM-33 reconciliation source: ok");

--- a/scripts/verify/verify-forum-counter-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-counter-reconciliation-source.mjs
@@ -185,6 +185,10 @@ for (const forbidden of ["tenant_id: Option<Uuid>", "Mutation", "UPDATE forum_"]
 for (const marker of [
   "mod reconciliation_query;",
   "reconciliation_query::ForumReconciliationQuery",
+  "GqlForumCounterReconciliationReport",
+  "GqlForumSolutionDrift",
+  "GqlForumSolutionReconciliationReport",
+  "topic_reply_range_move_mutation::ForumTopicReplyRangeMoveMutation",
 ]) {
   requireText(graphqlMod, marker, `Forum GraphQL composition missing ${marker}`);
 }
@@ -211,6 +215,7 @@ for (const marker of [
   "page-local snapshot",
   "node scripts/verify/verify-forum-counter-reconciliation-source.mjs",
   "subscriptions",
+  "empty source registry",
 ]) {
   requireText(plan, marker, `canonical Forum plan missing ${marker}`);
 }


### PR DESCRIPTION
## Summary

Continue FORUM-33 after bounded counter keyset continuation landed in #3296.

- add a read-only `ForumSolutionReconciliationService` alongside counter reconciliation;
- reconcile accepted-solution authority against the exact same-tenant/topic reply and require the accepted reply to remain `approved`;
- reconcile `forum_user_stats.solution_count` as a projection of approved accepted solutions, including missing stat rows and stale/mismatched counts;
- keep solution rows and solution-stat rows independently bounded with strict UUID keyset cursors and default 100 / hard 500 limits;
- execute both shapes inside the same page-local PostgreSQL `REPEATABLE READ READ ONLY` / SQLite transaction snapshot;
- expose `forumSolutionReconciliationReport(limit, solutionAfter, solutionStatAfter)` through the existing Forum reconciliation GraphQL object;
- reuse the exact module/tenant/operator admission and independently reauthorize both `forum_categories:manage` and `forum_topics:manage` in the owner service;
- keep all reconciliation read-only and reuse platform entrypoint/span/error telemetry;
- update the canonical FORUM-33 plan, dated actualization and source guard, advancing the next source cursor to subscriptions.

## Deliberately open

SQLite/PostgreSQL execution evidence remains maintainer-run. Write repair remains blocked on explicit operator RBAC, dry-run, durable audit, idempotent job/receipt state and bounded recovery. Subscription/mention/attachment/shared-owner reconciliation and non-duplicative operational metrics remain open. CLI integration still requires a synchronized workspace dependency and `Cargo.lock` update.

## Dependencies / migrations

No Cargo.toml, Cargo.lock, package dependency, schema or migration changes.

## Validation

Per maintainer instruction, no Cargo tests/checks, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was run. Review is source-only.