### PR TITLE
docs(parity): synchronize Pages Page Builder canonical plans

### DIFF
--- a/crates/rustok-page-builder/docs/implementation-plan.md
+++ b/crates/rustok-page-builder/docs/implementation-plan.md
@@ -181,6 +181,18 @@ Authenticated real-DOM authoring, dedicated authoring JS/WASM delivery, same-ori
 deterministic release composition and anonymous-authoring exclusion are source-ready. They remain
 execution/rollout work rather than open source architecture gaps.
 
+Forum is the second production consumer and its Page Builder source path is complete through canonical
+module metadata, Fly component/block registration, `ContributionAdapter`, owner preview and owner-backed
+property editing. Provider-neutral Page Builder host ports compose Forum only when tenant/module/RBAC
+admission succeeds; Forum persistence, visibility, widget schemas, validation and authorization remain
+Forum-owned. Exact-source browser, runtime authorization/visibility and deployed server-function
+attestation harnesses are retained source, but execution and observed tenant Wave evidence remain open.
+
+The explicit `pages_reference_consumer_gate` source contract now closes the former implicit blocker gap.
+It remains fail-closed with `accepted = false`, `execution_gate = pending`, provider health `unobserved`
+and no FFA/FBA promotion. The next Page Builder/Pages/Forum work is acceptance evidence, not connecting
+another production consumer architecture slice.
+
 ## Machine-readable contracts
 
 - `contracts/page-builder-service-boundary.json` records capability/preview ports and composition.
@@ -196,6 +208,9 @@ execution/rollout work rather than open source architecture gaps.
   isolated non-builder lifecycle and cache invalidation/read state.
 - `contracts/evidence/page-builder-admin-provider-status-source.json` records the admin provider-status
   and degraded-control source boundary without claiming observed health or execution.
+- `crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json` records the exact
+  Pages reference-consumer blocker used by Forum Wave evidence; source is ready while acceptance remains
+  maintainer-owned.
 - `scripts/verify/verify-page-builder-admin-provider-status.mjs` source-locks the provider status seam,
   fail-closed capability narrowing, server-preview control and Pages server/UI rollout-flag identity.
 - `scripts/verify/verify-page-builder-publish-runtime-review.mjs` source-locks reviewed runtime,
@@ -203,6 +218,9 @@ execution/rollout work rather than open source architecture gaps.
 - `scripts/verify/verify-page-builder-publish-transport-cutover.mjs` forbids public legacy/default
   publication and source-locks GraphQL, HTTP, admin reviewed DTO/receipt, scenario-selection and
   non-builder lifecycle boundaries.
+- `crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate.mjs` source-locks the Pages
+  gate identity, profile requirements, owner-read availability, Forum source state and no-live-claim
+  boundary.
 - `crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs` source-locks exact
   contribution-schema binding, Pages ownership, optimistic metadata revision, registered draft and
   published surfaces, legacy-form absence and the absence of production Fly document writes.
@@ -220,14 +238,15 @@ execution/rollout work rather than open source architecture gaps.
 
 - **FFA:** `core_transport_ui` for the browser-host slice. Explicit promoted-scenario selection,
   typed rollback control, generation-aware Pages storefront/artifact readers, registered draft and
-  published Pages metadata properties, and the typed admin provider-status/degraded-control seam are
-  source-connected. Executed metadata conflict/isolation, observed provider-health, inline edit and
-  anonymous bundle evidence remain open.
+  published Pages metadata properties, typed admin provider-status/degraded-control seams, and the
+  Forum second-consumer host composition are source-connected. Executed metadata conflict/isolation,
+  observed provider-health, inline edit, anonymous bundle and Forum browser evidence remain open.
 - **FBA:** `boundary_ready` for preview, consumer-property contracts and policy-bound
   sanitization/materialization, and `service_and_public_transport_integrated` for Pages reviewed
-  publication and immutable rollback/repair continuity. The default-runtime lifecycle is removed and
-  source-level cache invalidation/read boundaries are connected; executed metadata/sanitizer/rollback/
-  repair/cache proof, observed provider health and rollout evidence remain open.
+  publication, immutable rollback/repair continuity and Forum owner-preserving contribution runtime
+  source. The default-runtime lifecycle is removed and source-level cache invalidation/read boundaries
+  are connected; executed Pages gate/sanitizer/rollback/repair/cache proof, Forum runtime evidence,
+  observed provider health and rollout evidence remain open.
 - **Structural shape:** `core_transport_ui` for browser host and `core_transport` for capability,
   properties and publish contracts.
 - **Evidence:**
@@ -256,7 +275,9 @@ execution/rollout work rather than open source architecture gaps.
   - `crates/rustok-pages/admin/src/metadata_properties.rs`;
   - `crates/rustok-pages/admin/src/standalone_metadata.rs`;
   - `crates/rustok-pages/admin/src/lib.rs`;
+  - `crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json`;
   - `crates/rustok-pages/contracts/evidence/pages-metadata-revision-isolation-source.json`;
