### PR TITLE
feat(product): declare lifecycle corequisites

### DIFF
--- a/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
+++ b/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
@@ -1,12 +1,16 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30",
-  "status": "product_lifecycle_collaboration_contained_unvalidated",
-  "source_base_revision": "c4cd6e281e6a40122843617e0471edc8f589f931",
+  "generated_at": "2026-08-08",
+  "status": "product_lifecycle_corequisites_declared_unvalidated",
+  "source_base_revision": "bb65b7f0d3b6d2663519260841097c0e0f5f6cb8",
   "scope": "Product create/delete transaction collaboration with Inventory and Pricing owners",
   "module_topology": {
     "product_dependencies": [
       "taxonomy"
+    ],
+    "product_co_requisites": [
+      "inventory",
+      "pricing"
     ],
     "inventory_dependencies": [
       "product"
@@ -15,7 +19,9 @@
       "product"
     ],
     "ordinary_reverse_dependencies_forbidden": true,
-    "reason": "Declaring Inventory or Pricing as ordinary Product dependencies would create a module dependency cycle",
+    "co_requisites_are_ordering_dependencies": false,
+    "co_requisite_control_plane_enforcement_proven": false,
+    "reason": "Inventory and Pricing remain ordinary Product dependents; Product declares them only as deployment co-requisites to avoid a dependency-order cycle",
     "default_enabled_bundle": [
       "product",
       "pricing",
@@ -58,13 +64,15 @@
   },
   "decision": {
     "containment_complete": true,
+    "corequisite_contract_declared": true,
     "dependency_contract_resolved": false,
-    "next_slice": "Choose and implement a control-plane co-requisite contract or host-injected transaction participant ports; prove Product write behavior when optional modules are selected outside the default ecommerce bundle",
+    "next_slice": "Teach the static module control plane to consume Product co-requisites during deployment selection without adding dependency-order edges; then prove non-default Product write activation and rollback",
     "do_not": [
       "add inventory or pricing to Product ordinary module dependencies",
       "move Inventory or Pricing ORM entities into Product",
       "replace atomic owner collaboration with unproven best-effort post-commit writes",
-      "claim standalone Product write activation"
+      "claim standalone Product write activation",
+      "claim co-requisite enforcement before the control plane consumes the contract"
     ]
   },
   "validation": {
@@ -75,6 +83,7 @@
     "workflow_checks_run": false,
     "ci_run": false,
     "standalone_activation_proven": false,
+    "non_default_deployment_selection_proven": false,
     "transaction_rollback_proven": false
   }
 }

--- a/crates/rustok-product/docs/product-lifecycle-collaboration.md
+++ b/crates/rustok-product/docs/product-lifecycle-collaboration.md
@@ -1,18 +1,29 @@
 # Product lifecycle owner collaboration
 
-Status: contained source boundary, unresolved activation contract, unvalidated.
+Status: deployment co-requisite contract declared, control-plane enforcement pending, unvalidated.
 
 ## Problem
 
 Product creation persists Product-owned variants and also accepts initial inventory and price input. The first Inventory and Pricing rows must commit or roll back with the Product write. Current source performs that collaboration through owner-owned, transaction-aware bootstrap services.
 
-The module graph cannot represent this by adding ordinary Product dependencies:
+The ordinary module graph cannot represent the collaboration by adding reverse Product dependencies:
 
 - Inventory depends on Product;
 - Pricing depends on Product;
-- making Product depend on either owner would create a dependency cycle.
+- making Product ordinarily depend on either owner would create a dependency-order cycle.
 
-The default ecommerce deployment currently enables Product, Pricing, and Inventory together, but that does not prove Product write behavior for every optional-module selection.
+The default ecommerce deployment enables Product, Pricing, and Inventory together, but relying on that bundle implicitly leaves non-default deployment selection underspecified.
+
+## Selected source contract
+
+Product now declares Inventory and Pricing in `rustok-module.toml` under `[co_requisites]` with explicit version requirements. A co-requisite is a deployment-selection constraint, not an ordinary dependency edge:
+
+- it says the owner implementation must be present in the selected deployment whenever Product lifecycle writes are available;
+- it must not participate in dependency or migration ordering;
+- it must not be copied into `ProductModule::dependencies()`;
+- it therefore does not create `Product -> Inventory -> Product` or `Product -> Pricing -> Product` cycles.
+
+This slice only declares and source-locks that contract. The current module control plane does not yet consume `[co_requisites]`; deployment enforcement and non-default selection evidence remain the next implementation step. Until that enforcement exists, the canonical ecommerce dependency-contract item must remain open.
 
 ## Current contained boundary
 
@@ -44,31 +55,31 @@ This is a native transaction collaboration contract, not a GraphQL, REST, gRPC, 
 
 ## Guarded invariants
 
-`scripts/verify/verify-product-lifecycle-collaboration.mjs` requires:
+`scripts/verify/verify-product-lifecycle-collaboration.mjs` source-locks that:
 
 - Product's ordinary module dependency remains Taxonomy only;
