### PR TITLE
feat(index): bind source continuation to locale scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,15 @@ parallel package exports for repository-owned callers. Change the canonical
 contract in place, migrate its data, update every caller atomically, and keep
 one unversioned implementation.
 
+Unreleased tokens, cursors, envelopes, and other repository-owned serialized
+formats are explicitly covered by this rule. When their shape changes, replace
+the canonical encoder and decoder in place and update all repository-owned
+callers, tests, fixtures, scripts, and current documentation in the same change.
+Delete prior-format readers, writers, version bytes/tags, compatibility fixtures,
+and fallback decoders. Do not introduce `V1`/`V2` claim structs or retain an old
+format reader "temporarily" unless the user explicitly approves an external
+compatibility bridge under the exception above.
+
 **Why:** an internal version does not remove migration work; it postpones it
 while multiplying code paths, security fixes, test matrices, documentation,
 and operational states. Two "temporary" versions quickly become two plausible

--- a/apps/server/docs/index-replay-graphql-transport.md
+++ b/apps/server/docs/index-replay-graphql-transport.md
@@ -1,6 +1,6 @@
 # Index replay GraphQL transport
 
-Status: `full_locale_and_schema_wide_shadow_source_complete_execution_pending`.
+Status: `full_locale_schema_wide_shadow_and_locale_safe_continuation_source_complete_execution_pending`.
 
 ## Boundary
 
@@ -25,7 +25,7 @@ Only after authorization does the durable Full run path canonicalize a supplied 
 `rustok_index::LocaleKey`. Locale input is bounded to 32 bytes before parsing. Omission is not inferred from schema
 metadata and preserves the historical schema-wide durable replay identity exactly.
 
-The schema-wide Shadow path intentionally has no locale input in this slice. Its continuation input is bounded to
+The current Shadow GraphQL path intentionally still has no locale input. Its continuation input is bounded to
 16 KiB only after authorization. The token is then authenticated, decrypted, expired and scope-checked by the
 server-owned Shadow transport runtime before any raw `IndexSourceCursor` is reconstructed.
 
@@ -71,14 +71,22 @@ resumed only by presenting the sealed caller-carried continuation token to a lat
 `IndexReplayOperatorRuntime::run_shadow` method. It reuses the deployment continuation keyring and frozen
 `SharedIndexSourceRegistry` already used by the source-page diagnosis transport.
 
-Authorization happens before token parsing. The adapter derives `IndexSourceContinuationScope` from the exact
-authenticated tenant, requested schema and frozen source owner. Incoming continuation is opened only after that
-scope is known; outgoing raw source cursor is sealed before the result crosses the adapter boundary.
+Authorization happens before token parsing. The adapter currently derives schema-wide
+`IndexSourceContinuationScope::from_registry` from the exact authenticated tenant, requested schema and frozen
+source owner. Incoming continuation is opened only after that scope is known; outgoing raw source cursor is sealed
+before the result crosses the adapter boundary.
 
-The current continuation scope is tenant/schema/source-bound but not locale-bound. Therefore this transport is
-intentionally schema-wide only. Exposing exact-locale Shadow replay before locale is included in continuation scope
-would permit an otherwise valid token to be replayed across different scan scopes, so locale transport remains a
-separate source boundary.
+The continuation contract itself is now locale-safe. Its encrypted canonical scope distinguishes schema-wide
+`locale = None` from one exact canonical `LocaleKey`, and `IndexSourceContinuationScope::for_locale` constructs
+the exact-locale identity from the same frozen source registry. A schema-wide token cannot open under a locale
+scope, a locale token cannot open schema-wide, and different canonical locales cannot exchange tokens.
+
+The codec has one current unversioned envelope. No old-format decoder, token version byte, or parallel claim family
+is retained. This repository-owned pre-release format is replaced in place when its shape changes.
+
+Exact-locale Shadow GraphQL remains a separate next source boundary because locale still must be carried through
+`IndexReplayDryRunRequest`, the actual `IndexSourceScanRequest::for_locale` execution path, the sealed Shadow
+adapter and authorization-first input parsing. The now-complete continuation scope no longer blocks that work.
 
 The Shadow result exposes only Complete/Yielded status, bounded page/mutation/upsert/delete counters and the
 optional sealed continuation. It does not expose raw cursor JSON, source name, source payloads, source version,
@@ -140,8 +148,8 @@ cancellation payload exposes only the normalized durable outcome: requested, can
 found.
 
 Operational runner failures are mapped to generic GraphQL errors; unknown source-owned schemas are reported as bad
-user input. Invalid/expired Shadow continuations receive stable input error codes while missing/unresolvable
-continuation keyring dependencies are reported through fixed server-owned error identities.
+user input. Invalid/expired/scope-mismatched Shadow continuations receive stable input error handling while
+missing/unresolvable continuation keyring dependencies are reported through fixed server-owned error identities.
 
 ## Evidence state
 
@@ -155,6 +163,8 @@ Source guards retain:
 - locale-aware interruptible runner acquisition and terminal success fencing;
 - fixed server-owned `100 × 8` bounds for both durable Full and schema-wide Shadow invocations;
 - Shadow continuation open/seal through the deployment keyring and frozen source scope;
+- canonical continuation scope separation between schema-wide and exact-locale scans;
+- one current unversioned continuation envelope with no legacy decoder family;
 - delegation of Shadow execution only through guarded `IndexReplayOperatorRuntime::run_shadow`;
 - merged GraphQL schema registration through the existing `IndexReplayMutation` object;
 - one shared lifecycle handle and API-host watch keepalive for durable Full replay;
@@ -164,7 +174,8 @@ GraphQL execution, actual Shadow source execution, continuation key deployment e
 replay/restart execution, actual process-shutdown replay interruption, database replay execution, cancellation
 races, CI, and retained runtime evidence remain maintainer-owned and are not claimed by this source slice.
 
-Exact-locale Shadow transport remains source-open until continuation identity is locale-safe.
+Exact-locale Shadow transport remains source-open only for the dry-run/runtime/GraphQL locale execution path; the
+continuation identity prerequisite is source-complete.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_drift_source_page_diagnosis.rs
+++ b/apps/server/src/graphql/index_drift_source_page_diagnosis.rs
@@ -328,16 +328,15 @@ fn map_continuation_error(error: rustok_index::IndexSourceContinuationError) -> 
         | Error::PlaintextTooLarge { .. }
         | Error::Base64(_)
         | Error::MalformedEnvelope
-        | Error::UnsupportedVersion(_)
         | Error::InvalidKeyId(_)
         | Error::KeyUnavailable(_)
         | Error::InvalidToken
         | Error::Postcard(_)
-        | Error::ContractVersionMismatch
         | Error::TenantMismatch
         | Error::SchemaMismatch
         | Error::SourceOwnerMismatch
         | Error::SourceNameMismatch
