### PR TITLE
feat(index): define explicit replay mode contract

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@bb65b7f0d3b6d2663519260841097c0e0f5f6cb8` and continued on
-`agent/index-replay-multihost-reclaim-evidence-20260808`.
+Status overlay rechecked at `main@e91926363cfcdf6a91836358add1afdf94f65ffa` and continued on
+`agent/index-replay-mode-contract-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -229,6 +229,24 @@ Together with bounded resume, graceful duplicate-safe restart and fresh GraphQL 
 this closes the currently tracked source-only multi-host/restart boundary. Execution/admission and any required
 PostgreSQL/process orchestration evidence remain maintainer-owned.
 
+## M6 explicit replay mode contract
+
+`IndexReplayMode` now separates `Full`, `Targeted` and `Shadow` rebuild intent from locale and future partition
+scope. `IndexReplayModeSelection` maps those modes to non-aliasing execution surfaces:
+
+- `Full` -> `DurableScan`; this is the only mode admitted to the existing `PostgresIndexReplayRunner` and retains
+  the current fenced replay job/checkpoint, cancellation, locale and lease semantics;
+- `Targeted` -> `TargetedLoad`; construction owns the canonical `IndexSourceLoadRequest`, preserving the existing
+  bounded exact-key count, tenant/schema scope and uniqueness checks;
+- `Shadow` -> `SideEffectFreeScan`; this matches the existing `SharedIndexReplayDryRunRuntime` no-write boundary.
+
+The contract does not expose caller-controlled mode input yet and does not add a mode column to jobs/checkpoints,
+a second lease owner, retry state, partition dimension, targeted mutation executor or shadow persistence. See
+`m6-replay-mode-contract.md`.
+
+The explicit mode identity/routing contract is source-complete. Runtime dispatch/admission remains open and
+maintainer execution is not claimed.
+
 ## Remaining Storefront parity/evidence blockers
 
 - execute/admit the deterministic budgeted timeout packet and retain acceptable runtime latency/cancellation
@@ -268,6 +286,7 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
 - [x] Retain deterministic locale replay/restart command evidence through the real GraphQL/runtime/runner path.
 - [x] Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds.
 - [x] Retain deterministic two-host lease-expiry/reclaim/stale-owner fencing evidence through distinct replay runners.
