### PR TITLE
feat(product): guard tenant lifecycle corequisites

### DIFF
--- a/apps/server/src/modules/manifest/corequisites.rs
+++ b/apps/server/src/modules/manifest/corequisites.rs
@@ -1,9 +1,12 @@
+use rustok_modules::{ModuleEffectivePolicy, ModuleEffectivePolicyFact};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use super::validation::{default_manifest_path, module_package_manifest_path, resolve_module_specs};
-use super::{ManifestError, ManifestModuleSpec, ModulesManifest};
+use super::{ManifestError, ManifestManager, ManifestModuleSpec, ModulesManifest};
+
+type ModulePolicyCoRequisites = BTreeMap<String, BTreeMap<String, String>>;
 
 #[derive(Debug, Deserialize, Default)]
 struct PackageCoRequisiteManifest {
@@ -22,6 +25,160 @@ struct StaticSelectionModule {
     version: Option<String>,
     ordinary_dependencies: BTreeSet<String>,
     co_requisites: BTreeMap<String, String>,
+}
+
+impl ManifestManager {
+    /// Returns package-owned co-requisite metadata for every installed static
+    /// module. Tenant policy uses this contract without changing dependency order.
+    pub(crate) fn module_policy_corequisites(
+        manifest: &ModulesManifest,
+    ) -> Result<BTreeMap<String, BTreeMap<String, String>>, ManifestError> {
+        module_policy_corequisites(manifest)
+    }
+
+    /// Fails closed when an owner-resolved tenant policy leaves an enabled
+    /// module without a required package co-requisite.
+    pub(crate) fn validate_effective_policy_corequisites(
+        policy: &ModuleEffectivePolicy,
+        co_requisites: &BTreeMap<String, BTreeMap<String, String>>,
+    ) -> Result<(), String> {
+        validate_effective_policy_corequisites(policy, co_requisites)
+    }
+
+    /// Validates a tenant intent write without imposing a second enable/disable
+    /// ordering graph. Effective availability is enforced separately.
+    pub(crate) fn validate_corequisite_toggle(
+        policy: &ModuleEffectivePolicy,
+        co_requisites: &BTreeMap<String, BTreeMap<String, String>>,
+        module_slug: &str,
+        enabled: bool,
+    ) -> Result<(), String> {
+        validate_corequisite_toggle(policy, co_requisites, module_slug, enabled)
+    }
+}
+
+fn module_policy_corequisites(
+    manifest: &ModulesManifest,
+) -> Result<ModulePolicyCoRequisites, ManifestError> {
+    let resolved_specs = resolve_module_specs(manifest)?;
+    let mut policy = BTreeMap::new();
+    let mut slugs = resolved_specs.keys().cloned().collect::<Vec<_>>();
+    slugs.sort();
+    for slug in slugs {
+        let spec = resolved_specs
+            .get(&slug)
+            .expect("resolved module slug must have a manifest spec");
+        let co_requisites = load_package_corequisites(spec)?;
+        if !co_requisites.is_empty() {
+            policy.insert(slug, co_requisites);
+        }
+    }
+    Ok(policy)
+}
+
+/// Fails closed when the owner-resolved tenant policy leaves an enabled module
+/// without one of its package-declared co-requisites. This guard consumes the
+/// policy result; it does not rewrite ordinary dependency or migration order.
+fn validate_effective_policy_corequisites(
+    policy: &ModuleEffectivePolicy,
+    co_requisites: &ModulePolicyCoRequisites,
+) -> Result<(), String> {
+    for (consumer, required_modules) in co_requisites {
+        if !policy.contains(consumer) {
+            continue;
+        }
+        for (provider, version_requirement) in required_modules {
+            if !policy.contains(provider) {
+                return Err(format!(
+                    "module '{consumer}' requires effectively enabled co-requisite '{provider}'"
+                ));
+            }
+            validate_policy_provider_contract(
+                policy,
+                consumer,
+                provider,
+                version_requirement,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Tenant intent must remain sequentially orderable. Product can be staged
+/// before Inventory/Pricing are enabled because those owners ordinarily depend
+/// on Product; the externally visible effective-policy guard remains fail-closed
+/// until the whole owner set is available. Here we validate only the admitted
+/// owner definitions/version contract before persisting an enable intent.
+fn validate_corequisite_toggle(
+    policy: &ModuleEffectivePolicy,
+    co_requisites: &ModulePolicyCoRequisites,
+    module_slug: &str,
+    enabled: bool,
+) -> Result<(), String> {
+    if !enabled {
+        return Ok(());
+    }
+    if let Some(required_modules) = co_requisites.get(module_slug) {
+        for (provider, version_requirement) in required_modules {
+            validate_policy_provider_contract(
+                policy,
+                module_slug,
+                provider,
+                version_requirement,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_policy_provider_contract(
+    policy: &ModuleEffectivePolicy,
+    consumer: &str,
+    provider: &str,
+    raw_requirement: &str,
+) -> Result<(), String> {
+    let version = policy_definition_version(policy, provider).ok_or_else(|| {
+        format!(
+            "module '{consumer}' co-requisite '{provider}' has no effective-policy definition version"
+        )
+    })?;
+    let requirement = raw_requirement.trim();
+    if requirement.is_empty() {
+        return Ok(());
+    }
+    let requirement = VersionReq::parse(requirement).map_err(|_| {
+        format!(
+            "module '{consumer}' co-requisite '{provider}' has invalid version requirement '{}'",
+            raw_requirement.trim()
+        )
+    })?;
+    let version = Version::parse(version).map_err(|_| {
+        format!(
+            "module '{consumer}' co-requisite '{provider}' has invalid effective-policy version '{version}'"
+        )
+    })?;
+    if !requirement.matches(&version) {
+        return Err(format!(
+            "module '{consumer}' requires co-requisite '{provider}' version '{}', but effective policy has '{version}'",
+            raw_requirement.trim()
+        ));
+    }
+    Ok(())
+}
+
+fn policy_definition_version<'a>(
+    policy: &'a ModuleEffectivePolicy,
+    module_slug: &str,
+) -> Option<&'a str> {
+    policy
+        .decisions()
+        .find(|decision| decision.module_slug == module_slug)
+        .and_then(|decision| {
+            decision.facts.iter().find_map(|fact| match fact {
+                ModuleEffectivePolicyFact::Definition { version, .. } => Some(version.as_str()),
+                _ => None,
+            })
+        })
 }
 
 /// Validates deployment-selection co-requisites after ordinary static topology
@@ -118,11 +275,11 @@ fn validate_corequisite_selection(
                     "module '{slug}' declares '{co_requisite}' as both an ordinary dependency and a deployment co-requisite"
                 ));
             }
-            let requirement = raw_requirement.trim();
-            if !requirement.is_empty() {
-                VersionReq::parse(requirement).map_err(|_| {
+            let version_req = raw_requirement.trim();
+            if !version_req.is_empty() {
+                VersionReq::parse(version_req).map_err(|_| {
                     format!(
-                        "module '{slug}' deployment co-requisite '{co_requisite}' has invalid version requirement '{requirement}'"
+                        "module '{slug}' deployment co-requisite '{co_requisite}' has invalid version requirement '{version_req}'"
                     )
                 })?;
             }

--- a/apps/server/src/services/effective_module_policy.rs
+++ b/apps/server/src/services/effective_module_policy.rs
@@ -1,3 +1,4 @@
+use crate::modules::ManifestManager;
 use crate::services::platform_composition::{PlatformCompositionError, PlatformCompositionService};
 use rustok_core::ModuleRegistry;
 use rustok_modules::{
@@ -24,12 +25,15 @@ impl EffectiveModulePolicyService {
         tenant_id: uuid::Uuid,
     ) -> Result<EffectiveModulePolicySnapshot, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
         let default_enabled_modules = manifest.settings.default_enabled;
         let policy = ModuleControlPlane::new(db.clone())
             .effective_policy(registry, default_enabled_modules.clone())
             .resolve(tenant_id)
             .await
             .map_err(map_effective_policy_error)?;
+        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
+            .map_err(PlatformCompositionError::EffectivePolicy)?;
         let cache_identity = policy
             .cache_identity(tenant_id)
             .map_err(|error| PlatformCompositionError::EffectivePolicy(error.to_string()))?;
@@ -61,8 +65,8 @@ impl EffectiveModulePolicyService {
     }
 
     /// Resolves module availability from a channel-owner snapshot. Channel
-    /// resolution remains in `rustok-channel`; this adapter only forwards its
-    /// validated neutral contract to the module owner.
+    /// resolution remains in `rustok-channel`; this adapter forwards the owner
+    /// result through the deployment co-requisite fail-closed guard.
     pub async fn resolve_for_channel(
         db: &DatabaseConnection,
         registry: &ModuleRegistry,
@@ -70,15 +74,19 @@ impl EffectiveModulePolicyService {
         channel: ModuleEffectivePolicyChannelInput,
     ) -> Result<ModuleEffectivePolicy, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
-        ModuleControlPlane::new(db.clone())
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
+        let policy = ModuleControlPlane::new(db.clone())
             .effective_policy(registry, manifest.settings.default_enabled)
             .resolve_for_channel(tenant_id, channel)
             .await
-            .map_err(map_effective_policy_error)
+            .map_err(map_effective_policy_error)?;
+        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
+            .map_err(PlatformCompositionError::EffectivePolicy)?;
+        Ok(policy)
     }
 
     /// Forwards all host-owned policy snapshots to the single module owner
-    /// decision. Channel and maintenance resolution stay outside this adapter.
+    /// decision, then fail-closes if a selected consumer lost a co-requisite.
     pub async fn resolve_for_context(
         db: &DatabaseConnection,
         registry: &ModuleRegistry,
@@ -88,11 +96,15 @@ impl EffectiveModulePolicyService {
         node_readiness: Option<ModuleEffectivePolicyNodeReadinessInput>,
     ) -> Result<ModuleEffectivePolicy, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
-        ModuleControlPlane::new(db.clone())
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
+        let policy = ModuleControlPlane::new(db.clone())
             .effective_policy(registry, manifest.settings.default_enabled)
             .resolve_for_context(tenant_id, channel, maintenance, node_readiness)
             .await
-            .map_err(map_effective_policy_error)
+            .map_err(map_effective_policy_error)?;
+        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
+            .map_err(PlatformCompositionError::EffectivePolicy)?;
+        Ok(policy)
     }
 
     pub async fn resolve_for_node_readiness(
@@ -102,11 +114,15 @@ impl EffectiveModulePolicyService {
         node_readiness: ModuleEffectivePolicyNodeReadinessInput,
     ) -> Result<ModuleEffectivePolicy, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
-        ModuleControlPlane::new(db.clone())
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
+        let policy = ModuleControlPlane::new(db.clone())
             .effective_policy(registry, manifest.settings.default_enabled)
             .resolve_for_node_readiness(tenant_id, node_readiness)
             .await
-            .map_err(map_effective_policy_error)
+            .map_err(map_effective_policy_error)?;
+        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
+            .map_err(PlatformCompositionError::EffectivePolicy)?;
+        Ok(policy)
     }
 
     pub async fn list_enabled(

--- a/apps/server/src/services/module_lifecycle.rs
+++ b/apps/server/src/services/module_lifecycle.rs
@@ -106,8 +106,24 @@ impl ModuleLifecycleService {
         let manifest = PlatformCompositionService::active_manifest(db)
             .await
             .map_err(|error| ToggleModuleError::Policy(error.to_string()))?;
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)
+            .map_err(|error| ToggleModuleError::Policy(error.to_string()))?;
+        let default_enabled = manifest.settings.default_enabled;
+        let current_policy = ModuleControlPlane::new(db.clone())
+            .effective_policy(registry, default_enabled.clone())
+            .resolve(tenant_id)
+            .await
+            .map_err(map_lifecycle_writer_error)?;
+        ManifestManager::validate_corequisite_toggle(
+            &current_policy,
+            &co_requisites,
+            module_slug,
+            enabled,
+        )
+        .map_err(ToggleModuleError::Policy)?;
+
         let result = ModuleControlPlane::new(db.clone())
-            .lifecycle(registry, manifest.settings.default_enabled)
+            .lifecycle(registry, default_enabled)
             .toggle(tenant_id, module_slug, enabled, requested_by)
             .await
             .map_err(map_lifecycle_writer_error)?;
@@ -165,11 +181,30 @@ impl ModuleLifecycleService {
         requested_by: Option<String>,
         idempotency_key: uuid::Uuid,
     ) -> Result<tenant_modules::Model, ModuleOperationRecoveryError> {
+        let plan = module_operation_recovery_plan(db, operation_id)
+            .await
+            .map_err(map_module_recovery_error)?;
         let manifest = PlatformCompositionService::active_manifest(db)
             .await
             .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)
+            .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
+        let default_enabled = manifest.settings.default_enabled;
+        let current_policy = ModuleControlPlane::new(db.clone())
+            .effective_policy(registry, default_enabled.clone())
+            .resolve(plan.tenant_id)
+            .await
+            .map_err(map_lifecycle_writer_recovery_error)?;
+        ManifestManager::validate_corequisite_toggle(
+            &current_policy,
+            &co_requisites,
+            &plan.module_slug,
+            plan.previous_effective_enabled,
+        )
+        .map_err(ModuleOperationRecoveryError::Policy)?;
+
         let result = ModuleControlPlane::new(db.clone())
-            .lifecycle(registry, manifest.settings.default_enabled)
+            .lifecycle(registry, default_enabled)
             .compensate_failed_operation(operation_id, requested_by, idempotency_key)
             .await
             .map_err(map_lifecycle_writer_recovery_error)?;

--- a/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
+++ b/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-08-08",
-  "status": "product_lifecycle_static_corequisite_selection_enforced_unvalidated",
-  "source_base_revision": "0ae8f7f4382a4218107c43a4e1e6f1e5b957a84e",
+  "status": "product_lifecycle_tenant_corequisite_host_guard_source_complete_unvalidated",
+  "source_base_revision": "9221664d677f3f8775ef4ade66ffe14a4b316c54",
   "scope": "Product create/delete transaction collaboration with Inventory and Pricing owners",
   "module_topology": {
     "product_dependencies": [
@@ -21,9 +21,12 @@
     "ordinary_reverse_dependencies_forbidden": true,
     "co_requisites_are_ordering_dependencies": false,
     "static_default_selection_enforcement_source_complete": true,
+    "tenant_lifecycle_corequisite_guard_source_complete": true,
+    "effective_policy_corequisite_guard_source_complete": true,
+    "canonical_policy_revision_corequisite_identity_source_complete": false,
     "co_requisite_control_plane_execution_proven": false,
-    "tenant_lifecycle_corequisite_enforcement_proven": false,
-    "reason": "Static startup validates selected Product co-requisites separately from ordinary dependencies so Inventory/Pricing remain owner modules without a dependency-order cycle",
+    "tenant_lifecycle_corequisite_execution_proven": false,
+    "reason": "Static selection and tenant host guards consume Product co-requisites separately from ordinary dependencies; canonical owner policy revision/explanation integration remains open",
     "default_enabled_bundle": [
       "product",
       "pricing",
@@ -68,14 +71,16 @@
     "containment_complete": true,
     "corequisite_contract_declared": true,
     "static_default_selection_enforcement_source_complete": true,
+    "tenant_lifecycle_corequisite_guard_source_complete": true,
+    "effective_policy_corequisite_guard_source_complete": true,
     "dependency_contract_resolved": false,
-    "next_slice": "Apply Product co-requisite semantics to tenant lifecycle/effective-policy selection without adding dependency-order edges, then prove non-default Product activation and rollback",
+    "next_slice": "Include Product co-requisite availability in canonical modules-owner effective-policy revision/cache identity and explicit decision explanation without adding dependency-order edges; then retain execution evidence",
     "do_not": [
       "add inventory or pricing to Product ordinary module dependencies",
       "move Inventory or Pricing ORM entities into Product",
       "replace atomic owner collaboration with unproven best-effort post-commit writes",
       "claim standalone Product write activation",
-      "claim tenant co-requisite enforcement before lifecycle/effective policy consumes the contract"
+      "claim canonical policy-revision integration before the modules owner hashes and explains co-requisites"
     ]
   },
   "validation": {
@@ -86,6 +91,9 @@
     "workflow_checks_run": false,
     "ci_run": false,
     "static_default_selection_execution_proven": false,
+    "tenant_lifecycle_execution_proven": false,
+    "effective_policy_guard_execution_proven": false,
+    "policy_cache_identity_execution_proven": false,
     "standalone_activation_proven": false,
     "non_default_deployment_selection_proven": false,
     "transaction_rollback_proven": false

--- a/crates/rustok-product/docs/product-lifecycle-collaboration.md
+++ b/crates/rustok-product/docs/product-lifecycle-collaboration.md
@@ -1,6 +1,6 @@
 # Product lifecycle owner collaboration
 
-Status: static deployment co-requisite enforcement source-complete, tenant lifecycle enforcement pending, unvalidated.
+Status: static and tenant host co-requisite guards source-complete, canonical policy-revision integration pending, unvalidated.
 
 ## Problem
 
@@ -12,22 +12,31 @@ The ordinary module graph cannot represent the collaboration by adding reverse P
 - Pricing depends on Product;
 - making Product ordinarily depend on either owner would create a dependency-order cycle.
 
-The default ecommerce activation enables Product, Pricing, and Inventory together. Source must still reject a deployment-default selection that enables Product without those owner implementations while preserving acyclic installation and migration ordering.
+The default ecommerce activation enables Product, Pricing, and Inventory together. Source must reject unsafe effective selections without creating a second tenant enable/disable ordering graph.
 
 ## Selected source contract
 
-Product declares Inventory and Pricing in `rustok-module.toml` under `[co_requisites]` with explicit version requirements. A co-requisite is a deployment-selection constraint, not an ordinary dependency edge:
+Product declares Inventory and Pricing in `rustok-module.toml` under `[co_requisites]` with explicit version requirements. A co-requisite is an availability/selection constraint, not an ordinary dependency edge:
 
-- it says the owner implementation must be selected whenever Product lifecycle writes are available;
+- it says the owner implementation must be available whenever Product lifecycle writes are available;
 - it must not participate in dependency or migration ordering;
 - it must not be copied into `ProductModule::dependencies()`;
 - it therefore does not create `Product -> Inventory -> Product` or `Product -> Pricing -> Product` cycles.
 
-The static server control plane now consumes this declaration through `ManifestManager::validate_deployment_selection`. Startup `validate_registry_vs_manifest` first runs the existing ordinary manifest validation, then the deployment co-requisite preflight, then the ordinary static-registry comparison. The preflight reads selected package `[co_requisites]` and rejects a default-enabled Product when Inventory or Pricing is not also selected, when a declared requirement is malformed, or when the selected owner version is missing, invalid, or incompatible.
+The static server control plane consumes this declaration through `ManifestManager::validate_deployment_selection`. Startup `validate_registry_vs_manifest` first runs the existing ordinary manifest validation, then the deployment co-requisite preflight, then the ordinary static-registry comparison. The preflight reads selected package `[co_requisites]` and rejects a default-enabled Product when Inventory or Pricing is not also selected, when a declared requirement is malformed, or when the selected owner version is missing, invalid, or incompatible.
 
-Deployment co-requisite validation is intentionally separate from `ManifestManager::validate`. Built-in installation and ordinary topology validation therefore remain able to add Product, Inventory, and Pricing sequentially without creating an installation deadlock. Registry and migration/dependency ordering continue to consume only ordinary `depends_on` / `RusToKModule::dependencies()` edges.
+Deployment co-requisite validation remains separate from `ManifestManager::validate`. Built-in installation and ordinary topology validation therefore remain able to add Product, Inventory, and Pricing sequentially without creating an installation deadlock. Registry and migration/dependency ordering continue to consume only ordinary `depends_on` / `RusToKModule::dependencies()` edges.
 
-This closes the static/default deployment-selection source gap. Tenant-scoped lifecycle toggles and effective-policy resolution do not yet consume the package co-requisite contract, so non-default tenant activation enforcement and execution evidence remain open.
+## Tenant lifecycle and effective-policy guard
+
+The server now derives the same package co-requisite map for the active composition through `ManifestManager::module_policy_corequisites` and applies two fail-closed host guards around the existing modules-owner policy:
+
+- `ModuleLifecycleService` resolves the current revisioned effective policy before a tenant override write. A Product enable intent verifies that admitted Inventory and Pricing definitions exist and satisfy the declared version requirements, but it does **not** require those owners to be already enabled. This is deliberate: Inventory/Pricing ordinarily depend on Product, so requiring either side to be effectively enabled first would create an enable deadlock. Tenant intent can therefore be staged Product-first, then Inventory/Pricing; effective availability remains fail-closed until the whole owner set is active. Disable intent likewise remains governed by the ordinary dependency topology so a tenant can tear the group down in the reverse order without a second deadlock. Compensation uses the same contract check when it would re-enable a consumer; post-hook retry does not change state and needs no second selection check.
+- `EffectiveModulePolicyService` validates every externally returned owner policy snapshot, including channel, maintenance, and node-readiness contexts. If Product remains enabled while an Inventory/Pricing co-requisite is unavailable or version-incompatible, the adapter returns a policy error instead of exposing an unsafe availability result.
+
+These guards consume `ModuleEffectivePolicy` facts and enabled state; they do not mutate `ModuleDefinition.dependencies`, `validate_module_toggle`, registry comparison, or migration ordering.
+
+This source slice deliberately does **not** claim canonical owner-policy integration yet. The package co-requisite map is not part of `ModuleEffectivePolicy.policy_revision`, and the host guard does not rewrite the owner decision with a dedicated co-requisite denial reason. That revision/cache identity gap remains the next source task before the overall dependency contract can be considered resolved.
 
 ## Current contained boundary
 
@@ -67,17 +76,20 @@ This is a native transaction collaboration contract, not a GraphQL, REST, gRPC, 
 - the default deployment bundle contains Product, Pricing, and Inventory;
 - the server owns a separate deployment co-requisite preflight and invokes it from startup manifest/registry validation;
 - built-in installation remains on ordinary `ManifestManager::validate` and does not invoke the co-requisite preflight;
-- selected co-requisites are required and version-checked without being copied into ordinary dependency ordering;
+- the active manifest exposes package co-requisite metadata to tenant policy guards without copying it into ordinary dependency ordering;
+- Product enable intent validates admitted/version-compatible co-requisite definitions without requiring an impossible pre-enabled owner order;
+- tenant enable/disable remains orderable through the ordinary dependency topology;
+- externally returned effective-policy snapshots fail closed when an enabled consumer loses a co-requisite;
 - Product uses the exact owner bootstrap services and operations;
 - Product does not import foreign owner entities or query known foreign tables directly;
 - the owner services remain explicitly transaction-aware;
-- tenant lifecycle/effective-policy enforcement and runtime rollback evidence remain unvalidated.
+- canonical policy-revision identity, runtime selection, and rollback execution evidence remain unvalidated.
 
 ## Next implementation slice
 
-Carry the same deployment co-requisite semantics into tenant lifecycle/effective-policy selection without turning co-requisites into dependency-order edges. Enabling Product for a tenant must fail closed unless Inventory and Pricing are effectively enabled with compatible admitted owner versions; disabling either owner while Product remains effectively enabled must likewise be rejected or make Product unavailable through one canonical owner policy decision.
+Move the co-requisite availability contract into the canonical modules-owner effective-policy identity/explanation surface without turning it into dependency ordering. The co-requisite contract must contribute to policy revision/cache identity, and an unavailable owner should produce an explicit owner decision for Product rather than only a host-level rejection.
 
-After tenant source enforcement exists, retain maintainer-run evidence for:
+After that source identity gap closes, retain maintainer-run evidence for:
 
 - default and non-default tenant module selections;
 - clean migration ordering;
@@ -94,4 +106,4 @@ Source evidence is stored at:
 
 `crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json`
 
-No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, or transaction rollback execution evidence are claimed by this source wave.
+No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, policy-cache execution, or transaction rollback execution evidence are claimed by this source wave.

--- a/scripts/verify/verify-product-lifecycle-collaboration.mjs
+++ b/scripts/verify/verify-product-lifecycle-collaboration.mjs
@@ -22,6 +22,8 @@ const inventoryBootstrap = read('crates/rustok-inventory/src/services/bootstrap.
 const pricingBootstrap = read('crates/rustok-pricing-persistence/src/lib.rs');
 const manifestCorequisites = read('apps/server/src/modules/manifest/corequisites.rs');
 const manifestManager = read('apps/server/src/modules/manifest/mod.rs');
+const tenantLifecycle = read('apps/server/src/services/module_lifecycle.rs');
+const effectivePolicy = read('apps/server/src/services/effective_module_policy.rs');
 const note = read('crates/rustok-product/docs/product-lifecycle-collaboration.md');
 const evidence = JSON.parse(
   read('crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json'),
@@ -44,24 +46,9 @@ const between = (source, start, end, label) => {
   return source.slice(startIndex, endIndex);
 };
 
-const productModuleEntry = between(
-  modules,
-  'product = {',
-  '\nprofiles = {',
-  'root Product module entry',
-);
-const pricingModuleEntry = between(
-  modules,
-  'pricing = {',
-  '\ninventory = {',
-  'root Pricing module entry',
-);
-const inventoryModuleEntry = between(
-  modules,
-  'inventory = {',
-  '\norder = {',
-  'root Inventory module entry',
-);
+const productModuleEntry = between(modules, 'product = {', '\nprofiles = {', 'root Product module entry');
+const pricingModuleEntry = between(modules, 'pricing = {', '\ninventory = {', 'root Pricing module entry');
+const inventoryModuleEntry = between(modules, 'inventory = {', '\norder = {', 'root Inventory module entry');
 const defaultEnabled = modules.slice(modules.indexOf('[settings]'));
 const productDependencySection = between(
   productManifest,
@@ -102,6 +89,18 @@ const registryValidationBlock = between(
 const startupValidationBlock = manifestManager.slice(
   manifestManager.indexOf('pub fn validate_registry_vs_manifest'),
 );
+const lifecycleToggleBlock = between(
+  tenantLifecycle,
+  'pub async fn toggle_module_with_actor(',
+  '\n    pub async fn module_operation_recovery_plan(',
+  'tenant lifecycle toggle block',
+);
+const compensationBlock = between(
+  tenantLifecycle,
+  'pub async fn compensate_failed_operation(',
+  '\n    pub async fn update_module_settings(',
+  'tenant lifecycle compensation block',
+);
 
 for (const [source, value, label] of [
   [productModuleEntry, 'depends_on = ["taxonomy"]', 'root Product dependency'],
@@ -131,22 +130,34 @@ for (const [source, value, label] of [
   [pricingBootstrap, 'C: ConnectionTrait', 'Pricing transaction connection'],
   [manifestCorequisites, 'co_requisites: BTreeMap<String, PackageCoRequisiteSpec>', 'typed package co-requisite parser'],
   [manifestCorequisites, 'pub(super) fn validate_default_corequisite_selection', 'deployment selection preflight'],
-  [manifestCorequisites, 'let selected = manifest', 'default selection source'],
+  [manifestCorequisites, 'pub(crate) fn module_policy_corequisites', 'tenant co-requisite metadata entrypoint'],
+  [manifestCorequisites, 'pub(crate) fn validate_effective_policy_corequisites', 'effective-policy co-requisite guard'],
+  [manifestCorequisites, 'pub(crate) fn validate_corequisite_toggle', 'tenant lifecycle co-requisite contract guard'],
+  [manifestCorequisites, 'if !policy.contains(provider)', 'effective provider availability rejection'],
+  [manifestCorequisites, 'validate_policy_provider_contract(', 'shared admitted provider contract validation'],
+  [manifestCorequisites, 'if !enabled {', 'orderable tenant disable intent'],
+  [manifestCorequisites, 'VersionReq::parse(requirement)', 'co-requisite version requirement validation'],
+  [manifestCorequisites, 'requirement.matches(&version)', 'tenant co-requisite effective version validation'],
   [manifestCorequisites, 'module.ordinary_dependencies.contains(co_requisite)', 'dependency/co-requisite separation'],
   [manifestCorequisites, '!selected.contains(co_requisite)', 'missing selected co-requisite rejection'],
-  [manifestCorequisites, 'VersionReq::parse(requirement)', 'co-requisite version requirement validation'],
-  [manifestCorequisites, 'requirement.matches(&installed_version)', 'co-requisite selected version validation'],
   [manifestCorequisites, 'selection_requires_corequisites_without_creating_dependency_edges', 'selection source test'],
   [manifestCorequisites, 'selection_rejects_incompatible_corequisite_version', 'version source test'],
   [manifestManager, 'mod corequisites;', 'manifest co-requisite module wiring'],
   [manifestManager, 'pub fn validate_deployment_selection(', 'manifest deployment selection API'],
-  [manifestManager, 'validate_default_corequisite_selection(manifest)', 'manifest deployment selection delegation'],
   [startupValidationBlock, '.and_then(|_| ManifestManager::validate_deployment_selection(&manifest))', 'startup co-requisite preflight'],
   [registryValidationBlock, 'dependencies: resolved_spec.depends_on.iter().cloned().collect()', 'ordinary registry dependency source'],
   [installBuiltinBlock, 'Self::validate(manifest)?;', 'ordinary install validation'],
-  [note, 'Status: static deployment co-requisite enforcement source-complete, tenant lifecycle enforcement pending, unvalidated.', 'focused note status'],
-  [note, 'ManifestManager::validate_deployment_selection', 'focused note static enforcement'],
-  [note, 'Tenant-scoped lifecycle toggles and effective-policy resolution do not yet consume', 'focused note tenant debt'],
+  [lifecycleToggleBlock, 'ManifestManager::module_policy_corequisites(&manifest)', 'tenant lifecycle co-requisite contract load'],
+  [lifecycleToggleBlock, '.effective_policy(registry, default_enabled.clone())', 'tenant lifecycle current owner policy'],
+  [lifecycleToggleBlock, 'ManifestManager::validate_corequisite_toggle(', 'tenant lifecycle pre-write contract guard'],
+  [compensationBlock, 'plan.previous_effective_enabled', 'compensation requested state source'],
+  [compensationBlock, 'ManifestManager::validate_corequisite_toggle(', 'compensation co-requisite guard'],
+  [effectivePolicy, 'ManifestManager::module_policy_corequisites(&manifest)', 'effective-policy co-requisite contract load'],
+  [effectivePolicy, 'ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)', 'effective-policy result guard'],
+  [note, 'Status: static and tenant host co-requisite guards source-complete, canonical policy-revision integration pending, unvalidated.', 'focused note status'],
+  [note, 'Tenant intent can therefore be staged Product-first', 'orderable tenant intent note'],
+  [note, 'EffectiveModulePolicyService', 'effective policy note'],
+  [note, 'not part of `ModuleEffectivePolicy.policy_revision`', 'policy revision debt'],
 ]) requireText(source, value, label);
 
 for (const [source, value, label] of [
@@ -158,6 +169,7 @@ for (const [source, value, label] of [
   [productRuntime, '"pricing"', 'cyclic Product runtime Pricing dependency'],
   [installBuiltinBlock, 'validate_deployment_selection', 'cyclic install-time co-requisite preflight'],
   [registryValidationBlock, 'co_requisite', 'co-requisite leaked into registry dependency comparison'],
+  [manifestCorequisites, 'cannot be disabled while required as a co-requisite', 'tenant co-requisite disable deadlock'],
   [catalog, 'rustok_commerce_foundation::entities', 'foreign foundation entity import'],
   [commands, 'rustok_commerce_foundation::entities', 'foreign foundation entity import in commands'],
   [commands, 'inventory_item::Entity', 'direct Inventory entity access'],
@@ -171,30 +183,27 @@ for (const [source, value, label] of [
   [commands, 'INTO prices', 'direct Pricing SQL write'],
 ]) forbidText(source, value, label);
 
-if (evidence.status !== 'product_lifecycle_static_corequisite_selection_enforced_unvalidated') {
+if (evidence.status !== 'product_lifecycle_tenant_corequisite_host_guard_source_complete_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 const coRequisites = [...(evidence.module_topology?.product_co_requisites ?? [])].sort();
 if (JSON.stringify(coRequisites) !== JSON.stringify(['inventory', 'pricing'])) {
   failures.push(`evidence Product co-requisites mismatch: ${JSON.stringify(coRequisites)}`);
 }
-if (evidence.module_topology?.ordinary_reverse_dependencies_forbidden !== true) {
-  failures.push('evidence must forbid ordinary reverse dependencies');
-}
-if (evidence.module_topology?.co_requisites_are_ordering_dependencies !== false) {
-  failures.push('co-requisites must not become ordering dependencies');
-}
-if (evidence.module_topology?.static_default_selection_enforcement_source_complete !== true) {
-  failures.push('static default selection enforcement must be source-complete');
-}
-if (evidence.module_topology?.co_requisite_control_plane_execution_proven !== false) {
-  failures.push('co-requisite control-plane execution must remain unproven');
-}
-if (evidence.module_topology?.tenant_lifecycle_corequisite_enforcement_proven !== false) {
-  failures.push('tenant lifecycle co-requisite enforcement must remain unproven');
-}
-if (evidence.module_topology?.standalone_product_write_activation_proven !== false) {
-  failures.push('standalone Product write activation must remain unproven');
+for (const [key, expected] of [
+  ['ordinary_reverse_dependencies_forbidden', true],
+  ['co_requisites_are_ordering_dependencies', false],
+  ['static_default_selection_enforcement_source_complete', true],
+  ['tenant_lifecycle_corequisite_guard_source_complete', true],
+  ['effective_policy_corequisite_guard_source_complete', true],
+  ['canonical_policy_revision_corequisite_identity_source_complete', false],
+  ['co_requisite_control_plane_execution_proven', false],
+  ['tenant_lifecycle_corequisite_execution_proven', false],
+  ['standalone_product_write_activation_proven', false],
+]) {
+  if (evidence.module_topology?.[key] !== expected) {
+    failures.push(`evidence module_topology.${key} must be ${expected}`);
+  }
 }
 if (evidence.product_boundary?.foreign_owner_entities_imported !== false ||
     evidence.product_boundary?.foreign_owner_tables_queried_directly !== false ||
@@ -204,8 +213,10 @@ if (evidence.product_boundary?.foreign_owner_entities_imported !== false ||
 if (evidence.decision?.containment_complete !== true ||
     evidence.decision?.corequisite_contract_declared !== true ||
     evidence.decision?.static_default_selection_enforcement_source_complete !== true ||
+    evidence.decision?.tenant_lifecycle_corequisite_guard_source_complete !== true ||
+    evidence.decision?.effective_policy_corequisite_guard_source_complete !== true ||
     evidence.decision?.dependency_contract_resolved !== false) {
-  failures.push('evidence decision must source-complete static selection while keeping tenant enforcement open');
+  failures.push('evidence decision must retain tenant host guards while keeping canonical policy identity open');
 }
 for (const key of [
   'tests_run',
@@ -215,6 +226,9 @@ for (const key of [
   'workflow_checks_run',
   'ci_run',
   'static_default_selection_execution_proven',
+  'tenant_lifecycle_execution_proven',
+  'effective_policy_guard_execution_proven',
+  'policy_cache_identity_execution_proven',
   'standalone_activation_proven',
   'non_default_deployment_selection_proven',
   'transaction_rollback_proven',
@@ -231,5 +245,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Product static/default deployment selection enforces Inventory/Pricing co-requisites without changing ordinary dependency ordering; tenant lifecycle and runtime evidence remain open',
+  '✔ Product static selection and tenant host policy/lifecycle guards enforce Inventory/Pricing co-requisites without changing ordinary dependency ordering; canonical policy revision identity and execution evidence remain open',
 );


### PR DESCRIPTION
## Summary
- derive package `[co_requisites]` from the active static composition for tenant policy without adding ordinary dependency edges
- preserve tenant transition ordering through the existing dependency graph: Product intent may be staged before Inventory/Pricing because those owners ordinarily depend on Product, and owner disable remains orderable for teardown
- validate admitted Inventory/Pricing definitions and version requirements before Product enable/compensation intent is persisted
- fail closed on externally returned effective-policy snapshots when Product is effectively enabled but Inventory/Pricing are unavailable or version-incompatible
- apply the same outward policy guard to base, channel, context, and node-readiness resolution paths
- actualize Product lifecycle docs/evidence and source guard around the tenant host boundary

## Plan status
- closes the tenant host lifecycle/effective-availability source guard selected after #3329
- does **not** close the overall Product dependency-contract item yet: package co-requisites are not part of `ModuleEffectivePolicy.policy_revision` / cache identity and the modules owner does not yet emit an explicit co-requisite denial decision
- static deployment preflight and ordinary install/registry/migration ordering remain unchanged
- next source slice is canonical modules-owner policy revision/cache identity and explanation integration without turning co-requisites into ordering dependencies

## Verification
- source and GitHub diff inspection only
- tests, source verifier execution, Cargo commands, formatting, workflows, CI, and runtime validation were intentionally not run per maintainer instruction