### PR TITLE
feat(index): expose sealed shadow replay GraphQL transport

### DIFF
--- a/apps/server/docs/index-replay-graphql-transport.md
+++ b/apps/server/docs/index-replay-graphql-transport.md
@@ -1,33 +1,38 @@
 # Index replay GraphQL transport
 
-Status: `locale_source_complete_execution_pending`.
+Status: `full_locale_and_schema_wide_shadow_source_complete_execution_pending`.
 
 ## Boundary
 
-The server exposes two bounded GraphQL mutations over the guarded `IndexReplayOperatorRuntime`:
+The server exposes three bounded GraphQL mutations over server-owned guarded replay capabilities:
 
-- `runIndexReplay(input: ...)` runs one bounded schema-wide or exact-locale replay chunk and samples the server-owned graceful-shutdown signal at replay durable safe points;
-- `cancelIndexReplay(input: ...)` requests cancellation of one replay job in the authenticated tenant.
+- `runIndexReplay(input: ...)` runs one bounded durable Full schema-wide or exact-locale replay chunk and samples the server-owned graceful-shutdown signal at replay durable safe points;
+- `runIndexReplayShadow(input: ...)` runs one bounded **schema-wide**, side-effect-free Shadow validation chunk and returns only an authenticated confidential continuation token when more source pages remain;
+- `cancelIndexReplay(input: ...)` requests cancellation of one durable replay job in the authenticated tenant.
 
-This remains a command transport. It does not add automatic replay scheduling, background worker ownership, a
-new replay algorithm, partition checkpoint scope, explicit targeted/full/shadow rebuild modes, or a traffic
+This remains command transport. It does not add automatic replay scheduling, background worker ownership, a new
+replay algorithm, partition checkpoint scope, Targeted mutation execution, Shadow persistence, or a traffic
 cutover.
 
 ## Authority before input parsing
 
 Tenant and actor identities are never accepted from GraphQL input. The transport derives both from
 `TenantContext` / `AuthContext`, requires the request-bound effective permission snapshot, and requires
-`modules:manage` before parsing untrusted schema identifiers, schema version, optional locale, or job UUID.
+`modules:manage` before parsing untrusted schema identifiers, schema version, durable Full locale, Shadow
+continuation, or job UUID.
 
-Only after authorization does the run path canonicalize a supplied locale through `rustok_index::LocaleKey`.
-Locale input is bounded to 32 bytes before parsing. Omission is not inferred from schema metadata and preserves
-the historical schema-wide replay identity exactly.
+Only after authorization does the durable Full run path canonicalize a supplied locale through
+`rustok_index::LocaleKey`. Locale input is bounded to 32 bytes before parsing. Omission is not inferred from schema
+metadata and preserves the historical schema-wide durable replay identity exactly.
 
-The server-owned `IndexReplayOperatorRuntime` performs the same authorization again before delegating to the
-canonical shared replay runtime. A cross-tenant job UUID is therefore only looked up in the authenticated
-tenant and cannot widen authority.
+The schema-wide Shadow path intentionally has no locale input in this slice. Its continuation input is bounded to
+16 KiB only after authorization. The token is then authenticated, decrypted, expired and scope-checked by the
+server-owned Shadow transport runtime before any raw `IndexSourceCursor` is reconstructed.
 
-## Server-owned replay budget
+The guarded server runtimes perform the same request-bound authorization again before source execution. A
+cross-tenant durable job UUID or Shadow continuation therefore cannot widen authority.
+
+## Server-owned replay budgets
 
 `IndexReplayRunInput` contains only:
 
@@ -36,20 +41,50 @@ tenant and cannot widen authority.
 - positive schema routing key;
 - optional canonicalizable locale.
 
-It does not accept tenant, actor, worker identity, page limit, page count, heartbeat cadence, lease duration,
-partition, source name, database handle, scheduler controls, shutdown state, or a stop handle.
+`IndexReplayShadowRunInput` contains only:
 
-Each GraphQL invocation constructs a fresh server-owned worker identity and uses one fixed bounded chunk:
+- module name;
+- entity name;
+- positive schema routing key;
+- optional sealed continuation token.
+
+Neither input accepts tenant, actor, source name, database handle, scheduler controls, partition, retry state, or
+resource budget controls. The durable Full input additionally exposes no worker identity, heartbeat cadence, lease
+duration, shutdown state, or stop handle. The Shadow input exposes no job, checkpoint, lease, cancellation,
+worker, locale, page limit, or max-page field.
+
+Each durable Full GraphQL invocation constructs a fresh server-owned worker identity and uses one fixed bounded
+chunk:
 
 - page limit: `100` mutations;
 - maximum pages: `8`;
 - heartbeat cadence: every page;
 - lease duration: `60` seconds.
 
-Those transport caps are intentionally narrower than the generic replay runner bounds. A yielded job remains
-resumable by a later authorized invocation through the existing durable job/checkpoint contract.
+Each schema-wide Shadow invocation uses the same fixed source page limit and maximum-page count (`100 × 8`) but has
+no worker, lease or heartbeat because it creates no durable replay ownership. A yielded Shadow invocation is
+resumed only by presenting the sealed caller-carried continuation token to a later authorized invocation.
 
-## Locale identity
+## Shadow continuation boundary
+
+`IndexReplayShadowTransportRuntime` is a server-owned adapter over the already-guarded
+`IndexReplayOperatorRuntime::run_shadow` method. It reuses the deployment continuation keyring and frozen
+`SharedIndexSourceRegistry` already used by the source-page diagnosis transport.
+
+Authorization happens before token parsing. The adapter derives `IndexSourceContinuationScope` from the exact
+authenticated tenant, requested schema and frozen source owner. Incoming continuation is opened only after that
+scope is known; outgoing raw source cursor is sealed before the result crosses the adapter boundary.
+
+The current continuation scope is tenant/schema/source-bound but not locale-bound. Therefore this transport is
+intentionally schema-wide only. Exposing exact-locale Shadow replay before locale is included in continuation scope
+would permit an otherwise valid token to be replayed across different scan scopes, so locale transport remains a
+separate source boundary.
+
+The Shadow result exposes only Complete/Yielded status, bounded page/mutation/upsert/delete counters and the
+optional sealed continuation. It does not expose raw cursor JSON, source name, source payloads, source version,
+database errors, job/checkpoint identity, lease state, cancellation state, retry state or key material.
+
+## Locale identity for durable Full replay
 
 A supplied locale is canonicalized once at the transport boundary and carried by `IndexReplayRunRequest` into
 the multi-page runner. The runner derives both durable job lease scope and every page request from that same
@@ -88,45 +123,48 @@ The interruptible runner uses the same locale-aware lease helper as ordinary rep
 therefore keeps the same durable locale identity on the next authorized attempt instead of falling back to a
 schema job.
 
-The Index runtime and server operator remain lifecycle-type neutral; neither imports `StopHandle`. They accept
-only the boolean probe and keep authorization ahead of replay execution.
-
-If shutdown is observed at a replay safe point, the runner-level contract returns the job to durable `pending`
-without setting `cancel_requested` or publishing failure. A later process/authorized invocation may resume from
-the last committed checkpoint; already-durable deliveries remain duplicate-safe.
+Shadow replay does not import this durable lifecycle/cancellation path. It remains bounded by server-owned page
+counts and the source call timeout policy and creates no durable pending state to resume on host shutdown.
 
 The cancellation mutation does not sample or mutate shutdown state. User cancellation and host shutdown remain
 separate state machines.
 
 ## Result surface
 
-The run payload exposes only bounded operational counters plus status and job UUID. It does not expose source
-payloads, SQL, database errors, request authority, lease owner identity, locale internals, shutdown state, or raw
-dependency causes.
+The durable Full run payload exposes only bounded operational counters plus status and job UUID. It does not expose
+source payloads, SQL, database errors, request authority, lease owner identity, locale internals, shutdown state,
+or raw dependency causes.
 
-The cancellation payload exposes only the normalized outcome: requested, cancelled, already terminal, or not
-found. Operational runner failures are mapped to a generic GraphQL error; an unknown source-owned schema is
-reported as bad user input.
+The Shadow payload exposes only bounded validation counters plus status and optional sealed continuation. The
+cancellation payload exposes only the normalized durable outcome: requested, cancelled, already terminal, or not
+found.
+
+Operational runner failures are mapped to generic GraphQL errors; unknown source-owned schemas are reported as bad
+user input. Invalid/expired Shadow continuations receive stable input error codes while missing/unresolvable
+continuation keyring dependencies are reported through fixed server-owned error identities.
 
 ## Evidence state
 
 Source guards retain:
 
-- authorization-before-schema/locale parsing ordering;
+- authorization-before-schema/locale/continuation/job parsing ordering;
 - absence of caller authority/worker/resource-budget/shutdown/partition fields;
-- optional locale canonicalization and schema-wide omission compatibility;
-- exact runner page/job/checkpoint locale coupling;
+- optional durable locale canonicalization and schema-wide omission compatibility;
+- schema-wide Shadow input limited to schema identity plus sealed continuation;
+- exact durable runner page/job/checkpoint locale coupling;
 - locale-aware interruptible runner acquisition and terminal success fencing;
-- fixed server-owned bounds;
-- delegation only through `IndexReplayOperatorRuntime`;
-- merged GraphQL schema registration;
-- one shared lifecycle handle and API-host watch keepalive;
-- `StopHandle::is_stopping` as the only replay shutdown observation;
-- no direct database/source/scheduler access and no `.stop()` call from the transport.
+- fixed server-owned `100 × 8` bounds for both durable Full and schema-wide Shadow invocations;
+- Shadow continuation open/seal through the deployment keyring and frozen source scope;
+- delegation of Shadow execution only through guarded `IndexReplayOperatorRuntime::run_shadow`;
+- merged GraphQL schema registration through the existing `IndexReplayMutation` object;
+- one shared lifecycle handle and API-host watch keepalive for durable Full replay;
+- no direct database/source/scheduler access from GraphQL and no `.stop()` call from the transport.
 
-GraphQL execution, actual locale replay/restart execution, actual process-shutdown replay interruption, database
-replay execution, cancellation races, CI, and retained runtime evidence remain maintainer-owned and are not
-claimed by this source slice.
+GraphQL execution, actual Shadow source execution, continuation key deployment evidence, durable locale
+replay/restart execution, actual process-shutdown replay interruption, database replay execution, cancellation
+races, CI, and retained runtime evidence remain maintainer-owned and are not claimed by this source slice.
+
+Exact-locale Shadow transport remains source-open until continuation identity is locale-safe.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_replay.rs
+++ b/apps/server/src/graphql/index_replay.rs
@@ -14,12 +14,15 @@ use crate::context::{AuthContext, TenantContext};
 use crate::services::app_lifecycle::StopHandle;
 use crate::services::index_replay_runtime_composition::{
     IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
+    IndexReplayShadowOperatorError, IndexReplayShadowTransportError,
+    IndexReplayShadowTransportOutcome, IndexReplayShadowTransportRuntime,
 };
 use crate::services::rbac_request_scope::permissions_for;
 
 const MAX_SCHEMA_IDENTIFIER_BYTES: usize = 128;
 const MAX_SCHEMA_VERSION_BYTES: usize = 10;
 const MAX_LOCALE_BYTES: usize = 32;
+const MAX_CONTINUATION_BYTES: usize = 16 * 1024;
 const GRAPHQL_REPLAY_PAGE_LIMIT: usize = 100;
 const GRAPHQL_REPLAY_MAX_PAGES: usize = 8;
 const GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES: usize = 1;
@@ -35,6 +38,19 @@ pub struct IndexReplayRunInput {
     pub entity_name: String,
     pub schema_version: String,
     pub locale: Option<String>,
+}
+
+/// Untrusted input for one bounded schema-wide Shadow validation run.
+///
+/// The only resumable state is an authenticated confidential continuation token. Locale, source
+/// identity, page budget, jobs, checkpoints, leases, cancellation and retry controls are not
+/// caller fields in this schema-wide transport slice.
+#[derive(Debug, Clone, InputObject)]
+pub struct IndexReplayShadowRunInput {
+    pub module_name: String,
+    pub entity_name: String,
+    pub schema_version: String,
+    pub continuation: Option<String>,
 }
 
 #[derive(Debug, Clone, InputObject)]
