### PR TITLE
fix(groups): serialize feature settings with enforcement

### DIFF
--- a/crates/rustok-groups/docs/feature-enforcement-authorization-contract.md
+++ b/crates/rustok-groups/docs/feature-enforcement-authorization-contract.md
@@ -1,0 +1,56 @@
+# Groups feature-settings effective authorization contract
+
+Status: **source complete / maintainer runtime execution pending**
+
+`GroupCommandPort::set_group_feature` mutates Groups-owned feature-binding state. Manager authorization therefore belongs inside the same Groups owner transaction as the feature write.
+
+## Owner transaction
+
+The effective `GroupsService` now performs feature mutation in this order:
+
+1. validate the write `PortContext`, tenant and user actor;
+2. begin one Groups transaction;
+3. reserve the group writer with `reserve_group_write_for_update`;
+4. confirm the tenant/group owner aggregate exists;
+5. evaluate `GroupManagerCapability::ManageSettings` with `require_effective_manager_owned`;
+6. read and insert/update the feature binding through that transaction;
+7. advance `groups.version` in the same transaction;
+8. commit once.
+
+The authorization lock boundary remains the canonical:
+
+```text
+Group -> GroupMembership -> GroupMembershipEnforcement
+```
+
+PostgreSQL/MySQL retain row locks. SQLite uses the shared no-op group update writer reservation. A concurrent enforcement mutation cannot commit a suspension between manager authorization and the feature mutation.
+
+## Effective authority
+
+Local authority requires an effective-active owner or administrator. Stored lifecycle `active` is compatibility state only and cannot restore authority while an effective suspension is present.
+
+Stable owner failures are preserved:
+
+- active suspension: `groups.membership_suspended`;
+- legacy ban: `groups.membership_banned`;
+- inactive membership or insufficient role: `groups.manager_required`.
+
+Platform `groups:manage`, `groups:*`, and `*:*` authority remains an explicit bypass of local membership requirements, but still enters the owner transaction and group serialization boundary before feature mutation.
+
+## Aggregate semantics
+
+Feature insert/update and the corresponding `groups.version` increment are atomic. Feature settings do not change stored membership lifecycle status or `groups.member_count`.
+
+No receipt, alternate owner, direct enforcement write, Moderation dependency, fallback, manifest change, or lockfile change is introduced by this slice.
+
+## Evidence status
+
+This source change was not executed while preparing the slice. SQLite/PostgreSQL suspension/expiry and enforcement-vs-feature-write contention evidence remains maintainer-owned and the canonical plan stays `in_progress`.
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-feature-enforcement-authorization.mjs
+```
+
+No Cargo command, Rust test, Node verifier, formatter, migration execution, workflow, or CI job was run while preparing this source.

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -122,7 +122,7 @@ Source exists for:
   suspension/expiry/revocation while every enforcement mutation still advances group version;
 - append-only membership suspend/revoke semantic events beside targeted invitation events;
 - effective core `GroupsService` for access, redaction, join/rejoin, membership listing, enabled
-  features, and feature settings;
+  features, and transaction-aware feature settings using the canonical effective-manager lock protocol;
 - effective localization management reads plus transaction-aware translation upsert/delete using the
   same owner-clock manager semantics and `Group -> GroupMembership -> GroupMembershipEnforcement`
   write lock protocol;
@@ -146,6 +146,7 @@ Evidence still open:
 - direct enforcement replay, expected-revision contention, hierarchy, owner-protection, expiry,
   revoke, lifecycle-count invariance, audit/event atomicity and security evidence;
 - executed native/GraphQL parity and schema/error-mapping evidence for direct enforcement;
+- executed feature-settings suspension/expiry and concurrent enforcement-vs-write evidence;
 - executed localization suspension/expiry, native/GraphQL parity, and concurrent enforcement-vs-write
   evidence;
 - maintainer execution of the PostgreSQL and SQLite governance/enforcement evidence sources plus
@@ -166,7 +167,7 @@ Evidence still open:
 | GROUPS-04 | in_progress | typed summary/membership/access/localization/invitation/application/governance/enforcement ports | consumer/fallback runtime matrix |
 | GROUPS-05 | in_progress | GraphQL/native transports, invitation acceptance/delivery | parity and Notifications evidence |
 | GROUPS-06 | in_progress | localized policy, CAS, lifecycle, focused/bulk review, FFA UX | profiles/events/parity/concurrency/accessibility |
-| GROUPS-07 | in_progress | revision, enforcement read/direct command/GraphQL, effective core/localization/governance access, transactional invitation/application authorization | moderation adapter, provider cutover, runtime/concurrency/parity evidence |
+| GROUPS-07 | in_progress | revision, enforcement read/direct command/GraphQL, effective core/feature/localization/governance access, transactional invitation/application authorization | moderation adapter, provider cutover, runtime/concurrency/parity evidence |
 | GROUPS-08 | planned | dynamic feature-provider registry and navigation | registry/degradation evidence |
 | GROUPS-09 | planned | Forum group spaces and ACL inheritance | Forum integration evidence |
 | GROUPS-10 | planned | Blog and Pages/Wiki group contexts | owner/privacy evidence |
@@ -319,6 +320,25 @@ expiry/revocation state and replay flag.
 Runtime schema execution, error-code parity, replay/CAS and authorization parity remain evidence
 gates; source composition is not promoted to `done`.
 
+### Source-complete feature-settings effective authorization
+
+`GroupCommandPort::set_group_feature` now treats feature bindings as transactionally serialized Groups
+owner state instead of evaluating manager authority on one database snapshot and writing the feature on
+a later snapshot. The command starts one owner transaction, reserves the group writer first, confirms
+group existence, and then evaluates `GroupManagerCapability::ManageSettings` through the canonical
+`Group -> GroupMembership -> GroupMembershipEnforcement` effective-manager guard before reading or
+writing the feature binding.
+
+A concurrently committed suspension therefore cannot land between authorization and feature mutation.
+Suspended/banned local managers receive the stable `groups.membership_suspended` /
+`groups.membership_banned` identities and inactive/insufficient roles receive `groups.manager_required`.
+Platform `groups:manage` remains the explicit authority bypass, but it still participates in group
+serialization before changing feature state.
+
+Feature insert/update and the corresponding `groups.version` advance now commit in the same transaction.
+The stored lifecycle `member_count` is unchanged. Runtime SQLite/PostgreSQL suspension/expiry and
+feature-write contention evidence remains open; source completeness is not promoted to `done`.
+
 ### Source-complete localization effective authorization
 
 Localization management no longer authorizes against raw stored membership status. Read-only
@@ -408,7 +428,7 @@ observe independent databases and provide false concurrency evidence.
 
 Status is **maintainer execution pending**. SQLite concurrency/replay/recovery is not runtime evidence
 until this test is actually executed. The handoff is documented in
-`docs/governance-enforcement-sqlite-contract.md` and guarded by
+docs/governance-enforcement-sqlite-contract.md` and guarded by
 `scripts/verify/verify-groups-governance-enforcement-sqlite.mjs`.
 
 ### Planned moderation adapter