+- [x] Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
 - [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
@@ -275,8 +294,9 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
 - [ ] Execute/admit retained page lease-heartbeat evidence.
 - [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
 - [ ] Execute/admit retained multi-host reclaim evidence.
+- [ ] Add request-bound host dispatch for the existing side-effect-free Shadow replay surface.
+- [ ] Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.
 - [ ] Add partition replay scope only after a real partition-capable source contract exists.
-- [ ] Add explicit targeted/full/shadow rebuild modes under a separate contract.
 
 ## M7 Product Storefront graph
 
@@ -311,16 +331,17 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
 
 The locale request/source/job/checkpoint/runner/GraphQL identity chain, dependency timeout set,
-page-duration/lease-heartbeat policy and deterministic multi-host/restart source evidence are complete. Their next
-actions are maintainer execution/admission rather than further ownership abstraction.
+page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence and explicit Full/Targeted/Shadow
+mode identity are source-complete. Their retained packets still require maintainer execution/admission.
 
 Partition replay remains blocked: no real partition-capable source contract can yet filter a partition before
 pagination, so do not merely populate `partition_key`.
 
-For source-only M6 continuation, the next independent boundary is the explicit targeted/full/shadow rebuild-mode
-contract. That work must define mode identity and admission separately from locale/partition scope, preserve the
-existing fenced job/checkpoint semantics, and must not turn shadow/targeted modes into a second ownership or retry
-state machine.
+For source-only M6 continuation, the next independent boundary is request-bound host dispatch for the existing
+side-effect-free `Shadow` replay surface. It must reuse `SharedIndexReplayDryRunRuntime`, preserve authorization-first
+input parsing, keep `Full` routed to the existing durable runner, and must not introduce caller-controlled job,
+checkpoint, lease or retry state. Targeted execution remains separate until the bounded mutation-application
+contract over `IndexSource::load` is defined.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -1,0 +1,70 @@
+# M6 replay mode contract
+
+Status: `source_complete_execution_routing_pending`.
+
+This slice defines explicit rebuild mode identity without changing the existing durable replay runner, job,
+checkpoint, cancellation, locale or lease state machines.
+
+## Mode identity
+
+`IndexReplayMode` has exactly three modes:
+
+- `Full` — cursor-based durable source scan. Its execution surface is `DurableScan` and the existing
+  `PostgresIndexReplayRunner` remains the only admitted implementation.
+- `Targeted` — bounded exact-key source load. Its execution surface is `TargetedLoad`; construction delegates to
+  the canonical `IndexSourceLoadRequest`, so the existing 1..=256 key bound, exact tenant/schema scope and key
+  uniqueness remain authoritative.
+- `Shadow` — side-effect-free cursor scan. Its execution surface is `SideEffectFreeScan`, matching the existing
+  `SharedIndexReplayDryRunRuntime` no-write boundary.
+
+Mode is not locale scope and is not future partition scope. Adding a locale to a full scan does not create a new
+mode, and adding partition replay later must not encode partition identity as a mode.
+
+## Fail-closed routing
+
+`IndexReplayModeSelection::is_admitted_to_durable_scan_runner` returns true only for `Full`.
+
+Targeted and shadow modes must not alias the full durable job/checkpoint identity:
+
+- targeted execution must be a bounded `IndexSource::load` path and must define its own operator execution
+  contract before it can persist mutations;
+- shadow execution must remain no-write and use the dry-run surface rather than the durable mutation/job/checkpoint
+  path;
+- neither mode introduces automatic retry/requeue, another lease owner, another terminal job state, or a second
+  cancellation model.
+
+The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner`, `IndexReplayOperatorRuntime` and GraphQL
+`runIndexReplay` command remain full-scan behavior. This PR does not add caller-controlled mode input or silently
+reinterpret existing commands.
+
+## Existing contracts reused
+
+The mode contract composes already-retained boundaries rather than duplicating them:
+
+- full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
+- targeted: `IndexSourceLoadRequest` exact-key validation and `IndexSource::load` source boundary;
+- shadow: `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan validation.
+
+Partition replay remains blocked until a real partition-capable source can filter before pagination.
+
+## Non-goals
+
+This slice does not add:
+
+- targeted mutation execution;
+- shadow persistence or shadow tables;
+- GraphQL/API mode selection;
+- a mode column in `index_jobs` or `index_checkpoints`;
+- partition replay scope;
+- automatic retry/requeue or scheduler ownership;
+- a second durable ownership/fencing model.
+
+## Next source boundary
+
+The next source-only boundary is request-bound host dispatch for the already-existing no-write `Shadow` surface.
+That work should reuse `SharedIndexReplayDryRunRuntime`, preserve authorization-first parsing, and keep `Full`
+routed to the existing durable runner. Targeted execution remains a separate later slice because it needs an
+explicit bounded mutation-application contract over `IndexSource::load` rather than a scan checkpoint.
+
+Execution/admission remains maintainer-owned. The Rust tests and Node verifiers for this source slice were not
+executed by the implementation agent.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -19,6 +19,7 @@ mod postgres_query_sql;
 mod query_port;
 mod query_runtime;
 mod registry;
+mod replay_mode;
 mod source_absence;
 mod source_continuation;
 mod source_event_id;
@@ -147,6 +148,9 @@ pub use query_port::{
 pub use query_runtime::SharedIndexQueryRuntime;
 pub use registry::{
     LinkPathStep, RegisteredSchema, RegistrationOutcome, SchemaRegistry, SchemaRegistryError,
+};
+pub use replay_mode::{
+    IndexReplayExecutionSurface, IndexReplayMode, IndexReplayModeSelection,
 };
 pub use source_absence::{
     IndexSourceAbsenceCatalog, IndexSourceAbsenceDescriptor, IndexSourceAbsenceError,

--- a/crates/rustok-index/src/application/replay_mode.rs
+++ b/crates/rustok-index/src/application/replay_mode.rs
@@ -1,0 +1,158 @@
+use crate::{EntityKey, IndexSourceError, IndexSourceLoadRequest};
+
+/// Operator-visible rebuild intent.
+///
+/// Mode identity is deliberately separate from locale and future partition scope. A mode selects
+/// an execution surface; it does not create another replay ownership or retry state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayMode {
+    /// Cursor-based durable source scan through the fenced replay job/checkpoint runner.
+    Full,
+    /// Bounded exact-key load through `IndexSource::load`.
+    Targeted,
+    /// Side-effect-free cursor scan through the replay dry-run runtime.
+    Shadow,
+}
+
+/// Existing execution surface selected by one replay mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexReplayExecutionSurface {
+    DurableScan,
+    TargetedLoad,
+    SideEffectFreeScan,
+}
+
+/// Validated mode selection.
+///
+/// Targeted mode owns the canonical bounded `IndexSourceLoadRequest`, so target count,
+/// tenant/schema scope and uniqueness cannot drift from the source contract. Full and shadow
+/// carry no target list and therefore cannot accidentally reinterpret exact keys as scan scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexReplayModeSelection {
+    Full,
+    Targeted(IndexSourceLoadRequest),
+    Shadow,
+}
+
+impl IndexReplayModeSelection {
+    pub fn full() -> Self {
+        Self::Full
+    }
+
+    pub fn targeted(keys: Vec<EntityKey>) -> Result<Self, IndexSourceError> {
+        Ok(Self::Targeted(IndexSourceLoadRequest::new(keys)?))
+    }
+
+    pub fn shadow() -> Self {
+        Self::Shadow
+    }
+
+    pub fn mode(&self) -> IndexReplayMode {
+        match self {
+            Self::Full => IndexReplayMode::Full,
+            Self::Targeted(_) => IndexReplayMode::Targeted,
+            Self::Shadow => IndexReplayMode::Shadow,
+        }
+    }
+
+    pub fn execution_surface(&self) -> IndexReplayExecutionSurface {
+        match self {
+            Self::Full => IndexReplayExecutionSurface::DurableScan,
+            Self::Targeted(_) => IndexReplayExecutionSurface::TargetedLoad,
+            Self::Shadow => IndexReplayExecutionSurface::SideEffectFreeScan,
+        }
+    }
+
+    pub fn targeted_load_request(&self) -> Option<&IndexSourceLoadRequest> {
+        match self {
+            Self::Targeted(request) => Some(request),
+            Self::Full | Self::Shadow => None,
+        }
+    }
+
+    /// The current `PostgresIndexReplayRunner` remains the durable full-scan executor only.
+    /// Targeted and shadow modes must use their separate execution surfaces instead of aliasing
+    /// the full job/checkpoint identity.
+    pub fn is_admitted_to_durable_scan_runner(&self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::{EntityName, LocaleKey, ModuleName, SchemaRef, SchemaVersion};
+
+    use super::*;
+
+    fn schema() -> SchemaRef {
+        SchemaRef {
+            module: ModuleName::new("mode-owner").unwrap(),
+            entity: EntityName::new("item").unwrap(),
+            version: SchemaVersion::INITIAL,
+        }
+    }
+
+    fn key(entity_id: u128, locale: Option<&str>) -> EntityKey {
+        EntityKey {
+            tenant_id: Uuid::from_u128(1),
+            schema: schema(),
+            entity_id: Uuid::from_u128(entity_id),
+            locale: locale.map(|value| LocaleKey::new(value).unwrap()),
+        }
+    }
+
+    #[test]
+    fn full_is_the_only_mode_admitted_to_the_existing_durable_scan_runner() {
+        let selection = IndexReplayModeSelection::full();
+        assert_eq!(selection.mode(), IndexReplayMode::Full);
+        assert_eq!(
+            selection.execution_surface(),
+            IndexReplayExecutionSurface::DurableScan
+        );
+        assert!(selection.targeted_load_request().is_none());
+        assert!(selection.is_admitted_to_durable_scan_runner());
+    }
+
+    #[test]
+    fn targeted_reuses_the_canonical_bounded_load_request() {
+        let selection = IndexReplayModeSelection::targeted(vec![
+            key(10, Some("en-US")),
+            key(11, Some("de")),
+        ])
+        .unwrap();
+        assert_eq!(selection.mode(), IndexReplayMode::Targeted);
+        assert_eq!(
+            selection.execution_surface(),
+            IndexReplayExecutionSurface::TargetedLoad
+        );
+        assert_eq!(selection.targeted_load_request().unwrap().keys().len(), 2);
+        assert!(!selection.is_admitted_to_durable_scan_runner());
+    }
+
+    #[test]
+    fn targeted_rejects_empty_duplicate_and_mixed_scope_keys() {
+        assert!(IndexReplayModeSelection::targeted(Vec::new()).is_err());
+        let duplicate = key(10, None);
+        assert!(
+            IndexReplayModeSelection::targeted(vec![duplicate.clone(), duplicate]).is_err()
+        );
+
+        let mut mixed = key(11, None);
+        mixed.tenant_id = Uuid::from_u128(2);
+        assert!(IndexReplayModeSelection::targeted(vec![key(10, None), mixed]).is_err());
+    }
+
+    #[test]
+    fn shadow_routes_only_to_the_side_effect_free_scan_surface() {
+        let selection = IndexReplayModeSelection::shadow();
+        assert_eq!(selection.mode(), IndexReplayMode::Shadow);
+        assert_eq!(
+            selection.execution_surface(),
+            IndexReplayExecutionSurface::SideEffectFreeScan
+        );
+        assert!(selection.targeted_load_request().is_none());
+        assert!(!selection.is_admitted_to_durable_scan_runner());
+    }
+}

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -69,6 +69,7 @@ const scripts = [
   'verify-index-reconciliation-dead-letter-inspection.mjs',
   'verify-index-reconciliation-dead-letter-requeue.mjs',
   'verify-index-replay-dry-run.mjs',
+  'verify-index-replay-mode-contract.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',
   'verify-index-replay-dead-letter-admission.mjs',

--- a/scripts/verify/verify-index-replay-mode-contract.mjs
+++ b/scripts/verify/verify-index-replay-mode-contract.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-mode-contract] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const modePath = 'crates/rustok-index/src/application/replay_mode.rs';
+const mode = requireMarkers(modePath, [
+  'pub enum IndexReplayMode {',
+  'Full,',
+  'Targeted,',
+  'Shadow,',
+  'pub enum IndexReplayExecutionSurface {',
+  'DurableScan,',
+  'TargetedLoad,',
+  'SideEffectFreeScan,',
+  'pub enum IndexReplayModeSelection {',
+  'Targeted(IndexSourceLoadRequest)',
+  'IndexSourceLoadRequest::new(keys)?',
+  'IndexReplayExecutionSurface::DurableScan',
+  'IndexReplayExecutionSurface::TargetedLoad',
+  'IndexReplayExecutionSurface::SideEffectFreeScan',
+  'pub fn is_admitted_to_durable_scan_runner(&self) -> bool',
+  'matches!(self, Self::Full)',
+  'targeted_reuses_the_canonical_bounded_load_request',
+  'targeted_rejects_empty_duplicate_and_mixed_scope_keys',
+  'shadow_routes_only_to_the_side_effect_free_scan_surface',
+]);
+for (const forbidden of [
+  'PostgresIndexReplayJobStore',
+  'PostgresIndexReplayCheckpointStore',
+  'PostgresMutationStore',
+  'DatabaseConnection',
+  'partition_key',
+  'request_cancel',
+  'Retrying',
+  'auto_requeue',
+]) {
+  if (mode.includes(forbidden)) fail(`${modePath} must remain an application mode/routing contract: ${forbidden}`);
+}
+
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod replay_mode;',
+  'IndexReplayExecutionSurface, IndexReplayMode, IndexReplayModeSelection',
+]);
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = read(runnerPath);
+for (const forbidden of ['IndexReplayMode::Targeted', 'IndexReplayMode::Shadow', 'TargetedLoad', 'SideEffectFreeScan']) {
+  if (runner.includes(forbidden)) {
+    fail(`${runnerPath} must remain the durable full-scan runner until a separate dispatcher is added: ${forbidden}`);
+  }
+}
+
+const dryRunPath = 'crates/rustok-index/src/replay_dry_run.rs';
+requireMarkers(dryRunPath, [
+  'No mutation, inbox delivery, job, checkpoint, or reconciliation progress is persisted',
+  'pub struct SharedIndexReplayDryRunRuntime',
+  '.scan(scan_request)',
+]);
+
+requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
+  'Status: `source_complete_execution_routing_pending`.',
+  '`Full` — cursor-based durable source scan',
+  '`Targeted` — bounded exact-key source load',
+  '`Shadow` — side-effect-free cursor scan',
+  'Mode is not locale scope and is not future partition scope.',
+  'returns true only for `Full`',
+  'must not alias the full durable job/checkpoint identity',
+  'The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner`, `IndexReplayOperatorRuntime` and GraphQL',
+  'does not add caller-controlled mode input',
+  'next source-only boundary is request-bound host dispatch',
+  'Execution/admission remains maintainer-owned.',
+]);
+
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  'Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.',
+  'Add request-bound host dispatch for the existing side-effect-free Shadow replay surface.',
+  'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
+  'Add partition replay scope only after a real partition-capable source contract exists.',
+]);
+
+console.log('[verify-index-replay-mode-contract] full, targeted and shadow modes remain explicit, bounded and routed to non-aliasing execution surfaces');