-- Inventory and Pricing continue to depend on Product;
+- Product declares Inventory and Pricing as package co-requisites with bounded version requirements;
+- Inventory and Pricing continue to depend ordinarily on Product;
 - the default deployment bundle contains Product, Pricing, and Inventory;
 - Product uses the exact owner bootstrap services and operations;
 - Product does not import foreign owner entities or query known foreign tables directly;
 - the owner services remain explicitly transaction-aware;
-- evidence remains unvalidated and does not claim standalone activation.
+- control-plane co-requisite enforcement and standalone/non-default activation evidence remain unvalidated.
 
-## Open architecture decision
+## Next implementation slice
 
-Choose one design before calling the dependency contract resolved:
+Teach the static module control plane to parse and validate package co-requisites during deployment selection without feeding them into dependency ordering. The control plane must reject a selected Product module when an admitted Inventory or Pricing co-requisite is absent or version-incompatible, while preserving the existing ordinary reverse dependencies owned by Inventory and Pricing.
 
-1. add a control-plane co-requisite concept that affects module selection without creating dependency-order cycles; or
-2. publish host-injected transaction participant ports through a neutral contract crate and compose embedded Inventory/Pricing adapters without changing atomicity.
+After source enforcement exists, retain maintainer-run evidence for:
 
-The selected design must prove:
-
-- Product write startup and activation for non-default module selections;
+- default and non-default module selections;
 - clean migration ordering;
-- create/delete rollback across all three owners;
+- Product create/delete rollback across all three owners;
 - no silent post-commit partial state;
 - no ordinary cyclic dependency;
 - no Product ownership of Inventory or Pricing persistence.
+
+Host-injected transaction participant ports remain a future alternative if Product lifecycle writes need a remote/distributed collaboration profile; they are not required to describe the current embedded atomic contract.
 
 ## Evidence
 
@@ -76,4 +87,4 @@ Source evidence is stored at:
 
 `crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json`
 
-No tests, Cargo commands, formatting, verifier execution, workflow checks, standalone activation, or transaction rollback evidence are claimed by this source wave.
+No tests, Cargo commands, formatting, verifier execution, workflow checks, standalone activation, non-default deployment selection, or transaction rollback evidence are claimed by this source wave.

--- a/crates/rustok-product/rustok-module.toml
+++ b/crates/rustok-product/rustok-module.toml
@@ -14,6 +14,14 @@ entry_type = "ProductModule"
 [dependencies]
 taxonomy = { version_req = ">=0.1.0" }
 
+# Product lifecycle writes use Inventory- and Pricing-owned transaction-aware
+# bootstrap contracts. These are deployment co-requisites, not ordering
+# dependencies: both owners already depend on Product, so adding ordinary
+# reverse dependencies here would create a module cycle.
+[co_requisites]
+inventory = { version_req = ">=0.1.0" }
+pricing = { version_req = ">=0.1.0" }
+
 [provides.admin_ui]
 leptos_crate = "rustok-product-admin"
 route_segment = "product"

