### PR TITLE
feat(modules): revision Product corequisites in owner policy

### DIFF
--- a/apps/server/src/modules/manifest/corequisites.rs
+++ b/apps/server/src/modules/manifest/corequisites.rs
@@ -1,4 +1,3 @@
-use rustok_modules::{ModuleEffectivePolicy, ModuleEffectivePolicyFact};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -29,31 +28,12 @@ struct StaticSelectionModule {
 
 impl ManifestManager {
     /// Returns package-owned co-requisite metadata for every installed static
-    /// module. Tenant policy uses this contract without changing dependency order.
+    /// module. The modules owner consumes this as availability input without
+    /// changing ordinary dependency or migration ordering.
     pub(crate) fn module_policy_corequisites(
         manifest: &ModulesManifest,
     ) -> Result<BTreeMap<String, BTreeMap<String, String>>, ManifestError> {
         module_policy_corequisites(manifest)
-    }
-
-    /// Fails closed when an owner-resolved tenant policy leaves an enabled
-    /// module without a required package co-requisite.
-    pub(crate) fn validate_effective_policy_corequisites(
-        policy: &ModuleEffectivePolicy,
-        co_requisites: &BTreeMap<String, BTreeMap<String, String>>,
-    ) -> Result<(), String> {
-        validate_effective_policy_corequisites(policy, co_requisites)
-    }
-
-    /// Validates a tenant intent write without imposing a second enable/disable
-    /// ordering graph. Effective availability is enforced separately.
-    pub(crate) fn validate_corequisite_toggle(
-        policy: &ModuleEffectivePolicy,
-        co_requisites: &BTreeMap<String, BTreeMap<String, String>>,
-        module_slug: &str,
-        enabled: bool,
-    ) -> Result<(), String> {
-        validate_corequisite_toggle(policy, co_requisites, module_slug, enabled)
     }
 }
 
@@ -74,111 +54,6 @@ fn module_policy_corequisites(
         }
     }
     Ok(policy)
-}
-
-/// Fails closed when the owner-resolved tenant policy leaves an enabled module
-/// without one of its package-declared co-requisites. This guard consumes the
-/// policy result; it does not rewrite ordinary dependency or migration order.
-fn validate_effective_policy_corequisites(
-    policy: &ModuleEffectivePolicy,
-    co_requisites: &ModulePolicyCoRequisites,
-) -> Result<(), String> {
-    for (consumer, required_modules) in co_requisites {
-        if !policy.contains(consumer) {
-            continue;
-        }
-        for (provider, version_requirement) in required_modules {
-            if !policy.contains(provider) {
-                return Err(format!(
-                    "module '{consumer}' requires effectively enabled co-requisite '{provider}'"
-                ));
-            }
-            validate_policy_provider_contract(
-                policy,
-                consumer,
-                provider,
-                version_requirement,
-            )?;
-        }
-    }
-    Ok(())
-}
-
-/// Tenant intent must remain sequentially orderable. Product can be staged
-/// before Inventory/Pricing are enabled because those owners ordinarily depend
-/// on Product; the externally visible effective-policy guard remains fail-closed
-/// until the whole owner set is available. Here we validate only the admitted
-/// owner definitions/version contract before persisting an enable intent.
-fn validate_corequisite_toggle(
-    policy: &ModuleEffectivePolicy,
-    co_requisites: &ModulePolicyCoRequisites,
-    module_slug: &str,
-    enabled: bool,
-) -> Result<(), String> {
-    if !enabled {
-        return Ok(());
-    }
-    if let Some(required_modules) = co_requisites.get(module_slug) {
-        for (provider, version_requirement) in required_modules {
-            validate_policy_provider_contract(
-                policy,
-                module_slug,
-                provider,
-                version_requirement,
-            )?;
-        }
-    }
-    Ok(())
-}
-
-fn validate_policy_provider_contract(
-    policy: &ModuleEffectivePolicy,
-    consumer: &str,
-    provider: &str,
-    raw_requirement: &str,
-) -> Result<(), String> {
-    let version = policy_definition_version(policy, provider).ok_or_else(|| {
-        format!(
-            "module '{consumer}' co-requisite '{provider}' has no effective-policy definition version"
-        )
-    })?;
-    let requirement = raw_requirement.trim();
-    if requirement.is_empty() {
-        return Ok(());
-    }
-    let requirement = VersionReq::parse(requirement).map_err(|_| {
-        format!(
-            "module '{consumer}' co-requisite '{provider}' has invalid version requirement '{}'",
-            raw_requirement.trim()
-        )
-    })?;
-    let version = Version::parse(version).map_err(|_| {
-        format!(
-            "module '{consumer}' co-requisite '{provider}' has invalid effective-policy version '{version}'"
-        )
-    })?;
-    if !requirement.matches(&version) {
-        return Err(format!(
-            "module '{consumer}' requires co-requisite '{provider}' version '{}', but effective policy has '{version}'",
-            raw_requirement.trim()
-        ));
-    }
-    Ok(())
-}
-
-fn policy_definition_version<'a>(
-    policy: &'a ModuleEffectivePolicy,
-    module_slug: &str,
-) -> Option<&'a str> {
-    policy
-        .decisions()
-        .find(|decision| decision.module_slug == module_slug)
-        .and_then(|decision| {
-            decision.facts.iter().find_map(|fact| match fact {
-                ModuleEffectivePolicyFact::Definition { version, .. } => Some(version.as_str()),
-                _ => None,
-            })
-        })
 }
 
 /// Validates deployment-selection co-requisites after ordinary static topology

--- a/apps/server/src/services/effective_module_policy.rs
+++ b/apps/server/src/services/effective_module_policy.rs
@@ -28,12 +28,11 @@ impl EffectiveModulePolicyService {
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
         let default_enabled_modules = manifest.settings.default_enabled;
         let policy = ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, default_enabled_modules.clone())
-            .resolve(tenant_id)
+            .lifecycle(registry, default_enabled_modules.clone())
+            .with_corequisites(co_requisites)
+            .effective_policy(tenant_id)
             .await
             .map_err(map_effective_policy_error)?;
-        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
-            .map_err(PlatformCompositionError::EffectivePolicy)?;
         let cache_identity = policy
             .cache_identity(tenant_id)
             .map_err(|error| PlatformCompositionError::EffectivePolicy(error.to_string()))?;
@@ -65,8 +64,8 @@ impl EffectiveModulePolicyService {
     }
 
     /// Resolves module availability from a channel-owner snapshot. Channel
-    /// resolution remains in `rustok-channel`; this adapter forwards the owner
-    /// result through the deployment co-requisite fail-closed guard.
+    /// resolution remains in `rustok-channel`; the active package co-requisite
+    /// contract is supplied to the canonical modules-owner decision.
     pub async fn resolve_for_channel(
         db: &DatabaseConnection,
         registry: &ModuleRegistry,
@@ -75,18 +74,16 @@ impl EffectiveModulePolicyService {
     ) -> Result<ModuleEffectivePolicy, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
-        let policy = ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, manifest.settings.default_enabled)
-            .resolve_for_channel(tenant_id, channel)
+        ModuleControlPlane::new(db.clone())
+            .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites)
+            .effective_policy_for_channel(tenant_id, channel)
             .await
-            .map_err(map_effective_policy_error)?;
-        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
-            .map_err(PlatformCompositionError::EffectivePolicy)?;
-        Ok(policy)
+            .map_err(map_effective_policy_error)
     }
 
-    /// Forwards all host-owned policy snapshots to the single module owner
-    /// decision, then fail-closes if a selected consumer lost a co-requisite.
+    /// Forwards all host-owned policy snapshots and the active package
+    /// co-requisite contract into one canonical modules-owner decision.
     pub async fn resolve_for_context(
         db: &DatabaseConnection,
         registry: &ModuleRegistry,
@@ -97,14 +94,12 @@ impl EffectiveModulePolicyService {
     ) -> Result<ModuleEffectivePolicy, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
-        let policy = ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, manifest.settings.default_enabled)
-            .resolve_for_context(tenant_id, channel, maintenance, node_readiness)
+        ModuleControlPlane::new(db.clone())
+            .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites)
+            .effective_policy_for_context(tenant_id, channel, maintenance, node_readiness)
             .await
