### PR TITLE
feat(product): receipt schema state updates

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, mandatory GraphQL caller identity, and the first durable attribute-create receipt slice. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open while update-style owner replay semantics are defined and implemented.
+This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, mandatory GraphQL caller identity, and durable receipts for all six schema create operations. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open while the two attribute-value writes gain exact completed-projection replay semantics.
 
 ## Current source result
 
@@ -15,7 +15,7 @@ This source-only continuation follows Product schema-write capability publicatio
 
 ## Durable schema-create receipts
 
-All six Product schema create operations now use the shared `rustok-outbox::idempotency` owner-operation ledger under `owner_slug = product`:
+All six Product schema create operations use the shared `rustok-outbox::idempotency` owner-operation ledger under `owner_slug = product`:
 
 1. attribute create;
 2. attribute-option create;
@@ -26,7 +26,7 @@ All six Product schema create operations now use the shared `rustok-outbox::idem
 
 For each admitted create, the receipt binds tenant, Product owner namespace, caller idempotency key, operation, authenticated actor, and canonical request input. The receipt operation UUID is reused as the Product-owned resource ID while the receipt scope is active. A stale lease reclaim therefore reuses the same attribute, option, category, schema, or group identity instead of allocating a second row.
 
-The receipt fence now records the **actual result produced inside the owner create method** rather than requiring the port adapter to predict the response before the Product transaction starts. `ProductWriteTransaction` captures an explicitly scoped lease plus an initially empty result slot. Each receipted create records its concrete result after its schema rows and transactional outbox publication are prepared and before commit. Transaction commit fails closed if a receipt scope has no recorded result.
+The receipt fence records the actual result produced inside the owner method rather than requiring the port adapter to predict the response before the Product transaction starts. `ProductWriteTransaction` captures an explicitly scoped lease plus an initially empty result slot. Each receipted create records its concrete result after its schema rows and transactional outbox publication are prepared and before commit. Transaction commit fails closed if a receipt scope has no recorded result.
 
 This is material for `create_category`: `CatalogCategoryRecord.path` depends on the parent row read inside the Product transaction. The port does not perform an external parent/path preflight. The actual path computed by the same transaction is stored in the receipt, so lost-response replay returns the exact committed category result.
 
@@ -36,25 +36,39 @@ A completed receipt decodes the typed create result. Reusing the same key for a 
 
 Direct Product service callers remain outside receipt semantics. Without the explicit task-local owner-port scope, create methods use normal generated resource IDs, result recording is a no-op for receipt state, and `ProductWriteTransaction` commits without receipt completion.
 
+## Durable unit-result state-write receipts
+
+The three update-style state writes now use durable owner receipts as well:
+
+1. `set_category_schema_mode`;
+2. `bind_schema_attribute`;
+3. `bind_category_attribute`.
+
+Each port call admits the caller key against the authenticated actor and canonical input before owner execution. On a new lease, the owner method runs inside the same task-local Product receipt scope used by schema creates. The owner method records its successful `()` result as JSON `null` after the state mutation and transactional outbox publication are prepared and before `ProductWriteTransaction::commit`.
+
+Receipt completion therefore commits atomically with the category assignment or attribute binding plus its domain event. Lost-response replay decodes the stored `null` back to `()` and does not rerun the upsert or publish a duplicate event. Immutable key rebinding and terminal/retryable failure handling reuse the same Product receipt admission and failure policy as schema creates.
+
+The receipt operation UUID is not used as a domain resource ID for these three updates because they mutate an existing category/schema binding identity. It remains only the receipt fence identity.
+
 ## Why the canonical item remains open
 
-Durable owner replay is now source-complete for all six non-idempotent schema create operations. Update-style schema writes remain open:
+Two attribute-value writes remain open:
 
-- `set_category_schema_mode`;
-- `bind_schema_attribute`;
-- `bind_category_attribute`;
 - `save_product_attribute_values`;
 - `clear_detached_product_attribute_values`.
 
-Those operations need an explicit replay result/state contract. In particular, the two attribute-value writes return projections that must replay the exact intended completed outcome rather than merely assuming repeated state mutation is harmless. The combined canonical item therefore remains `[ ]`.
+Both return `Vec<ProductAttributeValueRecord>`. Their current owner implementations commit the EAV mutation and outbox event first and then load the returned projection through a separate database read. Simply adding the receipt wrapper at the port would therefore be incorrect: `ProductWriteTransaction` would have no exact completed result to store before commit, and replaying by re-reading later state could return a projection changed by a subsequent legitimate write.
+
+Those operations need an owner-transaction-local projection loader or equivalent canonical result capture so the exact returned `ProductAttributeValueRecord` vector is serialized into the receipt before the same write transaction commits. Until that exists, both methods intentionally remain outside receipt admission rather than claiming durable replay through repeated mutation or post-commit state reads.
 
 Remaining source order:
 
-1. define owner receipt/replay semantics for update-style schema writes, including exact returned attribute-value projections;
-2. implement those update-style semantics through the same owner transaction fence where appropriate;
-3. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
-4. retain static/compile/parity/lost-response/restart/backend evidence as separate maintainer-run verification before any promotion.
+1. make the attribute-value result projection readable from the active `ProductWriteTransaction` without a post-commit owner read;
+2. record and complete the exact `save_product_attribute_values` result inside the mutation/outbox transaction;
+3. record and complete the exact `clear_detached_product_attribute_values` result inside the delete/outbox transaction, including the empty-target path;
+4. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
+5. retain static/compile/parity/lost-response/restart/backend evidence as separate maintainer-run verification before any promotion.
 
 ## Verification state
 
-No tests, checks, formatters, workflows, or runtime verification were executed in this slice per maintainer instruction. Source and GitHub diff inspection only. No FBA/FFA status is promoted.
+Source and GitHub diff inspection only. No tests, checks, formatters, workflows, or runtime verification were executed per maintainer instruction. No FBA/FFA status is promoted.

--- a/crates/rustok-product/src/catalog_schema_write_port.rs
+++ b/crates/rustok-product/src/catalog_schema_write_port.rs
@@ -22,13 +22,12 @@ use crate::CommerceError;
 /// idempotency identity and deadline. Consumers must receive this capability from host
 /// composition rather than constructing `ProductCatalogSchemaService` directly.
 ///
-/// The embedded adapter durably binds all six Product schema create operations to the
-/// shared owner-operation receipt ledger. Receipt completion is committed in the same
-/// Product transaction as schema rows and outbox publication using the actual result
-/// recorded by the owner create method, so transaction-derived fields such as category
-/// path replay exactly without an external preflight read. Update-style schema writes
-/// still require explicit replay result/state semantics before the combined ecommerce
-/// task can be closed.
+/// The embedded adapter durably binds all six Product schema create operations plus
+/// category schema-mode and schema/category attribute-binding updates to the shared
+/// owner-operation receipt ledger. Receipt completion is committed in the same Product
+/// transaction as schema rows and outbox publication using the actual result recorded by
+/// the owner write method. Attribute-value writes still require exact completed projection
+/// replay semantics before the combined ecommerce task can be closed.
 #[async_trait]
 pub trait ProductCatalogSchemaWritePort: Send + Sync {
     async fn create_attribute(
@@ -255,9 +254,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<(), PortError> {
         let operation = "set_category_schema_mode";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.set_category_schema_mode(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.set_category_schema_mode(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn bind_schema_attribute(
@@ -267,9 +278,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<(), PortError> {
         let operation = "bind_schema_attribute";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.bind_schema_attribute(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.bind_schema_attribute(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn bind_category_attribute(
@@ -279,9 +302,21 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<(), PortError> {
         let operation = "bind_category_attribute";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.bind_category_attribute(tenant_id, actor_id, input)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({ "actor": &context.actor, "input": &input });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.bind_category_attribute(tenant_id, actor_id, input),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn save_product_attribute_values(

--- a/crates/rustok-product/src/services/catalog_schema_service/categories.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/categories.rs
@@ -267,6 +267,7 @@ impl ProductCatalogSchemaService {
             },
         )
         .await?;
+        record_product_operation_result(&())?;
         txn.commit().await?;
         Ok(())
     }
@@ -333,6 +334,7 @@ impl ProductCatalogSchemaService {
             },
         )
         .await?;
+        record_product_operation_result(&())?;
         txn.commit().await?;
         Ok(())
     }

--- a/crates/rustok-product/src/services/catalog_schema_service/schemas.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/schemas.rs
@@ -208,6 +208,7 @@ impl ProductCatalogSchemaService {
             },
         )
         .await?;
+        record_product_operation_result(&())?;
         txn.commit().await?;
         Ok(())
     }

--- a/crates/rustok-product/src/services/write_transaction.rs
+++ b/crates/rustok-product/src/services/write_transaction.rs
@@ -36,7 +36,7 @@ tokio::task_local! {
 /// The scope is intentionally task-local: the shared `ProductCatalogSchemaService`
 /// stays stateless across concurrent callers, while `ProductWriteTransaction::begin`
 /// captures the receipt only for the explicitly wrapped owner command. The concrete
-/// owner create method records its actual result before commit, so transaction-derived
+/// owner write method records its actual result before commit, so transaction-derived
 /// fields such as category path never need a preflight read outside the owner transaction.
 pub(crate) async fn with_product_operation_receipt<F, T>(
     lease: idempotency::Lease,
@@ -97,7 +97,7 @@ pub(crate) fn record_product_operation_result<T: Serialize>(value: &T) -> Commer
 /// transport unavailable to product write paths before the transaction commits.
 /// When a Product owner receipt scope is active, terminal success is completed
 /// in this same transaction before commit using the actual result recorded by the
-/// owner create method.
+/// owner write method.
 pub(crate) struct ProductWriteTransaction {
     transaction: DatabaseTransaction,
     event_bus: TransactionalEventBus,

--- a/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
+++ b/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
@@ -22,6 +22,13 @@ const functionSlice = (source, name, nextName) => {
   const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
   return source.slice(start, end < 0 ? source.length : end);
 };
+const requireRecordedBeforeCommit = (source, label) => {
+  const recorded = source.indexOf("record_product_operation_result(&())?");
+  const commit = source.indexOf("txn.commit().await?");
+  if (recorded < 0 || commit < 0 || recorded > commit) {
+    failures.push(`${label}: unit receipt result must be recorded before owner transaction commit`);
+  }
+};
 
 const port = read("crates/rustok-product/src/catalog_schema_write_port.rs");
 const transaction = read("crates/rustok-product/src/services/write_transaction.rs");
@@ -44,7 +51,7 @@ for (const required of [
   '"product.schema_idempotency_conflict"',
   '"product.schema_receipt_unavailable"',
 ]) {
-  requireText(port, required, "Product schema create receipt port");
+  requireText(port, required, "Product schema receipt port");
 }
 
 for (const [name, nextName] of [
@@ -54,6 +61,9 @@ for (const [name, nextName] of [
   ["create_schema", "create_schema_group"],
   ["create_schema_group", "create_category_group"],
   ["create_category_group", "set_category_schema_mode"],
+  ["set_category_schema_mode", "bind_schema_attribute"],
+  ["bind_schema_attribute", "bind_category_attribute"],
+  ["bind_category_attribute", "save_product_attribute_values"],
 ]) {
   const slice = functionSlice(portImpl, name, nextName);
   for (const required of [
@@ -67,14 +77,15 @@ for (const [name, nextName] of [
 }
 
 for (const [name, nextName] of [
-  ["set_category_schema_mode", "bind_schema_attribute"],
-  ["bind_schema_attribute", "bind_category_attribute"],
-  ["bind_category_attribute", "save_product_attribute_values"],
   ["save_product_attribute_values", "clear_detached_product_attribute_values"],
   ["clear_detached_product_attribute_values", "admit_schema_operation"],
 ]) {
   const slice = functionSlice(portImpl, name, nextName);
-  forbidText(slice, "admit_schema_operation(", `${name} must remain explicit update-style receipt follow-up debt`);
+  forbidText(
+    slice,
+    "admit_schema_operation(",
+    `${name} must remain explicit exact-projection replay follow-up debt`,
+  );
 }
 
 for (const required of [
@@ -129,6 +140,17 @@ for (const required of [
   requireText(categoryCreate, required, "category create actual-result receipt");
 }
 
+const categoryMode = functionSlice(categories, "set_category_schema_mode", "bind_category_attribute");
+const categoryBinding = functionSlice(categories, "bind_category_attribute", null);
+const schemaBinding = functionSlice(schemas, "bind_schema_attribute", null);
+for (const [slice, label] of [
+  [categoryMode, "category schema mode update"],
+  [categoryBinding, "category attribute binding update"],
+  [schemaBinding, "schema attribute binding update"],
+]) {
+  requireRecordedBeforeCommit(slice, label);
+}
+
 requireText(
   plan,
   "durable owner receipts cover all six schema create operations",
@@ -141,19 +163,19 @@ requireText(
 );
 requireText(
   recheck,
-  "all six Product schema create operations",
-  "Product schema write recheck must describe complete create receipt coverage",
+  "three update-style state writes now use durable owner receipts",
+  "Product schema write recheck must record state-write receipt coverage",
 );
 requireText(
   recheck,
-  "update-style schema writes remain open",
-  "Product schema write recheck must preserve remaining update-style debt",
+  "attribute-value writes remain open",
+  "Product schema write recheck must preserve exact-projection replay debt",
 );
 
 if (failures.length) {
-  console.error("Product schema create receipt source verification failed:");
+  console.error("Product schema receipt source verification failed:");
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ All six Product schema creates bind durable owner receipts to actual transaction results; update-style replay semantics remain explicit debt");
+console.log("✔ Product schema creates and three unit-result state writes use durable owner receipts; exact attribute-value projection replay remains explicit debt");


### PR DESCRIPTION
## Summary
- add durable Product owner receipts to category schema mode and schema/category attribute binding writes
- record successful unit results inside the owner transaction before commit so lost-response replay does not rerun state changes or transactional outbox publication
- keep Product attribute-value save/clear explicitly open until their exact returned projections can be captured inside the owner transaction
- expand the source verifier and Product schema-write recheck documentation for this boundary

## Verification
- source and diff inspection only
- tests, checks, formatters, workflows, and runtime verification were not run per maintainer instruction