--- a/scripts/verify/verify-product-lifecycle-collaboration.mjs
+++ b/scripts/verify/verify-product-lifecycle-collaboration.mjs
@@ -64,8 +64,14 @@ const defaultEnabled = modules.slice(modules.indexOf('[settings]'));
 const productDependencySection = between(
   productManifest,
   '[dependencies]',
-  '\n[provides.admin_ui]',
+  '\n[co_requisites]',
   'Product package dependency section',
+);
+const productCoRequisiteSection = between(
+  productManifest,
+  '[co_requisites]',
+  '\n[provides.admin_ui]',
+  'Product package co-requisite section',
 );
 const inventoryDependencySection = between(
   inventoryManifest,
@@ -88,6 +94,8 @@ for (const [source, value, label] of [
   [defaultEnabled, '"pricing"', 'default Pricing activation'],
   [defaultEnabled, '"inventory"', 'default Inventory activation'],
   [productDependencySection, 'taxonomy = { version_req = ">=0.1.0" }', 'Product Taxonomy dependency'],
+  [productCoRequisiteSection, 'inventory = { version_req = ">=0.1.0" }', 'Product Inventory co-requisite'],
+  [productCoRequisiteSection, 'pricing = { version_req = ">=0.1.0" }', 'Product Pricing co-requisite'],
   [inventoryDependencySection, 'product = { version_req = ">=0.1.0" }', 'Inventory Product dependency'],
   [pricingDependencySection, 'product = { version_req = ">=0.1.0" }', 'Pricing Product dependency'],
   [productRuntime, '&["taxonomy"]', 'Product runtime dependency'],
@@ -104,14 +112,14 @@ for (const [source, value, label] of [
   [inventoryBootstrap, 'C: ConnectionTrait', 'Inventory transaction connection'],
   [pricingBootstrap, 'Pricing-owned transaction-aware operations required by Product lifecycle writes.', 'Pricing owner contract'],
   [pricingBootstrap, 'C: ConnectionTrait', 'Pricing transaction connection'],
-  [note, 'Status: contained source boundary, unresolved activation contract, unvalidated.', 'focused note status'],
-  [note, 'control-plane co-requisite concept', 'co-requisite decision'],
-  [note, 'host-injected transaction participant ports', 'port decision'],
+  [note, 'Status: deployment co-requisite contract declared, control-plane enforcement pending, unvalidated.', 'focused note status'],
+  [note, 'deployment-selection constraint, not an ordinary dependency edge', 'co-requisite semantics'],
+  [note, 'current module control plane does not yet consume `[co_requisites]`', 'explicit enforcement debt'],
 ]) requireText(source, value, label);
 
 for (const [source, value, label] of [
-  [productModuleEntry, '"inventory"', 'cyclic Product-to-Inventory dependency'],
-  [productModuleEntry, '"pricing"', 'cyclic Product-to-Pricing dependency'],
+  [productModuleEntry, '"inventory"', 'cyclic Product-to-Inventory root dependency'],
+  [productModuleEntry, '"pricing"', 'cyclic Product-to-Pricing root dependency'],
   [productDependencySection, 'inventory =', 'cyclic Product package Inventory dependency'],
   [productDependencySection, 'pricing =', 'cyclic Product package Pricing dependency'],
   [productRuntime, '"inventory"', 'cyclic Product runtime Inventory dependency'],
@@ -129,11 +137,21 @@ for (const [source, value, label] of [
   [commands, 'INTO prices', 'direct Pricing SQL write'],
 ]) forbidText(source, value, label);
 
-if (evidence.status !== 'product_lifecycle_collaboration_contained_unvalidated') {
+if (evidence.status !== 'product_lifecycle_corequisites_declared_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
+}
+const coRequisites = [...(evidence.module_topology?.product_co_requisites ?? [])].sort();
+if (JSON.stringify(coRequisites) !== JSON.stringify(['inventory', 'pricing'])) {
+  failures.push(`evidence Product co-requisites mismatch: ${JSON.stringify(coRequisites)}`);
 }
 if (evidence.module_topology?.ordinary_reverse_dependencies_forbidden !== true) {
   failures.push('evidence must forbid ordinary reverse dependencies');
+}
+if (evidence.module_topology?.co_requisites_are_ordering_dependencies !== false) {
+  failures.push('co-requisites must not become ordering dependencies');
+}
+if (evidence.module_topology?.co_requisite_control_plane_enforcement_proven !== false) {
+  failures.push('co-requisite control-plane enforcement must remain unproven');
 }
 if (evidence.module_topology?.standalone_product_write_activation_proven !== false) {
   failures.push('standalone Product write activation must remain unproven');
@@ -144,8 +162,9 @@ if (evidence.product_boundary?.foreign_owner_entities_imported !== false ||
   failures.push('evidence Product owner boundary mismatch');
 }
 if (evidence.decision?.containment_complete !== true ||
+    evidence.decision?.corequisite_contract_declared !== true ||
     evidence.decision?.dependency_contract_resolved !== false) {
-  failures.push('evidence decision must keep dependency resolution open');
+  failures.push('evidence decision must declare co-requisites while keeping enforcement open');
 }
 for (const key of [
   'tests_run',
@@ -155,6 +174,7 @@ for (const key of [
   'workflow_checks_run',
   'ci_run',
   'standalone_activation_proven',
+  'non_default_deployment_selection_proven',
   'transaction_rollback_proven',
 ]) {
   if (evidence.validation?.[key] !== false) {
@@ -169,5 +189,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Product uses transaction-aware Inventory/Pricing owner bootstrap contracts without direct foreign entities or cyclic module dependencies; activation contract and runtime evidence remain open',
+  '✔ Product declares Inventory/Pricing deployment co-requisites while preserving owner bootstrap atomicity and acyclic ordinary dependencies; control-plane enforcement and runtime evidence remain open',
 );


### PR DESCRIPTION
## Summary
- declare Inventory and Pricing as Product deployment co-requisites in `rustok-module.toml` without introducing ordinary dependency or migration-order edges
- preserve Inventory/Pricing -> Product ordinary dependencies and the existing same-transaction owner bootstrap collaboration
- update Product lifecycle collaboration documentation and machine-readable source evidence
- extend the source guard so it requires the co-requisite declaration while explicitly keeping control-plane enforcement and non-default activation evidence open

## Plan status
- this narrows the ecommerce Product dependency-contract debt by selecting and declaring the co-requisite design
- it does **not** close that debt yet: the static module control plane still needs to consume `[co_requisites]` during deployment selection and reject absent/version-incompatible owner modules
- Product schema-write durable replay is already source-complete for all eleven mounted writes from #3321; execution/promotion evidence remains maintainer-run

## Verification
- source and GitHub diff inspection only
- tests, verifiers, Cargo commands, formatters, workflows, and runtime validation were intentionally not run per maintainer instruction