+        | Error::LocaleScopeMismatch
         | Error::InvalidClaimsLifetime
         | Error::IssuedAtInFuture => continuation_input_error("INDEX_SOURCE_CONTINUATION_INVALID"),
         _ => <FieldError as GraphQLError>::internal_error(

--- a/apps/server/src/graphql/index_replay.rs
+++ b/apps/server/src/graphql/index_replay.rs
@@ -535,16 +535,15 @@ fn map_shadow_continuation_error(error: rustok_index::IndexSourceContinuationErr
         | Error::PlaintextTooLarge { .. }
         | Error::Base64(_)
         | Error::MalformedEnvelope
-        | Error::UnsupportedVersion(_)
         | Error::InvalidKeyId(_)
         | Error::KeyUnavailable(_)
         | Error::InvalidToken
         | Error::Postcard(_)
-        | Error::ContractVersionMismatch
         | Error::TenantMismatch
         | Error::SchemaMismatch
         | Error::SourceOwnerMismatch
         | Error::SourceNameMismatch
+        | Error::LocaleScopeMismatch
         | Error::InvalidClaimsLifetime
         | Error::IssuedAtInFuture => {
             shadow_continuation_input_error("INDEX_REPLAY_SHADOW_CONTINUATION_INVALID")

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@488803a831e725ef0fbeaa8540f09458ee461b85` and continued on
-`agent/index-replay-shadow-graphql-transport-20260808`.
+Status overlay rechecked at `main@82f301231463cdce296ae4a88b0ac479c51ff9d1` and continued on
+`agent/index-source-continuation-locale-scope-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -117,7 +117,7 @@ The guarded operator retains both the durable `SharedIndexReplayRuntime` and the
 request-bound `modules:manage` snapshot before delegating to the side-effect-free runtime. It creates no replay
 job/checkpoint and exposes no lease, cancellation, scheduler or database handle.
 
-The GraphQL layer now exposes three source-complete command surfaces:
+The GraphQL layer exposes three source-complete command surfaces:
 
 - schema-wide or exact-locale durable `runIndexReplay`;
 - schema-wide no-write `runIndexReplayShadow`;
@@ -132,20 +132,27 @@ exactly schema-wide; it is not rewritten from schema locale defaults. Each durab
 worker identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page
 and a 60-second lease.
 
-Caller Shadow input contains only module/entity/schema key plus one optional bounded sealed continuation. It has
-no locale, source name, raw source cursor, worker, page/max-page budget, job, checkpoint, lease, cancellation,
-retry or scheduler fields. The server uses the same fixed 100-page-size / 8-page invocation budget, repeats exact
-tenant authorization, opens continuation through the deployment keyring under frozen tenant/schema/source scope,
-calls guarded `run_shadow`, and seals any outgoing cursor before GraphQL serialization.
+Caller Shadow input currently contains only module/entity/schema key plus one optional bounded sealed
+continuation. It has no locale, source name, raw source cursor, worker, page/max-page budget, job, checkpoint,
+lease, cancellation, retry or scheduler fields. The server uses the same fixed 100-page-size / 8-page invocation
+budget, repeats exact tenant authorization, opens continuation through the deployment keyring under frozen
+schema-wide tenant/schema/source scope, calls guarded `run_shadow`, and seals any outgoing cursor before GraphQL
+serialization.
 
-The current source continuation scope does not include locale identity, so Shadow transport is deliberately
-schema-wide. Exact-locale Shadow remains blocked until schema-wide and canonical locale continuations cannot be
-replayed across one another.
+The source continuation contract now includes canonical locale identity in encrypted claims. Schema-wide scope is
+`locale = None`; exact-locale scope is `Some(LocaleKey)`. `IndexSourceContinuationScope::from_registry` constructs
+the former and `IndexSourceContinuationScope::for_locale` the latter. Opening requires exact locale equality in
+addition to tenant/schema/source binding, so schema-wide and exact-locale tokens cannot cross scopes and different
+locales cannot exchange tokens.
+
+The continuation format is one current unversioned repository-owned envelope. The previous pre-release shape was
+replaced in place; there is no version byte, `contract_version`, `V1`/`V2` claim family, or fallback decoder.
 
 Retained durable command source evidence includes schema-wide command behavior, locale command canonicalization
-and a dedicated locale yield/isolation/fresh-runtime resume packet. Shadow source evidence now retains
-authorization-first schema/continuation preparation and sealed non-durable resume routing. GraphQL execution and
-admission remain maintainer-owned.
+and a dedicated locale yield/isolation/fresh-runtime resume packet. Shadow source evidence retains
+authorization-first schema/continuation preparation, sealed non-durable resume routing and locale-safe core
+continuation identity. Exact-locale Shadow dry-run/runtime/GraphQL execution remains source-open. GraphQL execution
+and admission remain maintainer-owned.
 
 ## M6 replay graceful interruption and server lifecycle binding
 
@@ -229,7 +236,7 @@ production admission remain maintainer-owned. See `m6-locale-replay-command-evid
 
 ## M6 multi-host/restart retained source state
 
-The replay ownership/restart chain now includes one deterministic concurrent reclaim packet in addition to the
+The replay ownership/restart chain includes one deterministic concurrent reclaim packet in addition to the
 existing sequential and fresh-runtime restart evidence.
 
 `source_replay_multihost_restart_tests.rs` retains two distinct `PostgresIndexReplayRunner` instances over one
@@ -262,13 +269,13 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
 - `Shadow` -> `SideEffectFreeScan`; this matches the existing `SharedIndexReplayDryRunRuntime` no-write boundary.
 
 The server guards `Shadow` through `IndexReplayOperatorRuntime::run_shadow`, using the same exact request-bound
-`modules:manage` authorization check as Full. Schema-wide GraphQL Shadow transport now sits on a separate sealed
+`modules:manage` authorization check as Full. Schema-wide GraphQL Shadow transport sits on a separate sealed
 continuation adapter and does not reinterpret the durable `runIndexReplay` command or add a mode column to jobs or
 checkpoints.
 
-The explicit mode identity, Shadow host dispatch and schema-wide Shadow GraphQL transport are source-complete.
-Exact-locale Shadow transport remains source-open behind locale-safe continuation identity. Maintainer execution
-and admission are not claimed.
+The explicit mode identity, Shadow host dispatch, schema-wide Shadow GraphQL transport and locale-safe Shadow
+continuation identity are source-complete. Exact-locale Shadow dry-run/runtime/GraphQL execution remains
+source-open. Maintainer execution and admission are not claimed.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -312,7 +319,8 @@ and admission are not claimed.
 - [x] Define explicit Full/Targeted/Shadow replay mode identity and fail-closed execution surfaces.
 - [x] Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.
 - [x] Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.
-- [ ] Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.
+- [x] Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.
+- [ ] Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
 - [ ] Execute/admit schema-wide Shadow GraphQL transport and continuation-key deployment evidence.
@@ -358,17 +366,19 @@ M7 Storefront remains execution/admission-gated and must not gain a traffic swit
 
 The locale request/source/job/checkpoint/runner/GraphQL identity chain, dependency timeout set,
 page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence, explicit Full/Targeted/Shadow
-mode identity, guarded Shadow host dispatch and schema-wide Shadow GraphQL transport are source-complete. Their
-retained packets still require maintainer execution/admission.
+mode identity, guarded Shadow host dispatch, schema-wide Shadow GraphQL transport and locale-safe source
+continuation identity are source-complete. Their retained packets still require maintainer execution/admission.
 
 Partition replay remains blocked: no real partition-capable source contract can yet filter a partition before
 pagination, so do not merely populate `partition_key`.
 
-For source-only M6 continuation, the next independent boundary is locale-safe Shadow continuation identity before
-exact-locale GraphQL transport. The source continuation contract must distinguish schema-wide from canonical
-exact-locale scans while preserving tenant/schema/source binding and existing schema-wide continuation behavior.
-Only after that boundary should Shadow GraphQL accept locale and construct `IndexSourceScanRequest::for_locale`;
-it still must not create job, checkpoint, lease, cancellation or retry state.
+For source-only M6 continuation, the next independent boundary is exact-locale Shadow execution through the
+existing no-write stack. Add optional canonical locale to `IndexReplayDryRunRequest`, construct every actual
+source scan through schema-wide `IndexSourceScanRequest::new` or exact-locale `IndexSourceScanRequest::for_locale`,
+derive the sealed token scope with `IndexSourceContinuationScope::from_registry` or `for_locale`, and add the
+locale field to `runIndexReplayShadow` only after request-bound `modules:manage` authorization. Keep the existing
+schema-wide behavior and fixed `100 × 8` transport budget. Do not add jobs, checkpoints, leases, cancellation,
+retry/requeue, source-name input, partition scope, or another token format.
 
 Targeted execution remains separate until the bounded mutation-application contract over `IndexSource::load` is
 defined.

--- a/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
+++ b/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
@@ -1,21 +1,29 @@
 # M6 bounded replay dry-run
 
-Status: `source_complete_schema_wide_transport_execution_pending`
+Status: `source_complete_schema_wide_transport_locale_execution_pending`
 
 This slice adds an Index-owned, side-effect-free validation runtime over the exact immutable
 `SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay, binds that capability
-behind the server-owned request-bound replay operator guard, and now exposes a bounded schema-wide GraphQL Shadow
+behind the server-owned request-bound replay operator guard, and exposes a bounded schema-wide GraphQL Shadow
 command through an authenticated confidential continuation boundary.
+
+The shared continuation contract is now locale-safe, so schema-wide and exact canonical-locale tokens cannot cross
+scan scopes. Locale still must be carried through the dry-run execution path before exact-locale Shadow transport
+is exposed.
 
 ## Contract
 
-`IndexReplayDryRunRequest` carries:
+`IndexReplayDryRunRequest` currently carries:
 
 - one non-nil tenant;
 - one exact registered schema;
 - one optional source-owned continuation cursor;
 - one source page limit already bounded by `IndexSourceScanRequest`;
 - one invocation budget from 1 through 1024 pages.
+
+It remains schema-wide today. The next source boundary is to add one optional canonical `LocaleKey` to this request
+and construct the actual source request through schema-wide `IndexSourceScanRequest::new` or exact-locale
+`IndexSourceScanRequest::for_locale` without creating durable mode state.
 
 `SharedIndexReplayDryRunRuntime::run` resolves source ownership only from the immutable registry,
 then scans at most the requested page budget. For every returned page it verifies:
@@ -73,7 +81,7 @@ does not alter the Full runner.
 
 ## Schema-wide GraphQL Shadow transport
 
-`runIndexReplayShadow` now exposes one bounded schema-wide invocation through
+`runIndexReplayShadow` exposes one bounded schema-wide invocation through
 `IndexReplayShadowTransportRuntime`.
 
 The GraphQL preparation path derives tenant/actor from request context and requires effective `modules:manage`
@@ -82,21 +90,24 @@ authorization before opening the token or constructing `IndexReplayDryRunRequest
 
 Caller input contains only module/entity/schema routing identity plus one optional sealed continuation token. Page
 limit and maximum pages remain server-owned at `100` and `8`. Locale, source identity, raw cursor JSON, job,
-checkpoint, lease, worker, cancellation and retry controls are unavailable.
+checkpoint, lease, worker, cancellation and retry controls are unavailable in the current schema-wide surface.
 
 The adapter reuses the deployment `IndexSourceContinuationKeyringRuntime` and canonical frozen
-`IndexSourceContinuationScope`. Incoming tokens are authenticated, decrypted, expired and tenant/schema/source
-scope-checked before the raw cursor is reconstructed. An outgoing raw cursor is sealed before returning to GraphQL.
-The transport-safe result contains only Complete/Yielded status, bounded counters and optional sealed
-continuation; it omits internal source name and source version.
+`IndexSourceContinuationScope`. Incoming tokens are authenticated, decrypted, expired and scope-checked before the
+raw cursor is reconstructed. An outgoing raw cursor is sealed before returning to GraphQL. The transport-safe
+result contains only Complete/Yielded status, bounded counters and optional sealed continuation; it omits internal
+source name and source version.
 
-This transport is intentionally schema-wide. The existing continuation scope does not yet carry locale identity,
-so exact-locale Shadow replay must not be exposed until schema-wide versus exact-locale continuation scopes are
-cryptographically distinct.
+The continuation scope now binds optional canonical locale identity. Schema-wide (`None`) and exact-locale
+(`Some(LocaleKey)`) tokens are mutually incompatible, and different canonical locales cannot exchange tokens.
+The codec has one current unversioned envelope with no old-format decoder or version-tagged claim family.
+
+Exact-locale Shadow remains source-open only because the dry-run request/runtime and GraphQL adapter have not yet
+carried locale into `IndexSourceScanRequest::for_locale`. The continuation prerequisite is complete.
 
 ## Explicitly open
 
-- exact-locale Shadow/dry-run transport after continuation identity becomes locale-safe;
+- exact-locale Shadow/dry-run request, source-scan execution and authorization-first GraphQL transport;
 - persisted dry-run reports or comparison snapshots;
 - cross-page duplicate event detection beyond one bounded page;
 - mutation/checkpoint timing simulation and interruption;
@@ -120,6 +131,7 @@ Suggested commands:
 cargo test -p rustok-index --test replay_dry_run_contract -- --nocapture
 cargo test -p rustok-index replay_dry_run -- --nocapture
 cargo check -p rustok-index --all-targets
+node scripts/verify/verify-index-source-continuation.mjs
 node scripts/verify/verify-index-replay-runtime-composition.mjs
 node scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
 node scripts/verify/verify-index-replay-shadow-graphql-transport.mjs

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -1,10 +1,12 @@
 # M6 replay mode contract
 
-Status: `source_complete_shadow_schema_wide_transport_locale_pending`.
+Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.
 
 This slice defines explicit rebuild mode identity without changing the existing durable replay runner, job,
 checkpoint, cancellation, locale or lease state machines. Shadow execution is bound to the server-owned request
-authorization guard and now has a dedicated schema-wide GraphQL command through a sealed continuation boundary.
+authorization guard and has a dedicated schema-wide GraphQL command through a sealed continuation boundary.
+The shared continuation identity is now locale-safe; exact-locale Shadow execution remains the next separate
+transport/runtime slice.
 
 ## Mode identity
 
@@ -18,8 +20,8 @@ authorization guard and now has a dedicated schema-wide GraphQL command through 
 - `Shadow` — side-effect-free cursor scan. Its execution surface is `SideEffectFreeScan`, matching the existing
   `SharedIndexReplayDryRunRuntime` no-write boundary.
 
-Mode is not locale scope and is not future partition scope. Adding a locale to a Full scan does not create a new
-mode, and adding partition replay later must not encode partition identity as a mode.
+Mode is not locale scope and is not future partition scope. Adding a locale to a Full or Shadow scan does not
+create a new mode, and adding partition replay later must not encode partition identity as a mode.
 
 ## Fail-closed routing
 
@@ -55,22 +57,37 @@ This remains a host dispatch boundary, not a new durable mode state machine:
 
 ## Schema-wide Shadow GraphQL transport
 
-`runIndexReplayShadow` is now a dedicated transport rather than a generic mode selector on `runIndexReplay`.
-It accepts only schema routing identity and an optional authenticated confidential continuation token.
+`runIndexReplayShadow` is a dedicated transport rather than a generic mode selector on `runIndexReplay`.
+It currently accepts only schema routing identity and an optional authenticated confidential continuation token.
 
 The GraphQL layer authorizes request-bound `modules:manage` before parsing schema/continuation input. A separate
 server-owned `IndexReplayShadowTransportRuntime` repeats exact-tenant authorization, opens continuation only under
-the frozen tenant/schema/source scope, constructs the existing `IndexReplayDryRunRequest`, calls guarded
-`run_shadow`, and seals any outgoing cursor before returning.
+the frozen schema-wide tenant/schema/source scope, constructs the existing `IndexReplayDryRunRequest`, calls
+guarded `run_shadow`, and seals any outgoing cursor before returning.
 
 Resource bounds remain server-owned: `100` mutations per source page and at most `8` pages per invocation. Shadow
 has no caller-visible worker, lease, heartbeat, job, checkpoint, cancel, retry/requeue or source-name field.
 Its payload contains only Complete/Yielded status, bounded scan counters and optional sealed continuation.
 
-The transport is intentionally schema-wide. `IndexSourceContinuationScope` currently binds tenant/schema/source
-but not locale. Until continuation claims make schema-wide and exact-locale scopes distinct, exposing a locale
-field would allow a valid source cursor token to cross scan scopes. Exact-locale Shadow transport therefore
-remains fail-closed and source-open.
+## Locale-safe continuation identity
+
+`IndexSourceContinuationScope` now distinguishes scan scope as part of the encrypted claims:
+
+- schema-wide -> `locale = None`;
+- exact locale -> `locale = Some(LocaleKey)`.
+
+`from_registry` constructs only schema-wide scope and `for_locale` constructs only exact canonical-locale scope.
+Opening requires exact locale equality in addition to tenant/schema/source ownership. Schema-wide and locale
+tokens cannot cross scopes, and different canonical locales cannot exchange tokens.
+
+The continuation codec has one current unversioned envelope. The previous pre-release shape was replaced in place:
+there is no version byte, `contract_version`, old-format claims type, or fallback decoder. Key rotation remains a
+cryptographic-key concern only and does not create format compatibility.
+
+Exact-locale Shadow transport remains source-open because locale still must be carried through
+`IndexReplayDryRunRequest`, `SharedIndexReplayDryRunRuntime`, the sealed server adapter and authorization-first
+GraphQL input. That next slice can now use `IndexSourceContinuationScope::for_locale` without changing the
+continuation format again.
 
 ## Existing contracts reused
 
@@ -90,7 +107,8 @@ This slice does not add:
 - Targeted mutation execution;
 - Shadow persistence or shadow tables;
 - a generic caller-controlled mode selector;
-- exact-locale Shadow transport before locale-safe continuation scope;
+- exact-locale Shadow execution/GraphQL transport yet;
+- token-format version families or legacy continuation decoders;
 - a mode column in `index_jobs` or `index_checkpoints`;
 - partition replay scope;
 - automatic retry/requeue or scheduler ownership;
@@ -98,10 +116,11 @@ This slice does not add:
 
 ## Next source boundary
 
-The next independent Shadow boundary is locale-safe continuation identity before exact-locale GraphQL transport.
-The continuation contract must distinguish schema-wide from canonical exact-locale source scans without weakening
-existing tenant/schema/source binding or invalidating retained schema-wide transport semantics. Only after that
-scope exists should Shadow reuse the canonical `LocaleKey` / `IndexSourceScanRequest::for_locale` contract.
+The next independent Shadow boundary is exact-locale dry-run/runtime/GraphQL execution using the now-canonical
+locale-safe continuation scope. Locale must be authorization-first, canonicalized through `LocaleKey`, carried by
+`IndexReplayDryRunRequest`, applied through `IndexSourceScanRequest::for_locale`, and used to derive
+`IndexSourceContinuationScope::for_locale` for open/seal. It still must not create job, checkpoint, lease,
+cancellation or retry state.
 
 Targeted execution remains a separate later slice because it needs an explicit bounded mutation-application
 contract over `IndexSource::load` rather than a scan checkpoint.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -10,6 +10,8 @@ This composition freezes the complete immutable Index source/schema registries a
 
 The server wraps both replay execution surfaces in one request-bound operator: durable Full replay through `SharedIndexReplayRuntime` and side-effect-free Shadow replay through `SharedIndexReplayDryRunRuntime`. It also publishes a separate schema-wide Shadow transport adapter that seals caller-carried continuation state. None of these boundaries add automatic replay-job scheduling.
 
+The shared continuation contract now has one current unversioned envelope and binds optional canonical locale identity inside encrypted claims. Runtime composition still exposes schema-wide Shadow only; exact-locale dry-run/runtime/GraphQL execution remains a separate next slice.
+
 ## Composition order
 
 1. selected modules contribute generic schema, source, and PostgreSQL source-factory contracts;
@@ -34,7 +36,9 @@ The Index materializer performs no SQL and calls neither `tokio::spawn` nor a po
 
 Durable ordinary/interruptible run rejects cross-tenant requests before delegation and cancellation derives tenant only from the authorized context. `run_shadow` applies the same exact tenant and `modules:manage` guard before delegating to the side-effect-free dry-run runtime. Shadow keeps a separate typed operator error wrapper so the existing Full/cancel error contract is not reinterpreted.
 
-`IndexReplayShadowTransportRuntime` sits above that guarded operator. It owns no database handle, scheduler, job, checkpoint, lease, cancellation or retry state. It repeats exact-tenant authorization before opening continuation, derives tenant/schema/source scope from the frozen source registry, calls only `IndexReplayOperatorRuntime::run_shadow`, and seals any outgoing raw source cursor before returning a transport-safe outcome.
+`IndexReplayShadowTransportRuntime` sits above that guarded operator. It owns no database handle, scheduler, job, checkpoint, lease, cancellation or retry state. It repeats exact-tenant authorization before opening continuation, currently derives schema-wide tenant/schema/source scope from the frozen source registry, calls only `IndexReplayOperatorRuntime::run_shadow`, and seals any outgoing raw source cursor before returning a transport-safe outcome.
+
+`IndexSourceContinuationScope` can now also derive an exact-locale identity through `for_locale`. Schema-wide and exact-locale tokens cannot cross scopes, and different canonical locales cannot exchange tokens. The codec does not retain an old-format decoder or format-version family.
 
 The GraphQL transport authorizes before parsing caller input. Durable Full uses a fixed 100-row × 8-page chunk, per-page heartbeat and 60-second lease. Schema-wide Shadow uses the same fixed 100-row × 8-page scan budget but no worker, heartbeat or lease. Its only resumable caller state is the authenticated confidential continuation token.
 
@@ -62,7 +66,7 @@ It does not schedule replay/rebuild jobs, create a second task, own a database l
 
 ## Explicitly open
 
-- locale-safe continuation identity before exact-locale Shadow GraphQL transport;
+- exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation identity;
 - execute/admit schema-wide Shadow GraphQL and continuation-key deployment evidence;
 - execute/admit retained replay interruption/restart evidence and end-to-end process-shutdown command evidence;
 - durable GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;

--- a/crates/rustok-index/docs/m6-source-continuation-codec.md
+++ b/crates/rustok-index/docs/m6-source-continuation-codec.md
@@ -1,6 +1,6 @@
 # M6 confidential source continuation codec
 
-Status: `source_complete_owner_execution_pending`.
+Status: `source_complete_locale_scope_owner_execution_pending`.
 
 ## Purpose
 
@@ -9,31 +9,45 @@ checkpoint store but not for public transport because it can contain owner ident
 positions, or other implementation details.
 
 `IndexSourceContinuationCodec` provides a transport-neutral authenticated and confidential envelope.
-The server-owned keyring, sealed one-page service method, and bounded GraphQL transport are composed
+The server-owned keyring, sealed source-page service, and bounded GraphQL transports are composed
 separately around this database-neutral contract.
 
 ## Canonical scope
 
-`IndexSourceContinuationScope::from_registry(tenant_id, schema, sources)` is the only public scope
-constructor. It binds:
+`IndexSourceContinuationScope` binds:
 
 - non-nil tenant UUID;
-- exact `SchemaRef`, including version;
+- exact `SchemaRef`, including schema routing version;
 - canonical owner module;
-- canonical source name.
+- canonical source name;
+- source scan locale identity: schema-wide (`None`) or one exact canonical `LocaleKey`.
 
-Opening compares every scope field before returning a raw cursor.
+`IndexSourceContinuationScope::from_registry(tenant_id, schema, sources)` constructs only the
+schema-wide scope. `IndexSourceContinuationScope::for_locale(tenant_id, schema, locale, sources)`
+constructs only the exact canonical-locale scope. Both source identities come from the frozen source
+registry rather than caller-controlled source fields.
+
+Opening compares every scope field before returning a raw cursor. A schema-wide token cannot open
+under an exact-locale scope. A locale token cannot open schema-wide or under another locale. Locale
+aliases/casing first canonicalize through `LocaleKey`, so equivalent locale input maps to one token
+scope.
 
 ## Cryptographic envelope
 
-Version 1 uses AES-256-GCM and a fresh 96-bit operating-system nonce for every seal operation.
+The repository has one current unversioned continuation envelope. It uses AES-256-GCM and a fresh
+96-bit operating-system nonce for every seal operation.
 
-The URL-safe unpadded outer envelope contains only version, bounded key ID, nonce, authenticated
-ciphertext, and the GCM tag. Encrypted claims contain tenant, exact schema, canonical owner/source,
-issued-at, expiry, and the complete raw cursor.
+The URL-safe unpadded outer envelope contains only bounded key ID, nonce, authenticated ciphertext,
+and the GCM tag. Encrypted claims contain tenant, exact schema, canonical owner/source, optional
+canonical locale, issued-at, expiry, and the complete raw cursor.
 
-The domain string, version, and key ID are authenticated as additional data. The cursor JSON,
-tenant, schema, source identity, timestamps, and entity-like positions are never cleartext.
+The fixed domain string and key ID are authenticated as additional data. The cursor JSON, tenant,
+schema, source identity, locale, timestamps, and entity-like positions are never cleartext.
+
+There is no internal continuation version byte, version-tagged claim family, legacy decoder, or
+fallback parser. This is a pre-release repository-owned contract: changing its shape replaces the
+canonical encoder/decoder atomically and invalidates superseded token shapes rather than accumulating
+parallel formats.
 
 This contract is intentionally separate from the checksum-only query `CursorCodec`.
 
@@ -50,7 +64,8 @@ Authenticated lifetime claims are revalidated while opening.
 
 ## Key rotation
 
-One key ID is active for sealing. Every retained key can decrypt. A safe sequence is:
+One key ID is active for sealing. Every retained key can decrypt tokens produced by the current
+canonical envelope. A safe sequence is:
 
 1. add a new key while retaining the old key;
 2. switch the active ID;
@@ -60,24 +75,31 @@ One key ID is active for sealing. Every retained key can decrypt. A safe sequenc
 A token naming a removed key fails closed. Codec `Debug` exposes only active ID and key count; token
 `Debug` exposes only encoded length.
 
+Key rotation is not format compatibility: retained keys decrypt only the one current envelope shape.
+
 ## Server composition and GraphQL boundary
 
 The server validates bounded deployment configuration containing only key IDs and `SecretRef`
 values. Secret material must be canonical URL-safe unpadded base64 decoding to exactly 32 bytes.
 
-Because resolution is asynchronous, keys are resolved inside `diagnose_source_page_sealed` before
-token parsing or scan-request construction. One short-lived codec opens the incoming token and seals
-the outgoing cursor.
+Because resolution is asynchronous, keys are resolved inside sealed server adapters before token
+parsing or scan-request construction. One short-lived codec opens the incoming token and seals the
+outgoing cursor.
 
-The root GraphQL mutation `diagnoseIndexSourcePage` treats continuation as an opaque bounded string,
-authorizes before schema/limit/token parsing, and delegates exactly once to the sealed method. No raw
-cursor, keyring handle, secret reference, or decoded key material crosses the resolver.
+`diagnoseIndexSourcePage` and the current schema-wide `runIndexReplayShadow` transport treat
+continuation as an opaque bounded string, authorize before untrusted input parsing, and never expose
+raw cursor, keyring handle, secret reference, or decoded key material.
+
+The locale-safe scope is source-complete. Exact-locale Shadow transport remains a separate next slice:
+it must carry canonical locale through the dry-run scan request and choose `for_locale` rather than
+changing or bypassing the continuation codec.
 
 ## Deliberate limits
 
 This slice does not add or claim:
 
-- persisted cursor state, multi-page scheduling, or restart state;
+- persisted continuation state, multi-page scheduling, or restart jobs;
+- exact-locale Shadow GraphQL input or dry-run locale execution;
 - stale Index-only or orphan-link discovery;
 - finding lifecycle or repair;
 - retained cryptographic, secret-resolution, GraphQL, workflow, or CI execution evidence.
@@ -90,7 +112,7 @@ cargo test -p rustok-server index_source_continuation_runtime -- --nocapture
 cargo test -p rustok-server index_drift_source_page_diagnosis -- --nocapture
 node scripts/verify/verify-index-source-continuation.mjs
 node scripts/verify/verify-index-source-continuation-server.mjs
-node scripts/verify/verify-index-drift-source-page-graphql-transport.mjs
+node scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
 node scripts/verify/verify-index-query-contract.mjs
 cargo check -p rustok-index --all-targets
 cargo check -p rustok-server --all-targets --features mod-product

--- a/crates/rustok-index/docs/m6-source-continuation-server-keyring.md
+++ b/crates/rustok-index/docs/m6-source-continuation-server-keyring.md
@@ -11,6 +11,10 @@ debug output.
 It retains only one active key ID, one lifetime in 1 through 900 seconds, at most 16
 key-ID-to-`SecretRef` mappings, and one process-owned `SecretResolverRegistry`.
 
+The keyring serves the single current unversioned continuation envelope. It does not select token
+format versions and does not retain keys as a mechanism for decoding superseded pre-release envelope
+shapes.
+
 ## Configuration
 
 `RUSTOK_INDEX_SOURCE_CONTINUATION_KEYRING_JSON` is read only when a frozen Index source registry
@@ -35,32 +39,37 @@ resolver cause, reference key, secret value, or decoded material.
 Composition validates configuration shape, bounds, active-key presence, uniqueness, aliases,
 lifetime, and resolver policy synchronously.
 
-`diagnose_source_page_sealed` resolves every reference asynchronously after authorization and limit
-validation but before token parsing or source scan. The decoded map constructs one short-lived
+Sealed server adapters resolve every reference asynchronously after authorization but before token
+parsing or source scan. The decoded map constructs one short-lived
 `IndexSourceContinuationCodec`, which opens the incoming token and seals the outgoing cursor before
 the map and codec are dropped.
 
-The keyring is passed privately into `IndexDriftSourcePageDiagnosisRuntime` and is not inserted as a
-separately retrievable extension capability.
+The same private keyring snapshot is supplied to the sealed source-page diagnosis adapter and the
+Shadow replay continuation adapter. It is not inserted as a separately retrievable extension
+capability.
 
 ## Rotation
 
-One active key seals. Retained non-active keys decrypt existing tokens. After adding and activating a
-new key, deployment must wait longer than maximum token lifetime plus operational skew before removing
-the old key.
+One active key seals. Retained non-active keys decrypt tokens produced by the same current canonical
+envelope. After adding and activating a new key, deployment must wait longer than maximum token
+lifetime plus operational skew before removing the old key.
 
 A token naming a removed key fails closed before cursor return.
 
+Key rotation preserves cryptographic key continuity only; it is not a legacy token-format bridge.
+
 ## Sealed service and GraphQL boundary
 
-`diagnose_source_page_sealed` authorizes, derives canonical scope, resolves keys, opens the incoming
-token before scan-request construction, diagnoses exactly one page, and seals the outgoing cursor.
+`diagnose_source_page_sealed` authorizes, derives canonical schema-wide scope, resolves keys, opens
+the incoming token before scan-request construction, diagnoses exactly one page, and seals the
+outgoing cursor.
 
-`diagnoseIndexSourcePage` is the only public source-page transport in this slice. It accepts one
-bounded schema identity, one limit, and one optional opaque token. It delegates exactly once to the
-sealed method and returns only counters, finding receipts, completion state, and an opaque token.
+`runIndexReplayShadow` currently derives the same schema-wide continuation scope around its bounded
+no-write scan. The core scope can now also bind one canonical `LocaleKey`; exact-locale Shadow will
+use that canonical scope only when locale is carried through the dry-run scan contract in the next
+source slice.
 
-No raw cursor, source entity ID, owner/index payload, secret reference, or key material crosses the
+No raw cursor, source entity ID, owner/index payload, secret reference, or key material crosses a
 GraphQL resolver.
 
 ## Deliberate limits
@@ -70,6 +79,7 @@ This slice does not add:
 - persisted cursor state or multi-page jobs;
 - background scanning, scheduling, lifecycle commands, or repair;
 - cloud, Vault, or Kubernetes resolver configuration specific to this Index keyring;
+- old-format token readers or format-version selection;
 - retained secret-resolution, rotation, expiry, authorization, database, GraphQL, workflow, or CI
   evidence.
 

--- a/crates/rustok-index/src/application/source_continuation.rs
+++ b/crates/rustok-index/src/application/source_continuation.rs
@@ -10,12 +10,11 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::domain::SchemaRef;
+use crate::domain::{LocaleKey, SchemaRef};
 
 use super::{IndexSourceCursor, SharedIndexSourceRegistry};
 
-const CONTINUATION_DOMAIN: &[u8] = b"rustok-index-source-continuation-v1";
-const CONTINUATION_VERSION: u8 = 1;
+const CONTINUATION_DOMAIN: &[u8] = b"rustok-index-source-continuation";
 const KEY_BYTES: usize = 32;
 const NONCE_BYTES: usize = 12;
 const TAG_BYTES: usize = 16;
@@ -28,22 +27,44 @@ const MAX_PLAINTEXT_BYTES: usize = 10 * 1024;
 const MAX_DECODED_TOKEN_BYTES: usize = 12 * 1024;
 const MAX_ENCODED_TOKEN_BYTES: usize = 16 * 1024;
 
-/// Canonical tenant/schema/source identity to which a continuation token is sealed.
+/// Canonical tenant/schema/source/locale identity to which a continuation token is sealed.
 ///
 /// The scope can only be constructed from the frozen source registry. This prevents a transport
 /// from inventing a source name independently of the schema owner selected during composition.
+/// `locale = None` is the schema-wide scan identity; `Some(LocaleKey)` is one exact canonical locale.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexSourceContinuationScope {
     tenant_id: Uuid,
     schema: SchemaRef,
     owner_module: String,
     source_name: String,
+    locale: Option<LocaleKey>,
 }
 
 impl IndexSourceContinuationScope {
+    /// Construct the canonical schema-wide continuation scope.
     pub fn from_registry(
         tenant_id: Uuid,
         schema: SchemaRef,
+        sources: &SharedIndexSourceRegistry,
+    ) -> Result<Self, IndexSourceContinuationError> {
+        Self::from_registry_with_locale(tenant_id, schema, None, sources)
+    }
+
+    /// Construct the canonical exact-locale continuation scope.
+    pub fn for_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: LocaleKey,
+        sources: &SharedIndexSourceRegistry,
+    ) -> Result<Self, IndexSourceContinuationError> {
+        Self::from_registry_with_locale(tenant_id, schema, Some(locale), sources)
+    }
+
+    fn from_registry_with_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: Option<LocaleKey>,
         sources: &SharedIndexSourceRegistry,
     ) -> Result<Self, IndexSourceContinuationError> {
         if tenant_id.is_nil() {
@@ -57,6 +78,7 @@ impl IndexSourceContinuationScope {
             schema,
             owner_module: descriptor.owner_module().to_owned(),
             source_name: descriptor.source_name().to_owned(),
+            locale,
         })
     }
 
@@ -75,9 +97,13 @@ impl IndexSourceContinuationScope {
     pub fn source_name(&self) -> &str {
         &self.source_name
     }
+
+    pub fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
+    }
 }
 
-/// Bounded encoded continuation value suitable for a future transport boundary.
+/// Bounded encoded continuation value suitable for a transport boundary.
 ///
 /// Debug deliberately reveals only length. Callers must use `as_str` explicitly when serializing
 /// the token and must never log it as an identifier.
@@ -119,11 +145,11 @@ impl fmt::Debug for IndexSourceContinuationToken {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ContinuationClaims {
-    contract_version: u8,
     tenant_id: Uuid,
     schema: SchemaRef,
     owner_module: String,
     source_name: String,
+    locale: Option<LocaleKey>,
     issued_at_unix_millis: i64,
     expires_at_unix_millis: i64,
     cursor: IndexSourceCursor,
@@ -133,6 +159,8 @@ struct ContinuationClaims {
 ///
 /// One active key is used for sealing. Every key retained in the bounded keyring can decrypt, so a
 /// key can be rotated without invalidating already-issued tokens until its maximum lifetime passes.
+/// The repository keeps one current unversioned envelope; superseded pre-release token formats are
+/// not decoded or retained as compatibility paths.
 #[derive(Clone)]
 pub struct IndexSourceContinuationCodec {
     active_key_id: String,
@@ -179,7 +207,7 @@ impl IndexSourceContinuationCodec {
         self.keys.len()
     }
 
-    /// Seal one raw source cursor under the canonical frozen source identity.
+    /// Seal one raw source cursor under the canonical frozen source and locale identity.
     pub fn seal(
         &self,
         scope: &IndexSourceContinuationScope,
@@ -202,11 +230,11 @@ impl IndexSourceContinuationCodec {
             .checked_add(lifetime_millis)
             .ok_or(IndexSourceContinuationError::TimestampOverflow)?;
         let claims = ContinuationClaims {
-            contract_version: CONTINUATION_VERSION,
             tenant_id: scope.tenant_id,
             schema: scope.schema.clone(),
             owner_module: scope.owner_module.clone(),
             source_name: scope.source_name.clone(),
+            locale: scope.locale.clone(),
             issued_at_unix_millis,
             expires_at_unix_millis,
             cursor: cursor.clone(),
@@ -229,7 +257,7 @@ impl IndexSourceContinuationCodec {
             .map_err(|_| IndexSourceContinuationError::InvalidKeyMaterial(self.active_key_id.clone()))?;
         let mut nonce = [0_u8; NONCE_BYTES];
         OsRng.fill_bytes(&mut nonce);
-        let aad = associated_data(CONTINUATION_VERSION, &self.active_key_id);
+        let aad = associated_data(&self.active_key_id);
         let ciphertext = cipher
             .encrypt(
                 (&nonce).into(),
@@ -241,9 +269,8 @@ impl IndexSourceContinuationCodec {
             .map_err(|_| IndexSourceContinuationError::EncryptionFailed)?;
         let key_id_bytes = self.active_key_id.as_bytes();
         let mut decoded = Vec::with_capacity(
-            2 + key_id_bytes.len() + NONCE_BYTES + ciphertext.len(),
+            1 + key_id_bytes.len() + NONCE_BYTES + ciphertext.len(),
         );
-        decoded.push(CONTINUATION_VERSION);
         decoded.push(key_id_bytes.len() as u8);
         decoded.extend_from_slice(key_id_bytes);
         decoded.extend_from_slice(&nonce);
@@ -282,18 +309,14 @@ impl IndexSourceContinuationCodec {
                 max: MAX_DECODED_TOKEN_BYTES,
             });
         }
-        if decoded.len() < 2 + 1 + NONCE_BYTES + TAG_BYTES {
+        if decoded.len() < 1 + 1 + NONCE_BYTES + TAG_BYTES {
             return Err(IndexSourceContinuationError::MalformedEnvelope);
         }
-        let version = decoded[0];
-        if version != CONTINUATION_VERSION {
-            return Err(IndexSourceContinuationError::UnsupportedVersion(version));
-        }
-        let key_id_len = decoded[1] as usize;
+        let key_id_len = decoded[0] as usize;
         if !(1..=MAX_KEY_ID_BYTES).contains(&key_id_len) {
             return Err(IndexSourceContinuationError::MalformedEnvelope);
         }
-        let key_id_end = 2_usize
+        let key_id_end = 1_usize
             .checked_add(key_id_len)
             .ok_or(IndexSourceContinuationError::MalformedEnvelope)?;
         let nonce_end = key_id_end
@@ -305,7 +328,7 @@ impl IndexSourceContinuationCodec {
         if decoded.len() < minimum_len {
             return Err(IndexSourceContinuationError::MalformedEnvelope);
         }
-        let key_id = std::str::from_utf8(&decoded[2..key_id_end])
+        let key_id = std::str::from_utf8(&decoded[1..key_id_end])
             .map_err(|_| IndexSourceContinuationError::MalformedEnvelope)?;
         validate_key_id(key_id)?;
         let key = self
@@ -316,7 +339,7 @@ impl IndexSourceContinuationCodec {
             .map_err(|_| IndexSourceContinuationError::InvalidKeyMaterial(key_id.to_owned()))?;
         let nonce = &decoded[key_id_end..nonce_end];
         let ciphertext = &decoded[nonce_end..];
-        let aad = associated_data(version, key_id);
+        let aad = associated_data(key_id);
         let plaintext = cipher
             .decrypt(
                 nonce.into(),
@@ -386,16 +409,12 @@ pub enum IndexSourceContinuationError {
     Base64(#[from] base64::DecodeError),
     #[error("Index source continuation envelope is malformed")]
     MalformedEnvelope,
-    #[error("Index source continuation version is unsupported: {0}")]
-    UnsupportedVersion(u8),
     #[error("Index source continuation encryption failed")]
     EncryptionFailed,
     #[error("Index source continuation token authentication failed")]
     InvalidToken,
     #[error("Index source continuation payload serialization failed")]
     Postcard(#[from] postcard::Error),
-    #[error("Index source continuation contract version does not match")]
-    ContractVersionMismatch,
     #[error("Index source continuation tenant does not match request scope")]
     TenantMismatch,
     #[error("Index source continuation schema does not match request scope")]
@@ -404,6 +423,8 @@ pub enum IndexSourceContinuationError {
     SourceOwnerMismatch,
     #[error("Index source continuation source name does not match the frozen source")]
     SourceNameMismatch,
+    #[error("Index source continuation locale scope does not match request scope")]
+    LocaleScopeMismatch,
     #[error("Index source continuation claims contain an invalid lifetime")]
     InvalidClaimsLifetime,
     #[error("Index source continuation token was issued too far in the future")]
@@ -417,9 +438,6 @@ fn validate_claims(
     expected_scope: &IndexSourceContinuationScope,
     now: DateTime<Utc>,
 ) -> Result<(), IndexSourceContinuationError> {
-    if claims.contract_version != CONTINUATION_VERSION {
-        return Err(IndexSourceContinuationError::ContractVersionMismatch);
-    }
     if claims.tenant_id != expected_scope.tenant_id {
         return Err(IndexSourceContinuationError::TenantMismatch);
     }
@@ -431,6 +449,9 @@ fn validate_claims(
     }
     if claims.source_name != expected_scope.source_name {
         return Err(IndexSourceContinuationError::SourceNameMismatch);
+    }
+    if claims.locale != expected_scope.locale {
+        return Err(IndexSourceContinuationError::LocaleScopeMismatch);
     }
     let lifetime = claims
         .expires_at_unix_millis
@@ -452,10 +473,9 @@ fn validate_claims(
     Ok(())
 }
 
-fn associated_data(version: u8, key_id: &str) -> Vec<u8> {
-    let mut aad = Vec::with_capacity(CONTINUATION_DOMAIN.len() + 2 + key_id.len());
+fn associated_data(key_id: &str) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(CONTINUATION_DOMAIN.len() + 1 + key_id.len());
     aad.extend_from_slice(CONTINUATION_DOMAIN);
-    aad.push(version);
     aad.push(key_id.len() as u8);
     aad.extend_from_slice(key_id.as_bytes());
     aad
@@ -503,6 +523,17 @@ mod tests {
             schema: schema(),
             owner_module: "source-continuation".to_string(),
             source_name: "source-continuation-primary".to_string(),
+            locale: None,
+        }
+    }
+
+    fn locale_scope(tenant_id: Uuid, locale: &str) -> IndexSourceContinuationScope {
+        IndexSourceContinuationScope {
+            tenant_id,
+            schema: schema(),
+            owner_module: "source-continuation".to_string(),
+            source_name: "source-continuation-primary".to_string(),
+            locale: Some(LocaleKey::new(locale).unwrap()),
         }
     }
 
@@ -552,6 +583,41 @@ mod tests {
         assert!(matches!(
             codec.open(&other_schema, &token, now()),
             Err(IndexSourceContinuationError::SchemaMismatch)
+        ));
+    }
+
+    #[test]
+    fn schema_wide_and_exact_locale_continuations_cannot_cross_scopes() {
+        let tenant_id = Uuid::new_v4();
+        let schema_wide = scope(tenant_id);
+        let locale_alias = locale_scope(tenant_id, "EN-us");
+        let locale_canonical = locale_scope(tenant_id, "en-US");
+        let other_locale = locale_scope(tenant_id, "de");
+        assert_eq!(locale_alias.locale(), locale_canonical.locale());
+
+        let codec = codec("current", &[("current", 8)]);
+        let schema_wide_token = codec
+            .seal(&schema_wide, &cursor(), now(), Duration::from_secs(300))
+            .unwrap();
+        assert!(matches!(
+            codec.open(&locale_canonical, &schema_wide_token, now()),
+            Err(IndexSourceContinuationError::LocaleScopeMismatch)
+        ));
+
+        let locale_token = codec
+            .seal(&locale_alias, &cursor(), now(), Duration::from_secs(300))
+            .unwrap();
+        assert_eq!(
+            codec.open(&locale_canonical, &locale_token, now()).unwrap(),
+            cursor()
+        );
+        assert!(matches!(
+            codec.open(&schema_wide, &locale_token, now()),
+            Err(IndexSourceContinuationError::LocaleScopeMismatch)
+        ));
+        assert!(matches!(
+            codec.open(&other_locale, &locale_token, now()),
+            Err(IndexSourceContinuationError::LocaleScopeMismatch)
         ));
     }
 

--- a/scripts/verify/verify-index-replay-dry-run.mjs
+++ b/scripts/verify/verify-index-replay-dry-run.mjs
@@ -103,6 +103,12 @@ requireMarkers('crates/rustok-index/src/application/source_timeout.rs', [
   'const INDEX_SOURCE_SCAN_TIMEOUT_CODE: &str = "index_source_scan_timeout";',
   'TimedIndexSource::new(source, DEFAULT_INDEX_SOURCE_CALL_TIMEOUT)',
 ]);
+requireMarkers('crates/rustok-index/src/application/source_continuation.rs', [
+  'locale: Option<LocaleKey>',
+  'pub fn for_locale(',
+  'IndexSourceContinuationError::LocaleScopeMismatch',
+  'schema_wide_and_exact_locale_continuations_cannot_cross_scopes',
+]);
 
 requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
@@ -126,8 +132,8 @@ requireMarkers('apps/server/src/graphql/index_replay.rs', [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_schema_wide_transport_execution_pending`',
-  '`IndexReplayDryRunRequest`',
+  'Status: `source_complete_schema_wide_transport_locale_execution_pending`',
+  '`IndexReplayDryRunRequest` currently carries:',
   '`SharedIndexReplayDryRunRuntime::run`',
   'one invocation budget from 1 through 1024 pages',
   'complete `SchemaRegistry::validate_mutation` validity',
@@ -138,7 +144,8 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
   'Server-owned host guard',
   '`IndexReplayOperatorRuntime::run_shadow`',
   '`runIndexReplayShadow`',
-  'intentionally schema-wide',
+  'continuation scope now binds optional canonical locale identity',
+  'Exact-locale Shadow remains source-open only because the dry-run request/runtime and GraphQL adapter',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
@@ -153,4 +160,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-shadow-graphql-transport.mjs'",
 ]);
 
-console.log('[verify-index-replay-dry-run] bounded no-write validation stays Index-owned while schema-wide GraphQL resumes only through the sealed guarded Shadow adapter');
+console.log('[verify-index-replay-dry-run] bounded no-write validation stays schema-wide today while the one canonical continuation scope is ready for exact-locale execution');

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -60,6 +60,7 @@ const transport = requireMarkers(transportPath, [
   'replay_transport_derives_authority_worker_and_server_owned_budgets',
   'replay_transport_canonicalizes_optional_locale_after_authorization',
   'replay_cancel_authorizes_before_job_id_parsing_and_derives_tenant',
+  'Error::LocaleScopeMismatch',
 ]);
 
 const runPrepare = transport.indexOf('fn prepare_authorized_run(');
@@ -159,20 +160,26 @@ requireMarkers('apps/server/src/services/app_lifecycle.rs', [
   'pub async fn stop(&self)',
   'pub fn is_stopping(&self) -> bool',
 ]);
+requireMarkers('crates/rustok-index/src/application/source_continuation.rs', [
+  'pub fn for_locale(',
+  'claims.locale != expected_scope.locale',
+  'IndexSourceContinuationError::LocaleScopeMismatch',
+]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `full_locale_and_schema_wide_shadow_source_complete_execution_pending`.',
+  'Status: `full_locale_schema_wide_shadow_and_locale_safe_continuation_source_complete_execution_pending`.',
   '`runIndexReplay(input: ...)`',
   '`runIndexReplayShadow(input: ...)`',
   '`cancelIndexReplay(input: ...)`',
   'Tenant and actor identities are never accepted',
   'optional canonicalizable locale',
-  'schema-wide Shadow path intentionally has no locale input',
+  'current Shadow GraphQL path intentionally still has no locale input',
   'page limit: `100` mutations',
   'maximum pages: `8`',
   'lease duration: `60` seconds',
   'same fixed source page limit and maximum-page count (`100 × 8`)',
+  'continuation contract itself is now locale-safe',
   '`StopHandle::is_stopping`',
   'maintainer-owned',
 ]);
 