+  - `crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate.mjs`;
   - `crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs`;
   - `crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`;
   - `crates/rustok-pages/src/dto/page.rs`;
@@ -295,14 +316,14 @@ execution/rollout work rather than open source architecture gaps.
 5. Supply and retain observed provider-health evidence from a real composition/runtime source, then
    exercise degraded publish-off, preview-off and unavailable/read-only behavior. The admin seam is
    source-ready; live SLO observation is not fabricated by Pages.
-6. Connect the next production consumer's concrete tenant-scoped store and contextual preview
-   renderer to the canonical composition root without consumer-local authorization or save-result
-   side channels.
-7. Add the first Dioxus host renderer after Dioxus enters the workspace. It must render
+6. Execute and accept `pages_reference_consumer_gate` against an exact reviewed source/deployment;
+   the gate source is ready but remains `accepted = false` until all required Pages profiles and
+   execution evidence are retained with owner sign-off and rollback decision.
+7. After the Pages gate is accepted, execute the retained Forum browser/runtime/deployment-attestation
+   packets and replace synthetic Forum Wave evidence with an observed tenant packet.
+8. Add the first Dioxus host renderer after Dioxus enters the workspace. It must render
    `PageBuilderBrowserModuleDescriptor` and reuse the canonical runtime DTO.
-8. Replace synthetic Wave evidence with observed tenant packets correlating preview context,
-   sanitizer identity, materialization, Pages publish/rollback/repair receipts, cache generation,
-   provider status and storefront read.
+9. Promote FFA/FBA only after observed Pages/Forum evidence and provider-health requirements are met.
 
 ## Verification
 
@@ -311,6 +332,11 @@ execution/rollout work rather than open source architecture gaps.
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-preview-runtime-contract.mjs`;
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-publish-runtime-review.mjs`;
 - `node crates/rustok-page-builder/scripts/verify/verify-page-builder-publish-transport-cutover.mjs`;
+- `node crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate.mjs`;
+- `node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs`;
+- `node scripts/verify/verify-forum-page-builder-browser-evidence-harness.mjs`;
+- `node scripts/verify/verify-forum-page-builder-runtime-authorization-evidence.mjs`;
+- `node scripts/verify/verify-forum-page-builder-serverfn-deployment-attestation.mjs`;
 - `node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs`;
 - `node crates/rustok-pages/scripts/verify/verify-pages-metadata-revision-isolation.mjs`;
 - `cargo test -p rustok-pages-admin stale_metadata_revision_short_circuits_before_patch_transport`;
@@ -334,5 +360,7 @@ These are execution cursors only. They were not run by this source-authoring sli
 - Consumer modules own property values, optimistic revisions, persistence, publication lifecycle,
   exact artifact manifests, rollback/repair, receipts, cache scope/key policy, concrete tenant-scoped
   ports and the live provider-health source when one exists for that composition.
+- Forum remains owner of Forum widget configuration/schema/validation, owner data reads, visibility and
+  authorization even when Page Builder hosts its contribution surfaces.
 - Cache/server infrastructure owns shared connection, byte storage and generation primitives only.
 - Host frameworks render or bind module surfaces and do not define provider-local contracts.

