### PR TITLE
feat(index): guard shadow replay host dispatch

### DIFF
--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -80,21 +80,28 @@ pub enum IndexReplayOperatorError {
     Forbidden,
     #[error(transparent)]
     Replay(#[from] rustok_index::IndexReplayRunError),
+    #[error(transparent)]
+    Shadow(#[from] rustok_index::IndexReplayDryRunError),
 }
 
-/// Server-owned guarded operator boundary over the canonical Index replay runtime.
+/// Server-owned guarded operator boundary over the canonical Index replay runtimes.
 ///
 /// Transport adapters must provide an exact request-bound tenant/actor context. The boundary
-/// accepts only `modules:manage`, rejects cross-tenant requests before database access, and exposes
-/// no connection, source registry, scheduler, or worker-spawn handle.
+/// accepts only `modules:manage`, rejects cross-tenant requests before execution, and exposes no
+/// connection, source registry, scheduler, or worker-spawn handle. Durable full replay and
+/// side-effect-free shadow replay remain separate execution surfaces behind the same guard.
 #[derive(Clone)]
 pub struct IndexReplayOperatorRuntime {
     inner: rustok_index::SharedIndexReplayRuntime,
+    shadow: rustok_index::SharedIndexReplayDryRunRuntime,
 }
 
 impl IndexReplayOperatorRuntime {
-    fn new(inner: rustok_index::SharedIndexReplayRuntime) -> Self {
-        Self { inner }
+    fn new(
+        inner: rustok_index::SharedIndexReplayRuntime,
+        shadow: rustok_index::SharedIndexReplayDryRunRuntime,
+    ) -> Self {
+        Self { inner, shadow }
     }
 
     pub async fn run(
@@ -104,6 +111,17 @@ impl IndexReplayOperatorRuntime {
     ) -> Result<rustok_index::IndexReplayRunOutcome, IndexReplayOperatorError> {
         context.authorize_for(request.page_request().tenant_id())?;
         self.inner.run(request).await.map_err(Into::into)
+    }
+
+    /// Runs the existing side-effect-free replay dry-run capability through the same exact
+    /// request-bound authorization boundary as durable full replay.
+    pub async fn run_shadow(
+        &self,
+        context: IndexReplayOperatorContext,
+        request: rustok_index::IndexReplayDryRunRequest,
+    ) -> Result<rustok_index::IndexReplayDryRunOutcome, IndexReplayOperatorError> {
+        context.authorize_for(request.tenant_id())?;
+        self.shadow.run(request).await.map_err(Into::into)
     }
 
     /// Runs replay through the same authorization boundary while sampling one host-owned
@@ -149,8 +167,8 @@ impl fmt::Debug for IndexReplayOperatorRuntime {
 ///
 /// This function performs no database I/O and starts no worker. It invokes selected source
 /// factories only to construct adapters, freezes the complete source catalog, binds the immutable
-/// schema/source registries to the host database, and publishes the guarded bounded replay,
-/// reconciliation, exact-entity drift diagnosis, and one-page source-candidate diagnosis
+/// schema/source registries to the host database, and publishes the guarded bounded full/shadow
+/// replay, reconciliation, exact-entity drift diagnosis, and one-page source-candidate diagnosis
 /// capabilities through `ModuleRuntimeExtensions`.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
@@ -183,7 +201,15 @@ pub(crate) fn materialize_index_replay_runtime(
             ServerError::Message(format!("Index replay runtime composition failed: {error}"))
         })?;
     if let Some(runtime) = runtime {
-        extensions.insert(IndexReplayOperatorRuntime::new(runtime));
+        let shadow = extensions
+            .get::<rustok_index::SharedIndexReplayDryRunRuntime>()
+            .cloned()
+            .ok_or_else(|| {
+                ServerError::Message(
+                    "Index replay shadow runtime is missing after replay composition".to_string(),
+                )
+            })?;
+        extensions.insert(IndexReplayOperatorRuntime::new(runtime, shadow));
     }
     reconciliation_operator::materialize_index_reconciliation_operator(extensions, db.clone())?;
     drift_diagnosis_operator::materialize_index_drift_diagnosis_operator(extensions, db)?;
@@ -213,11 +239,12 @@ mod tests {
         MigrationSource, ModuleRegistry, ModuleRuntimeExtensions, RusToKModule, UserRole,
     };
     use rustok_index::{
-        EntityName, FieldCardinality, FieldName, IndexField, IndexModule, IndexSchema, IndexSource,
+        EntityName, FieldCardinality, FieldName, IndexField, IndexModule,
+        IndexReplayDryRunRequest, IndexReplayDryRunStatus, IndexSchema, IndexSource,
         IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest, IndexSourcePage,
         IndexSourceScanRequest, IndexValueType, LocaleMode, ModuleName, SchemaRef, SchemaVersion,
-        SharedIndexReplayRuntime, SharedIndexSchemaRegistry, SharedIndexSourceRegistry,
-        register_index_schema_source, register_index_source,
+        SharedIndexReplayDryRunRuntime, SharedIndexReplayRuntime, SharedIndexSchemaRegistry,
+        SharedIndexSourceRegistry, register_index_schema_source, register_index_source,
     };
     use sea_orm::Database;
     use sea_orm_migration::MigrationTrait;
@@ -337,6 +364,7 @@ mod tests {
             .expect("missing sources should remain optional");
         assert!(!extensions.contains::<SharedIndexSourceRegistry>());
         assert!(!extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(!extensions.contains::<SharedIndexReplayDryRunRuntime>());
         assert!(!extensions.contains::<IndexReplayOperatorRuntime>());
         assert!(!extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
         assert!(!extensions.contains::<IndexDriftSourcePageDiagnosisRuntime>());
@@ -359,6 +387,7 @@ mod tests {
             .expect("complete replay runtime should compose");
         assert!(extensions.contains::<SharedIndexSourceRegistry>());
         assert!(extensions.contains::<SharedIndexReplayRuntime>());
+        assert!(extensions.contains::<SharedIndexReplayDryRunRuntime>());
         assert!(extensions.contains::<IndexReplayOperatorRuntime>());
         assert!(extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
         assert!(extensions.contains::<IndexDriftSourcePageDiagnosisRuntime>());
@@ -371,6 +400,64 @@ mod tests {
         assert!(host
             .shared_get::<IndexDriftSourcePageDiagnosisRuntime>()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn shadow_dispatch_reuses_request_bound_modules_manage_guard() {
+        let registry = ModuleRegistry::new()
+            .register(IndexModule)
+            .register(DemoReplayModule);
+        let mut extensions = rustok_distribution::build_runtime_extensions(&registry)
+            .expect("source schema composition should build");
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database");
+        materialize_index_replay_runtime(&mut extensions, db)
+            .expect("complete replay runtime should compose");
+        let runtime = extensions
+            .get::<IndexReplayOperatorRuntime>()
+            .cloned()
+            .expect("guarded replay operator runtime");
+
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let context = IndexReplayOperatorContext::new(tenant_id, actor_id).unwrap();
+        let request = IndexReplayDryRunRequest::new(
+            tenant_id,
+            demo_schema().reference,
+            None,
+            10,
+            1,
+        )
+        .unwrap();
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            runtime.run_shadow(context, request.clone()),
+        )
+        .await
+        .expect_err("modules:read must not invoke shadow replay");
+        assert!(matches!(forbidden, IndexReplayOperatorError::Forbidden));
+
+        let outcome = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            runtime.run_shadow(context, request),
+        )
+        .await
+        .expect("modules:manage should invoke side-effect-free shadow replay");
+        assert_eq!(outcome.status(), IndexReplayDryRunStatus::Complete);
+        assert_eq!(outcome.pages_scanned(), 1);
+        assert_eq!(outcome.mutation_count(), 0);
     }
 
     #[tokio::test]

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -80,8 +80,14 @@ pub enum IndexReplayOperatorError {
     Forbidden,
     #[error(transparent)]
     Replay(#[from] rustok_index::IndexReplayRunError),
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReplayShadowOperatorError {
     #[error(transparent)]
-    Shadow(#[from] rustok_index::IndexReplayDryRunError),
+    Authorization(#[from] IndexReplayOperatorError),
+    #[error(transparent)]
+    DryRun(#[from] rustok_index::IndexReplayDryRunError),
 }
 
 /// Server-owned guarded operator boundary over the canonical Index replay runtimes.
@@ -119,7 +125,7 @@ impl IndexReplayOperatorRuntime {
         &self,
         context: IndexReplayOperatorContext,
         request: rustok_index::IndexReplayDryRunRequest,
-    ) -> Result<rustok_index::IndexReplayDryRunOutcome, IndexReplayOperatorError> {
+    ) -> Result<rustok_index::IndexReplayDryRunOutcome, IndexReplayShadowOperatorError> {
         context.authorize_for(request.tenant_id())?;
         self.shadow.run(request).await.map_err(Into::into)
     }
@@ -253,7 +259,7 @@ mod tests {
     use super::{
         IndexDriftDiagnosisOperatorRuntime, IndexDriftSourcePageDiagnosisRuntime,
         IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
-        materialize_index_replay_runtime,
+        IndexReplayShadowOperatorError, materialize_index_replay_runtime,
     };
     use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
 
@@ -442,7 +448,10 @@ mod tests {
         )
         .await
         .expect_err("modules:read must not invoke shadow replay");
-        assert!(matches!(forbidden, IndexReplayOperatorError::Forbidden));
+        assert!(matches!(
+            forbidden,
+            IndexReplayShadowOperatorError::Authorization(IndexReplayOperatorError::Forbidden)
+        ));
 
         let outcome = with_rbac_request_scope(
             Some(RbacRequestScope::new(

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@e91926363cfcdf6a91836358add1afdf94f65ffa` and continued on
-`agent/index-replay-mode-contract-20260808`.
+Status overlay rechecked at `main@cbf01df654252e53013da60e5621274a2ce08497` and continued on
+`agent/index-replay-shadow-host-dispatch-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -112,16 +112,21 @@ register a key3 Product source/factory. Runtime dual-read compatibility remains 
 request-bound tenant/actor context and effective `modules:manage`, rejects cross-tenant run requests and derives
 cancel tenant from that context.
 
-The GraphQL layer exposes source-complete schema-wide or exact-locale `runIndexReplay` plus `cancelIndexReplay`
-without calling source adapters or PostgreSQL directly. Authorization occurs before parsing untrusted schema,
+The guarded operator now retains both the durable `SharedIndexReplayRuntime` and the existing no-write
+`SharedIndexReplayDryRunRuntime`. `run_shadow` authorizes the exact dry-run request tenant through the same
+request-bound `modules:manage` snapshot before delegating to the side-effect-free runtime. It creates no replay
+job/checkpoint and exposes no lease, cancellation, scheduler or database handle.
+
+The GraphQL layer still exposes only source-complete schema-wide or exact-locale durable `runIndexReplay` plus
+`cancelIndexReplay`; Shadow transport is not exposed yet. Authorization occurs before parsing untrusted schema,
 locale or job input.
 
-Caller run input contains only module/entity/schema key plus one optional bounded locale. Tenant, actor, worker
-ID, source name, partition, scheduler handle, replay resource budget, stop handle and shutdown flag remain
+Caller durable run input contains only module/entity/schema key plus one optional bounded locale. Tenant, actor,
+worker ID, source name, partition, scheduler handle, replay resource budget, stop handle and shutdown flag remain
 server-owned or unavailable. Locale is canonicalized through `LocaleKey` after authorization. Omission remains
-exactly schema-wide; it is not rewritten from schema locale defaults. Each run creates a server-owned worker
-identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page and a
-60-second lease.
+exactly schema-wide; it is not rewritten from schema locale defaults. Each durable run creates a server-owned
+worker identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page
+and a 60-second lease.
 
 Retained command source evidence includes schema-wide command behavior, locale command canonicalization and a
 dedicated locale yield/isolation/fresh-runtime resume packet. GraphQL execution/admission remains maintainer-owned.
@@ -231,8 +236,8 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
 
 ## M6 explicit replay mode contract
 
-`IndexReplayMode` now separates `Full`, `Targeted` and `Shadow` rebuild intent from locale and future partition
-scope. `IndexReplayModeSelection` maps those modes to non-aliasing execution surfaces:
+`IndexReplayMode` separates `Full`, `Targeted` and `Shadow` rebuild intent from locale and future partition scope.
+`IndexReplayModeSelection` maps those modes to non-aliasing execution surfaces:
 
 - `Full` -> `DurableScan`; this is the only mode admitted to the existing `PostgresIndexReplayRunner` and retains
   the current fenced replay job/checkpoint, cancellation, locale and lease semantics;
@@ -240,12 +245,13 @@ scope. `IndexReplayModeSelection` maps those modes to non-aliasing execution sur
   bounded exact-key count, tenant/schema scope and uniqueness checks;
 - `Shadow` -> `SideEffectFreeScan`; this matches the existing `SharedIndexReplayDryRunRuntime` no-write boundary.
 
-The contract does not expose caller-controlled mode input yet and does not add a mode column to jobs/checkpoints,
-a second lease owner, retry state, partition dimension, targeted mutation executor or shadow persistence. See
-`m6-replay-mode-contract.md`.
+The server host now guards `Shadow` through `IndexReplayOperatorRuntime::run_shadow`, using the same exact
+request-bound `modules:manage` authorization check as Full. This does not add a mode column to jobs/checkpoints, a
+second lease owner, retry state, partition dimension, targeted mutation executor or shadow persistence. See
+`m6-replay-mode-contract.md` and `m6-bounded-replay-dry-run.md`.
 
-The explicit mode identity/routing contract is source-complete. Runtime dispatch/admission remains open and
-maintainer execution is not claimed.
+The explicit mode identity and Shadow host dispatch are source-complete. Public Shadow transport/admission remains
+open and maintainer execution is not claimed.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -287,6 +293,7 @@ maintainer execution is not claimed.
 - [x] Define/retain whole-page duration versus lease/heartbeat policy beyond per-dependency bounds.
 - [x] Retain deterministic two-host lease-expiry/reclaim/stale-owner fencing evidence through distinct replay runners.
 - [x] Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.
+- [x] Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
 - [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
@@ -294,7 +301,7 @@ maintainer execution is not claimed.
 - [ ] Execute/admit retained page lease-heartbeat evidence.
 - [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
 - [ ] Execute/admit retained multi-host reclaim evidence.
-- [ ] Add request-bound host dispatch for the existing side-effect-free Shadow replay surface.
+- [ ] Add authorization-first GraphQL transport for the guarded Shadow replay command.
 - [ ] Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.
 - [ ] Add partition replay scope only after a real partition-capable source contract exists.
 
@@ -331,17 +338,21 @@ maintainer execution is not claimed.
 M7 Storefront remains execution/admission-gated and must not gain a traffic switch from source inspection alone.
 
 The locale request/source/job/checkpoint/runner/GraphQL identity chain, dependency timeout set,
-page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence and explicit Full/Targeted/Shadow
-mode identity are source-complete. Their retained packets still require maintainer execution/admission.
+page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence, explicit Full/Targeted/Shadow
+mode identity and guarded Shadow host dispatch are source-complete. Their retained packets still require maintainer
+execution/admission.
 
 Partition replay remains blocked: no real partition-capable source contract can yet filter a partition before
 pagination, so do not merely populate `partition_key`.
 
-For source-only M6 continuation, the next independent boundary is request-bound host dispatch for the existing
-side-effect-free `Shadow` replay surface. It must reuse `SharedIndexReplayDryRunRuntime`, preserve authorization-first
-input parsing, keep `Full` routed to the existing durable runner, and must not introduce caller-controlled job,
-checkpoint, lease or retry state. Targeted execution remains separate until the bounded mutation-application
-contract over `IndexSource::load` is defined.
+For source-only M6 continuation, the next independent boundary is authorization-first GraphQL transport for the
+guarded `Shadow` replay command. It must call `IndexReplayOperatorRuntime::run_shadow`, keep the existing durable
+`runIndexReplay` path as Full, keep any resume cursor caller-carried/non-durable, and must not expose job,
+checkpoint, lease, cancellation or retry controls for Shadow. Optional locale support should reuse the canonical
+source-scan locale contract rather than become mode-specific durable state.
+
+Targeted execution remains separate until the bounded mutation-application contract over `IndexSource::load` is
+defined.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
+++ b/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
@@ -1,9 +1,10 @@
 # M6 bounded replay dry-run
 
-Status: `source_complete_host_guard_pending`
+Status: `source_complete_transport_pending`
 
 This slice adds an Index-owned, side-effect-free validation runtime over the exact immutable
-`SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay.
+`SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay, and now
+binds that capability behind the server-owned request-bound replay operator guard.
 
 ## Contract
 
@@ -54,25 +55,38 @@ registry without its shared schema registry fails closed.
 A yielded run is resumed only by explicitly passing its returned opaque cursor into another
 bounded request. No durable cursor is implied.
 
+## Server-owned host guard
+
+`IndexReplayOperatorRuntime` now retains the already-materialized
+`SharedIndexReplayDryRunRuntime` beside the durable `SharedIndexReplayRuntime` and exposes
+`IndexReplayOperatorRuntime::run_shadow`.
+
+`run_shadow` reuses the same request-bound `modules:manage` authorization boundary as durable full
+replay. The exact request tenant must match the operator context before the side-effect-free source
+scan can start. The operator publishes no database connection, source registry, scheduler, worker
+handle, job identifier, lease control, cancellation state, or retry/requeue control to the caller.
+
+Server composition fails closed if durable replay materializes but the expected dry-run capability
+is missing. Retained server source evidence covers `modules:read` rejection and an authorized
+`modules:manage` empty-page completion through the guarded Shadow method. That completion creates
+no durable replay job or checkpoint and does not alter the Full runner.
+
 ## Explicitly open
 
-- server-owned request-bound `modules:manage` delegation for dry-run invocation;
-- GraphQL, HTTP, CLI, or admin transport surfaces;
+- GraphQL, HTTP, CLI, or admin transport surfaces for Shadow invocation;
+- authorization-first parsing/serialization of a bounded Shadow transport request and resume cursor;
+- optional canonical locale scope for the Shadow/dry-run transport path;
 - persisted dry-run reports or comparison snapshots;
 - cross-page duplicate event detection beyond one bounded page;
 - mutation/checkpoint timing simulation and interruption;
-- targeted-key, full, and shadow rebuild mode contracts;
+- targeted mutation execution over `IndexSource::load`;
 - cooperative cancellation while a source or validation future is already pending;
 - configurable per-source or per-request timeout policy;
 - retained production-source and PostgreSQL execution evidence.
 
-Transport code must not treat `SharedIndexReplayDryRunRuntime` as an authorized public endpoint.
-The raw capability is an engine seam awaiting the same server-owned guard used by executable
-replay.
-
-The canonical combined roadmap item for complete in-page interruption, dry-run, and rebuild modes
-remains open because this slice provides only bounded no-write source validation. It does not add
-a guarded invocation surface or any targeted/full/shadow rebuild execution.
+Transport code must call the guarded operator boundary rather than treat
+`SharedIndexReplayDryRunRuntime` as an authorized public endpoint. The existing GraphQL
+`runIndexReplay` command remains durable Full replay and is unchanged by the host-guard slice.
 
 ## Validation ownership
 
@@ -86,4 +100,5 @@ cargo test -p rustok-index --test replay_dry_run_contract -- --nocapture
 cargo test -p rustok-index replay_dry_run -- --nocapture
 cargo check -p rustok-index --all-targets
 node scripts/verify/verify-index-replay-runtime-composition.mjs
+node scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
 ```

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -1,9 +1,10 @@
 # M6 replay mode contract
 
-Status: `source_complete_execution_routing_pending`.
+Status: `source_complete_shadow_host_dispatch_transport_pending`.
 
 This slice defines explicit rebuild mode identity without changing the existing durable replay runner, job,
-checkpoint, cancellation, locale or lease state machines.
+checkpoint, cancellation, locale or lease state machines. The Shadow execution surface is now also bound to the
+server-owned request authorization guard, while public transport remains separate.
 
 ## Mode identity
 
@@ -28,14 +29,30 @@ Targeted and shadow modes must not alias the full durable job/checkpoint identit
 
 - targeted execution must be a bounded `IndexSource::load` path and must define its own operator execution
   contract before it can persist mutations;
-- shadow execution must remain no-write and use the dry-run surface rather than the durable mutation/job/checkpoint
+- shadow execution remains no-write and uses the dry-run surface rather than the durable mutation/job/checkpoint
   path;
 - neither mode introduces automatic retry/requeue, another lease owner, another terminal job state, or a second
   cancellation model.
 
-The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner`, `IndexReplayOperatorRuntime` and GraphQL
-`runIndexReplay` command remain full-scan behavior. This PR does not add caller-controlled mode input or silently
-reinterpret existing commands.
+The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner` and GraphQL `runIndexReplay` command remain
+full-scan behavior. They do not accept a generic mode selector and are not reinterpreted by this contract.
+
+## Shadow host dispatch
+
+`Shadow` host dispatch is now source-complete through `IndexReplayOperatorRuntime::run_shadow`.
+
+The server replay materializer retrieves the `SharedIndexReplayDryRunRuntime` already published by Index replay
+composition and stores it beside the durable runtime inside the guarded operator. `run_shadow` authorizes the
+exact request tenant through the same request-bound `modules:manage` snapshot used by Full replay, then delegates
+to the no-write dry-run runtime.
+
+This is a host dispatch boundary, not a new durable mode state machine:
+
+- no job or checkpoint identity is created for Shadow;
+- no lease, heartbeat, cancel or terminal job transition is added;
+- no mutation sink or database connection is exposed;
+- Full continues to route to the durable runner unchanged;
+- GraphQL transport remains separate and does not yet expose Shadow.
 
 ## Existing contracts reused
 
@@ -43,7 +60,8 @@ The mode contract composes already-retained boundaries rather than duplicating t
 
 - full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
 - targeted: `IndexSourceLoadRequest` exact-key validation and `IndexSource::load` source boundary;
-- shadow: `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan validation.
+- shadow: `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan validation,
+  now guarded by the server replay operator.
 
 Partition replay remains blocked until a real partition-capable source can filter before pagination.
 
@@ -53,7 +71,7 @@ This slice does not add:
 
 - targeted mutation execution;
 - shadow persistence or shadow tables;
-- GraphQL/API mode selection;
+- GraphQL/API Shadow transport or generic mode selection;
 - a mode column in `index_jobs` or `index_checkpoints`;
 - partition replay scope;
 - automatic retry/requeue or scheduler ownership;
@@ -61,10 +79,13 @@ This slice does not add:
 
 ## Next source boundary
 
-The next source-only boundary is request-bound host dispatch for the already-existing no-write `Shadow` surface.
-That work should reuse `SharedIndexReplayDryRunRuntime`, preserve authorization-first parsing, and keep `Full`
-routed to the existing durable runner. Targeted execution remains a separate later slice because it needs an
-explicit bounded mutation-application contract over `IndexSource::load` rather than a scan checkpoint.
+The next source-only boundary is authorization-first GraphQL transport for the guarded Shadow command. It should
+call `IndexReplayOperatorRuntime::run_shadow`, preserve the existing Full `runIndexReplay` path, keep resume state
+caller-carried and non-durable, and add canonical locale scope only through the existing source-scan contract rather
+than by creating mode-specific job/checkpoint state.
+
+Targeted execution remains a separate later slice because it needs an explicit bounded mutation-application
+contract over `IndexSource::load` rather than a scan checkpoint.
 
 Execution/admission remains maintainer-owned. The Rust tests and Node verifiers for this source slice were not
 executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -5,10 +5,10 @@ Status: `source_complete_owner_execution_pending`
 This composition freezes the complete immutable Index source/schema registries and publishes three Index-owned capabilities from the same boundary:
 
 - bounded replay dry-run;
-- bounded guarded replay runtime;
+- bounded durable replay runtime;
 - one module-work registration for due reconciliation execution.
 
-It does not add automatic replay-job scheduling. The server exposes one bounded authorized GraphQL run/cancel command transport over the guarded replay operator; that transport remains separate from runtime materialization and scheduler ownership.
+The server now wraps both replay execution surfaces in one request-bound operator: durable Full replay through `SharedIndexReplayRuntime` and side-effect-free Shadow replay through `SharedIndexReplayDryRunRuntime`. It does not add automatic replay-job scheduling. Public Shadow transport remains separate from runtime materialization and scheduler ownership.
 
 ## Composition order
 
@@ -18,21 +18,24 @@ It does not add automatic replay-job scheduling. The server exposes one bounded 
 4. it publishes replay dry-run and calls `register_postgres_index_reconciliation_work`;
 5. only complete source/schema composition creates `ModuleWorkRegistrations` for Index;
 6. it publishes `SharedIndexReplayRuntime` with ordinary and lifecycle-neutral interruptible run entry points;
-7. the server wraps replay and reconciliation capabilities in guarded operator runtimes;
-8. GraphQL exposes only the guarded replay operator through bounded schema-wide run/cancel commands;
-9. GraphQL schema initialization supplies the server-owned `StopHandle::is_stopping` probe to authorized replay run commands without making shutdown caller-controlled.
+7. the server retrieves the already-materialized `SharedIndexReplayDryRunRuntime` and wraps Full plus Shadow behind `IndexReplayOperatorRuntime`;
+8. the server wraps reconciliation separately in its guarded operator runtime;
+9. GraphQL currently exposes only durable Full run/cancel commands; Shadow GraphQL transport remains a separate next slice;
+10. GraphQL schema initialization supplies the server-owned `StopHandle::is_stopping` probe to authorized durable replay run commands without making shutdown caller-controlled.
 
-An absent source registry publishes no replay runtime, no dry-run runtime, and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed.
+An absent source registry publishes no replay runtime, no dry-run runtime, and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed. Server composition also fails closed if a durable replay runtime exists without the dry-run runtime that the guarded Shadow route requires.
 
-The Index materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the same shared `StopHandle` lifecycle used by replay GraphQL execution.
+The Index materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the same shared `StopHandle` lifecycle used by durable replay GraphQL execution.
 
 ## Replay operator and command boundary
 
-`IndexReplayOperatorRuntime` remains the only server-owned replay invocation authority. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`. Both ordinary and interruptible run reject cross-tenant requests before delegation; cancellation derives tenant only from the authorized context.
+`IndexReplayOperatorRuntime` remains the only server-owned replay invocation authority. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`.
 
-The GraphQL transport authorizes before parsing caller schema/job input and delegates only to this operator. Tenant, actor, worker identity, source name, database handles, scheduler controls, replay resource budgets, and shutdown state are not caller fields. The run mutation creates a server-owned worker identity and uses a fixed 100-row × 8-page chunk, per-page heartbeat, and 60-second lease.
+Durable ordinary/interruptible run rejects cross-tenant requests before delegation and cancellation derives tenant only from the authorized context. `run_shadow` applies the same exact tenant and `modules:manage` guard before delegating to the side-effect-free dry-run runtime. Shadow has a separate typed operator error wrapper so the existing Full/cancel GraphQL error contract does not need to absorb an unexposed mode.
 
-Transport adapters must not call `SharedIndexReplayRuntime` directly. See the server transport contract in `apps/server/docs/index-replay-graphql-transport.md`.
+The current GraphQL transport authorizes before parsing caller schema/job input and delegates only durable Full run/cancel to this operator. Tenant, actor, worker identity, source name, database handles, scheduler controls, replay resource budgets, and shutdown state are not caller fields. The durable run mutation creates a server-owned worker identity and uses a fixed 100-row × 8-page chunk, per-page heartbeat, and 60-second lease.
+
+Transport adapters must not call either `SharedIndexReplayRuntime` or `SharedIndexReplayDryRunRuntime` directly. See the durable server transport contract in `apps/server/docs/index-replay-graphql-transport.md` and the Shadow host boundary in `m6-bounded-replay-dry-run.md`.
 
 ## In-page host interruption boundary
 
@@ -40,7 +43,7 @@ Transport adapters must not call `SharedIndexReplayRuntime` directly. See the se
 
 An interrupted page is not marked failed and does not manufacture a persisted cancellation. After preserving any cancellation race, the runner yields the fenced job back to `pending` with lease ownership cleared and the last committed checkpoint unchanged. A later attempt can replay the same page; already-durable deliveries remain safe through inbox deduplication and source-version ordering.
 
-`SharedIndexReplayRuntime::run_interruptible` and `IndexReplayOperatorRuntime::run_interruptible` now carry that boolean probe through the immutable replay/runtime and authorization boundaries without importing the server lifecycle type into the Index crate or operator composition.
+`SharedIndexReplayRuntime::run_interruptible` and `IndexReplayOperatorRuntime::run_interruptible` carry that boolean probe through the immutable replay/runtime and authorization boundaries without importing the server lifecycle type into the Index crate or operator composition.
 
 GraphQL schema initialization resolves or atomically creates one `StopHandle` in shared server runtime state and retains a watch receiver even for API-only hosts. `runIndexReplay` reads only `StopHandle::is_stopping` and invokes the guarded interruptible operator. It never calls `StopHandle::stop`, and no shutdown field is accepted from GraphQL input.
 
@@ -54,14 +57,14 @@ It does not schedule replay/rebuild jobs, create a second task, own a database l
 
 ## Explicitly open
 
+- authorization-first GraphQL transport for guarded Shadow replay, including caller-carried bounded resume state and canonical locale handling;
 - execute/admit retained replay interruption/restart evidence and end-to-end process-shutdown command evidence;
-- GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
+- durable GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
 - automatic replay/rebuild job scheduling;
 - retained PostgreSQL replay and reconciliation scheduler execution evidence;
 - operator-visible scheduler health and metrics;
-- in-page mutation/checkpoint timeout completion;
-- locale/partition replay checkpoint dimensions;
-- targeted/full/shadow repair and complete drift diagnosis.
+- targeted replay mutation execution over the bounded `IndexSource::load` contract;
+- partition replay scope only after a real partition-capable source can filter before pagination.
 
 ## Validation ownership
 

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -70,6 +70,7 @@ const scripts = [
   'verify-index-reconciliation-dead-letter-requeue.mjs',
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-mode-contract.mjs',
+  'verify-index-replay-shadow-host-dispatch.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',
   'verify-index-replay-dead-letter-admission.mjs',

--- a/scripts/verify/verify-index-replay-dry-run.mjs
+++ b/scripts/verify/verify-index-replay-dry-run.mjs
@@ -81,7 +81,7 @@ const replayRuntime = requireMarkers(replayRuntimePath, [
   'DryRun(#[from] IndexReplayDryRunRuntimeCompositionError)',
   'materialize_index_replay_dry_run_runtime(extensions)?;',
   'extensions.contains::<SharedIndexReplayDryRunRuntime>()',
-  'complete_registries_materialize_one_shared_replay_runtime',
+  'complete_registries_materialize_replay_and_module_work_registration',
 ]);
 for (const forbidden of ['tokio::spawn', '.execute(', '.begin()']) {
   if (replayRuntime.includes(forbidden)) {
@@ -104,14 +104,21 @@ requireMarkers('crates/rustok-index/src/application/source_timeout.rs', [
   'TimedIndexSource::new(source, DEFAULT_INDEX_SOURCE_CALL_TIMEOUT)',
 ]);
 
-const serverRuntimePath = 'apps/server/src/services/index_replay_runtime_composition.rs';
-const serverRuntime = read(serverRuntimePath);
-if (serverRuntime.includes('SharedIndexReplayDryRunRuntime')) {
-  fail(`${serverRuntimePath} must not expose the raw dry-run capability before a request-bound guard exists`);
+requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
+  'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
+  'pub async fn run_shadow(',
+  'context.authorize_for(request.tenant_id())?;',
+  'self.shadow.run(request).await.map_err(Into::into)',
+  '.get::<rustok_index::SharedIndexReplayDryRunRuntime>()',
+  'IndexReplayOperatorRuntime::new(runtime, shadow)',
+]);
+const graphql = read('apps/server/src/graphql/index_replay.rs');
+if (graphql.includes('SharedIndexReplayDryRunRuntime') || graphql.includes('.run_shadow(')) {
+  fail('GraphQL must not bypass the guarded Shadow operator before the dedicated transport slice');
 }
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_host_guard_pending`',
+  'Status: `source_complete_transport_pending`',
   '`IndexReplayDryRunRequest`',
   '`SharedIndexReplayDryRunRuntime::run`',
   'one invocation budget from 1 through 1024 pages',
@@ -120,8 +127,10 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
   '30-second source-call timeout',
   'Direct low-level `IndexSourceCatalog::register` usage',
   'No-write boundary',
-  'server-owned request-bound `modules:manage` delegation for dry-run invocation',
-  'canonical combined roadmap item',
+  'Server-owned host guard',
+  '`IndexReplayOperatorRuntime::run_shadow`',
+  'same request-bound `modules:manage` authorization boundary',
+  'GraphQL, HTTP, CLI, or admin transport surfaces for Shadow invocation',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
@@ -132,6 +141,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-dry-run.mjs'",
+  "'verify-index-replay-shadow-host-dispatch.mjs'",
 ]);
 
-console.log('[verify-index-replay-dry-run] OK');
+console.log('[verify-index-replay-dry-run] bounded no-write replay validation is now protected by the request-bound server operator while public transport remains separate');

--- a/scripts/verify/verify-index-replay-mode-contract.mjs
+++ b/scripts/verify/verify-index-replay-mode-contract.mjs
@@ -62,7 +62,7 @@ const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_repla
 const runner = read(runnerPath);
 for (const forbidden of ['IndexReplayMode::Targeted', 'IndexReplayMode::Shadow', 'TargetedLoad', 'SideEffectFreeScan']) {
   if (runner.includes(forbidden)) {
-    fail(`${runnerPath} must remain the durable full-scan runner until a separate dispatcher is added: ${forbidden}`);
+    fail(`${runnerPath} must remain the durable full-scan runner: ${forbidden}`);
   }
 }
 
@@ -73,25 +73,34 @@ requireMarkers(dryRunPath, [
   '.scan(scan_request)',
 ]);
 
+requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
+  'pub async fn run_shadow(',
+  'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
+  'context.authorize_for(request.tenant_id())?;',
+  'self.shadow.run(request).await.map_err(Into::into)',
+]);
+
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_execution_routing_pending`.',
+  'Status: `source_complete_shadow_host_dispatch_transport_pending`.',
   '`Full` — cursor-based durable source scan',
   '`Targeted` — bounded exact-key source load',
   '`Shadow` — side-effect-free cursor scan',
   'Mode is not locale scope and is not future partition scope.',
   'returns true only for `Full`',
   'must not alias the full durable job/checkpoint identity',
-  'The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner`, `IndexReplayOperatorRuntime` and GraphQL',
-  'does not add caller-controlled mode input',
-  'next source-only boundary is request-bound host dispatch',
+  '`Shadow` host dispatch is now source-complete',
+  '`IndexReplayOperatorRuntime::run_shadow`',
+  'GraphQL transport remains separate',
+  'The next source-only boundary is authorization-first GraphQL transport',
   'Execution/admission remains maintainer-owned.',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.',
-  'Add request-bound host dispatch for the existing side-effect-free Shadow replay surface.',
+  'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
+  'Add authorization-first GraphQL transport for the guarded Shadow replay command.',
   'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
   'Add partition replay scope only after a real partition-capable source contract exists.',
 ]);
 
-console.log('[verify-index-replay-mode-contract] full, targeted and shadow modes remain explicit, bounded and routed to non-aliasing execution surfaces');
+console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow now has a guarded no-write host route without public transport');

--- a/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
+++ b/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
@@ -117,7 +117,8 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Retain deterministic two-host lease-expiry/reclaim/stale-owner fencing evidence through distinct replay runners.',
   'Execute/admit retained multi-host reclaim evidence.',
   'Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.',
-  'Add request-bound host dispatch for the existing side-effect-free Shadow replay surface.',
+  'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
+  'Add authorization-first GraphQL transport for the guarded Shadow replay command.',
   'Partition replay remains blocked',
 ]);
 

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -27,6 +27,7 @@ const runtime = requireMarkers(runtimePath, [
   'pub enum IndexReplayRuntimeCompositionError',
   'AlreadyMaterialized',
   'MissingSchemaRegistry',
+  'DryRun(#[from] IndexReplayDryRunRuntimeCompositionError)',
   'ReconciliationScheduler(#[from] IndexReconciliationSchedulerCompositionError)',
   'pub fn materialize_postgres_index_replay_runtime(',
   'extensions.get::<SharedIndexSourceRegistry>().cloned()',
@@ -60,6 +61,11 @@ const serverPath = 'apps/server/src/services/index_replay_runtime_composition.rs
 const server = requireMarkers(serverPath, [
   'pub struct IndexReplayOperatorContext',
   'pub struct IndexReplayOperatorRuntime',
+  'inner: rustok_index::SharedIndexReplayRuntime',
+  'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
+  'pub async fn run_shadow(',
+  'context.authorize_for(request.tenant_id())?;',
+  'self.shadow.run(request).await.map_err(Into::into)',
   'pub async fn run_interruptible<Check>(',
   'self.inner',
   '.run_interruptible(request, should_interrupt)',
@@ -69,8 +75,9 @@ const server = requireMarkers(serverPath, [
   'materialize_postgres_index_sources(extensions, db.clone())',
   'materialize_index_source_registry(extensions)',
   'materialize_postgres_index_replay_runtime(extensions, db.clone())',
-  'extensions.insert(IndexReplayOperatorRuntime::new(runtime))',
-  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db)?;',
+  '.get::<rustok_index::SharedIndexReplayDryRunRuntime>()',
+  'IndexReplayOperatorRuntime::new(runtime, shadow)',
+  'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db.clone())?;',
 ]);
 for (const forbidden of ['tokio::spawn', 'tokio::time::sleep', 'loop {', 'StopHandle']) {
   if (server.includes(forbidden)) fail(`${serverPath} contains lifecycle marker ${forbidden}`);
@@ -109,7 +116,8 @@ requireMarkers('crates/rustok-index/docs/m6-reconciliation-host-scheduler.md', [
 ]);
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-runtime-composition.mjs'",
+  "'verify-index-replay-shadow-host-dispatch.mjs'",
   "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
-console.log('[verify-index-replay-runtime-composition] shared replay runtime/operator expose a lifecycle-neutral interruptible path while scheduler composition remains unchanged');
+console.log('[verify-index-replay-runtime-composition] shared replay runtime/operator retain lifecycle-neutral Full execution and a guarded no-write Shadow route while scheduler composition remains unchanged');

--- a/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+++ b/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
@@ -20,17 +20,20 @@ const requireMarkers = (relative, markers) => {
 
 const serverPath = 'apps/server/src/services/index_replay_runtime_composition.rs';
 const server = requireMarkers(serverPath, [
-  'Shadow(#[from] rustok_index::IndexReplayDryRunError)',
+  'pub enum IndexReplayShadowOperatorError',
+  'Authorization(#[from] IndexReplayOperatorError)',
+  'DryRun(#[from] rustok_index::IndexReplayDryRunError)',
   'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
   'pub async fn run_shadow(',
   'request: rustok_index::IndexReplayDryRunRequest',
+  'Result<rustok_index::IndexReplayDryRunOutcome, IndexReplayShadowOperatorError>',
   'context.authorize_for(request.tenant_id())?;',
   'self.shadow.run(request).await.map_err(Into::into)',
   '.get::<rustok_index::SharedIndexReplayDryRunRuntime>()',
   'IndexReplayOperatorRuntime::new(runtime, shadow)',
   'shadow_dispatch_reuses_request_bound_modules_manage_guard',
   'vec![Permission::MODULES_READ]',
-  'IndexReplayOperatorError::Forbidden',
+  'IndexReplayShadowOperatorError::Authorization(IndexReplayOperatorError::Forbidden)',
   'vec![Permission::MODULES_MANAGE]',
   'IndexReplayDryRunStatus::Complete',
 ]);
@@ -50,6 +53,7 @@ for (const forbidden of [
   '.run_shadow(',
   'IndexReplayDryRunRequest',
   'SharedIndexReplayDryRunRuntime',
+  'IndexReplayShadowOperatorError',
 ]) {
   if (graphql.includes(forbidden)) {
     fail(`${graphqlPath} must remain Full/cancel-only until the separate Shadow transport slice: ${forbidden}`);

--- a/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+++ b/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-shadow-host-dispatch] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const serverPath = 'apps/server/src/services/index_replay_runtime_composition.rs';
+const server = requireMarkers(serverPath, [
+  'Shadow(#[from] rustok_index::IndexReplayDryRunError)',
+  'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
+  'pub async fn run_shadow(',
+  'request: rustok_index::IndexReplayDryRunRequest',
+  'context.authorize_for(request.tenant_id())?;',
+  'self.shadow.run(request).await.map_err(Into::into)',
+  '.get::<rustok_index::SharedIndexReplayDryRunRuntime>()',
+  'IndexReplayOperatorRuntime::new(runtime, shadow)',
+  'shadow_dispatch_reuses_request_bound_modules_manage_guard',
+  'vec![Permission::MODULES_READ]',
+  'IndexReplayOperatorError::Forbidden',
+  'vec![Permission::MODULES_MANAGE]',
+  'IndexReplayDryRunStatus::Complete',
+]);
+for (const forbidden of ['tokio::spawn', 'tokio::time::sleep', 'loop {']) {
+  if (server.includes(forbidden)) fail(`${serverPath} must not create a Shadow scheduler/lifecycle owner: ${forbidden}`);
+}
+
+const graphqlPath = 'apps/server/src/graphql/index_replay.rs';
+const graphql = requireMarkers(graphqlPath, [
+  'async fn run_index_replay(',
+  '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
+  'async fn cancel_index_replay(',
+  'prepare_authorized_run(',
+]);
+for (const forbidden of [
+  'run_index_replay_shadow',
+  '.run_shadow(',
+  'IndexReplayDryRunRequest',
+  'SharedIndexReplayDryRunRuntime',
+]) {
+  if (graphql.includes(forbidden)) {
+    fail(`${graphqlPath} must remain Full/cancel-only until the separate Shadow transport slice: ${forbidden}`);
+  }
+}
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = read(runnerPath);
+for (const forbidden of ['IndexReplayMode::Shadow', 'SideEffectFreeScan', 'SharedIndexReplayDryRunRuntime']) {
+  if (runner.includes(forbidden)) {
+    fail(`${runnerPath} must remain the durable Full replay runner: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
+  'Status: `source_complete_transport_pending`',
+  '`IndexReplayOperatorRuntime::run_shadow`',
+  'same request-bound `modules:manage` authorization boundary',
+  'GraphQL, HTTP, CLI, or admin transport surfaces',
+  'no durable replay job or checkpoint',
+]);
+requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
+  'Status: `source_complete_shadow_host_dispatch_transport_pending`.',
+  '`Shadow` host dispatch is now source-complete',
+  '`IndexReplayOperatorRuntime::run_shadow`',
+  'GraphQL transport remains separate',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
+  'Add authorization-first GraphQL transport for the guarded Shadow replay command.',
+  'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
+]);
+
+console.log('[verify-index-replay-shadow-host-dispatch] Shadow replay is request-bound and modules:manage-guarded without changing Full durable ownership or exposing transport');


### PR DESCRIPTION
## Summary

- bind the existing side-effect-free `SharedIndexReplayDryRunRuntime` behind the same request-bound `modules:manage` operator boundary used by durable Full replay;
- add `IndexReplayOperatorRuntime::run_shadow`, authorizing the exact dry-run request tenant before delegating to the no-write runtime;
- keep Shadow errors in a separate `IndexReplayShadowOperatorError`, so the existing Full/cancel GraphQL error contract and public transport remain unchanged;
- make server composition fail closed if durable replay materializes without the already-required dry-run capability;
- retain source evidence that `modules:read` cannot invoke Shadow while `modules:manage` can complete an empty no-write scan;
- keep durable `runIndexReplay`, cancellation, StopHandle wiring, replay jobs/checkpoints, leases, mutation persistence and the Full runner unchanged;
- actualize dry-run/runtime/mode docs and guards, including a focused Shadow host-dispatch verifier;
- advance the M6 source cursor to authorization-first GraphQL transport for the guarded Shadow command; targeted mutation execution and partition replay remain separate.

## Mainline recheck

The branch was created while main was advancing and has merge base `0ae8f7f4382a4218107c43a4e1e6f1e5b957a84e` (#3328). Current main is `b96b27f03b2a2918fe614e982358fd7c722975ec`; intervening #3329 changes Product deployment corequisite preflight and #3330 changes Pages rollout snapshot paths. Both are disjoint from this Index/server replay slice.

## Production impact

This adds only a guarded server host route to an already-materialized no-write Index capability. No public Shadow GraphQL/API command is exposed in this PR, and no durable replay ownership or persistence semantics change.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.