### PR TITLE
feat(index): execute shadow replay by locale scope

### DIFF
--- a/apps/server/docs/index-replay-graphql-transport.md
+++ b/apps/server/docs/index-replay-graphql-transport.md
@@ -1,13 +1,13 @@
 # Index replay GraphQL transport
 
-Status: `full_locale_schema_wide_shadow_and_locale_safe_continuation_source_complete_execution_pending`.
+Status: `full_and_shadow_locale_source_complete_execution_pending`.
 
 ## Boundary
 
 The server exposes three bounded GraphQL mutations over server-owned guarded replay capabilities:
 
 - `runIndexReplay(input: ...)` runs one bounded durable Full schema-wide or exact-locale replay chunk and samples the server-owned graceful-shutdown signal at replay durable safe points;
-- `runIndexReplayShadow(input: ...)` runs one bounded **schema-wide**, side-effect-free Shadow validation chunk and returns only an authenticated confidential continuation token when more source pages remain;
+- `runIndexReplayShadow(input: ...)` runs one bounded schema-wide or exact-locale, side-effect-free Shadow validation chunk and returns only an authenticated confidential continuation token when more source pages remain;
 - `cancelIndexReplay(input: ...)` requests cancellation of one durable replay job in the authenticated tenant.
 
 This remains command transport. It does not add automatic replay scheduling, background worker ownership, a new
@@ -18,16 +18,16 @@ cutover.
 
 Tenant and actor identities are never accepted from GraphQL input. The transport derives both from
 `TenantContext` / `AuthContext`, requires the request-bound effective permission snapshot, and requires
-`modules:manage` before parsing untrusted schema identifiers, schema version, durable Full locale, Shadow
+`modules:manage` before parsing untrusted schema identifiers, schema version, optional Full/Shadow locale, Shadow
 continuation, or job UUID.
 
-Only after authorization does the durable Full run path canonicalize a supplied locale through
+Only after authorization do both replay run paths canonicalize a supplied locale through
 `rustok_index::LocaleKey`. Locale input is bounded to 32 bytes before parsing. Omission is not inferred from schema
-metadata and preserves the historical schema-wide durable replay identity exactly.
+metadata and preserves the exact schema-wide scan identity.
 
-The current Shadow GraphQL path intentionally still has no locale input. Its continuation input is bounded to
-16 KiB only after authorization. The token is then authenticated, decrypted, expired and scope-checked by the
-server-owned Shadow transport runtime before any raw `IndexSourceCursor` is reconstructed.
+Shadow continuation input is bounded to 16 KiB only after authorization. The token is then authenticated,
+decrypted, expired and scope-checked by the server-owned Shadow transport runtime before any raw
+`IndexSourceCursor` is reconstructed.
 
 The guarded server runtimes perform the same request-bound authorization again before source execution. A
 cross-tenant durable job UUID or Shadow continuation therefore cannot widen authority.
@@ -46,12 +46,13 @@ cross-tenant durable job UUID or Shadow continuation therefore cannot widen auth
 - module name;
 - entity name;
 - positive schema routing key;
+- optional canonicalizable locale;
 - optional sealed continuation token.
 
 Neither input accepts tenant, actor, source name, database handle, scheduler controls, partition, retry state, or
 resource budget controls. The durable Full input additionally exposes no worker identity, heartbeat cadence, lease
-duration, shutdown state, or stop handle. The Shadow input exposes no job, checkpoint, lease, cancellation,
-worker, locale, page limit, or max-page field.
+duration, shutdown state, or stop handle. The Shadow input exposes no job, checkpoint, lease, cancellation, worker,
+page limit, or max-page field.
 
 Each durable Full GraphQL invocation constructs a fresh server-owned worker identity and uses one fixed bounded
 chunk:
@@ -61,9 +62,9 @@ chunk:
 - heartbeat cadence: every page;
 - lease duration: `60` seconds.
 
-Each schema-wide Shadow invocation uses the same fixed source page limit and maximum-page count (`100 × 8`) but has
-no worker, lease or heartbeat because it creates no durable replay ownership. A yielded Shadow invocation is
-resumed only by presenting the sealed caller-carried continuation token to a later authorized invocation.
+Each Shadow invocation uses the same fixed source page limit and maximum-page count (`100 × 8`) but has no worker,
+lease or heartbeat because it creates no durable replay ownership. A yielded Shadow invocation is resumed only by
+presenting the sealed caller-carried continuation token to a later authorized invocation with the same scan scope.
 
 ## Shadow continuation boundary
 
@@ -71,22 +72,23 @@ resumed only by presenting the sealed caller-carried continuation token to a lat
 `IndexReplayOperatorRuntime::run_shadow` method. It reuses the deployment continuation keyring and frozen
 `SharedIndexSourceRegistry` already used by the source-page diagnosis transport.
 
-Authorization happens before token parsing. The adapter currently derives schema-wide
-`IndexSourceContinuationScope::from_registry` from the exact authenticated tenant, requested schema and frozen
-source owner. Incoming continuation is opened only after that scope is known; outgoing raw source cursor is sealed
-before the result crosses the adapter boundary.
+Authorization happens before token parsing. The adapter derives the canonical continuation scope from the exact
+authenticated tenant, requested schema, frozen source owner and optional canonical locale:
 
-The continuation contract itself is now locale-safe. Its encrypted canonical scope distinguishes schema-wide
-`locale = None` from one exact canonical `LocaleKey`, and `IndexSourceContinuationScope::for_locale` constructs
-the exact-locale identity from the same frozen source registry. A schema-wide token cannot open under a locale
-scope, a locale token cannot open schema-wide, and different canonical locales cannot exchange tokens.
+- schema-wide -> `IndexSourceContinuationScope::from_registry`;
+- exact-locale -> `IndexSourceContinuationScope::for_locale`.
 
-The codec has one current unversioned envelope. No old-format decoder, token version byte, or parallel claim family
-is retained. This repository-owned pre-release format is replaced in place when its shape changes.
+Incoming continuation is opened only after that exact scope is known. The adapter then creates the matching
+schema-wide `IndexReplayDryRunRequest::new` or exact-locale `IndexReplayDryRunRequest::for_locale`. Outgoing raw
+source cursor is sealed under the same scope before the result crosses the adapter boundary.
 
-Exact-locale Shadow GraphQL remains a separate next source boundary because locale still must be carried through
-`IndexReplayDryRunRequest`, the actual `IndexSourceScanRequest::for_locale` execution path, the sealed Shadow
-adapter and authorization-first input parsing. The now-complete continuation scope no longer blocks that work.
+`SharedIndexReplayDryRunRuntime` rejects exact-locale execution for `LocaleMode::None` before source scanning and
+constructs every actual page through `IndexSourceScanRequest::new` or `IndexSourceScanRequest::for_locale`. The
+source-page contract therefore rejects mutations that escape the selected locale.
+
+The continuation codec has one current unversioned envelope. No old-format decoder, token version byte, or
+parallel claim family is retained. Schema-wide and exact-locale tokens cannot cross scopes, and different canonical
+locales cannot exchange tokens.
 
 The Shadow result exposes only Complete/Yielded status, bounded page/mutation/upsert/delete counters and the
 optional sealed continuation. It does not expose raw cursor JSON, source name, source payloads, source version,
@@ -105,10 +107,10 @@ The terminal success fence checks the checkpoint using the leased locale rather 
 This keeps acquisition, page scan, checkpoint writes and final success on one exact scope. `partition_key`
 remains empty in both cases.
 
-The one-page worker still resolves the registered runtime schema before checkpoint/source work and rejects a
-locale run for `LocaleMode::None`. Product is the currently retained production source that filters exact locale
-before pagination. Schema-wide replay remains valid, including for `LocaleMode::Required`, so omission does not
-silently become one locale.
+The one-page worker resolves the registered runtime schema before checkpoint/source work and rejects a locale run
+for `LocaleMode::None`. Product is the currently retained production source that filters exact locale before
+pagination. Schema-wide replay remains valid, including for `LocaleMode::Required`, so omission does not silently
+become one locale.
 
 ## Graceful shutdown binding
 
@@ -147,9 +149,10 @@ The Shadow payload exposes only bounded validation counters plus status and opti
 cancellation payload exposes only the normalized durable outcome: requested, cancelled, already terminal, or not
 found.
 
-Operational runner failures are mapped to generic GraphQL errors; unknown source-owned schemas are reported as bad
-user input. Invalid/expired/scope-mismatched Shadow continuations receive stable input error handling while
-missing/unresolvable continuation keyring dependencies are reported through fixed server-owned error identities.
+Operational runner failures are mapped to generic GraphQL errors; unknown source-owned schemas and locale scope on
+a non-localized Shadow schema are reported as bad user input. Invalid/expired/scope-mismatched Shadow
+continuations receive stable input error handling while missing/unresolvable continuation keyring dependencies are
+reported through fixed server-owned error identities.
 
 ## Evidence state
 
@@ -157,11 +160,11 @@ Source guards retain:
 
 - authorization-before-schema/locale/continuation/job parsing ordering;
 - absence of caller authority/worker/resource-budget/shutdown/partition fields;
-- optional durable locale canonicalization and schema-wide omission compatibility;
-- schema-wide Shadow input limited to schema identity plus sealed continuation;
+- optional Full and Shadow locale canonicalization plus schema-wide omission compatibility;
 - exact durable runner page/job/checkpoint locale coupling;
+- exact Shadow request/source/token locale coupling without durable ownership;
 - locale-aware interruptible runner acquisition and terminal success fencing;
-- fixed server-owned `100 × 8` bounds for both durable Full and schema-wide Shadow invocations;
+- fixed server-owned `100 × 8` bounds for both Full and Shadow invocations;
 - Shadow continuation open/seal through the deployment keyring and frozen source scope;
 - canonical continuation scope separation between schema-wide and exact-locale scans;
 - one current unversioned continuation envelope with no legacy decoder family;
@@ -173,9 +176,6 @@ Source guards retain:
 GraphQL execution, actual Shadow source execution, continuation key deployment evidence, durable locale
 replay/restart execution, actual process-shutdown replay interruption, database replay execution, cancellation
 races, CI, and retained runtime evidence remain maintainer-owned and are not claimed by this source slice.
-
-Exact-locale Shadow transport remains source-open only for the dry-run/runtime/GraphQL locale execution path; the
-continuation identity prerequisite is source-complete.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/apps/server/src/graphql/index_replay.rs
+++ b/apps/server/src/graphql/index_replay.rs
@@ -40,16 +40,17 @@ pub struct IndexReplayRunInput {
     pub locale: Option<String>,
 }
 
-/// Untrusted input for one bounded schema-wide Shadow validation run.
+/// Untrusted input for one bounded schema-wide or exact-locale Shadow validation run.
 ///
-/// The only resumable state is an authenticated confidential continuation token. Locale, source
-/// identity, page budget, jobs, checkpoints, leases, cancellation and retry controls are not
-/// caller fields in this schema-wide transport slice.
+/// The only resumable state is an authenticated confidential continuation token. Source identity,
+/// page budget, jobs, checkpoints, leases, cancellation and retry controls are not caller fields.
+/// Omitting locale preserves the schema-wide Shadow scan identity.
 #[derive(Debug, Clone, InputObject)]
 pub struct IndexReplayShadowRunInput {
     pub module_name: String,
     pub entity_name: String,
     pub schema_version: String,
+    pub locale: Option<String>,
     pub continuation: Option<String>,
 }
 
