### PR TITLE
feat(index): maintain replay leases within pages

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@523b7fa6da9bed59743e4fed532e17095010eba7` and continued on
-`agent/index-replay-locale-command-evidence-20260808`.
+Status overlay rechecked at `main@5c0a50eded09efbd4f1b6437b46a94a7f2ef0989` and continued on
+`agent/index-replay-page-lease-heartbeat-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -123,8 +123,8 @@ exactly schema-wide; it is not rewritten from schema locale defaults. Each run c
 identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page and a
 60-second lease.
 
-Retained command source evidence now includes schema-wide command behavior, locale command canonicalization and
-a dedicated locale yield/isolation/fresh-runtime resume packet. GraphQL execution/admission remains maintainer-owned.
+Retained command source evidence includes schema-wide command behavior, locale command canonicalization and a
+dedicated locale yield/isolation/fresh-runtime resume packet. GraphQL execution/admission remains maintainer-owned.
 
 ## M6 replay graceful interruption and server lifecycle binding
 
@@ -136,7 +136,7 @@ An `IndexReplayError::Interrupted` first preserves any persisted cancellation ra
 job is yielded back to `pending`, lease ownership is cleared, no failure payload is recorded, and the last
 committed checkpoint is preserved.
 
-Retained source evidence now covers both runner and command boundaries:
+Retained source evidence covers both runner and command boundaries:
 
 - runner-level SQLite evidence covers stop before scan and the harder durable-mutation-before-checkpoint window,
   where attempt 2 replays the stable delivery as `Duplicate` before checkpoint/job completion;
@@ -151,39 +151,39 @@ bootstrap execution. Production schema lifecycle reservation/keepalive remains s
 Neither retained shutdown packet nor a full process-shutdown replay scenario has been executed or admitted by
 the implementation agent.
 
-## M6 replay pending storage-future timeout boundary
+## M6 replay dependency timeouts and page lease-heartbeat policy
 
-The PostgreSQL replay adapter now bounds the two storage futures that could remain pending after a page has
-already entered a durable phase:
+Production replay now has a bounded outer observation window for every dependency phase that can otherwise remain
+pending inside one page:
 
-- one replay mutation persistence call;
-- one replay checkpoint commit transaction.
+- production source scan: 30 seconds through the canonical `IndexSource` timeout wrapper;
+- checkpoint read transaction: 30 seconds with `index_replay_checkpoint_read_timeout`;
+- one replay mutation persistence call: 30 seconds with `index_replay_mutation_timeout`;
+- checkpoint commit transaction: 30 seconds with `index_replay_checkpoint_commit_timeout`.
 
-`source_replay_timeout.rs` applies a canonical 30-second outer bound and stable retryable dependency identities:
-`index_replay_mutation_timeout` and `index_replay_checkpoint_commit_timeout`.
+These are observation bounds, not rollback guarantees. Dropping a timed-out future does not prove that an
+underlying database operation was cancelled. Stable delivery identity, inbox deduplication, monotonic source
+versions, durable checkpoint reads and active-lease fencing remain authoritative.
 
-The one-page worker and multi-page runner error/state surfaces are unchanged. Mutation timeout still appears as
-`IndexReplayError::MutationFailed`; checkpoint timeout still appears as `IndexReplayError::CheckpointCommitFailed`.
-The existing runner records the dependency code plus `retryable: true`, but first rechecks persisted cancellation,
-so a user cancellation that won the race remains `Cancelled`.
+A coarse whole-page timeout is deliberately not added because it could mask the precise dependency failure code.
+Instead, `IndexReplayRunRequest` now requires at least a 60-second lease and both ordinary/graceful runners
+maintain an active page lease every one third of the configured lease duration. The server-owned 60-second lease
+therefore heartbeats a still-running page every 20 seconds. Existing page-count heartbeat cadence remains intact.
 
-These are observation bounds, not rollback guarantees. Dropping the timed-out future does not prove that the
-underlying database operation was cancelled. No synthetic checkpoint is created after mutation timeout. A timed
-checkpoint commit is treated as storage-state-unknown: the next admitted attempt must read the durable checkpoint
-normally under the existing lease fence.
+Checkpoint-read bounding closes the remaining replay data-plane future that could otherwise remain pending while
+lease heartbeats continued. The timeout helper still owns no `StopHandle`, persisted cancellation or retry/requeue
+policy. Persisted cancellation is rechecked before terminal page failure; graceful shutdown remains worker
+safe-point-only.
 
-The timeout helper contains no `StopHandle`, `request_cancel`, `cancel_requested` or yield semantics. Graceful
-shutdown remains safe-point-only, while replay retry/recovery policy remains the owner of later retry admission.
-
-Retained timeout unit source and source guard are complete but have **not** been executed or admitted by the
-implementation agent. See `m6-replay-pending-future-timeouts.md`.
+Retained source assertions and guards are complete but have **not** been executed/admitted by the implementation
+agent. See `m6-replay-pending-future-timeouts.md` and `m6-replay-page-lease-heartbeat.md`.
 
 ## M6 locale-scoped replay source state
 
 Locale replay is split from partition/rebuild-mode work and tracked end-to-end instead of as one aggregate
 future item.
 
-Already merged on reviewed `main`:
+Merged source-complete chain:
 
 - generic `IndexSourceScanRequest` accepts optional canonical `LocaleKey` and validates returned mutation scope;
 - current Product PostgreSQL replay scans honor exact locale before pagination while preserving the schema-wide
@@ -198,20 +198,12 @@ Already merged on reviewed `main`:
 - optional locale is carried through the multi-page replay runner and GraphQL command transport;
 - ordinary and graceful runner paths derive the durable job lease from the same page locale scope;
 - terminal success binds the leased locale checkpoint instead of hard-coding the schema-wide empty locale;
-- GraphQL locale parsing remains authorization-first and locale omission remains exactly schema-wide.
+- GraphQL locale parsing remains authorization-first and locale omission remains exactly schema-wide;
+- retained GraphQL/runtime/runner evidence forces bounded `en-US` yield, completes distinct `de` and schema-wide
+  jobs, rebuilds runtime composition and resumes the same `en-US` job as attempt 2 with duplicate-safe redelivery;
+- final evidence retains exactly three job/checkpoint scopes: schema-wide, `en-US` and `de`.
 
-Current branch source-complete work:
-
-- Retain deterministic locale replay/restart command evidence through the real GraphQL/runtime/runner path.
-- force bounded `en-US` yield at the fixed 8-page GraphQL cap and retain cursor `8` on attempt 1;
-- complete a distinct `de` locale job without advancing the pending `en-US` checkpoint;
-- complete a distinct schema-wide job over the same stable owner events and prove inbox duplicate safety without
-  stealing the locale checkpoint;
-- rebuild distribution/runtime/operator/GraphQL composition over the same durable database and require the same
-  `en-US` job to resume as attempt 2, redeliver the final event as `Duplicate`, and commit its own completion;
-- retain exactly three job/checkpoint scopes at completion: schema-wide, `en-US` and `de`.
-
-The retained packet is source-complete but has not been executed. SQLite/PostgreSQL runtime execution and
+The retained locale packet is source-complete but has not been executed. SQLite/PostgreSQL runtime execution and
 production admission remain maintainer-owned. See `m6-locale-replay-command-evidence.md`.
 
 ## Remaining Storefront parity/evidence blockers
@@ -245,18 +237,19 @@ production admission remain maintainer-owned. See `m6-locale-replay-command-evid
 - [x] Carry a host-owned interruption probe through replay runner safe points and retain duplicate-safe restart evidence source.
 - [x] Bind the shared server `StopHandle::is_stopping` signal through guarded replay runtime/operator composition without caller shutdown controls.
 - [x] Retain deterministic GraphQL StopHandle -> pending -> fresh-runtime attempt-2 completion evidence source without sleeps/polling.
-- [x] Bound replay mutation/checkpoint-commit pending futures with retryable timeout identities and preserve cancel/lease precedence.
+- [x] Bound replay checkpoint-read/mutation/checkpoint-commit pending futures with retryable timeout identities and preserve cancel/lease precedence.
 - [x] Define canonical locale-scoped source scan and make current Product filter before pagination.
 - [x] Add durable locale replay job scope and exact locale checkpoint identity.
 - [x] Carry locale through one-page replay worker/checkpoint storage with fail-closed `LocaleMode` admission.
 - [x] Carry optional locale through the multi-page replay runner and GraphQL command transport.
 - [x] Retain deterministic locale replay/restart command evidence through the real GraphQL/runtime/runner path.
+- [x] Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
 - [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
-- [ ] Execute/admit retained mutation/checkpoint pending-future timeout evidence.
+- [ ] Execute/admit retained dependency pending-future timeout evidence.
+- [ ] Execute/admit retained page lease-heartbeat evidence.
 - [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
-- [ ] Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds.
 - [ ] Complete remaining multi-host/restart evidence beyond existing convergence/replay packets.
 - [ ] Add partition replay scope only after a real partition-capable source contract exists.
 - [ ] Add explicit targeted/full/shadow rebuild modes under a separate contract.
@@ -293,13 +286,13 @@ production admission remain maintainer-owned. See `m6-locale-replay-command-evid
 
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
 