@@ -85,6 +101,47 @@ impl TryFrom<rustok_index::IndexReplayRunOutcome> for IndexReplayRunPayload {
             applied_count: bounded_count(outcome.applied_count())?,
             duplicate_count: bounded_count(outcome.duplicate_count())?,
             stale_count: bounded_count(outcome.stale_count())?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+#[graphql(rename_items = "SCREAMING_SNAKE_CASE")]
+pub enum IndexReplayGraphqlShadowStatus {
+    Complete,
+    Yielded,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct IndexReplayShadowRunPayload {
+    pub status: IndexReplayGraphqlShadowStatus,
+    pub pages_scanned: i32,
+    pub mutations_scanned: i32,
+    pub upsert_count: i32,
+    pub delete_count: i32,
+    pub continuation: Option<String>,
+}
+
+impl TryFrom<IndexReplayShadowTransportOutcome> for IndexReplayShadowRunPayload {
+    type Error = FieldError;
+
+    fn try_from(outcome: IndexReplayShadowTransportOutcome) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: match outcome.status() {
+                rustok_index::IndexReplayDryRunStatus::Complete => {
+                    IndexReplayGraphqlShadowStatus::Complete
+                }
+                rustok_index::IndexReplayDryRunStatus::Yielded => {
+                    IndexReplayGraphqlShadowStatus::Yielded
+                }
+            },
+            pages_scanned: bounded_count(outcome.pages_scanned())?,
+            mutations_scanned: bounded_count(outcome.mutation_count())?,
+            upsert_count: bounded_count(outcome.upsert_count())?,
+            delete_count: bounded_count(outcome.delete_count())?,
+            continuation: outcome
+                .next_token()
+                .map(|token| token.as_str().to_owned()),
         })
     }
 }
@@ -171,6 +228,34 @@ impl IndexReplayMutation {
             .try_into()
     }
 
+    /// Run one server-bounded schema-wide side-effect-free Shadow validation chunk.
+    async fn run_index_replay_shadow(
+        &self,
+        ctx: &Context<'_>,
+        input: IndexReplayShadowRunInput,
+    ) -> GraphqlResult<IndexReplayShadowRunPayload> {
+        let auth = ctx
+            .data::<AuthContext>()
+            .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+        let tenant = ctx.data::<TenantContext>()?;
+
+        let (operator_context, schema, continuation) =
+            prepare_authorized_shadow_run(tenant.id, auth.user_id, input)
+                .map_err(map_preparation_error)?;
+        let runtime = shadow_replay_runtime(ctx)?;
+        runtime
+            .run_schema_wide(
+                operator_context,
+                schema,
+                continuation.as_deref(),
+                GRAPHQL_REPLAY_PAGE_LIMIT,
+                GRAPHQL_REPLAY_MAX_PAGES,
+            )
+            .await
+            .map_err(map_shadow_transport_error)?
+            .try_into()
+    }
+
     /// Request cancellation of one replay job in the authenticated tenant.
     async fn cancel_index_replay(
         &self,
@@ -200,6 +285,17 @@ fn replay_runtime(ctx: &Context<'_>) -> GraphqlResult<IndexReplayOperatorRuntime
         .cloned()
         .ok_or_else(|| {
             <FieldError as GraphQLError>::internal_error("Index replay runtime is not available")
+        })
+}
+
+fn shadow_replay_runtime(ctx: &Context<'_>) -> GraphqlResult<IndexReplayShadowTransportRuntime> {
+    ctx.data::<Arc<ModuleRuntimeExtensions>>()?
+        .get::<IndexReplayShadowTransportRuntime>()
+        .cloned()
+        .ok_or_else(|| {
+            <FieldError as GraphQLError>::internal_error(
+                "Index replay Shadow transport runtime is not available",
+            )
         })
 }
 
@@ -241,6 +337,30 @@ fn prepare_authorized_run(
         field: "schema_version",
     })?;
     Ok((context, request))
+}
+
+fn prepare_authorized_shadow_run(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    input: IndexReplayShadowRunInput,
+) -> std::result::Result<
+    (
+        IndexReplayOperatorContext,
+        rustok_index::SchemaRef,
+        Option<String>,
+    ),
+    IndexReplayTransportPreparationError,
+> {
+    let context = authorize(tenant_id, actor_id)?;
+    let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;
+    let continuation = input
+        .continuation
+        .map(|value| {
+            bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;
+            Ok(value)
+        })
+        .transpose()?;
+    Ok((context, schema, continuation))
 }
 
 fn prepare_authorized_cancel(
@@ -373,6 +493,94 @@ fn map_operator_error(error: IndexReplayOperatorError) -> FieldError {
     }
 }
 
+fn map_shadow_transport_error(error: IndexReplayShadowTransportError) -> FieldError {
+    match error {
+        IndexReplayShadowTransportError::Authorization(error) => map_operator_error(error),
+        IndexReplayShadowTransportError::ContinuationUnavailable => fixed_shadow_dependency_error(
+            "INDEX_REPLAY_SHADOW_CONTINUATION_UNAVAILABLE",
+            false,
+            "Index replay Shadow continuation is unavailable",
+        ),
+        IndexReplayShadowTransportError::ContinuationKeyringUnavailable => {
+            fixed_shadow_dependency_error(
+                "INDEX_REPLAY_SHADOW_CONTINUATION_KEYRING_UNAVAILABLE",
+                true,
+                "Index replay Shadow continuation dependency failed",
+            )
+        }
+        IndexReplayShadowTransportError::Continuation(error) => {
+            map_shadow_continuation_error(error)
+        }
+        IndexReplayShadowTransportError::Request(error) => map_shadow_dry_run_error(error),
+        IndexReplayShadowTransportError::Shadow(
+            IndexReplayShadowOperatorError::Authorization(error),
+        ) => map_operator_error(error),
+        IndexReplayShadowTransportError::Shadow(IndexReplayShadowOperatorError::DryRun(error)) => {
+            map_shadow_dry_run_error(error)
+        }
+    }
+}
+
+fn map_shadow_continuation_error(error: rustok_index::IndexSourceContinuationError) -> FieldError {
+    use rustok_index::IndexSourceContinuationError as Error;
+
+    match error {
+        Error::UnknownSchemaSource(_) => {
+            <FieldError as GraphQLError>::bad_user_input("Unknown Index replay schema")
+        }
+        Error::Expired => shadow_continuation_input_error("INDEX_REPLAY_SHADOW_CONTINUATION_EXPIRED"),
+        Error::EmptyToken
+        | Error::TokenTooLarge { .. }
+        | Error::DecodedTokenTooLarge { .. }
+        | Error::PlaintextTooLarge { .. }
+        | Error::Base64(_)
+        | Error::MalformedEnvelope
+        | Error::UnsupportedVersion(_)
+        | Error::InvalidKeyId(_)
+        | Error::KeyUnavailable(_)
+        | Error::InvalidToken
+        | Error::Postcard(_)
+        | Error::ContractVersionMismatch
+        | Error::TenantMismatch
+        | Error::SchemaMismatch
+        | Error::SourceOwnerMismatch
+        | Error::SourceNameMismatch
+        | Error::InvalidClaimsLifetime
+        | Error::IssuedAtInFuture => {
+            shadow_continuation_input_error("INDEX_REPLAY_SHADOW_CONTINUATION_INVALID")
+        }
+        _ => <FieldError as GraphQLError>::internal_error(
+            "Index replay Shadow continuation processing failed",
+        ),
+    }
+}
+
+fn shadow_continuation_input_error(code: &'static str) -> FieldError {
+    FieldError::new("Invalid Index replay Shadow continuation").extend_with(|_, extensions| {
+        extensions.set("code", code);
+    })
+}
+
+fn map_shadow_dry_run_error(error: rustok_index::IndexReplayDryRunError) -> FieldError {
+    match error {
+        rustok_index::IndexReplayDryRunError::UnknownSchemaSource(_) => {
+            <FieldError as GraphQLError>::bad_user_input("Unknown Index replay schema")
+        }
+        _ => <FieldError as GraphQLError>::internal_error("Index replay Shadow command failed"),
+    }
+}
+
+fn fixed_shadow_dependency_error(
+    code: &'static str,
+    retryable: bool,
+    message: &'static str,
+) -> FieldError {
+    FieldError::new(message).extend_with(|_, extensions| {
+        extensions.set("code", code);
+        extensions.set("retryable", retryable);
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use rustok_api::Permission;
@@ -381,9 +589,10 @@ mod tests {
 
     use super::{
         GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES, GRAPHQL_REPLAY_LEASE_SECONDS,
-        GRAPHQL_REPLAY_MAX_PAGES, GRAPHQL_REPLAY_PAGE_LIMIT, IndexReplayCancelInput,
-        IndexReplayRunInput, IndexReplayTransportPreparationError, prepare_authorized_cancel,
-        prepare_authorized_run,
+        GRAPHQL_REPLAY_MAX_PAGES, GRAPHQL_REPLAY_PAGE_LIMIT, MAX_CONTINUATION_BYTES,
+        IndexReplayCancelInput, IndexReplayRunInput, IndexReplayShadowRunInput,
+        IndexReplayTransportPreparationError, prepare_authorized_cancel, prepare_authorized_run,
+        prepare_authorized_shadow_run,
     };
     use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
 
@@ -393,6 +602,15 @@ mod tests {
             entity_name: "product".to_owned(),
             schema_version: "zero".to_owned(),
             locale: Some("not a locale!!!".to_owned()),
+        }
+    }
+
+    fn malformed_shadow_run() -> IndexReplayShadowRunInput {
+        IndexReplayShadowRunInput {
+            module_name: "Rustok Product".to_owned(),
+            entity_name: "product".to_owned(),
+            schema_version: "zero".to_owned(),
+            continuation: Some("not-a-token".to_owned()),
         }
     }
 
@@ -423,6 +641,100 @@ mod tests {
         .await
         .expect_err("modules:read must fail before replay input parsing");
         assert_eq!(forbidden, IndexReplayTransportPreparationError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn shadow_transport_authorizes_before_schema_and_continuation_parsing() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+
+        let missing = with_rbac_request_scope(None, async {
+            prepare_authorized_shadow_run(tenant_id, actor_id, malformed_shadow_run())
+        })
+        .await
+        .expect_err("missing authority must win over malformed Shadow input");
+        assert_eq!(
+            missing,
+            IndexReplayTransportPreparationError::MissingRequestAuthority
+        );
+
+        let forbidden = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_READ],
+                UserRole::Admin,
+            )),
+            async {
+                prepare_authorized_shadow_run(tenant_id, actor_id, malformed_shadow_run())
+            },
+        )
+        .await
+        .expect_err("modules:read must fail before Shadow input parsing");
+        assert_eq!(forbidden, IndexReplayTransportPreparationError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn shadow_transport_accepts_only_schema_and_bounded_sealed_continuation() {
+        let tenant_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let (_, schema, continuation) = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                prepare_authorized_shadow_run(
+                    tenant_id,
+                    actor_id,
+                    IndexReplayShadowRunInput {
+                        module_name: "rustok-product".to_owned(),
+                        entity_name: "product".to_owned(),
+                        schema_version: "4".to_owned(),
+                        continuation: Some("sealed-token".to_owned()),
+                    },
+                )
+            },
+        )
+        .await
+        .expect("authorized Shadow input should parse");
+
+        assert_eq!(schema.module.as_str(), "rustok-product");
+        assert_eq!(schema.entity.as_str(), "product");
+        assert_eq!(schema.version.get(), 4);
+        assert_eq!(continuation.as_deref(), Some("sealed-token"));
+
+        let oversized = "x".repeat(MAX_CONTINUATION_BYTES + 1);
+        let error = with_rbac_request_scope(
+            Some(RbacRequestScope::new(
+                tenant_id,
+                actor_id,
+                vec![Permission::MODULES_MANAGE],
+                UserRole::Admin,
+            )),
+            async {
+                prepare_authorized_shadow_run(
+                    tenant_id,
+                    actor_id,
+                    IndexReplayShadowRunInput {
+                        module_name: "rustok-product".to_owned(),
+                        entity_name: "product".to_owned(),
+                        schema_version: "4".to_owned(),
+                        continuation: Some(oversized),
+                    },
+                )
+            },
+        )
+        .await
+        .expect_err("oversized Shadow continuation must fail closed");
+        assert_eq!(
+            error,
+            IndexReplayTransportPreparationError::InvalidInput {
+                field: "continuation"
+            }
+        );
     }
 
     #[tokio::test]