-console.log('[verify-index-replay-graphql-transport] durable Full/cancel and sealed schema-wide Shadow commands remain authorization-first and server-bounded without transport-owned execution state');
+console.log('[verify-index-replay-graphql-transport] durable Full/cancel and sealed schema-wide Shadow commands remain authorization-first/server-bounded while continuation scope is locale-safe');

--- a/scripts/verify/verify-index-replay-mode-contract.mjs
+++ b/scripts/verify/verify-index-replay-mode-contract.mjs
@@ -73,6 +73,18 @@ requireMarkers(dryRunPath, [
   '.scan(scan_request)',
 ]);
 
+const continuationPath = 'crates/rustok-index/src/application/source_continuation.rs';
+const continuation = requireMarkers(continuationPath, [
+  'locale: Option<LocaleKey>',
+  'pub fn for_locale(',
+  'IndexSourceContinuationError::LocaleScopeMismatch',
+]);
+for (const forbidden of ['CONTINUATION_VERSION', 'ContinuationClaimsV1', 'ContinuationClaimsV2']) {
+  if (continuation.includes(forbidden)) {
+    fail(`${continuationPath} must keep one canonical unversioned envelope: ${forbidden}`);
+  }
+}
+
 requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'pub async fn run_shadow(',
   'shadow: rustok_index::SharedIndexReplayDryRunRuntime',