-The locale request/source/job/checkpoint/runner/GraphQL identity chain and deterministic command/restart evidence
-source are complete. The next locale action is maintainer execution/admission of the retained packet, not another
-scope abstraction.
+The locale request/source/job/checkpoint/runner/GraphQL identity chain, deterministic locale command/restart
+evidence, dependency timeout set and page-duration/lease-heartbeat source policy are complete. Their next actions
+are maintainer execution/admission, not additional scope abstraction.
 
-For source-only M6 continuation, the next independent boundary is to define/retain whole-page duration versus
-lease/heartbeat policy beyond the existing per-dependency timeout bounds. That work must preserve cancellation,
-graceful-stop and locale job/checkpoint identities.
+For source-only M6 continuation, the next independent boundary is the remaining multi-host/restart evidence under
+the established lease, cancellation, graceful-stop and locale identities. Any retained packet must prove existing
+fencing/reclaim behavior rather than introduce automatic retry or a second job-ownership model.
 
 Partition remains separate and blocked. Add partition replay scope only after a real partition-capable source
 contract exists and can filter before pagination; do not merely populate `partition_key`. Explicit

--- a/crates/rustok-index/docs/m6-bounded-multipage-runner.md
+++ b/crates/rustok-index/docs/m6-bounded-multipage-runner.md
@@ -5,16 +5,16 @@ Status: `source_complete_owner_execution_pending`
 This slice composes the existing one-page replay worker, fenced rebuild jobs, mutation
 store, and lease-bound checkpoint store into one bounded PostgreSQL runner. It includes
 durable cancellation requests, between-page terminal cancellation, a separate host-probed
-in-page interruption path, and server-owned graceful-shutdown binding through the guarded
-replay command. It does not add a scheduler, background task, automatic retry/backoff,
-dry-run, or production source adapter.
+in-page interruption path, server-owned graceful-shutdown binding through the guarded
+replay command, and time-based in-page lease maintenance. It does not add a scheduler,
+background task, automatic retry/backoff, dry-run, or production source adapter.
 
 ## Request bounds
 
 `IndexReplayRunRequest` fixes one invocation to:
 
 - one non-nil tenant and exact `SchemaRef`;
-- one bounded worker identity and whole-second lease duration;
+- one bounded worker identity and whole-second lease duration of at least 60 seconds;
 - a source page limit already constrained to 1 through 1000;
 - 1 through 1024 pages per invocation;
 - a heartbeat cadence from 1 through the invocation page budget.
@@ -22,6 +22,12 @@ dry-run, or production source adapter.
 The source name is never caller supplied. `PostgresIndexReplayRunner` resolves the exact
 owner from `SharedIndexSourceRegistry` before acquiring the durable job. The job request
 therefore uses the same source identity as page execution and checkpoint persistence.
+
+The 60-second minimum is the page-duration lease floor. Production source calls and replay
+checkpoint-read/mutation/checkpoint-commit futures each have a canonical 30-second outer
+observation bound. Long pages keep their lease alive every one third of the configured lease
+while preserving those dependency-specific timeout identities; see
+`m6-replay-page-lease-heartbeat.md`.
 
 ## Ordinary execution order
 
@@ -31,17 +37,18 @@ For an acquired `IndexReplayJobLease`, ordinary `PostgresIndexReplayRunner::run`
 2. observes and terminalizes a previously requested cancellation before each page;
 3. executes no more than the requested page budget through
    `IndexReplayWorker::run_next_page`;
-4. extends the lease between pages at the requested completed-page cadence;
-5. observes cancellation again after heartbeat and after every completed page;
-6. accumulates applied, duplicate, stale, mutation, page, and heartbeat counts;
-7. calls fenced terminal success only after the one-page worker persisted a JSON `null`
+4. while a page is pending, extends the active lease every one third of the lease duration;
+5. also extends the lease between pages at the requested completed-page cadence;
+6. observes cancellation again after boundary heartbeat and after every completed page;
+7. accumulates applied, duplicate, stale, mutation, page, and both boundary/in-page heartbeat counts;
+8. calls fenced terminal success only after the one-page worker persisted a JSON `null`
    cursor;
-8. when the page budget ends with continuation, atomically returns the same job to
+9. when the page budget ends with continuation, atomically returns the same job to
    `pending`, clears lease ownership, and makes it immediately claimable for resume.
 
 A persisted cancellation requested during ordinary execution is still observed after the
-current page's idempotent mutations and checkpoint are durable. This existing user-cancel
-contract is intentionally unchanged by host interruption work.
+current page's idempotent mutations and checkpoint are durable. In-page lease heartbeats do
+not inspect or reinterpret `cancel_requested`; the existing user-cancel contract is unchanged.
 
 ## Host-probed in-page interruption
 
@@ -49,6 +56,10 @@ contract is intentionally unchanged by host interruption work.
 same job/checkpoint/mutation stores. It adapts a host-owned probe to
 `IndexReplayWorker::run_next_page_interruptible`, whose safe points are before source scan,
 before every mutation, and before checkpoint commit.
+
+The interruptible page future is awaited through the same time-based lease-maintenance helper
+as ordinary replay. Lease ownership can therefore stay valid during a long page without
+turning the heartbeat into a shutdown or cancellation probe.
 
 If the worker returns `IndexReplayError::Interrupted`, the runner first preserves any
 persisted cancellation race. Otherwise it uses the ordinary fenced pending-yield transition:
@@ -115,12 +126,20 @@ A running cancellation request survives lease expiry and reclaim. The next owner
 persisted flag before reading the source and terminalizes the job with the incremented
 attempt fence.
 
+If an in-page heartbeat itself loses the lease, page execution fails closed through the
+existing `IndexReplayRunError::LeaseLost` path. The runner does not manufacture a checkpoint,
+rollback, retry or terminal state after losing ownership.
+
 ## Failure boundary
 
 Source, mutation, and checkpoint failures are recorded as one bounded
 `index.replay_page_failed` terminal job error with an `index_replay_run_failure_v1`
 detail object containing only the dependency code and retryable classification. No raw
 database, transport, or source-domain message is persisted.
+
+Checkpoint read, mutation persistence and checkpoint commit each retain their own retryable
+30-second timeout code. There is deliberately no generic whole-page timeout that could mask
+one of those dependency identities.
 
 Cancellation takes precedence when it races with page failure. Checkpoint failures
 classified as `checkpoint_lease_lost`, heartbeat loss, terminal completion loss, yield
@@ -131,22 +150,24 @@ Host interruption is not a page failure and does not enter this failure path.
 
 ## Still open
 
-- execute/admit retained interruption/restart and end-to-end server-shutdown evidence;
-- automatic bounded retry/backoff and dead-letter scheduling;
+- execute/admit retained interruption/restart, page lease-heartbeat and end-to-end server-shutdown evidence;
+- automatic bounded retry/backoff and dead-letter scheduling remains a separate owner policy;
 - operator-visible scheduler health and metrics;
 - explicit targeted/full/shadow rebuild modes;
-- locale and partition checkpoint dimensions;
+- partition replay scope only after a real partition-capable source contract exists;
 - retained PostgreSQL cancellation, crash, lease-expiry, restart, timing, and
   multi-instance evidence beyond current focused packets.
 