--- a/apps/server/src/services/index_replay_runtime_composition.rs
+++ b/apps/server/src/services/index_replay_runtime_composition.rs
@@ -6,6 +6,8 @@ mod drift_diagnosis_operator;
 mod source_continuation_runtime;
 #[path = "index_drift_source_page_diagnosis.rs"]
 mod drift_source_page_diagnosis;
+#[path = "index_replay_shadow_transport.rs"]
+mod replay_shadow_transport;
 
 pub use drift_diagnosis_operator::{
     IndexDriftDiagnosisOperatorError, IndexDriftDiagnosisOperatorRuntime,
@@ -17,6 +19,10 @@ pub use drift_source_page_diagnosis::{
 pub use reconciliation_operator::{
     IndexReconciliationOperatorContext, IndexReconciliationOperatorError,
     IndexReconciliationOperatorRuntime,
+};
+pub use replay_shadow_transport::{
+    IndexReplayShadowTransportError, IndexReplayShadowTransportOutcome,
+    IndexReplayShadowTransportRuntime,
 };
 
 use std::fmt;
@@ -174,8 +180,8 @@ impl fmt::Debug for IndexReplayOperatorRuntime {
 /// This function performs no database I/O and starts no worker. It invokes selected source
 /// factories only to construct adapters, freezes the complete source catalog, binds the immutable
 /// schema/source registries to the host database, and publishes the guarded bounded full/shadow
-/// replay, reconciliation, exact-entity drift diagnosis, and one-page source-candidate diagnosis
-/// capabilities through `ModuleRuntimeExtensions`.
+/// replay, reconciliation, exact-entity drift diagnosis, one-page source-candidate diagnosis, and
+/// sealed schema-wide Shadow transport capabilities through `ModuleRuntimeExtensions`.
 pub(crate) fn materialize_index_replay_runtime(
     extensions: &mut ModuleRuntimeExtensions,
     db: DatabaseConnection,
@@ -230,6 +236,10 @@ pub(crate) fn materialize_index_replay_runtime(
     } else {
         None
     };
+    replay_shadow_transport::materialize_index_replay_shadow_transport(
+        extensions,
+        continuation.clone(),
+    )?;
     drift_source_page_diagnosis::materialize_index_drift_source_page_diagnosis(
         extensions,
         continuation,
@@ -259,7 +269,8 @@ mod tests {
     use super::{
         IndexDriftDiagnosisOperatorRuntime, IndexDriftSourcePageDiagnosisRuntime,
         IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
-        IndexReplayShadowOperatorError, materialize_index_replay_runtime,
+        IndexReplayShadowOperatorError, IndexReplayShadowTransportRuntime,
+        materialize_index_replay_runtime,
     };
     use crate::services::rbac_request_scope::{RbacRequestScope, with_rbac_request_scope};
 
@@ -372,6 +383,7 @@ mod tests {
         assert!(!extensions.contains::<SharedIndexReplayRuntime>());
         assert!(!extensions.contains::<SharedIndexReplayDryRunRuntime>());
         assert!(!extensions.contains::<IndexReplayOperatorRuntime>());
+        assert!(!extensions.contains::<IndexReplayShadowTransportRuntime>());
         assert!(!extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
         assert!(!extensions.contains::<IndexDriftSourcePageDiagnosisRuntime>());
     }
@@ -395,11 +407,13 @@ mod tests {
         assert!(extensions.contains::<SharedIndexReplayRuntime>());
         assert!(extensions.contains::<SharedIndexReplayDryRunRuntime>());
         assert!(extensions.contains::<IndexReplayOperatorRuntime>());
+        assert!(extensions.contains::<IndexReplayShadowTransportRuntime>());
         assert!(extensions.contains::<IndexDriftDiagnosisOperatorRuntime>());
         assert!(extensions.contains::<IndexDriftSourcePageDiagnosisRuntime>());
 
         let host = extensions.apply_to_host_runtime(rustok_api::HostRuntimeContext::new(db));
         assert!(host.shared_get::<IndexReplayOperatorRuntime>().is_some());
+        assert!(host.shared_get::<IndexReplayShadowTransportRuntime>().is_some());
         assert!(host
             .shared_get::<IndexDriftDiagnosisOperatorRuntime>()
             .is_some());

--- a/apps/server/src/services/index_replay_shadow_transport.rs
+++ b/apps/server/src/services/index_replay_shadow_transport.rs
@@ -1,0 +1,179 @@
+use chrono::Utc;
+use rustok_core::ModuleRuntimeExtensions;
+use thiserror::Error;
+
+use super::{
+    IndexReplayOperatorContext, IndexReplayOperatorError, IndexReplayOperatorRuntime,
+    IndexReplayShadowOperatorError,
+    source_continuation_runtime::IndexSourceContinuationKeyringRuntime,
+};
+use crate::error::{Error as ServerError, Result};
+
+#[derive(Debug, Error)]
+pub enum IndexReplayShadowTransportError {
+    #[error(transparent)]
+    Authorization(#[from] IndexReplayOperatorError),
+    #[error("Index replay Shadow continuation keyring is not configured")]
+    ContinuationUnavailable,
+    #[error("Index replay Shadow continuation keyring could not be resolved")]
+    ContinuationKeyringUnavailable,
+    #[error(transparent)]
+    Continuation(#[from] rustok_index::IndexSourceContinuationError),
+    #[error(transparent)]
+    Request(#[from] rustok_index::IndexReplayDryRunError),
+    #[error(transparent)]
+    Shadow(#[from] IndexReplayShadowOperatorError),
+}
+
+/// Transport-safe Shadow replay result.
+///
+/// Raw source cursors and source ownership are intentionally absent. An unfinished run returns only
+/// the authenticated confidential continuation token produced by the deployment-owned keyring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayShadowTransportOutcome {
+    status: rustok_index::IndexReplayDryRunStatus,
+    next_token: Option<rustok_index::IndexSourceContinuationToken>,
+    pages_scanned: usize,
+    mutation_count: usize,
+    upsert_count: usize,
+    delete_count: usize,
+}
+
+impl IndexReplayShadowTransportOutcome {
+    fn from_dry_run(
+        outcome: rustok_index::IndexReplayDryRunOutcome,
+        next_token: Option<rustok_index::IndexSourceContinuationToken>,
+    ) -> Self {
+        Self {
+            status: outcome.status(),
+            next_token,
+            pages_scanned: outcome.pages_scanned(),
+            mutation_count: outcome.mutation_count(),
+            upsert_count: outcome.upsert_count(),
+            delete_count: outcome.delete_count(),
+        }
+    }
+
+    pub fn status(&self) -> rustok_index::IndexReplayDryRunStatus {
+        self.status
+    }
+
+    pub fn next_token(&self) -> Option<&rustok_index::IndexSourceContinuationToken> {
+        self.next_token.as_ref()
+    }
+
+    pub fn pages_scanned(&self) -> usize {
+        self.pages_scanned
+    }
+
+    pub fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    pub fn upsert_count(&self) -> usize {
+        self.upsert_count
+    }
+
+    pub fn delete_count(&self) -> usize {
+        self.delete_count
+    }
+}
+
+/// Server-owned transport adapter for schema-wide Shadow replay.
+///
+/// Authorization runs before continuation parsing. The adapter owns no database connection,
+/// replay job, checkpoint, lease, cancellation state, retry state, scheduler, or worker handle.
+#[derive(Clone)]
+pub struct IndexReplayShadowTransportRuntime {
+    operator: IndexReplayOperatorRuntime,
+    sources: rustok_index::SharedIndexSourceRegistry,
+    continuation: Option<IndexSourceContinuationKeyringRuntime>,
+}
+
+impl IndexReplayShadowTransportRuntime {
+    fn new(
+        operator: IndexReplayOperatorRuntime,
+        sources: rustok_index::SharedIndexSourceRegistry,
+        continuation: Option<IndexSourceContinuationKeyringRuntime>,
+    ) -> Self {
+        Self {
+            operator,
+            sources,
+            continuation,
+        }
+    }
+
+    pub async fn run_schema_wide(
+        &self,
+        context: IndexReplayOperatorContext,
+        schema: rustok_index::SchemaRef,
+        continuation: Option<&str>,
+        page_limit: usize,
+        max_pages: usize,
+    ) -> std::result::Result<
+        IndexReplayShadowTransportOutcome,
+        IndexReplayShadowTransportError,
+    > {
+        context.authorize_for(context.tenant_id())?;
+        let keyring = self
+            .continuation
+            .as_ref()
+            .ok_or(IndexReplayShadowTransportError::ContinuationUnavailable)?;
+        let scope = rustok_index::IndexSourceContinuationScope::from_registry(
+            context.tenant_id(),
+            schema.clone(),
+            &self.sources,
+        )?;
+        let codec = keyring
+            .resolve_codec()
+            .await
+            .map_err(|_| IndexReplayShadowTransportError::ContinuationKeyringUnavailable)?;
+        let cursor = continuation
+            .map(|encoded| codec.open_encoded(&scope, encoded, Utc::now()))
+            .transpose()?;
+        let request = rustok_index::IndexReplayDryRunRequest::new(
+            context.tenant_id(),
+            schema,
+            cursor,
+            page_limit,
+            max_pages,
+        )?;
+        let outcome = self.operator.run_shadow(context, request).await?;
+        let next_token = outcome
+            .next_cursor()
+            .map(|cursor| codec.seal(&scope, cursor, Utc::now(), keyring.lifetime()))
+            .transpose()?;
+        Ok(IndexReplayShadowTransportOutcome::from_dry_run(
+            outcome,
+            next_token,
+        ))
+    }
+}
+
+pub(super) fn materialize_index_replay_shadow_transport(
+    extensions: &mut ModuleRuntimeExtensions,
+    continuation: Option<IndexSourceContinuationKeyringRuntime>,
+) -> Result<()> {
+    if extensions.contains::<IndexReplayShadowTransportRuntime>() {
+        return Err(ServerError::Message(
+            "Index replay Shadow transport runtime is already materialized".to_string(),
+        ));
+    }
+    let Some(operator) = extensions.get::<IndexReplayOperatorRuntime>().cloned() else {
+        return Ok(());
+    };
+    let sources = extensions
+        .get::<rustok_index::SharedIndexSourceRegistry>()
+        .cloned()
+        .ok_or_else(|| {
+            ServerError::Message(
+                "Index replay Shadow transport requires the shared source registry".to_string(),
+            )
+        })?;
+    extensions.insert(IndexReplayShadowTransportRuntime::new(
+        operator,
+        sources,
+        continuation,
+    ));
+    Ok(())
+}

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@cbf01df654252e53013da60e5621274a2ce08497` and continued on
-`agent/index-replay-shadow-host-dispatch-20260808`.
+Status overlay rechecked at `main@488803a831e725ef0fbeaa8540f09458ee461b85` and continued on
+`agent/index-replay-shadow-graphql-transport-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -108,18 +108,22 @@ register a key3 Product source/factory. Runtime dual-read compatibility remains 
 
 ## M6 replay command transport
 
-`IndexReplayOperatorRuntime` remains the only server-owned replay invocation authority. It requires exact
-request-bound tenant/actor context and effective `modules:manage`, rejects cross-tenant run requests and derives
-cancel tenant from that context.
+`IndexReplayOperatorRuntime` remains the server-owned replay invocation authority. It requires exact request-bound
+tenant/actor context and effective `modules:manage`, rejects cross-tenant run requests and derives cancel tenant
+from that context.
 
-The guarded operator now retains both the durable `SharedIndexReplayRuntime` and the existing no-write
+The guarded operator retains both the durable `SharedIndexReplayRuntime` and the no-write
 `SharedIndexReplayDryRunRuntime`. `run_shadow` authorizes the exact dry-run request tenant through the same
 request-bound `modules:manage` snapshot before delegating to the side-effect-free runtime. It creates no replay
 job/checkpoint and exposes no lease, cancellation, scheduler or database handle.
 
-The GraphQL layer still exposes only source-complete schema-wide or exact-locale durable `runIndexReplay` plus
-`cancelIndexReplay`; Shadow transport is not exposed yet. Authorization occurs before parsing untrusted schema,
-locale or job input.
+The GraphQL layer now exposes three source-complete command surfaces:
+
+- schema-wide or exact-locale durable `runIndexReplay`;
+- schema-wide no-write `runIndexReplayShadow`;
+- durable `cancelIndexReplay`.
+
+Authorization occurs before parsing untrusted schema, durable locale, Shadow continuation or job input.
 
 Caller durable run input contains only module/entity/schema key plus one optional bounded locale. Tenant, actor,
 worker ID, source name, partition, scheduler handle, replay resource budget, stop handle and shutdown flag remain
@@ -128,8 +132,20 @@ exactly schema-wide; it is not rewritten from schema locale defaults. Each durab
 worker identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page
 and a 60-second lease.
 
-Retained command source evidence includes schema-wide command behavior, locale command canonicalization and a
-dedicated locale yield/isolation/fresh-runtime resume packet. GraphQL execution/admission remains maintainer-owned.
+Caller Shadow input contains only module/entity/schema key plus one optional bounded sealed continuation. It has
+no locale, source name, raw source cursor, worker, page/max-page budget, job, checkpoint, lease, cancellation,
+retry or scheduler fields. The server uses the same fixed 100-page-size / 8-page invocation budget, repeats exact
+tenant authorization, opens continuation through the deployment keyring under frozen tenant/schema/source scope,
+calls guarded `run_shadow`, and seals any outgoing cursor before GraphQL serialization.
+
+The current source continuation scope does not include locale identity, so Shadow transport is deliberately
+schema-wide. Exact-locale Shadow remains blocked until schema-wide and canonical locale continuations cannot be
+replayed across one another.
+
+Retained durable command source evidence includes schema-wide command behavior, locale command canonicalization
+and a dedicated locale yield/isolation/fresh-runtime resume packet. Shadow source evidence now retains
+authorization-first schema/continuation preparation and sealed non-durable resume routing. GraphQL execution and
+admission remain maintainer-owned.
 
 ## M6 replay graceful interruption and server lifecycle binding
 
@@ -245,13 +261,14 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
   bounded exact-key count, tenant/schema scope and uniqueness checks;
 - `Shadow` -> `SideEffectFreeScan`; this matches the existing `SharedIndexReplayDryRunRuntime` no-write boundary.
 
-The server host now guards `Shadow` through `IndexReplayOperatorRuntime::run_shadow`, using the same exact
-request-bound `modules:manage` authorization check as Full. This does not add a mode column to jobs/checkpoints, a
-second lease owner, retry state, partition dimension, targeted mutation executor or shadow persistence. See
-`m6-replay-mode-contract.md` and `m6-bounded-replay-dry-run.md`.
+The server guards `Shadow` through `IndexReplayOperatorRuntime::run_shadow`, using the same exact request-bound
+`modules:manage` authorization check as Full. Schema-wide GraphQL Shadow transport now sits on a separate sealed
+continuation adapter and does not reinterpret the durable `runIndexReplay` command or add a mode column to jobs or
+checkpoints.
 
-The explicit mode identity and Shadow host dispatch are source-complete. Public Shadow transport/admission remains
-open and maintainer execution is not claimed.
+The explicit mode identity, Shadow host dispatch and schema-wide Shadow GraphQL transport are source-complete.
+Exact-locale Shadow transport remains source-open behind locale-safe continuation identity. Maintainer execution
+and admission are not claimed.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -294,14 +311,16 @@ open and maintainer execution is not claimed.
 - [x] Retain deterministic two-host lease-expiry/reclaim/stale-owner fencing evidence through distinct replay runners.
 - [x] Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.
 - [x] Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.
+- [x] Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.
+- [ ] Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
+- [ ] Execute/admit schema-wide Shadow GraphQL transport and continuation-key deployment evidence.
 - [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
 - [ ] Execute/admit retained dependency pending-future timeout evidence.
 - [ ] Execute/admit retained page lease-heartbeat evidence.
 - [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
 - [ ] Execute/admit retained multi-host reclaim evidence.
-- [ ] Add authorization-first GraphQL transport for the guarded Shadow replay command.
 - [ ] Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.
 - [ ] Add partition replay scope only after a real partition-capable source contract exists.
 
@@ -339,17 +358,17 @@ M7 Storefront remains execution/admission-gated and must not gain a traffic swit
 
 The locale request/source/job/checkpoint/runner/GraphQL identity chain, dependency timeout set,
 page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence, explicit Full/Targeted/Shadow
-mode identity and guarded Shadow host dispatch are source-complete. Their retained packets still require maintainer
-execution/admission.
+mode identity, guarded Shadow host dispatch and schema-wide Shadow GraphQL transport are source-complete. Their
+retained packets still require maintainer execution/admission.
 
 Partition replay remains blocked: no real partition-capable source contract can yet filter a partition before
 pagination, so do not merely populate `partition_key`.
 
-For source-only M6 continuation, the next independent boundary is authorization-first GraphQL transport for the
-guarded `Shadow` replay command. It must call `IndexReplayOperatorRuntime::run_shadow`, keep the existing durable
-`runIndexReplay` path as Full, keep any resume cursor caller-carried/non-durable, and must not expose job,
-checkpoint, lease, cancellation or retry controls for Shadow. Optional locale support should reuse the canonical
-source-scan locale contract rather than become mode-specific durable state.
+For source-only M6 continuation, the next independent boundary is locale-safe Shadow continuation identity before
+exact-locale GraphQL transport. The source continuation contract must distinguish schema-wide from canonical
+exact-locale scans while preserving tenant/schema/source binding and existing schema-wide continuation behavior.
+Only after that boundary should Shadow GraphQL accept locale and construct `IndexSourceScanRequest::for_locale`;
+it still must not create job, checkpoint, lease, cancellation or retry state.
 
 Targeted execution remains separate until the bounded mutation-application contract over `IndexSource::load` is
 defined.

--- a/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
+++ b/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
@@ -1,10 +1,11 @@
 # M6 bounded replay dry-run
 
-Status: `source_complete_transport_pending`
+Status: `source_complete_schema_wide_transport_execution_pending`
 
 This slice adds an Index-owned, side-effect-free validation runtime over the exact immutable
-`SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay, and now
-binds that capability behind the server-owned request-bound replay operator guard.
+`SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay, binds that capability
+behind the server-owned request-bound replay operator guard, and now exposes a bounded schema-wide GraphQL Shadow
+command through an authenticated confidential continuation boundary.
 
 ## Contract
 
@@ -24,7 +25,7 @@ then scans at most the requested page budget. For every returned page it verifie
 - page-local event UUID uniqueness before accepting the page;
 - complete `SchemaRegistry::validate_mutation` validity for every upsert or delete.
 
-The outcome reports the stable source name, completion or bounded yield, a resume cursor only when
+The internal outcome reports the stable source name, completion or bounded yield, a resume cursor only when
 unfinished, page/mutation/upsert/delete counts, and the maximum observed source version.
 
 ## Source-call boundary
@@ -52,30 +53,50 @@ Materialization performs no source call and no database I/O. The capability is p
 when both immutable registries exist; an absent source registry publishes nothing, and a source
 registry without its shared schema registry fails closed.
 
-A yielded run is resumed only by explicitly passing its returned opaque cursor into another
-bounded request. No durable cursor is implied.
+A yielded internal dry-run is resumed only by explicitly passing its returned opaque cursor into another bounded
+request. No durable cursor is implied.
 
 ## Server-owned host guard
 
-`IndexReplayOperatorRuntime` now retains the already-materialized
-`SharedIndexReplayDryRunRuntime` beside the durable `SharedIndexReplayRuntime` and exposes
-`IndexReplayOperatorRuntime::run_shadow`.
+`IndexReplayOperatorRuntime` retains the already-materialized `SharedIndexReplayDryRunRuntime` beside the durable
+`SharedIndexReplayRuntime` and exposes `IndexReplayOperatorRuntime::run_shadow`.
 
-`run_shadow` reuses the same request-bound `modules:manage` authorization boundary as durable full
-replay. The exact request tenant must match the operator context before the side-effect-free source
-scan can start. The operator publishes no database connection, source registry, scheduler, worker
-handle, job identifier, lease control, cancellation state, or retry/requeue control to the caller.
+`run_shadow` reuses the same request-bound `modules:manage` authorization boundary as durable Full replay. The
+exact request tenant must match the operator context before the side-effect-free source scan can start. The
+operator publishes no database connection, source registry, scheduler, worker handle, job identifier, lease
+control, cancellation state, or retry/requeue control to the caller.
 
-Server composition fails closed if durable replay materializes but the expected dry-run capability
-is missing. Retained server source evidence covers `modules:read` rejection and an authorized
-`modules:manage` empty-page completion through the guarded Shadow method. That completion creates
-no durable replay job or checkpoint and does not alter the Full runner.
+Server composition fails closed if durable replay materializes but the expected dry-run capability is missing.
+Retained server source evidence covers `modules:read` rejection and an authorized `modules:manage` empty-page
+completion through the guarded Shadow method. That completion creates no durable replay job or checkpoint and
+does not alter the Full runner.
+
+## Schema-wide GraphQL Shadow transport
+
+`runIndexReplayShadow` now exposes one bounded schema-wide invocation through
+`IndexReplayShadowTransportRuntime`.
+
+The GraphQL preparation path derives tenant/actor from request context and requires effective `modules:manage`
+**before** parsing untrusted schema identifiers or continuation text. The server adapter repeats exact-tenant
+authorization before opening the token or constructing `IndexReplayDryRunRequest`.
+
+Caller input contains only module/entity/schema routing identity plus one optional sealed continuation token. Page
+limit and maximum pages remain server-owned at `100` and `8`. Locale, source identity, raw cursor JSON, job,
+checkpoint, lease, worker, cancellation and retry controls are unavailable.
+
+The adapter reuses the deployment `IndexSourceContinuationKeyringRuntime` and canonical frozen
+`IndexSourceContinuationScope`. Incoming tokens are authenticated, decrypted, expired and tenant/schema/source
+scope-checked before the raw cursor is reconstructed. An outgoing raw cursor is sealed before returning to GraphQL.
+The transport-safe result contains only Complete/Yielded status, bounded counters and optional sealed
+continuation; it omits internal source name and source version.
+
+This transport is intentionally schema-wide. The existing continuation scope does not yet carry locale identity,
+so exact-locale Shadow replay must not be exposed until schema-wide versus exact-locale continuation scopes are
+cryptographically distinct.
 
 ## Explicitly open
 
-- GraphQL, HTTP, CLI, or admin transport surfaces for Shadow invocation;
-- authorization-first parsing/serialization of a bounded Shadow transport request and resume cursor;
-- optional canonical locale scope for the Shadow/dry-run transport path;
+- exact-locale Shadow/dry-run transport after continuation identity becomes locale-safe;
 - persisted dry-run reports or comparison snapshots;
 - cross-page duplicate event detection beyond one bounded page;
 - mutation/checkpoint timing simulation and interruption;
@@ -84,14 +105,14 @@ no durable replay job or checkpoint and does not alter the Full runner.
 - configurable per-source or per-request timeout policy;
 - retained production-source and PostgreSQL execution evidence.
 
-Transport code must call the guarded operator boundary rather than treat
-`SharedIndexReplayDryRunRuntime` as an authorized public endpoint. The existing GraphQL
-`runIndexReplay` command remains durable Full replay and is unchanged by the host-guard slice.
+Transport code calls the guarded server adapter/operator chain rather than treating
+`SharedIndexReplayDryRunRuntime` as an authorized public endpoint. The existing GraphQL `runIndexReplay` command
+remains durable Full replay and is unchanged by Shadow transport.
 
 ## Validation ownership
 
-Formatting, Cargo checks/tests, JavaScript verifiers, source-adapter execution, and PostgreSQL
-validation are maintainer-run. The implementation agent did not execute them.
+Formatting, Cargo checks/tests, JavaScript verifiers, source-adapter execution, PostgreSQL validation, workflows
+and CI are maintainer-run. The implementation agent did not execute them.
 
 Suggested commands:
 
@@ -101,4 +122,5 @@ cargo test -p rustok-index replay_dry_run -- --nocapture
 cargo check -p rustok-index --all-targets
 node scripts/verify/verify-index-replay-runtime-composition.mjs
 node scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+node scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
 ```

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -1,10 +1,10 @@
 # M6 replay mode contract
 
-Status: `source_complete_shadow_host_dispatch_transport_pending`.
+Status: `source_complete_shadow_schema_wide_transport_locale_pending`.
 
 This slice defines explicit rebuild mode identity without changing the existing durable replay runner, job,
-checkpoint, cancellation, locale or lease state machines. The Shadow execution surface is now also bound to the
-server-owned request authorization guard, while public transport remains separate.
+checkpoint, cancellation, locale or lease state machines. Shadow execution is bound to the server-owned request
+authorization guard and now has a dedicated schema-wide GraphQL command through a sealed continuation boundary.
 
 ## Mode identity
 
@@ -18,50 +18,68 @@ server-owned request authorization guard, while public transport remains separat
 - `Shadow` — side-effect-free cursor scan. Its execution surface is `SideEffectFreeScan`, matching the existing
   `SharedIndexReplayDryRunRuntime` no-write boundary.
 
-Mode is not locale scope and is not future partition scope. Adding a locale to a full scan does not create a new
+Mode is not locale scope and is not future partition scope. Adding a locale to a Full scan does not create a new
 mode, and adding partition replay later must not encode partition identity as a mode.
 
 ## Fail-closed routing
 
 `IndexReplayModeSelection::is_admitted_to_durable_scan_runner` returns true only for `Full`.
 
-Targeted and shadow modes must not alias the full durable job/checkpoint identity:
+Targeted and Shadow modes must not alias the Full durable job/checkpoint identity:
 
-- targeted execution must be a bounded `IndexSource::load` path and must define its own operator execution
+- Targeted execution must be a bounded `IndexSource::load` path and must define its own operator execution
   contract before it can persist mutations;
-- shadow execution remains no-write and uses the dry-run surface rather than the durable mutation/job/checkpoint
+- Shadow execution remains no-write and uses the dry-run surface rather than the durable mutation/job/checkpoint
   path;
 - neither mode introduces automatic retry/requeue, another lease owner, another terminal job state, or a second
   cancellation model.
 
-The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner` and GraphQL `runIndexReplay` command remain
-full-scan behavior. They do not accept a generic mode selector and are not reinterpreted by this contract.
+The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner` and GraphQL `runIndexReplay` command remain Full
+scan behavior. They do not accept a generic mode selector and are not reinterpreted by this contract.
 
 ## Shadow host dispatch
 
-`Shadow` host dispatch is now source-complete through `IndexReplayOperatorRuntime::run_shadow`.
+`Shadow` host dispatch is source-complete through `IndexReplayOperatorRuntime::run_shadow`.
 
 The server replay materializer retrieves the `SharedIndexReplayDryRunRuntime` already published by Index replay
 composition and stores it beside the durable runtime inside the guarded operator. `run_shadow` authorizes the
 exact request tenant through the same request-bound `modules:manage` snapshot used by Full replay, then delegates
 to the no-write dry-run runtime.
 
-This is a host dispatch boundary, not a new durable mode state machine:
+This remains a host dispatch boundary, not a new durable mode state machine:
 
 - no job or checkpoint identity is created for Shadow;
 - no lease, heartbeat, cancel or terminal job transition is added;
 - no mutation sink or database connection is exposed;
-- Full continues to route to the durable runner unchanged;
-- GraphQL transport remains separate and does not yet expose Shadow.
+- Full continues to route to the durable runner unchanged.
+
+## Schema-wide Shadow GraphQL transport
+
+`runIndexReplayShadow` is now a dedicated transport rather than a generic mode selector on `runIndexReplay`.
+It accepts only schema routing identity and an optional authenticated confidential continuation token.
+
+The GraphQL layer authorizes request-bound `modules:manage` before parsing schema/continuation input. A separate
+server-owned `IndexReplayShadowTransportRuntime` repeats exact-tenant authorization, opens continuation only under
+the frozen tenant/schema/source scope, constructs the existing `IndexReplayDryRunRequest`, calls guarded
+`run_shadow`, and seals any outgoing cursor before returning.
+
+Resource bounds remain server-owned: `100` mutations per source page and at most `8` pages per invocation. Shadow
+has no caller-visible worker, lease, heartbeat, job, checkpoint, cancel, retry/requeue or source-name field.
+Its payload contains only Complete/Yielded status, bounded scan counters and optional sealed continuation.
+
+The transport is intentionally schema-wide. `IndexSourceContinuationScope` currently binds tenant/schema/source
+but not locale. Until continuation claims make schema-wide and exact-locale scopes distinct, exposing a locale
+field would allow a valid source cursor token to cross scan scopes. Exact-locale Shadow transport therefore
+remains fail-closed and source-open.
 
 ## Existing contracts reused
 
 The mode contract composes already-retained boundaries rather than duplicating them:
 
-- full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
-- targeted: `IndexSourceLoadRequest` exact-key validation and `IndexSource::load` source boundary;
-- shadow: `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan validation,
-  now guarded by the server replay operator.
+- Full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
+- Targeted: `IndexSourceLoadRequest` exact-key validation and `IndexSource::load` source boundary;
+- Shadow: `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan validation,
+  guarded by the server replay operator and transported only through sealed caller-carried continuation.
 
 Partition replay remains blocked until a real partition-capable source can filter before pagination.
 
@@ -69,9 +87,10 @@ Partition replay remains blocked until a real partition-capable source can filte
 
 This slice does not add:
 
-- targeted mutation execution;
-- shadow persistence or shadow tables;
-- GraphQL/API Shadow transport or generic mode selection;
+- Targeted mutation execution;
+- Shadow persistence or shadow tables;
+- a generic caller-controlled mode selector;
+- exact-locale Shadow transport before locale-safe continuation scope;
 - a mode column in `index_jobs` or `index_checkpoints`;
 - partition replay scope;
 - automatic retry/requeue or scheduler ownership;
@@ -79,13 +98,13 @@ This slice does not add:
 
 ## Next source boundary
 
-The next source-only boundary is authorization-first GraphQL transport for the guarded Shadow command. It should
-call `IndexReplayOperatorRuntime::run_shadow`, preserve the existing Full `runIndexReplay` path, keep resume state
-caller-carried and non-durable, and add canonical locale scope only through the existing source-scan contract rather
-than by creating mode-specific job/checkpoint state.
+The next independent Shadow boundary is locale-safe continuation identity before exact-locale GraphQL transport.
+The continuation contract must distinguish schema-wide from canonical exact-locale source scans without weakening
+existing tenant/schema/source binding or invalidating retained schema-wide transport semantics. Only after that
+scope exists should Shadow reuse the canonical `LocaleKey` / `IndexSourceScanRequest::for_locale` contract.
 
 Targeted execution remains a separate later slice because it needs an explicit bounded mutation-application
 contract over `IndexSource::load` rather than a scan checkpoint.
 
-Execution/admission remains maintainer-owned. The Rust tests and Node verifiers for this source slice were not
-executed by the implementation agent.
+Execution/admission remains maintainer-owned. Rust tests, Node verifiers, database scenarios and CI for this source
+slice were not executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -8,7 +8,7 @@ This composition freezes the complete immutable Index source/schema registries a
 - bounded durable replay runtime;
 - one module-work registration for due reconciliation execution.
 
-The server now wraps both replay execution surfaces in one request-bound operator: durable Full replay through `SharedIndexReplayRuntime` and side-effect-free Shadow replay through `SharedIndexReplayDryRunRuntime`. It does not add automatic replay-job scheduling. Public Shadow transport remains separate from runtime materialization and scheduler ownership.
+The server wraps both replay execution surfaces in one request-bound operator: durable Full replay through `SharedIndexReplayRuntime` and side-effect-free Shadow replay through `SharedIndexReplayDryRunRuntime`. It also publishes a separate schema-wide Shadow transport adapter that seals caller-carried continuation state. None of these boundaries add automatic replay-job scheduling.
 
 ## Composition order
 
@@ -19,23 +19,26 @@ The server now wraps both replay execution surfaces in one request-bound operato
 5. only complete source/schema composition creates `ModuleWorkRegistrations` for Index;
 6. it publishes `SharedIndexReplayRuntime` with ordinary and lifecycle-neutral interruptible run entry points;
 7. the server retrieves the already-materialized `SharedIndexReplayDryRunRuntime` and wraps Full plus Shadow behind `IndexReplayOperatorRuntime`;
-8. the server wraps reconciliation separately in its guarded operator runtime;
-9. GraphQL currently exposes only durable Full run/cancel commands; Shadow GraphQL transport remains a separate next slice;
-10. GraphQL schema initialization supplies the server-owned `StopHandle::is_stopping` probe to authorized durable replay run commands without making shutdown caller-controlled.
+8. the server materializes the deployment continuation keyring, then publishes `IndexReplayShadowTransportRuntime` and the source-page diagnosis runtime from that same keyring snapshot;
+9. the server wraps reconciliation separately in its guarded operator runtime;
+10. GraphQL exposes durable Full run/cancel plus schema-wide Shadow through the sealed transport adapter;
+11. GraphQL schema initialization supplies the server-owned `StopHandle::is_stopping` probe only to authorized durable replay run commands without making shutdown caller-controlled.
 
-An absent source registry publishes no replay runtime, no dry-run runtime, and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed. Server composition also fails closed if a durable replay runtime exists without the dry-run runtime that the guarded Shadow route requires.
+An absent source registry publishes no replay runtime, no dry-run runtime, no Shadow transport runtime and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed. Server composition fails closed if a durable replay runtime exists without the dry-run runtime that the guarded Shadow route requires.
 
 The Index materializer performs no SQL and calls neither `tokio::spawn` nor a polling loop. Later server bootstrap collects all module-work registrations, starts the single generic `ModuleWorkScheduler` only when registrations exist, and binds that scheduler to the same shared `StopHandle` lifecycle used by durable replay GraphQL execution.
 
 ## Replay operator and command boundary
 
-`IndexReplayOperatorRuntime` remains the only server-owned replay invocation authority. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`.
+`IndexReplayOperatorRuntime` remains the server-owned replay invocation authority. It requires an exact non-nil tenant/actor request context, a current request-scoped permission snapshot, and effective `modules:manage`.
 
-Durable ordinary/interruptible run rejects cross-tenant requests before delegation and cancellation derives tenant only from the authorized context. `run_shadow` applies the same exact tenant and `modules:manage` guard before delegating to the side-effect-free dry-run runtime. Shadow has a separate typed operator error wrapper so the existing Full/cancel GraphQL error contract does not need to absorb an unexposed mode.
+Durable ordinary/interruptible run rejects cross-tenant requests before delegation and cancellation derives tenant only from the authorized context. `run_shadow` applies the same exact tenant and `modules:manage` guard before delegating to the side-effect-free dry-run runtime. Shadow keeps a separate typed operator error wrapper so the existing Full/cancel error contract is not reinterpreted.
 
-The current GraphQL transport authorizes before parsing caller schema/job input and delegates only durable Full run/cancel to this operator. Tenant, actor, worker identity, source name, database handles, scheduler controls, replay resource budgets, and shutdown state are not caller fields. The durable run mutation creates a server-owned worker identity and uses a fixed 100-row × 8-page chunk, per-page heartbeat, and 60-second lease.
+`IndexReplayShadowTransportRuntime` sits above that guarded operator. It owns no database handle, scheduler, job, checkpoint, lease, cancellation or retry state. It repeats exact-tenant authorization before opening continuation, derives tenant/schema/source scope from the frozen source registry, calls only `IndexReplayOperatorRuntime::run_shadow`, and seals any outgoing raw source cursor before returning a transport-safe outcome.
 
-Transport adapters must not call either `SharedIndexReplayRuntime` or `SharedIndexReplayDryRunRuntime` directly. See the durable server transport contract in `apps/server/docs/index-replay-graphql-transport.md` and the Shadow host boundary in `m6-bounded-replay-dry-run.md`.
+The GraphQL transport authorizes before parsing caller input. Durable Full uses a fixed 100-row × 8-page chunk, per-page heartbeat and 60-second lease. Schema-wide Shadow uses the same fixed 100-row × 8-page scan budget but no worker, heartbeat or lease. Its only resumable caller state is the authenticated confidential continuation token.
+
+Transport adapters must not call either `SharedIndexReplayRuntime` or `SharedIndexReplayDryRunRuntime` directly. See `apps/server/docs/index-replay-graphql-transport.md` and `m6-bounded-replay-dry-run.md`.
 
 ## In-page host interruption boundary
 
@@ -47,17 +50,20 @@ An interrupted page is not marked failed and does not manufacture a persisted ca
 
 GraphQL schema initialization resolves or atomically creates one `StopHandle` in shared server runtime state and retains a watch receiver even for API-only hosts. `runIndexReplay` reads only `StopHandle::is_stopping` and invokes the guarded interruptible operator. It never calls `StopHandle::stop`, and no shutdown field is accepted from GraphQL input.
 
+Schema-wide Shadow does not use this durable interruption path. It has no durable pending state; source calls retain the existing timeout boundary and a later invocation can resume only from a sealed continuation returned by a completed bounded call.
+
 The retained SQLite runner packet covers interruption before source scan and interruption after one mutation is durable but before checkpoint commit. The latter resumes as `Duplicate` on attempt 2 before completing the checkpoint/job. Actual GraphQL/process-shutdown execution remains maintainer-run.
 
 ## Reconciliation scheduling boundary
 
 The work registration added here is reconciliation-only. It discovers due pending or expired-running reconciliation jobs and delegates actual claim/takeover to `PostgresIndexReconciliationRunner`.
 
-It does not schedule replay/rebuild jobs, create a second task, own a database lease, or expose a scheduler handle through either operator runtime.
+It does not schedule replay/rebuild jobs, create a second task, own a database lease, or expose a scheduler handle through either replay transport.
 
 ## Explicitly open
 
-- authorization-first GraphQL transport for guarded Shadow replay, including caller-carried bounded resume state and canonical locale handling;
+- locale-safe continuation identity before exact-locale Shadow GraphQL transport;
+- execute/admit schema-wide Shadow GraphQL and continuation-key deployment evidence;
 - execute/admit retained replay interruption/restart evidence and end-to-end process-shutdown command evidence;
 - durable GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
 - automatic replay/rebuild job scheduling;

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -71,6 +71,7 @@ const scripts = [
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-mode-contract.mjs',
   'verify-index-replay-shadow-host-dispatch.mjs',
+  'verify-index-replay-shadow-graphql-transport.mjs',
   'verify-index-replay-page-interruption.mjs',
   'verify-index-replay-retry-store.mjs',
   'verify-index-replay-dead-letter-admission.mjs',

--- a/scripts/verify/verify-index-replay-dry-run.mjs
+++ b/scripts/verify/verify-index-replay-dry-run.mjs
@@ -111,14 +111,22 @@ requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'self.shadow.run(request).await.map_err(Into::into)',
   '.get::<rustok_index::SharedIndexReplayDryRunRuntime>()',
   'IndexReplayOperatorRuntime::new(runtime, shadow)',
+  'IndexReplayShadowTransportRuntime',
 ]);
-const graphql = read('apps/server/src/graphql/index_replay.rs');
-if (graphql.includes('SharedIndexReplayDryRunRuntime') || graphql.includes('.run_shadow(')) {
-  fail('GraphQL must not bypass the guarded Shadow operator before the dedicated transport slice');
+const graphql = read('apps/server/src/graphql/index_replay.rs').split('\n#[cfg(test)]')[0];
+for (const forbidden of ['SharedIndexReplayDryRunRuntime', 'IndexReplayDryRunRequest', '.run_shadow(']) {
+  if (graphql.includes(forbidden)) {
+    fail(`GraphQL must use only the sealed Shadow transport adapter: ${forbidden}`);
+  }
 }
+requireMarkers('apps/server/src/graphql/index_replay.rs', [
+  'async fn run_index_replay_shadow(',
+  '.get::<IndexReplayShadowTransportRuntime>()',
+  '.run_schema_wide(',
+]);
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_transport_pending`',
+  'Status: `source_complete_schema_wide_transport_execution_pending`',
   '`IndexReplayDryRunRequest`',
   '`SharedIndexReplayDryRunRuntime::run`',
   'one invocation budget from 1 through 1024 pages',
@@ -129,8 +137,8 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
   'No-write boundary',
   'Server-owned host guard',
   '`IndexReplayOperatorRuntime::run_shadow`',
-  'same request-bound `modules:manage` authorization boundary',
-  'GraphQL, HTTP, CLI, or admin transport surfaces for Shadow invocation',
+  '`runIndexReplayShadow`',
+  'intentionally schema-wide',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
@@ -142,6 +150,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan.md', [
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-dry-run.mjs'",
   "'verify-index-replay-shadow-host-dispatch.mjs'",
+  "'verify-index-replay-shadow-graphql-transport.mjs'",
 ]);
 
-console.log('[verify-index-replay-dry-run] bounded no-write replay validation is now protected by the request-bound server operator while public transport remains separate');
+console.log('[verify-index-replay-dry-run] bounded no-write validation stays Index-owned while schema-wide GraphQL resumes only through the sealed guarded Shadow adapter');

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -25,56 +25,57 @@ const transport = requireMarkers(transportPath, [
   'pub entity_name: String',
   'pub schema_version: String',
   'pub locale: Option<String>',
+  'pub struct IndexReplayShadowRunInput',
+  'pub continuation: Option<String>',
   'pub struct IndexReplayCancelInput',
   'pub job_id: String',
   'const MAX_LOCALE_BYTES: usize = 32;',
+  'const MAX_CONTINUATION_BYTES: usize = 16 * 1024;',
   'const GRAPHQL_REPLAY_PAGE_LIMIT: usize = 100;',
   'const GRAPHQL_REPLAY_MAX_PAGES: usize = 8;',
   'const GRAPHQL_REPLAY_HEARTBEAT_EVERY_PAGES: usize = 1;',
   'const GRAPHQL_REPLAY_LEASE_SECONDS: u64 = 60;',
   'async fn run_index_replay(',
+  'async fn run_index_replay_shadow(',
   'async fn cancel_index_replay(',
   'prepare_authorized_run(tenant.id, auth.user_id, input)',
+  'prepare_authorized_shadow_run(tenant.id, auth.user_id, input)',
   'prepare_authorized_cancel(tenant.id, auth.user_id, input)',
   'permissions_for(&tenant_id, &actor_id)',
   'has_effective_permission(&permissions, &Permission::MODULES_MANAGE)',
-  'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
   'let locale = parse_locale(input.locale)?;',
   'rustok_index::LocaleKey::new(locale)',
   'rustok_index::IndexReplayRunRequest::for_locale(',
   'rustok_index::IndexReplayRunRequest::new(',
   'let worker_id = format!("graphql-replay-{}", Uuid::new_v4().simple());',
   '.get::<IndexReplayOperatorRuntime>()',
+  '.get::<IndexReplayShadowTransportRuntime>()',
   'let stop_handle = ctx.data::<StopHandle>()?.clone();',
   '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
+  '.run_schema_wide(',
   '.request_cancel(operator_context, job_id)',
   'replay_transport_authorizes_before_parsing_untrusted_run_input',
+  'shadow_transport_authorizes_before_schema_and_continuation_parsing',
+  'shadow_transport_accepts_only_schema_and_bounded_sealed_continuation',
   'replay_transport_derives_authority_worker_and_server_owned_budgets',
   'replay_transport_canonicalizes_optional_locale_after_authorization',
   'replay_cancel_authorizes_before_job_id_parsing_and_derives_tenant',
 ]);
 
-const authorizeStart = transport.indexOf('fn authorize(');
-const permissionCheck = transport.indexOf(
-  'let permissions = permissions_for(&tenant_id, &actor_id)',
-  authorizeStart,
-);
 const runPrepare = transport.indexOf('fn prepare_authorized_run(');
 const runAuthorize = transport.indexOf('let context = authorize(tenant_id, actor_id)?;', runPrepare);
-const runSchemaParse = transport.indexOf(
-  'let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;',
-  runPrepare,
-);
+const runSchemaParse = transport.indexOf('let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;', runPrepare);
 const runLocaleParse = transport.indexOf('let locale = parse_locale(input.locale)?;', runPrepare);
-if (
-  authorizeStart < 0 ||
-  permissionCheck < authorizeStart ||
-  runPrepare < 0 ||
-  runAuthorize < runPrepare ||
-  runSchemaParse <= runAuthorize ||
-  runLocaleParse <= runAuthorize
-) {
-  fail('run transport must authorize before parsing untrusted schema/locale input');
+if (runPrepare < 0 || runAuthorize < runPrepare || runSchemaParse <= runAuthorize || runLocaleParse <= runAuthorize) {
+  fail('durable Full transport must authorize before parsing untrusted schema/locale input');
+}
+
+const shadowPrepare = transport.indexOf('fn prepare_authorized_shadow_run(');
+const shadowAuthorize = transport.indexOf('let context = authorize(tenant_id, actor_id)?;', shadowPrepare);
+const shadowSchemaParse = transport.indexOf('let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;', shadowPrepare);
+const shadowContinuationParse = transport.indexOf('bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;', shadowPrepare);
+if (shadowPrepare < 0 || shadowAuthorize < shadowPrepare || shadowSchemaParse <= shadowAuthorize || shadowContinuationParse <= shadowSchemaParse) {
+  fail('Shadow transport must authorize before parsing untrusted schema/continuation input');
 }
 
 const cancelPrepare = transport.indexOf('fn prepare_authorized_cancel(');
@@ -88,24 +89,26 @@ const runInputStart = transport.indexOf('pub struct IndexReplayRunInput');
 const runInputEnd = transport.indexOf('\n}', runInputStart);
 const runInput = transport.slice(runInputStart, runInputEnd);
 for (const forbidden of [
-  'tenant',
-  'actor',
-  'user_id',
-  'worker',
-  'page_limit',
-  'max_pages',
-  'heartbeat',
-  'lease',
-  'partition',
-  'source_name',
-  'StopHandle',
-  'is_stopping',
-  'Uuid',
+  'tenant', 'actor', 'user_id', 'worker', 'page_limit', 'max_pages', 'heartbeat', 'lease',
+  'partition', 'source_name', 'StopHandle', 'is_stopping', 'Uuid',
 ]) {
-  if (runInput.includes(forbidden)) fail(`replay run input contains caller-owned field marker ${forbidden}`);
+  if (runInput.includes(forbidden)) fail(`durable replay input contains caller-owned field marker ${forbidden}`);
 }
 if (!runInput.includes('locale: Option<String>')) {
-  fail('replay run input must expose only one optional locale scope extension');
+  fail('durable replay input must expose only one optional locale scope extension');
+}
+
+const shadowInputStart = transport.indexOf('pub struct IndexReplayShadowRunInput');
+const shadowInputEnd = transport.indexOf('\n}', shadowInputStart);
+const shadowInput = transport.slice(shadowInputStart, shadowInputEnd);
+for (const forbidden of [
+  'tenant', 'actor', 'worker', 'locale', 'page_limit', 'max_pages', 'heartbeat', 'lease',
+  'partition', 'source_name', 'job_id', 'checkpoint', 'cancel', 'retry', 'StopHandle', 'Uuid',
+]) {
+  if (shadowInput.includes(forbidden)) fail(`Shadow replay input contains caller-owned field marker ${forbidden}`);
+}
+if (!shadowInput.includes('continuation: Option<String>')) {
+  fail('schema-wide Shadow input must expose only one optional sealed continuation extension');
 }
 
 const production = transport.split('\n#[cfg(test)]')[0];
@@ -116,6 +119,9 @@ for (const forbidden of [
   '.scan(',
   'PostgresIndexReplayRunner',
   'SharedIndexReplayRuntime',
+  'SharedIndexReplayDryRunRuntime',
+  'IndexReplayDryRunRequest',
+  '.run_shadow(',
   'PostgresMutationStore',
   'ModuleWorkScheduler',
   '.stop()',
@@ -132,22 +138,20 @@ requireMarkers('apps/server/src/graphql/schema.rs', [
   'pub stop_handle: StopHandle,',
   '.data(stop_handle)',
 ]);
-requireMarkers('apps/server/src/services/graphql_schema.rs', [
-  'let stop_handle = stop_handle_from_context(ctx);',
-  'let (candidate, _initial_receiver) = StopHandle::new();',
-  'ctx.shared_insert_if_absent(candidate);',
-  'IndexReplayStopKeepalive',
-  '_receiver: handle.subscribe()',
-  'avoid a zero-receiver window',
-  'stop_handle,',
-]);
 requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'pub struct IndexReplayOperatorRuntime',
   'pub async fn run_interruptible<Check>(',
-  '.run_interruptible(request, should_interrupt)',
+  'pub async fn run_shadow(',
   'pub async fn request_cancel(',
+  'IndexReplayShadowTransportRuntime',
   'Permission::MODULES_MANAGE',
-  'context.authorize_for(request.page_request().tenant_id())?;',
+]);
+requireMarkers('apps/server/src/services/index_replay_shadow_transport.rs', [
+  'pub struct IndexReplayShadowTransportRuntime',
+  'context.authorize_for(context.tenant_id())?;',
+  'IndexSourceContinuationScope::from_registry(',
+  'self.operator.run_shadow(context, request).await?',
+  'codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())',
 ]);
 requireMarkers('apps/server/src/services/app_lifecycle.rs', [
   'pub struct StopHandle',
@@ -156,17 +160,19 @@ requireMarkers('apps/server/src/services/app_lifecycle.rs', [
   'pub fn is_stopping(&self) -> bool',
 ]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `locale_source_complete_execution_pending`.',
+  'Status: `full_locale_and_schema_wide_shadow_source_complete_execution_pending`.',
   '`runIndexReplay(input: ...)`',
+  '`runIndexReplayShadow(input: ...)`',
   '`cancelIndexReplay(input: ...)`',
   'Tenant and actor identities are never accepted',
   'optional canonicalizable locale',
+  'schema-wide Shadow path intentionally has no locale input',
   'page limit: `100` mutations',
   'maximum pages: `8`',
   'lease duration: `60` seconds',
+  'same fixed source page limit and maximum-page count (`100 × 8`)',
   '`StopHandle::is_stopping`',
-  'delegation only through `IndexReplayOperatorRuntime`',
   'maintainer-owned',
 ]);
 
-console.log('[verify-index-replay-graphql-transport] guarded schema/locale replay run is authorized before optional locale parsing, bounded by server policy and bound to the server-owned StopHandle probe');
+console.log('[verify-index-replay-graphql-transport] durable Full/cancel and sealed schema-wide Shadow commands remain authorization-first and server-bounded without transport-owned execution state');

--- a/scripts/verify/verify-index-replay-mode-contract.mjs
+++ b/scripts/verify/verify-index-replay-mode-contract.mjs
@@ -62,7 +62,7 @@ const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_repla
 const runner = read(runnerPath);
 for (const forbidden of ['IndexReplayMode::Targeted', 'IndexReplayMode::Shadow', 'TargetedLoad', 'SideEffectFreeScan']) {
   if (runner.includes(forbidden)) {
-    fail(`${runnerPath} must remain the durable full-scan runner: ${forbidden}`);
+    fail(`${runnerPath} must remain the durable Full-scan runner: ${forbidden}`);
   }
 }
 
@@ -78,29 +78,37 @@ requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
   'context.authorize_for(request.tenant_id())?;',
   'self.shadow.run(request).await.map_err(Into::into)',
+  'IndexReplayShadowTransportRuntime',
+]);
+requireMarkers('apps/server/src/graphql/index_replay.rs', [
+  'pub struct IndexReplayShadowRunInput',
+  'async fn run_index_replay_shadow(',
+  '.get::<IndexReplayShadowTransportRuntime>()',
+  '.run_schema_wide(',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_host_dispatch_transport_pending`.',
+  'Status: `source_complete_shadow_schema_wide_transport_locale_pending`.',
   '`Full` — cursor-based durable source scan',
   '`Targeted` — bounded exact-key source load',
   '`Shadow` — side-effect-free cursor scan',
   'Mode is not locale scope and is not future partition scope.',
   'returns true only for `Full`',
-  'must not alias the full durable job/checkpoint identity',
-  '`Shadow` host dispatch is now source-complete',
-  '`IndexReplayOperatorRuntime::run_shadow`',
-  'GraphQL transport remains separate',
-  'The next source-only boundary is authorization-first GraphQL transport',
+  'must not alias the Full durable job/checkpoint identity',
+  '`Shadow` host dispatch is source-complete',
+  '`runIndexReplayShadow` is now a dedicated transport',
+  'transport is intentionally schema-wide',
+  'next independent Shadow boundary is locale-safe continuation identity',
   'Execution/admission remains maintainer-owned.',
 ]);
 
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.',
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
-  'Add authorization-first GraphQL transport for the guarded Shadow replay command.',
+  'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
+  'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
   'Add partition replay scope only after a real partition-capable source contract exists.',
 ]);
 
-console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow now has a guarded no-write host route without public transport');
+console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow is schema-wide transported without durable ownership while locale scope remains explicit debt');

--- a/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
+++ b/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
@@ -78,8 +78,7 @@ if (
   fail('packet order must remain host-a in-flight -> deterministic expiry -> host-b attempt-2 completion -> release host-a -> stale LeaseLost fence');
 }
 
-const modPath = 'crates/rustok-index/src/infrastructure/postgres/mod.rs';
-requireMarkers(modPath, [
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/mod.rs', [
   '#[cfg(test)]\nmod source_replay_multihost_restart_tests;'.replace('\\n', '\n'),
 ]);
 
@@ -94,8 +93,7 @@ if (job.includes('distributed_consensus')) {
   fail(`${jobPath} must not introduce a second ownership mechanism for this evidence slice`);
 }
 
-const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
-requireMarkers(runnerPath, [
+requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs', [
   'IndexReplayRunError::LeaseLost',
   'checkpoint_lease_lost',
   'terminal_write_outcome',
@@ -118,7 +116,8 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Execute/admit retained multi-host reclaim evidence.',
   'Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.',
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
-  'Add authorization-first GraphQL transport for the guarded Shadow replay command.',
+  'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
+  'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Partition replay remains blocked',
 ]);
 

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -67,22 +67,27 @@ const server = requireMarkers(serverPath, [
   'context.authorize_for(request.tenant_id())?;',
   'self.shadow.run(request).await.map_err(Into::into)',
   'pub async fn run_interruptible<Check>(',
-  'self.inner',
   '.run_interruptible(request, should_interrupt)',
   'Permission::MODULES_MANAGE',
   'permissions_for(&self.tenant_id, &self.actor_id)',
-  'context.authorize_for(request.page_request().tenant_id())?;',
   'materialize_postgres_index_sources(extensions, db.clone())',
   'materialize_index_source_registry(extensions)',
   'materialize_postgres_index_replay_runtime(extensions, db.clone())',
   '.get::<rustok_index::SharedIndexReplayDryRunRuntime>()',
   'IndexReplayOperatorRuntime::new(runtime, shadow)',
+  'materialize_index_replay_shadow_transport(',
+  'continuation.clone()',
   'reconciliation_operator::materialize_index_reconciliation_operator(extensions, db.clone())?;',
 ]);
 for (const forbidden of ['tokio::spawn', 'tokio::time::sleep', 'loop {', 'StopHandle']) {
   if (server.includes(forbidden)) fail(`${serverPath} contains lifecycle marker ${forbidden}`);
 }
 
+requireMarkers('apps/server/src/services/index_replay_shadow_transport.rs', [
+  'pub struct IndexReplayShadowTransportRuntime',
+  'IndexSourceContinuationScope::from_registry(',
+  'self.operator.run_shadow(context, request).await?',
+]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs', [
   'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
   'impl ModuleWorkSource for PostgresIndexReconciliationWorkAdapter',
@@ -103,10 +108,11 @@ requireMarkers('crates/rustok-index/src/lib.rs', [
 requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
   'Status: `source_complete_owner_execution_pending`',
   'one module-work registration for due reconciliation execution',
-  'publishes no replay runtime, no dry-run runtime, and no empty Index work registration',
-  'The materializer performs no SQL',
+  'publishes no replay runtime, no dry-run runtime, no Shadow transport runtime and no empty Index work registration',
+  'The Index materializer performs no SQL',
   'starts the single generic `ModuleWorkScheduler` only when registrations exist',
   '`SharedIndexReplayRuntime::run_interruptible`',
+  '`IndexReplayShadowTransportRuntime`',
   'The work registration added here is reconciliation-only',
   'maintainer-run',
 ]);
@@ -117,7 +123,8 @@ requireMarkers('crates/rustok-index/docs/m6-reconciliation-host-scheduler.md', [
 requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-runtime-composition.mjs'",
   "'verify-index-replay-shadow-host-dispatch.mjs'",
+  "'verify-index-replay-shadow-graphql-transport.mjs'",
   "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
-console.log('[verify-index-replay-runtime-composition] shared replay runtime/operator retain lifecycle-neutral Full execution and a guarded no-write Shadow route while scheduler composition remains unchanged');
+console.log('[verify-index-replay-runtime-composition] shared replay composition keeps Full durable, Shadow no-write/sealed, and reconciliation under the single generic scheduler boundary');

--- a/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-shadow-graphql-transport] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const servicePath = 'apps/server/src/services/index_replay_shadow_transport.rs';
+const service = requireMarkers(servicePath, [
+  'pub enum IndexReplayShadowTransportError',
+  'pub struct IndexReplayShadowTransportOutcome',
+  'pub struct IndexReplayShadowTransportRuntime',
+  'pub async fn run_schema_wide(',
+  'context.authorize_for(context.tenant_id())?;',
+  'IndexSourceContinuationScope::from_registry(',
+  '.open_encoded(&scope, encoded, Utc::now())',
+  'IndexReplayDryRunRequest::new(',
+  'self.operator.run_shadow(context, request).await?',
+  '.next_cursor()',
+  'codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())',
+  'materialize_index_replay_shadow_transport(',
+  'extensions.insert(IndexReplayShadowTransportRuntime::new(',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresIndexReplayRunner',
+  'PostgresMutationStore',
+  'index_jobs',
+  'index_checkpoints',
+  'request_cancel(',
+  'tokio::spawn',
+  'tokio::time::sleep',
+  '.execute(',
+  '.begin()',
+  'IndexSourceScanRequest::for_locale',
+  'LocaleKey',
+]) {
+  if (service.includes(forbidden)) {
+    fail(`${servicePath} must remain schema-wide, no-write and lifecycle-neutral: ${forbidden}`);
+  }
+}
+const authorize = service.indexOf('context.authorize_for(context.tenant_id())?;');
+const scope = service.indexOf('IndexSourceContinuationScope::from_registry(', authorize);
+const open = service.indexOf('.open_encoded(&scope, encoded, Utc::now())', scope);
+const request = service.indexOf('IndexReplayDryRunRequest::new(', open);
+const run = service.indexOf('self.operator.run_shadow(context, request).await?', request);
+const seal = service.indexOf('codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())', run);
+if (authorize < 0 || scope <= authorize || open <= scope || request <= open || run <= request || seal <= run) {
+  fail('Shadow transport order must remain authorize -> frozen scope -> open token -> dry-run request -> guarded Shadow -> seal cursor');
+}
+
+const graphqlPath = 'apps/server/src/graphql/index_replay.rs';
+const graphql = requireMarkers(graphqlPath, [
+  'const MAX_CONTINUATION_BYTES: usize = 16 * 1024;',
+  'pub struct IndexReplayShadowRunInput',
+  'pub continuation: Option<String>',
+  'pub enum IndexReplayGraphqlShadowStatus',
+  'pub struct IndexReplayShadowRunPayload',
+  'async fn run_index_replay_shadow(',
+  'prepare_authorized_shadow_run(tenant.id, auth.user_id, input)',
+  '.get::<IndexReplayShadowTransportRuntime>()',
+  '.run_schema_wide(',
+  'GRAPHQL_REPLAY_PAGE_LIMIT,',
+  'GRAPHQL_REPLAY_MAX_PAGES,',
+  'shadow_transport_authorizes_before_schema_and_continuation_parsing',
+  'shadow_transport_accepts_only_schema_and_bounded_sealed_continuation',
+  'INDEX_REPLAY_SHADOW_CONTINUATION_INVALID',
+  'INDEX_REPLAY_SHADOW_CONTINUATION_EXPIRED',
+]);
+const shadowPrepare = graphql.indexOf('fn prepare_authorized_shadow_run(');
+const shadowAuthorize = graphql.indexOf('let context = authorize(tenant_id, actor_id)?;', shadowPrepare);
+const shadowSchema = graphql.indexOf('let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;', shadowPrepare);
+const shadowContinuation = graphql.indexOf('bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;', shadowPrepare);
+if (shadowPrepare < 0 || shadowAuthorize < shadowPrepare || shadowSchema <= shadowAuthorize || shadowContinuation <= shadowSchema) {
+  fail('Shadow GraphQL preparation must authorize before parsing schema and continuation');
+}
+const inputStart = graphql.indexOf('pub struct IndexReplayShadowRunInput');
+const inputEnd = graphql.indexOf('\n}', inputStart);
+const input = graphql.slice(inputStart, inputEnd);
+for (const forbidden of [
+  'tenant', 'actor', 'worker', 'locale', 'page_limit', 'max_pages', 'heartbeat', 'lease',
+  'partition', 'source_name', 'job_id', 'checkpoint', 'cancel', 'retry', 'StopHandle', 'Uuid',
+]) {
+  if (input.includes(forbidden)) fail(`Shadow GraphQL input contains caller-owned field marker ${forbidden}`);
+}
+for (const forbidden of [
+  'SharedIndexReplayDryRunRuntime',
+  'IndexReplayDryRunRequest',
+  '.run_shadow(',
+  '.scan(',
+  'DatabaseConnection',
+  'PostgresIndexReplayRunner',
+  'PostgresMutationStore',
+]) {
+  if (graphql.split('\n#[cfg(test)]')[0].includes(forbidden)) {
+    fail(`${graphqlPath} must delegate Shadow only through the sealed transport adapter: ${forbidden}`);
+  }
+}
+
+requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
+  '#[path = "index_replay_shadow_transport.rs"]',
+  'IndexReplayShadowTransportRuntime',
+  'materialize_index_replay_shadow_transport(',
+  'continuation.clone()',
+]);
+requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
+  'Status: `full_locale_and_schema_wide_shadow_source_complete_execution_pending`.',
+  '`runIndexReplayShadow(input: ...)`',
+  'schema-wide Shadow path intentionally has no locale input',
+  'same fixed source page limit and maximum-page count (`100 × 8`)',
+  'current continuation scope is tenant/schema/source-bound but not locale-bound',
+]);
+requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
+  'Status: `source_complete_schema_wide_transport_execution_pending`',
+  '`runIndexReplayShadow`',
+  'intentionally schema-wide',
+]);
+requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
+  'Status: `source_complete_shadow_schema_wide_transport_locale_pending`.',
+  '`runIndexReplayShadow`',
+  'Exact-locale Shadow transport therefore remains fail-closed and source-open.',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
+  'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
+]);
+
+console.log('[verify-index-replay-shadow-graphql-transport] schema-wide Shadow GraphQL stays authorization-first, no-write and resumable only through sealed scoped continuation');

--- a/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+++ b/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
@@ -45,18 +45,18 @@ const graphqlPath = 'apps/server/src/graphql/index_replay.rs';
 const graphql = requireMarkers(graphqlPath, [
   'async fn run_index_replay(',
   '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
+  'async fn run_index_replay_shadow(',
+  '.get::<IndexReplayShadowTransportRuntime>()',
+  '.run_schema_wide(',
   'async fn cancel_index_replay(',
-  'prepare_authorized_run(',
 ]);
 for (const forbidden of [
-  'run_index_replay_shadow',
-  '.run_shadow(',
-  'IndexReplayDryRunRequest',
   'SharedIndexReplayDryRunRuntime',
-  'IndexReplayShadowOperatorError',
+  'IndexReplayDryRunRequest',
+  '.run_shadow(',
 ]) {
-  if (graphql.includes(forbidden)) {
-    fail(`${graphqlPath} must remain Full/cancel-only until the separate Shadow transport slice: ${forbidden}`);
+  if (graphql.split('\n#[cfg(test)]')[0].includes(forbidden)) {
+    fail(`${graphqlPath} must not bypass the sealed Shadow transport adapter: ${forbidden}`);
   }
 }
 
@@ -69,22 +69,23 @@ for (const forbidden of ['IndexReplayMode::Shadow', 'SideEffectFreeScan', 'Share
 }
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_transport_pending`',
+  'Status: `source_complete_schema_wide_transport_execution_pending`',
   '`IndexReplayOperatorRuntime::run_shadow`',
   'same request-bound `modules:manage` authorization boundary',
-  'GraphQL, HTTP, CLI, or admin transport surfaces',
-  'no durable replay job or checkpoint',
+  '`runIndexReplayShadow`',
+  'intentionally schema-wide',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_host_dispatch_transport_pending`.',
-  '`Shadow` host dispatch is now source-complete',
+  'Status: `source_complete_shadow_schema_wide_transport_locale_pending`.',
+  '`Shadow` host dispatch is source-complete',
   '`IndexReplayOperatorRuntime::run_shadow`',
-  'GraphQL transport remains separate',
+  '`runIndexReplayShadow` is now a dedicated transport',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
-  'Add authorization-first GraphQL transport for the guarded Shadow replay command.',
+  'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
+  'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
 ]);
 
-console.log('[verify-index-replay-shadow-host-dispatch] Shadow replay is request-bound and modules:manage-guarded without changing Full durable ownership or exposing transport');
+console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded and no-write while GraphQL uses only the sealed transport adapter');

--- a/scripts/verify/verify-index-source-continuation-server.mjs
+++ b/scripts/verify/verify-index-source-continuation-server.mjs
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises";
 const files = {
   keyring: "apps/server/src/services/index_source_continuation_runtime.rs",
   page: "apps/server/src/services/index_drift_source_page_diagnosis.rs",
+  shadow: "apps/server/src/services/index_replay_shadow_transport.rs",
   composition: "apps/server/src/services/index_replay_runtime_composition.rs",
   exactGraphql: "apps/server/src/graphql/index_drift_diagnosis.rs",
   pageGraphql: "apps/server/src/graphql/index_drift_source_page_diagnosis.rs",
@@ -108,9 +109,35 @@ if (sealed.includes("IndexSourceCursor") || sealed.includes("next_cursor(&self)"
   throw new Error("sealed page method must not expose a raw cursor type");
 }
 
+requireMarkers("shadow", [
+  "pub struct IndexReplayShadowTransportRuntime",
+  "context.authorize_for(context.tenant_id())?;",
+  "IndexSourceContinuationScope::from_registry(",
+  ".resolve_codec()",
+  "codec.open_encoded(&scope, encoded, Utc::now())",
+  "IndexReplayDryRunRequest::new(",
+  "self.operator.run_shadow(context, request).await?;",
+  "codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())",
+]);
+const shadowProduction = content.shadow.split("\n#[cfg(test)]")[0];
+for (const forbidden of [
+  "DatabaseConnection",
+  "IndexSourceContinuationKeyringRuntime>()",
+  "extensions.insert(keyring)",
+  "tokio::spawn",
+  ".execute(",
+]) {
+  if (shadowProduction.includes(forbidden)) {
+    throw new Error(`Shadow continuation adapter contains forbidden capability: ${forbidden}`);
+  }
+}
+
 requireMarkers("composition", [
   '#[path = "index_source_continuation_runtime.rs"]',
+  '#[path = "index_replay_shadow_transport.rs"]',
   "source_continuation_runtime::materialize_index_source_continuation_keyring()",
+  "materialize_index_replay_shadow_transport(",
+  "continuation.clone()",
   "materialize_index_drift_source_page_diagnosis(",
   "continuation,",
 ]);
@@ -118,7 +145,7 @@ if (
   content.composition.includes("extensions.insert(continuation)") ||
   content.composition.includes("extensions.insert(keyring)")
 ) {
-  throw new Error("continuation keyring must remain private to the page runtime");
+  throw new Error("continuation keyring must remain private to sealed server runtimes");
 }
 
 for (const forbidden of [
@@ -177,6 +204,7 @@ requireMarkers("plan", [
 requireMarkers("aggregate", [
   "'verify-index-source-continuation-server.mjs'",
   "'verify-index-drift-source-page-graphql-transport.mjs'",
+  "'verify-index-replay-shadow-graphql-transport.mjs'",
 ]);
 
-console.log("Index server sealed source continuation contract verified");
+console.log("Index server sealed source continuation contract verified for drift-page and schema-wide Shadow consumers");


### PR DESCRIPTION
## Summary

- expose a dedicated schema-wide `runIndexReplayShadow` GraphQL command over the already-guarded no-write Shadow replay surface;
- keep authorization first: request-bound `modules:manage` is checked before untrusted schema or continuation parsing, and exact tenant authorization is repeated before token open/source execution;
- add a server-owned `IndexReplayShadowTransportRuntime` that reuses the deployment source-continuation keyring and frozen tenant/schema/source scope, opens only authenticated confidential continuation, calls `IndexReplayOperatorRuntime::run_shadow`, and seals any outgoing raw source cursor;
- keep Shadow caller input limited to module/entity/schema routing identity plus optional sealed continuation; page size/max pages remain server-owned at 100 × 8;
- keep raw cursor JSON, source identity, locale, jobs, checkpoints, leases, workers, cancellation, retries, partition and scheduler controls unavailable to Shadow callers;
- keep the existing durable `runIndexReplay` Full path, exact-locale durable semantics, cancellation and StopHandle wiring unchanged;
- intentionally keep Shadow schema-wide only because the current continuation scope is tenant/schema/source-bound but not locale-bound; exact-locale Shadow remains blocked until continuation identity is locale-safe;
- actualize replay transport/runtime/mode/dry-run docs, source guards and the current M6 execution cursor.

## Production impact

Adds one bounded, side-effect-free GraphQL Shadow validation command and a sealed continuation adapter. It does not add mutation persistence, replay jobs/checkpoints, leases, automatic retry/requeue, scheduler ownership, Targeted execution, partition scope or serving-traffic cutover.

## Mainline recheck

The branch was created from `main@488803a831e725ef0fbeaa8540f09458ee461b85`. During final review, `main` advanced to `f7416e83979d538bc9982ccf303eef2adae519ac` through #3333. That PR changes only `rustok-pages` Page Builder rollout files and Pages docs/evidence; its paths are disjoint from this Index/server replay slice.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.