@@ -88,7 +100,7 @@ requireMarkers('apps/server/src/graphql/index_replay.rs', [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_schema_wide_transport_locale_pending`.',
+  'Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.',
   '`Full` — cursor-based durable source scan',
   '`Targeted` — bounded exact-key source load',
   '`Shadow` — side-effect-free cursor scan',
@@ -96,9 +108,10 @@ requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
   'returns true only for `Full`',
   'must not alias the Full durable job/checkpoint identity',
   '`Shadow` host dispatch is source-complete',
-  '`runIndexReplayShadow` is now a dedicated transport',
-  'transport is intentionally schema-wide',
-  'next independent Shadow boundary is locale-safe continuation identity',
+  '`runIndexReplayShadow` is a dedicated transport',
+  'Locale-safe continuation identity',
+  'one current unversioned envelope',
+  'next independent Shadow boundary is exact-locale dry-run/runtime/GraphQL execution',
   'Execution/admission remains maintainer-owned.',
 ]);
 
@@ -107,8 +120,9 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
   'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
+  'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
   'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
   'Add partition replay scope only after a real partition-capable source contract exists.',
 ]);
 
-console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow is schema-wide transported without durable ownership while locale scope remains explicit debt');
+console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow has one locale-safe continuation identity while exact-locale execution remains separate');

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -88,6 +88,16 @@ requireMarkers('apps/server/src/services/index_replay_shadow_transport.rs', [
   'IndexSourceContinuationScope::from_registry(',
   'self.operator.run_shadow(context, request).await?',
 ]);
+const continuation = requireMarkers('crates/rustok-index/src/application/source_continuation.rs', [
+  'pub fn for_locale(',
+  'claims.locale != expected_scope.locale',
+  'IndexSourceContinuationError::LocaleScopeMismatch',
+]);
+for (const forbidden of ['CONTINUATION_VERSION', 'ContinuationClaimsV1', 'ContinuationClaimsV2']) {
+  if (continuation.includes(forbidden)) {
+    fail(`source continuation must remain one canonical unversioned envelope: ${forbidden}`);
+  }
+}
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs', [
   'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
   'impl ModuleWorkSource for PostgresIndexReconciliationWorkAdapter',
@@ -113,6 +123,9 @@ requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
   'starts the single generic `ModuleWorkScheduler` only when registrations exist',
   '`SharedIndexReplayRuntime::run_interruptible`',
   '`IndexReplayShadowTransportRuntime`',
+  'one current unversioned envelope',
+  '`IndexSourceContinuationScope` can now also derive an exact-locale identity through `for_locale`',
+  'exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation identity',
   'The work registration added here is reconciliation-only',
   'maintainer-run',
 ]);
@@ -127,4 +140,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
-console.log('[verify-index-replay-runtime-composition] shared replay composition keeps Full durable, Shadow no-write/sealed, and reconciliation under the single generic scheduler boundary');
+console.log('[verify-index-replay-runtime-composition] shared replay composition keeps Full durable, Shadow no-write/sealed, one unversioned locale-safe continuation format, and reconciliation under the single generic scheduler boundary');

--- a/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
@@ -18,6 +18,26 @@ const requireMarkers = (relative, markers) => {
   return source;
 };
 
+const continuationPath = 'crates/rustok-index/src/application/source_continuation.rs';
+const continuationSource = requireMarkers(continuationPath, [
+  'locale: Option<LocaleKey>',
+  'pub fn for_locale(',
+  'claims.locale != expected_scope.locale',
+  'IndexSourceContinuationError::LocaleScopeMismatch',
+  'schema_wide_and_exact_locale_continuations_cannot_cross_scopes',
+]);
+for (const forbidden of [
+  'CONTINUATION_VERSION',
+  'ContinuationClaimsV1',
+  'ContinuationClaimsV2',
+  'UnsupportedVersion',
+  'ContractVersionMismatch',
+]) {
+  if (continuationSource.includes(forbidden)) {
+    fail(`${continuationPath} must retain one current unversioned envelope: ${forbidden}`);
+  }
+}
+
 const servicePath = 'apps/server/src/services/index_replay_shadow_transport.rs';
 const service = requireMarkers(servicePath, [
   'pub enum IndexReplayShadowTransportError',
@@ -49,7 +69,7 @@ for (const forbidden of [
   'LocaleKey',
 ]) {
   if (service.includes(forbidden)) {
-    fail(`${servicePath} must remain schema-wide, no-write and lifecycle-neutral: ${forbidden}`);
+    fail(`${servicePath} must remain schema-wide, no-write and lifecycle-neutral until the next locale execution slice: ${forbidden}`);
   }
 }
 const authorize = service.indexOf('context.authorize_for(context.tenant_id())?;');
@@ -59,7 +79,7 @@ const request = service.indexOf('IndexReplayDryRunRequest::new(', open);
 const run = service.indexOf('self.operator.run_shadow(context, request).await?', request);
 const seal = service.indexOf('codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())', run);
 if (authorize < 0 || scope <= authorize || open <= scope || request <= open || run <= request || seal <= run) {
-  fail('Shadow transport order must remain authorize -> frozen scope -> open token -> dry-run request -> guarded Shadow -> seal cursor');
+  fail('Shadow transport order must remain authorize -> frozen schema-wide scope -> open token -> dry-run request -> guarded Shadow -> seal cursor');
 }
 
 const graphqlPath = 'apps/server/src/graphql/index_replay.rs';
@@ -79,6 +99,7 @@ const graphql = requireMarkers(graphqlPath, [
   'shadow_transport_accepts_only_schema_and_bounded_sealed_continuation',
   'INDEX_REPLAY_SHADOW_CONTINUATION_INVALID',
   'INDEX_REPLAY_SHADOW_CONTINUATION_EXPIRED',
+  'Error::LocaleScopeMismatch',
 ]);
 const shadowPrepare = graphql.indexOf('fn prepare_authorized_shadow_run(');
 const shadowAuthorize = graphql.indexOf('let context = authorize(tenant_id, actor_id)?;', shadowPrepare);
@@ -117,25 +138,27 @@ requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'continuation.clone()',
 ]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `full_locale_and_schema_wide_shadow_source_complete_execution_pending`.',
+  'Status: `full_locale_schema_wide_shadow_and_locale_safe_continuation_source_complete_execution_pending`.',
   '`runIndexReplayShadow(input: ...)`',
-  'schema-wide Shadow path intentionally has no locale input',
+  'current Shadow GraphQL path intentionally still has no locale input',
   'same fixed source page limit and maximum-page count (`100 × 8`)',
-  'current continuation scope is tenant/schema/source-bound but not locale-bound',
+  'continuation contract itself is now locale-safe',
+  'one current unversioned envelope',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_schema_wide_transport_execution_pending`',
+  'Status: `source_complete_schema_wide_transport_locale_execution_pending`',
   '`runIndexReplayShadow`',
-  'intentionally schema-wide',
+  'continuation scope now binds optional canonical locale identity',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_schema_wide_transport_locale_pending`.',
+  'Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.',
   '`runIndexReplayShadow`',
-  'Exact-locale Shadow transport therefore remains fail-closed and source-open.',
+  'Locale-safe continuation identity',
+  'Exact-locale Shadow transport remains source-open',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
+  'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
 ]);
 
-console.log('[verify-index-replay-shadow-graphql-transport] schema-wide Shadow GraphQL stays authorization-first, no-write and resumable only through sealed scoped continuation');
+console.log('[verify-index-replay-shadow-graphql-transport] schema-wide Shadow GraphQL remains authorization-first/no-write while the single canonical continuation format now binds exact locale scope');

--- a/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+++ b/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
@@ -69,23 +69,25 @@ for (const forbidden of ['IndexReplayMode::Shadow', 'SideEffectFreeScan', 'Share
 }
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_schema_wide_transport_execution_pending`',
+  'Status: `source_complete_schema_wide_transport_locale_execution_pending`',
   '`IndexReplayOperatorRuntime::run_shadow`',
   'same request-bound `modules:manage` authorization boundary',
   '`runIndexReplayShadow`',
-  'intentionally schema-wide',
+  'Exact-locale Shadow remains source-open only because the dry-run request/runtime and GraphQL adapter',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_schema_wide_transport_locale_pending`.',
+  'Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.',
   '`Shadow` host dispatch is source-complete',
   '`IndexReplayOperatorRuntime::run_shadow`',
-  '`runIndexReplayShadow` is now a dedicated transport',
+  '`runIndexReplayShadow` is a dedicated transport',
+  'Locale-safe continuation identity',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
   'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
+  'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
   'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
 ]);
 
-console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded and no-write while GraphQL uses only the sealed transport adapter');
+console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded/no-write; continuation is locale-safe while execution remains schema-wide until the next slice');

--- a/scripts/verify/verify-index-source-continuation.mjs
+++ b/scripts/verify/verify-index-source-continuation.mjs
@@ -11,7 +11,8 @@ const files = {
   pageGraphql: "apps/server/src/graphql/index_drift_source_page_diagnosis.rs",
   doc: "crates/rustok-index/docs/m6-source-continuation-codec.md",
   serverDoc: "crates/rustok-index/docs/m6-source-continuation-server-keyring.md",
-  plan: "crates/rustok-index/docs/implementation-plan-current-2026-08-03.md",
+  plan: "crates/rustok-index/docs/implementation-plan-current-2026-08-08.md",
+  agents: "AGENTS.md",
   aggregate: "scripts/verify/verify-index-query-contract.mjs",
 };
 
@@ -37,18 +38,20 @@ requireMarkers("applicationMod", [
   "IndexSourceContinuationToken",
 ]);
 requireMarkers("source", [
-  'b"rustok-index-source-continuation-v1"',
-  "const CONTINUATION_VERSION: u8 = 1;",
+  'b"rustok-index-source-continuation"',
   "const KEY_BYTES: usize = 32;",
   "const NONCE_BYTES: usize = 12;",
   "const MAX_KEYS: usize = 16;",
   "const MAX_LIFETIME_MILLIS: u128 = 15 * 60 * 1_000;",
   "const MAX_CLOCK_SKEW_MILLIS: i64 = 30 * 1_000;",
   "pub struct IndexSourceContinuationScope",
+  "locale: Option<LocaleKey>",
   "pub fn from_registry(",
+  "pub fn for_locale(",
   ".source_for_schema(&schema)",
   "descriptor.owner_module()",
   "descriptor.source_name()",
+  "pub fn locale(&self) -> Option<&LocaleKey>",
   "pub struct IndexSourceContinuationToken(String);",
   "pub struct IndexSourceContinuationCodec",
   "keys: Arc<BTreeMap<String, [u8; KEY_BYTES]>>",
@@ -57,6 +60,8 @@ requireMarkers("source", [
   "pub fn seal(",
   "pub fn open_encoded(",
   "validate_claims(&claims, expected_scope, now)?;",
+  "claims.locale != expected_scope.locale",
+  "IndexSourceContinuationError::LocaleScopeMismatch",
   "IndexSourceContinuationError::TenantMismatch",
   "IndexSourceContinuationError::SchemaMismatch",
   "IndexSourceContinuationError::SourceOwnerMismatch",
@@ -65,6 +70,7 @@ requireMarkers("source", [
   "IndexSourceContinuationError::Expired",
   "IndexSourceContinuationError::KeyUnavailable",
   "sealed_cursor_round_trips_only_under_exact_scope",
+  "schema_wide_and_exact_locale_continuations_cannot_cross_scopes",
   "tampering_fails_authentication",
   "rotation_decodes_retained_old_key_and_rejects_removed_key",
   "token_and_codec_debug_do_not_expose_secret_material",
@@ -78,9 +84,17 @@ for (const forbidden of [
   "async_graphql",
   "std::env",
   "SecretResolverRegistry",
+  "CONTINUATION_VERSION",
+  "LEGACY_CONTINUATION",
+  "ContinuationClaimsV1",
+  "ContinuationClaimsV2",
+  "UnsupportedVersion",
+  "ContractVersionMismatch",
+  "-continuation-v1",
+  "-continuation-v2",
 ]) {
   if (production.includes(forbidden)) {
-    throw new Error(`source continuation codec contains forbidden dependency: ${forbidden}`);
+    throw new Error(`source continuation codec contains forbidden dependency/legacy marker: ${forbidden}`);
   }
 }
 
@@ -138,27 +152,33 @@ for (const forbidden of [
 }
 
 requireMarkers("doc", [
-  "Status: `source_complete_owner_execution_pending`.",
+  "Status: `source_complete_locale_scope_owner_execution_pending`.",
+  "one current unversioned continuation envelope",
   "AES-256-GCM",
   "fresh 96-bit operating-system nonce",
   "canonical owner module",
   "canonical source name",
+  "exact canonical `LocaleKey`",
+  "A schema-wide token cannot open",
+  "There is no internal continuation version byte",
   "between 1 second and 15 minutes",
   "A token naming a removed key fails closed",
-  "diagnoseIndexSourcePage",
   "No tests, verifiers, formatting, Cargo checks",
 ]);
 requireMarkers("serverDoc", [
   "Status: `source_complete_owner_execution_pending`.",
+  "single current unversioned continuation envelope",
   "SecretRef",
   "exactly 32 bytes",
-  "diagnose_source_page_sealed",
-  "diagnoseIndexSourcePage",
+  "Key rotation preserves cryptographic key continuity only",
+]);
+requireMarkers("agents", [
+  "Unreleased tokens, cursors, envelopes, and other repository-owned serialized",
+  "Delete prior-format readers, writers, version bytes/tags, compatibility fixtures,",
+  "Do not introduce `V1`/`V2` claim structs",
 ]);
 requireMarkers("plan", [
-  "M6 authenticated and confidential source continuation codec",
-  "M6 server-owned source continuation keyring and sealed page boundary",
-  "M6 bounded GraphQL sealed source-page diagnosis transport",
+  "Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.",
 ]);
 requireMarkers("aggregate", ["'verify-index-source-continuation.mjs'"]);
 
@@ -171,4 +191,4 @@ for (const claim of [
   }
 }
 
-console.log("Index confidential source continuation contract verified");
+console.log("Index confidential source continuation contract verified with canonical schema-wide/exact-locale scope and no legacy format family");


### PR DESCRIPTION
## Summary

- replace the pre-release source-continuation shape in place with one canonical **unversioned** authenticated/confidential envelope;
- remove the old continuation version byte, `contract_version`, version-specific errors, and any idea of a `V1`/`V2` claims/decoder family instead of adding compatibility code;
- bind encrypted continuation claims to optional canonical locale identity in addition to tenant/schema/source ownership;
- keep `IndexSourceContinuationScope::from_registry` as schema-wide (`locale = None`) and add `IndexSourceContinuationScope::for_locale` for one exact canonical `LocaleKey`;
- fail closed with `LocaleScopeMismatch` when schema-wide/exact-locale/different-locale tokens are crossed; canonical locale aliases resolve to the same scope;
- keep the currently exposed Shadow GraphQL execution schema-wide in this slice; exact-locale dry-run/runtime/GraphQL execution is the next boundary and can now reuse the canonical locale-safe scope without changing token format again;
- remove now-dead version-error branches from the two GraphQL continuation mappings;
- strengthen root `AGENTS.md`: unreleased tokens/cursors/envelopes/serialized formats must be replaced atomically, with prior-format readers/writers/version tags/fallback decoders deleted; no `V1`/`V2` internal format families without an explicit user-approved external compatibility bridge;
- actualize M6 docs, execution cursor, and retained source guards around the single-format policy.

## Zero-legacy rule

This PR deliberately does **not** preserve tokens emitted by the superseded pre-release repository-owned format. Key rotation remains supported for the one current envelope, but cryptographic key continuity must not become format compatibility.

## Mainline recheck

The branch was created from `main@82f301231463cdce296ae4a88b0ac479c51ff9d1`. During final static review, `main` advanced through four Groups/Pages/Admin commits to `51965c2ed193c601cd96116fcc06e5adae31b93a`. Their changed paths are disjoint from this PR, including `AGENTS.md`, server replay GraphQL, `rustok-index`, and Index verify scripts.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.