### PR TITLE
feat(pages): add trusted Page Builder rollout snapshot

### DIFF
--- a/crates/rustok-pages/admin/Cargo.toml
+++ b/crates/rustok-pages/admin/Cargo.toml
@@ -18,8 +18,9 @@ ssr = [
   "leptos-auth/ssr",
   "rustok-page-builder/server",
   "rustok-page-builder-admin/ssr",
+  "rustok-api/server",
   "dep:async-trait",
-  "dep:rustok-api",
+  "dep:leptos_axum",
 ]
 
 [dependencies]
@@ -28,6 +29,7 @@ fly-browser = { path = "../../fly-browser" }
 fly-ui = { path = "../../fly-ui" }
 rustok-ui-core.workspace = true
 leptos.workspace = true
+leptos_axum = { workspace = true, optional = true }
 leptos-auth.workspace = true
 rustok-graphql.workspace = true
 rustok-page-builder = { path = "../../rustok-page-builder", default-features = false }

--- a/crates/rustok-pages/admin/src/builder_rollout_settings.rs
+++ b/crates/rustok-pages/admin/src/builder_rollout_settings.rs
@@ -1,0 +1,137 @@
+use leptos::prelude::*;
+use rustok_page_builder::rollout::{BuilderCapabilityFlags, BuilderRolloutError};
+use serde_json::Value;
+
+fn nested_bool(settings: &Value, path: &[&str]) -> bool {
+    let mut current = settings;
+    for segment in path {
+        let Some(next) = current.get(*segment) else {
+            return true;
+        };
+        current = next;
+    }
+    current.as_bool().unwrap_or(true)
+}
+
+pub(crate) fn pages_builder_flags_from_settings(
+    settings: &Value,
+) -> Result<BuilderCapabilityFlags, BuilderRolloutError> {
+    let flags = BuilderCapabilityFlags {
+        builder_enabled: nested_bool(settings, &["builder", "enabled"]),
+        preview_enabled: nested_bool(settings, &["builder", "preview", "enabled"]),
+        properties_enabled: nested_bool(settings, &["builder", "properties", "enabled"]),
+        publish_enabled: nested_bool(settings, &["builder", "publish", "enabled"]),
+    };
+    flags.validate()?;
+    Ok(flags)
+}
+
+#[cfg(feature = "ssr")]
+fn ensure_trusted_tenant(
+    auth: &rustok_api::AuthContext,
+    tenant: &rustok_api::TenantContext,
+) -> Result<(), ServerFnError> {
+    use rustok_api::{Action, Permission, Resource, has_effective_permission};
+
+    if auth.tenant_id != tenant.id {
+        return Err(ServerFnError::new("Pages builder rollout access is denied"));
+    }
+    if !has_effective_permission(
+        &auth.permissions,
+        &Permission::new(Resource::Pages, Action::Read),
+    ) {
+        return Err(ServerFnError::new(
+            "Pages read permission is required for builder rollout status",
+        ));
+    }
+    Ok(())
+}
+
+#[server(prefix = "/api/fn", endpoint = "pages/builder-rollout-flags")]
+pub(crate) async fn pages_builder_rollout_flags() -> Result<BuilderCapabilityFlags, ServerFnError> {
+    #[cfg(feature = "ssr")]
+    {
+        use leptos::prelude::expect_context;
+        use rustok_api::{AuthContext, HostRuntimeContext, TenantContext, tenant_module_settings};
+
+        let runtime = expect_context::<HostRuntimeContext>();
+        let auth = leptos_axum::extract::<AuthContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        let tenant = leptos_axum::extract::<TenantContext>()
+            .await
+            .map_err(ServerFnError::new)?;
+        ensure_trusted_tenant(&auth, &tenant)?;
+
+        let settings = tenant_module_settings(runtime.db(), tenant.id, "pages")
+            .await
+            .map_err(|_| ServerFnError::new("Unable to read Pages builder rollout settings"))?
+            .ok_or_else(|| ServerFnError::new("Pages module is not enabled for the routed tenant"))?;
+        pages_builder_flags_from_settings(&settings)
+            .map_err(|_| ServerFnError::new("Pages builder rollout settings are invalid"))
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        Err(ServerFnError::new(
+            "pages/builder-rollout-flags requires the `ssr` feature",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_page_builder::rollout::BuilderToggleProfile;
+    use serde_json::json;
+
+    fn settings(profile: BuilderToggleProfile) -> Value {
+        let flags = profile.flags();
+        json!({
+            "builder": {
+                "enabled": flags.builder_enabled,
+                "preview": { "enabled": flags.preview_enabled },
+                "properties": { "enabled": flags.properties_enabled },
+                "publish": { "enabled": flags.publish_enabled }
+            }
+        })
+    }
+
+    #[test]
+    fn declared_profiles_normalize_to_their_exact_flags() {
+        for profile in BuilderToggleProfile::ALL {
+            assert_eq!(
+                pages_builder_flags_from_settings(&settings(profile)).unwrap(),
+                profile.flags()
+            );
+        }
+    }
+
+    #[test]
+    fn omitted_builder_settings_preserve_backward_compatible_all_on_defaults() {
+        assert_eq!(
+            pages_builder_flags_from_settings(&json!({})).unwrap(),
+            BuilderCapabilityFlags::default()
+        );
+    }
+
+    #[test]
+    fn invalid_flag_combinations_fail_closed() {
+        assert!(
+            pages_builder_flags_from_settings(&json!({
+                "builder": {
+                    "enabled": true,
+                    "preview": { "enabled": false },
+                    "properties": { "enabled": true },
+                    "publish": { "enabled": true }
+                }
+            }))
+            .is_err()
+        );
+        assert!(
+            pages_builder_flags_from_settings(&json!({
+                "builder": { "enabled": false }
+            }))
+            .is_err()
+        );
+    }
+}

--- a/crates/rustok-pages/admin/src/builder_rollout_settings.rs
+++ b/crates/rustok-pages/admin/src/builder_rollout_settings.rs
@@ -2,25 +2,36 @@ use leptos::prelude::*;
 use rustok_page_builder::rollout::{BuilderCapabilityFlags, BuilderRolloutError};
 use serde_json::Value;
 
-fn nested_bool(settings: &Value, path: &[&str]) -> bool {
+fn nested_bool(settings: &Value, path: &[&str]) -> Result<bool, BuilderRolloutError> {
     let mut current = settings;
     for segment in path {
-        let Some(next) = current.get(*segment) else {
-            return true;
+        let Value::Object(values) = current else {
+            return Err(BuilderRolloutError::InvalidFlagCombination(format!(
+                "Page Builder rollout setting `{}` must be an object",
+                path.join(".")
+            )));
+        };
+        let Some(next) = values.get(*segment) else {
+            return Ok(true);
         };
         current = next;
     }
-    current.as_bool().unwrap_or(true)
+    current.as_bool().ok_or_else(|| {
+        BuilderRolloutError::InvalidFlagCombination(format!(
+            "Page Builder rollout setting `{}` must be a boolean",
+            path.join(".")
+        ))
+    })
 }
 
 pub(crate) fn pages_builder_flags_from_settings(
     settings: &Value,
 ) -> Result<BuilderCapabilityFlags, BuilderRolloutError> {
     let flags = BuilderCapabilityFlags {
-        builder_enabled: nested_bool(settings, &["builder", "enabled"]),
-        preview_enabled: nested_bool(settings, &["builder", "preview", "enabled"]),
-        properties_enabled: nested_bool(settings, &["builder", "properties", "enabled"]),
-        publish_enabled: nested_bool(settings, &["builder", "publish", "enabled"]),
+        builder_enabled: nested_bool(settings, &["builder", "enabled"])?,
+        preview_enabled: nested_bool(settings, &["builder", "preview", "enabled"])?,
+        properties_enabled: nested_bool(settings, &["builder", "properties", "enabled"])?,
+        publish_enabled: nested_bool(settings, &["builder", "publish", "enabled"])?,
     };
     flags.validate()?;
     Ok(flags)
@@ -112,6 +123,18 @@ mod tests {
             pages_builder_flags_from_settings(&json!({})).unwrap(),
             BuilderCapabilityFlags::default()
         );
+    }
+
+    #[test]
+    fn malformed_setting_types_fail_closed() {
+        for value in [
+            json!({ "builder": "disabled" }),
+            json!({ "builder": { "enabled": "false" } }),
+            json!({ "builder": { "preview": false } }),
+            json!({ "builder": { "publish": { "enabled": 0 } } }),
+        ] {
+            assert!(pages_builder_flags_from_settings(&value).is_err());
+        }
     }
 
     #[test]

--- a/crates/rustok-pages/admin/src/lib.rs
+++ b/crates/rustok-pages/admin/src/lib.rs
@@ -2,6 +2,7 @@ mod access;
 mod browser_intent;
 mod browser_problem;
 mod builder;
+mod builder_rollout_settings;
 #[cfg(test)]
 mod builder_contract;
 mod composition;

--- a/crates/rustok-pages/contracts/evidence/pages-builder-rollout-server-snapshot-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-rollout-server-snapshot-source.json
@@ -15,6 +15,7 @@
     "raw_settings_are_not_returned": true,
     "only_builder_capability_flags_are_returned": true,
     "omitted_builder_keys_default_to_all_on_for_backward_compatibility": true,
+    "malformed_setting_types_fail_closed": true,
     "invalid_flag_combinations_fail_closed": true,
     "all_four_declared_profiles_have_source_tests": true,
     "browser_supplied_flags_accepted": false,

--- a/crates/rustok-pages/contracts/evidence/pages-builder-rollout-server-snapshot-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-rollout-server-snapshot-source.json
@@ -1,0 +1,41 @@
+{
+  "format": "pages_builder_rollout_server_snapshot_source_v1",
+  "status": "trusted_server_snapshot_source_ready_ui_dispatch_binding_pending",
+  "prepared_on": "2026-08-08",
+  "source_base": "0ae8f7f4382a4218107c43a4e1e6f1e5b957a84e",
+  "source_contract": {
+    "server_endpoint": "/api/fn/pages/builder-rollout-flags",
+    "tenant_context_is_server_extracted": true,
+    "auth_context_is_server_extracted": true,
+    "auth_tenant_must_match_routed_tenant": true,
+    "pages_read_authority_required": true,
+    "settings_source": "rustok_api::tenant_module_settings",
+    "module_slug_is_fixed_to_pages": true,
+    "enabled_pages_row_required": true,
+    "raw_settings_are_not_returned": true,
+    "only_builder_capability_flags_are_returned": true,
+    "omitted_builder_keys_default_to_all_on_for_backward_compatibility": true,
+    "invalid_flag_combinations_fail_closed": true,
+    "all_four_declared_profiles_have_source_tests": true,
+    "browser_supplied_flags_accepted": false,
+    "settings_mutation_added": false,
+    "pages_ui_facade_binding_complete": false,
+    "pages_ssr_dispatch_binding_complete": false,
+    "four_profile_runtime_matrix_executable": false,
+    "gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "validation": {
+    "tests_run": false,
+    "node_verifiers_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "database_run": false,
+    "http_run": false,
+    "browser_run": false,
+    "workflow_or_ci_run": false
+  },
+  "next_cursor": "consume pages_builder_rollout_flags in the Pages admin workspace and independently re-read the trusted snapshot in authoritative Page Builder SSR dispatch"
+}

--- a/crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json
@@ -14,6 +14,7 @@
     "plan_parity": "source_ready",
     "candidate_harness": "source_ready_maintainer_execution_pending",
     "tenant_rollout_settings": "platform_read_seam_source_ready_pages_binding_pending",
+    "trusted_rollout_server_snapshot": "source_ready_ui_and_dispatch_binding_pending",
     "forum_second_consumer": {
       "contribution_metadata": "source_ready",
       "fly_adapter": "source_ready",
@@ -112,6 +113,7 @@
     "execution_gate": "pending",
     "candidate_harness": "source_ready_maintainer_execution_pending",
     "tenant_rollout_settings": "platform_read_seam_source_ready_pages_binding_pending",
+    "trusted_rollout_server_snapshot": "source_ready_ui_and_dispatch_binding_pending",
     "four_profile_runtime_matrix": "blocked_on_pages_tenant_settings_binding",
     "forum_wave_blocker": "pages_reference_consumer_gate",
     "provider_health": "unobserved",
@@ -122,6 +124,7 @@
     "plan_parity_guard": "crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs",
     "candidate_harness_guard": "crates/rustok-pages/scripts/verify/verify-pages-reference-consumer-gate-evidence-harness.mjs",
     "tenant_rollout_settings_guard": "crates/rustok-pages/scripts/verify/verify-pages-tenant-rollout-settings-runtime.mjs",
+    "trusted_rollout_server_snapshot_guard": "crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs",
     "execution_status": "not_run_by_implementation_agent"
   },
   "forbidden_claims": [

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
@@ -53,6 +53,7 @@ for (const marker of [
   'nested_bool(settings, &["builder", "preview", "enabled"])',
   'nested_bool(settings, &["builder", "properties", "enabled"])',
   'nested_bool(settings, &["builder", "publish", "enabled"])',
+  "current.as_bool().ok_or_else",
   "flags.validate()?",
   "ensure_trusted_tenant(",
   "auth.tenant_id != tenant.id",
@@ -67,6 +68,7 @@ for (const marker of [
   "declared_profiles_normalize_to_their_exact_flags",
   "BuilderToggleProfile::ALL",
   "omitted_builder_settings_preserve_backward_compatible_all_on_defaults",
+  "malformed_setting_types_fail_closed",
   "invalid_flag_combinations_fail_closed",
 ]) need(sources.adapter, marker, "trusted rollout server adapter");
 
@@ -108,6 +110,7 @@ for (const [key, expected] of Object.entries({
   raw_settings_are_not_returned: true,
   only_builder_capability_flags_are_returned: true,
   omitted_builder_keys_default_to_all_on_for_backward_compatibility: true,
+  malformed_setting_types_fail_closed: true,
   invalid_flag_combinations_fail_closed: true,
   all_four_declared_profiles_have_source_tests: true,
   browser_supplied_flags_accepted: false,

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const files = {
+  adapter: "crates/rustok-pages/admin/src/builder_rollout_settings.rs",
+  cargo: "crates/rustok-pages/admin/Cargo.toml",
+  lib: "crates/rustok-pages/admin/src/lib.rs",
+  builder: "crates/rustok-pages/admin/src/builder.rs",
+  runtime: "crates/rustok-api/src/runtime.rs",
+  evidence: "crates/rustok-pages/contracts/evidence/pages-builder-rollout-server-snapshot-source.json",
+  gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
+  actualization: "docs/modules/pages-page-builder-rollout-server-snapshot-actualization-2026-08-08.md",
+};
+const failures = [];
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length > 0) {
+  console.error("[verify-pages-builder-rollout-server-snapshot] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const evidence = JSON.parse(sources.evidence);
+const gate = JSON.parse(sources.gate);
+
+for (const marker of [
+  "pages_builder_flags_from_settings(",
+  'nested_bool(settings, &["builder", "enabled"])',
+  'nested_bool(settings, &["builder", "preview", "enabled"])',
+  'nested_bool(settings, &["builder", "properties", "enabled"])',
+  'nested_bool(settings, &["builder", "publish", "enabled"])',
+  "flags.validate()?",
+  "ensure_trusted_tenant(",
+  "auth.tenant_id != tenant.id",
+  "Permission::new(Resource::Pages, Action::Read)",
+  '#[server(prefix = "/api/fn", endpoint = "pages/builder-rollout-flags")]',
+  "expect_context::<HostRuntimeContext>()",
+  "leptos_axum::extract::<AuthContext>()",
+  "leptos_axum::extract::<TenantContext>()",
+  'tenant_module_settings(runtime.db(), tenant.id, "pages")',
+  "Pages module is not enabled for the routed tenant",
+  "Pages builder rollout settings are invalid",
+  "declared_profiles_normalize_to_their_exact_flags",
+  "BuilderToggleProfile::ALL",
+  "omitted_builder_settings_preserve_backward_compatible_all_on_defaults",
+  "invalid_flag_combinations_fail_closed",
+]) need(sources.adapter, marker, "trusted rollout server adapter");
+
+for (const marker of [
+  "browser",
+  "query",
+  "header",
+  "localStorage",
+  "sessionStorage",
+]) forbid(sources.adapter, marker, "rollout adapter must not accept browser-controlled flags");
+
+for (const marker of [
+  '"rustok-api/server"',
+  '"dep:leptos_axum"',
+  "leptos_axum = { workspace = true, optional = true }",
+]) need(sources.cargo, marker, "Pages admin SSR dependencies");
+need(sources.lib, "mod builder_rollout_settings;", "Pages admin module registration");
+need(sources.runtime, "pub async fn tenant_module_settings(", "platform settings read seam");
+
+for (const marker of [
+  "fn pages_builder_capability_flags() -> BuilderCapabilityFlags",
+  "BuilderCapabilityFlags::default()",
+  "compose_fly_page_builder_handlers(store, renderer, pages_builder_capability_flags())",
+]) need(sources.builder, marker, "remaining Pages UI/dispatch binding blocker");
+
+if (evidence.format !== "pages_builder_rollout_server_snapshot_source_v1") {
+  failures.push(`evidence format drifted: ${evidence.format}`);
+}
+if (evidence.status !== "trusted_server_snapshot_source_ready_ui_dispatch_binding_pending") {
+  failures.push(`evidence status drifted: ${evidence.status}`);
+}
+for (const [key, expected] of Object.entries({
+  tenant_context_is_server_extracted: true,
+  auth_context_is_server_extracted: true,
+  auth_tenant_must_match_routed_tenant: true,
+  pages_read_authority_required: true,
+  module_slug_is_fixed_to_pages: true,
+  enabled_pages_row_required: true,
+  raw_settings_are_not_returned: true,
+  only_builder_capability_flags_are_returned: true,
+  omitted_builder_keys_default_to_all_on_for_backward_compatibility: true,
+  invalid_flag_combinations_fail_closed: true,
+  all_four_declared_profiles_have_source_tests: true,
+  browser_supplied_flags_accepted: false,
+  settings_mutation_added: false,
+  pages_ui_facade_binding_complete: false,
+  pages_ssr_dispatch_binding_complete: false,
+  four_profile_runtime_matrix_executable: false,
+  gate_accepted: false,
+  forum_wave_accepted: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.source_contract?.[key] !== expected) {
+    failures.push(`evidence source_contract.${key} must be ${expected}`);
+  }
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`evidence validation.${key} must remain false`);
+}
+
+if (gate.accepted !== false) failures.push("Pages reference-consumer gate must remain unaccepted");
+if (
+  gate.current_boundary?.trusted_rollout_server_snapshot !==
+  "source_ready_ui_and_dispatch_binding_pending"
+) {
+  failures.push("Pages gate trusted rollout server snapshot cursor drifted");
+}
+if (
+  gate.verification?.trusted_rollout_server_snapshot_guard !==
+  "crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs"
+) {
+  failures.push("Pages gate trusted rollout server snapshot guard is not registered");
+}
+
+for (const marker of [
+  "trusted server snapshot is source-ready",
+  "UI facade binding remains pending",
+  "SSR capability dispatch binding remains pending",
+  "browser never supplies rollout flags",
+  "No tests, Node verifiers, Cargo commands",
+]) need(sources.actualization, marker, "actualization");
+
+if (failures.length > 0) {
+  console.error("[verify-pages-builder-rollout-server-snapshot] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "[verify-pages-builder-rollout-server-snapshot] PASS trusted_server_snapshot=source_ready ui_binding=pending ssr_dispatch_binding=pending",
+);

--- a/docs/modules/pages-page-builder-rollout-server-snapshot-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-rollout-server-snapshot-actualization-2026-08-08.md
@@ -1,0 +1,66 @@
+# Pages / Page Builder trusted rollout server snapshot actualization — 2026-08-08
+
+Status: `trusted-server-snapshot-source-ready / ui-facade-binding-pending / ssr-dispatch-binding-pending / four-profile-runtime-evidence-blocked`.
+
+Base rechecked: `main@0ae8f7f4382a4218107c43a4e1e6f1e5b957a84e`.
+
+## Why this slice exists
+
+The previous slice added the neutral `rustok_api::tenant_module_settings` read seam. It deliberately did not decide tenant authority or expose a Pages-specific transport.
+
+The Pages reference consumer still needs a trusted way to turn the routed tenant's persisted module settings into `BuilderCapabilityFlags` without accepting rollout state from browser input. That trusted snapshot must be reusable by the admin facade and the authoritative SSR Page Builder capability dispatch before the four gate profiles can be exercised honestly.
+
+## Trusted server snapshot
+
+The trusted server snapshot is source-ready in `crates/rustok-pages/admin/src/builder_rollout_settings.rs`.
+
+`pages_builder_rollout_flags` is a native server-function endpoint. On the server it:
+
+1. resolves the host `HostRuntimeContext`;
+2. extracts `AuthContext` and routed `TenantContext`;
+3. rejects an auth/routed-tenant mismatch;
+4. requires effective `Pages:Read` authority;
+5. reads the exact enabled `pages` row through `rustok_api::tenant_module_settings`;
+6. normalizes only the declared nested builder flags;
+7. validates the resulting `BuilderCapabilityFlags` combination before returning it.
+
+The raw tenant-module settings document is never returned. The client-visible result is only the normalized Page Builder capability flag structure.
+
+Omitted builder keys preserve the existing backward-compatible all-on defaults. Invalid persisted combinations fail closed instead of being repaired silently. Source tests retain all four declared profiles plus default and invalid-combination behavior.
+
+The browser never supplies rollout flags to this endpoint; it can only request the server-owned snapshot.
+
+## Authority boundary
+
+The low-level `rustok_api::tenant_module_settings` helper remains authority-neutral. This Pages adapter supplies the tenant id from `TenantContext` and explicitly checks that the authenticated tenant matches the routed tenant before reading settings.
+
+This follows the same transport boundary used elsewhere by native admin adapters: tenant routing establishes scope, authenticated authority is bound to that scope, and only then is tenant-owned state read.
+
+## Current boundary
+
+The trusted server snapshot is source-ready.
+
+UI facade binding remains pending: `PagesBuilderFacade::provider_status()` still reads the hardcoded default provider flags.
+
+SSR capability dispatch binding remains pending: the Page Builder handler dispatch still composes handlers from the hardcoded default provider flags.
+
+Therefore the four-profile runtime matrix is still blocked and `pages_reference_consumer_gate` remains unaccepted. Provider health remains `unobserved`; Forum Wave and FFA/FBA remain blocked.
+
+## Next exact source cursor
+
+Wire the server-owned snapshot into both remaining consumer seams without creating a browser-controlled authority path:
+
+- load `pages_builder_rollout_flags()` as part of the Pages workspace data needed to construct `PagesBuilderFacade` and pass the returned flags into provider status;
+- make authoritative SSR Page Builder capability dispatch independently read the same routed-tenant settings snapshot on every request rather than trusting the UI copy;
+- remove the hardcoded `BuilderCapabilityFlags::default()` source once both paths use equivalent normalization;
+- retain source tests proving all four profiles map to the exact expected admin/provider and SSR handler capability outcomes.
+
+Only after that binding is complete should a four-profile runtime evidence harness be admitted to the Pages reference-consumer candidate packet.
+
+## Source evidence
+
+- `crates/rustok-pages/contracts/evidence/pages-builder-rollout-server-snapshot-source.json`
+- `crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs`
+- `crates/rustok-pages/admin/src/builder_rollout_settings.rs`
+
+No tests, Node verifiers, Cargo commands, formatting, database scenarios, HTTP requests, browser runs, workflows, or CI were executed by this implementation slice.


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder reference-consumer gate after #3328 by adding the trusted Pages-specific server snapshot needed before UI/SSR rollout binding.

- add native server function `/api/fn/pages/builder-rollout-flags`;
- extract both `AuthContext` and routed `TenantContext` on the server and reject tenant mismatch;
- require effective `Pages:Read` authority before reading rollout state;
- read only the exact enabled Pages module settings through `rustok_api::tenant_module_settings`;
- return only validated `BuilderCapabilityFlags`, never raw tenant-module settings;
- keep omitted builder keys backward-compatible (`true`) while rejecting present non-boolean values and invalid flag combinations fail-closed;
- retain source tests for all four declared profiles, defaults, malformed types and invalid combinations without executing them;
- enable only the SSR dependencies needed for the trusted adapter (`rustok-api/server`, `leptos_axum`);
- source-lock the adapter and record the next cursor in the Pages reference gate;
- keep the existing hardcoded `PagesBuilderFacade` / SSR handler composition explicit and pending, so the four-profile runtime matrix is not overclaimed.

## Boundary

This PR does **not** accept rollout flags from the browser and does not yet wire the returned snapshot into `PagesBuilderFacade::provider_status()` or authoritative Page Builder SSR dispatch. Those two bindings are the next source slice. `pages_reference_consumer_gate` remains `accepted=false`; provider health is still `unobserved`; Forum Wave and FFA/FBA remain blocked.

## Main recheck

The branch started at `main@0ae8f7f4382a4218107c43a4e1e6f1e5b957a84e`. Current `main@816767e342bafb7cd9f16663f854b4367d5c2a53` only adds Product deployment co-requisite enforcement under the Modules control plane; those paths are disjoint from this Pages admin slice.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting, database scenarios, HTTP requests, browser runs, workflows, or CI were executed. Source review only.