### PR TITLE
test(groups): retain feature enforcement SQLite evidence

### DIFF
--- a/apps/server/tests/groups_feature_enforcement_sqlite.rs
+++ b/apps/server/tests/groups_feature_enforcement_sqlite.rs
@@ -1,0 +1,455 @@
+#![cfg(feature = "mod-groups")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use rustok_api::{PortActor, PortContext};
+use rustok_groups::{
+    GroupAccessReadPort, GroupCommandPort, GroupMembershipEffectiveStatus,
+    GroupMembershipEnforcementCommandPort, GroupMembershipEnforcementCommandService,
+    GroupMembershipEnforcementReadPort, GroupMembershipEnforcementService, GroupsService,
+    ReadGroupMembershipEnforcementRequest, SetGroupFeatureRequest, SuspendGroupMembershipRequest,
+};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, Statement,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tempfile::TempDir;
+use tokio::sync::Barrier;
+use uuid::Uuid;
+
+const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
+const ROUNDS: usize = 8;
+
+fn sqlite_fixture_url(temp: &TempDir) -> String {
+    let path = temp.path().join("groups-feature-enforcement.sqlite");
+    format!("sqlite://{}?mode=rwc", path.display())
+}
+
+async fn connect(url: &str) -> DatabaseConnection {
+    let mut options = ConnectOptions::new(url.to_string());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .connect_timeout(Duration::from_secs(5))
+        .acquire_timeout(Duration::from_secs(5))
+        .sqlx_logging(false);
+    let db = Database::connect(options)
+        .await
+        .expect("Groups feature enforcement SQLite connection should open");
+    db.execute_unprepared(&format!(
+        "PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS};"
+    ))
+    .await
+    .expect("Groups feature enforcement SQLite connection should configure busy timeout");
+    db
+}
+
+async fn install_groups_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    for migration in rustok_groups::migrations::migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("production Groups migration should apply for feature enforcement evidence");
+    }
+}
+
+async fn seed_group_fixture(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    owner_id: Uuid,
+    admin_id: Uuid,
+    handle: &str,
+) {
+    db.execute_unprepared(&format!(
+        r#"
+INSERT INTO groups (id, tenant_id, owner_user_id, handle, visibility, status, member_count)
+VALUES ('{group_id}', '{tenant_id}', '{owner_id}', '{handle}', 'public', 'active', 2);
+
+INSERT INTO group_memberships
+    (id, tenant_id, group_id, user_id, role, status, joined_at)
+VALUES
+    ('{}', '{tenant_id}', '{group_id}', '{owner_id}', 'owner', 'active', CURRENT_TIMESTAMP),
+    ('{}', '{tenant_id}', '{group_id}', '{admin_id}', 'admin', 'active', CURRENT_TIMESTAMP);
+"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+    ))
+    .await
+    .expect("Groups feature enforcement SQLite fixture should seed");
+}
+
+fn write_context(tenant_id: Uuid, actor_id: Uuid, operation: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-feature-enforcement-{operation}-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+    .with_idempotency_key(format!("{operation}-{}", Uuid::new_v4()))
+}
+
+fn read_context(tenant_id: Uuid, actor_id: Uuid) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(actor_id.to_string()),
+        "en",
+        format!("groups-feature-enforcement-read-{}", Uuid::new_v4()),
+    )
+    .with_deadline(Duration::from_secs(10))
+}
+
+fn enforcement_read_context(tenant_id: Uuid, owner_id: Uuid) -> PortContext {
+    read_context(tenant_id, owner_id).with_claim("groups:access:read")
+}
+
+fn feature_request(group_id: Uuid, phase: &str) -> SetGroupFeatureRequest {
+    SetGroupFeatureRequest {
+        group_id,
+        feature_key: "forum.discussions".to_string(),
+        contract_version: "groups-feature-evidence.v1".to_string(),
+        enabled: true,
+        sort_order: 10,
+        configuration: serde_json::json!({ "phase": phase }),
+    }
+}
+
+async fn group_version(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT version FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group version query should succeed")
+        .expect("group should exist");
+    row.try_get("", "version")
+        .expect("group version should decode")
+}
+
+async fn member_count(db: &DatabaseConnection, tenant_id: Uuid, group_id: Uuid) -> i64 {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT member_count FROM groups WHERE tenant_id = '{tenant_id}' AND id = '{group_id}'"
+            ),
+        ))
+        .await
+        .expect("group member_count query should succeed")
+        .expect("group should exist");
+    row.try_get("", "member_count")
+        .expect("group member_count should decode")
+}
+
+async fn membership_snapshot(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> (String, i64) {
+    let row = db
+        .query_one(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            format!(
+                "SELECT status, revision FROM group_memberships WHERE tenant_id = '{tenant_id}' AND group_id = '{group_id}' AND user_id = '{user_id}'"
+            ),
+        ))
+        .await
+        .expect("membership snapshot query should succeed")
+        .expect("membership should exist");
+    (
+        row.try_get("", "status")
+            .expect("membership status should decode"),
+        row.try_get("", "revision")
+            .expect("membership revision should decode"),
+    )
+}
+
+async fn feature_phase(
+    db: DatabaseConnection,
+    tenant_id: Uuid,
+    owner_id: Uuid,
+    group_id: Uuid,
+) -> Option<String> {
+    let service = GroupsService::new(db);
+    GroupAccessReadPort::enabled_group_features(
+        &service,
+        read_context(tenant_id, owner_id),
+        group_id,
+    )
+    .await
+    .expect("owner should read enabled group features")
+    .into_iter()
+    .find(|feature| feature.feature_key == "forum.discussions")
+    .and_then(|feature| {
+        feature
+            .configuration
+            .get("phase")
+            .and_then(|value| value.as_str())
+            .map(str::to_owned)
+    })
+}
+
+#[tokio::test]
+async fn feature_settings_follow_suspension_and_owner_clock_expiry_sqlite() {
+    let temp = tempfile::tempdir()
+        .expect("temporary Groups feature enforcement directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let db = connect(&url).await;
+    db.execute_unprepared("PRAGMA journal_mode = WAL;")
+        .await
+        .expect("Groups feature enforcement SQLite fixture should enable WAL");
+    install_groups_schema(&db).await;
+
+    let tenant_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let admin_id = Uuid::new_v4();
+    seed_group_fixture(
+        &db,
+        tenant_id,
+        group_id,
+        owner_id,
+        admin_id,
+        "feature-expiry",
+    )
+    .await;
+
+    let base_version = group_version(&db, tenant_id, group_id).await;
+    let feature_service = GroupsService::new(db.clone());
+    GroupCommandPort::set_group_feature(
+        &feature_service,
+        write_context(tenant_id, admin_id, "initial-feature"),
+        feature_request(group_id, "before-suspension"),
+    )
+    .await
+    .expect("effective-active admin should configure the group feature");
+    let feature_version = group_version(&db, tenant_id, group_id).await;
+    assert_eq!(feature_version, base_version + 1);
+
+    let expires_at = Utc::now() + ChronoDuration::milliseconds(500);
+    let enforcement = GroupMembershipEnforcementCommandService::new(db.clone());
+    let suspended = GroupMembershipEnforcementCommandPort::suspend_membership(
+        &enforcement,
+        write_context(tenant_id, owner_id, "suspend-feature-admin"),
+        SuspendGroupMembershipRequest {
+            group_id,
+            target_user_id: admin_id,
+            expected_membership_revision: 1,
+            reason_code: "harassment".to_string(),
+            effective_until: Some(expires_at),
+        },
+    )
+    .await
+    .expect("owner should suspend feature administrator");
+    assert_eq!(suspended.group_version as i64, feature_version + 1);
+    assert_eq!(suspended.member_count, 2);
+
+    let (stored_status, suspended_revision) =
+        membership_snapshot(&db, tenant_id, group_id, admin_id).await;
+    assert_eq!(stored_status, "active");
+    assert_eq!(suspended_revision, 2);
+
+    let blocked = GroupCommandPort::set_group_feature(
+        &feature_service,
+        write_context(tenant_id, admin_id, "blocked-feature"),
+        feature_request(group_id, "must-not-commit"),
+    )
+    .await
+    .expect_err("effective-suspended admin must not configure a group feature");
+    assert_eq!(blocked.code, "groups.membership_suspended");
+    assert!(!blocked.retryable);
+    assert_eq!(
+        group_version(&db, tenant_id, group_id).await,
+        suspended.group_version as i64,
+        "denied feature write must not advance the aggregate"
+    );
+    assert_eq!(
+        feature_phase(db.clone(), tenant_id, owner_id, group_id).await.as_deref(),
+        Some("before-suspension")
+    );
+
+    let effective_reader = GroupMembershipEnforcementService::new(db.clone());
+    let during = GroupMembershipEnforcementReadPort::read_membership_enforcement(
+        &effective_reader,
+        enforcement_read_context(tenant_id, owner_id),
+        ReadGroupMembershipEnforcementRequest {
+            group_id,
+            user_id: admin_id,
+        },
+    )
+    .await
+    .expect("owner should read suspended feature administrator state");
+    assert_eq!(during.effective_status, GroupMembershipEffectiveStatus::Suspended);
+
+    let remaining = expires_at
+        .signed_duration_since(Utc::now())
+        .to_std()
+        .unwrap_or_default();
+    tokio::time::sleep(remaining + Duration::from_millis(100)).await;
+
+    let after_expiry = GroupMembershipEnforcementReadPort::read_membership_enforcement(
+        &effective_reader,
+        enforcement_read_context(tenant_id, owner_id),
+        ReadGroupMembershipEnforcementRequest {
+            group_id,
+            user_id: admin_id,
+        },
+    )
+    .await
+    .expect("owner-clock expiry should restore effective admin membership");
+    assert_eq!(after_expiry.effective_status, GroupMembershipEffectiveStatus::Active);
+    assert_eq!(after_expiry.membership_revision, Some(2));
+
+    GroupCommandPort::set_group_feature(
+        &feature_service,
+        write_context(tenant_id, admin_id, "restored-feature"),
+        feature_request(group_id, "after-expiry"),
+    )
+    .await
+    .expect("expired suspension should restore feature-management authority without cleanup");
+    assert_eq!(
+        group_version(&db, tenant_id, group_id).await,
+        suspended.group_version as i64 + 1
+    );
+    assert_eq!(
+        membership_snapshot(&db, tenant_id, group_id, admin_id).await,
+        ("active".to_string(), 2),
+        "owner-clock expiry must not synthesize a membership lifecycle revision"
+    );
+    assert_eq!(member_count(&db, tenant_id, group_id).await, 2);
+    assert_eq!(
+        feature_phase(db.clone(), tenant_id, owner_id, group_id).await.as_deref(),
+        Some("after-expiry")
+    );
+
+    drop(effective_reader);
+    drop(enforcement);
+    drop(feature_service);
+    drop(db);
+    drop(temp);
+}
+
+#[tokio::test]
+async fn feature_write_and_suspension_serialize_on_sqlite_group_writer() {
+    let temp = tempfile::tempdir()
+        .expect("temporary Groups feature concurrency directory should create");
+    let url = sqlite_fixture_url(&temp);
+    let fixture_db = connect(&url).await;
+    fixture_db
+        .execute_unprepared("PRAGMA journal_mode = WAL;")
+        .await
+        .expect("Groups feature concurrency SQLite fixture should enable WAL");
+    install_groups_schema(&fixture_db).await;
+
+    for round in 0..ROUNDS {
+        let tenant_id = Uuid::new_v4();
+        let group_id = Uuid::new_v4();
+        let owner_id = Uuid::new_v4();
+        let admin_id = Uuid::new_v4();
+        seed_group_fixture(
+            &fixture_db,
+            tenant_id,
+            group_id,
+            owner_id,
+            admin_id,
+            &format!("feature-race-{round}"),
+        )
+        .await;
+        let base_version = group_version(&fixture_db, tenant_id, group_id).await;
+
+        let feature_db = connect(&url).await;
+        let enforcement_db = connect(&url).await;
+        let barrier = Arc::new(Barrier::new(3));
+
+        let feature_barrier = barrier.clone();
+        let feature_task = tokio::spawn(async move {
+            let service = GroupsService::new(feature_db);
+            feature_barrier.wait().await;
+            GroupCommandPort::set_group_feature(
+                &service,
+                write_context(tenant_id, admin_id, "raced-feature"),
+                feature_request(group_id, "raced"),
+            )
+            .await
+        });
+
+        let enforcement_barrier = barrier.clone();
+        let enforcement_task = tokio::spawn(async move {
+            let service = GroupMembershipEnforcementCommandService::new(enforcement_db);
+            enforcement_barrier.wait().await;
+            GroupMembershipEnforcementCommandPort::suspend_membership(
+                &service,
+                write_context(tenant_id, owner_id, "raced-suspension"),
+                SuspendGroupMembershipRequest {
+                    group_id,
+                    target_user_id: admin_id,
+                    expected_membership_revision: 1,
+                    reason_code: "concurrent_settings_review".to_string(),
+                    effective_until: None,
+                },
+            )
+            .await
+        });
+
+        barrier.wait().await;
+        let feature_result = feature_task
+            .await
+            .expect("SQLite feature race task should join without panic");
+        let suspension = enforcement_task
+            .await
+            .expect("SQLite enforcement race task should join without panic")
+            .expect("owner suspension must serialize to a successful commit");
+        assert_eq!(suspension.membership_revision, 2);
+        assert_eq!(suspension.member_count, 2);
+
+        let phase = feature_phase(
+            fixture_db.clone(),
+            tenant_id,
+            owner_id,
+            group_id,
+        )
+        .await;
+        match feature_result {
+            Ok(feature) => {
+                assert_eq!(feature.feature_key, "forum.discussions");
+                assert_eq!(phase.as_deref(), Some("raced"));
+                assert_eq!(
+                    suspension.group_version as i64,
+                    base_version + 2,
+                    "successful feature write must serialize before the suspension"
+                );
+            }
+            Err(error) => {
+                assert_eq!(error.code, "groups.membership_suspended");
+                assert!(!error.retryable);
+                assert_eq!(phase, None);
+                assert_eq!(
+                    suspension.group_version as i64,
+                    base_version + 1,
+                    "denied feature write must not advance group version"
+                );
+            }
+        }
+
+        assert_eq!(
+            group_version(&fixture_db, tenant_id, group_id).await,
+            suspension.group_version as i64
+        );
+        assert_eq!(
+            membership_snapshot(&fixture_db, tenant_id, group_id, admin_id).await,
+            ("active".to_string(), 2)
+        );
+        assert_eq!(member_count(&fixture_db, tenant_id, group_id).await, 2);
+    }
+
+    drop(fixture_db);
+    drop(temp);
+}

--- a/crates/rustok-groups/docs/feature-enforcement-sqlite-contract.md
+++ b/crates/rustok-groups/docs/feature-enforcement-sqlite-contract.md
@@ -1,0 +1,53 @@
+# Groups feature-settings enforcement SQLite evidence contract
+
+Status: **executable source added / maintainer execution pending**
+
+`apps/server/tests/groups_feature_enforcement_sqlite.rs` retains file-backed SQLite evidence for the transaction-aware Groups feature-settings authorization boundary introduced by `set_group_feature`.
+
+## Storage profile
+
+The packet uses one temporary SQLite file, production Groups migrations, one-connection SeaORM pools, `PRAGMA busy_timeout = 5000`, and WAL mode. It does not use `sqlite::memory:` and does not accept `database is locked` or persistence-unavailable behavior as a domain result.
+
+## Suspension and owner-clock expiry
+
+An effective-active administrator first writes `forum.discussions` through `GroupCommandPort::set_group_feature`. The feature write advances `groups.version` by one.
+
+The group owner then applies a temporary suspension through the production `GroupMembershipEnforcementCommandPort`. While stored membership remains lifecycle `active`, a fresh feature write by that administrator must fail non-retryably with `groups.membership_suspended`, leave feature configuration unchanged, and leave `groups.version` unchanged.
+
+The packet reads effective state through `GroupMembershipEnforcementReadPort`. After `effective_until`, the same administrator must become effective-active again without revoke or cleanup and may update the feature. Expiry itself must not synthesize a membership revision or change lifecycle `member_count`.
+
+## Enforcement-versus-feature-write serialization
+
+Eight independent race fixtures release a feature mutation and suspension through one barrier, using separate pre-opened SQLite connections. The commands address the same group and administrator.
+
+Only these serialized outcomes are allowed:
+
+- feature write commits first, then suspension commits; the aggregate advances by two versions and the feature exists;
+- suspension commits first, then the feature write fails with `groups.membership_suspended`; the aggregate advances only for suspension and no feature row is exposed by the owner read port.
+
+Suspension must always commit with membership revision two. The stored membership remains `active`, lifecycle `member_count` stays two, and final group version must equal the suspension result. A retryable/storage error, task panic, partial feature write, or extra aggregate version advance is evidence failure.
+
+## Owner surfaces only
+
+Feature mutation uses `GroupsService` through `GroupCommandPort`; enforcement uses the production command port; feature observation uses `GroupAccessReadPort::enabled_group_features`; effective membership observation uses `GroupMembershipEnforcementReadPort`. Raw SQL is limited to fixture creation and diagnostic aggregate/lifecycle revision reads.
+
+No production behavior, dependency, manifest, lockfile, migration, Moderation adapter, or fallback is introduced by this evidence slice.
+
+## Execution status
+
+The packet was not executed while preparing this slice. The canonical plan therefore remains `in_progress` and the feature-settings runtime/concurrency gate remains maintainer-owned.
+
+Maintainer command:
+
+```bash
+cargo test -p rustok-server --features mod-groups \
+  --test groups_feature_enforcement_sqlite -- --nocapture
+```
+
+Source guard:
+
+```bash
+node scripts/verify/verify-groups-feature-enforcement-sqlite.mjs
+```
+
+No Cargo command, Rust test, Node verifier, formatter, migration execution, workflow, or CI job was run while adding this source.

--- a/scripts/verify/verify-groups-feature-enforcement-sqlite.mjs
+++ b/scripts/verify/verify-groups-feature-enforcement-sqlite.mjs
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+
+const testPath = "apps/server/tests/groups_feature_enforcement_sqlite.rs";
+const docsPath = "crates/rustok-groups/docs/feature-enforcement-sqlite-contract.md";
+const planPath = "crates/rustok-groups/docs/implementation-plan.md";
+
+const test = fs.readFileSync(testPath, "utf8");
+const docs = fs.readFileSync(docsPath, "utf8");
+const plan = fs.readFileSync(planPath, "utf8");
+
+function requireText(source, marker, message) {
+  if (!source.includes(marker)) throw new Error(message);
+}
+
+for (const marker of [
+  '#![cfg(feature = "mod-groups")]',
+  "tempfile::tempdir()",
+  "mode=rwc",
+  "PRAGMA busy_timeout",
+  "PRAGMA journal_mode = WAL",
+  ".max_connections(1)",
+  "rustok_groups::migrations::migrations()",
+  "GroupCommandPort::set_group_feature",
+  "GroupMembershipEnforcementCommandPort::suspend_membership",
+  "GroupMembershipEnforcementReadPort::read_membership_enforcement",
+  "GroupAccessReadPort::enabled_group_features",
+  '"groups.membership_suspended"',
+  "GroupMembershipEffectiveStatus::Suspended",
+  "GroupMembershipEffectiveStatus::Active",
+  "const ROUNDS: usize = 8",
+  "Barrier::new(3)",
+  "base_version + 2",
+  "base_version + 1",
+  '("active".to_string(), 2)',
+  "member_count",
+]) {
+  requireText(test, marker, `Groups feature enforcement SQLite evidence is missing ${marker}`);
+}
+
+for (const forbidden of [
+  "database is locked",
+  "groups.persistence_unavailable",
+  "rustok_moderation::",
+  "group_feature_bindings SET",
+  "INSERT INTO group_feature_bindings",
+]) {
+  if (test.includes(forbidden)) {
+    throw new Error(`Groups feature enforcement SQLite evidence contains shortcut ${forbidden}`);
+  }
+}
+
+for (const marker of [
+  "executable source added / maintainer execution pending",
+  "Storage profile",
+  "Suspension and owner-clock expiry",
+  "Enforcement-versus-feature-write serialization",
+  "groups.membership_suspended",
+  "lifecycle `member_count`",
+  "Owner surfaces only",
+]) {
+  requireText(docs, marker, `Groups feature enforcement SQLite handoff is missing ${marker}`);
+}
+
+for (const marker of [
+  "executed feature-settings suspension/expiry and concurrent enforcement-vs-write evidence",
+  "Source-complete feature-settings effective authorization",
+]) {
+  requireText(plan, marker, `canonical Groups plan is missing feature evidence gate ${marker}`);
+}
+
+console.log("Groups feature enforcement SQLite source guard passed");


### PR DESCRIPTION
## Summary
- add file-backed SQLite executable source for Groups feature-settings suspension/expiry and enforcement-vs-write serialization
- use production Groups migrations, `GroupCommandPort::set_group_feature`, enforcement command/read ports, and owner feature reads
- retain stored lifecycle `active` while effective suspension blocks feature management with `groups.membership_suspended`
- retain owner-clock expiry recovery without cleanup, revoke, membership revision bump, or lifecycle count change
- exercise eight independent feature-write versus suspension races on separate SQLite connections using busy timeout and WAL
- allow only feature-before-suspension or suspension-before-denied-feature serialized outcomes, with exact aggregate-version semantics
- add no dependency, manifest, lockfile, migration, production behavior, Moderation adapter, or fallback change
- leave runtime evidence maintainer-owned; source was not executed

## Verification
Static source and diff review only. Cargo commands, Rust tests, Node verifiers, formatters, migration execution, workflows, and CI were intentionally not run per maintainer instruction.