-            .map_err(map_effective_policy_error)?;
-        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
-            .map_err(PlatformCompositionError::EffectivePolicy)?;
-        Ok(policy)
+            .map_err(map_effective_policy_error)
     }
 
     pub async fn resolve_for_node_readiness(
@@ -115,14 +110,12 @@ impl EffectiveModulePolicyService {
     ) -> Result<ModuleEffectivePolicy, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
-        let policy = ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, manifest.settings.default_enabled)
-            .resolve_for_node_readiness(tenant_id, node_readiness)
+        ModuleControlPlane::new(db.clone())
+            .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites)
+            .effective_policy_for_node_readiness(tenant_id, node_readiness)
             .await
-            .map_err(map_effective_policy_error)?;
-        ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)
-            .map_err(PlatformCompositionError::EffectivePolicy)?;
-        Ok(policy)
+            .map_err(map_effective_policy_error)
     }
 
     pub async fn list_enabled(
@@ -146,7 +139,7 @@ impl EffectiveModulePolicyService {
     ) -> Result<Vec<TenantModuleOverrideSnapshot>, PlatformCompositionError> {
         let manifest = PlatformCompositionService::active_manifest(db).await?;
         ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, manifest.settings.default_enabled)
+            .lifecycle(registry, manifest.settings.default_enabled)
             .tenant_override_snapshots(tenant_id, limit)
             .await
             .map_err(map_effective_policy_error)

--- a/apps/server/src/services/module_lifecycle.rs
+++ b/apps/server/src/services/module_lifecycle.rs
@@ -108,22 +108,9 @@ impl ModuleLifecycleService {
             .map_err(|error| ToggleModuleError::Policy(error.to_string()))?;
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)
             .map_err(|error| ToggleModuleError::Policy(error.to_string()))?;
-        let default_enabled = manifest.settings.default_enabled;
-        let current_policy = ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, default_enabled.clone())
-            .resolve(tenant_id)
-            .await
-            .map_err(map_lifecycle_writer_error)?;
-        ManifestManager::validate_corequisite_toggle(
-            &current_policy,
-            &co_requisites,
-            module_slug,
-            enabled,
-        )
-        .map_err(ToggleModuleError::Policy)?;
-
         let result = ModuleControlPlane::new(db.clone())
-            .lifecycle(registry, default_enabled)
+            .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites)
             .toggle(tenant_id, module_slug, enabled, requested_by)
             .await
             .map_err(map_lifecycle_writer_error)?;
@@ -163,8 +150,11 @@ impl ModuleLifecycleService {
         let manifest = PlatformCompositionService::active_manifest(db)
             .await
             .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)
+            .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
         let retry_operation = ModuleControlPlane::new(db.clone())
             .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites)
             .retry_post_hook(operation_id, requested_by, idempotency_key)
             .await
             .map_err(map_lifecycle_writer_recovery_error)?;
@@ -181,30 +171,14 @@ impl ModuleLifecycleService {
         requested_by: Option<String>,
         idempotency_key: uuid::Uuid,
     ) -> Result<tenant_modules::Model, ModuleOperationRecoveryError> {
-        let plan = module_operation_recovery_plan(db, operation_id)
-            .await
-            .map_err(map_module_recovery_error)?;
         let manifest = PlatformCompositionService::active_manifest(db)
             .await
             .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)
             .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
-        let default_enabled = manifest.settings.default_enabled;
-        let current_policy = ModuleControlPlane::new(db.clone())
-            .effective_policy(registry, default_enabled.clone())
-            .resolve(plan.tenant_id)
-            .await
-            .map_err(map_lifecycle_writer_recovery_error)?;
-        ManifestManager::validate_corequisite_toggle(
-            &current_policy,
-            &co_requisites,
-            &plan.module_slug,
-            plan.previous_effective_enabled,
-        )
-        .map_err(ModuleOperationRecoveryError::Policy)?;
-
         let result = ModuleControlPlane::new(db.clone())
-            .lifecycle(registry, default_enabled)
+            .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites)
             .compensate_failed_operation(operation_id, requested_by, idempotency_key)
             .await
             .map_err(map_lifecycle_writer_recovery_error)?;
@@ -232,8 +206,10 @@ impl ModuleLifecycleService {
         let manifest = PlatformCompositionService::active_manifest(db)
             .await
             .map_err(|error| UpdateModuleSettingsError::Policy(error.to_string()))?;
+        let co_requisites = ManifestManager::module_policy_corequisites(&manifest)?;
         let writer = ModuleControlPlane::new(db.clone())
-            .lifecycle(registry, manifest.settings.default_enabled);
+            .lifecycle(registry, manifest.settings.default_enabled)
+            .with_corequisites(co_requisites);
         writer
             .require_module_definition(module_slug)
             .map_err(map_lifecycle_writer_settings_error)?;

--- a/crates/rustok-modules/src/executor.rs
+++ b/crates/rustok-modules/src/executor.rs
@@ -20,7 +20,11 @@ pub struct ModuleLifecycleToggleRequest {
     pub requested_by: Option<String>,
     pub correlation_id: Option<String>,
     pub idempotency_key: Option<uuid::Uuid>,
+    /// Canonical serving availability, including co-requisite constraints.
     pub effective_enabled_modules: HashSet<String>,
+    /// Ordinary dependency-order selection used only to validate sequential
+    /// lifecycle transitions. Co-requisites must not create a second ordering graph.
+    pub ordering_enabled_modules: HashSet<String>,
     pub current_settings: serde_json::Value,
     pub policy_transition: Option<ModulePolicyRevisionTransition>,
 }
@@ -83,7 +87,7 @@ pub async fn execute_module_toggle(
     }
     validate_module_toggle(
         dispatcher.catalog(),
-        &request.effective_enabled_modules,
+        &request.ordering_enabled_modules,
         &request.module_slug,
         request.enabled,
     )?;
@@ -383,6 +387,7 @@ mod tests {
                 correlation_id: None,
                 idempotency_key: None,
                 effective_enabled_modules: HashSet::new(),
+                ordering_enabled_modules: HashSet::new(),
                 current_settings: serde_json::json!({}),
                 policy_transition: None,
             },

--- a/crates/rustok-modules/src/lifecycle_writer.rs
+++ b/crates/rustok-modules/src/lifecycle_writer.rs
@@ -1,24 +1,25 @@
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use thiserror::Error;
 use uuid::Uuid;
 
 use rustok_core::ModuleRegistry;
 
 use crate::policy::{
-    ModuleEffectivePolicyChannelInput, ModuleEffectivePolicyInstallationFact,
-    ModuleEffectivePolicyMaintenanceInput, ModuleEffectivePolicyNodeReadinessInput,
-    ModuleEffectivePolicyQuery, ModuleEffectivePolicyRuntimeInput,
+    ModuleEffectivePolicyChannelInput, ModuleEffectivePolicyCoRequisite,
+    ModuleEffectivePolicyInstallationFact, ModuleEffectivePolicyMaintenanceInput,
+    ModuleEffectivePolicyNodeReadinessInput, ModuleEffectivePolicyQuery,
+    ModuleEffectivePolicyRuntimeInput,
 };
 use crate::{
     ArtifactInstallationResolver, ArtifactLifecycleExecutor, ArtifactSandboxPolicyResolver,
     ControlPlaneInfrastructure, ModuleDefinitionCatalog, ModuleDefinitionError,
-    ModuleDefinitionKind, ModuleDefinitionSource, ModuleEffectivePolicy,
-    ModuleEffectivePolicyError, ModuleEffectivePolicyTransitionCoordinator,
-    ModuleExecutionDispatcher, ModuleLifecycleExecutionError, ModuleLifecycleToggleRequest,
-    ModuleOperationIssue, ModuleOperationJournal, ModuleOperationRecord,
-    ModuleOperationRecoveryError, ModuleOperationRequest, ModuleOperationStoreError,
-    ModulePolicyRevisionTransition, ModulePostHookRetryRequest, SeaOrmArtifactInstallationStore,
+    ModuleDefinitionKind, ModuleDefinitionSource, ModuleEffectivePolicy, ModuleEffectivePolicyError,
+    ModuleEffectivePolicyTransitionCoordinator, ModuleExecutionDispatcher,
+    ModuleLifecycleExecutionError, ModuleLifecycleToggleRequest, ModuleOperationIssue,
+    ModuleOperationJournal, ModuleOperationRecord, ModuleOperationRecoveryError,
+    ModuleOperationRequest, ModuleOperationStoreError, ModulePolicyRevisionTransition,
+    ModulePostHookRetryRequest, SeaOrmArtifactInstallationStore,
     SeaOrmArtifactSandboxPolicyResolver, SeaOrmModuleArtifactSecurityResolver,
     SeaOrmModulePolicyRevisionConsumer, TenantModuleOverride, TenantModuleSettingsRecord,
     TenantModuleSettingsRequest, TenantModuleStateStore,
@@ -37,6 +38,7 @@ pub struct ModuleLifecycleDbWriter<'a> {
     static_registry: Option<&'a ModuleRegistry>,
     artifact_executor: Option<&'a dyn ArtifactLifecycleExecutor>,
     default_enabled_modules: Vec<String>,
+    co_requisites: Vec<ModuleEffectivePolicyCoRequisite>,
     settings_schema_validators: ArtifactSchemaValidatorCache,
 }
 
@@ -76,6 +78,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             static_registry: Some(registry),
             artifact_executor: None,
             default_enabled_modules,
+            co_requisites: Vec::new(),
             settings_schema_validators: ArtifactSchemaValidatorCache::default(),
         }
     }