-The guarded schema-wide GraphQL run/cancel command transport and server `StopHandle` observation
-are source-complete; execution evidence remains maintainer-owned.
+The guarded schema/locale GraphQL run/cancel command transport, locale checkpoint identity,
+server `StopHandle` observation and in-page lease-maintenance source are complete; execution
+evidence remains maintainer-owned.
 
 ## Owner validation
 
 ```bash
 node scripts/verify/verify-index-replay-multipage-runner.mjs
 node scripts/verify/verify-index-replay-graceful-shutdown.mjs
+node scripts/verify/verify-index-replay-page-lease-heartbeat.mjs
 node scripts/verify/verify-index-replay-job-leases.mjs
 node scripts/verify/verify-index-source-replay-contract.mjs
 cargo check -p rustok-index --all-targets

--- a/crates/rustok-index/docs/m6-replay-page-lease-heartbeat.md
+++ b/crates/rustok-index/docs/m6-replay-page-lease-heartbeat.md
@@ -1,0 +1,104 @@
+# M6 replay page-duration / lease-heartbeat policy
+
+Status: `source_complete_execution_pending`.
+
+## Purpose
+
+Replay already bounded production source calls plus mutation/checkpoint storage futures, and the multi-page runner already heartbeated between pages. That was not sufficient for a large page: one page may contain many mutations, so a valid run could spend longer than its lease inside `run_next_page` before the next page-count heartbeat.
+
+This slice defines and enforces the page-duration / lease policy without adding a coarse whole-page timeout that would hide the existing dependency-specific timeout identities.
+
+## Canonical dependency windows
+
+The production replay page now has bounded outer observation windows for each dependency phase that can otherwise remain pending:
+
+- production `IndexSource::scan`: `30s`, with `index_source_scan_timeout`;
+- checkpoint read transaction: `30s`, with `index_replay_checkpoint_read_timeout`;
+- one mutation persistence future: `30s`, with `index_replay_mutation_timeout`;
+- checkpoint commit transaction: `30s`, with `index_replay_checkpoint_commit_timeout`.
+
+Checkpoint identity validation remains outside the read/commit timeout wrappers. A timeout is still only an observation bound: dropping the future does not prove that an underlying database operation was rolled back or cancelled.
+
+The newly bounded checkpoint read closes the one replay data-plane phase that could otherwise remain pending while an in-page heartbeat kept extending the job lease indefinitely.
+
+## Minimum run lease
+
+`IndexReplayRunRequest` now rejects lease durations shorter than `60s`.
+
+The minimum deliberately reserves two current canonical dependency windows: one window for a single bounded page dependency plus one full window of lease/fencing margin. The existing durable job request continues to enforce whole-second leases and the 24-hour upper bound.
+
+The GraphQL command already uses the exact `60s` minimum, so the public server transport does not change its configured replay budget.
+
+This is a fail-closed contract. If the canonical dependency window changes, the lease policy and retained guard must be reviewed together rather than silently allowing the run lease to become smaller than the page dependency budget.
+
+## In-page heartbeat
+
+Both ordinary and graceful replay runners wrap each one-page future in the same `await_page_with_lease_heartbeats` helper.
+
+For an active page:
+
+1. compute the heartbeat interval as one third of the configured lease duration;
+2. continue polling the real page future;
+3. when the interval elapses while the page is still pending, race the page future with `PostgresIndexReplayJobStore::heartbeat`;
+4. after a successful heartbeat, schedule the next heartbeat from the completion time;
+5. include successful in-page heartbeats in `IndexReplayRunOutcome::heartbeat_count`.
+
+For the server-owned `60s` lease this produces a `20s` in-page heartbeat interval.
+
+The pre-existing `heartbeat_every_pages` boundary heartbeat remains intact. It still provides an explicit page-count cadence for fast pages; the in-page timer protects a slow or mutation-heavy page from losing its lease merely because the next page boundary has not been reached yet.
+
+## Why there is no whole-page timeout
+
+A single outer page timeout would race the more precise source/mutation/checkpoint timeout contracts. It could turn a known `index_replay_mutation_timeout` or `index_replay_checkpoint_commit_timeout` into a generic page-duration failure and would make durable-state recovery harder to diagnose.
+
+This policy therefore keeps dependency-specific timeout identity authoritative and uses lease heartbeats only for ownership maintenance. There is no new page terminal state and no generic `index_replay_page_timeout` code.
+
+## Lease-maintenance failure
+
+If an in-page heartbeat reports `LeaseLost`, the runner returns the existing fenced `IndexReplayRunError::LeaseLost`. If heartbeat storage itself fails, the runner returns the existing job-storage error path.
+
+In either case the page future is no longer trusted. Mutations that may already be durable remain protected by stable delivery IDs, inbox deduplication and monotonic source versions; checkpoint writes remain protected by active-lease fencing.
+
+No synthetic checkpoint, rollback, success or failure transition is invented after lost lease ownership.
+
+## Cancellation and graceful shutdown
+
+This slice does not merge persisted cancellation, graceful shutdown and lease maintenance into one state machine.
+
+- the in-page heartbeat does not set, clear or reinterpret `cancel_requested`;
+- the ordinary runner retains its existing persisted-cancellation checks before and after each page and before terminal failure publication;
+- `StopHandle` interruption is still observed only through the worker's cooperative safe points;
+- the graceful runner uses the same in-page lease helper around that interruptible page future;
+- a graceful interruption still yields the owned job to `pending` and preserves the last committed checkpoint;
+- no automatic retry/requeue policy is added.
+
+## Production source boundary
+
+Production sources registered through `register_index_source` retain the canonical 30-second source-call wrapper. Direct `IndexSourceCatalog::register` remains a low-level/test boundary and is not promoted here as a production way to bypass source-call bounds.
+
+## Retained source evidence
+
+Source assertions now retain:
+
+- minimum replay lease rejection below `60s` and acceptance at `60s`;
+- one-third in-page heartbeat interval (`60s -> 20s`);
+- ordinary and graceful page futures both routed through the common lease-heartbeat helper;
+- successful in-page heartbeat accounting;
+- checkpoint-read timeout identity and retryability;
+- unchanged mutation/checkpoint-commit timeout identities;
+- persisted cancellation precedence after page failure;
+- no generic whole-page timeout or new retry/requeue behavior.
+
+`verify-index-replay-page-lease-heartbeat.mjs` cross-checks the runner, source/storage timeout constants, GraphQL's fixed lease, graceful path, current plan and this document.
+
+The retained Rust tests and Node verifiers were not executed by the implementation agent.
+
+## Still open
+
+- maintainer execution/admission of this page-duration/lease-heartbeat source evidence;
+- maintainer execution/admission of the existing dependency-timeout packets;
+- broader multi-host/restart execution evidence;
+- partition replay only after a real partition-capable source contract exists;
+- explicit targeted/full/shadow rebuild modes under a separate contract.
+
+No Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-pending-future-timeouts.md
+++ b/crates/rustok-index/docs/m6-replay-pending-future-timeouts.md
@@ -4,25 +4,37 @@ Status: `source_complete_execution_pending`.
 
 ## Purpose
 
-Replay already had bounded owner-source calls and cooperative safe-point interruption, but those controls did not bound a storage future after mutation persistence or checkpoint commit had already started.
+Replay already had bounded owner-source calls and cooperative safe-point interruption, but storage futures inside one page also need finite outer observation bounds so lease maintenance cannot keep an indefinitely pending storage operation alive.
 
-This slice adds an outer timeout to the two PostgreSQL replay storage phases that can otherwise remain pending inside one page:
+The production PostgreSQL replay adapter now bounds all three storage phases that can otherwise remain pending inside one page:
 
+- checkpoint read transaction;
 - `PostgresMutationStore` when used through `IndexReplayMutationSink`;
 - `PostgresIndexReplayCheckpointStore::commit_replay_checkpoint`.
 
-The one-page worker and multi-page runner state machines are unchanged.
+The one-page worker error surface remains unchanged.
 
 ## Timeout contract
 
-`source_replay_timeout.rs` owns one canonical 30-second outer bound for each storage future and two stable retryable dependency codes:
+`source_replay_timeout.rs` owns one canonical 30-second outer bound for each replay storage dependency future and three stable retryable dependency codes:
 
+- `index_replay_checkpoint_read_timeout`;
 - `index_replay_mutation_timeout`;
 - `index_replay_checkpoint_commit_timeout`.
 
-The bound applies only after replay-specific contract preparation has succeeded. A normal dependency failure still passes through with its existing permanent/retryable classification.
+The bound applies only after replay-specific identity/contract preparation that can fail synchronously has succeeded. A normal dependency failure still passes through with its existing permanent/retryable classification.
 
-Source scan/load calls remain independently bounded by the existing canonical Index source timeout wrapper. This slice does not merge source and storage timeouts into one page deadline.
+Production source scan/load calls remain independently bounded by the existing canonical Index source timeout wrapper at 30 seconds. The page-duration/lease policy does not merge source and storage timeouts into one generic page deadline; see `m6-replay-page-lease-heartbeat.md`.
+
+## Checkpoint read timeout semantics
+
+Checkpoint identity validation remains outside the timeout so invalid lease/scope input fails immediately as the existing permanent contract error.
+
+The database transaction, active lease check, checkpoint read/decode and transaction commit/rollback are then observed through one bounded checkpoint-read future. Timeout returns retryable `index_replay_checkpoint_read_timeout`, preserved by the worker as `IndexReplayError::CheckpointReadFailed`.
+
+A timed-out read does not synthesize a checkpoint and does not claim that the database cancelled every underlying operation immediately when the future was dropped. The next attempt still reads durable state normally under the existing lease fence.
+
+Bounding the read is also required by the page lease-heartbeat policy: otherwise a pending checkpoint read could keep receiving lease extensions indefinitely without ever reaching source scan, mutation persistence, or checkpoint commit.
 
 ## Mutation timeout semantics
 
@@ -44,9 +56,9 @@ The timeout path does not execute a synthetic rollback, rewind or checkpoint wri
 
 ## Runner failure and cancellation precedence
 
-No new runner terminal state is introduced. Existing `replay_failure_details` already maps mutation/checkpoint dependency failures to their machine code and `IndexReplayFailureKind` retryability.
+No new runner terminal state is introduced. Existing `replay_failure_details` maps checkpoint-read, mutation and checkpoint-commit dependency failures to their machine code and `IndexReplayFailureKind` retryability.
 
-For either timeout, the multi-page runner still checks persisted cancellation after the page error and before writing terminal failure. Therefore:
+For any of these timeout paths, the multi-page runner still checks persisted cancellation after the page error and before writing terminal failure. Therefore:
 
 1. a user cancellation that won the race remains `Cancelled`;
 2. otherwise an active fenced attempt records the existing `index.replay_page_failed` terminal job failure with timeout dependency code and `retryable: true` in details;
@@ -57,27 +69,33 @@ This slice does not automatically requeue a failed replay job. Existing replay r
 
 ## Lease boundary
 
-The 30-second value is an upper bound for one storage dependency future, not a guarantee that a whole page fits inside a job lease. Existing heartbeat and lease fencing remain authoritative. A future page-budget/lease policy may tighten these per-phase values, but must not weaken the timeout error semantics retained here.
+Per-dependency 30-second bounds are not summed into a whole-page timeout. Large pages can legitimately span many bounded mutation futures, so the runner now maintains lease ownership while the real page future is pending.
+
+`IndexReplayRunRequest` requires at least a 60-second lease, and the ordinary/graceful runners heartbeat an active page every one third of the configured lease duration. With the server-owned 60-second lease, the in-page cadence is 20 seconds. The existing page-count heartbeat remains intact for fast pages.
+
+This keeps exact source/checkpoint/mutation timeout identities authoritative. There is deliberately no generic `index_replay_page_timeout` code. Full policy and retained evidence are documented in `m6-replay-page-lease-heartbeat.md`.
 
 ## Retained source evidence
 
 `source_replay_timeout.rs` retains unit source for:
 
+- a never-completing checkpoint-read future becoming retryable `index_replay_checkpoint_read_timeout`;
 - a never-completing mutation future becoming retryable `index_replay_mutation_timeout`;
-- a never-completing checkpoint commit future becoming retryable `index_replay_checkpoint_commit_timeout`;
+- a never-completing checkpoint-commit future becoming retryable `index_replay_checkpoint_commit_timeout`;
 - an immediate dependency failure passing through unchanged instead of being rewritten as timeout.
 
-`verify-index-replay-pending-future-timeout.mjs` additionally locks the production adapter wiring, timeout codes, runner retryability mapping, cancellation precedence and the deliberate absence of `StopHandle` / `request_cancel` from the timeout helper.
+`verify-index-replay-pending-future-timeout.mjs` locks production adapter wiring, all three timeout codes, runner retryability mapping, cancellation precedence and the deliberate absence of `StopHandle` / `request_cancel` from the timeout helper.
 
-The retained tests and verifier were not executed by the implementation agent.
+`verify-index-replay-page-lease-heartbeat.mjs` separately locks the minimum lease, in-page heartbeat policy and the deliberate absence of a generic whole-page timeout.
+
+The retained tests and verifiers were not executed by the implementation agent.
 
 ## Still open
 
-- maintainer execution/admission of the retained timeout source evidence;
-- broader page-duration versus lease/heartbeat budgeting under multi-mutation pages;
-- checkpoint-read pending-future policy if later evidence shows it needs a separate bound;
-- locale/partition replay checkpoint dimensions;
+- maintainer execution/admission of the retained dependency-timeout source evidence;
+- maintainer execution/admission of the page lease-heartbeat source evidence;
+- broader multi-host/restart execution evidence;
+- partition replay only after a real partition-capable source contract exists;
 - explicit targeted/full/shadow rebuild modes;
-- broader multi-host/restart execution evidence.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay.rs
@@ -18,7 +18,9 @@ use super::{
     source_replay_job::{
         assert_active_replay_job_lease, IndexReplayJobError, IndexReplayJobLease,
     },
-    source_replay_timeout::{bounded_replay_checkpoint_commit, bounded_replay_mutation},
+    source_replay_timeout::{
+        bounded_replay_checkpoint_commit, bounded_replay_checkpoint_read, bounded_replay_mutation,
+    },
 };
 
 #[async_trait]
@@ -70,77 +72,80 @@ impl IndexReplayCheckpointStore for PostgresIndexReplayCheckpointStore {
         key: &IndexReplayCheckpointKey,
     ) -> Result<Option<IndexReplayCheckpoint>, IndexReplayFailure> {
         validate_checkpoint_identity(&self.lease, key)?;
-        let transaction = self
-            .db
-            .begin()
-            .await
-            .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
-        let result = async {
-            let backend = transaction.get_database_backend();
-            ensure_supported_backend(backend)?;
-            assert_active_replay_job_lease(&transaction, &self.lease, backend)
-                .await
-                .map_err(classify_job_lease_failure)?;
-            let row = transaction
-                .query_one(Statement::from_sql_and_values(
-                    backend,
-                    select_checkpoint_sql(backend),
-                    checkpoint_key_values(key, backend),
-                ))
+        bounded_replay_checkpoint_read(async {
+            let transaction = self
+                .db
+                .begin()
                 .await
                 .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
-            let Some(row) = row else {
-                return Ok(None);
-            };
-
-            let cursor_json: JsonValue = row.try_get("", "cursor").map_err(|error| {
-                checkpoint_contract_failure("checkpoint_cursor_invalid", error)
-            })?;
-            let cursor = serde_json::from_value(cursor_json).map_err(|error| {
-                checkpoint_contract_failure("checkpoint_cursor_invalid", error)
-            })?;
-            let source_version_text: Option<String> = row
-                .try_get("", "source_version_text")
-                .map_err(|error| {
-                    checkpoint_contract_failure("checkpoint_source_version_invalid", error)
-                })?;
-            let source_version = source_version_text
-                .map(|value| {
-                    value.parse::<u64>().map_err(|error| {
-                        checkpoint_contract_failure("checkpoint_source_version_invalid", error)
-                    })
-                })
-                .transpose()?;
-            let last_delivery_id: Option<String> = row.try_get("", "last_delivery_id").map_err(
-                |error| checkpoint_contract_failure("checkpoint_delivery_invalid", error),
-            )?;
-
-            IndexReplayCheckpoint::new(key.clone(), cursor, source_version, last_delivery_id)
-                .map(Some)
-                .map_err(|error| {
-                    checkpoint_contract_failure("checkpoint_contract_invalid", error)
-                })
-        }
-        .await;
-
-        match result {
-            Ok(checkpoint) => {
-                transaction
-                    .commit()
+            let result = async {
+                let backend = transaction.get_database_backend();
+                ensure_supported_backend(backend)?;
+                assert_active_replay_job_lease(&transaction, &self.lease, backend)
+                    .await
+                    .map_err(classify_job_lease_failure)?;
+                let row = transaction
+                    .query_one(Statement::from_sql_and_values(
+                        backend,
+                        select_checkpoint_sql(backend),
+                        checkpoint_key_values(key, backend),
+                    ))
                     .await
                     .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
-                Ok(checkpoint)
-            }
-            Err(error) => {
-                transaction
-                    .rollback()
-                    .await
-                    .map_err(|rollback| {
-                        checkpoint_storage_failure("checkpoint_read_rollback_failed", rollback)
+                let Some(row) = row else {
+                    return Ok(None);
+                };
+
+                let cursor_json: JsonValue = row.try_get("", "cursor").map_err(|error| {
+                    checkpoint_contract_failure("checkpoint_cursor_invalid", error)
+                })?;
+                let cursor = serde_json::from_value(cursor_json).map_err(|error| {
+                    checkpoint_contract_failure("checkpoint_cursor_invalid", error)
+                })?;
+                let source_version_text: Option<String> = row
+                    .try_get("", "source_version_text")
+                    .map_err(|error| {
+                        checkpoint_contract_failure("checkpoint_source_version_invalid", error)
                     })?;
-                Err(error)
+                let source_version = source_version_text
+                    .map(|value| {
+                        value.parse::<u64>().map_err(|error| {
+                            checkpoint_contract_failure("checkpoint_source_version_invalid", error)
+                        })
+                    })
+                    .transpose()?;
+                let last_delivery_id: Option<String> = row.try_get("", "last_delivery_id").map_err(
+                    |error| checkpoint_contract_failure("checkpoint_delivery_invalid", error),
+                )?;
+
+                IndexReplayCheckpoint::new(key.clone(), cursor, source_version, last_delivery_id)
+                    .map(Some)
+                    .map_err(|error| {
+                        checkpoint_contract_failure("checkpoint_contract_invalid", error)
+                    })
             }
-        }
+            .await;
+
+            match result {
+                Ok(checkpoint) => {
+                    transaction
+                        .commit()
+                        .await
+                        .map_err(|error| checkpoint_storage_failure("checkpoint_read_failed", error))?;
+                    Ok(checkpoint)
+                }
+                Err(error) => {
+                    transaction
+                        .rollback()
+                        .await
+                        .map_err(|rollback| {
+                            checkpoint_storage_failure("checkpoint_read_rollback_failed", rollback)
+                        })?;
+                    Err(error)
+                }
+            }
+        })
+        .await
     }
 
     async fn commit_replay_checkpoint(

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
@@ -6,6 +6,7 @@ use sea_orm::{
 };
 use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
+use tokio::time::{Instant, sleep_until};
 use uuid::Uuid;
 
 use crate::{
@@ -21,6 +22,8 @@ use super::{
 };
 
 const MAX_PAGES_PER_RUN: usize = 1_024;
+const MIN_REPLAY_RUN_LEASE_DURATION: Duration = Duration::from_secs(60);
+const PAGE_LEASE_HEARTBEAT_DIVISOR: u32 = 3;
 const REPLAY_PAGE_FAILURE_CODE: &str = "index.replay_page_failed";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -96,6 +99,12 @@ impl IndexReplayRunRequest {
             return Err(IndexReplayRunError::InvalidHeartbeatCadence {
                 actual: heartbeat_every_pages,
                 max: max_pages,
+            });
+        }
+        if lease_duration < MIN_REPLAY_RUN_LEASE_DURATION {
+            return Err(IndexReplayRunError::LeaseDurationTooShort {
+                actual: lease_duration,
+                minimum: MIN_REPLAY_RUN_LEASE_DURATION,
             });
         }
         let page_request = match locale {
@@ -323,7 +332,15 @@ impl PostgresIndexReplayRunner {
                 }
             }
 
-            let page = match worker.run_next_page(request.page_request().clone()).await {
+            let (page_result, in_page_heartbeat_count) = await_page_with_lease_heartbeats(
+                &job_store,
+                &lease,
+                request.lease_duration(),
+                worker.run_next_page(request.page_request().clone()),
+            )
+            .await?;
+            aggregate.heartbeat_count += in_page_heartbeat_count;
+            let page = match page_result {
                 Ok(page) => page,
                 Err(error) if replay_error_is_lease_lost(&error) => {
                     return Err(lease_lost(&lease));
@@ -433,6 +450,44 @@ fn empty_outcome(
         applied_count: 0,
         duplicate_count: 0,
         stale_count: 0,
+    }
+}
+
+fn page_lease_heartbeat_interval(lease_duration: Duration) -> Duration {
+    lease_duration / PAGE_LEASE_HEARTBEAT_DIVISOR
+}
+
+async fn await_page_with_lease_heartbeats<T, F>(
+    job_store: &PostgresIndexReplayJobStore,
+    lease: &IndexReplayJobLease,
+    lease_duration: Duration,
+    page_future: F,
+) -> Result<(Result<T, IndexReplayError>, usize), IndexReplayRunError>
+where
+    F: Future<Output = Result<T, IndexReplayError>>,
+{
+    let heartbeat_interval = page_lease_heartbeat_interval(lease_duration);
+    debug_assert!(!heartbeat_interval.is_zero());
+    tokio::pin!(page_future);
+    let mut heartbeat_count = 0usize;
+    let mut next_heartbeat = Instant::now() + heartbeat_interval;
+
+    loop {
+        tokio::select! {
+            page_result = &mut page_future => return Ok((page_result, heartbeat_count)),
+            _ = sleep_until(next_heartbeat) => {
+                let heartbeat_future = heartbeat(job_store, lease, lease_duration);
+                tokio::pin!(heartbeat_future);
+                tokio::select! {
+                    page_result = &mut page_future => return Ok((page_result, heartbeat_count)),
+                    heartbeat_result = &mut heartbeat_future => {
+                        heartbeat_result?;
+                        heartbeat_count += 1;
+                        next_heartbeat = Instant::now() + heartbeat_interval;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -752,6 +807,10 @@ pub enum IndexReplayRunError {
     InvalidMaxPages { actual: usize, max: usize },
     #[error("Index replay heartbeat cadence is invalid: actual={actual}, max={max}")]
     InvalidHeartbeatCadence { actual: usize, max: usize },
+    #[error(
+        "Index replay lease duration is too short for the page heartbeat policy: actual={actual:?}, minimum={minimum:?}"
+    )]
+    LeaseDurationTooShort { actual: Duration, minimum: Duration },
     #[error("Index replay cancellation tenant id must not be nil")]
     NilCancelTenantId,
     #[error("Index replay cancellation job id must not be nil")]
@@ -829,5 +888,39 @@ mod locale_scope_tests {
         let lease_request = lease_request_for_run(&request, "product-postgres-primary".to_owned())
             .unwrap();
         assert!(lease_request.locale().is_none());
+    }
+
+    #[test]
+    fn page_lease_policy_requires_two_dependency_windows_and_heartbeats_at_one_third() {
+        let too_short = IndexReplayRunRequest::new(
+            Uuid::new_v4(),
+            product_schema(),
+            "short-lease-test",
+            100,
+            8,
+            1,
+            Duration::from_secs(59),
+        )
+        .expect_err("lease shorter than the canonical page reserve must fail closed");
+        assert!(matches!(
+            too_short,
+            IndexReplayRunError::LeaseDurationTooShort { .. }
+        ));
+
+        let minimum = IndexReplayRunRequest::new(
+            Uuid::new_v4(),
+            product_schema(),
+            "minimum-lease-test",
+            100,
+            8,
+            1,
+            Duration::from_secs(60),
+        )
+        .expect("canonical 60 second replay lease should remain valid");
+        assert_eq!(minimum.lease_duration(), Duration::from_secs(60));
+        assert_eq!(
+            page_lease_heartbeat_interval(minimum.lease_duration()),
+            Duration::from_secs(20)
+        );
     }
 }

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs
@@ -79,13 +79,22 @@ impl PostgresIndexReplayRunner {
                 }
             }
 
-            let page = match worker
-                .run_next_page_interruptible(request.page_request().clone(), || {
+            let page_future = worker.run_next_page_interruptible(
+                request.page_request().clone(),
+                || {
                     let interrupted = should_interrupt();
                     async move { Ok::<bool, crate::IndexReplayFailure>(interrupted) }
-                })
-                .await
-            {
+                },
+            );
+            let (page_result, in_page_heartbeat_count) = await_page_with_lease_heartbeats(
+                &job_store,
+                &lease,
+                request.lease_duration(),
+                page_future,
+            )
+            .await?;
+            aggregate.heartbeat_count += in_page_heartbeat_count;
+            let page = match page_result {
                 Ok(page) => page,
                 Err(crate::IndexReplayError::Interrupted) => {
                     return yield_after_host_interruption(&self.db, &lease, aggregate).await;

--- a/crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs
+++ b/crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs
@@ -4,7 +4,7 @@ use tokio::time::timeout;
 
 use crate::IndexReplayFailure;
 
-/// Canonical upper bound for one replay mutation persistence call or one replay checkpoint commit.
+/// Canonical upper bound for one replay storage dependency future.
 ///
 /// This is an outer future bound, not a claim that the underlying database operation is rolled back
 /// or cancelled after the future is dropped. Replay correctness must therefore continue to rely on
@@ -13,6 +13,7 @@ use crate::IndexReplayFailure;
 const DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT: Duration = Duration::from_secs(30);
 
 const INDEX_REPLAY_MUTATION_TIMEOUT_CODE: &str = "index_replay_mutation_timeout";
+const INDEX_REPLAY_CHECKPOINT_READ_TIMEOUT_CODE: &str = "index_replay_checkpoint_read_timeout";
 const INDEX_REPLAY_CHECKPOINT_COMMIT_TIMEOUT_CODE: &str =
     "index_replay_checkpoint_commit_timeout";
 
@@ -24,6 +25,21 @@ where
         DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT,
         INDEX_REPLAY_MUTATION_TIMEOUT_CODE,
         "mutation",
+        future,
+    )
+    .await
+}
+
+pub(super) async fn bounded_replay_checkpoint_read<T, F>(
+    future: F,
+) -> Result<T, IndexReplayFailure>
+where
+    F: Future<Output = Result<T, IndexReplayFailure>>,
+{
+    bounded_replay_storage_future(
+        DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT,
+        INDEX_REPLAY_CHECKPOINT_READ_TIMEOUT_CODE,
+        "checkpoint_read",
         future,
     )
     .await
@@ -90,6 +106,21 @@ mod tests {
 
         assert_eq!(failure.kind(), IndexReplayFailureKind::Retryable);
         assert_eq!(failure.code(), INDEX_REPLAY_MUTATION_TIMEOUT_CODE);
+    }
+
+    #[tokio::test]
+    async fn pending_checkpoint_read_future_times_out_as_retryable() {
+        let failure = bounded_replay_storage_future(
+            Duration::from_millis(1),
+            INDEX_REPLAY_CHECKPOINT_READ_TIMEOUT_CODE,
+            "checkpoint_read",
+            pending::<Result<(), IndexReplayFailure>>(),
+        )
+        .await
+        .expect_err("pending replay checkpoint read should hit the outer timeout");
+
+        assert_eq!(failure.kind(), IndexReplayFailureKind::Retryable);
+        assert_eq!(failure.code(), INDEX_REPLAY_CHECKPOINT_READ_TIMEOUT_CODE);
     }
 
     #[tokio::test]

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -35,6 +35,7 @@ const scripts = [
   'verify-index-replay-multipage-runner.mjs',
   'verify-index-replay-graceful-shutdown.mjs',
   'verify-index-replay-pending-future-timeout.mjs',
+  'verify-index-replay-page-lease-heartbeat.mjs',
   'verify-index-source-reconciliation.mjs',
   'verify-index-replay-runtime-composition.mjs',
   'verify-index-replay-graphql-transport.mjs',

--- a/scripts/verify/verify-index-replay-graceful-shutdown.mjs
+++ b/scripts/verify/verify-index-replay-graceful-shutdown.mjs
@@ -33,8 +33,11 @@ const extensionPath = 'crates/rustok-index/src/infrastructure/postgres/source_re
 const extension = requireMarkers(extensionPath, [
   'pub async fn run_interruptible<Check>(',
   'Check: FnMut() -> bool',
-  '.run_next_page_interruptible(request.page_request().clone(), || {',
+  'let page_future = worker.run_next_page_interruptible(',
+  'request.page_request().clone(),',
   'Ok::<bool, crate::IndexReplayFailure>(interrupted)',
+  'await_page_with_lease_heartbeats(',
+  'aggregate.heartbeat_count += in_page_heartbeat_count;',
   'Err(crate::IndexReplayError::Interrupted) => {',
   'yield_after_host_interruption(&self.db, &lease, aggregate).await',
   'if cancel_if_requested(db, lease).await?',
@@ -48,6 +51,7 @@ for (const forbidden of [
   'finish_failure(db, lease',
   'IndexReplayRunStatus::Complete;',
   'StopHandle',
+  'index_replay_page_timeout',
 ]) {
   if (extension.includes(forbidden)) {
     fail(`${extensionPath} must yield host interruption without manufacturing cancellation/failure/lifecycle ownership: ${forbidden}`);
@@ -65,11 +69,12 @@ const ordinaryPath = 'crates/rustok-index/src/infrastructure/postgres/source_rep
 const ordinary = requireMarkers(ordinaryPath, [
   'pub async fn run(',
   'worker.run_next_page(request.page_request().clone())',
+  'await_page_with_lease_heartbeats(',
   'pub async fn request_cancel(',
   'yield_for_resume(&self.db, &lease).await?',
 ]);
 if (ordinary.includes('run_interruptible<Check>')) {
-  fail(`${ordinaryPath} ordinary runner file must remain unchanged by the host-probe extension`);
+  fail(`${ordinaryPath} ordinary runner file must remain separate from the host-probe extension`);
 }
 
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/replay_runtime.rs', [
@@ -167,4 +172,4 @@ requireMarkers('crates/rustok-index/docs/m6-replay-graceful-shutdown.md', [
   'actual server-shutdown path have not been executed',
 ]);
 
-console.log('[verify-index-replay-graceful-shutdown] server-owned StopHandle observation is bound through guarded lifecycle-neutral replay probes while interruption remains pending/duplicate-safe and distinct from user cancellation');
+console.log('[verify-index-replay-graceful-shutdown] server-owned StopHandle observation remains pending/duplicate-safe while interruptible pages share the ordinary in-page lease-maintenance policy');

--- a/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
+++ b/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
@@ -28,6 +28,7 @@ const runner = requireMarkers(runnerPath, [
   'lease.locale()',
   'checkpoint.locale_key = {prefix}9',
   "checkpoint.partition_key = ''",
+  'await_page_with_lease_heartbeats(',
 ]);
 if (runner.includes("checkpoint.locale_key = ''")) {
   fail(`${runnerPath} must not hard-code schema locale in the terminal success fence`);
@@ -40,7 +41,9 @@ const gracefulPath =
   'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';
 const graceful = requireMarkers(gracefulPath, [
   'let lease_request = lease_request_for_run(&request, source_name)?;',
-  'run_next_page_interruptible(request.page_request().clone()',
+  'let page_future = worker.run_next_page_interruptible(',
+  'request.page_request().clone(),',
+  'await_page_with_lease_heartbeats(',
   'yield_after_host_interruption',
 ]);
 if (graceful.includes('IndexReplayJobLeaseRequest::new(')) {
@@ -80,7 +83,7 @@ requireMarkers('crates/rustok-index/docs/m6-locale-replay-runner-graphql.md', [
   'runner_graphql_source_complete_execution_pending',
   'checkpoint.locale_key',
   'Partition replay must remain blocked',
-  'end-to-end retained locale replay/restart execution',
+  'retained end-to-end locale replay/restart execution',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Carry optional locale through the multi-page replay runner and GraphQL command transport',
@@ -88,4 +91,4 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Add explicit targeted/full/shadow rebuild modes under a separate contract',
 ]);
 
-console.log('[verify-index-replay-locale-runner-graphql] source contract markers present');
+console.log('[verify-index-replay-locale-runner-graphql] locale replay identity remains stable while ordinary and graceful pages share the lease-maintenance helper');

--- a/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
+++ b/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
@@ -83,10 +83,11 @@ requireMarkers('crates/rustok-index/docs/m6-locale-replay-runner-graphql.md', [
   'runner_graphql_source_complete_execution_pending',
   'checkpoint.locale_key',
   'Partition replay must remain blocked',
-  'retained end-to-end locale replay/restart execution',
+  'end-to-end GraphQL locale yield/isolation/fresh-runtime resume',
+  'Execution/admission remains maintainer-owned',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Carry optional locale through the multi-page replay runner and GraphQL command transport',
+  'optional locale is carried through the multi-page replay runner and GraphQL command transport',
   'Add partition replay scope only after a real partition-capable source contract exists',
   'Add explicit targeted/full/shadow rebuild modes under a separate contract',
 ]);

--- a/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
+++ b/scripts/verify/verify-index-replay-locale-runner-graphql.mjs
@@ -80,7 +80,7 @@ requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
   '`partition_key`',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-locale-replay-runner-graphql.md', [
-  'runner_graphql_source_complete_execution_pending',
+  'runner_graphql_evidence_source_complete_execution_pending',
   'checkpoint.locale_key',
   'Partition replay must remain blocked',
   'end-to-end GraphQL locale yield/isolation/fresh-runtime resume',

--- a/scripts/verify/verify-index-replay-multipage-runner.mjs
+++ b/scripts/verify/verify-index-replay-multipage-runner.mjs
@@ -35,7 +35,7 @@ const runner = requireMarkers(runnerPath, [
   'for page_index in 0..request.max_pages()',
   'page_index % request.heartbeat_every_pages() == 0',
   'worker.run_next_page(request.page_request().clone())',
-  'await_page_with_lease_heartbeats(',
+  'let (page_result, in_page_heartbeat_count) = await_page_with_lease_heartbeats(',
   'aggregate.heartbeat_count += in_page_heartbeat_count;',
   'cancel_if_requested(&self.db, &lease).await?',
   'finish_success(&self.db, &lease).await?',
@@ -66,18 +66,18 @@ for (const forbidden of [
 
 const runLoop = runner.indexOf('for page_index in 0..request.max_pages()');
 const prePageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', runLoop);
-const pageCall = runner.indexOf('worker.run_next_page(request.page_request().clone())', runLoop);
-const pageAwait = runner.indexOf('await_page_with_lease_heartbeats(', pageCall);
-const pageMatch = runner.indexOf('let page = match page_result {', pageAwait);
+const pageAwait = runner.indexOf('let (page_result, in_page_heartbeat_count) = await_page_with_lease_heartbeats(', prePageCancel);
+const pageCall = runner.indexOf('worker.run_next_page(request.page_request().clone())', pageAwait);
+const pageMatch = runner.indexOf('let page = match page_result {', pageCall);
 const postPageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', pageMatch);
 const successCall = runner.indexOf('finish_success(&self.db, &lease).await?', postPageCancel);
 const yieldCall = runner.indexOf('yield_for_resume(&self.db, &lease).await?', successCall);
 if (
   runLoop < 0
   || prePageCancel <= runLoop
-  || pageCall <= prePageCancel
-  || pageAwait <= pageCall
-  || pageMatch <= pageAwait
+  || pageAwait <= prePageCancel
+  || pageCall <= pageAwait
+  || pageMatch <= pageCall
   || postPageCancel <= pageMatch
   || successCall <= postPageCancel
   || yieldCall <= successCall

--- a/scripts/verify/verify-index-replay-multipage-runner.mjs
+++ b/scripts/verify/verify-index-replay-multipage-runner.mjs
@@ -21,6 +21,7 @@ const requireMarkers = (relative, markers) => {
 const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
 const runner = requireMarkers(runnerPath, [
   'const MAX_PAGES_PER_RUN: usize = 1_024;',
+  'const MIN_REPLAY_RUN_LEASE_DURATION: Duration = Duration::from_secs(60);',
   'pub struct IndexReplayRunRequest',
   'pub enum IndexReplayRunStatus',
   'Cancelled,',
@@ -34,6 +35,8 @@ const runner = requireMarkers(runnerPath, [
   'for page_index in 0..request.max_pages()',
   'page_index % request.heartbeat_every_pages() == 0',
   'worker.run_next_page(request.page_request().clone())',
+  'await_page_with_lease_heartbeats(',
+  'aggregate.heartbeat_count += in_page_heartbeat_count;',
   'cancel_if_requested(&self.db, &lease).await?',
   'finish_success(&self.db, &lease).await?',
   'finish_failure(&self.db, &lease, details).await?',
@@ -51,13 +54,12 @@ const runner = requireMarkers(runnerPath, [
 
 for (const forbidden of [
   'tokio::spawn',
-  'loop {',
-  'tokio::time::sleep',
   'DELETE FROM index_jobs',
   'rustok_product',
   'rustok_content',
   'rustok_flex',
   'run_interruptible<Check>',
+  'index_replay_page_timeout',
 ]) {
   if (runner.includes(forbidden)) fail(`${runnerPath} contains forbidden marker ${forbidden}`);
 }
@@ -65,18 +67,22 @@ for (const forbidden of [
 const runLoop = runner.indexOf('for page_index in 0..request.max_pages()');
 const prePageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', runLoop);
 const pageCall = runner.indexOf('worker.run_next_page(request.page_request().clone())', runLoop);
-const postPageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', pageCall);
+const pageAwait = runner.indexOf('await_page_with_lease_heartbeats(', pageCall);
+const pageMatch = runner.indexOf('let page = match page_result {', pageAwait);
+const postPageCancel = runner.indexOf('cancel_if_requested(&self.db, &lease).await?', pageMatch);
 const successCall = runner.indexOf('finish_success(&self.db, &lease).await?', postPageCancel);
 const yieldCall = runner.indexOf('yield_for_resume(&self.db, &lease).await?', successCall);
 if (
   runLoop < 0
   || prePageCancel <= runLoop
   || pageCall <= prePageCancel
-  || postPageCancel <= pageCall
+  || pageAwait <= pageCall
+  || pageMatch <= pageAwait
+  || postPageCancel <= pageMatch
   || successCall <= postPageCancel
   || yieldCall <= successCall
 ) {
-  fail('ordinary runner must preserve cancellation before/after pages, complete on null cursor, then yield');
+  fail('ordinary runner must preserve cancel -> bounded page/lease maintenance -> cancel -> complete/yield ordering');
 }
 
 for (const terminalSql of ['finish_success_sql', 'finish_failure_sql', 'yield_job_sql']) {
@@ -151,4 +157,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-source-replay-contract.mjs'",
 ]);
 
-console.log('[verify-index-replay-multipage-runner] ordinary replay/cancel semantics remain stable while the separate interruptible path is bound to server shutdown through lifecycle-neutral runtime/operator probes');
+console.log('[verify-index-replay-multipage-runner] ordinary replay/cancel semantics remain stable while long pages retain fenced lease ownership through the shared in-page heartbeat helper');

--- a/scripts/verify/verify-index-replay-page-lease-heartbeat.mjs
+++ b/scripts/verify/verify-index-replay-page-lease-heartbeat.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-page-lease-heartbeat] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const sourceTimeoutPath = 'crates/rustok-index/src/application/source_timeout.rs';
+requireMarkers(sourceTimeoutPath, [
+  'DEFAULT_INDEX_SOURCE_CALL_TIMEOUT: Duration = Duration::from_secs(30)',
+  'INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout"',
+  'TimedIndexSource::new(source, DEFAULT_INDEX_SOURCE_CALL_TIMEOUT)',
+]);
+
+const storageTimeoutPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_timeout.rs';
+requireMarkers(storageTimeoutPath, [
+  'DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT: Duration = Duration::from_secs(30)',
+  'INDEX_REPLAY_CHECKPOINT_READ_TIMEOUT_CODE: &str = "index_replay_checkpoint_read_timeout"',
+  'INDEX_REPLAY_MUTATION_TIMEOUT_CODE: &str = "index_replay_mutation_timeout"',
+  '"index_replay_checkpoint_commit_timeout"',
+  'bounded_replay_checkpoint_read',
+  'bounded_replay_mutation',
+  'bounded_replay_checkpoint_commit',
+]);
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = requireMarkers(runnerPath, [
+  'const MIN_REPLAY_RUN_LEASE_DURATION: Duration = Duration::from_secs(60);',
+  'const PAGE_LEASE_HEARTBEAT_DIVISOR: u32 = 3;',
+  'if lease_duration < MIN_REPLAY_RUN_LEASE_DURATION {',
+  'IndexReplayRunError::LeaseDurationTooShort',
+  'fn page_lease_heartbeat_interval(lease_duration: Duration) -> Duration',
+  'lease_duration / PAGE_LEASE_HEARTBEAT_DIVISOR',
+  'async fn await_page_with_lease_heartbeats<T, F>(',
+  'tokio::select!',
+  'sleep_until(next_heartbeat)',
+  'heartbeat(job_store, lease, lease_duration)',
+  'aggregate.heartbeat_count += in_page_heartbeat_count;',
+  'page_index % request.heartbeat_every_pages() == 0',
+  'Duration::from_secs(59)',
+  'Duration::from_secs(60)',
+  'Duration::from_secs(20)',
+]);
+for (const forbidden of [
+  'index_replay_page_timeout',
+  'IndexReplayRunStatus::Retrying',
+  'automatic_retry',
+  'auto_requeue',
+]) {
+  if (runner.includes(forbidden)) fail(`${runnerPath} absorbed forbidden page/retry semantics: ${forbidden}`);
+}
+
+const ordinaryPage = runner.indexOf('worker.run_next_page(request.page_request().clone())');
+const ordinaryHelper = runner.indexOf('await_page_with_lease_heartbeats(', ordinaryPage);
+if (ordinaryPage < 0 || ordinaryHelper <= ordinaryPage) {
+  fail('ordinary replay page must be awaited through the common lease-heartbeat helper');
+}
+
+const gracefulPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';
+const graceful = requireMarkers(gracefulPath, [
+  'let page_future = worker.run_next_page_interruptible(',
+  'await_page_with_lease_heartbeats(',
+  'aggregate.heartbeat_count += in_page_heartbeat_count;',
+  'Err(crate::IndexReplayError::Interrupted) => {',
+  'yield_after_host_interruption(&self.db, &lease, aggregate).await',
+]);
+if (graceful.includes('index_replay_page_timeout')) {
+  fail(`${gracefulPath} must not add a generic page timeout`);
+}
+
+requireMarkers('apps/server/src/graphql/index_replay.rs', [
+  'const GRAPHQL_REPLAY_LEASE_SECONDS: u64 = 60;',
+  'Duration::from_secs(GRAPHQL_REPLAY_LEASE_SECONDS)',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-replay-page-lease-heartbeat.md', [
+  'Status: `source_complete_execution_pending`.',
+  '`index_replay_checkpoint_read_timeout`',
+  '`IndexReplayRunRequest` now rejects lease durations shorter than `60s`',
+  'one third of the configured lease duration',
+  '`60s` lease this produces a `20s` in-page heartbeat interval',
+  'There is no new page terminal state and no generic `index_replay_page_timeout` code.',
+  'persisted cancellation',
+  'graceful interruption',
+  'The retained Rust tests and Node verifiers were not executed',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-replay-pending-future-timeouts.md', [
+  '`index_replay_checkpoint_read_timeout`',
+  '`IndexReplayRunRequest` requires at least a 60-second lease',
+  '`m6-replay-page-lease-heartbeat.md`',
+  'There is deliberately no generic `index_replay_page_timeout` code.',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  'Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds',
+  'Complete remaining multi-host/restart evidence beyond existing convergence/replay packets',
+  'Add partition replay scope only after a real partition-capable source contract exists',
+]);
+
+console.log('[verify-index-replay-page-lease-heartbeat] replay pages retain exact dependency timeouts while ordinary/graceful runners maintain a minimum-60s fenced lease every one-third lease interval');

--- a/scripts/verify/verify-index-replay-page-lease-heartbeat.mjs
+++ b/scripts/verify/verify-index-replay-page-lease-heartbeat.mjs
@@ -63,10 +63,11 @@ for (const forbidden of [
   if (runner.includes(forbidden)) fail(`${runnerPath} absorbed forbidden page/retry semantics: ${forbidden}`);
 }
 
-const ordinaryPage = runner.indexOf('worker.run_next_page(request.page_request().clone())');
-const ordinaryHelper = runner.indexOf('await_page_with_lease_heartbeats(', ordinaryPage);
-if (ordinaryPage < 0 || ordinaryHelper <= ordinaryPage) {
-  fail('ordinary replay page must be awaited through the common lease-heartbeat helper');
+const ordinaryHelper = runner.indexOf('let (page_result, in_page_heartbeat_count) = await_page_with_lease_heartbeats(');
+const ordinaryPage = runner.indexOf('worker.run_next_page(request.page_request().clone())', ordinaryHelper);
+const ordinaryMatch = runner.indexOf('let page = match page_result {', ordinaryPage);
+if (ordinaryHelper < 0 || ordinaryPage <= ordinaryHelper || ordinaryMatch <= ordinaryPage) {
+  fail('ordinary replay page must be nested inside the common lease-heartbeat await before result handling');
 }
 
 const gracefulPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner/graceful_shutdown.rs';

--- a/scripts/verify/verify-index-replay-pending-future-timeout.mjs
+++ b/scripts/verify/verify-index-replay-pending-future-timeout.mjs
@@ -22,12 +22,15 @@ const helperPath = 'crates/rustok-index/src/infrastructure/postgres/source_repla
 const helper = requireMarkers(helperPath, [
   'DEFAULT_INDEX_REPLAY_STORAGE_FUTURE_TIMEOUT: Duration = Duration::from_secs(30)',
   'INDEX_REPLAY_MUTATION_TIMEOUT_CODE: &str = "index_replay_mutation_timeout"',
+  'INDEX_REPLAY_CHECKPOINT_READ_TIMEOUT_CODE: &str = "index_replay_checkpoint_read_timeout"',
   '"index_replay_checkpoint_commit_timeout"',
   'tokio::time::timeout',
   'bounded_replay_mutation',
+  'bounded_replay_checkpoint_read',
   'bounded_replay_checkpoint_commit',
   'IndexReplayFailure::retryable_static(timeout_code)',
   'pending::<Result<(), IndexReplayFailure>>()',
+  'pending_checkpoint_read_future_times_out_as_retryable',
   'IndexReplayFailureKind::Retryable',
   'dependency_failure_is_preserved_before_timeout',
 ]);
@@ -39,43 +42,48 @@ for (const forbidden of ['StopHandle', 'request_cancel', 'cancel_requested', 'yi
 
 const adapterPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay.rs';
 const adapter = requireMarkers(adapterPath, [
-  'source_replay_timeout::{bounded_replay_checkpoint_commit, bounded_replay_mutation}',
+  'bounded_replay_checkpoint_commit, bounded_replay_checkpoint_read, bounded_replay_mutation',
   'bounded_replay_mutation(async {',
   'self.apply(registry, &delivery)',
+  'bounded_replay_checkpoint_read(async {',
   'bounded_replay_checkpoint_commit(async {',
+  'validate_checkpoint_identity(&self.lease, key)?;',
   'validate_checkpoint_identity(&self.lease, checkpoint.key())?;',
   'assert_active_replay_job_lease(&transaction, &self.lease, backend)',
   'upsert_checkpoint_sql(backend)',
-  'transaction\n                    .commit()'.replace('\\n', '\n'),
 ]);
-const identityValidation = adapter.indexOf('validate_checkpoint_identity(&self.lease, checkpoint.key())?;');
-const checkpointTimeout = adapter.indexOf('bounded_replay_checkpoint_commit(async {', identityValidation);
-if (identityValidation < 0 || checkpointTimeout <= identityValidation) {
-  fail('checkpoint identity validation must remain outside/before the bounded commit future');
+const readIdentity = adapter.indexOf('validate_checkpoint_identity(&self.lease, key)?;');
+const readTimeout = adapter.indexOf('bounded_replay_checkpoint_read(async {', readIdentity);
+if (readIdentity < 0 || readTimeout <= readIdentity) {
+  fail('checkpoint read identity validation must remain outside/before the bounded read future');
 }
-if (adapter.includes('bounded_replay_checkpoint_commit(async {\n            validate_checkpoint_identity'.replace('\\n', '\n'))) {
-  fail('checkpoint identity validation must not be delayed inside the timeout future');
+const commitIdentity = adapter.indexOf('validate_checkpoint_identity(&self.lease, checkpoint.key())?;');
+const commitTimeout = adapter.indexOf('bounded_replay_checkpoint_commit(async {', commitIdentity);
+if (commitIdentity < 0 || commitTimeout <= commitIdentity) {
+  fail('checkpoint commit identity validation must remain outside/before the bounded commit future');
 }
 
 const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
 const runner = requireMarkers(runnerPath, [
-  'let page = match worker.run_next_page(request.page_request().clone()).await {',
+  'let (page_result, in_page_heartbeat_count) = await_page_with_lease_heartbeats(',
+  'let page = match page_result {',
   'if cancel_if_requested(&self.db, &lease).await? {',
   'let details = replay_failure_details(&error);',
   'finish_failure(&self.db, &lease, details).await?',
   'IndexReplayError::MutationFailed { failure, .. }',
+  '| IndexReplayError::CheckpointReadFailed(failure)',
   '| IndexReplayError::CheckpointCommitFailed(failure)',
   'failure.kind() == IndexReplayFailureKind::Retryable',
   '"retryable": retryable',
 ]);
-const pageMatch = runner.indexOf('let page = match worker.run_next_page(request.page_request().clone()).await {');
-const pageFailure = runner.indexOf('Err(error) => {', pageMatch);
+const pageResult = runner.indexOf('let page = match page_result {');
+const pageFailure = runner.indexOf('Err(error) => {', pageResult);
 const cancelCheck = runner.indexOf('if cancel_if_requested(&self.db, &lease).await? {', pageFailure);
 const failureDetails = runner.indexOf('let details = replay_failure_details(&error);', cancelCheck);
 const finishFailure = runner.indexOf('finish_failure(&self.db, &lease, details).await?', failureDetails);
 if (
-  pageMatch < 0 ||
-  pageFailure <= pageMatch ||
+  pageResult < 0 ||
+  pageFailure <= pageResult ||
   cancelCheck <= pageFailure ||
   failureDetails <= cancelCheck ||
   finishFailure <= failureDetails
@@ -90,13 +98,13 @@ requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
 requireMarkers('crates/rustok-index/docs/m6-replay-pending-future-timeouts.md', [
   'Status: `source_complete_execution_pending`.',
   '`index_replay_mutation_timeout`',
+  '`index_replay_checkpoint_read_timeout`',
   '`index_replay_checkpoint_commit_timeout`',
   'does **not** prove that the database operation was rolled back or cancelled',
-  'does not execute a synthetic rollback, rewind or checkpoint write',
   'user cancellation that won the race remains `Cancelled`',
   '`retryable: true`',
   '`StopHandle` interruption remains a separate safe-point-only',
-  'not a guarantee that a whole page fits inside a job lease',
+  '`m6-replay-page-lease-heartbeat.md`',
 ]);
 
-console.log('[verify-index-replay-pending-future-timeout] replay mutation/checkpoint storage futures are bounded with retryable timeout identity while lease, cancel, and graceful-stop semantics stay separate');
+console.log('[verify-index-replay-pending-future-timeout] replay checkpoint-read/mutation/checkpoint-commit futures retain bounded retryable identities while lease, cancel, and graceful-stop semantics stay separate');


### PR DESCRIPTION
## Summary

- close the M6 whole-page duration versus lease/heartbeat source boundary without adding a coarse page timeout;
- bound replay checkpoint-read transactions with the same canonical 30-second observation window used by replay mutation/checkpoint-commit storage futures, using retryable `index_replay_checkpoint_read_timeout`;
- require `IndexReplayRunRequest` leases to be at least 60 seconds, preserving the server-owned GraphQL 60-second lease as the minimum supported command budget;
- keep an active replay page lease alive every one third of the configured lease duration (`60s -> 20s`) while continuing to poll the real page future;
- route both ordinary and graceful/interruptible page execution through the same in-page lease-maintenance helper while retaining the existing page-count heartbeat cadence;
- preserve dependency-specific timeout identities instead of introducing `index_replay_page_timeout`;
- preserve persisted cancellation precedence, `StopHandle` safe-point interruption, locale job/checkpoint identity, lease fencing and existing retry/recovery ownership;
- actualize the timeout/multipage docs and current execution plan, advance the next source-only M6 boundary to remaining multi-host/restart evidence, and repair/register focused source guards.

## Recheck findings

- production Index source scan/load is already bounded at 30 seconds and documents that replay leases must exceed that dependency window plus persistence margin;
- replay mutation persistence and checkpoint commit were already bounded at 30 seconds, but checkpoint read was still unbounded;
- the runner heartbeated only at page boundaries, so one valid multi-mutation page could outlive its lease before the next page-count heartbeat;
- a generic page timeout would race and potentially mask exact source/mutation/checkpoint timeout codes, so this PR uses lease maintenance rather than a second timeout identity;
- several retained verifier scripts encoded the pre-policy direct page-call shape and were actualized to the common page-await helper.

## Boundary

No scheduler/background ownership, automatic retry/requeue, new replay terminal state, generic page timeout, partition scope, targeted/full/shadow rebuild mode, Product behavior, or serving-path change is added. Heartbeats do not become cancellation or shutdown probes.

The branch was created from `main@0f64eb62f9521e0c08027ab04433256429321c62`. Current `main` advanced through Pages-only #3320 and Product-only #3321 (`5c0a50eded09efbd4f1b6437b46a94a7f2ef0989`); those changed paths are disjoint from this PR.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.