--- a/crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
@@ -69,6 +69,12 @@ for (const marker of [
   "forum-runtime-composition-source-ready",
   "forum-evidence-harness-source-ready",
   "pages-reference-consumer-gate-source-ready",
+]) {
+  requireText(sharedPlan, marker, `${sharedPlanPath}: status`);
+}
+forbidText(sharedPlan, "forum-fly-adapter-open", `${sharedPlanPath}: status`);
+
+for (const marker of [
   "PR #3239",
   "PR #3247",
   "PR #3254",
@@ -79,13 +85,12 @@ for (const marker of [
   "adapter_state = \"fly_contract_ready\"",
   "preview_data_state = \"owner_preview_transport_ready\"",
   "property_data_state = \"owner_property_editor_ready\"",
-  "accepted remains `false`",
+  "acceptance remains `false`",
 ]) {
   requireText(sharedCurrent, marker, `${sharedPlanPath}: current reconciliation`);
 }
 
 for (const stale of [
-  "forum-fly-adapter-open",
   "adapter_state = \"pending\"",
   "because Forum has no real Fly component registry or `ContributionAdapter` yet",
   "The next contribution source cursor is the real Forum Fly adapter/component-registry slice",
@@ -129,6 +134,14 @@ if (gate.artifact !== "pages_reference_consumer_gate_source") {
 }
 if (gate.mode !== "source_ready" || gate.accepted !== false) {
   failures.push(`${gatePath}: source gate must remain source_ready and accepted=false`);
+}
+if (gate.source_recheck?.plan_parity !== "source_ready") {
+  failures.push(`${gatePath}: plan parity source state must remain source_ready`);
+}
+if (!(gate.gate?.required_source_guards ?? []).includes(
+  "crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs",
+)) {
+  failures.push(`${gatePath}: required source guards must include plan parity verification`);
 }
 if (gate.current_boundary?.execution_gate !== "pending") {
   failures.push(`${gatePath}: execution gate must remain pending`);

--- a/crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(scriptDir, "..", "..", "..", "..");
+
+const sharedPlanPath = "docs/modules/pages-page-builder-parity-continuation-plan.md";
+const localPlanPath = "crates/rustok-page-builder/docs/implementation-plan.md";
+const centralPlanPath = "docs/modules/page-builder-implementation-plan.md";
+const gatePath = "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json";
+const forumManifestPath = "crates/rustok-forum/rustok-module.toml";
+const forumWavePath = "crates/rustok-forum/contracts/evidence/forum-wave1-rollout-evidence.json";
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function parseJson(source, relativePath) {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return {};
+  }
+}
+
+function requireText(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing marker '${marker}'`);
+}
+
+function forbidText(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: stale marker remains '${marker}'`);
+}
+
+function section(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) return "";
+  const end = endMarker ? source.indexOf(endMarker, start + startMarker.length) : -1;
+  return end > start ? source.slice(start, end) : source.slice(start);
+}
+
+const sharedPlan = read(sharedPlanPath);
+const localPlan = read(localPlanPath);
+const centralPlan = read(centralPlanPath);
+const gate = parseJson(read(gatePath), gatePath);
+const forumManifest = read(forumManifestPath);
+const forumWave = parseJson(read(forumWavePath), forumWavePath);
+
+const sharedCurrent = section(
+  sharedPlan,
+  "## 2026-08-08 current source reconciliation",
+  "## Rechecked merged cursor",
+);
+const sharedNext = section(sharedPlan, "## Next cursor", "## Maintainer validation");
+const localOpen = section(localPlan, "## Open results", "## Verification");
+
+for (const marker of [
+  "forum-runtime-composition-source-ready",
+  "forum-evidence-harness-source-ready",
+  "pages-reference-consumer-gate-source-ready",
+  "PR #3239",
+  "PR #3247",
+  "PR #3254",
+  "PR #3264",
+  "PR #3266",
+  "PR #3274",
+  "PR #3320",
+  "adapter_state = \"fly_contract_ready\"",
+  "preview_data_state = \"owner_preview_transport_ready\"",
+  "property_data_state = \"owner_property_editor_ready\"",
+  "accepted remains `false`",
+]) {
+  requireText(sharedCurrent, marker, `${sharedPlanPath}: current reconciliation`);
+}
+
+for (const stale of [
+  "forum-fly-adapter-open",
+  "adapter_state = \"pending\"",
+  "because Forum has no real Fly component registry or `ContributionAdapter` yet",
+  "The next contribution source cursor is the real Forum Fly adapter/component-registry slice",
+]) {
+  forbidText(sharedCurrent, stale, `${sharedPlanPath}: current reconciliation`);
+}
+
+for (const marker of [
+  "Maintainer executes and accepts `pages_reference_consumer_gate`",
+  "execute the retained Forum browser/runtime/deployment-attestation packets",
+  "health remains `unobserved`",
+  "Promote FFA/FBA only after",
+]) {
+  requireText(sharedNext, marker, `${sharedPlanPath}: next cursor`);
+}
+
+for (const marker of [
+  "Forum is the second production consumer",
+  "pages_reference_consumer_gate",
+  "accepted = false",
+  "execute the retained Forum browser/runtime/deployment-attestation",
+]) {
+  requireText(localPlan, marker, localPlanPath);
+}
+forbidText(
+  localOpen,
+  "Connect the next production consumer's concrete tenant-scoped store",
+  `${localPlanPath}: open results`,
+);
+
+for (const marker of [
+  "Forum Fly adapter/component registry: source-ready",
+  "Forum owner preview transport/Pages host composition: source-ready",
+  "Forum owner-backed property editing: source-ready",
+]) {
+  requireText(centralPlan, marker, centralPlanPath);
+}
+
+if (gate.artifact !== "pages_reference_consumer_gate_source") {
+  failures.push(`${gatePath}: gate artifact identity drifted`);
+}
+if (gate.mode !== "source_ready" || gate.accepted !== false) {
+  failures.push(`${gatePath}: source gate must remain source_ready and accepted=false`);
+}
+if (gate.current_boundary?.execution_gate !== "pending") {
+  failures.push(`${gatePath}: execution gate must remain pending`);
+}
+if (gate.current_boundary?.provider_health !== "unobserved") {
+  failures.push(`${gatePath}: provider health must remain unobserved`);
+}
+if (gate.current_boundary?.forum_wave_blocker !== "pages_reference_consumer_gate") {
+  failures.push(`${gatePath}: Forum Wave blocker drifted`);
+}
+
+for (const marker of [
+  'id = "rustok.forum.widget-catalog"',
+  'id = "rustok.forum.widget-preview"',
+  'adapter_state = "fly_contract_ready"',
+  'preview_data_state = "owner_preview_transport_ready"',
+  'property_data_state = "owner_property_editor_ready"',
+  'persistence_owner = "forum"',
+  'authorization_owner = "forum"',
+]) {
+  requireText(forumManifest, marker, forumManifestPath);
+}
+
+if (forumWave.mode !== "source_ready" || forumWave.execution_status !== "not_run_by_implementation_agent") {
+  failures.push(`${forumWavePath}: Forum Wave must remain source_ready and unexecuted`);
+}
+if (forumWave.observed_run?.blocked_by !== "pages_reference_consumer_gate") {
+  failures.push(`${forumWavePath}: observed Forum Wave must remain blocked by Pages gate`);
+}
+
+if (failures.length > 0) {
+  console.error("Pages / Page Builder plan parity verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Pages / Page Builder plan parity verification passed");

--- a/crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json
@@ -11,6 +11,7 @@
     "main_base": "0f64eb62f9521e0c08027ab04433256429321c62",
     "pages_source_boundary": "complete_execution_pending",
     "page_builder_provider_status": "source_ready_health_unobserved",
+    "plan_parity": "source_ready",
     "forum_second_consumer": {
       "contribution_metadata": "source_ready",
       "fly_adapter": "source_ready",
@@ -58,6 +59,7 @@
       }
     },
     "required_source_guards": [
+      "crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs",
       "crates/rustok-page-builder/scripts/verify/verify-page-builder-consumer-readiness.mjs",
       "crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs",
       "crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs",
@@ -99,6 +101,7 @@
   },
   "verification": {
     "source_guard": "crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate.mjs",
+    "plan_parity_guard": "crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs",
     "execution_status": "not_run_by_implementation_agent"
   },
   "forbidden_claims": [

--- a/docs/modules/pages-page-builder-parity-continuation-plan.md
+++ b/docs/modules/pages-page-builder-parity-continuation-plan.md
@@ -1,7 +1,7 @@
 # Pages / Page Builder Parity Continuation Plan
 
 Date: 2026-08-08  
-Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / contribution-module-metadata-generation-source-ready / shared-contribution-tooling-source-ready / forum-second-consumer-discovery-source-ready / forum-fly-adapter-open / observed-health-open / execution-browser-rollout-pending
+Status: source-parity-current / pages-repeated-artifact-loss-recovery-source-ready / provider-degraded-controls-source-ready / contribution-registry-version-parity-source-ready / contribution-module-metadata-generation-source-ready / shared-contribution-tooling-source-ready / forum-runtime-composition-source-ready / forum-evidence-harness-source-ready / pages-reference-consumer-gate-source-ready / observed-health-open / execution-browser-rollout-pending
 Scope: `rustok-pages` admin/storefront FFA and `rustok-page-builder` document, publication, artifact, routing, cache, authenticated inline-authoring and deterministic deployment boundaries
 
 ## Source-of-truth policy
@@ -15,8 +15,8 @@ Pages and Page Builder remain one vertical pipeline with explicit owners:
 - Pages owns persistence, lifecycle, immutable bindings, localized route identity, cache policy, public reads, authenticated inline grants/save transport and the module-owned authoring asset HTTP contract.
 - Pages admin owns the optional same-origin authoring launch control and consumes build-generated contribution metadata.
 - Platform build tooling owns the reusable parsing/normalization contract for canonical module contribution metadata; it does not own runtime registry policy.
-- Forum owns Forum category/topic/reply lifecycle, visibility, widget contracts, widget validation and widget authorization even when its Page Builder contribution metadata is discovered through shared tooling.
-- Page Builder/Fly owns the reviewed document, sanitizer, runtime materialization, renderer, artifact producer contracts and reusable real-DOM inline adapter/session.
+- Forum owns Forum category/topic/reply lifecycle, visibility, widget contracts, widget validation and widget authorization even when its Page Builder contribution metadata and Fly identities are composed through shared tooling.
+- Page Builder/Fly owns the reviewed document, sanitizer, runtime materialization, renderer, artifact producer contracts, reusable real-DOM inline adapter/session and provider-neutral contribution host seams.
 - Navigation and SEO own their resolved payloads.
 - Hosts own route admission, CSP and HTTP composition, not Pages/Forum domain persistence, route policy, asset policy or launch policy.
 - Release engineering owns deterministic composition and durable evidence, not runtime authorization or persistence.
@@ -34,18 +34,27 @@ The recheck includes all relevant merged source after the former PR #3063 cursor
 - the existing `fly-ui` contribution path already has separate admin/storefront factories, tenant/permission/capability/provider-policy/provider-health filtering, and duplicate/missing-provider/missing-dependency/cycle diagnostics;
 - PR #3205 restored exact owner/target provider versions and fail-closed manifest-routed provider-version admission;
 - PR #3215 moved the Pages reference-consumer declaration into canonical `rustok-module.toml` and generated the version-pinned runtime manifest at build time;
-- PR #3222 moved generic contribution parsing/normalization into platform `rustok-build` tooling and reused it from Pages generation plus module publish readiness.
+- PR #3222 moved generic contribution parsing/normalization into platform `rustok-build` tooling and reused it from Pages generation plus module publish readiness;
+- PR #3227 onboarded Forum as the second production consumer through canonical shared contribution metadata;
+- PR #3239 added the real Forum Fly component/block registry and `ContributionAdapter`;
+- PR #3247 composed Forum-owned preview reads through provider-neutral Page Builder host ports on the real Pages admin route;
+- PR #3254 completed owner-backed Forum widget property schema/validation and normalized Fly property patching;
+- PR #3264 retained the exact-source Forum browser evidence harness without executing it;
+- PR #3266 retained direct Forum runtime authorization/visibility evidence source without executing it;
+- PR #3274 retained deployed native server-function attestation source without executing it;
+- PR #3320 made the existing `pages_reference_consumer_gate` blocker explicit as a machine-readable fail-closed source contract and bound Forum Wave source evidence to it.
 
-The current source slice advances the shared-tooling cursor to the second production consumer without changing Pages persistence, publication or runtime registry ownership:
+The current Forum contribution/runtime source boundary is now complete without changing Forum persistence, visibility, widget validation or authorization ownership:
 
-- Forum is selected because its persistence, authorization and preview/widget ownership are already explicit: Forum owns topic/reply lifecycle and visibility plus `ForumWidgetContractService`, while Page Builder remains optional composition/authoring infrastructure;
-- `crates/rustok-forum/rustok-module.toml` now declares one canonical owner-provider discovery contribution, `rustok.forum.widget-catalog`, through the same `[fba.builder_consumer.contribution_manifest]` shape used by shared tooling;
-- the Forum discovery contribution is permission-gated by `forum_topics:read`, capability-gated by `preview`, points at the existing Forum-owned catalog/validation endpoints and derives exact owner version from `[module].version` through the shared normalizer;
-- the previous `topic_detail` schema-id drift is corrected from `forum.topic_list.v1` to the distinct `forum.topic_detail.v1` identity;
-- the contribution is deliberately discovery-only: `blocks = []`, no renderers, no property editors, no storefront contribution and `adapter_state = "pending"` because Forum has no real Fly component registry or `ContributionAdapter` yet;
-- `xtask module validate forum` therefore exercises the shared module-metadata/publish-readiness boundary without a Forum-local parser or generator;
-- Forum admin receives no new `fly-ui` or Page Builder UI dependency and this slice introduces no Cargo dependency/lockfile change;
-- source guards require the discovery-only boundary and reject premature renderer/property-editor/storefront claims.
+- `crates/rustok-forum/rustok-module.toml` declares complementary `rustok.forum.widget-catalog` and `rustok.forum.widget-preview` contributions through the shared `[fba.builder_consumer.contribution_manifest]` shape;
+- `forum.topic_list`, `forum.topic_detail` and `forum.reply_stream` have real Fly block/component identities;
+- owner schema references remain metadata-only while actual schemas and validation stay behind `ForumWidgetContractService`;
+- `adapter_state = "fly_contract_ready"`, `preview_data_state = "owner_preview_transport_ready"` and `property_data_state = "owner_property_editor_ready"` are the current source states;
+- preview renderer admission is capability-separated from tree/property admission so `preview_off` does not erase otherwise-authorized property editing;
+- Forum owner preview rechecks tenant/module/RBAC/visibility and performs bounded owner reads;
+- owner-backed property editing validates only through the Forum owner contract and patches normalized object props through ordinary Fly history;
+- browser, runtime-authorization and deployed-attestation harnesses exist but remain unexecuted;
+- observed Forum Wave remains blocked by `pages_reference_consumer_gate`, whose source contract is ready but whose acceptance remains `false` until maintainer execution evidence is retained.
 
 Rechecked Page Builder Phase 9 source state:
 
@@ -54,17 +63,30 @@ Rechecked Page Builder Phase 9 source state:
 - [x] Filter by tenant, permission, capability, provider policy and health.
 - [x] Duplicate, missing-provider, missing-dependency, cycle and provider-version diagnostics.
 - [x] Generalize canonical contribution metadata parsing/normalization into platform build tooling and module publish validation.
-- [x] Onboard Forum as the second production consumer to canonical shared contribution discovery metadata.
-- [ ] Define and connect the real Forum Fly component/block/adapter runtime before advertising non-empty Forum blocks/renderers/property editors.
+- [x] Onboard Forum as the second production consumer to canonical shared contribution metadata.
+- [x] Define and connect the real Forum Fly component/block/adapter runtime.
+- [x] Connect Forum owner preview through provider-neutral Page Builder host ports.
+- [x] Connect Forum owner-backed property editing without moving owner validation/persistence into Page Builder.
+- [x] Retain browser/runtime/deployment evidence harness source without claiming execution.
+- [x] Define the machine-readable Pages reference-consumer gate source contract.
+- [ ] Execute and accept the Pages reference-consumer gate with exact-source deployment and runtime/browser evidence.
+- [ ] Execute Forum browser/runtime/deployment evidence and retain observed tenant Wave only after the Pages gate is accepted.
 
-The next contribution source cursor is the real Forum Fly adapter/component-registry slice. It must preserve Forum-owned persistence, visibility, widget validation and authorization rather than creating a second domain authority. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
+No new source architecture gap is identified in the Pages/Forum composition by this reconciliation. Real provider health remains a separate open composition/runtime cursor because the repository still has no authoritative live Page Builder SLO observation source. Execution evidence remains maintainer-owned.
 
-Detailed evidence for the 2026-08-08 contribution slices is retained in:
+Detailed evidence for the 2026-08-08 contribution and gate slices is retained in:
 
 - `docs/modules/pages-page-builder-contribution-parity-actualization-2026-08-08.md`;
 - `docs/modules/pages-page-builder-module-metadata-contribution-generation-2026-08-08.md`;
 - `docs/modules/pages-page-builder-shared-contribution-tooling-2026-08-08.md`;
-- `docs/modules/forum-page-builder-contribution-metadata-actualization-2026-08-08.md`.
+- `docs/modules/forum-page-builder-contribution-metadata-actualization-2026-08-08.md`;
+- `docs/modules/forum-page-builder-fly-adapter-actualization-2026-08-08.md`;
+- `docs/modules/forum-page-builder-owner-preview-actualization-2026-08-08.md`;
+- `docs/modules/forum-page-builder-owner-properties-actualization-2026-08-08.md`;
+- `docs/modules/forum-page-builder-browser-evidence-harness-actualization-2026-08-08.md`;
+- `docs/modules/forum-page-builder-runtime-authorization-evidence-actualization-2026-08-08.md`;
+- `docs/modules/forum-page-builder-serverfn-deployment-attestation-actualization-2026-08-08.md`;
+- `docs/modules/pages-page-builder-reference-consumer-gate-actualization-2026-08-08.md`.
 
 ## Rechecked merged cursor
 
@@ -118,7 +140,12 @@ No build, workflow, Docker, HTTP or browser execution is claimed.
 - `contribution-registry-version-parity-source-ready` — contribution owner/target provider versions are pinned and fail closed on missing/mismatched versions.
 - `contribution-module-metadata-generation-source-ready` — Pages contribution declarations and property schema are generated from canonical module metadata at build time.
 - `shared-contribution-tooling-source-ready` — canonical contribution parsing/normalization is shared by platform build tooling, Pages generation and module publish readiness.
-- `forum-second-consumer-discovery-source-ready` — Forum uses the same canonical contribution metadata/publish-validation boundary while truthfully keeping its Fly adapter pending.
+- `forum-second-consumer-discovery-source-ready` — historical discovery checkpoint; superseded by the runtime-composition markers below.
+- `forum-fly-adapter-source-ready` — Forum Fly component/block registration and `ContributionAdapter` are source-ready.
+- `forum-owner-preview-source-ready` — Forum owner preview transport and Pages host composition are source-ready.
+- `forum-owner-properties-source-ready` — Forum owner-backed property schema/validation and normalized Fly patching are source-ready.
+- `forum-evidence-harness-source-ready` — Forum browser/runtime/deployment evidence harnesses exist but remain unexecuted.
+- `pages-reference-consumer-gate-source-ready` — the blocker used by Forum Wave evidence is explicit and fail-closed; acceptance remains pending.
 
 ## Current parity state
 
@@ -136,9 +163,9 @@ Execution evidence remains pending.
 
 Pages owns one canonical contribution declaration in `rustok-module.toml`. Its build script materializes the version-pinned Fly manifest and metadata property schema into `OUT_DIR`; runtime consumes only generated Rust/JSON and retains no TOML dependency or handwritten descriptor tree.
 
-Generic parsing, provider/version injection, capability admission and nested provider validation live once in `rustok-build` tooling and are reused by Pages build generation and `xtask` publish readiness. Forum is now the second production consumer of that canonical metadata boundary: its owner-provider widget-catalog discovery entry is normalized/publish-validated without a Forum-local parser or new runtime dependency.
+Generic parsing, provider/version injection, capability admission and nested provider validation live once in `rustok-build` tooling and are reused by Pages build generation and `xtask` publish readiness. Forum is the second production consumer of that canonical metadata boundary and now also has real Fly component/block identities plus adapter, owner preview and owner property paths composed through provider-neutral Page Builder host seams.
 
-Forum runtime contribution assembly remains intentionally open. The source does not yet contain Forum Fly component/block definitions or an adapter, so the Forum manifest advertises no blocks/renderers/property editors/storefront contribution.
+Forum persistence, visibility, widget schemas, validation and authorization remain Forum-owned. Page Builder receives only the bounded contribution/preview/property contracts required for composition. Browser/runtime/deployment evidence harnesses exist but execution remains pending.
 
 ### Public locale, route and cache authority: source-ready
 
@@ -273,7 +300,11 @@ Page Builder provider flags can only narrow an already authorized capability set
 
 ### Contribution registry version parity: source-ready
 
-Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Pages supplies those identities through canonical metadata and the shared build normalizer rather than a handwritten runtime manifest. Forum now supplies canonical owner-provider discovery metadata through the same normalizer but does not yet claim runtime adapter surfaces.
+Admin/storefront assembly, policy filters and structural diagnostics are source-ready. Owner and target provider versions are exact and fail closed on missing/mismatched contribution metadata. Pages supplies those identities through canonical metadata and the shared build normalizer rather than a handwritten runtime manifest. Forum supplies canonical metadata plus real adapter/preview/property runtime source through the same owner-preserving composition boundary.
+
+### Pages reference-consumer gate: source-ready / acceptance-open
+
+`crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json` defines the exact blocker already referenced by Forum Wave evidence. It requires the Pages `1.1` Page Builder contract, `all_on`, `publish_off`, `preview_off` and `builder_off` profiles, Pages-owned reads in every profile and the existing source guards plus maintainer execution evidence. The source packet remains `accepted = false`, `execution_gate = pending`, `provider_health = unobserved` and `ffa_fba_promotion = not_claimed`.
 
 ## Parity matrix
 
@@ -283,7 +314,8 @@ Admin/storefront assembly, policy filters and structural diagnostics are source-
 | Reviewed publish and immutable rollback | Complete | DB/runtime execution pending |
 | Repeated immutable-artifact loss recovery | Source-ready | Repair/rollback execution pending |
 | Canonical contribution metadata generation | Source-ready (Pages + shared tooling) | Execution pending |
-| Forum second-consumer contribution discovery | Source-ready | Fly adapter/runtime/browser pending |
+| Forum contribution/runtime composition | Source-ready (metadata + Fly adapter + owner preview + owner properties) | Browser/runtime/deployment evidence pending |
+| Pages reference-consumer gate | Source-ready | Maintainer acceptance pending |
 | Public locale fallback | Source-ready | Native/GraphQL execution pending |
 | Published aliases, tombstones and history import | Source-ready | SQLite/PostgreSQL/host execution pending |
 | Host canonical/redirect/gone response | Source-ready | HTTP/SSR execution pending |
@@ -322,7 +354,7 @@ These exact phrases are retained only because earlier static guards consume the 
 
 ## Boundaries
 
-The historical deployment slice remains unchanged; the 2026-08-08 reconciliation additionally restores contribution version parity, moves Pages contribution authority to canonical module metadata, centralizes metadata normalization in platform build tooling and onboards Forum to discovery-only shared metadata.
+The historical deployment slice remains unchanged; the current reconciliation additionally restores contribution version parity, moves Pages contribution authority to canonical module metadata, centralizes metadata normalization in platform build tooling, completes the Forum second-consumer adapter/preview/property source path and defines the Pages reference-consumer gate source contract.
 
 It does not:
 
@@ -335,26 +367,30 @@ It does not:
 - add runtime build tooling to `apps/server/Dockerfile.release`;
 - add a TOML parser to Pages or Forum admin/WASM runtime;
 - make platform build tooling a runtime contribution registry or tenant policy owner;
-- claim a Forum Fly block, renderer, property editor, storefront adapter or observed Wave before such runtime source exists;
+- move Forum schema, validation, persistence, visibility or authorization into Page Builder;
+- claim Forum browser/runtime/deployment harness execution or an observed Wave;
+- claim the Pages reference-consumer gate is accepted;
 - claim verifier, Cargo, npm, Trunk, WASM, server, Docker, workflow, HTTP, browser or rollout execution;
 - fabricate Page Builder provider-health observations;
 - promote FFA or FBA.
 
 ## Next cursor
 
-Source continuation:
+Source architecture for the Pages reference consumer and Forum second-consumer composition is complete at this cursor. The next work is evidence and acceptance rather than another adapter architecture slice:
 
-1. Define real Forum Fly component/block identities and adapter behavior against the existing Forum-owned widget catalog, then connect runtime contribution assembly without moving Forum persistence/authorization into Page Builder.
-2. Keep current Pages repair/recovery and Page Builder degraded-control source boundaries unchanged while Forum adapter work proceeds.
-3. Connect real provider-health observation only after an authoritative Page Builder SLO source exists.
+1. Maintainer executes and accepts `pages_reference_consumer_gate` against an exact reviewed source/deployment, retaining metadata-isolation, sanitizer/resource-limit, cache-generation, authenticated-authoring, anonymous-exclusion and degraded-profile evidence.
+2. After the Pages gate is accepted, execute the retained Forum browser/runtime/deployment-attestation packets and replace synthetic Forum Wave evidence with an observed tenant packet.
+3. Connect real provider-health observation only after an authoritative Page Builder SLO source exists; until then health remains `unobserved`.
+4. Promote FFA/FBA only after the corresponding observed evidence is reviewed and accepted.
 
-Maintainer-owned execution evidence remains pending for the contribution-generation/tooling, Forum adapter/rollout, release, browser, database and recovery slices.
+Maintainer-owned execution evidence remains pending for the contribution/tooling, Pages gate, Forum rollout, release, browser, database and recovery slices.
 
 ## Maintainer validation
 
 Suggested commands, intentionally not run in this slice:
 
 ```bash
+node crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate.mjs
 node scripts/verify/verify-fly-ui-contributions.mjs
 node scripts/verify/verify-forum-page-builder-contribution-metadata.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-metadata-properties.mjs

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,0 +1,55 @@
+# Pages / Page Builder plan parity actualization — 2026-08-08
+
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-gate-source-ready / execution-acceptance-pending`
+
+Base rechecked: `main@bb65b7f0d3b6d2663519260841097c0e0f5f6cb8`.
+
+## Why this slice exists
+
+PR #3320 made `pages_reference_consumer_gate` explicit and recorded the current Pages/Forum evidence boundary, but two canonical planning surfaces still carried older source cursors:
+
+- `docs/modules/pages-page-builder-parity-continuation-plan.md` still advertised `forum-fly-adapter-open` and a discovery-only Forum state;
+- `crates/rustok-page-builder/docs/implementation-plan.md` still listed connecting the next production consumer as open work.
+
+Those statements were stale relative to merged Forum Page Builder source through PRs #3239, #3247 and #3254 and retained evidence harness source through #3264, #3266 and #3274.
+
+## Current source truth
+
+The synchronized plans now record:
+
+- Pages source architecture remains complete with execution evidence open;
+- Forum is the second production Page Builder consumer;
+- Forum canonical metadata, Fly adapter/component registry, owner preview and owner-backed property editing are source-ready;
+- Forum persistence, visibility, widget schemas, validation and authorization remain Forum-owned;
+- Forum browser/runtime/deployment-attestation harnesses are source-ready but unexecuted;
+- `pages_reference_consumer_gate` is source-ready but remains `accepted = false` and `execution_gate = pending`;
+- provider health remains `unobserved` until a real SLO source exists;
+- the next cursor is maintainer acceptance evidence for the Pages gate, followed by Forum evidence/Wave execution, not another Forum adapter architecture slice;
+- FFA/FBA promotion remains unclaimed.
+
+## Anti-drift guard
+
+`crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs` source-locks the synchronized cursor across:
+
+- the shared Pages/Page Builder parity plan;
+- the local Page Builder implementation plan;
+- the central Page Builder plan;
+- the Pages reference-consumer gate source packet;
+- the current Forum contribution manifest;
+- the Forum Wave source packet.
+
+The guard rejects the former `forum-fly-adapter-open`/discovery-only cursor, the old local `next production consumer` task, an accepted Pages gate without evidence, fabricated provider health, and Forum Wave promotion while the Pages gate remains pending.
+
+The Pages reference-consumer gate now lists this plan-parity verifier as a required source guard.
+
+## Execution boundary
+
+No tests, Node verifiers, Cargo commands, formatting, builds, HTTP requests, browsers, workflows, CI or runtime evidence were executed by this slice.
+
+Suggested maintainer command, intentionally not run:
+
+```bash
+node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+```
+
+All execution and acceptance evidence remains maintainer-owned.


### PR DESCRIPTION
## Summary

Continue Pages / Page Builder parity after #3320 by removing stale canonical planning cursors without claiming execution.

- actualize `docs/modules/pages-page-builder-parity-continuation-plan.md` from discovery-only / `forum-fly-adapter-open` to the merged Forum runtime source state;
- record merged Forum Fly adapter, owner preview and owner-backed property editing plus retained browser/runtime/deployment evidence harness source;
- replace the stale local Page Builder `next production consumer` open item with the real next cursor: execute/accept `pages_reference_consumer_gate`, then Forum evidence and observed Wave;
- keep provider health `unobserved`, Pages gate `accepted=false`, execution pending and FFA/FBA unpromoted;
- add `verify-pages-page-builder-plan-parity.mjs` to source-lock the shared/local/central plan cursor against the Pages gate, Forum manifest and Forum Wave source packet;
- register that plan-parity guard as a required Pages reference-consumer gate source guard;
- retain a dated plan-parity actualization packet for the exact base.

## Rechecked source state

The canonical plans now agree that Forum is already the second production consumer and source-complete through canonical metadata, Fly component/block registration, `ContributionAdapter`, owner preview and owner-backed property editing. Forum remains the owner of persistence, visibility, widget schemas, validation and authorization.

The next Pages/Page Builder/Forum work is acceptance/execution evidence, not another Forum adapter architecture slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting, builds, HTTP requests, browser runs, workflows, CI or runtime evidence were executed. Source review only.