### PR TITLE
feat(product): receipt attribute value projections

### DIFF
--- a/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
+++ b/crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md
@@ -2,11 +2,11 @@
 
 ## Scope
 
-This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, mandatory GraphQL caller identity, and durable receipts for all six schema create operations. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`; its combined Product schema-write/idempotency item remains open while the two attribute-value writes gain exact completed-projection replay semantics.
+This source-only continuation follows Product schema-write capability publication, mounted consumer cutover, mandatory GraphQL caller identity, durable receipts for all six schema create operations, and durable receipts for the three unit-result schema state updates. The canonical ecommerce source of truth remains `crates/rustok-commerce/docs/implementation-plan.md`. This slice closes the remaining Product attribute-value source gap by capturing the exact completed projection inside the owner transaction before receipt completion and commit. Runtime, backend, restart, and lost-response evidence remain maintainer-run work and are not promoted here.
 
 ## Current source result
 
-- Product publishes `ProductCatalogSchemaWritePort` for every Product schema write used by mounted Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
+- Product publishes `ProductCatalogSchemaWritePort` for all eleven mounted Product schema writes used by Commerce GraphQL: attribute and option creation, category/schema/group creation, category schema mode, schema/category bindings, Product attribute-value save, and detached-value clear.
 - Mounted Commerce GraphQL no longer constructs `ProductCatalogSchemaService` for those writes. Every schema-write path resolves the host-selected `ProductCatalogCommandRuntime`, obtains its optional `schema_write_port()`, and fails closed with bounded `PRODUCT_TEMPORARILY_UNAVAILABLE` when an external profile has not supplied the capability.
 - Schema writes derive tenant/actor/claims/request context from `PortContext`, retain the existing two-second Product command deadline, and scope-hash the caller key with tenant, authenticated actor, operation, and Product id when one exists.
 - All eleven mounted Product schema-write resolver arguments use `String`, so the generated GraphQL SDL requires `idempotencyKey: String!` before resolver execution.
@@ -28,46 +28,44 @@ For each admitted create, the receipt binds tenant, Product owner namespace, cal
 
 The receipt fence records the actual result produced inside the owner method rather than requiring the port adapter to predict the response before the Product transaction starts. `ProductWriteTransaction` captures an explicitly scoped lease plus an initially empty result slot. Each receipted create records its concrete result after its schema rows and transactional outbox publication are prepared and before commit. Transaction commit fails closed if a receipt scope has no recorded result.
 
-This is material for `create_category`: `CatalogCategoryRecord.path` depends on the parent row read inside the Product transaction. The port does not perform an external parent/path preflight. The actual path computed by the same transaction is stored in the receipt, so lost-response replay returns the exact committed category result.
-
-`ProductWriteTransaction` calls `idempotency::complete` with that recorded result inside the same database transaction as Product schema rows and transactional outbox publication, then commits. A response lost after commit is therefore replayed without rerunning the create or publishing a duplicate event.
-
-A completed receipt decodes the typed create result. Reusing the same key for a different operation, actor, or request is rejected by the shared immutable request binding and mapped to bounded Product idempotency errors. A non-retryable Product failure is persisted only after the owner write future has returned and its transaction has rolled back. Retryable database/receipt failures are not converted into terminal failure receipts; the processing lease remains reclaimable under the shared stale-lease policy.
-
-Direct Product service callers remain outside receipt semantics. Without the explicit task-local owner-port scope, create methods use normal generated resource IDs, result recording is a no-op for receipt state, and `ProductWriteTransaction` commits without receipt completion.
+This remains material for `create_category`: `CatalogCategoryRecord.path` depends on the parent row read inside the Product transaction. The actual path computed by that transaction is stored in the receipt, so lost-response replay returns the exact committed category result without rerunning the create.
 
 ## Durable unit-result state-write receipts
 
-The three update-style state writes now use durable owner receipts as well:
+The three update-style state writes use the same owner receipt fence:
 
 1. `set_category_schema_mode`;
 2. `bind_schema_attribute`;
 3. `bind_category_attribute`.
 
-Each port call admits the caller key against the authenticated actor and canonical input before owner execution. On a new lease, the owner method runs inside the same task-local Product receipt scope used by schema creates. The owner method records its successful `()` result as JSON `null` after the state mutation and transactional outbox publication are prepared and before `ProductWriteTransaction::commit`.
+Each owner method records successful `()` as JSON `null` after its mutation and transactional outbox publication are prepared and before `ProductWriteTransaction::commit`. Receipt completion therefore commits atomically with the state update and its domain event. Lost-response replay decodes the stored `null` back to `()` and does not rerun the upsert or publish a duplicate event.
 
-Receipt completion therefore commits atomically with the category assignment or attribute binding plus its domain event. Lost-response replay decodes the stored `null` back to `()` and does not rerun the upsert or publish a duplicate event. Immutable key rebinding and terminal/retryable failure handling reuse the same Product receipt admission and failure policy as schema creates.
+## Exact Product attribute-value replay
 
-The receipt operation UUID is not used as a domain resource ID for these three updates because they mutate an existing category/schema binding identity. It remains only the receipt fence identity.
-
-## Why the canonical item remains open
-
-Two attribute-value writes remain open:
+The remaining two write methods now participate in the same durable owner receipt protocol:
 
 - `save_product_attribute_values`;
 - `clear_detached_product_attribute_values`.
 
-Both return `Vec<ProductAttributeValueRecord>`. Their current owner implementations commit the EAV mutation and outbox event first and then load the returned projection through a separate database read. Simply adding the receipt wrapper at the port would therefore be incorrect: `ProductWriteTransaction` would have no exact completed result to store before commit, and replaying by re-reading later state could return a projection changed by a subsequent legitimate write.
+Their response type is `Vec<ProductAttributeValueRecord>`, so a later database read is not an acceptable replay source: another legitimate Product write could change the projection after the original command commits. The response therefore has to be captured from the exact owner transaction that contains the EAV mutation and outbox publication.
 
-Those operations need an owner-transaction-local projection loader or equivalent canonical result capture so the exact returned `ProductAttributeValueRecord` vector is serialized into the receipt before the same write transaction commits. Until that exists, both methods intentionally remain outside receipt admission rather than claiming durable replay through repeated mutation or post-commit state reads.
+`load_product_attribute_values` is now backed by a connection-neutral projection helper using SeaORM `ConnectionTrait`. The helper can read from both the normal `DatabaseConnection` and the active `ProductWriteTransaction`. Effective-form resolution uses the same connection-neutral path, including existing-value discovery, category/schema maps, localized values, option rows, ordering, and detached classification. The public read behavior therefore keeps the existing projection semantics while the write path can observe its own uncommitted mutation.
 
-Remaining source order:
+For `save_product_attribute_values`, Product applies all validated patches, publishes `ProductAttributeValuesChanged` when the patch set is non-empty, loads the exact completed projection from the active transaction, records that vector into the receipt result slot, and only then commits. A lost response is replayed from the completed receipt instead of rerunning the EAV mutation or reconstructing state later.
 
-1. make the attribute-value result projection readable from the active `ProductWriteTransaction` without a post-commit owner read;
-2. record and complete the exact `save_product_attribute_values` result inside the mutation/outbox transaction;
-3. record and complete the exact `clear_detached_product_attribute_values` result inside the delete/outbox transaction, including the empty-target path;
-4. remove superseded Product Admin schema-write compatibility strings only after compile/source evidence confirms they are unmounted;
-5. retain static/compile/parity/lost-response/restart/backend evidence as separate maintainer-run verification before any promotion.
+For `clear_detached_product_attribute_values`, the delete and event publication remain conditional on a non-empty detached target set, but projection capture and receipt completion are unconditional. The empty-target detached clear therefore opens an owner transaction, reads the unchanged exact projection inside that transaction, records it, and commits the receipt without fabricating an outbox event. This prevents a successful no-op from leaving an admitted lease permanently incomplete.
+
+Request binding for both methods includes authenticated actor, Product id, locale, and the exact patch or attribute-id payload. Reusing one caller key with a different Product, locale, patch set, clear target, actor, or operation remains an immutable-request conflict rather than a second execution.
+
+## Source completion boundary
+
+The mounted Product schema-write boundary now has source-complete durable owner replay across all eleven operations:
+
+1. six create operations with stable receipt-owned resource IDs and exact transaction-derived results;
+2. three state updates with atomically stored unit results;
+3. two Product attribute-value writes with exact transaction-local EAV projection results, including the no-op clear path.
+
+This closes the implementation gap identified by the prior recheck. It does not provide runtime promotion evidence. Compile coverage, static verifier execution, lost-response injection, stale-lease reclaim, restart replay, tenant/request conflict checks, and SQLite/PostgreSQL/MySQL evidence remain separate maintainer-run verification work. Superseded Product Admin compatibility strings should still be removed only after compile/source evidence confirms they are unmounted.
 
 ## Verification state
 

--- a/crates/rustok-product/src/catalog_schema_write_port.rs
+++ b/crates/rustok-product/src/catalog_schema_write_port.rs
@@ -22,12 +22,11 @@ use crate::CommerceError;
 /// idempotency identity and deadline. Consumers must receive this capability from host
 /// composition rather than constructing `ProductCatalogSchemaService` directly.
 ///
-/// The embedded adapter durably binds all six Product schema create operations plus
-/// category schema-mode and schema/category attribute-binding updates to the shared
-/// owner-operation receipt ledger. Receipt completion is committed in the same Product
-/// transaction as schema rows and outbox publication using the actual result recorded by
-/// the owner write method. Attribute-value writes still require exact completed projection
-/// replay semantics before the combined ecommerce task can be closed.
+/// The embedded adapter durably binds all eleven mounted Product schema writes to the
+/// shared owner-operation receipt ledger. Receipt completion is committed in the same
+/// Product transaction as schema/EAV rows and outbox publication using the actual result
+/// recorded by the owner write method. Attribute-value writes capture their exact
+/// completed projection from that active owner transaction before commit.
 #[async_trait]
 pub trait ProductCatalogSchemaWritePort: Send + Sync {
     async fn create_attribute(
@@ -328,9 +327,26 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<Vec<ProductAttributeValueRecord>, PortError> {
         let operation = "save_product_attribute_values";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.save_product_attribute_values(tenant_id, actor_id, product_id, &locale, patches)
-            .await
-            .map_err(|error| schema_write_error(&context, operation, error))
+        let request = serde_json::json!({
+            "actor": &context.actor,
+            "product_id": product_id,
+            "locale": &locale,
+            "patches": &patches,
+        });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.save_product_attribute_values(tenant_id, actor_id, product_id, &locale, patches),
+        )
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 
     async fn clear_detached_product_attribute_values(
@@ -342,15 +358,32 @@ impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService {
     ) -> Result<Vec<ProductAttributeValueRecord>, PortError> {
         let operation = "clear_detached_product_attribute_values";
         let (tenant_id, actor_id) = schema_write_scope(&context, operation)?;
-        self.clear_detached_product_attribute_values(
-            tenant_id,
-            actor_id,
-            product_id,
-            &locale,
-            attribute_ids,
+        let request = serde_json::json!({
+            "actor": &context.actor,
+            "product_id": product_id,
+            "locale": &locale,
+            "attribute_ids": &attribute_ids,
+        });
+        let lease = match admit_schema_operation(self, &context, tenant_id, operation, &request).await?
+        {
+            idempotency::Admission::Run(lease) => lease,
+            idempotency::Admission::Replay(value) => {
+                return decode_schema_receipt(&context, operation, value)
+            }
+            idempotency::Admission::ReplayError(error) => return Err(error),
+        };
+        let result = with_product_operation_receipt(
+            lease,
+            self.clear_detached_product_attribute_values(
+                tenant_id,
+                actor_id,
+                product_id,
+                &locale,
+                attribute_ids,
+            ),
         )
-        .await
-        .map_err(|error| schema_write_error(&context, operation, error))
+        .await;
+        finish_receipted_schema_write(self, &context, operation, lease, result).await
     }
 }
 

--- a/crates/rustok-product/src/services/catalog_schema_service/effective_forms.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/effective_forms.rs
@@ -6,30 +6,42 @@ impl ProductCatalogSchemaService {
         tenant_id: Uuid,
         product_id: Uuid,
     ) -> CommerceResult<Option<EffectiveProductForm>> {
+        Self::load_effective_form_for_product_in(&self.db, tenant_id, product_id).await
+    }
+
+    pub(super) async fn load_effective_form_for_product_in<C>(
+        db: &C,
+        tenant_id: Uuid,
+        product_id: Uuid,
+    ) -> CommerceResult<Option<EffectiveProductForm>>
+    where
+        C: ConnectionTrait,
+    {
         let product = ProductPrimaryCategoryRow::find_by_statement(Statement::from_sql_and_values(
-            self.db.get_database_backend(),
+            db.get_database_backend(),
             "SELECT primary_category_id FROM products WHERE tenant_id = $1 AND id = $2",
             vec![tenant_id.into(), product_id.into()],
         ))
-        .one(&self.db)
+        .one(db)
         .await?;
         let Some(primary_category_id) = product.and_then(|row| row.primary_category_id) else {
             return Ok(None);
         };
 
         let value_rows = AttributeIdRow::find_by_statement(Statement::from_sql_and_values(
-            self.db.get_database_backend(),
+            db.get_database_backend(),
             "SELECT attribute_id FROM product_attribute_values WHERE tenant_id = $1 AND product_id = $2",
             vec![tenant_id.into(), product_id.into()],
         ))
-        .all(&self.db)
+        .all(db)
         .await?;
         let existing_value_attribute_ids = value_rows
             .into_iter()
             .map(|row| row.attribute_id)
             .collect::<Vec<_>>();
 
-        self.load_effective_form_for_category(
+        Self::load_effective_form_for_category_in(
+            db,
             tenant_id,
             primary_category_id,
             &existing_value_attribute_ids,
@@ -44,8 +56,26 @@ impl ProductCatalogSchemaService {
         category_id: Uuid,
         existing_value_attribute_ids: &[Uuid],
     ) -> CommerceResult<EffectiveProductForm> {
-        let categories = Self::load_category_schema_map(&self.db, tenant_id).await?;
-        let schemas = Self::load_attribute_schema_map(&self.db, tenant_id).await?;
+        Self::load_effective_form_for_category_in(
+            &self.db,
+            tenant_id,
+            category_id,
+            existing_value_attribute_ids,
+        )
+        .await
+    }
+
+    async fn load_effective_form_for_category_in<C>(
+        db: &C,
+        tenant_id: Uuid,
+        category_id: Uuid,
+        existing_value_attribute_ids: &[Uuid],
+    ) -> CommerceResult<EffectiveProductForm>
+    where
+        C: ConnectionTrait,
+    {
+        let categories = Self::load_category_schema_map(db, tenant_id).await?;
+        let schemas = Self::load_attribute_schema_map(db, tenant_id).await?;
         resolve_effective_product_form(
             category_id,
             &categories,
@@ -144,10 +174,13 @@ impl ProductCatalogSchemaService {
         Ok(labels)
     }
 
-    async fn load_category_schema_map(
-        db: &DatabaseConnection,
+    async fn load_category_schema_map<C>(
+        db: &C,
         tenant_id: Uuid,
-    ) -> CommerceResult<HashMap<Uuid, CatalogCategorySchema>> {
+    ) -> CommerceResult<HashMap<Uuid, CatalogCategorySchema>>
+    where
+        C: ConnectionTrait,
+    {
         let category_rows = CategorySchemaRow::find_by_statement(Statement::from_sql_and_values(
             db.get_database_backend(),
             r#"
@@ -232,10 +265,13 @@ impl ProductCatalogSchemaService {
         Ok(categories)
     }
 
-    async fn load_attribute_schema_map(
-        db: &DatabaseConnection,
+    async fn load_attribute_schema_map<C>(
+        db: &C,
         tenant_id: Uuid,
-    ) -> CommerceResult<HashMap<Uuid, ProductAttributeSchema>> {
+    ) -> CommerceResult<HashMap<Uuid, ProductAttributeSchema>>
+    where
+        C: ConnectionTrait,
+    {
         let schema_rows = SchemaRow::find_by_statement(Statement::from_sql_and_values(
             db.get_database_backend(),
             "SELECT id, code FROM product_attribute_schemas WHERE tenant_id = $1 AND archived_at IS NULL",

--- a/crates/rustok-product/src/services/catalog_schema_service/values.rs
+++ b/crates/rustok-product/src/services/catalog_schema_service/values.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::services::write_transaction::record_product_operation_result;
 
 impl ProductCatalogSchemaService {
     pub async fn load_product_attribute_values(
@@ -7,22 +8,37 @@ impl ProductCatalogSchemaService {
         product_id: Uuid,
         locale: &str,
     ) -> CommerceResult<Vec<ProductAttributeValueRecord>> {
+        Self::load_product_attribute_values_in(&self.db, tenant_id, product_id, locale).await
+    }
+
+    pub(super) async fn load_product_attribute_values_in<C>(
+        conn: &C,
+        tenant_id: Uuid,
+        product_id: Uuid,
+        locale: &str,
+    ) -> CommerceResult<Vec<ProductAttributeValueRecord>>
+    where
+        C: ConnectionTrait,
+    {
         validate_locale(locale)?;
-        ensure_product(&self.db, tenant_id, product_id).await?;
-        let detached_attribute_ids = match self
-            .load_effective_form_for_product(tenant_id, product_id)
-            .await?
+        ensure_product(conn, tenant_id, product_id).await?;
+        let detached_attribute_ids = match Self::load_effective_form_for_product_in(
+            conn,
+            tenant_id,
+            product_id,
+        )
+        .await?
         {
             Some(form) => form
                 .detached_attribute_ids
                 .into_iter()
                 .collect::<HashSet<_>>(),
             None => AttributeIdRow::find_by_statement(Statement::from_sql_and_values(
-                self.db.get_database_backend(),
+                conn.get_database_backend(),
                 "SELECT attribute_id FROM product_attribute_values WHERE tenant_id = $1 AND product_id = $2",
                 vec![tenant_id.into(), product_id.into()],
             ))
-            .all(&self.db)
+            .all(conn)
             .await?
             .into_iter()
             .map(|row| row.attribute_id)
@@ -30,7 +46,7 @@ impl ProductCatalogSchemaService {
         };
 
         let rows = ProductAttributeValueRow::find_by_statement(Statement::from_sql_and_values(
-            self.db.get_database_backend(),
+            conn.get_database_backend(),
             r#"
             SELECT
                 pav.id,
@@ -56,12 +72,12 @@ impl ProductCatalogSchemaService {
             "#,
             vec![tenant_id.into(), product_id.into(), locale.trim().into()],
         ))
-        .all(&self.db)
+        .all(conn)
         .await?;
 
         let option_rows =
             ProductAttributeValueOptionRow::find_by_statement(Statement::from_sql_and_values(
-                self.db.get_database_backend(),
+                conn.get_database_backend(),
                 r#"
                 SELECT pavo.value_id, pavo.option_id
                 FROM product_attribute_value_options pavo
@@ -71,7 +87,7 @@ impl ProductCatalogSchemaService {
                 "#,
                 vec![tenant_id.into(), product_id.into()],
             ))
-            .all(&self.db)
+            .all(conn)
             .await?;
         let mut options_by_value: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
         for row in option_rows {
@@ -336,10 +352,11 @@ impl ProductCatalogSchemaService {
             )
             .await?;
         }
+        let result = Self::load_product_attribute_values_in(&txn, tenant_id, product_id, locale)
+            .await?;
+        record_product_operation_result(&result)?;
         txn.commit().await?;
-
-        self.load_product_attribute_values(tenant_id, product_id, locale)
-            .await
+        Ok(result)
     }
 
     pub async fn clear_detached_product_attribute_values(
@@ -393,38 +410,37 @@ impl ProductCatalogSchemaService {
             }
             attribute_ids
         };
-        if target_attribute_ids.is_empty() {
-            return self
-                .load_product_attribute_values(tenant_id, product_id, locale)
-                .await;
-        }
 
         let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?;
-        let (placeholders, mut values) = uuid_filter_values(tenant_id, &target_attribute_ids);
-        let product_placeholder = format!("${}", values.len() + 1);
-        values.push(product_id.into());
-        txn.execute(Statement::from_sql_and_values(
-            txn.get_database_backend(),
-            format!(
-                r#"
-                DELETE FROM product_attribute_values
-                WHERE tenant_id = $1
-                  AND attribute_id IN ({placeholders})
-                  AND product_id = {product_placeholder}
-                "#
-            ),
-            values,
-        ))
-        .await?;
-        txn.publish(
-            tenant_id,
-            Some(actor_id),
-            DomainEvent::ProductAttributeValuesChanged { product_id },
-        )
-        .await?;
+        ensure_product(&txn, tenant_id, product_id).await?;
+        if !target_attribute_ids.is_empty() {
+            let (placeholders, mut values) = uuid_filter_values(tenant_id, &target_attribute_ids);
+            let product_placeholder = format!("${}", values.len() + 1);
+            values.push(product_id.into());
+            txn.execute(Statement::from_sql_and_values(
+                txn.get_database_backend(),
+                format!(
+                    r#"
+                    DELETE FROM product_attribute_values
+                    WHERE tenant_id = $1
+                      AND attribute_id IN ({placeholders})
+                      AND product_id = {product_placeholder}
+                    "#
+                ),
+                values,
+            ))
+            .await?;
+            txn.publish(
+                tenant_id,
+                Some(actor_id),
+                DomainEvent::ProductAttributeValuesChanged { product_id },
+            )
+            .await?;
+        }
+        let result = Self::load_product_attribute_values_in(&txn, tenant_id, product_id, locale)
+            .await?;
+        record_product_operation_result(&result)?;
         txn.commit().await?;
-
-        self.load_product_attribute_values(tenant_id, product_id, locale)
-            .await
+        Ok(result)
     }
 }

--- a/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
+++ b/scripts/verify/verify-product-schema-attribute-create-receipts.mjs
@@ -10,9 +10,6 @@ const failures = [];
 const requireText = (source, text, label) => {
   if (!source.includes(text)) failures.push(`${label}: missing ${text}`);
 };
-const forbidText = (source, text, label) => {
-  if (source.includes(text)) failures.push(`${label}: forbidden ${text}`);
-};
 const functionSlice = (source, name, nextName) => {
   const start = source.indexOf(`async fn ${name}(`);
   if (start < 0) {
@@ -22,11 +19,11 @@ const functionSlice = (source, name, nextName) => {
   const end = nextName ? source.indexOf(`async fn ${nextName}(`, start + 1) : -1;
   return source.slice(start, end < 0 ? source.length : end);
 };
-const requireRecordedBeforeCommit = (source, label) => {
-  const recorded = source.indexOf("record_product_operation_result(&())?");
+const requireRecordedBeforeCommit = (source, expected, label) => {
+  const recorded = source.indexOf(expected);
   const commit = source.indexOf("txn.commit().await?");
   if (recorded < 0 || commit < 0 || recorded > commit) {
-    failures.push(`${label}: unit receipt result must be recorded before owner transaction commit`);
+    failures.push(`${label}: receipt result must be recorded before owner transaction commit`);
   }
 };
 
@@ -35,7 +32,8 @@ const transaction = read("crates/rustok-product/src/services/write_transaction.r
 const attributes = read("crates/rustok-product/src/services/catalog_schema_service/attributes.rs");
 const categories = read("crates/rustok-product/src/services/catalog_schema_service/categories.rs");
 const schemas = read("crates/rustok-product/src/services/catalog_schema_service/schemas.rs");
-const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+const values = read("crates/rustok-product/src/services/catalog_schema_service/values.rs");
+const effectiveForms = read("crates/rustok-product/src/services/catalog_schema_service/effective_forms.rs");
 const recheck = read("crates/rustok-commerce/docs/product-schema-write-recheck-2026-08-08.md");
 const implStart = port.indexOf("impl ProductCatalogSchemaWritePort for ProductCatalogSchemaService");
 if (implStart < 0) failures.push("missing ProductCatalogSchemaWritePort implementation");
@@ -64,6 +62,8 @@ for (const [name, nextName] of [
   ["set_category_schema_mode", "bind_schema_attribute"],
   ["bind_schema_attribute", "bind_category_attribute"],
   ["bind_category_attribute", "save_product_attribute_values"],
+  ["save_product_attribute_values", "clear_detached_product_attribute_values"],
+  ["clear_detached_product_attribute_values", "admit_schema_operation"],
 ]) {
   const slice = functionSlice(portImpl, name, nextName);
   for (const required of [
@@ -74,18 +74,6 @@ for (const [name, nextName] of [
   ]) {
     requireText(slice, required, `${name} durable receipt`);
   }
-}
-
-for (const [name, nextName] of [
-  ["save_product_attribute_values", "clear_detached_product_attribute_values"],
-  ["clear_detached_product_attribute_values", "admit_schema_operation"],
-]) {
-  const slice = functionSlice(portImpl, name, nextName);
-  forbidText(
-    slice,
-    "admit_schema_operation(",
-    `${name} must remain explicit exact-projection replay follow-up debt`,
-  );
 }
 
 for (const required of [
@@ -148,29 +136,87 @@ for (const [slice, label] of [
   [categoryBinding, "category attribute binding update"],
   [schemaBinding, "schema attribute binding update"],
 ]) {
-  requireRecordedBeforeCommit(slice, label);
+  requireRecordedBeforeCommit(slice, "record_product_operation_result(&())?", label);
 }
 
-requireText(
-  plan,
-  "durable owner receipts cover all six schema create operations",
-  "canonical Product schema-write debt must record complete create receipt coverage",
+for (const required of [
+  "pub(super) async fn load_product_attribute_values_in<C>",
+  "C: ConnectionTrait",
+  "Self::load_effective_form_for_product_in(",
+  ".all(conn)",
+]) {
+  requireText(values, required, "transaction-local Product attribute-value projection");
+}
+for (const required of [
+  "pub(super) async fn load_effective_form_for_product_in<C>",
+  "async fn load_effective_form_for_category_in<C>",
+  "async fn load_category_schema_map<C>",
+  "async fn load_attribute_schema_map<C>",
+  "C: ConnectionTrait",
+]) {
+  requireText(effectiveForms, required, "connection-neutral Product effective-form projection");
+}
+
+const saveValues = functionSlice(values, "save_product_attribute_values", "clear_detached_product_attribute_values");
+for (const required of [
+  "let result = Self::load_product_attribute_values_in(&txn, tenant_id, product_id, locale)",
+  "record_product_operation_result(&result)?",
+  "txn.commit().await?",
+  "Ok(result)",
+]) {
+  requireText(saveValues, required, "attribute-value save exact receipt result");
+}
+requireRecordedBeforeCommit(
+  saveValues,
+  "record_product_operation_result(&result)?",
+  "attribute-value save exact projection",
 );
-requireText(
-  plan,
-  "update-style schema writes still need explicit owner replay semantics",
-  "canonical Product schema-write debt must remain open",
+const saveProjection = saveValues.indexOf("Self::load_product_attribute_values_in(&txn");
+const saveCommit = saveValues.indexOf("txn.commit().await?");
+if (saveProjection < 0 || saveCommit < 0 || saveProjection > saveCommit) {
+  failures.push("attribute-value save projection must be loaded from the owner transaction before commit");
+}
+
+const clearValues = functionSlice(values, "clear_detached_product_attribute_values", null);
+for (const required of [
+  "let txn = ProductWriteTransaction::begin(&self.db, self.event_bus.clone()).await?",
+  "if !target_attribute_ids.is_empty()",
+  "let result = Self::load_product_attribute_values_in(&txn, tenant_id, product_id, locale)",
+  "record_product_operation_result(&result)?",
+  "txn.commit().await?",
+  "Ok(result)",
+]) {
+  requireText(clearValues, required, "detached attribute-value clear exact receipt result");
+}
+requireRecordedBeforeCommit(
+  clearValues,
+  "record_product_operation_result(&result)?",
+  "detached attribute-value clear exact projection",
 );
-requireText(
-  recheck,
-  "three update-style state writes now use durable owner receipts",
-  "Product schema write recheck must record state-write receipt coverage",
-);
-requireText(
-  recheck,
-  "attribute-value writes remain open",
-  "Product schema write recheck must preserve exact-projection replay debt",
-);
+const clearTxn = clearValues.indexOf("let txn = ProductWriteTransaction::begin");
+const clearEmptyGuard = clearValues.indexOf("if !target_attribute_ids.is_empty()");
+const clearProjection = clearValues.indexOf("Self::load_product_attribute_values_in(&txn");
+const clearCommit = clearValues.indexOf("txn.commit().await?");
+if (
+  clearTxn < 0 ||
+  clearEmptyGuard < 0 ||
+  clearProjection < 0 ||
+  clearCommit < 0 ||
+  clearTxn > clearEmptyGuard ||
+  clearEmptyGuard > clearProjection ||
+  clearProjection > clearCommit
+) {
+  failures.push("detached clear must complete both mutation and empty-target paths through one receipt-capable owner transaction");
+}
+
+for (const required of [
+  "all eleven mounted Product schema writes",
+  "exact completed projection",
+  "empty-target detached clear",
+  "source-complete durable owner replay",
+]) {
+  requireText(recheck, required, "Product schema write recheck must record completed receipt coverage");
+}
 
 if (failures.length) {
   console.error("Product schema receipt source verification failed:");
@@ -178,4 +224,4 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("✔ Product schema creates and three unit-result state writes use durable owner receipts; exact attribute-value projection replay remains explicit debt");
+console.log("✔ all eleven mounted Product schema writes use durable owner receipts; attribute-value results are captured from the owner transaction before commit");


### PR DESCRIPTION
## Summary
- make Product effective-form and attribute-value projection reads connection-neutral so the exact EAV result can be read from the active owner transaction
- add durable owner receipt admission/replay to `save_product_attribute_values` and `clear_detached_product_attribute_values`
- serialize the exact `Vec<ProductAttributeValueRecord>` into the receipt before the same Product transaction commits, avoiding post-commit reconstruction and duplicate mutation/outbox publication after a lost response
- complete the empty-target detached-clear no-op through a receipt-capable owner transaction without fabricating a domain event
- extend the Product schema receipt source guard and recheck documentation to cover all eleven mounted schema writes

## Plan status
- this closes the remaining Product schema-write durable-replay implementation gap described by the ecommerce plan
- promotion/runtime evidence remains open; the canonical plan checkbox must stay unpromoted until maintainer-run compile/static/lost-response/restart/backend evidence is retained

## Verification
- source and GitHub diff inspection only
- tests, checks, formatters, workflows, and runtime verification were intentionally not run per maintainer instruction