--- a/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
+++ b/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
@@ -116,7 +116,8 @@ requireMarkers('crates/rustok-index/docs/m6-replay-multihost-reclaim-evidence.md
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Retain deterministic two-host lease-expiry/reclaim/stale-owner fencing evidence through distinct replay runners.',
   'Execute/admit retained multi-host reclaim evidence.',
-  'next independent boundary is the explicit targeted/full/shadow rebuild-mode',
+  'Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.',
+  'Add request-bound host dispatch for the existing side-effect-free Shadow replay surface.',
   'Partition replay remains blocked',
 ]);
 


### PR DESCRIPTION
## Summary

- define explicit `Full`, `Targeted` and `Shadow` replay mode identity in the Index application layer;
- map modes to non-aliasing execution surfaces: `DurableScan`, `TargetedLoad` and `SideEffectFreeScan`;
- keep the existing `PostgresIndexReplayRunner` admitted only for `Full`, preserving the current fenced job/checkpoint, cancellation, locale and lease semantics;
- make `Targeted` construction own the canonical `IndexSourceLoadRequest`, reusing the existing exact-key bound, tenant/schema scope and uniqueness checks instead of inventing a second target contract;
- map `Shadow` to the already-retained side-effect-free replay dry-run surface without adding shadow persistence or job/checkpoint state;
- add focused source guards, register them in the Index aggregate, and advance the current M6 source cursor;
- leave caller-controlled mode input and runtime dispatch for a later slice; the next source-only boundary is request-bound host dispatch for the existing no-write Shadow runtime;
- keep targeted mutation execution separate until a bounded mutation-application contract over `IndexSource::load` is defined;
- keep partition replay blocked until a real partition-capable source filters before pagination.

## Production impact

No durable replay runner, replay job/checkpoint schema, mutation store, GraphQL command or server runtime behavior changes are included. The new production source is a typed application-level contract only; existing commands remain full-scan behavior.

## Mainline recheck

The branch was created from current `main@e91926363cfcdf6a91836358add1afdf94f65ffa`. The immediately preceding #3326 is Pages-only and disjoint from this Index slice.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.