@@ -97,6 +100,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             static_registry: Some(registry),
             artifact_executor: None,
             default_enabled_modules,
+            co_requisites: Vec::new(),
             settings_schema_validators: ArtifactSchemaValidatorCache::default(),
         }
     }
@@ -133,8 +137,32 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             static_registry: None,
             artifact_executor: Some(artifact_executor),
             default_enabled_modules,
+            co_requisites: Vec::new(),
             settings_schema_validators: ArtifactSchemaValidatorCache::default(),
         }
+    }
+
+    /// Adds deployment-admitted availability constraints to every effective
+    /// policy resolved by this lifecycle owner. The host-facing shape is only
+    /// a normalized selection map; the owner converts it to its typed policy
+    /// input without creating dependency or migration-order edges.
+    pub fn with_corequisites(
+        mut self,
+        co_requisites: BTreeMap<String, BTreeMap<String, String>>,
+    ) -> Self {
+        self.co_requisites = co_requisites
+            .into_iter()
+            .flat_map(|(module_slug, required_modules)| {
+                required_modules.into_iter().map(move |(required_module_slug, version_requirement)| {
+                    ModuleEffectivePolicyCoRequisite {
+                        module_slug: module_slug.clone(),
+                        required_module_slug,
+                        version_requirement,
+                    }
+                })
+            })
+            .collect();
+        self
     }
 
     pub async fn toggle(
@@ -164,7 +192,13 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         correlation_id: Option<String>,
         idempotency_key: Option<Uuid>,
     ) -> Result<crate::ModuleLifecycleToggleResult, ModuleLifecycleDbWriterError> {
-        let (catalog, effective_enabled_modules, current_settings, policy_transition) = self
+        let (
+            catalog,
+            effective_enabled_modules,
+            ordering_enabled_modules,
+            current_settings,
+            policy_transition,
+        ) = self
             .toggle_execution_context(tenant_id, module_slug, enabled)
             .await?;
         let dispatcher = match (self.static_registry, self.artifact_executor) {
@@ -195,6 +229,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
                 correlation_id,
                 idempotency_key,
                 effective_enabled_modules,
+                ordering_enabled_modules,
                 current_settings,
                 policy_transition,
             },
@@ -572,11 +607,33 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             maintenance,
             node_readiness,
         )