@@ -228,7 +229,7 @@ impl IndexReplayMutation {
             .try_into()
     }
 
-    /// Run one server-bounded schema-wide side-effect-free Shadow validation chunk.
+    /// Run one server-bounded schema-wide or exact-locale side-effect-free Shadow validation chunk.
     async fn run_index_replay_shadow(
         &self,
         ctx: &Context<'_>,
@@ -239,14 +240,15 @@ impl IndexReplayMutation {
             .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
         let tenant = ctx.data::<TenantContext>()?;
 
-        let (operator_context, schema, continuation) =
+        let (operator_context, schema, locale, continuation) =
             prepare_authorized_shadow_run(tenant.id, auth.user_id, input)
                 .map_err(map_preparation_error)?;
         let runtime = shadow_replay_runtime(ctx)?;
         runtime
-            .run_schema_wide(
+            .run(
                 operator_context,
                 schema,
+                locale,
                 continuation.as_deref(),
                 GRAPHQL_REPLAY_PAGE_LIMIT,
                 GRAPHQL_REPLAY_MAX_PAGES,
@@ -347,12 +349,14 @@ fn prepare_authorized_shadow_run(
     (
         IndexReplayOperatorContext,
         rustok_index::SchemaRef,
+        Option<rustok_index::LocaleKey>,
         Option<String>,
     ),
     IndexReplayTransportPreparationError,
 > {
     let context = authorize(tenant_id, actor_id)?;
     let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;
+    let locale = parse_locale(input.locale)?;
     let continuation = input
         .continuation
         .map(|value| {
@@ -360,7 +364,7 @@ fn prepare_authorized_shadow_run(
             Ok(value)
         })
         .transpose()?;
-    Ok((context, schema, continuation))
+    Ok((context, schema, locale, continuation))
 }
 
 fn prepare_authorized_cancel(
@@ -565,6 +569,11 @@ fn map_shadow_dry_run_error(error: rustok_index::IndexReplayDryRunError) -> Fiel
         rustok_index::IndexReplayDryRunError::UnknownSchemaSource(_) => {
             <FieldError as GraphQLError>::bad_user_input("Unknown Index replay schema")
         }
+        rustok_index::IndexReplayDryRunError::LocaleScopeUnsupported(_) => {
+            <FieldError as GraphQLError>::bad_user_input(
+                "Index replay Shadow schema does not support locale scope",
+            )
+        }
         _ => <FieldError as GraphQLError>::internal_error("Index replay Shadow command failed"),
     }
 }
@@ -609,6 +618,7 @@ mod tests {
             module_name: "Rustok Product".to_owned(),
             entity_name: "product".to_owned(),
             schema_version: "zero".to_owned(),
+            locale: Some("not a locale!!!".to_owned()),
             continuation: Some("not-a-token".to_owned()),
         }
     }
@@ -643,7 +653,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shadow_transport_authorizes_before_schema_and_continuation_parsing() {
+    async fn shadow_transport_authorizes_before_schema_locale_and_continuation_parsing() {
         let tenant_id = Uuid::new_v4();
         let actor_id = Uuid::new_v4();
 
@@ -674,10 +684,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shadow_transport_accepts_only_schema_and_bounded_sealed_continuation() {
+    async fn shadow_transport_accepts_schema_locale_and_bounded_sealed_continuation() {
         let tenant_id = Uuid::new_v4();
         let actor_id = Uuid::new_v4();
-        let (_, schema, continuation) = with_rbac_request_scope(
+        let (_, schema, locale, continuation) = with_rbac_request_scope(
             Some(RbacRequestScope::new(
                 tenant_id,
                 actor_id,
@@ -692,6 +702,7 @@ mod tests {
                         module_name: "rustok-product".to_owned(),
                         entity_name: "product".to_owned(),
                         schema_version: "4".to_owned(),
+                        locale: Some("EN-us".to_owned()),
                         continuation: Some("sealed-token".to_owned()),
                     },
                 )
@@ -703,6 +714,7 @@ mod tests {
         assert_eq!(schema.module.as_str(), "rustok-product");
         assert_eq!(schema.entity.as_str(), "product");
         assert_eq!(schema.version.get(), 4);
+        assert_eq!(locale.as_ref().map(|locale| locale.as_str()), Some("en-US"));
         assert_eq!(continuation.as_deref(), Some("sealed-token"));
 
         let oversized = "x".repeat(MAX_CONTINUATION_BYTES + 1);
@@ -721,6 +733,7 @@ mod tests {
                         module_name: "rustok-product".to_owned(),
                         entity_name: "product".to_owned(),
                         schema_version: "4".to_owned(),
+                        locale: None,
                         continuation: Some(oversized),
                     },
                 )

--- a/apps/server/src/services/index_replay_shadow_transport.rs
+++ b/apps/server/src/services/index_replay_shadow_transport.rs
@@ -79,7 +79,7 @@ impl IndexReplayShadowTransportOutcome {
     }
 }
 
-/// Server-owned transport adapter for schema-wide Shadow replay.
+/// Server-owned transport adapter for schema-wide or exact-locale Shadow replay.
 ///
 /// Authorization runs before continuation parsing. The adapter owns no database connection,
 /// replay job, checkpoint, lease, cancellation state, retry state, scheduler, or worker handle.
@@ -103,10 +103,11 @@ impl IndexReplayShadowTransportRuntime {
         }
     }
 
-    pub async fn run_schema_wide(
+    pub async fn run(
         &self,
         context: IndexReplayOperatorContext,
         schema: rustok_index::SchemaRef,
+        locale: Option<rustok_index::LocaleKey>,
         continuation: Option<&str>,
         page_limit: usize,
         max_pages: usize,
@@ -119,11 +120,19 @@ impl IndexReplayShadowTransportRuntime {
             .continuation
             .as_ref()
             .ok_or(IndexReplayShadowTransportError::ContinuationUnavailable)?;
-        let scope = rustok_index::IndexSourceContinuationScope::from_registry(
-            context.tenant_id(),
-            schema.clone(),
-            &self.sources,
-        )?;
+        let scope = match locale.as_ref() {
+            Some(locale) => rustok_index::IndexSourceContinuationScope::for_locale(
+                context.tenant_id(),
+                schema.clone(),
+                locale.clone(),
+                &self.sources,
+            ),
+            None => rustok_index::IndexSourceContinuationScope::from_registry(
+                context.tenant_id(),
+                schema.clone(),
+                &self.sources,
+            ),
+        }?;
         let codec = keyring
             .resolve_codec()
             .await
@@ -131,13 +140,23 @@ impl IndexReplayShadowTransportRuntime {
         let cursor = continuation
             .map(|encoded| codec.open_encoded(&scope, encoded, Utc::now()))
             .transpose()?;
-        let request = rustok_index::IndexReplayDryRunRequest::new(
-            context.tenant_id(),
-            schema,
-            cursor,
-            page_limit,
-            max_pages,
-        )?;
+        let request = match locale {
+            Some(locale) => rustok_index::IndexReplayDryRunRequest::for_locale(
+                context.tenant_id(),
+                schema,
+                locale,
+                cursor,
+                page_limit,
+                max_pages,
+            ),
+            None => rustok_index::IndexReplayDryRunRequest::new(
+                context.tenant_id(),
+                schema,
+                cursor,
+                page_limit,
+                max_pages,
+            ),
+        }?;
         let outcome = self.operator.run_shadow(context, request).await?;
         let next_token = outcome
             .next_cursor()

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@82f301231463cdce296ae4a88b0ac479c51ff9d1` and continued on
-`agent/index-source-continuation-locale-scope-20260808`.
+Status overlay rechecked at `main@92f3bec486c1c3e98b300aff0d96cf5800790971` and continued on
+`agent/index-replay-shadow-locale-execution-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -120,10 +120,10 @@ job/checkpoint and exposes no lease, cancellation, scheduler or database handle.
 The GraphQL layer exposes three source-complete command surfaces:
 
 - schema-wide or exact-locale durable `runIndexReplay`;
-- schema-wide no-write `runIndexReplayShadow`;
+- schema-wide or exact-locale no-write `runIndexReplayShadow`;
 - durable `cancelIndexReplay`.
 
-Authorization occurs before parsing untrusted schema, durable locale, Shadow continuation or job input.
+Authorization occurs before parsing untrusted schema, Full/Shadow locale, Shadow continuation or job input.
 
 Caller durable run input contains only module/entity/schema key plus one optional bounded locale. Tenant, actor,
 worker ID, source name, partition, scheduler handle, replay resource budget, stop handle and shutdown flag remain
@@ -132,27 +132,33 @@ exactly schema-wide; it is not rewritten from schema locale defaults. Each durab
 worker identity and applies fixed transport caps: 100 mutations per page, at most 8 pages, heartbeat every page
 and a 60-second lease.
 
-Caller Shadow input currently contains only module/entity/schema key plus one optional bounded sealed
-continuation. It has no locale, source name, raw source cursor, worker, page/max-page budget, job, checkpoint,
-lease, cancellation, retry or scheduler fields. The server uses the same fixed 100-page-size / 8-page invocation
-budget, repeats exact tenant authorization, opens continuation through the deployment keyring under frozen
-schema-wide tenant/schema/source scope, calls guarded `run_shadow`, and seals any outgoing cursor before GraphQL
-serialization.
+Caller Shadow input contains only module/entity/schema key plus one optional bounded locale and one optional
+bounded sealed continuation. It has no source name, raw source cursor, worker, page/max-page budget, job,
+checkpoint, lease, cancellation, retry or scheduler fields. Locale is canonicalized through the same `LocaleKey`
+contract only after request-bound authorization. The server uses the same fixed 100-page-size / 8-page invocation
+budget, repeats exact tenant authorization, and derives one exact frozen continuation/dry-run scope:
 
-The source continuation contract now includes canonical locale identity in encrypted claims. Schema-wide scope is
-`locale = None`; exact-locale scope is `Some(LocaleKey)`. `IndexSourceContinuationScope::from_registry` constructs
-the former and `IndexSourceContinuationScope::for_locale` the latter. Opening requires exact locale equality in
-addition to tenant/schema/source binding, so schema-wide and exact-locale tokens cannot cross scopes and different
-locales cannot exchange tokens.
+- schema-wide -> `IndexSourceContinuationScope::from_registry` + `IndexReplayDryRunRequest::new`;
+- exact locale -> `IndexSourceContinuationScope::for_locale` + `IndexReplayDryRunRequest::for_locale`.
+
+Incoming continuation is opened under that scope before a raw source cursor is reconstructed. The no-write runtime
+rejects exact-locale execution for `LocaleMode::None`, constructs every actual scan through the matching
+`IndexSourceScanRequest::new` or `for_locale`, calls the existing source registry, and seals any outgoing cursor
+under the same scope before GraphQL serialization.
+
+The source continuation contract includes canonical locale identity in encrypted claims. Schema-wide scope is
+`locale = None`; exact-locale scope is `Some(LocaleKey)`. Opening requires exact locale equality in addition to
+tenant/schema/source binding, so schema-wide and exact-locale tokens cannot cross scopes and different locales
+cannot exchange tokens.
 
 The continuation format is one current unversioned repository-owned envelope. The previous pre-release shape was
 replaced in place; there is no version byte, `contract_version`, `V1`/`V2` claim family, or fallback decoder.
 
 Retained durable command source evidence includes schema-wide command behavior, locale command canonicalization
-and a dedicated locale yield/isolation/fresh-runtime resume packet. Shadow source evidence retains
-authorization-first schema/continuation preparation, sealed non-durable resume routing and locale-safe core
-continuation identity. Exact-locale Shadow dry-run/runtime/GraphQL execution remains source-open. GraphQL execution
-and admission remain maintainer-owned.
+and a dedicated locale yield/isolation/fresh-runtime resume packet. Shadow source evidence now retains
+authorization-first schema/locale/continuation preparation, exact schema-wide/locale dry-run scope selection,
+`LocaleMode` fail-closed admission, sealed non-durable resume routing and locale-safe continuation identity.
+Schema-wide/exact-locale Shadow execution and admission remain maintainer-owned.
 
 ## M6 replay graceful interruption and server lifecycle binding
 
@@ -269,13 +275,12 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
 - `Shadow` -> `SideEffectFreeScan`; this matches the existing `SharedIndexReplayDryRunRuntime` no-write boundary.
 
 The server guards `Shadow` through `IndexReplayOperatorRuntime::run_shadow`, using the same exact request-bound
-`modules:manage` authorization check as Full. Schema-wide GraphQL Shadow transport sits on a separate sealed
+`modules:manage` authorization check as Full. Schema-wide/exact-locale GraphQL Shadow transport sits on one sealed
 continuation adapter and does not reinterpret the durable `runIndexReplay` command or add a mode column to jobs or
 checkpoints.
 
-The explicit mode identity, Shadow host dispatch, schema-wide Shadow GraphQL transport and locale-safe Shadow
-continuation identity are source-complete. Exact-locale Shadow dry-run/runtime/GraphQL execution remains
-source-open. Maintainer execution and admission are not claimed.
+The explicit mode identity, Shadow host dispatch, schema-wide/exact-locale Shadow GraphQL transport and
+locale-safe Shadow continuation identity are source-complete. Maintainer execution and admission are not claimed.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -320,16 +325,16 @@ source-open. Maintainer execution and admission are not claimed.
 - [x] Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.
 - [x] Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.
 - [x] Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.
-- [ ] Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.
+- [x] Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
-- [ ] Execute/admit schema-wide Shadow GraphQL transport and continuation-key deployment evidence.
+- [ ] Execute/admit schema-wide/exact-locale Shadow GraphQL transport and continuation-key deployment evidence.
 - [ ] Execute/admit retained graceful interruption/restart and GraphQL shutdown evidence.
 - [ ] Execute/admit retained dependency pending-future timeout evidence.
 - [ ] Execute/admit retained page lease-heartbeat evidence.
 - [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
 - [ ] Execute/admit retained multi-host reclaim evidence.
-- [ ] Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.
+- [ ] Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.
 - [ ] Add partition replay scope only after a real partition-capable source contract exists.
 
 ## M7 Product Storefront graph
@@ -366,22 +371,19 @@ M7 Storefront remains execution/admission-gated and must not gain a traffic swit
 
 The locale request/source/job/checkpoint/runner/GraphQL identity chain, dependency timeout set,
 page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence, explicit Full/Targeted/Shadow
-mode identity, guarded Shadow host dispatch, schema-wide Shadow GraphQL transport and locale-safe source
-continuation identity are source-complete. Their retained packets still require maintainer execution/admission.
+mode identity, guarded Shadow host dispatch, schema-wide/exact-locale Shadow GraphQL transport and locale-safe
+source continuation identity are source-complete. Their retained packets still require maintainer
+execution/admission.
 
 Partition replay remains blocked: no real partition-capable source contract can yet filter a partition before
 pagination, so do not merely populate `partition_key`.
 
-For source-only M6 continuation, the next independent boundary is exact-locale Shadow execution through the
-existing no-write stack. Add optional canonical locale to `IndexReplayDryRunRequest`, construct every actual
-source scan through schema-wide `IndexSourceScanRequest::new` or exact-locale `IndexSourceScanRequest::for_locale`,
-derive the sealed token scope with `IndexSourceContinuationScope::from_registry` or `for_locale`, and add the
-locale field to `runIndexReplayShadow` only after request-bound `modules:manage` authorization. Keep the existing
-schema-wide behavior and fixed `100 × 8` transport budget. Do not add jobs, checkpoints, leases, cancellation,
-retry/requeue, source-name input, partition scope, or another token format.
-
-Targeted execution remains separate until the bounded mutation-application contract over `IndexSource::load` is
-defined.
+For source-only M6 continuation, the next independent boundary is the bounded Targeted mutation-application
+contract over the canonical `IndexSource::load` path. Reuse `IndexReplayModeSelection::Targeted` and its validated
+`IndexSourceLoadRequest`; define one bounded mutation-application invocation without creating or aliasing Full scan
+jobs/checkpoints, leases, cancellation, scheduler ownership, retry/requeue state, partition scope, or another mode
+selector. Authorization and tenant ownership must remain request-bound before any untrusted target parsing or
+source execution.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
+++ b/crates/rustok-index/docs/m6-bounded-replay-dry-run.md
@@ -1,34 +1,39 @@
 # M6 bounded replay dry-run
 
-Status: `source_complete_schema_wide_transport_locale_execution_pending`
+Status: `source_complete_locale_transport_execution_pending`
 
 This slice adds an Index-owned, side-effect-free validation runtime over the exact immutable
 `SharedIndexSourceRegistry` and `SharedIndexSchemaRegistry` used by production replay, binds that capability
-behind the server-owned request-bound replay operator guard, and exposes a bounded schema-wide GraphQL Shadow
-command through an authenticated confidential continuation boundary.
+behind the server-owned request-bound replay operator guard, and exposes bounded schema-wide or exact-locale
+GraphQL Shadow commands through the authenticated confidential continuation boundary.
 
-The shared continuation contract is now locale-safe, so schema-wide and exact canonical-locale tokens cannot cross
-scan scopes. Locale still must be carried through the dry-run execution path before exact-locale Shadow transport
-is exposed.
+The shared continuation contract is locale-safe, so schema-wide and exact canonical-locale tokens cannot cross
+scan scopes. The dry-run execution path now carries the same canonical locale identity through request validation,
+source scanning, sealed continuation scope and GraphQL transport.
 
 ## Contract
 
-`IndexReplayDryRunRequest` currently carries:
+`IndexReplayDryRunRequest` carries:
 
 - one non-nil tenant;
 - one exact registered schema;
+- one explicit schema-wide (`None`) or exact canonical-locale (`Some(LocaleKey)`) scope;
 - one optional source-owned continuation cursor;
 - one source page limit already bounded by `IndexSourceScanRequest`;
 - one invocation budget from 1 through 1024 pages.
 
-It remains schema-wide today. The next source boundary is to add one optional canonical `LocaleKey` to this request
-and construct the actual source request through schema-wide `IndexSourceScanRequest::new` or exact-locale
-`IndexSourceScanRequest::for_locale` without creating durable mode state.
+`IndexReplayDryRunRequest::new` constructs the schema-wide scope. `IndexReplayDryRunRequest::for_locale` constructs
+one exact canonical locale scope. Both delegate validation to the existing source-scan contract rather than
+creating another locale representation.
 
-`SharedIndexReplayDryRunRuntime::run` resolves source ownership only from the immutable registry,
-then scans at most the requested page budget. For every returned page it verifies:
+`SharedIndexReplayDryRunRuntime::run` resolves source ownership and the registered schema from the immutable
+registries before scanning. An exact-locale request fails closed with `LocaleScopeUnsupported` when the registered
+schema has `LocaleMode::None`. Every actual source page is then constructed from the same request scope through
+schema-wide `IndexSourceScanRequest::new` or exact-locale `IndexSourceScanRequest::for_locale`.
 
-- the existing source-page tenant/schema, size, key uniqueness, and cursor-progress contract;
+For every returned page the runtime verifies:
+
+- the existing source-page tenant/schema/locale, size, key uniqueness, and cursor-progress contract;
 - non-nil event UUIDs;
 - page-local event UUID uniqueness before accepting the page;
 - complete `SchemaRegistry::validate_mutation` validity for every upsert or delete.
@@ -62,7 +67,7 @@ when both immutable registries exist; an absent source registry publishes nothin
 registry without its shared schema registry fails closed.
 
 A yielded internal dry-run is resumed only by explicitly passing its returned opaque cursor into another bounded
-request. No durable cursor is implied.
+request with the same schema-wide or exact-locale scope. No durable cursor is implied.
 
 ## Server-owned host guard
 
@@ -79,35 +84,34 @@ Retained server source evidence covers `modules:read` rejection and an authorize
 completion through the guarded Shadow method. That completion creates no durable replay job or checkpoint and
 does not alter the Full runner.
 
-## Schema-wide GraphQL Shadow transport
+## GraphQL Shadow transport
 
-`runIndexReplayShadow` exposes one bounded schema-wide invocation through
+`runIndexReplayShadow` exposes one bounded schema-wide or exact-locale invocation through
 `IndexReplayShadowTransportRuntime`.
 
 The GraphQL preparation path derives tenant/actor from request context and requires effective `modules:manage`
-**before** parsing untrusted schema identifiers or continuation text. The server adapter repeats exact-tenant
-authorization before opening the token or constructing `IndexReplayDryRunRequest`.
+**before** parsing untrusted schema identifiers, optional locale or continuation text. Locale is bounded and
+canonicalized through the same `LocaleKey` parser used by durable Full replay. The server adapter repeats
+exact-tenant authorization before opening the token or constructing `IndexReplayDryRunRequest`.
 
-Caller input contains only module/entity/schema routing identity plus one optional sealed continuation token. Page
-limit and maximum pages remain server-owned at `100` and `8`. Locale, source identity, raw cursor JSON, job,
-checkpoint, lease, worker, cancellation and retry controls are unavailable in the current schema-wide surface.
+Caller input contains only module/entity/schema routing identity, one optional locale and one optional sealed
+continuation token. Page limit and maximum pages remain server-owned at `100` and `8`. Source identity, raw cursor
+JSON, job, checkpoint, lease, worker, cancellation and retry controls remain unavailable.
 
 The adapter reuses the deployment `IndexSourceContinuationKeyringRuntime` and canonical frozen
-`IndexSourceContinuationScope`. Incoming tokens are authenticated, decrypted, expired and scope-checked before the
-raw cursor is reconstructed. An outgoing raw cursor is sealed before returning to GraphQL. The transport-safe
-result contains only Complete/Yielded status, bounded counters and optional sealed continuation; it omits internal
-source name and source version.
+`IndexSourceContinuationScope`. Schema-wide requests derive scope through `from_registry`; exact-locale requests
+derive it through `for_locale`. Incoming tokens are authenticated, decrypted, expired and exact-scope checked
+before the raw cursor is reconstructed. An outgoing raw cursor is sealed under that same scope before returning to
+GraphQL. The transport-safe result contains only Complete/Yielded status, bounded counters and optional sealed
+continuation; it omits internal source name and source version.
 
-The continuation scope now binds optional canonical locale identity. Schema-wide (`None`) and exact-locale
-(`Some(LocaleKey)`) tokens are mutually incompatible, and different canonical locales cannot exchange tokens.
-The codec has one current unversioned envelope with no old-format decoder or version-tagged claim family.
-
-Exact-locale Shadow remains source-open only because the dry-run request/runtime and GraphQL adapter have not yet
-carried locale into `IndexSourceScanRequest::for_locale`. The continuation prerequisite is complete.
+Schema-wide (`None`) and exact-locale (`Some(LocaleKey)`) tokens are mutually incompatible, and different canonical
+locales cannot exchange tokens. The codec has one current unversioned envelope with no old-format decoder or
+version-tagged claim family.
 
 ## Explicitly open
 
-- exact-locale Shadow/dry-run request, source-scan execution and authorization-first GraphQL transport;
+- execute/admit schema-wide and exact-locale Shadow GraphQL/source behavior plus continuation-key deployment evidence;
 - persisted dry-run reports or comparison snapshots;
 - cross-page duplicate event detection beyond one bounded page;
 - mutation/checkpoint timing simulation and interruption;

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -1,12 +1,11 @@
 # M6 replay mode contract
 
-Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.
+Status: `source_complete_shadow_locale_transport_execution_pending`.
 
 This slice defines explicit rebuild mode identity without changing the existing durable replay runner, job,
 checkpoint, cancellation, locale or lease state machines. Shadow execution is bound to the server-owned request
-authorization guard and has a dedicated schema-wide GraphQL command through a sealed continuation boundary.
-The shared continuation identity is now locale-safe; exact-locale Shadow execution remains the next separate
-transport/runtime slice.
+authorization guard and has a dedicated schema-wide or exact-locale GraphQL command through one sealed
+continuation boundary.
 
 ## Mode identity
 
@@ -55,39 +54,37 @@ This remains a host dispatch boundary, not a new durable mode state machine:
 - no mutation sink or database connection is exposed;
 - Full continues to route to the durable runner unchanged.
 
-## Schema-wide Shadow GraphQL transport
+## Shadow GraphQL transport
 
 `runIndexReplayShadow` is a dedicated transport rather than a generic mode selector on `runIndexReplay`.
-It currently accepts only schema routing identity and an optional authenticated confidential continuation token.
+It accepts schema routing identity, one optional canonicalizable locale and one optional authenticated confidential
+continuation token.
 
-The GraphQL layer authorizes request-bound `modules:manage` before parsing schema/continuation input. A separate
-server-owned `IndexReplayShadowTransportRuntime` repeats exact-tenant authorization, opens continuation only under
-the frozen schema-wide tenant/schema/source scope, constructs the existing `IndexReplayDryRunRequest`, calls
-guarded `run_shadow`, and seals any outgoing cursor before returning.
+The GraphQL layer authorizes request-bound `modules:manage` before parsing schema/locale/continuation input. Locale
+uses the same bounded `LocaleKey` canonicalization as durable Full replay. A separate server-owned
+`IndexReplayShadowTransportRuntime` repeats exact-tenant authorization, derives schema-wide or exact-locale frozen
+continuation scope, opens the token, constructs the matching `IndexReplayDryRunRequest`, calls guarded
+`run_shadow`, and seals any outgoing cursor under that same scope.
 
 Resource bounds remain server-owned: `100` mutations per source page and at most `8` pages per invocation. Shadow
 has no caller-visible worker, lease, heartbeat, job, checkpoint, cancel, retry/requeue or source-name field.
 Its payload contains only Complete/Yielded status, bounded scan counters and optional sealed continuation.
 
-## Locale-safe continuation identity
+## Locale-safe continuation and dry-run execution
 
-`IndexSourceContinuationScope` now distinguishes scan scope as part of the encrypted claims:
+`IndexSourceContinuationScope` distinguishes scan scope in encrypted claims:
 
 - schema-wide -> `locale = None`;
 - exact locale -> `locale = Some(LocaleKey)`.
 
-`from_registry` constructs only schema-wide scope and `for_locale` constructs only exact canonical-locale scope.
-Opening requires exact locale equality in addition to tenant/schema/source ownership. Schema-wide and locale
-tokens cannot cross scopes, and different canonical locales cannot exchange tokens.
+`IndexReplayDryRunRequest` now carries that same optional canonical locale. `SharedIndexReplayDryRunRuntime` rejects
+exact-locale execution for `LocaleMode::None` and constructs every actual scan through schema-wide
+`IndexSourceScanRequest::new` or exact-locale `IndexSourceScanRequest::for_locale`. Source-page validation therefore
+keeps every returned mutation on the same exact scope.
 
-The continuation codec has one current unversioned envelope. The previous pre-release shape was replaced in place:
-there is no version byte, `contract_version`, old-format claims type, or fallback decoder. Key rotation remains a
-cryptographic-key concern only and does not create format compatibility.
-
-Exact-locale Shadow transport remains source-open because locale still must be carried through
-`IndexReplayDryRunRequest`, `SharedIndexReplayDryRunRuntime`, the sealed server adapter and authorization-first
-GraphQL input. That next slice can now use `IndexSourceContinuationScope::for_locale` without changing the
-continuation format again.
+The continuation codec has one current unversioned envelope. There is no version byte, `contract_version`,
+old-format claims type, or fallback decoder. Key rotation remains a cryptographic-key concern only and does not
+create format compatibility.
 
 ## Existing contracts reused
 
@@ -95,8 +92,9 @@ The mode contract composes already-retained boundaries rather than duplicating t
 
 - Full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
 - Targeted: `IndexSourceLoadRequest` exact-key validation and `IndexSource::load` source boundary;
-- Shadow: `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan validation,
-  guarded by the server replay operator and transported only through sealed caller-carried continuation.
+- Shadow: locale-aware `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan
+  validation, guarded by the server replay operator and transported only through sealed caller-carried
+  continuation.
 
 Partition replay remains blocked until a real partition-capable source can filter before pagination.
 
@@ -107,7 +105,6 @@ This slice does not add:
 - Targeted mutation execution;
 - Shadow persistence or shadow tables;
 - a generic caller-controlled mode selector;
-- exact-locale Shadow execution/GraphQL transport yet;
 - token-format version families or legacy continuation decoders;
 - a mode column in `index_jobs` or `index_checkpoints`;
 - partition replay scope;
@@ -116,14 +113,10 @@ This slice does not add:
 
 ## Next source boundary
 
-The next independent Shadow boundary is exact-locale dry-run/runtime/GraphQL execution using the now-canonical
-locale-safe continuation scope. Locale must be authorization-first, canonicalized through `LocaleKey`, carried by
-`IndexReplayDryRunRequest`, applied through `IndexSourceScanRequest::for_locale`, and used to derive
-`IndexSourceContinuationScope::for_locale` for open/seal. It still must not create job, checkpoint, lease,
-cancellation or retry state.
-
-Targeted execution remains a separate later slice because it needs an explicit bounded mutation-application
-contract over `IndexSource::load` rather than a scan checkpoint.
+The explicit Full/Targeted/Shadow identity, guarded Shadow host dispatch and schema-wide/exact-locale Shadow
+transport are source-complete. The next independent source-only M6 boundary is the bounded mutation-application
+contract required before Targeted can execute over `IndexSource::load`. It must reuse the canonical targeted load
+request and must not alias durable scan jobs/checkpoints or invent a second ownership/retry state machine.
 
 Execution/admission remains maintainer-owned. Rust tests, Node verifiers, database scenarios and CI for this source
 slice were not executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-runtime-composition.md
+++ b/crates/rustok-index/docs/m6-replay-runtime-composition.md
@@ -8,9 +8,9 @@ This composition freezes the complete immutable Index source/schema registries a
 - bounded durable replay runtime;
 - one module-work registration for due reconciliation execution.
 
-The server wraps both replay execution surfaces in one request-bound operator: durable Full replay through `SharedIndexReplayRuntime` and side-effect-free Shadow replay through `SharedIndexReplayDryRunRuntime`. It also publishes a separate schema-wide Shadow transport adapter that seals caller-carried continuation state. None of these boundaries add automatic replay-job scheduling.
+The server wraps both replay execution surfaces in one request-bound operator: durable Full replay through `SharedIndexReplayRuntime` and side-effect-free Shadow replay through `SharedIndexReplayDryRunRuntime`. It also publishes a separate schema-wide/exact-locale Shadow transport adapter that seals caller-carried continuation state. None of these boundaries add automatic replay-job scheduling.
 
-The shared continuation contract now has one current unversioned envelope and binds optional canonical locale identity inside encrypted claims. Runtime composition still exposes schema-wide Shadow only; exact-locale dry-run/runtime/GraphQL execution remains a separate next slice.
+The shared continuation contract has one current unversioned envelope and binds optional canonical locale identity inside encrypted claims. Shadow dry-run and GraphQL execution now carry that same locale scope end to end.
 
 ## Composition order
 
@@ -23,7 +23,7 @@ The shared continuation contract now has one current unversioned envelope and bi
 7. the server retrieves the already-materialized `SharedIndexReplayDryRunRuntime` and wraps Full plus Shadow behind `IndexReplayOperatorRuntime`;
 8. the server materializes the deployment continuation keyring, then publishes `IndexReplayShadowTransportRuntime` and the source-page diagnosis runtime from that same keyring snapshot;
 9. the server wraps reconciliation separately in its guarded operator runtime;
-10. GraphQL exposes durable Full run/cancel plus schema-wide Shadow through the sealed transport adapter;
+10. GraphQL exposes durable Full run/cancel plus schema-wide or exact-locale Shadow through the sealed transport adapter;
 11. GraphQL schema initialization supplies the server-owned `StopHandle::is_stopping` probe only to authorized durable replay run commands without making shutdown caller-controlled.
 
 An absent source registry publishes no replay runtime, no dry-run runtime, no Shadow transport runtime and no empty Index work registration. A source registry without the shared schema registry fails closed. Duplicate replay or reconciliation-work materialization also fails closed. Server composition fails closed if a durable replay runtime exists without the dry-run runtime that the guarded Shadow route requires.
@@ -36,11 +36,13 @@ The Index materializer performs no SQL and calls neither `tokio::spawn` nor a po
 
 Durable ordinary/interruptible run rejects cross-tenant requests before delegation and cancellation derives tenant only from the authorized context. `run_shadow` applies the same exact tenant and `modules:manage` guard before delegating to the side-effect-free dry-run runtime. Shadow keeps a separate typed operator error wrapper so the existing Full/cancel error contract is not reinterpreted.
 
-`IndexReplayShadowTransportRuntime` sits above that guarded operator. It owns no database handle, scheduler, job, checkpoint, lease, cancellation or retry state. It repeats exact-tenant authorization before opening continuation, currently derives schema-wide tenant/schema/source scope from the frozen source registry, calls only `IndexReplayOperatorRuntime::run_shadow`, and seals any outgoing raw source cursor before returning a transport-safe outcome.
+`IndexReplayShadowTransportRuntime` sits above that guarded operator. It owns no database handle, scheduler, job, checkpoint, lease, cancellation or retry state. It repeats exact-tenant authorization before opening continuation, derives schema-wide or exact-locale tenant/schema/source scope from the frozen source registry, calls only `IndexReplayOperatorRuntime::run_shadow`, and seals any outgoing raw source cursor before returning a transport-safe outcome.
 
-`IndexSourceContinuationScope` can now also derive an exact-locale identity through `for_locale`. Schema-wide and exact-locale tokens cannot cross scopes, and different canonical locales cannot exchange tokens. The codec does not retain an old-format decoder or format-version family.
+`IndexSourceContinuationScope::from_registry` is schema-wide; `for_locale` binds one exact canonical `LocaleKey`. The transport constructs the matching `IndexReplayDryRunRequest::new` or `for_locale`, and the dry-run runtime builds every actual source page with the same `IndexSourceScanRequest::new` or `for_locale` scope. Exact-locale dry-run fails closed for `LocaleMode::None` before source execution.
 
-The GraphQL transport authorizes before parsing caller input. Durable Full uses a fixed 100-row × 8-page chunk, per-page heartbeat and 60-second lease. Schema-wide Shadow uses the same fixed 100-row × 8-page scan budget but no worker, heartbeat or lease. Its only resumable caller state is the authenticated confidential continuation token.
+Schema-wide and exact-locale tokens cannot cross scopes, and different canonical locales cannot exchange tokens. The codec does not retain an old-format decoder or format-version family.
+
+The GraphQL transport authorizes before parsing caller input. Durable Full uses a fixed 100-row × 8-page chunk, per-page heartbeat and 60-second lease. Shadow uses the same fixed 100-row × 8-page scan budget but no worker, heartbeat or lease. Its only resumable caller state is the authenticated confidential continuation token.
 
 Transport adapters must not call either `SharedIndexReplayRuntime` or `SharedIndexReplayDryRunRuntime` directly. See `apps/server/docs/index-replay-graphql-transport.md` and `m6-bounded-replay-dry-run.md`.
 
@@ -54,7 +56,7 @@ An interrupted page is not marked failed and does not manufacture a persisted ca
 
 GraphQL schema initialization resolves or atomically creates one `StopHandle` in shared server runtime state and retains a watch receiver even for API-only hosts. `runIndexReplay` reads only `StopHandle::is_stopping` and invokes the guarded interruptible operator. It never calls `StopHandle::stop`, and no shutdown field is accepted from GraphQL input.
 
-Schema-wide Shadow does not use this durable interruption path. It has no durable pending state; source calls retain the existing timeout boundary and a later invocation can resume only from a sealed continuation returned by a completed bounded call.
+Shadow does not use this durable interruption path. It has no durable pending state; source calls retain the existing timeout boundary and a later invocation can resume only from a sealed continuation returned by a completed bounded call under the same schema/locale scope.
 
 The retained SQLite runner packet covers interruption before source scan and interruption after one mutation is durable but before checkpoint commit. The latter resumes as `Duplicate` on attempt 2 before completing the checkpoint/job. Actual GraphQL/process-shutdown execution remains maintainer-run.
 
@@ -66,8 +68,7 @@ It does not schedule replay/rebuild jobs, create a second task, own a database l
 
 ## Explicitly open
 
-- exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation identity;
-- execute/admit schema-wide Shadow GraphQL and continuation-key deployment evidence;
+- execute/admit schema-wide and exact-locale Shadow GraphQL plus continuation-key deployment evidence;
 - execute/admit retained replay interruption/restart evidence and end-to-end process-shutdown command evidence;
 - durable GraphQL command execution/admission evidence and any separately justified HTTP/CLI/admin surfaces;
 - automatic replay/rebuild job scheduling;

--- a/crates/rustok-index/src/replay_dry_run.rs
+++ b/crates/rustok-index/src/replay_dry_run.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
-    IndexMutation, IndexSourceCursor, IndexSourceError, IndexSourceScanRequest,
+    IndexMutation, IndexSourceCursor, IndexSourceError, IndexSourceScanRequest, LocaleKey, LocaleMode,
     RecordValidationError, SchemaRef, SchemaRegistry, SharedIndexSchemaRegistry,
     SharedIndexSourceRegistry,
 };
@@ -14,12 +14,14 @@ const MAX_DRY_RUN_PAGES: usize = 1_024;
 
 /// One bounded, side-effect-free replay validation request.
 ///
-/// The request carries an optional source-owned continuation cursor so a large source can be
-/// inspected over multiple operator calls without creating a replay job or durable checkpoint.
+/// The request carries one explicit schema-wide or exact-locale source scope plus an optional
+/// source-owned continuation cursor so a large source can be inspected over multiple operator
+/// calls without creating a replay job or durable checkpoint.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexReplayDryRunRequest {
     tenant_id: Uuid,
     schema: SchemaRef,
+    locale: Option<LocaleKey>,
     cursor: Option<IndexSourceCursor>,
     page_limit: usize,
     max_pages: usize,
@@ -33,8 +35,51 @@ impl IndexReplayDryRunRequest {
         page_limit: usize,
         max_pages: usize,
     ) -> Result<Self, IndexReplayDryRunError> {
-        IndexSourceScanRequest::new(tenant_id, schema.clone(), cursor.clone(), page_limit)
-            .map_err(IndexReplayDryRunError::InvalidRequest)?;
+        Self::new_scoped(tenant_id, schema, None, cursor, page_limit, max_pages)
+    }
+
+    pub fn for_locale(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: LocaleKey,
+        cursor: Option<IndexSourceCursor>,
+        page_limit: usize,
+        max_pages: usize,
+    ) -> Result<Self, IndexReplayDryRunError> {
+        Self::new_scoped(
+            tenant_id,
+            schema,
+            Some(locale),
+            cursor,
+            page_limit,
+            max_pages,
+        )
+    }
+
+    fn new_scoped(
+        tenant_id: Uuid,
+        schema: SchemaRef,
+        locale: Option<LocaleKey>,
+        cursor: Option<IndexSourceCursor>,
+        page_limit: usize,
+        max_pages: usize,
+    ) -> Result<Self, IndexReplayDryRunError> {
+        match locale.as_ref() {
+            Some(locale) => IndexSourceScanRequest::for_locale(
+                tenant_id,
+                schema.clone(),
+                locale.clone(),
+                cursor.clone(),
+                page_limit,
+            ),
+            None => IndexSourceScanRequest::new(
+                tenant_id,
+                schema.clone(),
+                cursor.clone(),
+                page_limit,
+            ),
+        }
+        .map_err(IndexReplayDryRunError::InvalidRequest)?;
         if !(1..=MAX_DRY_RUN_PAGES).contains(&max_pages) {
             return Err(IndexReplayDryRunError::InvalidMaxPages {
                 actual: max_pages,
@@ -44,6 +89,7 @@ impl IndexReplayDryRunRequest {
         Ok(Self {
             tenant_id,
             schema,
+            locale,
             cursor,
             page_limit,
             max_pages,
@@ -56,6 +102,10 @@ impl IndexReplayDryRunRequest {
 
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
+    }
+
+    pub fn locale(&self) -> Option<&LocaleKey> {
+        self.locale.as_ref()
     }
 
     pub fn cursor(&self) -> Option<&IndexSourceCursor> {
@@ -147,6 +197,16 @@ impl SharedIndexReplayDryRunRuntime {
             .sources
             .source_for_schema(request.schema())
             .ok_or_else(|| IndexReplayDryRunError::UnknownSchemaSource(request.schema.clone()))?;
+        let registered = self
+            .schemas
+            .get(request.schema())
+            .ok_or_else(|| IndexReplayDryRunError::SchemaNotRegistered(request.schema.clone()))?;
+        if request.locale().is_some() && registered.schema.locale_mode == LocaleMode::None {
+            return Err(IndexReplayDryRunError::LocaleScopeUnsupported(
+                request.schema.clone(),
+            ));
+        }
+
         let source_name = descriptor.source_name().to_owned();
         let mut cursor = request.cursor.clone();
         let mut pages_scanned = 0usize;
@@ -156,12 +216,21 @@ impl SharedIndexReplayDryRunRuntime {
         let mut max_source_version = None::<u64>;
 
         for page_index in 0..request.max_pages {
-            let scan_request = IndexSourceScanRequest::new(
-                request.tenant_id,
-                request.schema.clone(),
-                cursor.clone(),
-                request.page_limit,
-            )
+            let scan_request = match request.locale() {
+                Some(locale) => IndexSourceScanRequest::for_locale(
+                    request.tenant_id,
+                    request.schema.clone(),
+                    locale.clone(),
+                    cursor.clone(),
+                    request.page_limit,
+                ),
+                None => IndexSourceScanRequest::new(
+                    request.tenant_id,
+                    request.schema.clone(),
+                    cursor.clone(),
+                    request.page_limit,
+                ),
+            }
             .map_err(IndexReplayDryRunError::InvalidRequest)?;
             let page = self
                 .sources
@@ -251,6 +320,10 @@ pub enum IndexReplayDryRunError {
     InvalidMaxPages { actual: usize, max: usize },
     #[error("No Index replay source owns dry-run schema {0}")]
     UnknownSchemaSource(SchemaRef),
+    #[error("Index replay dry-run schema is not registered in the active runtime: {0}")]
+    SchemaNotRegistered(SchemaRef),
+    #[error("Index replay dry-run schema does not support locale-scoped pages: {0}")]
+    LocaleScopeUnsupported(SchemaRef),
     #[error("Index replay dry-run source failed")]
     Source(#[source] IndexSourceError),
     #[error(
@@ -354,7 +427,7 @@ mod tests {
                         tenant_id: request.tenant_id(),
                         schema: request.schema().clone(),
                         entity_id,
-                        locale: None,
+                        locale: request.locale().cloned(),
                     },
                     source_version: page_index as u64 + 1,
                     fields,
@@ -377,14 +450,14 @@ mod tests {
         }
     }
 
-    fn schema() -> IndexSchema {
+    fn schema(locale_mode: LocaleMode) -> IndexSchema {
         IndexSchema {
             reference: SchemaRef {
                 module: ModuleName::new("dry-run-owner").unwrap(),
                 entity: EntityName::new("item").unwrap(),
                 version: SchemaVersion::INITIAL,
             },
-            locale_mode: LocaleMode::None,
+            locale_mode,
             fields: vec![IndexField {
                 name: FieldName::new("id").unwrap(),
                 value_type: IndexValueType::Uuid,
@@ -398,9 +471,13 @@ mod tests {
         }
     }
 
-    fn runtime(page_count: usize, invalid_record: bool) -> SharedIndexReplayDryRunRuntime {
+    fn runtime(
+        page_count: usize,
+        invalid_record: bool,
+        locale_mode: LocaleMode,
+    ) -> SharedIndexReplayDryRunRuntime {
         let mut extensions = ModuleRuntimeExtensions::default();
-        let schema = schema();
+        let schema = schema(locale_mode);
         register_index_schema_source(&mut extensions, "dry_run_owner", schema.clone()).unwrap();
         register_index_source(
             &mut extensions,
@@ -428,12 +505,12 @@ mod tests {
 
     #[tokio::test]
     async fn bounded_dry_run_yields_a_resume_cursor_and_completes_without_state() {
-        let runtime = runtime(3, false);
+        let runtime = runtime(3, false, LocaleMode::Optional);
         let first = runtime
             .run(
                 IndexReplayDryRunRequest::new(
                     Uuid::from_u128(1),
-                    schema().reference,
+                    schema(LocaleMode::Optional).reference,
                     None,
                     10,
                     1,
@@ -453,7 +530,7 @@ mod tests {
             .run(
                 IndexReplayDryRunRequest::new(
                     Uuid::from_u128(1),
-                    schema().reference,
+                    schema(LocaleMode::Optional).reference,
                     first.next_cursor().cloned(),
                     10,
                     2,
@@ -470,12 +547,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exact_locale_dry_run_uses_the_same_canonical_scope_for_every_page() {
+        let runtime = runtime(2, false, LocaleMode::Optional);
+        let locale = LocaleKey::new("EN-us").unwrap();
+        let first = runtime
+            .run(
+                IndexReplayDryRunRequest::for_locale(
+                    Uuid::from_u128(1),
+                    schema(LocaleMode::Optional).reference,
+                    locale.clone(),
+                    None,
+                    10,
+                    1,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(locale.as_str(), "en-US");
+        assert_eq!(first.status(), IndexReplayDryRunStatus::Yielded);
+
+        let second = runtime
+            .run(
+                IndexReplayDryRunRequest::for_locale(
+                    Uuid::from_u128(1),
+                    schema(LocaleMode::Optional).reference,
+                    locale,
+                    first.next_cursor().cloned(),
+                    10,
+                    1,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), IndexReplayDryRunStatus::Complete);
+        assert!(second.next_cursor().is_none());
+    }
+
+    #[tokio::test]
+    async fn exact_locale_dry_run_rejects_a_non_localized_schema_before_source_scan() {
+        let error = runtime(1, false, LocaleMode::None)
+            .run(
+                IndexReplayDryRunRequest::for_locale(
+                    Uuid::from_u128(1),
+                    schema(LocaleMode::None).reference,
+                    LocaleKey::new("en-US").unwrap(),
+                    None,
+                    10,
+                    1,
+                )
+                .unwrap(),
+            )
+            .await
+            .expect_err("non-localized schema must reject exact-locale dry-run");
+        assert!(matches!(
+            error,
+            IndexReplayDryRunError::LocaleScopeUnsupported(_)
+        ));
+    }
+
+    #[tokio::test]
     async fn dry_run_rejects_a_schema_invalid_mutation_before_any_persistence_boundary() {
-        let error = runtime(1, true)
+        let error = runtime(1, true, LocaleMode::Optional)
             .run(
                 IndexReplayDryRunRequest::new(
                     Uuid::from_u128(1),
-                    schema().reference,
+                    schema(LocaleMode::Optional).reference,
                     None,
                     10,
                     1,
@@ -495,7 +633,7 @@ mod tests {
         let tenant_id = Uuid::from_u128(1);
         assert!(IndexReplayDryRunRequest::new(
             tenant_id,
-            schema().reference,
+            schema(LocaleMode::Optional).reference,
             None,
             10,
             0,
@@ -503,7 +641,7 @@ mod tests {
         .is_err());
         assert!(IndexReplayDryRunRequest::new(
             tenant_id,
-            schema().reference,
+            schema(LocaleMode::Optional).reference,
             None,
             10,
             MAX_DRY_RUN_PAGES + 1,

--- a/scripts/verify/verify-index-replay-dry-run.mjs
+++ b/scripts/verify/verify-index-replay-dry-run.mjs
@@ -22,11 +22,17 @@ const dryRunPath = 'crates/rustok-index/src/replay_dry_run.rs';
 const dryRun = requireMarkers(dryRunPath, [
   'const MAX_DRY_RUN_PAGES: usize = 1_024;',
   'pub struct IndexReplayDryRunRequest',
+  'locale: Option<LocaleKey>',
+  'pub fn for_locale(',
+  'pub fn locale(&self) -> Option<&LocaleKey>',
   'pub enum IndexReplayDryRunStatus',
   'pub struct IndexReplayDryRunOutcome',
   'pub struct SharedIndexReplayDryRunRuntime',
   'pub async fn run(',
   'source_for_schema(request.schema())',
+  'registered.schema.locale_mode == LocaleMode::None',
+  'IndexReplayDryRunError::LocaleScopeUnsupported',
+  'IndexSourceScanRequest::for_locale(',
   '.scan(scan_request)',
   'let mut event_ids = BTreeSet::new();',
   'event_id.is_nil()',
@@ -35,6 +41,8 @@ const dryRun = requireMarkers(dryRunPath, [
   'IndexMutation::Upsert',
   'IndexMutation::Delete',
   'next_cursor: cursor',
+  'exact_locale_dry_run_uses_the_same_canonical_scope_for_every_page',
+  'exact_locale_dry_run_rejects_a_non_localized_schema_before_source_scan',
   'pub fn materialize_index_replay_dry_run_runtime(',
   'extensions.get::<SharedIndexSourceRegistry>().cloned()',
   '.get::<SharedIndexSchemaRegistry>()',
@@ -128,13 +136,15 @@ for (const forbidden of ['SharedIndexReplayDryRunRuntime', 'IndexReplayDryRunReq
 requireMarkers('apps/server/src/graphql/index_replay.rs', [
   'async fn run_index_replay_shadow(',
   '.get::<IndexReplayShadowTransportRuntime>()',
-  '.run_schema_wide(',
+  'pub locale: Option<String>',
+  '.run(',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_schema_wide_transport_locale_execution_pending`',
-  '`IndexReplayDryRunRequest` currently carries:',
+  'Status: `source_complete_locale_transport_execution_pending`',
+  '`IndexReplayDryRunRequest::for_locale`',
   '`SharedIndexReplayDryRunRuntime::run`',
+  '`LocaleScopeUnsupported`',
   'one invocation budget from 1 through 1024 pages',
   'complete `SchemaRegistry::validate_mutation` validity',
   'Product, ProductVariant, SalesChannel',
@@ -144,8 +154,7 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
   'Server-owned host guard',
   '`IndexReplayOperatorRuntime::run_shadow`',
   '`runIndexReplayShadow`',
-  'continuation scope now binds optional canonical locale identity',
-  'Exact-locale Shadow remains source-open only because the dry-run request/runtime and GraphQL adapter',
+  'schema-wide or exact-locale invocation',
   'maintainer-run',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
@@ -160,4 +169,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-shadow-graphql-transport.mjs'",
 ]);
 
-console.log('[verify-index-replay-dry-run] bounded no-write validation stays schema-wide today while the one canonical continuation scope is ready for exact-locale execution');
+console.log('[verify-index-replay-dry-run] bounded no-write validation carries one canonical schema-wide or exact-locale scope without durable ownership');

--- a/scripts/verify/verify-index-replay-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-graphql-transport.mjs
@@ -52,15 +52,16 @@ const transport = requireMarkers(transportPath, [
   '.get::<IndexReplayShadowTransportRuntime>()',
   'let stop_handle = ctx.data::<StopHandle>()?.clone();',
   '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
-  '.run_schema_wide(',
+  '.run(',
   '.request_cancel(operator_context, job_id)',
   'replay_transport_authorizes_before_parsing_untrusted_run_input',
-  'shadow_transport_authorizes_before_schema_and_continuation_parsing',
-  'shadow_transport_accepts_only_schema_and_bounded_sealed_continuation',
+  'shadow_transport_authorizes_before_schema_locale_and_continuation_parsing',
+  'shadow_transport_accepts_schema_locale_and_bounded_sealed_continuation',
   'replay_transport_derives_authority_worker_and_server_owned_budgets',
   'replay_transport_canonicalizes_optional_locale_after_authorization',
   'replay_cancel_authorizes_before_job_id_parsing_and_derives_tenant',
   'Error::LocaleScopeMismatch',
+  'IndexReplayDryRunError::LocaleScopeUnsupported',
 ]);
 
 const runPrepare = transport.indexOf('fn prepare_authorized_run(');
@@ -74,9 +75,16 @@ if (runPrepare < 0 || runAuthorize < runPrepare || runSchemaParse <= runAuthoriz
 const shadowPrepare = transport.indexOf('fn prepare_authorized_shadow_run(');
 const shadowAuthorize = transport.indexOf('let context = authorize(tenant_id, actor_id)?;', shadowPrepare);
 const shadowSchemaParse = transport.indexOf('let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;', shadowPrepare);
-const shadowContinuationParse = transport.indexOf('bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;', shadowPrepare);
-if (shadowPrepare < 0 || shadowAuthorize < shadowPrepare || shadowSchemaParse <= shadowAuthorize || shadowContinuationParse <= shadowSchemaParse) {
-  fail('Shadow transport must authorize before parsing untrusted schema/continuation input');
+const shadowLocaleParse = transport.indexOf('let locale = parse_locale(input.locale)?;', shadowSchemaParse);
+const shadowContinuationParse = transport.indexOf('bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;', shadowLocaleParse);
+if (
+  shadowPrepare < 0 ||
+  shadowAuthorize < shadowPrepare ||
+  shadowSchemaParse <= shadowAuthorize ||
+  shadowLocaleParse <= shadowSchemaParse ||
+  shadowContinuationParse <= shadowLocaleParse
+) {
+  fail('Shadow transport must authorize before parsing untrusted schema/locale/continuation input');
 }
 
 const cancelPrepare = transport.indexOf('fn prepare_authorized_cancel(');
@@ -96,20 +104,20 @@ for (const forbidden of [
   if (runInput.includes(forbidden)) fail(`durable replay input contains caller-owned field marker ${forbidden}`);
 }
 if (!runInput.includes('locale: Option<String>')) {
-  fail('durable replay input must expose only one optional locale scope extension');
+  fail('durable replay input must expose one optional locale scope extension');
 }
 
 const shadowInputStart = transport.indexOf('pub struct IndexReplayShadowRunInput');
 const shadowInputEnd = transport.indexOf('\n}', shadowInputStart);
 const shadowInput = transport.slice(shadowInputStart, shadowInputEnd);
 for (const forbidden of [
-  'tenant', 'actor', 'worker', 'locale', 'page_limit', 'max_pages', 'heartbeat', 'lease',
+  'tenant', 'actor', 'worker', 'page_limit', 'max_pages', 'heartbeat', 'lease',
   'partition', 'source_name', 'job_id', 'checkpoint', 'cancel', 'retry', 'StopHandle', 'Uuid',
 ]) {
   if (shadowInput.includes(forbidden)) fail(`Shadow replay input contains caller-owned field marker ${forbidden}`);
 }
-if (!shadowInput.includes('continuation: Option<String>')) {
-  fail('schema-wide Shadow input must expose only one optional sealed continuation extension');
+for (const required of ['locale: Option<String>', 'continuation: Option<String>']) {
+  if (!shadowInput.includes(required)) fail(`Shadow replay input is missing ${required}`);
 }
 
 const production = transport.split('\n#[cfg(test)]')[0];
@@ -149,8 +157,11 @@ requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
 ]);
 requireMarkers('apps/server/src/services/index_replay_shadow_transport.rs', [
   'pub struct IndexReplayShadowTransportRuntime',
+  'locale: Option<rustok_index::LocaleKey>',
   'context.authorize_for(context.tenant_id())?;',
+  'IndexSourceContinuationScope::for_locale(',
   'IndexSourceContinuationScope::from_registry(',
+  'IndexReplayDryRunRequest::for_locale(',
   'self.operator.run_shadow(context, request).await?',
   'codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())',
 ]);
@@ -166,20 +177,19 @@ requireMarkers('crates/rustok-index/src/application/source_continuation.rs', [
   'IndexSourceContinuationError::LocaleScopeMismatch',
 ]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `full_locale_schema_wide_shadow_and_locale_safe_continuation_source_complete_execution_pending`.',
+  'Status: `full_and_shadow_locale_source_complete_execution_pending`.',
   '`runIndexReplay(input: ...)`',
   '`runIndexReplayShadow(input: ...)`',
   '`cancelIndexReplay(input: ...)`',
   'Tenant and actor identities are never accepted',
   'optional canonicalizable locale',
-  'current Shadow GraphQL path intentionally still has no locale input',
   'page limit: `100` mutations',
   'maximum pages: `8`',
   'lease duration: `60` seconds',
   'same fixed source page limit and maximum-page count (`100 × 8`)',
-  'continuation contract itself is now locale-safe',
+  '`IndexSourceContinuationScope::for_locale`',
   '`StopHandle::is_stopping`',
   'maintainer-owned',
 ]);
 
-console.log('[verify-index-replay-graphql-transport] durable Full/cancel and sealed schema-wide Shadow commands remain authorization-first/server-bounded while continuation scope is locale-safe');
+console.log('[verify-index-replay-graphql-transport] durable Full/cancel and sealed locale-aware Shadow commands remain authorization-first and server-bounded without transport-owned execution state');

--- a/scripts/verify/verify-index-replay-mode-contract.mjs
+++ b/scripts/verify/verify-index-replay-mode-contract.mjs
@@ -70,6 +70,9 @@ const dryRunPath = 'crates/rustok-index/src/replay_dry_run.rs';
 requireMarkers(dryRunPath, [
   'No mutation, inbox delivery, job, checkpoint, or reconciliation progress is persisted',
   'pub struct SharedIndexReplayDryRunRuntime',
+  'locale: Option<LocaleKey>',
+  'IndexSourceScanRequest::for_locale(',
+  'IndexReplayDryRunError::LocaleScopeUnsupported',
   '.scan(scan_request)',
 ]);
 
@@ -92,15 +95,21 @@ requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'self.shadow.run(request).await.map_err(Into::into)',
   'IndexReplayShadowTransportRuntime',
 ]);
+requireMarkers('apps/server/src/services/index_replay_shadow_transport.rs', [
+  'locale: Option<rustok_index::LocaleKey>',
+  'IndexSourceContinuationScope::for_locale(',
+  'IndexReplayDryRunRequest::for_locale(',
+]);
 requireMarkers('apps/server/src/graphql/index_replay.rs', [
   'pub struct IndexReplayShadowRunInput',
+  'pub locale: Option<String>',
   'async fn run_index_replay_shadow(',
   '.get::<IndexReplayShadowTransportRuntime>()',
-  '.run_schema_wide(',
+  '.run(',
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.',
+  'Status: `source_complete_shadow_locale_transport_execution_pending`.',
   '`Full` — cursor-based durable source scan',
   '`Targeted` — bounded exact-key source load',
   '`Shadow` — side-effect-free cursor scan',
@@ -109,9 +118,9 @@ requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
   'must not alias the Full durable job/checkpoint identity',
   '`Shadow` host dispatch is source-complete',
   '`runIndexReplayShadow` is a dedicated transport',
-  'Locale-safe continuation identity',
+  'Locale-safe continuation and dry-run execution',
   'one current unversioned envelope',
-  'next independent Shadow boundary is exact-locale dry-run/runtime/GraphQL execution',
+  'bounded mutation-application',
   'Execution/admission remains maintainer-owned.',
 ]);
 
@@ -121,8 +130,8 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
-  'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
+  'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
   'Add partition replay scope only after a real partition-capable source contract exists.',
 ]);
 
-console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow has one locale-safe continuation identity while exact-locale execution remains separate');
+console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow executes schema-wide or exact-locale only through the no-write sealed surface');

--- a/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
+++ b/scripts/verify/verify-index-replay-multihost-reclaim-evidence.mjs
@@ -118,6 +118,8 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
   'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
+  'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
+  'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
   'Partition replay remains blocked',
 ]);
 

--- a/scripts/verify/verify-index-replay-runtime-composition.mjs
+++ b/scripts/verify/verify-index-replay-runtime-composition.mjs
@@ -85,7 +85,10 @@ for (const forbidden of ['tokio::spawn', 'tokio::time::sleep', 'loop {', 'StopHa
 
 requireMarkers('apps/server/src/services/index_replay_shadow_transport.rs', [
   'pub struct IndexReplayShadowTransportRuntime',
+  'locale: Option<rustok_index::LocaleKey>',
+  'IndexSourceContinuationScope::for_locale(',
   'IndexSourceContinuationScope::from_registry(',
+  'IndexReplayDryRunRequest::for_locale(',
   'self.operator.run_shadow(context, request).await?',
 ]);
 const continuation = requireMarkers('crates/rustok-index/src/application/source_continuation.rs', [
@@ -98,6 +101,11 @@ for (const forbidden of ['CONTINUATION_VERSION', 'ContinuationClaimsV1', 'Contin
     fail(`source continuation must remain one canonical unversioned envelope: ${forbidden}`);
   }
 }
+requireMarkers('crates/rustok-index/src/replay_dry_run.rs', [
+  'locale: Option<LocaleKey>',
+  'registered.schema.locale_mode == LocaleMode::None',
+  'IndexSourceScanRequest::for_locale(',
+]);
 requireMarkers('crates/rustok-index/src/infrastructure/postgres/source_reconciliation_scheduler.rs', [
   'impl ModuleWorkRegistration for IndexReconciliationWorkRegistration',
   'impl ModuleWorkSource for PostgresIndexReconciliationWorkAdapter',
@@ -124,8 +132,8 @@ requireMarkers('crates/rustok-index/docs/m6-replay-runtime-composition.md', [
   '`SharedIndexReplayRuntime::run_interruptible`',
   '`IndexReplayShadowTransportRuntime`',
   'one current unversioned envelope',
-  '`IndexSourceContinuationScope` can now also derive an exact-locale identity through `for_locale`',
-  'exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation identity',
+  '`IndexSourceContinuationScope::from_registry` is schema-wide; `for_locale` binds one exact canonical `LocaleKey`',
+  'execute/admit schema-wide and exact-locale Shadow GraphQL plus continuation-key deployment evidence',
   'The work registration added here is reconciliation-only',
   'maintainer-run',
 ]);
@@ -140,4 +148,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-reconciliation-host-scheduler.mjs'",
 ]);
 
-console.log('[verify-index-replay-runtime-composition] shared replay composition keeps Full durable, Shadow no-write/sealed, one unversioned locale-safe continuation format, and reconciliation under the single generic scheduler boundary');
+console.log('[verify-index-replay-runtime-composition] shared replay composition keeps Full durable, Shadow no-write/sealed and locale-aware, one unversioned continuation format, and reconciliation under the single generic scheduler boundary');

--- a/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
@@ -38,15 +38,39 @@ for (const forbidden of [
   }
 }
 
+const dryRunPath = 'crates/rustok-index/src/replay_dry_run.rs';
+const dryRun = requireMarkers(dryRunPath, [
+  'locale: Option<LocaleKey>',
+  'pub fn for_locale(',
+  'pub fn locale(&self) -> Option<&LocaleKey>',
+  'registered.schema.locale_mode == LocaleMode::None',
+  'IndexReplayDryRunError::LocaleScopeUnsupported',
+  'IndexSourceScanRequest::for_locale(',
+  'exact_locale_dry_run_uses_the_same_canonical_scope_for_every_page',
+  'exact_locale_dry_run_rejects_a_non_localized_schema_before_source_scan',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresMutationStore',
+  'PostgresIndexReplayJobStore',
+  'PostgresIndexReplayCheckpointStore',
+]) {
+  if (dryRun.includes(forbidden)) fail(`${dryRunPath} gained forbidden durable capability: ${forbidden}`);
+}
+
 const servicePath = 'apps/server/src/services/index_replay_shadow_transport.rs';
 const service = requireMarkers(servicePath, [
   'pub enum IndexReplayShadowTransportError',
   'pub struct IndexReplayShadowTransportOutcome',
   'pub struct IndexReplayShadowTransportRuntime',
-  'pub async fn run_schema_wide(',
+  'pub async fn run(',
+  'locale: Option<rustok_index::LocaleKey>',
   'context.authorize_for(context.tenant_id())?;',
+  'let scope = match locale.as_ref()',
+  'IndexSourceContinuationScope::for_locale(',
   'IndexSourceContinuationScope::from_registry(',
   '.open_encoded(&scope, encoded, Utc::now())',
+  'IndexReplayDryRunRequest::for_locale(',
   'IndexReplayDryRunRequest::new(',
   'self.operator.run_shadow(context, request).await?',
   '.next_cursor()',
@@ -65,54 +89,62 @@ for (const forbidden of [
   'tokio::time::sleep',
   '.execute(',
   '.begin()',
-  'IndexSourceScanRequest::for_locale',
-  'LocaleKey',
 ]) {
   if (service.includes(forbidden)) {
-    fail(`${servicePath} must remain schema-wide, no-write and lifecycle-neutral until the next locale execution slice: ${forbidden}`);
+    fail(`${servicePath} must remain no-write and lifecycle-neutral: ${forbidden}`);
   }
 }
 const authorize = service.indexOf('context.authorize_for(context.tenant_id())?;');
-const scope = service.indexOf('IndexSourceContinuationScope::from_registry(', authorize);
+const scope = service.indexOf('let scope = match locale.as_ref()', authorize);
 const open = service.indexOf('.open_encoded(&scope, encoded, Utc::now())', scope);
-const request = service.indexOf('IndexReplayDryRunRequest::new(', open);
+const request = service.indexOf('let request = match locale', open);
 const run = service.indexOf('self.operator.run_shadow(context, request).await?', request);
 const seal = service.indexOf('codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())', run);
 if (authorize < 0 || scope <= authorize || open <= scope || request <= open || run <= request || seal <= run) {
-  fail('Shadow transport order must remain authorize -> frozen schema-wide scope -> open token -> dry-run request -> guarded Shadow -> seal cursor');
+  fail('Shadow transport order must remain authorize -> exact frozen scope -> open token -> scoped dry-run request -> guarded Shadow -> seal cursor');
 }
 
 const graphqlPath = 'apps/server/src/graphql/index_replay.rs';
 const graphql = requireMarkers(graphqlPath, [
+  'const MAX_LOCALE_BYTES: usize = 32;',
   'const MAX_CONTINUATION_BYTES: usize = 16 * 1024;',
   'pub struct IndexReplayShadowRunInput',
+  'pub locale: Option<String>',
   'pub continuation: Option<String>',
   'pub enum IndexReplayGraphqlShadowStatus',
   'pub struct IndexReplayShadowRunPayload',
   'async fn run_index_replay_shadow(',
   'prepare_authorized_shadow_run(tenant.id, auth.user_id, input)',
   '.get::<IndexReplayShadowTransportRuntime>()',
-  '.run_schema_wide(',
+  '.run(',
   'GRAPHQL_REPLAY_PAGE_LIMIT,',
   'GRAPHQL_REPLAY_MAX_PAGES,',
-  'shadow_transport_authorizes_before_schema_and_continuation_parsing',
-  'shadow_transport_accepts_only_schema_and_bounded_sealed_continuation',
+  'shadow_transport_authorizes_before_schema_locale_and_continuation_parsing',
+  'shadow_transport_accepts_schema_locale_and_bounded_sealed_continuation',
   'INDEX_REPLAY_SHADOW_CONTINUATION_INVALID',
   'INDEX_REPLAY_SHADOW_CONTINUATION_EXPIRED',
   'Error::LocaleScopeMismatch',
+  'IndexReplayDryRunError::LocaleScopeUnsupported',
 ]);
 const shadowPrepare = graphql.indexOf('fn prepare_authorized_shadow_run(');
 const shadowAuthorize = graphql.indexOf('let context = authorize(tenant_id, actor_id)?;', shadowPrepare);
 const shadowSchema = graphql.indexOf('let schema = parse_schema(input.module_name, input.entity_name, input.schema_version)?;', shadowPrepare);
-const shadowContinuation = graphql.indexOf('bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;', shadowPrepare);
-if (shadowPrepare < 0 || shadowAuthorize < shadowPrepare || shadowSchema <= shadowAuthorize || shadowContinuation <= shadowSchema) {
-  fail('Shadow GraphQL preparation must authorize before parsing schema and continuation');
+const shadowLocale = graphql.indexOf('let locale = parse_locale(input.locale)?;', shadowSchema);
+const shadowContinuation = graphql.indexOf('bounded_text("continuation", &value, MAX_CONTINUATION_BYTES)?;', shadowLocale);
+if (
+  shadowPrepare < 0 ||
+  shadowAuthorize < shadowPrepare ||
+  shadowSchema <= shadowAuthorize ||
+  shadowLocale <= shadowSchema ||
+  shadowContinuation <= shadowLocale
+) {
+  fail('Shadow GraphQL preparation must authorize before parsing schema, locale and continuation');
 }
 const inputStart = graphql.indexOf('pub struct IndexReplayShadowRunInput');
 const inputEnd = graphql.indexOf('\n}', inputStart);
 const input = graphql.slice(inputStart, inputEnd);
 for (const forbidden of [
-  'tenant', 'actor', 'worker', 'locale', 'page_limit', 'max_pages', 'heartbeat', 'lease',
+  'tenant', 'actor', 'worker', 'page_limit', 'max_pages', 'heartbeat', 'lease',
   'partition', 'source_name', 'job_id', 'checkpoint', 'cancel', 'retry', 'StopHandle', 'Uuid',
 ]) {
   if (input.includes(forbidden)) fail(`Shadow GraphQL input contains caller-owned field marker ${forbidden}`);
@@ -138,27 +170,28 @@ requireMarkers('apps/server/src/services/index_replay_runtime_composition.rs', [
   'continuation.clone()',
 ]);
 requireMarkers('apps/server/docs/index-replay-graphql-transport.md', [
-  'Status: `full_locale_schema_wide_shadow_and_locale_safe_continuation_source_complete_execution_pending`.',
+  'Status: `full_and_shadow_locale_source_complete_execution_pending`.',
   '`runIndexReplayShadow(input: ...)`',
-  'current Shadow GraphQL path intentionally still has no locale input',
+  'optional canonicalizable locale',
   'same fixed source page limit and maximum-page count (`100 × 8`)',
-  'continuation contract itself is now locale-safe',
+  'IndexSourceContinuationScope::for_locale',
   'one current unversioned envelope',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_schema_wide_transport_locale_execution_pending`',
+  'Status: `source_complete_locale_transport_execution_pending`',
+  '`IndexReplayDryRunRequest::for_locale`',
+  '`LocaleScopeUnsupported`',
   '`runIndexReplayShadow`',
-  'continuation scope now binds optional canonical locale identity',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.',
+  'Status: `source_complete_shadow_locale_transport_execution_pending`.',
   '`runIndexReplayShadow`',
-  'Locale-safe continuation identity',
-  'Exact-locale Shadow transport remains source-open',
+  'Locale-safe continuation and dry-run execution',
+  'bounded mutation-application',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
-  'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
+  'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
 ]);
 
-console.log('[verify-index-replay-shadow-graphql-transport] schema-wide Shadow GraphQL remains authorization-first/no-write while the single canonical continuation format now binds exact locale scope');
+console.log('[verify-index-replay-shadow-graphql-transport] Shadow GraphQL is authorization-first, locale-scoped, sealed and no-write without a parallel transport or token format');

--- a/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+++ b/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
@@ -47,7 +47,8 @@ const graphql = requireMarkers(graphqlPath, [
   '.run_interruptible(operator_context, request, || stop_handle.is_stopping())',
   'async fn run_index_replay_shadow(',
   '.get::<IndexReplayShadowTransportRuntime>()',
-  '.run_schema_wide(',
+  'pub locale: Option<String>',
+  '.run(',
   'async fn cancel_index_replay(',
 ]);
 for (const forbidden of [
@@ -60,6 +61,16 @@ for (const forbidden of [
   }
 }
 
+const shadowTransportPath = 'apps/server/src/services/index_replay_shadow_transport.rs';
+requireMarkers(shadowTransportPath, [
+  'locale: Option<rustok_index::LocaleKey>',
+  'IndexSourceContinuationScope::for_locale(',
+  'IndexSourceContinuationScope::from_registry(',
+  'IndexReplayDryRunRequest::for_locale(',
+  'IndexReplayDryRunRequest::new(',
+  'self.operator.run_shadow(context, request).await?',
+]);
+
 const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
 const runner = read(runnerPath);
 for (const forbidden of ['IndexReplayMode::Shadow', 'SideEffectFreeScan', 'SharedIndexReplayDryRunRuntime']) {
@@ -69,25 +80,25 @@ for (const forbidden of ['IndexReplayMode::Shadow', 'SideEffectFreeScan', 'Share
 }
 
 requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
-  'Status: `source_complete_schema_wide_transport_locale_execution_pending`',
+  'Status: `source_complete_locale_transport_execution_pending`',
   '`IndexReplayOperatorRuntime::run_shadow`',
   'same request-bound `modules:manage` authorization boundary',
   '`runIndexReplayShadow`',
-  'Exact-locale Shadow remains source-open only because the dry-run request/runtime and GraphQL adapter',
+  'schema-wide or exact-locale invocation',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_schema_wide_transport_locale_execution_pending`.',
+  'Status: `source_complete_shadow_locale_transport_execution_pending`.',
   '`Shadow` host dispatch is source-complete',
   '`IndexReplayOperatorRuntime::run_shadow`',
   '`runIndexReplayShadow` is a dedicated transport',
-  'Locale-safe continuation identity',
+  'Locale-safe continuation and dry-run execution',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
   'Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.',
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
-  'Targeted execution remains separate until a bounded mutation-application contract over `IndexSource::load` exists.',
+  'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
 ]);
 
-console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded/no-write; continuation is locale-safe while execution remains schema-wide until the next slice');
+console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded/no-write while the sealed adapter carries one canonical schema-wide or exact-locale scope');

--- a/scripts/verify/verify-index-source-continuation-server.mjs
+++ b/scripts/verify/verify-index-source-continuation-server.mjs
@@ -111,10 +111,13 @@ if (sealed.includes("IndexSourceCursor") || sealed.includes("next_cursor(&self)"
 
 requireMarkers("shadow", [
   "pub struct IndexReplayShadowTransportRuntime",
+  "locale: Option<rustok_index::LocaleKey>",
   "context.authorize_for(context.tenant_id())?;",
+  "IndexSourceContinuationScope::for_locale(",
   "IndexSourceContinuationScope::from_registry(",
   ".resolve_codec()",
   "codec.open_encoded(&scope, encoded, Utc::now())",
+  "IndexReplayDryRunRequest::for_locale(",
   "IndexReplayDryRunRequest::new(",
   "self.operator.run_shadow(context, request).await?;",
   "codec.seal(&scope, cursor, Utc::now(), keyring.lifetime())",
@@ -207,4 +210,4 @@ requireMarkers("aggregate", [
   "'verify-index-replay-shadow-graphql-transport.mjs'",
 ]);
 
-console.log("Index server sealed source continuation contract verified for drift-page and schema-wide Shadow consumers");
+console.log("Index server sealed source continuation contract verified for drift-page plus schema-wide/exact-locale Shadow consumers");


### PR DESCRIPTION
## Summary

- carry one optional canonical `LocaleKey` through `IndexReplayDryRunRequest` and every actual no-write source scan;
- keep `IndexReplayDryRunRequest::new` schema-wide and add canonical `for_locale` exact-locale construction, mirroring the existing source/durable replay contracts;
- resolve the registered schema before Shadow scanning and fail closed with `LocaleScopeUnsupported` when an exact-locale request targets `LocaleMode::None`;
- replace the schema-wide-only Shadow transport method with one canonical `run` that derives either `IndexSourceContinuationScope::from_registry` or `for_locale`, opens continuation under that exact scope, builds the matching dry-run request, calls the existing guarded `run_shadow`, and seals the outgoing cursor under the same scope;
- extend the existing `runIndexReplayShadow` input with one optional locale, canonicalized only after request-bound `modules:manage` authorization; no parallel GraphQL field or mode selector is added;
- preserve the fixed server-owned `100 × 8` Shadow budget and the no-write boundary: no jobs, checkpoints, leases, worker, cancellation, retry/requeue, scheduler or database ownership;
- keep the single unversioned continuation envelope from #3339; this change adds no token version, legacy decoder or compatibility path;
- actualize M6 docs/guards and advance the current source cursor to the bounded Targeted mutation-application contract over canonical `IndexSource::load`.

## Mainline recheck

The branch started from `main@92f3bec486c1c3e98b300aff0d96cf5800790971`. During final static review `main` advanced to `6c079a947415a30759923a49720a6e9d574e746b` through Groups/Modules/Product-lifecycle changes. Their paths are disjoint from this PR's Index replay/Shadow files.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.