### PR TITLE
feat(modules): enforce Product deployment corequisites

### DIFF
--- a/apps/server/src/modules/manifest/corequisites.rs
+++ b/apps/server/src/modules/manifest/corequisites.rs
@@ -1,0 +1,271 @@
+use semver::{Version, VersionReq};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use super::validation::{default_manifest_path, module_package_manifest_path, resolve_module_specs};
+use super::{ManifestError, ManifestModuleSpec, ModulesManifest};
+
+#[derive(Debug, Deserialize, Default)]
+struct PackageCoRequisiteManifest {
+    #[serde(default)]
+    co_requisites: BTreeMap<String, PackageCoRequisiteSpec>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PackageCoRequisiteSpec {
+    #[serde(default)]
+    version_req: String,
+}
+
+#[derive(Debug, Clone, Default)]
+struct StaticSelectionModule {
+    version: Option<String>,
+    ordinary_dependencies: BTreeSet<String>,
+    co_requisites: BTreeMap<String, String>,
+}
+
+/// Validates deployment-selection co-requisites after ordinary static topology
+/// validation has succeeded. Co-requisites constrain the selected deployment
+/// set only; they never become dependency or migration-order edges.
+pub(super) fn validate_default_corequisite_selection(
+    manifest: &ModulesManifest,
+) -> Result<(), ManifestError> {
+    let resolved_specs = resolve_module_specs(manifest)?;
+    let selected = manifest
+        .settings
+        .default_enabled
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut modules = resolved_specs
+        .iter()
+        .map(|(slug, spec)| {
+            (
+                slug.clone(),
+                StaticSelectionModule {
+                    version: spec.version.clone(),
+                    ordinary_dependencies: spec.depends_on.iter().cloned().collect(),
+                    co_requisites: BTreeMap::new(),
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    for slug in &selected {
+        let Some(spec) = resolved_specs.get(slug) else {
+            // Canonical static topology validation reports unknown selections
+            // before this deployment-only constraint runs.
+            continue;
+        };
+        let co_requisites = load_package_corequisites(spec)?;
+        if let Some(module) = modules.get_mut(slug) {
+            module.co_requisites = co_requisites;
+        }
+    }
+
+    validate_corequisite_selection(&modules, &selected).map_err(|error| ManifestError::Parse {
+        path: default_manifest_path().display().to_string(),
+        error,
+    })
+}
+
+fn load_package_corequisites(
+    spec: &ManifestModuleSpec,
+) -> Result<BTreeMap<String, String>, ManifestError> {
+    let Some(path) = module_package_manifest_path(spec) else {
+        return Ok(BTreeMap::new());
+    };
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(|error| ManifestError::ModulePackageRead {
+        path: path.display().to_string(),
+        error: error.to_string(),
+    })?;
+    let package: PackageCoRequisiteManifest =
+        toml::from_str(&raw).map_err(|error| ManifestError::ModulePackageParse {
+            path: path.display().to_string(),
+            error: error.to_string(),
+        })?;
+
+    Ok(package
+        .co_requisites
+        .into_iter()
+        .map(|(slug, spec)| (slug, spec.version_req))
+        .collect())
+}
+
+fn validate_corequisite_selection(
+    modules: &HashMap<String, StaticSelectionModule>,
+    selected: &BTreeSet<String>,
+) -> Result<(), String> {
+    for slug in selected {
+        let Some(module) = modules.get(slug) else {
+            continue;
+        };
+
+        let mut missing = Vec::new();
+        for (raw_co_requisite, raw_requirement) in &module.co_requisites {
+            let co_requisite = raw_co_requisite.trim();
+            if !valid_module_slug(co_requisite) || co_requisite == slug {
+                return Err(format!(
+                    "module '{slug}' declares invalid deployment co-requisite '{raw_co_requisite}'"
+                ));
+            }
+            if module.ordinary_dependencies.contains(co_requisite) {
+                return Err(format!(
+                    "module '{slug}' declares '{co_requisite}' as both an ordinary dependency and a deployment co-requisite"
+                ));
+            }
+            let requirement = raw_requirement.trim();
+            if !requirement.is_empty() {
+                VersionReq::parse(requirement).map_err(|_| {
+                    format!(
+                        "module '{slug}' deployment co-requisite '{co_requisite}' has invalid version requirement '{requirement}'"
+                    )
+                })?;
+            }
+            if !selected.contains(co_requisite) {
+                missing.push(co_requisite.to_string());
+            }
+        }
+
+        missing.sort();
+        missing.dedup();
+        if !missing.is_empty() {
+            return Err(format!(
+                "module '{slug}' is selected without deployment co-requisites: {}",
+                missing.join(", ")
+            ));
+        }
+
+        for (raw_co_requisite, raw_requirement) in &module.co_requisites {
+            let co_requisite = raw_co_requisite.trim();
+            let requirement = raw_requirement.trim();
+            if requirement.is_empty() {
+                continue;
+            }
+            let provider = modules.get(co_requisite).ok_or_else(|| {
+                format!(
+                    "module '{slug}' selected deployment co-requisite '{co_requisite}' is not installed"
+                )
+            })?;
+            let installed = provider.version.as_deref().ok_or_else(|| {
+                format!(
+                    "module '{slug}' deployment co-requisite '{co_requisite}' requires '{requirement}', but the selected module has no version"
+                )
+            })?;
+            let installed_version = Version::parse(installed).map_err(|_| {
+                format!(
+                    "selected deployment co-requisite '{co_requisite}' has invalid module version '{installed}'"
+                )
+            })?;
+            let requirement = VersionReq::parse(requirement).expect(
+                "deployment co-requisite requirement was validated before provider comparison",
+            );
+            if !requirement.matches(&installed_version) {
+                return Err(format!(
+                    "module '{slug}' requires deployment co-requisite '{co_requisite}' version '{}', but selected '{installed}'",
+                    raw_requirement.trim()
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn valid_module_slug(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().all(|character| {
+            character.is_ascii_lowercase()
+                || character.is_ascii_digit()
+                || character == '-'
+                || character == '_'
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn module(
+        version: &str,
+        ordinary_dependencies: &[&str],
+        co_requisites: &[(&str, &str)],
+    ) -> StaticSelectionModule {
+        StaticSelectionModule {
+            version: Some(version.to_string()),
+            ordinary_dependencies: ordinary_dependencies
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            co_requisites: co_requisites
+                .iter()
+                .map(|(slug, requirement)| ((*slug).to_string(), (*requirement).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn selection_requires_corequisites_without_creating_dependency_edges() {
+        let modules = HashMap::from([
+            (
+                "product".to_string(),
+                module(
+                    "0.1.0",
+                    &["taxonomy"],
+                    &[("inventory", ">=0.1.0"), ("pricing", ">=0.1.0")],
+                ),
+            ),
+            ("inventory".to_string(), module("0.1.0", &["product"], &[])),
+            ("pricing".to_string(), module("0.1.0", &["product"], &[])),
+            ("taxonomy".to_string(), module("0.1.0", &[], &[])),
+        ]);
+
+        let incomplete = BTreeSet::from(["product".to_string(), "taxonomy".to_string()]);
+        let error = validate_corequisite_selection(&modules, &incomplete)
+            .expect_err("Product-only selection must be rejected");
+        assert!(error.contains("inventory"));
+        assert!(error.contains("pricing"));
+
+        let complete = BTreeSet::from([
+            "product".to_string(),
+            "inventory".to_string(),
+            "pricing".to_string(),
+            "taxonomy".to_string(),
+        ]);
+        assert_eq!(validate_corequisite_selection(&modules, &complete), Ok(()));
+    }
+
+    #[test]
+    fn selection_rejects_incompatible_corequisite_version() {
+        let modules = HashMap::from([
+            (
+                "product".to_string(),
+                module("0.1.0", &[], &[("inventory", ">=0.2.0")]),
+            ),
+            ("inventory".to_string(), module("0.1.0", &["product"], &[])),
+        ]);
+        let selected = BTreeSet::from(["product".to_string(), "inventory".to_string()]);
+        let error = validate_corequisite_selection(&modules, &selected)
+            .expect_err("incompatible selected owner version must be rejected");
+        assert!(error.contains("requires deployment co-requisite 'inventory' version"));
+    }
+
+    #[test]
+    fn selection_rejects_corequisite_dependency_overlap() {
+        let modules = HashMap::from([
+            (
+                "product".to_string(),
+                module("0.1.0", &["inventory"], &[("inventory", ">=0.1.0")]),
+            ),
+            ("inventory".to_string(), module("0.1.0", &["product"], &[])),
+        ]);
+        let selected = BTreeSet::from(["product".to_string(), "inventory".to_string()]);
+        let error = validate_corequisite_selection(&modules, &selected)
+            .expect_err("co-requisite must remain separate from ordering dependencies");
+        assert!(error.contains("both an ordinary dependency and a deployment co-requisite"));
+    }
+}

--- a/apps/server/src/modules/manifest/mod.rs
+++ b/apps/server/src/modules/manifest/mod.rs
@@ -1,3 +1,4 @@
+mod corequisites;
 pub mod plans;
 pub mod types;
 pub mod validation;
@@ -9,6 +10,7 @@ pub use plans::*;
 pub use types::*;
 pub use validation::*;
 
+use corequisites::validate_default_corequisite_selection;
 use crate::error::{Error as ServerError, Result as ServerResult};
 use rustok_api::module_registry_contract::{
     ManifestModuleContract, ModuleRegistryContractError, RegistryModuleContract,
@@ -457,6 +459,15 @@ impl ManifestManager {
         Ok(())
     }
 
+    /// Validates deployment-only co-requisites after the ordinary package and
+    /// registry topology is known. This is intentionally separate from
+    /// `validate` so module installation order remains acyclic.
+    pub fn validate_deployment_selection(
+        manifest: &ModulesManifest,
+    ) -> Result<(), ManifestError> {
+        validate_default_corequisite_selection(manifest)
+    }
+
     pub fn validate_with_registry(
         manifest: &ModulesManifest,
         registry: &ModuleRegistry,
@@ -510,6 +521,7 @@ pub fn validate_registry_vs_manifest(registry: &ModuleRegistry) -> ServerResult<
     })?;
 
     ManifestManager::validate(&manifest)
+        .and_then(|_| ManifestManager::validate_deployment_selection(&manifest))
         .and_then(|_| ManifestManager::validate_with_registry(&manifest, registry))
         .map_err(|error| {
             ServerError::BadRequest(format!("modules.toml validation failed: {error}"))

--- a/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
+++ b/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-08-08",
-  "status": "product_lifecycle_corequisites_declared_unvalidated",
-  "source_base_revision": "bb65b7f0d3b6d2663519260841097c0e0f5f6cb8",
+  "status": "product_lifecycle_static_corequisite_selection_enforced_unvalidated",
+  "source_base_revision": "0ae8f7f4382a4218107c43a4e1e6f1e5b957a84e",
   "scope": "Product create/delete transaction collaboration with Inventory and Pricing owners",
   "module_topology": {
     "product_dependencies": [
@@ -20,8 +20,10 @@
     ],
     "ordinary_reverse_dependencies_forbidden": true,
     "co_requisites_are_ordering_dependencies": false,
-    "co_requisite_control_plane_enforcement_proven": false,
-    "reason": "Inventory and Pricing remain ordinary Product dependents; Product declares them only as deployment co-requisites to avoid a dependency-order cycle",
+    "static_default_selection_enforcement_source_complete": true,
+    "co_requisite_control_plane_execution_proven": false,
+    "tenant_lifecycle_corequisite_enforcement_proven": false,
+    "reason": "Static startup validates selected Product co-requisites separately from ordinary dependencies so Inventory/Pricing remain owner modules without a dependency-order cycle",
     "default_enabled_bundle": [
       "product",
       "pricing",
@@ -65,14 +67,15 @@
   "decision": {
     "containment_complete": true,
     "corequisite_contract_declared": true,
+    "static_default_selection_enforcement_source_complete": true,
     "dependency_contract_resolved": false,
-    "next_slice": "Teach the static module control plane to consume Product co-requisites during deployment selection without adding dependency-order edges; then prove non-default Product write activation and rollback",
+    "next_slice": "Apply Product co-requisite semantics to tenant lifecycle/effective-policy selection without adding dependency-order edges, then prove non-default Product activation and rollback",
     "do_not": [
       "add inventory or pricing to Product ordinary module dependencies",
       "move Inventory or Pricing ORM entities into Product",
       "replace atomic owner collaboration with unproven best-effort post-commit writes",
       "claim standalone Product write activation",
-      "claim co-requisite enforcement before the control plane consumes the contract"
+      "claim tenant co-requisite enforcement before lifecycle/effective policy consumes the contract"
     ]
   },
   "validation": {
@@ -82,6 +85,7 @@
     "verifiers_run": false,
     "workflow_checks_run": false,
     "ci_run": false,
+    "static_default_selection_execution_proven": false,
     "standalone_activation_proven": false,
     "non_default_deployment_selection_proven": false,
     "transaction_rollback_proven": false

--- a/crates/rustok-product/docs/product-lifecycle-collaboration.md
+++ b/crates/rustok-product/docs/product-lifecycle-collaboration.md
@@ -1,6 +1,6 @@
 # Product lifecycle owner collaboration
 
-Status: deployment co-requisite contract declared, control-plane enforcement pending, unvalidated.
+Status: static deployment co-requisite enforcement source-complete, tenant lifecycle enforcement pending, unvalidated.
 
 ## Problem
 
@@ -12,18 +12,22 @@ The ordinary module graph cannot represent the collaboration by adding reverse P
 - Pricing depends on Product;
 - making Product ordinarily depend on either owner would create a dependency-order cycle.
 
-The default ecommerce deployment enables Product, Pricing, and Inventory together, but relying on that bundle implicitly leaves non-default deployment selection underspecified.
+The default ecommerce activation enables Product, Pricing, and Inventory together. Source must still reject a deployment-default selection that enables Product without those owner implementations while preserving acyclic installation and migration ordering.
 
 ## Selected source contract
 
-Product now declares Inventory and Pricing in `rustok-module.toml` under `[co_requisites]` with explicit version requirements. A co-requisite is a deployment-selection constraint, not an ordinary dependency edge:
+Product declares Inventory and Pricing in `rustok-module.toml` under `[co_requisites]` with explicit version requirements. A co-requisite is a deployment-selection constraint, not an ordinary dependency edge:
 
-- it says the owner implementation must be present in the selected deployment whenever Product lifecycle writes are available;
+- it says the owner implementation must be selected whenever Product lifecycle writes are available;
 - it must not participate in dependency or migration ordering;
 - it must not be copied into `ProductModule::dependencies()`;
 - it therefore does not create `Product -> Inventory -> Product` or `Product -> Pricing -> Product` cycles.
 
-This slice only declares and source-locks that contract. The current module control plane does not yet consume `[co_requisites]`; deployment enforcement and non-default selection evidence remain the next implementation step. Until that enforcement exists, the canonical ecommerce dependency-contract item must remain open.
+The static server control plane now consumes this declaration through `ManifestManager::validate_deployment_selection`. Startup `validate_registry_vs_manifest` first runs the existing ordinary manifest validation, then the deployment co-requisite preflight, then the ordinary static-registry comparison. The preflight reads selected package `[co_requisites]` and rejects a default-enabled Product when Inventory or Pricing is not also selected, when a declared requirement is malformed, or when the selected owner version is missing, invalid, or incompatible.
+
+Deployment co-requisite validation is intentionally separate from `ManifestManager::validate`. Built-in installation and ordinary topology validation therefore remain able to add Product, Inventory, and Pricing sequentially without creating an installation deadlock. Registry and migration/dependency ordering continue to consume only ordinary `depends_on` / `RusToKModule::dependencies()` edges.
+
+This closes the static/default deployment-selection source gap. Tenant-scoped lifecycle toggles and effective-policy resolution do not yet consume the package co-requisite contract, so non-default tenant activation enforcement and execution evidence remain open.
 
 ## Current contained boundary
 
@@ -61,18 +65,21 @@ This is a native transaction collaboration contract, not a GraphQL, REST, gRPC, 
 - Product declares Inventory and Pricing as package co-requisites with bounded version requirements;
 - Inventory and Pricing continue to depend ordinarily on Product;
 - the default deployment bundle contains Product, Pricing, and Inventory;
+- the server owns a separate deployment co-requisite preflight and invokes it from startup manifest/registry validation;
+- built-in installation remains on ordinary `ManifestManager::validate` and does not invoke the co-requisite preflight;
+- selected co-requisites are required and version-checked without being copied into ordinary dependency ordering;
 - Product uses the exact owner bootstrap services and operations;
 - Product does not import foreign owner entities or query known foreign tables directly;
 - the owner services remain explicitly transaction-aware;
-- control-plane co-requisite enforcement and standalone/non-default activation evidence remain unvalidated.
+- tenant lifecycle/effective-policy enforcement and runtime rollback evidence remain unvalidated.
 
 ## Next implementation slice
 
-Teach the static module control plane to parse and validate package co-requisites during deployment selection without feeding them into dependency ordering. The control plane must reject a selected Product module when an admitted Inventory or Pricing co-requisite is absent or version-incompatible, while preserving the existing ordinary reverse dependencies owned by Inventory and Pricing.
+Carry the same deployment co-requisite semantics into tenant lifecycle/effective-policy selection without turning co-requisites into dependency-order edges. Enabling Product for a tenant must fail closed unless Inventory and Pricing are effectively enabled with compatible admitted owner versions; disabling either owner while Product remains effectively enabled must likewise be rejected or make Product unavailable through one canonical owner policy decision.
 
-After source enforcement exists, retain maintainer-run evidence for:
+After tenant source enforcement exists, retain maintainer-run evidence for:
 
-- default and non-default module selections;
+- default and non-default tenant module selections;
 - clean migration ordering;
 - Product create/delete rollback across all three owners;
 - no silent post-commit partial state;
@@ -87,4 +94,4 @@ Source evidence is stored at:
 
 `crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json`
 
-No tests, Cargo commands, formatting, verifier execution, workflow checks, standalone activation, non-default deployment selection, or transaction rollback evidence are claimed by this source wave.
+No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, or transaction rollback execution evidence are claimed by this source wave.

--- a/scripts/verify/verify-product-lifecycle-collaboration.mjs
+++ b/scripts/verify/verify-product-lifecycle-collaboration.mjs
@@ -20,6 +20,8 @@ const catalog = read('crates/rustok-product/src/services/catalog.rs');
 const commands = read('crates/rustok-product/src/services/catalog/commands.rs');
 const inventoryBootstrap = read('crates/rustok-inventory/src/services/bootstrap.rs');
 const pricingBootstrap = read('crates/rustok-pricing-persistence/src/lib.rs');
+const manifestCorequisites = read('apps/server/src/modules/manifest/corequisites.rs');
+const manifestManager = read('apps/server/src/modules/manifest/mod.rs');
 const note = read('crates/rustok-product/docs/product-lifecycle-collaboration.md');
 const evidence = JSON.parse(
   read('crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json'),
@@ -85,6 +87,21 @@ const pricingDependencySection = between(
   '\n[crate]',
   'Pricing package dependency section',
 );
+const installBuiltinBlock = between(
+  manifestManager,
+  'pub fn install_builtin_module(',
+  '\n    pub fn uninstall_module(',
+  'builtin install block',
+);
+const registryValidationBlock = between(
+  manifestManager,
+  'pub fn validate_with_registry(',
+  '\n}\n\npub fn validate_registry_vs_manifest',
+  'registry validation block',
+);
+const startupValidationBlock = manifestManager.slice(
+  manifestManager.indexOf('pub fn validate_registry_vs_manifest'),
+);
 
 for (const [source, value, label] of [
   [productModuleEntry, 'depends_on = ["taxonomy"]', 'root Product dependency'],
@@ -112,9 +129,24 @@ for (const [source, value, label] of [
   [inventoryBootstrap, 'C: ConnectionTrait', 'Inventory transaction connection'],
   [pricingBootstrap, 'Pricing-owned transaction-aware operations required by Product lifecycle writes.', 'Pricing owner contract'],
   [pricingBootstrap, 'C: ConnectionTrait', 'Pricing transaction connection'],
-  [note, 'Status: deployment co-requisite contract declared, control-plane enforcement pending, unvalidated.', 'focused note status'],
-  [note, 'deployment-selection constraint, not an ordinary dependency edge', 'co-requisite semantics'],
-  [note, 'current module control plane does not yet consume `[co_requisites]`', 'explicit enforcement debt'],
+  [manifestCorequisites, 'co_requisites: BTreeMap<String, PackageCoRequisiteSpec>', 'typed package co-requisite parser'],
+  [manifestCorequisites, 'pub(super) fn validate_default_corequisite_selection', 'deployment selection preflight'],
+  [manifestCorequisites, 'let selected = manifest', 'default selection source'],
+  [manifestCorequisites, 'module.ordinary_dependencies.contains(co_requisite)', 'dependency/co-requisite separation'],
+  [manifestCorequisites, '!selected.contains(co_requisite)', 'missing selected co-requisite rejection'],
+  [manifestCorequisites, 'VersionReq::parse(requirement)', 'co-requisite version requirement validation'],
+  [manifestCorequisites, 'requirement.matches(&installed_version)', 'co-requisite selected version validation'],
+  [manifestCorequisites, 'selection_requires_corequisites_without_creating_dependency_edges', 'selection source test'],
+  [manifestCorequisites, 'selection_rejects_incompatible_corequisite_version', 'version source test'],
+  [manifestManager, 'mod corequisites;', 'manifest co-requisite module wiring'],
+  [manifestManager, 'pub fn validate_deployment_selection(', 'manifest deployment selection API'],
+  [manifestManager, 'validate_default_corequisite_selection(manifest)', 'manifest deployment selection delegation'],
+  [startupValidationBlock, '.and_then(|_| ManifestManager::validate_deployment_selection(&manifest))', 'startup co-requisite preflight'],
+  [registryValidationBlock, 'dependencies: resolved_spec.depends_on.iter().cloned().collect()', 'ordinary registry dependency source'],
+  [installBuiltinBlock, 'Self::validate(manifest)?;', 'ordinary install validation'],
+  [note, 'Status: static deployment co-requisite enforcement source-complete, tenant lifecycle enforcement pending, unvalidated.', 'focused note status'],
+  [note, 'ManifestManager::validate_deployment_selection', 'focused note static enforcement'],
+  [note, 'Tenant-scoped lifecycle toggles and effective-policy resolution do not yet consume', 'focused note tenant debt'],
 ]) requireText(source, value, label);
 
 for (const [source, value, label] of [
@@ -124,6 +156,8 @@ for (const [source, value, label] of [
   [productDependencySection, 'pricing =', 'cyclic Product package Pricing dependency'],
   [productRuntime, '"inventory"', 'cyclic Product runtime Inventory dependency'],
   [productRuntime, '"pricing"', 'cyclic Product runtime Pricing dependency'],
+  [installBuiltinBlock, 'validate_deployment_selection', 'cyclic install-time co-requisite preflight'],
+  [registryValidationBlock, 'co_requisite', 'co-requisite leaked into registry dependency comparison'],
   [catalog, 'rustok_commerce_foundation::entities', 'foreign foundation entity import'],
   [commands, 'rustok_commerce_foundation::entities', 'foreign foundation entity import in commands'],
   [commands, 'inventory_item::Entity', 'direct Inventory entity access'],
@@ -137,7 +171,7 @@ for (const [source, value, label] of [
   [commands, 'INTO prices', 'direct Pricing SQL write'],
 ]) forbidText(source, value, label);
 
-if (evidence.status !== 'product_lifecycle_corequisites_declared_unvalidated') {
+if (evidence.status !== 'product_lifecycle_static_corequisite_selection_enforced_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 const coRequisites = [...(evidence.module_topology?.product_co_requisites ?? [])].sort();
@@ -150,8 +184,14 @@ if (evidence.module_topology?.ordinary_reverse_dependencies_forbidden !== true) 
 if (evidence.module_topology?.co_requisites_are_ordering_dependencies !== false) {
   failures.push('co-requisites must not become ordering dependencies');
 }
-if (evidence.module_topology?.co_requisite_control_plane_enforcement_proven !== false) {
-  failures.push('co-requisite control-plane enforcement must remain unproven');
+if (evidence.module_topology?.static_default_selection_enforcement_source_complete !== true) {
+  failures.push('static default selection enforcement must be source-complete');
+}
+if (evidence.module_topology?.co_requisite_control_plane_execution_proven !== false) {
+  failures.push('co-requisite control-plane execution must remain unproven');
+}
+if (evidence.module_topology?.tenant_lifecycle_corequisite_enforcement_proven !== false) {
+  failures.push('tenant lifecycle co-requisite enforcement must remain unproven');
 }
 if (evidence.module_topology?.standalone_product_write_activation_proven !== false) {
   failures.push('standalone Product write activation must remain unproven');
@@ -163,8 +203,9 @@ if (evidence.product_boundary?.foreign_owner_entities_imported !== false ||
 }
 if (evidence.decision?.containment_complete !== true ||
     evidence.decision?.corequisite_contract_declared !== true ||
+    evidence.decision?.static_default_selection_enforcement_source_complete !== true ||
     evidence.decision?.dependency_contract_resolved !== false) {
-  failures.push('evidence decision must declare co-requisites while keeping enforcement open');
+  failures.push('evidence decision must source-complete static selection while keeping tenant enforcement open');
 }
 for (const key of [
   'tests_run',
@@ -173,6 +214,7 @@ for (const key of [
   'verifiers_run',
   'workflow_checks_run',
   'ci_run',
+  'static_default_selection_execution_proven',
   'standalone_activation_proven',
   'non_default_deployment_selection_proven',
   'transaction_rollback_proven',
@@ -189,5 +231,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Product declares Inventory/Pricing deployment co-requisites while preserving owner bootstrap atomicity and acyclic ordinary dependencies; control-plane enforcement and runtime evidence remain open',
+  '✔ Product static/default deployment selection enforces Inventory/Pricing co-requisites without changing ordinary dependency ordering; tenant lifecycle and runtime evidence remain open',
 );


### PR DESCRIPTION
## Summary
- parse Product package `[co_requisites]` in a deployment-only static startup preflight
- reject a default-selected Product when Inventory/Pricing are not selected or their declared versions do not satisfy the Product co-requisite requirements
- keep built-in installation, ordinary `depends_on`, static-registry comparison, and migration/dependency ordering unchanged so the existing Inventory/Pricing -> Product edges remain acyclic
- add source-level unit cases for missing, incompatible, and dependency-overlap co-requisites
- actualize Product lifecycle documentation/evidence and extend the source guard around the new preflight

## Plan status
- closes the static/default deployment-selection source gap selected in #3324
- does **not** close the overall Product dependency-contract item yet: tenant lifecycle/effective-policy selection still needs to consume co-requisites for non-default activation/disable behavior
- runtime/default-selection execution and Product create/delete rollback evidence remain maintainer-owned

## Verification
- source and GitHub diff inspection only
- tests, source verifier execution, Cargo commands, formatting, workflows, CI, and runtime validation were intentionally not run per maintainer instruction