--- a/crates/rustok-groups/docs/implementation-plan.md
+++ b/crates/rustok-groups/docs/implementation-plan.md
@@ -428,7 +428,7 @@ observe independent databases and provide false concurrency evidence.
 
 Status is **maintainer execution pending**. SQLite concurrency/replay/recovery is not runtime evidence
 until this test is actually executed. The handoff is documented in
-docs/governance-enforcement-sqlite-contract.md` and guarded by
+`docs/governance-enforcement-sqlite-contract.md` and guarded by
 `scripts/verify/verify-groups-governance-enforcement-sqlite.mjs`.
 
 ### Planned moderation adapter
@@ -466,8 +466,8 @@ above rather than introduce a second Groups enforcement state path.
 1. Add the neutral moderation subject adapter over the shared enforcement owner mutation.
 2. Convert provider ACL consumers and remote/degraded profiles.
 3. Execute and retain the PostgreSQL/SQLite governance-enforcement evidence sources, then produce
-   remaining direct-enforcement, localization, governance and adapter runtime, parity, concurrency,
-   security, migration and accessibility evidence.
+   remaining direct-enforcement, feature-settings, localization, governance and adapter runtime,
+   parity, concurrency, security, migration and accessibility evidence.
 
 ## Degraded modes
 
@@ -498,6 +498,7 @@ cargo test -p rustok-groups
 RUSTOK_GROUPS_TEST_POSTGRES_URL='postgres://...' cargo test -p rustok-server --features mod-groups --test groups_governance_enforcement_postgres -- --ignored --nocapture
 cargo test -p rustok-server --features mod-groups --test groups_governance_enforcement_sqlite -- --nocapture
 node scripts/verify/verify-groups-boundary.mjs
+node scripts/verify/verify-groups-feature-enforcement-authorization.mjs
 node scripts/verify/verify-groups-localization-boundary.mjs
 node scripts/verify/verify-groups-governance-effective-authorization.mjs
 node scripts/verify/verify-groups-governance-enforcement-postgres.mjs

--- a/crates/rustok-groups/src/effective_service.rs
+++ b/crates/rustok-groups/src/effective_service.rs
@@ -15,9 +15,13 @@ use crate::domain::{
     GroupMembershipStatus, GroupRole, GroupStatus, GroupVisibility, normalize_feature_key,
 };
 use crate::dto::*;
+use crate::effective_membership_guard::{
+    GroupManagerCapability, require_effective_manager_owned,
+};
 use crate::entities::{feature_binding, group, membership};
 use crate::error::{GroupsError, GroupsResult};
 use crate::membership_enforcement::resolve_group_membership_enforcement;
+use crate::membership_enforcement_transaction::reserve_group_write_for_update;
 use crate::ports::{
     GroupAccessReadPort, GroupCommandPort, GroupMembershipReadPort, GroupSummaryReadPort,
 };
@@ -219,23 +223,28 @@ impl GroupsService {
         require_write(context)?;
         let tenant_id = context_tenant_id(context)?;
         let actor_id = actor_user_id(context)?;
-        self.group_model(tenant_id, request.group_id).await?;
+        let transaction = self.db.begin().await?;
 
-        let effective = resolve_group_membership_enforcement(
-            &self.db,
+        // Feature settings are Groups owner state. Serialize the aggregate before evaluating
+        // effective manager authority so a concurrent suspension cannot commit between auth and
+        // the feature write. SQLite receives the same writer reservation through the shared no-op
+        // group update used by the rest of the enforcement-aware owner boundary.
+        reserve_group_write_for_update(&transaction, tenant_id, request.group_id).await?;
+        let group_model = group::Entity::find()
+            .filter(group::Column::TenantId.eq(tenant_id))
+            .filter(group::Column::Id.eq(request.group_id))
+            .one(&transaction)
+            .await?
+            .ok_or(GroupsError::NotFound)?;
+        require_effective_manager_owned(
+            &transaction,
+            context,
             tenant_id,
             request.group_id,
             actor_id,
-            Utc::now(),
+            GroupManagerCapability::ManageSettings,
         )
         .await?;
-        let local_allowed =
-            effective.active_member && effective.role.is_some_and(GroupRole::can_manage_settings);
-        if !local_allowed && !has_platform_manage(context) {
-            return Err(GroupsError::Forbidden(
-                "active group owner or administrator role is required".to_string(),
-            ));
-        }
 
         let feature_key =
             normalize_feature_key(&request.feature_key).map_err(GroupsError::Validation)?;
@@ -253,7 +262,7 @@ impl GroupsService {
             .filter(feature_binding::Column::TenantId.eq(tenant_id))
             .filter(feature_binding::Column::GroupId.eq(request.group_id))
             .filter(feature_binding::Column::FeatureKey.eq(feature_key.clone()))
-            .one(&self.db)
+            .one(&transaction)
             .await?;
 
         let model = if let Some(existing) = existing {
@@ -263,7 +272,7 @@ impl GroupsService {
             active.sort_order = Set(request.sort_order);
             active.configuration = Set(request.configuration);
             active.updated_at = Set(now);
-            active.update(&self.db).await?
+            active.update(&transaction).await?
         } else {
             feature_binding::ActiveModel {
                 id: Set(Uuid::new_v4()),
@@ -278,9 +287,16 @@ impl GroupsService {
                 created_at: Set(now),
                 updated_at: Set(now),
             }
-            .insert(&self.db)
+            .insert(&transaction)
             .await?
         };
+
+        let mut group_active: group::ActiveModel = group_model.into();
+        group_active.version = Set(group_active.version.take().unwrap_or_default().saturating_add(1));
+        group_active.updated_at = Set(now);
+        group_active.update(&transaction).await?;
+
+        transaction.commit().await?;
         map_feature(model)
     }
 }

--- a/scripts/verify/verify-groups-feature-enforcement-authorization.mjs
+++ b/scripts/verify/verify-groups-feature-enforcement-authorization.mjs
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+
+const sourcePath = "crates/rustok-groups/src/effective_service.rs";
+const planPath = "crates/rustok-groups/docs/implementation-plan.md";
+const docsPath = "crates/rustok-groups/docs/feature-enforcement-authorization-contract.md";
+
+const source = fs.readFileSync(sourcePath, "utf8");
+const plan = fs.readFileSync(planPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+const featureStart = source.indexOf("async fn set_group_feature_owned(");
+const featureEnd = source.indexOf("\n}\n\n#[async_trait]\nimpl GroupSummaryReadPort", featureStart);
+if (featureStart < 0 || featureEnd < 0) {
+  throw new Error("effective Groups feature owner function could not be isolated");
+}
+const feature = source.slice(featureStart, featureEnd);
+
+for (const marker of [
+  "let transaction = self.db.begin().await?",
+  "reserve_group_write_for_update(&transaction, tenant_id, request.group_id).await?",
+  "require_effective_manager_owned(",
+  "GroupManagerCapability::ManageSettings",
+  ".one(&transaction)",
+  ".update(&transaction)",
+  ".insert(&transaction)",
+  "group_active.version = Set(",
+  "transaction.commit().await?",
+]) {
+  requireText(feature, marker, `feature owner transaction is missing ${marker}`);
+}
+
+for (const forbidden of [
+  ".one(&self.db)",
+  ".update(&self.db)",
+  ".insert(&self.db)",
+  "resolve_group_membership_enforcement(\n            &self.db",
+  "rustok_moderation::",
+]) {
+  if (feature.includes(forbidden)) {
+    throw new Error(`feature owner transaction contains pre-transaction or foreign-owner shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "Source-complete feature-settings effective authorization",
+  "Group -> GroupMembership -> GroupMembershipEnforcement",
+  "groups.membership_suspended",
+  "groups.membership_banned",
+  "groups.manager_required",
+  "Feature insert/update and the corresponding `groups.version` advance now commit in the same transaction",
+]) {
+  requireText(plan, marker, `canonical Groups plan is missing feature authorization marker ${marker}`);
+}
+
+for (const marker of [
+  "source complete / maintainer runtime execution pending",
+  "reserve_group_write_for_update",
+  "require_effective_manager_owned",
+  "groups.version",
+  "groups.member_count",
+  "groups.membership_suspended",
+]) {
+  requireText(docs, marker, `feature authorization handoff is missing ${marker}`);
+}
+
+console.log("Groups feature enforcement authorization source guard passed");


### PR DESCRIPTION
## Summary
- make `GroupCommandPort::set_group_feature` one Groups owner transaction instead of authorization/read/write across separate database snapshots
- reserve the group writer before effective manager authorization and feature state access
- evaluate local owner/admin authority through the canonical `Group -> GroupMembership -> GroupMembershipEnforcement` guard
- preserve platform `groups:manage` authority while keeping it inside group serialization
- commit feature insert/update and the matching `groups.version` advance atomically without changing lifecycle `member_count`
- preserve stable suspended/banned/manager-required owner errors
- update the canonical Groups implementation plan in the same behavior change and add a focused source contract/guard
- add no dependency, migration, manifest, lockfile, Moderation owner, or fallback change

## Verification
Static source and diff review only. Cargo commands, Rust tests, Node verifiers, formatters, migration execution, workflows, and CI were intentionally not run per maintainer instruction.