+        .with_corequisites(self.co_requisites.iter().cloned())
         .execute()
         .map_err(ModuleLifecycleDbWriterError::Policy)
     }
 
     async fn effective_policy_from_overrides(
+        &self,
+        tenant_id: Uuid,
+        catalog: &ModuleDefinitionCatalog,
+        overrides: Vec<TenantModuleOverride>,
+    ) -> Result<ModuleEffectivePolicy, ModuleLifecycleDbWriterError> {
+        let runtime_inputs = self.runtime_policy_inputs(catalog, tenant_id).await;
+        ModuleEffectivePolicyQuery::new_with_context(
+            catalog,
+            self.default_enabled_modules.iter().cloned(),
+            overrides,
+            runtime_inputs,
+            None,
+            None,
+            None,
+        )
+        .with_corequisites(self.co_requisites.iter().cloned())
+        .execute()
+        .map_err(ModuleLifecycleDbWriterError::Policy)
+    }
+
+    async fn ordering_policy_from_overrides(
         &self,
         tenant_id: Uuid,
         catalog: &ModuleDefinitionCatalog,
@@ -675,6 +732,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         (
             ModuleDefinitionCatalog,
             HashSet<String>,
+            HashSet<String>,
             serde_json::Value,
             Option<ModulePolicyRevisionTransition>,
         ),
@@ -684,6 +742,9 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         let overrides = self.overrides(tenant_id).await?;
         let current_policy = self
             .effective_policy_from_overrides(tenant_id, &catalog, overrides.clone())
+            .await?;
+        let ordering_policy = self
+            .ordering_policy_from_overrides(tenant_id, &catalog, overrides.clone())
             .await?;
         let mut next_overrides = overrides;
         if let Some(override_value) = next_overrides
@@ -719,6 +780,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         Ok((
             catalog,
             current_policy.into_enabled_modules(),
+            ordering_policy.into_enabled_modules(),
             current_settings,
             policy_transition,
         ))

--- a/crates/rustok-modules/src/policy.rs
+++ b/crates/rustok-modules/src/policy.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use rustok_api::manifest_hash::hash_manifest;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -17,6 +18,19 @@ use crate::{
 pub struct TenantModuleOverride {
     pub module_slug: String,
     pub enabled: bool,
+}
+
+/// Deployment-admitted availability requirement evaluated by effective policy.
+///
+/// Co-requisites deliberately do not participate in dependency or migration
+/// ordering. Hosts supply this normalized owner input separately from the
+/// definition catalog's ordinary `dependencies` edges.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModuleEffectivePolicyCoRequisite {
+    pub module_slug: String,
+    pub required_module_slug: String,
+    pub version_requirement: String,
 }
 
 /// Canonical channel state supplied by the channel owner at a policy boundary.
@@ -89,6 +103,13 @@ pub enum ModuleEffectivePolicyFact {
         module_slug: String,
         enabled: bool,
     },
+    CoRequisite {
+        module_slug: String,
+        version_requirement: String,
+        version: String,
+        enabled: bool,
+        compatible: bool,
+    },
     ArtifactInstallation {
         installation_id: uuid::Uuid,
         scope: ModuleInstallationScope,
@@ -148,6 +169,8 @@ pub enum ModuleEffectivePolicyDenialReason {
     CapabilityPolicyUnavailable,
     ExecutorUnavailable,
     DependencyUnavailable { module_slug: String },
+    CoRequisiteUnavailable { module_slug: String },
+    CoRequisiteVersionMismatch { module_slug: String },
     RegistryReleaseUnavailable,
     SecurityStateUnavailable,
     Quarantined,
@@ -230,6 +253,8 @@ pub enum ModuleEffectivePolicyError {
     RevisionEncoding(String),
     #[error("effective module policy cache identity is invalid: {0}")]
     InvalidCacheIdentity(String),
+    #[error("effective module policy co-requisite input is invalid: {0}")]
+    InvalidCoRequisiteInput(String),
     #[error("effective module policy channel input is invalid: {0}")]
     InvalidChannelInput(String),
     #[error("effective module policy maintenance input is invalid: {0}")]
@@ -409,6 +434,7 @@ pub(crate) struct ModuleEffectivePolicyQuery<'a> {
     default_enabled: Vec<String>,
     tenant_overrides: Vec<TenantModuleOverride>,
     runtime_inputs: Vec<ModuleEffectivePolicyRuntimeInput>,
+    co_requisites: Vec<ModuleEffectivePolicyCoRequisite>,
     channel: Option<ModuleEffectivePolicyChannelInput>,
     maintenance: Option<ModuleEffectivePolicyMaintenanceInput>,
     node_readiness: Option<ModuleEffectivePolicyNodeReadinessInput>,
@@ -492,10 +518,19 @@ impl<'a> ModuleEffectivePolicyQuery<'a> {
             default_enabled: default_enabled.into_iter().collect(),
             tenant_overrides: tenant_overrides.into_iter().collect(),
             runtime_inputs: runtime_inputs.into_iter().collect(),
+            co_requisites: Vec::new(),
             channel,
             maintenance,
             node_readiness,
         }
+    }
+
+    pub(crate) fn with_corequisites(
+        mut self,
+        co_requisites: impl IntoIterator<Item = ModuleEffectivePolicyCoRequisite>,
+    ) -> Self {
+        self.co_requisites = co_requisites.into_iter().collect();
+        self
     }
 
     /// Resolves the immutable core set, selected optional defaults, and tenant
@@ -505,6 +540,7 @@ impl<'a> ModuleEffectivePolicyQuery<'a> {
         validate_channel_input(self.channel.as_ref())?;
         validate_maintenance_input(self.maintenance.as_ref())?;
         validate_node_readiness_input(self.node_readiness.as_ref(), None)?;
+        let co_requisites = normalize_corequisites(self.catalog, self.co_requisites)?;
         let channel = self.channel;
         let mut maintenance = self.maintenance;
         let mut node_readiness = self.node_readiness;
@@ -532,6 +568,7 @@ impl<'a> ModuleEffectivePolicyQuery<'a> {
             &default_enabled,
             &tenant_overrides,
             &runtime_inputs,
+            &co_requisites,
             channel.as_ref(),
             maintenance.as_ref(),
             None,
@@ -542,6 +579,7 @@ impl<'a> ModuleEffectivePolicyQuery<'a> {
             &default_enabled,
             &tenant_overrides,
             &runtime_inputs,
+            &co_requisites,
             channel.as_ref(),
             maintenance.as_ref(),
             node_readiness.as_ref(),
@@ -785,16 +823,52 @@ impl<'a> ModuleEffectivePolicyQuery<'a> {
                     (!missing.is_empty()).then(|| (definition.slug.clone(), missing))
                 })
                 .collect::<Vec<_>>();
-            if unavailable_dependencies.is_empty() {
+            let unavailable_corequisites = co_requisites
+                .iter()
+                .filter(|co_requisite| enabled.contains(&co_requisite.module_slug))
+                .filter_map(|co_requisite| {
+                    let provider_enabled = enabled.contains(&co_requisite.required_module_slug);
+                    let compatible = corequisite_version_compatible(self.catalog, co_requisite);
+                    (!provider_enabled || !compatible).then(|| {
+                        (
+                            co_requisite.module_slug.clone(),
+                            co_requisite.required_module_slug.clone(),
+                            provider_enabled,
+                            compatible,
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            if unavailable_dependencies.is_empty() && unavailable_corequisites.is_empty() {
                 break;
             }
             for (module_slug, dependencies) in unavailable_dependencies {
-                enabled.remove(&module_slug);
-                denial_reasons.entry(module_slug).or_default().extend(
-                    dependencies.into_iter().map(|module_slug| {
-                        ModuleEffectivePolicyDenialReason::DependencyUnavailable { module_slug }
-                    }),
-                );
+                if enabled.remove(&module_slug) {
+                    denial_reasons.entry(module_slug).or_default().extend(
+                        dependencies.into_iter().map(|module_slug| {
+                            ModuleEffectivePolicyDenialReason::DependencyUnavailable { module_slug }
+                        }),
+                    );
+                }
+            }
+            for (module_slug, required_module_slug, provider_enabled, compatible) in
+                unavailable_corequisites
+            {
+                if !enabled.remove(&module_slug) {
+                    continue;
+                }
+                let reason = if !provider_enabled {
+                    ModuleEffectivePolicyDenialReason::CoRequisiteUnavailable {
+                        module_slug: required_module_slug,
+                    }
+                } else if !compatible {
+                    ModuleEffectivePolicyDenialReason::CoRequisiteVersionMismatch {
+                        module_slug: required_module_slug,
+                    }
+                } else {
+                    unreachable!("unavailable co-requisite must have a denial cause")
+                };
+                denial_reasons.entry(module_slug).or_default().push(reason);
             }
         }
 
@@ -891,6 +965,27 @@ impl<'a> ModuleEffectivePolicyQuery<'a> {
                         enabled: enabled.contains(&dependency.slug),
                     }
                 }));
+                facts.extend(
+                    co_requisites
+                        .iter()
+                        .filter(|co_requisite| co_requisite.module_slug == definition.slug)
+                        .map(|co_requisite| {
+                            let provider = self
+                                .catalog
+                                .get(&co_requisite.required_module_slug)
+                                .expect("co-requisite provider was normalized against the catalog");
+                            ModuleEffectivePolicyFact::CoRequisite {
+                                module_slug: co_requisite.required_module_slug.clone(),
+                                version_requirement: co_requisite.version_requirement.clone(),
+                                version: provider.version.clone(),
+                                enabled: enabled.contains(&co_requisite.required_module_slug),
+                                compatible: corequisite_version_compatible(
+                                    self.catalog,
+                                    co_requisite,
+                                ),
+                            }
+                        }),
+                );
                 let module_denial_reasons = denial_reasons
                     .get(&definition.slug)
                     .cloned()
@@ -967,6 +1062,7 @@ struct EffectivePolicyRevisionInput<'a> {
     default_enabled: &'a [String],
     tenant_overrides: &'a [TenantModuleOverride],
     runtime_inputs: &'a [ModuleEffectivePolicyRuntimeInput],
+    co_requisites: &'a [ModuleEffectivePolicyCoRequisite],
     channel: Option<&'a ModuleEffectivePolicyChannelInput>,
     maintenance: Option<&'a ModuleEffectivePolicyMaintenanceInput>,
     node_readiness: Option<&'a ModuleEffectivePolicyNodeReadinessInput>,
@@ -977,22 +1073,117 @@ fn effective_policy_revision(
     default_enabled: &[String],
     tenant_overrides: &[TenantModuleOverride],
     runtime_inputs: &[ModuleEffectivePolicyRuntimeInput],
+    co_requisites: &[ModuleEffectivePolicyCoRequisite],
     channel: Option<&ModuleEffectivePolicyChannelInput>,
     maintenance: Option<&ModuleEffectivePolicyMaintenanceInput>,
     node_readiness: Option<&ModuleEffectivePolicyNodeReadinessInput>,
 ) -> Result<String, ModuleEffectivePolicyError> {
     let digest = hash_manifest(&EffectivePolicyRevisionInput {
-        contract: "rustok.module_effective_policy",
+        contract: "rustok.module_effective_policy.v2",
         catalog,
         default_enabled,
         tenant_overrides,
         runtime_inputs,
+        co_requisites,
         channel,
         maintenance,
         node_readiness,
     })
     .map_err(|error| ModuleEffectivePolicyError::RevisionEncoding(error.to_string()))?;
     Ok(format!("sha256:{digest}"))
+}
+
+fn normalize_corequisites(
+    catalog: &ModuleDefinitionCatalog,
+    co_requisites: Vec<ModuleEffectivePolicyCoRequisite>,
+) -> Result<Vec<ModuleEffectivePolicyCoRequisite>, ModuleEffectivePolicyError> {
+    let mut normalized = BTreeMap::<(String, String), String>::new();
+    for co_requisite in co_requisites {
+        let module_slug = co_requisite.module_slug.trim().to_string();
+        let required_module_slug = co_requisite.required_module_slug.trim().to_string();
+        let version_requirement = co_requisite.version_requirement.trim().to_string();
+        if !valid_text(&module_slug, 128) || !valid_text(&required_module_slug, 128) {
+            return Err(ModuleEffectivePolicyError::InvalidCoRequisiteInput(
+                "module slugs must be non-empty and at most 128 characters".to_string(),
+            ));
+        }
+        if module_slug == required_module_slug {
+            return Err(ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                "module '{module_slug}' cannot require itself as a co-requisite"
+            )));
+        }
+        let module = catalog.get(&module_slug).ok_or_else(|| {
+            ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                "co-requisite consumer '{module_slug}' is absent from the active definition catalog"
+            ))
+        })?;
+        let provider = catalog.get(&required_module_slug).ok_or_else(|| {
+            ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                "co-requisite provider '{required_module_slug}' is absent from the active definition catalog"
+            ))
+        })?;
+        if module
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.slug == required_module_slug)
+        {
+            return Err(ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                "module '{module_slug}' declares '{required_module_slug}' as both an ordinary dependency and a co-requisite"
+            )));
+        }
+        if !version_requirement.is_empty() {
+            VersionReq::parse(&version_requirement).map_err(|_| {
+                ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                    "module '{module_slug}' co-requisite '{required_module_slug}' has invalid version requirement '{version_requirement}'"
+                ))
+            })?;
+            Version::parse(&provider.version).map_err(|_| {
+                ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                    "co-requisite provider '{required_module_slug}' has invalid module version '{}'",
+                    provider.version
+                ))
+            })?;
+        }
+        let key = (module_slug.clone(), required_module_slug.clone());
+        if let Some(existing) = normalized.get(&key) {
+            if existing != &version_requirement {
+                return Err(ModuleEffectivePolicyError::InvalidCoRequisiteInput(format!(
+                    "module '{module_slug}' has conflicting co-requisite requirements for '{required_module_slug}'"
+                )));
+            }
+            continue;
+        }
+        normalized.insert(key, version_requirement);
+    }
+    Ok(normalized
+        .into_iter()
+        .map(
+            |((module_slug, required_module_slug), version_requirement)| {
+                ModuleEffectivePolicyCoRequisite {
+                    module_slug,
+                    required_module_slug,
+                    version_requirement,
+                }
+            },
+        )
+        .collect())
+}
+
+fn corequisite_version_compatible(
+    catalog: &ModuleDefinitionCatalog,
+    co_requisite: &ModuleEffectivePolicyCoRequisite,
+) -> bool {
+    if co_requisite.version_requirement.is_empty() {
+        return true;
+    }
+    let provider = catalog
+        .get(&co_requisite.required_module_slug)
+        .expect("co-requisite provider was normalized against the catalog");
+    let requirement = VersionReq::parse(&co_requisite.version_requirement)
+        .expect("co-requisite version requirement was normalized");
+    let version = Version::parse(&provider.version)
+        .expect("co-requisite provider version was normalized");
+    requirement.matches(&version)
 }
 
 fn validate_channel_input(
@@ -1147,18 +1338,18 @@ fn valid_text(value: &str, max_chars: usize) -> bool {
 mod tests {
     use super::{
         ModuleEffectivePolicyChannelBinding, ModuleEffectivePolicyChannelInput,
-        ModuleEffectivePolicyDenialReason, ModuleEffectivePolicyFact,
-        ModuleEffectivePolicyInstallationFact, ModuleEffectivePolicyMaintenanceInput,
-        ModuleEffectivePolicyNodeReadinessInput, ModuleEffectivePolicyQuery,
-        ModuleEffectivePolicyRuntimeInput, ModulePolicyRevisionApplyOutcome,
-        ModulePolicyRevisionGate, ModulePolicyRevisionGateError, ModulePolicyRevisionTransition,
-        TenantModuleOverride,
+        ModuleEffectivePolicyCoRequisite, ModuleEffectivePolicyDenialReason,
+        ModuleEffectivePolicyFact, ModuleEffectivePolicyInstallationFact,
+        ModuleEffectivePolicyMaintenanceInput, ModuleEffectivePolicyNodeReadinessInput,
+        ModuleEffectivePolicyQuery, ModuleEffectivePolicyRuntimeInput,
+        ModulePolicyRevisionApplyOutcome, ModulePolicyRevisionGate, ModulePolicyRevisionGateError,
+        ModulePolicyRevisionTransition, TenantModuleOverride,
     };
     use crate::{
         ArtifactPayloadKind, ArtifactReleaseRef, ModuleArtifactRegistryReleaseStatus,
         ModuleArtifactSecuritySnapshot, ModuleArtifactSecurityStatus, ModuleDefinition,
         ModuleDefinitionCatalog, ModuleDefinitionKind, ModuleDefinitionSource,
-        ModuleInstallationScope, ModulesModule,
+        ModuleDependencyConstraint, ModuleInstallationScope, ModulesModule,
     };
     use rustok_core::ModuleRegistry;
     use uuid::Uuid;
@@ -1550,6 +1741,77 @@ mod tests {
     }
 
     #[test]
+    fn corequisites_are_revisioned_explainable_availability_not_dependency_edges() {
+        let catalog = corequisite_catalog();
+        let co_requisites = vec![
+            ModuleEffectivePolicyCoRequisite {
+                module_slug: "product".to_string(),
+                required_module_slug: "inventory".to_string(),
+                version_requirement: ">=0.1.0".to_string(),
+            },
+            ModuleEffectivePolicyCoRequisite {
+                module_slug: "product".to_string(),
+                required_module_slug: "pricing".to_string(),
+                version_requirement: ">=0.1.0".to_string(),
+            },
+        ];
+        let staged = ModuleEffectivePolicyQuery::new(
+            &catalog,
+            ["taxonomy".to_string(), "product".to_string()],
+            [],
+            [],
+        )
+        .with_corequisites(co_requisites.clone())
+        .execute()
+        .expect("staged policy");
+        let product = staged.decision("product");
+        assert!(!product.enabled);
+        assert!(product.denial_reasons.iter().any(|reason| matches!(
+            reason,
+            ModuleEffectivePolicyDenialReason::CoRequisiteUnavailable { module_slug }
+                if module_slug == "inventory"
+        )));
+        assert!(product.facts.iter().any(|fact| matches!(
+            fact,
+            ModuleEffectivePolicyFact::CoRequisite {
+                module_slug,
+                enabled: false,
+                compatible: true,
+                ..
+            } if module_slug == "inventory"
+        )));
+
+        let complete = ModuleEffectivePolicyQuery::new(
+            &catalog,
+            [
+                "taxonomy".to_string(),
+                "product".to_string(),
+                "inventory".to_string(),
+                "pricing".to_string(),
+            ],
+            [],
+            [],
+        )
+        .with_corequisites(co_requisites)
+        .execute()
+        .expect("complete policy");
+        assert!(complete.contains("product"));
+        assert!(complete.contains("inventory"));
+        assert!(complete.contains("pricing"));
+        assert_ne!(staged.policy_revision(), complete.policy_revision());
+        assert_eq!(
+            catalog
+                .get("product")
+                .expect("product definition")
+                .dependencies
+                .iter()
+                .map(|dependency| dependency.slug.as_str())
+                .collect::<Vec<_>>(),
+            vec!["taxonomy"]
+        );
+    }
+
+    #[test]
     fn cache_identity_requires_exact_tenant_and_policy_revision() {
         let catalog = ModuleDefinitionCatalog::from_static_registry(
             &ModuleRegistry::new().register(ModulesModule),
@@ -1670,6 +1932,41 @@ mod tests {
                 status: ModuleArtifactRegistryReleaseStatus::Yanked
             }
         )));
+    }
+
+    fn corequisite_catalog() -> ModuleDefinitionCatalog {
+        let mut catalog = ModuleDefinitionCatalog::default();
+        for (slug, dependencies) in [
+            ("taxonomy", Vec::<&str>::new()),
+            ("product", vec!["taxonomy"]),
+            ("inventory", vec!["product"]),
+            ("pricing", vec!["product"]),
+        ] {
+            catalog
+                .insert(ModuleDefinition {
+                    slug: slug.to_string(),
+                    version: "0.1.0".to_string(),
+                    kind: ModuleDefinitionKind::Optional,
+                    source: ModuleDefinitionSource::PlatformNative {
+                        distribution_version: "0.1.0".to_string(),
+                    },
+                    dependencies: dependencies
+                        .into_iter()
+                        .map(|dependency| ModuleDependencyConstraint {
+                            slug: dependency.to_string(),
+                            version_requirement: "*".to_string(),
+                        })
+                        .collect(),
+                    permissions: Vec::new(),
+                    settings_schema_digest: None,
+                    schema_documents: Vec::new(),
+                    bindings: Vec::new(),
+                    ui: Vec::new(),
+                    capabilities: Vec::new(),
+                })
+                .expect("corequisite definition");
+        }
+        catalog
     }
 
     fn artifact_catalog() -> ModuleDefinitionCatalog {

--- a/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
+++ b/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "generated_at": "2026-08-08",
-  "status": "product_lifecycle_tenant_corequisite_host_guard_source_complete_unvalidated",
-  "source_base_revision": "9221664d677f3f8775ef4ade66ffe14a4b316c54",
+  "status": "product_lifecycle_owner_corequisite_policy_identity_source_complete_unvalidated",
+  "source_base_revision": "d7eb11aa73e41bd7ada51c03cb798dc332a10a2b",
   "scope": "Product create/delete transaction collaboration with Inventory and Pricing owners",
   "module_topology": {
     "product_dependencies": [
@@ -23,10 +23,13 @@
     "static_default_selection_enforcement_source_complete": true,
     "tenant_lifecycle_corequisite_guard_source_complete": true,
     "effective_policy_corequisite_guard_source_complete": true,
-    "canonical_policy_revision_corequisite_identity_source_complete": false,
+    "canonical_policy_revision_corequisite_identity_source_complete": true,
+    "owner_corequisite_decision_explanation_source_complete": true,
+    "lifecycle_ordering_separated_from_corequisite_availability_source_complete": true,
+    "staged_intent_recovery_semantics_source_complete": false,
     "co_requisite_control_plane_execution_proven": false,
     "tenant_lifecycle_corequisite_execution_proven": false,
-    "reason": "Static selection and tenant host guards consume Product co-requisites separately from ordinary dependencies; canonical owner policy revision/explanation integration remains open",
+    "reason": "The modules owner now hashes normalized Product co-requisites into canonical effective-policy revision/cache identity and explains availability separately from ordinary lifecycle ordering; staged retry/compensation predecessor semantics remain open",
     "default_enabled_bundle": [
       "product",
       "pricing",
@@ -73,14 +76,17 @@
     "static_default_selection_enforcement_source_complete": true,
     "tenant_lifecycle_corequisite_guard_source_complete": true,
     "effective_policy_corequisite_guard_source_complete": true,
+    "canonical_policy_revision_corequisite_identity_source_complete": true,
+    "owner_corequisite_decision_explanation_source_complete": true,
+    "lifecycle_ordering_separated_from_corequisite_availability_source_complete": true,
     "dependency_contract_resolved": false,
-    "next_slice": "Include Product co-requisite availability in canonical modules-owner effective-policy revision/cache identity and explicit decision explanation without adding dependency-order edges; then retain execution evidence",
+    "next_slice": "Separate persisted tenant selected-intent predecessor/current state from effective availability in post-hook retry and compensation while retaining canonical co-requisite-aware policy revision identity",
     "do_not": [
       "add inventory or pricing to Product ordinary module dependencies",
       "move Inventory or Pricing ORM entities into Product",
       "replace atomic owner collaboration with unproven best-effort post-commit writes",
       "claim standalone Product write activation",
-      "claim canonical policy-revision integration before the modules owner hashes and explains co-requisites"
+      "reuse effective availability as the staged tenant-intent recovery predecessor"
     ]
   },
   "validation": {
@@ -94,6 +100,7 @@
     "tenant_lifecycle_execution_proven": false,
     "effective_policy_guard_execution_proven": false,
     "policy_cache_identity_execution_proven": false,
+    "staged_intent_recovery_execution_proven": false,
     "standalone_activation_proven": false,
     "non_default_deployment_selection_proven": false,
     "transaction_rollback_proven": false

--- a/crates/rustok-product/docs/product-lifecycle-collaboration.md
+++ b/crates/rustok-product/docs/product-lifecycle-collaboration.md
@@ -1,6 +1,6 @@
 # Product lifecycle owner collaboration
 
-Status: static and tenant host co-requisite guards source-complete, canonical policy-revision integration pending, unvalidated.
+Status: deployment selection and canonical owner effective-policy co-requisite identity source-complete, staged lifecycle recovery semantics and execution evidence pending, unvalidated.
 
 ## Problem
 
@@ -27,16 +27,34 @@ The static server control plane consumes this declaration through `ManifestManag
 
 Deployment co-requisite validation remains separate from `ManifestManager::validate`. Built-in installation and ordinary topology validation therefore remain able to add Product, Inventory, and Pricing sequentially without creating an installation deadlock. Registry and migration/dependency ordering continue to consume only ordinary `depends_on` / `RusToKModule::dependencies()` edges.
 
-## Tenant lifecycle and effective-policy guard
+## Canonical tenant effective-policy identity
 
-The server now derives the same package co-requisite map for the active composition through `ManifestManager::module_policy_corequisites` and applies two fail-closed host guards around the existing modules-owner policy:
+The active composition still derives package co-requisites through `ManifestManager::module_policy_corequisites`, but the manifest layer is now only the trusted parser/translator. Availability semantics are owned by `rustok-modules`:
 
-- `ModuleLifecycleService` resolves the current revisioned effective policy before a tenant override write. A Product enable intent verifies that admitted Inventory and Pricing definitions exist and satisfy the declared version requirements, but it does **not** require those owners to be already enabled. This is deliberate: Inventory/Pricing ordinarily depend on Product, so requiring either side to be effectively enabled first would create an enable deadlock. Tenant intent can therefore be staged Product-first, then Inventory/Pricing; effective availability remains fail-closed until the whole owner set is active. Disable intent likewise remains governed by the ordinary dependency topology so a tenant can tear the group down in the reverse order without a second deadlock. Compensation uses the same contract check when it would re-enable a consumer; post-hook retry does not change state and needs no second selection check.
-- `EffectiveModulePolicyService` validates every externally returned owner policy snapshot, including channel, maintenance, and node-readiness contexts. If Product remains enabled while an Inventory/Pricing co-requisite is unavailable or version-incompatible, the adapter returns a policy error instead of exposing an unsafe availability result.
+- `ModuleLifecycleDbWriter::with_corequisites` accepts the normalized `consumer -> provider -> version requirement` map separately from the definition catalog's ordinary dependencies;
+- `ModuleEffectivePolicyQuery` normalizes the co-requisite input against the active catalog, rejects self-references, dependency/co-requisite overlap, unknown consumers/providers, conflicting duplicates, and malformed version requirements;
+- the normalized co-requisite contract participates in both base and final `rustok.module_effective_policy.v2` revision input, so `policy_revision`, `EffectivePolicyCacheIdentity`, lifecycle current/next transitions, and the policy-transition outbox share one owner identity;
+- the owner fixed point applies ordinary dependencies and co-requisites as distinct constraints. A missing effective owner produces `CoRequisiteUnavailable`; a selected but incompatible owner version produces `CoRequisiteVersionMismatch`;
+- each Product decision carries `CoRequisite` facts with the admitted owner version, declared requirement, compatibility result, and final owner availability.
 
-These guards consume `ModuleEffectivePolicy` facts and enabled state; they do not mutate `ModuleDefinition.dependencies`, `validate_module_toggle`, registry comparison, or migration ordering.
+The server no longer post-validates a returned `ModuleEffectivePolicy`. Base, channel, maintenance, node-readiness, lifecycle, recovery, and settings adapters supply the active package co-requisite map to the same modules-owner writer and consume its canonical policy result.
 
-This source slice deliberately does **not** claim canonical owner-policy integration yet. The package co-requisite map is not part of `ModuleEffectivePolicy.policy_revision`, and the host guard does not rewrite the owner decision with a dedicated co-requisite denial reason. That revision/cache identity gap remains the next source task before the overall dependency contract can be considered resolved.
+## Tenant intent ordering
+
+Canonical availability cannot also be the lifecycle ordering graph. Inventory and Pricing ordinarily depend on Product, while Product requires both as co-requisites. If ordinary `validate_module_toggle` consumed the co-requisite-constrained enabled set, Product could not become available before Inventory/Pricing and Inventory/Pricing could not be enabled before Product: tenant activation would deadlock.
+
+The modules owner therefore keeps two explicit signals during normal lifecycle toggles:
+
+- **effective availability** is co-requisite-aware and is used for serving decisions, cache identity, operation effective-state reporting, and current/next policy revision;
+- **ordinary ordering selection** resolves the same tenant intent without co-requisites and is used only by `validate_module_toggle` for the existing dependency-order rules.
+
+This lets a tenant stage Product intent first, then Inventory/Pricing, while Product remains unavailable until the complete owner set satisfies the canonical co-requisite policy. Teardown remains governed by the ordinary dependency topology; co-requisites never become a second ordering graph.
+
+## Remaining staged recovery debt
+
+The legacy lifecycle recovery contract persists `previous_effective_enabled` in the operation journal and uses effective availability for retry/compensation state matching. Once tenant intent and serving availability are intentionally distinct, a staged Product row can be selected while Product is effectively unavailable. In that state, `previous_effective_enabled` is not a sufficient predecessor for restoring the exact tenant intent after a post-hook failure.
+
+This slice therefore does **not** claim staged lifecycle recovery source-complete. The next source task is to give retry/compensation an explicit selected-intent predecessor/current-state contract while retaining the co-requisite-aware policy revision for serving and outbox identity. That change must not reintroduce a second dependency-order graph.
 
 ## Current contained boundary
 
@@ -76,22 +94,27 @@ This is a native transaction collaboration contract, not a GraphQL, REST, gRPC, 
 - the default deployment bundle contains Product, Pricing, and Inventory;
 - the server owns a separate deployment co-requisite preflight and invokes it from startup manifest/registry validation;
 - built-in installation remains on ordinary `ManifestManager::validate` and does not invoke the co-requisite preflight;
-- the active manifest exposes package co-requisite metadata to tenant policy guards without copying it into ordinary dependency ordering;
-- Product enable intent validates admitted/version-compatible co-requisite definitions without requiring an impossible pre-enabled owner order;
-- tenant enable/disable remains orderable through the ordinary dependency topology;
-- externally returned effective-policy snapshots fail closed when an enabled consumer loses a co-requisite;
+- the active manifest supplies package co-requisite metadata to the modules owner without copying it into ordinary dependency ordering;
+- canonical effective-policy revision input includes normalized co-requisites under the v2 contract;
+- Product decisions expose explicit co-requisite facts and unavailable/version-mismatch denial reasons;
+- lifecycle current/next revisions use the same co-requisite-aware owner query as policy reads;
+- normal lifecycle validation uses a separate ordinary ordering selection so Product/Inventory/Pricing activation remains sequentially orderable;
+- host-level duplicate effective-policy/toggle co-requisite validation is absent;
 - Product uses the exact owner bootstrap services and operations;
 - Product does not import foreign owner entities or query known foreign tables directly;
 - the owner services remain explicitly transaction-aware;
-- canonical policy-revision identity, runtime selection, and rollback execution evidence remain unvalidated.
+- staged retry/compensation predecessor semantics and runtime rollback evidence remain unvalidated.
 
 ## Next implementation slice
 
-Move the co-requisite availability contract into the canonical modules-owner effective-policy identity/explanation surface without turning it into dependency ordering. The co-requisite contract must contribute to policy revision/cache identity, and an unavailable owner should produce an explicit owner decision for Product rather than only a host-level rejection.
+Separate persisted tenant selected-intent predecessor/current state from effective availability in module operation recovery. Post-hook retry and compensation must prove the exact committed tenant intent they are recovering while continuing to publish the canonical co-requisite-aware policy revision. Do not change ordinary dependency ordering or turn co-requisites into toggle dependencies.
 
-After that source identity gap closes, retain maintainer-run evidence for:
+After that recovery source gap closes, retain maintainer-run evidence for:
 
 - default and non-default tenant module selections;
+- co-requisite-aware policy/cache revision changes;
+- staged Product -> Inventory -> Pricing activation and reverse teardown;
+- post-hook retry/compensation across staged intent;
 - clean migration ordering;
 - Product create/delete rollback across all three owners;
 - no silent post-commit partial state;
@@ -106,4 +129,4 @@ Source evidence is stored at:
 
 `crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json`
 
-No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, policy-cache execution, or transaction rollback execution evidence are claimed by this source wave.
+No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, policy-cache execution, staged recovery, or transaction rollback execution evidence are claimed by this source wave.

--- a/scripts/verify/verify-product-lifecycle-collaboration.mjs
+++ b/scripts/verify/verify-product-lifecycle-collaboration.mjs
@@ -24,6 +24,10 @@ const manifestCorequisites = read('apps/server/src/modules/manifest/corequisites
 const manifestManager = read('apps/server/src/modules/manifest/mod.rs');
 const tenantLifecycle = read('apps/server/src/services/module_lifecycle.rs');
 const effectivePolicy = read('apps/server/src/services/effective_module_policy.rs');
+const ownerPolicy = read('crates/rustok-modules/src/policy.rs');
+const lifecycleWriter = read('crates/rustok-modules/src/lifecycle_writer.rs');
+const lifecycleExecutor = read('crates/rustok-modules/src/executor.rs');
+const recovery = read('crates/rustok-modules/src/recovery.rs');
 const note = read('crates/rustok-product/docs/product-lifecycle-collaboration.md');
 const evidence = JSON.parse(
   read('crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json'),
@@ -95,12 +99,6 @@ const lifecycleToggleBlock = between(
   '\n    pub async fn module_operation_recovery_plan(',
   'tenant lifecycle toggle block',
 );
-const compensationBlock = between(
-  tenantLifecycle,
-  'pub async fn compensate_failed_operation(',
-  '\n    pub async fn update_module_settings(',
-  'tenant lifecycle compensation block',
-);
 
 for (const [source, value, label] of [
   [productModuleEntry, 'depends_on = ["taxonomy"]', 'root Product dependency'],
@@ -128,36 +126,48 @@ for (const [source, value, label] of [
   [inventoryBootstrap, 'C: ConnectionTrait', 'Inventory transaction connection'],
   [pricingBootstrap, 'Pricing-owned transaction-aware operations required by Product lifecycle writes.', 'Pricing owner contract'],
   [pricingBootstrap, 'C: ConnectionTrait', 'Pricing transaction connection'],
+
   [manifestCorequisites, 'co_requisites: BTreeMap<String, PackageCoRequisiteSpec>', 'typed package co-requisite parser'],
+  [manifestCorequisites, 'pub(crate) fn module_policy_corequisites', 'owner co-requisite input entrypoint'],
   [manifestCorequisites, 'pub(super) fn validate_default_corequisite_selection', 'deployment selection preflight'],
-  [manifestCorequisites, 'pub(crate) fn module_policy_corequisites', 'tenant co-requisite metadata entrypoint'],
-  [manifestCorequisites, 'pub(crate) fn validate_effective_policy_corequisites', 'effective-policy co-requisite guard'],
-  [manifestCorequisites, 'pub(crate) fn validate_corequisite_toggle', 'tenant lifecycle co-requisite contract guard'],
-  [manifestCorequisites, 'if !policy.contains(provider)', 'effective provider availability rejection'],
-  [manifestCorequisites, 'validate_policy_provider_contract(', 'shared admitted provider contract validation'],
-  [manifestCorequisites, 'if !enabled {', 'orderable tenant disable intent'],
-  [manifestCorequisites, 'VersionReq::parse(requirement)', 'co-requisite version requirement validation'],
-  [manifestCorequisites, 'requirement.matches(&version)', 'tenant co-requisite effective version validation'],
   [manifestCorequisites, 'module.ordinary_dependencies.contains(co_requisite)', 'dependency/co-requisite separation'],
   [manifestCorequisites, '!selected.contains(co_requisite)', 'missing selected co-requisite rejection'],
-  [manifestCorequisites, 'selection_requires_corequisites_without_creating_dependency_edges', 'selection source test'],
-  [manifestCorequisites, 'selection_rejects_incompatible_corequisite_version', 'version source test'],
-  [manifestManager, 'mod corequisites;', 'manifest co-requisite module wiring'],
+  [manifestCorequisites, 'VersionReq::parse(requirement)', 'deployment co-requisite version validation'],
+  [manifestCorequisites, 'requirement.matches(&installed_version)', 'deployment selected version validation'],
   [manifestManager, 'pub fn validate_deployment_selection(', 'manifest deployment selection API'],
   [startupValidationBlock, '.and_then(|_| ManifestManager::validate_deployment_selection(&manifest))', 'startup co-requisite preflight'],
   [registryValidationBlock, 'dependencies: resolved_spec.depends_on.iter().cloned().collect()', 'ordinary registry dependency source'],
   [installBuiltinBlock, 'Self::validate(manifest)?;', 'ordinary install validation'],
-  [lifecycleToggleBlock, 'ManifestManager::module_policy_corequisites(&manifest)', 'tenant lifecycle co-requisite contract load'],
-  [lifecycleToggleBlock, '.effective_policy(registry, default_enabled.clone())', 'tenant lifecycle current owner policy'],
-  [lifecycleToggleBlock, 'ManifestManager::validate_corequisite_toggle(', 'tenant lifecycle pre-write contract guard'],
-  [compensationBlock, 'plan.previous_effective_enabled', 'compensation requested state source'],
-  [compensationBlock, 'ManifestManager::validate_corequisite_toggle(', 'compensation co-requisite guard'],
-  [effectivePolicy, 'ManifestManager::module_policy_corequisites(&manifest)', 'effective-policy co-requisite contract load'],
-  [effectivePolicy, 'ManifestManager::validate_effective_policy_corequisites(&policy, &co_requisites)', 'effective-policy result guard'],
-  [note, 'Status: static and tenant host co-requisite guards source-complete, canonical policy-revision integration pending, unvalidated.', 'focused note status'],
-  [note, 'Tenant intent can therefore be staged Product-first', 'orderable tenant intent note'],
-  [note, 'EffectiveModulePolicyService', 'effective policy note'],
-  [note, 'not part of `ModuleEffectivePolicy.policy_revision`', 'policy revision debt'],
+
+  [ownerPolicy, 'pub struct ModuleEffectivePolicyCoRequisite', 'owner co-requisite input'],
+  [ownerPolicy, 'CoRequisite {', 'owner co-requisite decision fact'],
+  [ownerPolicy, 'CoRequisiteUnavailable { module_slug: String }', 'owner unavailable denial'],
+  [ownerPolicy, 'CoRequisiteVersionMismatch { module_slug: String }', 'owner version denial'],
+  [ownerPolicy, 'co_requisites: Vec<ModuleEffectivePolicyCoRequisite>', 'owner query co-requisite state'],
+  [ownerPolicy, 'co_requisites: &\'a [ModuleEffectivePolicyCoRequisite]', 'revisioned co-requisite input'],
+  [ownerPolicy, 'contract: "rustok.module_effective_policy.v2"', 'effective policy v2 identity'],
+  [ownerPolicy, 'normalize_corequisites(self.catalog, self.co_requisites)', 'owner co-requisite normalization'],
+  [ownerPolicy, 'corequisite_version_compatible(self.catalog, co_requisite)', 'owner version decision'],
+  [ownerPolicy, 'corequisites_are_revisioned_explainable_availability_not_dependency_edges', 'owner policy source test'],
+
+  [lifecycleWriter, 'pub fn with_corequisites(', 'lifecycle writer co-requisite input'],
+  [lifecycleWriter, '.with_corequisites(self.co_requisites.iter().cloned())', 'canonical lifecycle policy co-requisites'],
+  [lifecycleWriter, 'ordering_policy_from_overrides', 'ordinary ordering projection'],
+  [lifecycleWriter, 'ordering_policy.into_enabled_modules()', 'ordinary ordering selection output'],
+  [lifecycleExecutor, 'pub ordering_enabled_modules: HashSet<String>', 'lifecycle ordering input'],
+  [lifecycleExecutor, '&request.ordering_enabled_modules', 'ordinary toggle validation input'],
+  [recovery, 'previous_effective_enabled', 'legacy recovery predecessor debt'],
+
+  [lifecycleToggleBlock, 'ManifestManager::module_policy_corequisites(&manifest)', 'lifecycle package contract load'],
+  [lifecycleToggleBlock, '.with_corequisites(co_requisites)', 'lifecycle owner policy binding'],
+  [effectivePolicy, 'ManifestManager::module_policy_corequisites(&manifest)', 'effective-policy package contract load'],
+  [effectivePolicy, '.with_corequisites(co_requisites)', 'effective-policy owner binding'],
+  [effectivePolicy, '.cache_identity(tenant_id)', 'canonical cache identity'],
+
+  [note, 'canonical owner effective-policy co-requisite identity source-complete', 'focused note status'],
+  [note, 'rustok.module_effective_policy.v2', 'focused note revision identity'],
+  [note, '**ordinary ordering selection**', 'focused note ordering split'],
+  [note, 'previous_effective_enabled', 'focused note staged recovery debt'],
 ]) requireText(source, value, label);
 
 for (const [source, value, label] of [
@@ -169,7 +179,10 @@ for (const [source, value, label] of [
   [productRuntime, '"pricing"', 'cyclic Product runtime Pricing dependency'],
   [installBuiltinBlock, 'validate_deployment_selection', 'cyclic install-time co-requisite preflight'],
   [registryValidationBlock, 'co_requisite', 'co-requisite leaked into registry dependency comparison'],
-  [manifestCorequisites, 'cannot be disabled while required as a co-requisite', 'tenant co-requisite disable deadlock'],
+  [manifestCorequisites, 'validate_effective_policy_corequisites', 'duplicate host effective-policy guard'],
+  [manifestCorequisites, 'validate_corequisite_toggle', 'duplicate host lifecycle guard'],
+  [tenantLifecycle, 'validate_corequisite_toggle', 'server lifecycle duplicate guard'],
+  [effectivePolicy, 'validate_effective_policy_corequisites', 'server effective-policy duplicate guard'],
   [catalog, 'rustok_commerce_foundation::entities', 'foreign foundation entity import'],
   [commands, 'rustok_commerce_foundation::entities', 'foreign foundation entity import in commands'],
   [commands, 'inventory_item::Entity', 'direct Inventory entity access'],
@@ -183,7 +196,7 @@ for (const [source, value, label] of [
   [commands, 'INTO prices', 'direct Pricing SQL write'],
 ]) forbidText(source, value, label);
 
-if (evidence.status !== 'product_lifecycle_tenant_corequisite_host_guard_source_complete_unvalidated') {
+if (evidence.status !== 'product_lifecycle_owner_corequisite_policy_identity_source_complete_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 const coRequisites = [...(evidence.module_topology?.product_co_requisites ?? [])].sort();
@@ -196,7 +209,10 @@ for (const [key, expected] of [
   ['static_default_selection_enforcement_source_complete', true],
   ['tenant_lifecycle_corequisite_guard_source_complete', true],
   ['effective_policy_corequisite_guard_source_complete', true],
-  ['canonical_policy_revision_corequisite_identity_source_complete', false],
+  ['canonical_policy_revision_corequisite_identity_source_complete', true],
+  ['owner_corequisite_decision_explanation_source_complete', true],
+  ['lifecycle_ordering_separated_from_corequisite_availability_source_complete', true],
+  ['staged_intent_recovery_semantics_source_complete', false],
   ['co_requisite_control_plane_execution_proven', false],
   ['tenant_lifecycle_corequisite_execution_proven', false],
   ['standalone_product_write_activation_proven', false],
@@ -210,13 +226,20 @@ if (evidence.product_boundary?.foreign_owner_entities_imported !== false ||
     evidence.product_boundary?.owner_bootstrap_services_only !== true) {
   failures.push('evidence Product owner boundary mismatch');
 }
+for (const key of [
+  'static_default_selection_enforcement_source_complete',
+  'tenant_lifecycle_corequisite_guard_source_complete',
+  'effective_policy_corequisite_guard_source_complete',
+  'canonical_policy_revision_corequisite_identity_source_complete',
+  'owner_corequisite_decision_explanation_source_complete',
+  'lifecycle_ordering_separated_from_corequisite_availability_source_complete',
+]) {
+  if (evidence.decision?.[key] !== true) failures.push(`evidence decision.${key} must be true`);
+}
 if (evidence.decision?.containment_complete !== true ||
     evidence.decision?.corequisite_contract_declared !== true ||
-    evidence.decision?.static_default_selection_enforcement_source_complete !== true ||
-    evidence.decision?.tenant_lifecycle_corequisite_guard_source_complete !== true ||
-    evidence.decision?.effective_policy_corequisite_guard_source_complete !== true ||
     evidence.decision?.dependency_contract_resolved !== false) {
-  failures.push('evidence decision must retain tenant host guards while keeping canonical policy identity open');
+  failures.push('evidence decision must close owner policy identity while keeping staged recovery open');
 }
 for (const key of [
   'tests_run',
@@ -229,6 +252,7 @@ for (const key of [
   'tenant_lifecycle_execution_proven',
   'effective_policy_guard_execution_proven',
   'policy_cache_identity_execution_proven',
+  'staged_intent_recovery_execution_proven',
   'standalone_activation_proven',
   'non_default_deployment_selection_proven',
   'transaction_rollback_proven',
@@ -245,5 +269,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Product static selection and tenant host policy/lifecycle guards enforce Inventory/Pricing co-requisites without changing ordinary dependency ordering; canonical policy revision identity and execution evidence remain open',
+  '✔ Product co-requisites are canonical owner effective-policy identity/explanation inputs and remain separate from ordinary lifecycle ordering; staged recovery and execution evidence remain open',
 );


### PR DESCRIPTION
## Summary
- move Product co-requisite availability semantics into the canonical `rustok-modules` effective-policy owner instead of server post-validation
- normalize package co-requisites separately from ordinary dependencies and hash them into `rustok.module_effective_policy.v2` base/final revisions
- expose owner-level `CoRequisite` facts plus `CoRequisiteUnavailable` / `CoRequisiteVersionMismatch` denial reasons
- carry the active manifest co-requisite map through `ModuleLifecycleDbWriter`, so policy reads, cache identity, lifecycle current/next revisions, settings availability, and transition outbox use the same owner query
- preserve sequential Product/Inventory/Pricing activation by separating co-requisite-aware effective availability from the ordinary ordering selection used by `validate_module_toggle`
- remove duplicate server-side effective-policy/toggle co-requisite guards; the manifest layer is now parser/static deployment preflight only
- actualize Product lifecycle docs/evidence/source guard

## Ordering invariant
Inventory and Pricing ordinarily depend on Product, while Product co-requires Inventory and Pricing. Co-requisites therefore remain availability constraints, never dependency/migration/toggle-order edges. Product intent may be staged first; serving availability remains false until the complete compatible owner set is selected.

## Remaining source debt
The operation journal/recovery contract still uses legacy `previous_effective_enabled`. Once selected tenant intent can differ from serving availability, staged post-hook retry/compensation needs an explicit selected-intent predecessor/current-state contract. This PR deliberately leaves that as the next source slice rather than overclaiming recovery completeness.

## Verification
- source and GitHub diff inspection only
- tests, source verifier execution, Cargo commands, formatting, workflows, CI, and runtime validation were intentionally not run per maintainer instruction