### PR TITLE
feat(parity): expose tenant rollout settings runtime seam

### DIFF
--- a/crates/rustok-api/src/lib.rs
+++ b/crates/rustok-api/src/lib.rs
@@ -81,7 +81,9 @@ pub use richtext::{
     RichTextView, document_json_schema,
 };
 #[cfg(feature = "runtime")]
-pub use runtime::{HostRuntimeContext, HostSettingsSnapshot, is_tenant_module_enabled};
+pub use runtime::{
+    HostRuntimeContext, HostSettingsSnapshot, is_tenant_module_enabled, tenant_module_settings,
+};
 pub use tenant_rbac::{
     SharedTenantRbacCatalog, TenantRbacCatalog, TenantRbacCatalogError, TenantRbacPermission,
     TenantRbacRole,

--- a/crates/rustok-api/src/runtime.rs
+++ b/crates/rustok-api/src/runtime.rs
@@ -37,6 +37,49 @@ pub async fn is_tenant_module_enabled(
     .map(|row| row.is_some())
 }
 
+/// Returns the settings snapshot for one exact enabled tenant module.
+///
+/// This is the read-only counterpart to [`is_tenant_module_enabled`]. Internal
+/// GraphQL and native server-function adapters can consume the same persisted
+/// tenant-module control-plane snapshot without importing tenant persistence
+/// entities or inventing a parallel settings store. Disabled, foreign and
+/// missing rows fail closed to `None`.
+pub async fn tenant_module_settings(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    module_slug: &str,
+) -> Result<Option<serde_json::Value>, DbErr> {
+    let backend = db.get_database_backend();
+    let query = match backend {
+        sea_orm::DbBackend::Sqlite => {
+            "SELECT CAST(settings AS TEXT) AS settings_json FROM tenant_modules WHERE tenant_id = ?1 AND module_slug = ?2 AND enabled = 1 LIMIT 1"
+        }
+        sea_orm::DbBackend::Postgres => {
+            "SELECT settings::text AS settings_json FROM tenant_modules WHERE tenant_id = $1 AND module_slug = $2 AND enabled = true LIMIT 1"
+        }
+        sea_orm::DbBackend::MySql => {
+            "SELECT CAST(settings AS CHAR) AS settings_json FROM tenant_modules WHERE tenant_id = ? AND module_slug = ? AND enabled = true LIMIT 1"
+        }
+    };
+
+    let Some(row) = db
+        .query_one(Statement::from_sql_and_values(
+            backend,
+            query,
+            vec![tenant_id.into(), module_slug.into()],
+        ))
+        .await?
+    else {
+        return Ok(None);
+    };
+    let encoded: String = row.try_get("", "settings_json")?;
+    serde_json::from_str(&encoded).map(Some).map_err(|error| {
+        DbErr::Custom(format!(
+            "tenant module `{module_slug}` settings are not valid JSON: {error}"
+        ))
+    })
+}
+
 /// Immutable host configuration snapshot provided to internal server-function
 /// adapters. It keeps adapters independent of a framework-specific app context.
 #[derive(Clone, Debug)]
@@ -119,8 +162,7 @@ mod tests {
     use super::*;
     use sea_orm::Database;
 
-    #[tokio::test]
-    async fn tenant_module_enablement_is_exact_and_fail_closed() {
+    async fn runtime_module_db() -> DatabaseConnection {
         let db = Database::connect("sqlite::memory:")
             .await
             .expect("runtime module evidence SQLite should connect");
@@ -130,13 +172,19 @@ CREATE TABLE tenant_modules (
     tenant_id TEXT NOT NULL,
     module_slug TEXT NOT NULL,
     enabled INTEGER NOT NULL,
+    settings TEXT NOT NULL DEFAULT '{}',
     PRIMARY KEY (tenant_id, module_slug)
 );
 "#,
         )
         .await
         .expect("tenant_modules evidence table should create");
+        db
+    }
 
+    #[tokio::test]
+    async fn tenant_module_enablement_is_exact_and_fail_closed() {
+        let db = runtime_module_db().await;
         let tenant_id = Uuid::new_v4();
         let foreign_tenant_id = Uuid::new_v4();
         db.execute_unprepared(&format!(
@@ -167,6 +215,49 @@ CREATE TABLE tenant_modules (
             !is_tenant_module_enabled(&db, tenant_id, "missing")
                 .await
                 .expect("missing module lookup should succeed")
+        );
+    }
+
+    #[tokio::test]
+    async fn tenant_module_settings_returns_only_the_exact_enabled_row() {
+        let db = runtime_module_db().await;
+        let tenant_id = Uuid::new_v4();
+        let foreign_tenant_id = Uuid::new_v4();
+        db.execute_unprepared(&format!(
+            r#"INSERT INTO tenant_modules (tenant_id, module_slug, enabled, settings) VALUES
+             ('{tenant_id}', 'pages', 1, '{{"builder":{{"enabled":false,"preview":{{"enabled":false}},"properties":{{"enabled":true}},"publish":{{"enabled":false}}}}}}'),
+             ('{tenant_id}', 'forum', 0, '{{"builder":{{"enabled":true}}}}'),
+             ('{foreign_tenant_id}', 'pages', 1, '{{"builder":{{"enabled":true}}}}')"#
+        ))
+        .await
+        .expect("tenant module settings evidence rows should insert");
+
+        let settings = tenant_module_settings(&db, tenant_id, "pages")
+            .await
+            .expect("enabled Pages settings lookup should succeed")
+            .expect("enabled Pages row should expose settings");
+        assert_eq!(settings["builder"]["enabled"], false);
+        assert_eq!(settings["builder"]["preview"]["enabled"], false);
+        assert_eq!(settings["builder"]["properties"]["enabled"], true);
+        assert_eq!(settings["builder"]["publish"]["enabled"], false);
+
+        assert_eq!(
+            tenant_module_settings(&db, tenant_id, "forum")
+                .await
+                .expect("disabled Forum settings lookup should succeed"),
+            None
+        );
+        assert_eq!(
+            tenant_module_settings(&db, foreign_tenant_id, "forum")
+                .await
+                .expect("foreign module settings lookup should succeed"),
+            None
+        );
+        assert_eq!(
+            tenant_module_settings(&db, tenant_id, "missing")
+                .await
+                .expect("missing module settings lookup should succeed"),
+            None
         );
     }
 }

--- a/crates/rustok-api/src/runtime.rs
+++ b/crates/rustok-api/src/runtime.rs
@@ -42,8 +42,9 @@ pub async fn is_tenant_module_enabled(
 /// This is the read-only counterpart to [`is_tenant_module_enabled`]. Internal
 /// GraphQL and native server-function adapters can consume the same persisted
 /// tenant-module control-plane snapshot without importing tenant persistence
-/// entities or inventing a parallel settings store. Disabled, foreign and
-/// missing rows fail closed to `None`.
+/// entities or inventing a parallel settings store. The caller must supply the
+/// tenant id from a trusted request context; this helper only applies the exact
+/// tenant/module/enabled-row lookup. Disabled or missing rows return `None`.
 pub async fn tenant_module_settings(
     db: &DatabaseConnection,
     tenant_id: Uuid,
@@ -241,16 +242,16 @@ CREATE TABLE tenant_modules (
         assert_eq!(settings["builder"]["properties"]["enabled"], true);
         assert_eq!(settings["builder"]["publish"]["enabled"], false);
 
+        let other_tenant_settings = tenant_module_settings(&db, foreign_tenant_id, "pages")
+            .await
+            .expect("other exact tenant Pages lookup should succeed")
+            .expect("other exact enabled Pages row should expose its own settings");
+        assert_eq!(other_tenant_settings["builder"]["enabled"], true);
+
         assert_eq!(
             tenant_module_settings(&db, tenant_id, "forum")
                 .await
                 .expect("disabled Forum settings lookup should succeed"),
-            None
-        );
-        assert_eq!(
-            tenant_module_settings(&db, foreign_tenant_id, "forum")
-                .await
-                .expect("foreign module settings lookup should succeed"),
             None
         );
         assert_eq!(

--- a/crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json
@@ -13,6 +13,7 @@
     "page_builder_provider_status": "source_ready_health_unobserved",
     "plan_parity": "source_ready",
     "candidate_harness": "source_ready_maintainer_execution_pending",
+    "tenant_rollout_settings": "platform_read_seam_source_ready_pages_binding_pending",
     "forum_second_consumer": {
       "contribution_metadata": "source_ready",
       "fly_adapter": "source_ready",
@@ -110,6 +111,8 @@
     "source_gate": "ready",
     "execution_gate": "pending",
     "candidate_harness": "source_ready_maintainer_execution_pending",
+    "tenant_rollout_settings": "platform_read_seam_source_ready_pages_binding_pending",
+    "four_profile_runtime_matrix": "blocked_on_pages_tenant_settings_binding",
     "forum_wave_blocker": "pages_reference_consumer_gate",
     "provider_health": "unobserved",
     "ffa_fba_promotion": "not_claimed"
@@ -118,6 +121,7 @@
     "source_guard": "crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate.mjs",
     "plan_parity_guard": "crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs",
     "candidate_harness_guard": "crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate-evidence-harness.mjs",
+    "tenant_rollout_settings_guard": "crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs",
     "execution_status": "not_run_by_implementation_agent"
   },
   "forbidden_claims": [

--- a/crates/rustok-pages/contracts/evidence/pages-tenant-rollout-settings-runtime-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-tenant-rollout-settings-runtime-source.json
@@ -5,6 +5,7 @@
   "source_base": "e91926363cfcdf6a91836358add1afdf94f65ffa",
   "source_contract": {
     "platform_runtime_helper": "rustok_api::tenant_module_settings",
+    "trusted_tenant_id_must_be_supplied_by_caller": true,
     "exact_tenant_id_required": true,
     "exact_module_slug_required": true,
     "enabled_row_required": true,
@@ -33,5 +34,5 @@
     "browser_run": false,
     "workflow_or_ci_run": false
   },
-  "next_cursor": "bind the exact enabled Pages tenant-module settings snapshot into PagesBuilderFacade provider status and SSR Page Builder capability composition, then retain the four-profile runtime matrix"
+  "next_cursor": "bind a trusted routed-tenant Pages settings snapshot into PagesBuilderFacade provider status and authoritative SSR Page Builder capability composition, then retain the four-profile runtime matrix"
 }

--- a/crates/rustok-pages/contracts/evidence/pages-tenant-rollout-settings-runtime-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-tenant-rollout-settings-runtime-source.json
@@ -1,0 +1,37 @@
+{
+  "format": "pages_tenant_rollout_settings_runtime_source_v1",
+  "status": "platform_settings_read_seam_source_ready_pages_binding_pending",
+  "prepared_on": "2026-08-08",
+  "source_base": "e91926363cfcdf6a91836358add1afdf94f65ffa",
+  "source_contract": {
+    "platform_runtime_helper": "rustok_api::tenant_module_settings",
+    "exact_tenant_id_required": true,
+    "exact_module_slug_required": true,
+    "enabled_row_required": true,
+    "disabled_row_returns_none": true,
+    "missing_row_returns_none": true,
+    "settings_json_decode_is_fail_closed": true,
+    "sqlite_supported": true,
+    "postgres_supported": true,
+    "mysql_supported": true,
+    "tenant_persistence_entity_import_required": false,
+    "settings_mutation_added": false,
+    "parallel_settings_store_added": false,
+    "pages_consumer_binding_complete": false,
+    "pages_runtime_profile_matrix_executable": false,
+    "gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "validation": {
+    "tests_run": false,
+    "node_verifiers_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "database_run": false,
+    "browser_run": false,
+    "workflow_or_ci_run": false
+  },
+  "next_cursor": "bind the exact enabled Pages tenant-module settings snapshot into PagesBuilderFacade provider status and SSR Page Builder capability composition, then retain the four-profile runtime matrix"
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const files = {
+  runtime: "crates/rustok-api/src/runtime.rs",
+  apiLib: "crates/rustok-api/src/lib.rs",
+  pagesBuilder: "crates/rustok-pages/admin/src/builder.rs",
+  evidence: "crates/rustok-pages/contracts/evidence/pages-tenant-rollout-settings-runtime-source.json",
+  gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
+  actualization: "docs/modules/pages-page-builder-tenant-rollout-settings-runtime-actualization-2026-08-08.md",
+};
+const failures = [];
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length > 0) {
+  console.error("[verify-pages-tenant-rollout-settings-runtime] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const evidence = JSON.parse(sources.evidence);
+const gate = JSON.parse(sources.gate);
+
+const functionStart = sources.runtime.indexOf("pub async fn tenant_module_settings(");
+const functionEnd = sources.runtime.indexOf("\n/// Immutable host configuration snapshot", functionStart);
+if (functionStart < 0 || functionEnd < 0) {
+  failures.push("runtime: unable to isolate tenant_module_settings");
+}
+const settingsFunction =
+  functionStart >= 0 && functionEnd > functionStart
+    ? sources.runtime.slice(functionStart, functionEnd)
+    : "";
+
+for (const marker of [
+  "pub async fn tenant_module_settings(",
+  "tenant_id: Uuid",
+  "module_slug: &str",
+  "enabled = 1",
+  "enabled = true",
+  "CAST(settings AS TEXT) AS settings_json",
+  "settings::text AS settings_json",
+  "CAST(settings AS CHAR) AS settings_json",
+  'row.try_get("", "settings_json")?',
+  "serde_json::from_str(&encoded)",
+  "DbErr::Custom",
+]) need(settingsFunction, marker, "runtime settings helper");
+
+for (const marker of ["INSERT ", "UPDATE ", "DELETE ", "ActiveModel", ".execute(", "execute_unprepared("]) {
+  forbid(settingsFunction, marker, "runtime settings helper must remain read-only");
+}
+
+for (const marker of [
+  "tenant_module_settings_returns_only_the_exact_enabled_row",
+  'tenant_module_settings(&db, tenant_id, "pages")',
+  'tenant_module_settings(&db, tenant_id, "forum")',
+  'tenant_module_settings(&db, tenant_id, "missing")',
+]) need(sources.runtime, marker, "runtime settings source test");
+
+need(sources.apiLib, "tenant_module_settings", "rustok-api runtime export");
+
+for (const marker of [
+  "fn pages_builder_capability_flags() -> BuilderCapabilityFlags",
+  "BuilderCapabilityFlags::default()",
+  "PageBuilderAdminProviderStatus::unobserved(",
+  "pages_builder_capability_flags()",
+  "compose_fly_page_builder_handlers(store, renderer, pages_builder_capability_flags())",
+]) need(sources.pagesBuilder, marker, "Pages binding blocker");
+
+if (evidence.format !== "pages_tenant_rollout_settings_runtime_source_v1") {
+  failures.push(`evidence format drifted: ${evidence.format}`);
+}
+if (evidence.status !== "platform_settings_read_seam_source_ready_pages_binding_pending") {
+  failures.push(`evidence status drifted: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  exact_tenant_id_required: true,
+  exact_module_slug_required: true,
+  enabled_row_required: true,
+  disabled_row_returns_none: true,
+  missing_row_returns_none: true,
+  settings_json_decode_is_fail_closed: true,
+  sqlite_supported: true,
+  postgres_supported: true,
+  mysql_supported: true,
+  tenant_persistence_entity_import_required: false,
+  settings_mutation_added: false,
+  parallel_settings_store_added: false,
+  pages_consumer_binding_complete: false,
+  pages_runtime_profile_matrix_executable: false,
+  gate_accepted: false,
+  forum_wave_accepted: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`evidence validation.${key} must remain false`);
+}
+
+if (gate.accepted !== false) failures.push("Pages reference-consumer gate must remain unaccepted");
+if (gate.current_boundary?.execution_gate !== "pending") {
+  failures.push("Pages reference-consumer execution gate must remain pending");
+}
+if (
+  gate.current_boundary?.tenant_rollout_settings !==
+  "platform_read_seam_source_ready_pages_binding_pending"
+) {
+  failures.push("Pages gate tenant rollout settings cursor drifted");
+}
+if (
+  gate.current_boundary?.four_profile_runtime_matrix !==
+  "blocked_on_pages_tenant_settings_binding"
+) {
+  failures.push("Pages gate four-profile runtime cursor drifted");
+}
+if (
+  gate.verification?.tenant_rollout_settings_guard !==
+  "crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs"
+) {
+  failures.push("Pages gate tenant rollout settings guard is not registered");
+}
+
+for (const marker of [
+  "hardcoded `BuilderCapabilityFlags::default()`",
+  "platform read seam is source-ready",
+  "Pages consumer binding remains pending",
+  "four-profile runtime matrix remains blocked",
+  "No tests, Node verifiers, Cargo commands",
+]) need(sources.actualization, marker, "actualization");
+
+if (failures.length > 0) {
+  console.error("[verify-pages-tenant-rollout-settings-runtime] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "[verify-pages-tenant-rollout-settings-runtime] PASS platform_read_seam=source_ready pages_binding=pending four_profile_runtime=blocked",
+);

--- a/crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs
@@ -59,6 +59,8 @@ for (const marker of [
   "pub async fn tenant_module_settings(",
   "tenant_id: Uuid",
   "module_slug: &str",
+  "caller must supply the",
+  "tenant id from a trusted request context",
   "enabled = 1",
   "enabled = true",
   "CAST(settings AS TEXT) AS settings_json",
@@ -76,6 +78,7 @@ for (const marker of ["INSERT ", "UPDATE ", "DELETE ", "ActiveModel", ".execute(
 for (const marker of [
   "tenant_module_settings_returns_only_the_exact_enabled_row",
   'tenant_module_settings(&db, tenant_id, "pages")',
+  'tenant_module_settings(&db, foreign_tenant_id, "pages")',
   'tenant_module_settings(&db, tenant_id, "forum")',
   'tenant_module_settings(&db, tenant_id, "missing")',
 ]) need(sources.runtime, marker, "runtime settings source test");
@@ -97,6 +100,7 @@ if (evidence.status !== "platform_settings_read_seam_source_ready_pages_binding_
   failures.push(`evidence status drifted: ${evidence.status}`);
 }
 for (const [key, expected] of Object.entries({
+  trusted_tenant_id_must_be_supplied_by_caller: true,
   exact_tenant_id_required: true,
   exact_module_slug_required: true,
   enabled_row_required: true,
@@ -150,6 +154,7 @@ if (
 for (const marker of [
   "hardcoded `BuilderCapabilityFlags::default()`",
   "platform read seam is source-ready",
+  "trusted `TenantContext`",
   "Pages consumer binding remains pending",
   "four-profile runtime matrix remains blocked",
   "No tests, Node verifiers, Cargo commands",

--- a/docs/modules/pages-page-builder-tenant-rollout-settings-runtime-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-tenant-rollout-settings-runtime-actualization-2026-08-08.md
@@ -1,0 +1,82 @@
+# Pages / Page Builder tenant rollout settings runtime actualization — 2026-08-08
+
+Status: `platform-settings-read-seam-source-ready / pages-consumer-binding-pending / four-profile-runtime-evidence-blocked / gate-acceptance-pending`
+
+Base rechecked: `main@e91926363cfcdf6a91836358add1afdf94f65ffa`.
+
+## Why this slice exists
+
+The Pages reference-consumer gate requires observed behavior for four provider profiles: `all_on`, `publish_off`, `preview_off`, and `builder_off`. PR #3326 retained a bounded candidate harness and focused Page Builder provider-profile tests, but a source recheck found that the Pages reference consumer itself cannot yet be driven through those persisted tenant profiles.
+
+`crates/rustok-pages/admin/src/builder.rs` still owns this source function:
+
+```text
+pages_builder_capability_flags() -> BuilderCapabilityFlags
+```
+
+and it currently returns the hardcoded `BuilderCapabilityFlags::default()` value. The same hardcoded all-on snapshot is exposed through `PagesBuilderFacade::provider_status()` and passed to SSR `compose_fly_page_builder_handlers(...)`.
+
+That is sufficient to keep both sides internally consistent for the default profile, but it is not sufficient to claim tenant-scoped execution of `publish_off`, `preview_off`, or `builder_off`. A candidate packet produced without fixing this boundary would only exercise provider-profile logic in focused tests, not the actual persisted Pages tenant rollout state required by the gate.
+
+Therefore owner review is not the next source step yet.
+
+## Existing owner settings contract
+
+Pages already interprets the persisted nested module settings shape in its owner service helpers:
+
+```text
+builder.enabled
+builder.preview.enabled
+builder.properties.enabled
+builder.publish.enabled
+```
+
+The canonical `crates/rustok-pages/rustok-module.toml` declares the same four toggle profiles and explicitly requires Pages-owned read paths to remain available when Page Builder capabilities are disabled.
+
+The missing part is transport/composition: Pages admin and its SSR Page Builder capability dispatch do not currently receive the exact enabled `tenant_modules.settings` snapshot.
+
+## Neutral platform read seam
+
+This slice adds `rustok_api::tenant_module_settings` next to the existing `rustok_api::is_tenant_module_enabled` runtime helper.
+
+The helper is intentionally read-only and provider-neutral:
+
+- it requires an exact tenant id and module slug;
+- it returns settings only from an exact **enabled** `tenant_modules` row;
+- disabled or missing rows return `None`;
+- malformed stored JSON fails closed as a database error;
+- SQLite, PostgreSQL, and MySQL use backend-specific read forms;
+- it does not import tenant persistence entities;
+- it does not mutate settings;
+- it does not create a second settings store or Pages-owned control plane.
+
+This keeps tenant-module lifecycle/settings ownership outside Pages while giving internal server adapters one neutral way to consume the persisted snapshot.
+
+## Current boundary
+
+The platform read seam is source-ready.
+
+Pages consumer binding remains pending.
+
+The four-profile runtime matrix remains blocked until Pages stops deriving both its admin provider status and SSR handler composition from the hardcoded all-on function.
+
+`pages_reference_consumer_gate` remains `accepted = false`; provider health remains `unobserved`; Forum Wave and FFA/FBA remain unaccepted/unpromoted.
+
+## Next exact source cursor
+
+Bind one normalized `BuilderCapabilityFlags` snapshot derived from the exact enabled Pages tenant-module settings into both sides of the reference-consumer boundary:
+
+1. the `PagesBuilderFacade::provider_status()` snapshot used to narrow the admin surface;
+2. the authoritative SSR `compose_fly_page_builder_handlers(...)` capability composition.
+
+The server side must independently resolve the trusted routed tenant and persisted Pages module settings rather than accepting rollout flags supplied by the browser. UI and SSR must use equivalent normalization/default rules so they cannot disagree about preview/properties/publish availability.
+
+After that binding is source-ready, retain a four-profile runtime evidence harness proving the exact gate outcomes and Pages-owned read guarantees. Only then should the candidate evidence advance to owner sign-off and rollback disposition.
+
+## Source evidence
+
+- `crates/rustok-pages/contracts/evidence/pages-tenant-rollout-settings-runtime-source.json`
+- `crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs`
+- `crates/rustok-api/src/runtime.rs`
+
+No tests, Node verifiers, Cargo commands, formatting, database scenarios, HTTP requests, browser runs, workflows, or CI were executed by this implementation slice.

--- a/docs/modules/pages-page-builder-tenant-rollout-settings-runtime-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-tenant-rollout-settings-runtime-actualization-2026-08-08.md
@@ -50,6 +50,8 @@ The helper is intentionally read-only and provider-neutral:
 - it does not mutate settings;
 - it does not create a second settings store or Pages-owned control plane.
 
+The helper deliberately does not authenticate or infer tenant authority. Its caller must supply the tenant id from a trusted `TenantContext` (and bind authenticated authority to that routed tenant where the transport requires authentication). The next Pages binding slice owns that server-adapter check; the low-level runtime helper only performs the exact tenant/module/enabled-row read.
+
 This keeps tenant-module lifecycle/settings ownership outside Pages while giving internal server adapters one neutral way to consume the persisted snapshot.
 
 ## Current boundary


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder reference-consumer gate after #3326 by fixing the next source prerequisite for honest four-profile runtime evidence.

A source recheck found that `PagesBuilderFacade::provider_status()` and the SSR `compose_fly_page_builder_handlers(...)` path still derive rollout flags from the same hardcoded `BuilderCapabilityFlags::default()` function. That keeps the default profile internally consistent, but it cannot execute the persisted `publish_off`, `preview_off`, or `builder_off` tenant profiles required by `pages_reference_consumer_gate`.

This PR deliberately lands only the neutral platform prerequisite:

- add `rustok_api::tenant_module_settings(db, tenant_id, module_slug)` next to the existing enablement helper;
- read only the exact enabled `tenant_modules` row and return `None` for disabled/missing rows;
- require the caller to supply tenant identity from a trusted request context rather than pretending the low-level DB helper authenticates tenant authority;
- use backend-specific SQLite/PostgreSQL/MySQL settings reads and fail closed on malformed JSON;
- avoid tenant persistence entity imports, settings mutations, or a parallel settings store;
- retain source-only tests for exact tenant/module/enabled-row selection without executing them;
- add a source evidence packet and verifier that explicitly keep the Pages consumer binding pending;
- update the Pages reference gate cursor to `platform_read_seam_source_ready_pages_binding_pending` and block the four-profile runtime matrix on that binding;
- keep `accepted=false`, provider health `unobserved`, Forum Wave blocked, and FFA/FBA unpromoted.

## Next source cursor

Bind a normalized Pages settings snapshot obtained from the trusted routed `TenantContext` into both `PagesBuilderFacade::provider_status()` and authoritative SSR Page Builder handler composition. The server adapter must bind authenticated authority to that routed tenant and must not accept rollout flags from the browser. Then retain the four-profile runtime matrix. Owner sign-off/rollback disposition comes after that matrix, not before it.

## Main recheck

The branch started at `main@e91926363cfcdf6a91836358add1afdf94f65ffa`. Current `main@cbf01df654252e53013da60e5621274a2ce08497` advanced only the Index replay-mode contract; those paths are disjoint from this API/Pages slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting, database scenarios, HTTP requests, browser runs, workflows, or CI were executed. Source review only.