### PR TITLE
feat(index): add bounded targeted replay application

### DIFF
--- a/crates/rustok-index/docs/README.md
+++ b/crates/rustok-index/docs/README.md
@@ -56,6 +56,7 @@ This directory contains the detailed technical architecture documentation for `r
 - [M6 Sealed Source-page GraphQL Transport](../../../apps/server/docs/index-drift-source-page-graphql-transport.md)
 - [M6 Bounded Source-call Timeout](./m6-source-call-timeout.md)
 - [M6 Bounded Replay Dry-run](./m6-bounded-replay-dry-run.md)
+- [M6 Targeted Replay Mutation Application](./m6-targeted-replay-mutation-application.md)
 - [M6 Cooperative Replay-page Interruption](./m6-cooperative-page-interruption.md)
 - [M6 Replay Retry Transition Store](./m6-replay-retry-transition-store.md)
 - [M6 Replay Dead-letter Admission](./m6-replay-dead-letter-admission.md)

--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,7 +1,7 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@92f3bec486c1c3e98b300aff0d96cf5800790971` and continued on
-`agent/index-replay-shadow-locale-execution-20260808`.
+Status overlay rechecked at `main@532d293d2bc6ad7f77362970d38469ba5db8e59d` and continued on
+`agent/index-replay-targeted-mutation-application-20260808`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
 
@@ -160,6 +160,9 @@ authorization-first schema/locale/continuation preparation, exact schema-wide/lo
 `LocaleMode` fail-closed admission, sealed non-durable resume routing and locale-safe continuation identity.
 Schema-wide/exact-locale Shadow execution and admission remain maintainer-owned.
 
+Targeted has no server/operator or public transport in the current source state. Its application executor remains
+separate until PostgreSQL mutation-sink composition and request-bound host authorization are source-complete.
+
 ## M6 replay graceful interruption and server lifecycle binding
 
 `PostgresIndexReplayRunner::run_interruptible` carries one host-owned synchronous probe into the existing
@@ -274,13 +277,22 @@ PostgreSQL/process orchestration evidence remain maintainer-owned.
   bounded exact-key count, tenant/schema scope and uniqueness checks;
 - `Shadow` -> `SideEffectFreeScan`; this matches the existing `SharedIndexReplayDryRunRuntime` no-write boundary.
 
+`IndexReplayTargetedExecutor` now makes the Targeted application surface executable without creating a second
+durable replay owner. It requires `IndexReplayModeSelection::Targeted`, resolves one exact source/schema, performs
+one bounded canonical `load`, preflights the full returned batch for non-nil/unique event IDs and complete schema
+validation, then applies source-owned stable event identities through `IndexReplayMutationSink`. Missing keys are
+counted and never reinterpreted as synthetic deletes. Partial mutation failure is retried through ordinary stable
+inbox identity rather than a Targeted checkpoint.
+
 The server guards `Shadow` through `IndexReplayOperatorRuntime::run_shadow`, using the same exact request-bound
 `modules:manage` authorization check as Full. Schema-wide/exact-locale GraphQL Shadow transport sits on one sealed
 continuation adapter and does not reinterpret the durable `runIndexReplay` command or add a mode column to jobs or
 checkpoints.
 
-The explicit mode identity, Shadow host dispatch, schema-wide/exact-locale Shadow GraphQL transport and
-locale-safe Shadow continuation identity are source-complete. Maintainer execution and admission are not claimed.
+The explicit mode identity, bounded Targeted application executor, Shadow host dispatch,
+schema-wide/exact-locale Shadow GraphQL transport and locale-safe Shadow continuation identity are source-complete.
+Targeted PostgreSQL/runtime composition and request-bound host dispatch remain source-open. Maintainer execution
+and admission are not claimed.
 
 ## Remaining Storefront parity/evidence blockers
 
@@ -326,6 +338,8 @@ locale-safe Shadow continuation identity are source-complete. Maintainer executi
 - [x] Add authorization-first schema-wide GraphQL transport for guarded Shadow replay with sealed caller-carried continuation.
 - [x] Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.
 - [x] Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.
+- [x] Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.
+- [ ] Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.
 - [ ] Execute and admit the concrete repair PostgreSQL packet.
 - [ ] Execute/admit replay GraphQL transport behavior and cancellation evidence.
 - [ ] Execute/admit schema-wide/exact-locale Shadow GraphQL transport and continuation-key deployment evidence.
@@ -334,7 +348,6 @@ locale-safe Shadow continuation identity are source-complete. Maintainer executi
 - [ ] Execute/admit retained page lease-heartbeat evidence.
 - [ ] Execute/admit retained locale replay/restart command evidence, including schema/locale isolation.
 - [ ] Execute/admit retained multi-host reclaim evidence.
-- [ ] Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.
 - [ ] Add partition replay scope only after a real partition-capable source contract exists.
 
 ## M7 Product Storefront graph
@@ -371,19 +384,20 @@ M7 Storefront remains execution/admission-gated and must not gain a traffic swit
 
 The locale request/source/job/checkpoint/runner/GraphQL identity chain, dependency timeout set,
 page-duration/lease-heartbeat policy, deterministic multi-host/restart evidence, explicit Full/Targeted/Shadow
-mode identity, guarded Shadow host dispatch, schema-wide/exact-locale Shadow GraphQL transport and locale-safe
-source continuation identity are source-complete. Their retained packets still require maintainer
-execution/admission.
+mode identity, bounded Targeted application executor, guarded Shadow host dispatch, schema-wide/exact-locale Shadow
+GraphQL transport and locale-safe source continuation identity are source-complete. Their retained packets still
+require maintainer execution/admission.
 
 Partition replay remains blocked: no real partition-capable source contract can yet filter a partition before
 pagination, so do not merely populate `partition_key`.
 
-For source-only M6 continuation, the next independent boundary is the bounded Targeted mutation-application
-contract over the canonical `IndexSource::load` path. Reuse `IndexReplayModeSelection::Targeted` and its validated
-`IndexSourceLoadRequest`; define one bounded mutation-application invocation without creating or aliasing Full scan
-jobs/checkpoints, leases, cancellation, scheduler ownership, retry/requeue state, partition scope, or another mode
-selector. Authorization and tenant ownership must remain request-bound before any untrusted target parsing or
-source execution.
+For source-only M6 continuation, the next independent boundary is Targeted PostgreSQL/runtime composition plus
+request-bound host dispatch. Materialize the bounded `IndexReplayTargetedExecutor` with the existing
+`PostgresMutationStore` / immutable source+schema registries, retain source-owned event UUID delivery identity, and
+expose execution only through exact tenant/effective `modules:manage` authorization. Keep Full replay jobs,
+checkpoints, leases, cancellation, graceful-stop handling and retry/requeue ownership out of Targeted. Do not add a
+public Targeted GraphQL/HTTP/CLI surface in the same slice; transport remains separate after the guarded host
+capability exists.
 
 No Rust tests, Node verifiers, Cargo checks, formatting, migrations, PostgreSQL scenarios, workflows, CI, or
 `git diff --check` were executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -1,11 +1,11 @@
 # M6 replay mode contract
 
-Status: `source_complete_shadow_locale_transport_execution_pending`.
+Status: `source_complete_targeted_application_host_guard_pending`.
 
-This slice defines explicit rebuild mode identity without changing the existing durable replay runner, job,
-checkpoint, cancellation, locale or lease state machines. Shadow execution is bound to the server-owned request
-authorization guard and has a dedicated schema-wide or exact-locale GraphQL command through one sealed
-continuation boundary.
+This contract keeps `Full`, `Targeted` and `Shadow` on separate execution surfaces without changing the existing
+durable replay runner, job, checkpoint, cancellation, locale or lease state machines. Shadow has guarded
+schema-wide/exact-locale transport. Targeted now has one bounded application mutation executor over the canonical
+exact-key load contract, but no server host dispatch or public transport yet.
 
 ## Mode identity
 
@@ -19,17 +19,17 @@ continuation boundary.
 - `Shadow` — side-effect-free cursor scan. Its execution surface is `SideEffectFreeScan`, matching the existing
   `SharedIndexReplayDryRunRuntime` no-write boundary.
 
-Mode is not locale scope and is not future partition scope. Adding a locale to a Full or Shadow scan does not
-create a new mode, and adding partition replay later must not encode partition identity as a mode.
+Mode is not locale scope and is not future partition scope. Targeted locale identity remains part of each exact
+`EntityKey`; adding partition replay later must not encode partition identity as a mode.
 
 ## Fail-closed routing
 
 `IndexReplayModeSelection::is_admitted_to_durable_scan_runner` returns true only for `Full`.
 
-Targeted and Shadow modes must not alias the Full durable job/checkpoint identity:
+Targeted and Shadow modes do not alias the Full durable job/checkpoint identity:
 
-- Targeted execution must be a bounded `IndexSource::load` path and must define its own operator execution
-  contract before it can persist mutations;
+- Targeted execution uses `IndexReplayTargetedExecutor` over one canonical `IndexSourceLoadRequest` and the
+  existing replay mutation sink;
 - Shadow execution remains no-write and uses the dry-run surface rather than the durable mutation/job/checkpoint
   path;
 - neither mode introduces automatic retry/requeue, another lease owner, another terminal job state, or a second
@@ -37,6 +37,37 @@ Targeted and Shadow modes must not alias the Full durable job/checkpoint identit
 
 The current `IndexReplayRunRequest`, `PostgresIndexReplayRunner` and GraphQL `runIndexReplay` command remain Full
 scan behavior. They do not accept a generic mode selector and are not reinterpreted by this contract.
+
+## Targeted mutation application
+
+`IndexReplayTargetedExecutor` accepts only `IndexReplayModeSelection::Targeted`. `Full` and `Shadow` fail before
+source or mutation execution.
+
+The Targeted selection already owns the canonical `IndexSourceLoadRequest`, preserving one non-nil tenant, one
+exact schema, 1..=256 unique requested keys and per-key locale identity. The executor resolves the frozen source
+owner and active schema, performs exactly one bounded `SharedIndexSourceRegistry::load`, then preflights the whole
+returned batch before the first write.
+
+The preflight requires:
+
+- every source mutation event UUID to be non-nil;
+- invocation-local event UUID uniqueness;
+- complete `SchemaRegistry::validate_mutation` validity.
+
+The source registry independently guarantees that every returned mutation corresponds to one requested key and
+that a key appears at most once. Only after all checks succeed are mutations applied sequentially through the
+existing `IndexReplayMutationSink`.
+
+Missing requested keys are allowed by the canonical load contract. Targeted reports their count and does not
+manufacture delete mutations. Owners that model authoritative deletion must return their own typed delete mutation.
+
+Targeted preserves each source-owned event UUID. With the existing PostgreSQL replay mutation sink this remains
+the stable `index_inbox` delivery identity, so exact retry after a partial mutation failure can converge through
+ordinary `Duplicate` / `StaleIgnored` behavior without a Targeted checkpoint.
+
+The Targeted executor owns no database handle itself and has no job, checkpoint, lease, worker, cancellation,
+scheduler, retry/requeue or partition state. PostgreSQL/runtime materialization and request-bound server host
+authorization are deliberately separate next steps.
 
 ## Shadow host dispatch
 
@@ -77,7 +108,7 @@ Its payload contains only Complete/Yielded status, bounded scan counters and opt
 - schema-wide -> `locale = None`;
 - exact locale -> `locale = Some(LocaleKey)`.
 
-`IndexReplayDryRunRequest` now carries that same optional canonical locale. `SharedIndexReplayDryRunRuntime` rejects
+`IndexReplayDryRunRequest` carries that same optional canonical locale. `SharedIndexReplayDryRunRuntime` rejects
 exact-locale execution for `LocaleMode::None` and constructs every actual scan through schema-wide
 `IndexSourceScanRequest::new` or exact-locale `IndexSourceScanRequest::for_locale`. Source-page validation therefore
 keeps every returned mutation on the same exact scope.
@@ -91,7 +122,8 @@ create format compatibility.
 The mode contract composes already-retained boundaries rather than duplicating them:
 
 - Full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
-- Targeted: `IndexSourceLoadRequest` exact-key validation and `IndexSource::load` source boundary;
+- Targeted: `IndexSourceLoadRequest`, `SharedIndexSourceRegistry::load`, full-batch replay preflight and
+  `IndexReplayMutationSink` stable delivery application;
 - Shadow: locale-aware `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan
   validation, guarded by the server replay operator and transported only through sealed caller-carried
   continuation.
@@ -102,21 +134,26 @@ Partition replay remains blocked until a real partition-capable source can filte
 
 This slice does not add:
 
-- Targeted mutation execution;
+- Targeted PostgreSQL/runtime materialization or request-bound host dispatch;
+- Targeted GraphQL/HTTP/CLI/admin transport;
+- Targeted jobs/checkpoints/leases/cancellation or automatic retry/requeue;
 - Shadow persistence or shadow tables;
 - a generic caller-controlled mode selector;
 - token-format version families or legacy continuation decoders;
 - a mode column in `index_jobs` or `index_checkpoints`;
 - partition replay scope;
-- automatic retry/requeue or scheduler ownership;
 - a second durable ownership/fencing model.
 
 ## Next source boundary
 
-The explicit Full/Targeted/Shadow identity, guarded Shadow host dispatch and schema-wide/exact-locale Shadow
-transport are source-complete. The next independent source-only M6 boundary is the bounded mutation-application
-contract required before Targeted can execute over `IndexSource::load`. It must reuse the canonical targeted load
-request and must not alias durable scan jobs/checkpoints or invent a second ownership/retry state machine.
+The explicit mode identity, bounded Targeted application executor, guarded Shadow host dispatch and
+schema-wide/exact-locale Shadow transport are source-complete. The next independent Targeted boundary is
+PostgreSQL/runtime composition plus request-bound server host dispatch. It should assemble the existing
+`PostgresMutationStore` as `IndexReplayMutationSink`, expose Targeted only through the same exact tenant/effective
+`modules:manage` operator authority as Full/Shadow, and keep jobs/checkpoints/leases/cancellation/retry ownership
+absent.
+
+Public Targeted transport remains separate until that guarded host capability is source-complete.
 
 Execution/admission remains maintainer-owned. Rust tests, Node verifiers, database scenarios and CI for this source
 slice were not executed by the implementation agent.

--- a/crates/rustok-index/docs/m6-replay-mode-contract.md
+++ b/crates/rustok-index/docs/m6-replay-mode-contract.md
@@ -43,12 +43,21 @@ scan behavior. They do not accept a generic mode selector and are not reinterpre
 `IndexReplayTargetedExecutor` accepts only `IndexReplayModeSelection::Targeted`. `Full` and `Shadow` fail before
 source or mutation execution.
 
-The Targeted selection already owns the canonical `IndexSourceLoadRequest`, preserving one non-nil tenant, one
-exact schema, 1..=256 unique requested keys and per-key locale identity. The executor resolves the frozen source
-owner and active schema, performs exactly one bounded `SharedIndexSourceRegistry::load`, then preflights the whole
-returned batch before the first write.
+The Targeted selection owns the canonical `IndexSourceLoadRequest`, preserving one non-nil tenant, one exact
+schema and 1..=256 unique requested keys. Because the generic load request does not own active-schema semantics,
+the executor validates requested keys against the active schema before source resolution or load:
 
-The preflight requires:
+- every requested entity UUID is non-nil;
+- `LocaleMode::Required` requires a locale on every requested key;
+- `LocaleMode::None` forbids a locale on every requested key;
+- `LocaleMode::Optional` accepts either key shape.
+
+This prevents an invalid exact target from being silently reclassified as a missing source key.
+
+After requested-key admission the executor resolves the frozen source owner, performs exactly one bounded
+`SharedIndexSourceRegistry::load`, then preflights the whole returned batch before the first write.
+
+The returned-batch preflight requires:
 
 - every source mutation event UUID to be non-nil;
 - invocation-local event UUID uniqueness;
@@ -58,12 +67,14 @@ The source registry independently guarantees that every returned mutation corres
 that a key appears at most once. Only after all checks succeed are mutations applied sequentially through the
 existing `IndexReplayMutationSink`.
 
-Missing requested keys are allowed by the canonical load contract. Targeted reports their count and does not
-manufacture delete mutations. Owners that model authoritative deletion must return their own typed delete mutation.
+Missing requested keys are allowed by the canonical load contract after requested-key admission. Targeted reports
+their count and does not manufacture delete mutations. Owners that model authoritative deletion must return their
+own typed delete mutation.
 
 Targeted preserves each source-owned event UUID. With the existing PostgreSQL replay mutation sink this remains
 the stable `index_inbox` delivery identity, so exact retry after a partial mutation failure can converge through
-ordinary `Duplicate` / `StaleIgnored` behavior without a Targeted checkpoint.
+ordinary `Duplicate` / `StaleIgnored` behavior without a Targeted checkpoint. Retained source evidence covers the
+mutation-1-applied / mutation-2-failed-once window and exact retry convergence.
 
 The Targeted executor owns no database handle itself and has no job, checkpoint, lease, worker, cancellation,
 scheduler, retry/requeue or partition state. PostgreSQL/runtime materialization and request-bound server host
@@ -122,8 +133,8 @@ create format compatibility.
 The mode contract composes already-retained boundaries rather than duplicating them:
 
 - Full: durable fenced replay job/checkpoint runner, optional canonical locale and page lease-heartbeat policy;
-- Targeted: `IndexSourceLoadRequest`, `SharedIndexSourceRegistry::load`, full-batch replay preflight and
-  `IndexReplayMutationSink` stable delivery application;
+- Targeted: `IndexSourceLoadRequest`, active-schema requested-key admission, `SharedIndexSourceRegistry::load`,
+  full-batch replay preflight and `IndexReplayMutationSink` stable delivery application;
 - Shadow: locale-aware `IndexReplayDryRunRequest` / `SharedIndexReplayDryRunRuntime` bounded side-effect-free scan
   validation, guarded by the server replay operator and transported only through sealed caller-carried
   continuation.

--- a/crates/rustok-index/docs/m6-targeted-replay-mutation-application.md
+++ b/crates/rustok-index/docs/m6-targeted-replay-mutation-application.md
@@ -7,13 +7,13 @@ Status: `source_complete_host_guard_pending`.
 `IndexReplayTargetedExecutor` defines the bounded mutation-application contract for
 `IndexReplayMode::Targeted` without reusing the durable Full replay job/checkpoint state machine.
 It consumes only `IndexReplayModeSelection::Targeted`, which already owns the canonical
-`IndexSourceLoadRequest` exact-key validation.
+`IndexSourceLoadRequest` bounded tenant/schema/key-set validation.
 
 This is an application execution boundary, not a public transport and not a new durable replay
 owner. PostgreSQL/runtime materialization and request-bound host dispatch remain separate follow-up
 slices.
 
-## Canonical Targeted request
+## Canonical Targeted request and key admission
 
 Targeted selection continues to reuse `IndexSourceLoadRequest` unchanged:
 
@@ -21,7 +21,18 @@ Targeted selection continues to reuse `IndexSourceLoadRequest` unchanged:
 - one non-nil tenant;
 - one exact schema;
 - per-key locale identity remains part of each `EntityKey`;
-- mixed tenant/schema keys and duplicate keys fail before source execution.
+- mixed tenant/schema keys and duplicate keys fail during request construction.
+
+The generic load request intentionally does not own active-schema semantics. Before source resolution
+or `IndexSource::load`, Targeted adds requested key admission against the active `SchemaRegistry`:
+
+- every requested entity UUID must be non-nil;
+- `LocaleMode::Required` requires every requested key to carry a locale;
+- `LocaleMode::None` rejects every requested key that carries a locale;
+- `LocaleMode::Optional` accepts either key shape.
+
+This prevents malformed or locale-incompatible exact targets from being reinterpreted as ordinary
+missing source keys.
 
 `Full` and `Shadow` selections are rejected by `IndexReplayTargetedExecutor`; they cannot alias the
 Targeted mutation path.
@@ -31,26 +42,28 @@ Targeted mutation path.
 One Targeted invocation performs exactly these steps:
 
 1. require `IndexReplayModeSelection::Targeted`;
-2. resolve the exact source owner from `SharedIndexSourceRegistry`;
-3. require the exact schema to exist in the active `SchemaRegistry`;
-4. call the canonical bounded `SharedIndexSourceRegistry::load` once;
-5. preflight the complete returned batch before the first mutation write;
-6. apply each returned mutation sequentially through the existing `IndexReplayMutationSink`;
-7. return bounded counters only.
+2. require the exact schema to exist in the active `SchemaRegistry`;
+3. validate every requested entity/locale key against that active schema;
+4. resolve the exact source owner from `SharedIndexSourceRegistry`;
+5. call the canonical bounded `SharedIndexSourceRegistry::load` once;
+6. preflight the complete returned batch before the first mutation write;
+7. apply each returned mutation sequentially through the existing `IndexReplayMutationSink`;
+8. return bounded counters only.
 
-The source registry already rejects mutations for unrequested keys and duplicate returned entity keys.
-The Targeted executor adds the replay-specific preflight used before persistence:
+The source registry rejects mutations for unrequested keys and duplicate returned entity keys. The
+Targeted executor then adds the replay-specific whole-batch preflight before persistence:
 
 - every mutation event UUID must be non-nil;
 - event UUIDs must be unique within the invocation;
 - every mutation must pass complete `SchemaRegistry::validate_mutation` validation.
 
-If any preflight check fails, no mutation sink call occurs.
+If requested key admission or any returned-batch preflight fails, no mutation sink call occurs.
 
 ## Missing requested keys
 
-`IndexSource::load` is allowed to return fewer mutations than requested keys. Targeted execution does
-not infer deletion from that absence and does not manufacture tombstones. The outcome reports
+`IndexSource::load` is allowed to return fewer mutations than requested keys. Once requested keys have
+passed active-schema admission, Targeted execution does not infer deletion from source absence and does
+not manufacture tombstones. The outcome reports
 `missing_count = requested_count - mutation_count` only.
 
 Owner adapters remain responsible for returning an authoritative delete mutation when deletion is the
@@ -67,9 +80,11 @@ When backed by the existing PostgreSQL replay mutation sink, that source event U
 `Duplicate` or `StaleIgnored` after an earlier invocation partially committed mutations before a later
 mutation failed.
 
-The executor intentionally does not add a checkpoint for partial progress. A failure reports the exact
-mutation position and existing bounded replay failure. Retry/requeue policy remains an operator/host
-concern and is not automatic here.
+Retained source evidence models the harder window where mutation 1 succeeds and mutation 2 fails once;
+the exact retry observes mutation 1 as `Duplicate` and applies mutation 2. The executor intentionally
+does not add a checkpoint for partial progress. A failure reports the exact mutation position and
+existing bounded replay failure. Retry/requeue policy remains an operator/host concern and is not
+automatic here.
 
 ## Outcome
 

--- a/crates/rustok-index/docs/m6-targeted-replay-mutation-application.md
+++ b/crates/rustok-index/docs/m6-targeted-replay-mutation-application.md
@@ -1,0 +1,116 @@
+# M6 targeted replay mutation application
+
+Status: `source_complete_host_guard_pending`.
+
+## Purpose
+
+`IndexReplayTargetedExecutor` defines the bounded mutation-application contract for
+`IndexReplayMode::Targeted` without reusing the durable Full replay job/checkpoint state machine.
+It consumes only `IndexReplayModeSelection::Targeted`, which already owns the canonical
+`IndexSourceLoadRequest` exact-key validation.
+
+This is an application execution boundary, not a public transport and not a new durable replay
+owner. PostgreSQL/runtime materialization and request-bound host dispatch remain separate follow-up
+slices.
+
+## Canonical Targeted request
+
+Targeted selection continues to reuse `IndexSourceLoadRequest` unchanged:
+
+- 1 through 256 unique `EntityKey` values;
+- one non-nil tenant;
+- one exact schema;
+- per-key locale identity remains part of each `EntityKey`;
+- mixed tenant/schema keys and duplicate keys fail before source execution.
+
+`Full` and `Shadow` selections are rejected by `IndexReplayTargetedExecutor`; they cannot alias the
+Targeted mutation path.
+
+## Execution order
+
+One Targeted invocation performs exactly these steps:
+
+1. require `IndexReplayModeSelection::Targeted`;
+2. resolve the exact source owner from `SharedIndexSourceRegistry`;
+3. require the exact schema to exist in the active `SchemaRegistry`;
+4. call the canonical bounded `SharedIndexSourceRegistry::load` once;
+5. preflight the complete returned batch before the first mutation write;
+6. apply each returned mutation sequentially through the existing `IndexReplayMutationSink`;
+7. return bounded counters only.
+
+The source registry already rejects mutations for unrequested keys and duplicate returned entity keys.
+The Targeted executor adds the replay-specific preflight used before persistence:
+
+- every mutation event UUID must be non-nil;
+- event UUIDs must be unique within the invocation;
+- every mutation must pass complete `SchemaRegistry::validate_mutation` validation.
+
+If any preflight check fails, no mutation sink call occurs.
+
+## Missing requested keys
+
+`IndexSource::load` is allowed to return fewer mutations than requested keys. Targeted execution does
+not infer deletion from that absence and does not manufacture tombstones. The outcome reports
+`missing_count = requested_count - mutation_count` only.
+
+Owner adapters remain responsible for returning an authoritative delete mutation when deletion is the
+owner contract for a requested key. Authorization-safe or otherwise intentional absence remains a
+missing key, not a synthetic write.
+
+## Mutation identity and partial failure
+
+Targeted execution preserves the source-owned mutation event UUID. It does not generate a command UUID,
+job UUID, checkpoint delivery identity, or transport-specific event identity.
+
+When backed by the existing PostgreSQL replay mutation sink, that source event UUID remains the
+`index_inbox` delivery identity. A later exact Targeted invocation can therefore safely encounter
+`Duplicate` or `StaleIgnored` after an earlier invocation partially committed mutations before a later
+mutation failed.
+
+The executor intentionally does not add a checkpoint for partial progress. A failure reports the exact
+mutation position and existing bounded replay failure. Retry/requeue policy remains an operator/host
+concern and is not automatic here.
+
+## Outcome
+
+A successful `IndexReplayTargetedOutcome` exposes only:
+
+- resolved source name;
+- requested key count;
+- returned mutation count;
+- missing key count;
+- applied count;
+- duplicate count;
+- stale-ignored count.
+
+It exposes no source payloads, database handles, SQL, job identity, checkpoint, lease owner, worker,
+retry state, cancellation state, scheduler handle, or partition scope.
+
+## Explicitly absent
+
+This slice does not add:
+
+- durable Targeted jobs or checkpoints;
+- lease/heartbeat/fencing state;
+- Targeted cancellation or automatic retry/requeue;
+- scheduler/background worker ownership;
+- a generic caller-controlled replay mode selector;
+- GraphQL/HTTP/CLI/admin transport;
+- request-bound host authorization;
+- partition replay scope;
+- synthetic deletes for missing load keys.
+
+## Next source boundary
+
+The next independent boundary is PostgreSQL/runtime composition plus request-bound server host dispatch
+for this executor. That slice should reuse `PostgresMutationStore` as the existing
+`IndexReplayMutationSink`, expose only a guarded Targeted capability under the same effective
+`modules:manage` authority as Full/Shadow, and still avoid durable scan jobs/checkpoints, leases,
+cancellation and automatic retry ownership.
+
+Public GraphQL transport should remain separate until the guarded host capability is source-complete.
+
+## Validation ownership
+
+Rust tests, Node verifiers, Cargo checks, formatting, database scenarios, workflows and CI are
+maintainer-run and were not executed by the implementation agent.

--- a/crates/rustok-index/src/application/mod.rs
+++ b/crates/rustok-index/src/application/mod.rs
@@ -28,6 +28,7 @@ mod source_registry;
 mod source_replay;
 mod source_schema_registry;
 mod source_timeout;
+mod targeted_replay;
 mod validation;
 
 #[cfg(test)]
@@ -185,4 +186,7 @@ pub use source_schema_registry::{
     SharedIndexSchemaRegistry, materialize_index_schema_registry, register_index_schema_source,
 };
 pub use source_timeout::register_index_source;
+pub use targeted_replay::{
+    IndexReplayTargetedError, IndexReplayTargetedExecutor, IndexReplayTargetedOutcome,
+};
 pub use validation::{QueryValidationError, RecordValidationError};

--- a/crates/rustok-index/src/application/targeted_replay.rs
+++ b/crates/rustok-index/src/application/targeted_replay.rs
@@ -201,7 +201,10 @@ pub enum IndexReplayTargetedError {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, sync::Mutex};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Mutex,
+    };
 
     use async_trait::async_trait;
     use rustok_core::ModuleRuntimeExtensions;
@@ -289,6 +292,47 @@ mod tests {
         ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
             self.event_ids.lock().unwrap().push(mutation.event_id());
             Ok(IndexReplayMutationOutcome::Applied)
+        }
+    }
+
+    struct RetryOnceSink {
+        applied: Mutex<BTreeSet<Uuid>>,
+        fail_event: Uuid,
+        fail_once: Mutex<bool>,
+    }
+
+    impl RetryOnceSink {
+        fn new(fail_event: Uuid) -> Self {
+            Self {
+                applied: Mutex::new(BTreeSet::new()),
+                fail_event,
+                fail_once: Mutex::new(true),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl IndexReplayMutationSink for RetryOnceSink {
+        async fn apply_replay_mutation(
+            &self,
+            _registry: &SchemaRegistry,
+            _source_name: &str,
+            mutation: &IndexMutation,
+        ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
+            let event_id = mutation.event_id();
+            let mut fail_once = self.fail_once.lock().unwrap();
+            if event_id == self.fail_event && *fail_once {
+                *fail_once = false;
+                return Err(IndexReplayFailure::retryable("targeted_retryable_failure").unwrap());
+            }
+            drop(fail_once);
+
+            let inserted = self.applied.lock().unwrap().insert(event_id);
+            Ok(if inserted {
+                IndexReplayMutationOutcome::Applied
+            } else {
+                IndexReplayMutationOutcome::Duplicate
+            })
         }
     }
 
@@ -401,5 +445,41 @@ mod tests {
             }
             assert!(executor.mutation_sink.event_ids.lock().unwrap().is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn targeted_exact_retry_replays_stable_event_ids_after_partial_failure() {
+        let template = executor(SourceMode::Valid);
+        let executor = IndexReplayTargetedExecutor::new(
+            template.sources.clone(),
+            template.schemas.clone(),
+            RetryOnceSink::new(Uuid::from_u128(901)),
+        );
+        let selection = || {
+            IndexReplayModeSelection::targeted(vec![key(10), key(11)]).unwrap()
+        };
+
+        let error = executor
+            .run(selection())
+            .await
+            .expect_err("second mutation should fail after first mutation is applied");
+        assert!(matches!(
+            error,
+            IndexReplayTargetedError::Mutation { position: 1, .. }
+        ));
+        assert_eq!(
+            executor.mutation_sink.applied.lock().unwrap().iter().copied().collect::<Vec<_>>(),
+            vec![Uuid::from_u128(900)]
+        );
+
+        let retry = executor
+            .run(selection())
+            .await
+            .expect("exact retry should converge through stable mutation identities");
+        assert_eq!(retry.mutation_count(), 2);
+        assert_eq!(retry.applied_count(), 1);
+        assert_eq!(retry.duplicate_count(), 1);
+        assert_eq!(retry.stale_count(), 0);
+        assert_eq!(executor.mutation_sink.applied.lock().unwrap().len(), 2);
     }
 }

--- a/crates/rustok-index/src/application/targeted_replay.rs
+++ b/crates/rustok-index/src/application/targeted_replay.rs
@@ -1,0 +1,405 @@
+use std::{collections::BTreeSet, fmt, sync::Arc};
+
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{RecordValidationError, SchemaRef, SchemaRegistry};
+
+use super::{
+    IndexReplayFailure, IndexReplayMode, IndexReplayModeSelection, IndexReplayMutationOutcome,
+    IndexReplayMutationSink, IndexSourceError, SharedIndexSourceRegistry,
+};
+
+/// Aggregate result of one bounded Targeted replay invocation.
+///
+/// Targeted replay owns no job, checkpoint, lease, retry state, scheduler or cancellation model.
+/// Missing requested keys are reported as a count and are not synthesized into delete mutations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReplayTargetedOutcome {
+    source_name: String,
+    requested_count: usize,
+    mutation_count: usize,
+    missing_count: usize,
+    applied_count: usize,
+    duplicate_count: usize,
+    stale_count: usize,
+}
+
+impl IndexReplayTargetedOutcome {
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    pub fn requested_count(&self) -> usize {
+        self.requested_count
+    }
+
+    pub fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    pub fn missing_count(&self) -> usize {
+        self.missing_count
+    }
+
+    pub fn applied_count(&self) -> usize {
+        self.applied_count
+    }
+
+    pub fn duplicate_count(&self) -> usize {
+        self.duplicate_count
+    }
+
+    pub fn stale_count(&self) -> usize {
+        self.stale_count
+    }
+}
+
+/// Bounded exact-key mutation application for `IndexReplayMode::Targeted`.
+///
+/// The executor consumes the canonical `IndexSourceLoadRequest` already owned by
+/// `IndexReplayModeSelection::Targeted`, validates the complete returned batch before the first
+/// mutation write, then applies source-owned stable mutation identities sequentially through the
+/// existing replay mutation sink. It deliberately has no scan cursor or durable replay ownership.
+pub struct IndexReplayTargetedExecutor<M> {
+    sources: SharedIndexSourceRegistry,
+    schemas: Arc<SchemaRegistry>,
+    mutation_sink: M,
+}
+
+impl<M> IndexReplayTargetedExecutor<M>
+where
+    M: IndexReplayMutationSink,
+{
+    pub fn new(
+        sources: SharedIndexSourceRegistry,
+        schemas: Arc<SchemaRegistry>,
+        mutation_sink: M,
+    ) -> Self {
+        Self {
+            sources,
+            schemas,
+            mutation_sink,
+        }
+    }
+
+    pub async fn run(
+        &self,
+        selection: IndexReplayModeSelection,
+    ) -> Result<IndexReplayTargetedOutcome, IndexReplayTargetedError> {
+        let request = match selection {
+            IndexReplayModeSelection::Targeted(request) => request,
+            other => {
+                return Err(IndexReplayTargetedError::WrongMode {
+                    actual: other.mode(),
+                });
+            }
+        };
+
+        let descriptor = self
+            .sources
+            .source_for_schema(request.schema())
+            .ok_or_else(|| IndexReplayTargetedError::UnknownSchemaSource(request.schema().clone()))?;
+        if self.schemas.get(request.schema()).is_none() {
+            return Err(IndexReplayTargetedError::SchemaNotRegistered(
+                request.schema().clone(),
+            ));
+        }
+        let source_name = descriptor.source_name().to_owned();
+        let requested_count = request.keys().len();
+        let batch = self
+            .sources
+            .load(request)
+            .await
+            .map_err(IndexReplayTargetedError::Source)?;
+        let mutations = batch.into_mutations();
+
+        // Fail the entire invocation before its first persistence call when the source batch cannot
+        // provide stable, schema-valid replay deliveries. This mirrors the durable page preflight
+        // without importing a checkpoint or job state machine into Targeted execution.
+        let mut event_ids = BTreeSet::<Uuid>::new();
+        for (position, mutation) in mutations.iter().enumerate() {
+            let event_id = mutation.event_id();
+            if event_id.is_nil() {
+                return Err(IndexReplayTargetedError::NilEventId { position });
+            }
+            if !event_ids.insert(event_id) {
+                return Err(IndexReplayTargetedError::DuplicateEventId { position, event_id });
+            }
+            self.schemas.validate_mutation(mutation).map_err(|source| {
+                IndexReplayTargetedError::InvalidMutation { position, source }
+            })?;
+        }
+
+        let mutation_count = mutations.len();
+        let mut applied_count = 0usize;
+        let mut duplicate_count = 0usize;
+        let mut stale_count = 0usize;
+        for (position, mutation) in mutations.iter().enumerate() {
+            match self
+                .mutation_sink
+                .apply_replay_mutation(self.schemas.as_ref(), &source_name, mutation)
+                .await
+                .map_err(|failure| IndexReplayTargetedError::Mutation { position, failure })?
+            {
+                IndexReplayMutationOutcome::Applied => applied_count += 1,
+                IndexReplayMutationOutcome::Duplicate => duplicate_count += 1,
+                IndexReplayMutationOutcome::StaleIgnored => stale_count += 1,
+            }
+        }
+
+        Ok(IndexReplayTargetedOutcome {
+            source_name,
+            requested_count,
+            mutation_count,
+            missing_count: requested_count - mutation_count,
+            applied_count,
+            duplicate_count,
+            stale_count,
+        })
+    }
+}
+
+impl<M> fmt::Debug for IndexReplayTargetedExecutor<M> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IndexReplayTargetedExecutor")
+            .field("sources", &self.sources)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IndexReplayTargetedError {
+    #[error("Index replay Targeted executor cannot run {actual:?} mode")]
+    WrongMode { actual: IndexReplayMode },
+    #[error("No Index replay source owns Targeted schema {0}")]
+    UnknownSchemaSource(SchemaRef),
+    #[error("Index replay Targeted schema is not registered in the active runtime: {0}")]
+    SchemaNotRegistered(SchemaRef),
+    #[error("Index replay Targeted source load failed")]
+    Source(#[source] IndexSourceError),
+    #[error("Index replay Targeted mutation at position {position} has a nil event id")]
+    NilEventId { position: usize },
+    #[error(
+        "Index replay Targeted mutation at position {position} duplicates event id {event_id}"
+    )]
+    DuplicateEventId { position: usize, event_id: Uuid },
+    #[error("Index replay Targeted mutation at position {position} violates the registered schema")]
+    InvalidMutation {
+        position: usize,
+        #[source]
+        source: RecordValidationError,
+    },
+    #[error("Index replay Targeted mutation at position {position} failed")]
+    Mutation {
+        position: usize,
+        #[source]
+        failure: IndexReplayFailure,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Mutex};
+
+    use async_trait::async_trait;
+    use rustok_core::ModuleRuntimeExtensions;
+
+    use crate::{
+        EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexMutation, IndexRecord,
+        IndexSchema, IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
+        IndexSourcePage, IndexSourceScanRequest, IndexValue, IndexValueType, LocaleMode, ModuleName,
+        SchemaVersion, materialize_index_schema_registry, materialize_index_source_registry,
+        register_index_schema_source, register_index_source,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum SourceMode {
+        Valid,
+        MissingSecond,
+        NilEvent,
+        DuplicateEvent,
+        InvalidRecord,
+    }
+
+    struct TargetedSource {
+        mode: SourceMode,
+    }
+
+    #[async_trait]
+    impl IndexSource for TargetedSource {
+        async fn scan(
+            &self,
+            request: IndexSourceScanRequest,
+        ) -> Result<IndexSourcePage, IndexSourceFailure> {
+            Ok(IndexSourcePage::new(&request, Vec::new(), None).unwrap())
+        }
+
+        async fn load(
+            &self,
+            request: IndexSourceLoadRequest,
+        ) -> Result<IndexSourceLoadBatch, IndexSourceFailure> {
+            let mut mutations = Vec::new();
+            for (position, key) in request.keys().iter().enumerate() {
+                if matches!(self.mode, SourceMode::MissingSecond) && position == 1 {
+                    continue;
+                }
+                let event_id = match self.mode {
+                    SourceMode::NilEvent if position == 0 => Uuid::nil(),
+                    SourceMode::DuplicateEvent => Uuid::from_u128(900),
+                    _ => Uuid::from_u128(900 + position as u128),
+                };
+                let fields = if matches!(self.mode, SourceMode::InvalidRecord) && position == 0 {
+                    BTreeMap::new()
+                } else {
+                    BTreeMap::from([(
+                        FieldName::new("id").unwrap(),
+                        IndexValue::Uuid(key.entity_id),
+                    )])
+                };
+                mutations.push(IndexMutation::Upsert {
+                    event_id,
+                    record: IndexRecord {
+                        key: key.clone(),
+                        source_version: position as u64 + 1,
+                        fields,
+                        links: Vec::new(),
+                    },
+                });
+            }
+            Ok(IndexSourceLoadBatch::new(&request, mutations).unwrap())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        event_ids: Mutex<Vec<Uuid>>,
+    }
+
+    #[async_trait]
+    impl IndexReplayMutationSink for RecordingSink {
+        async fn apply_replay_mutation(
+            &self,
+            _registry: &SchemaRegistry,
+            _source_name: &str,
+            mutation: &IndexMutation,
+        ) -> Result<IndexReplayMutationOutcome, IndexReplayFailure> {
+            self.event_ids.lock().unwrap().push(mutation.event_id());
+            Ok(IndexReplayMutationOutcome::Applied)
+        }
+    }
+
+    fn schema() -> IndexSchema {
+        IndexSchema {
+            reference: SchemaRef {
+                module: ModuleName::new("targeted-owner").unwrap(),
+                entity: EntityName::new("item").unwrap(),
+                version: SchemaVersion::INITIAL,
+            },
+            locale_mode: LocaleMode::Optional,
+            fields: vec![IndexField {
+                name: FieldName::new("id").unwrap(),
+                value_type: IndexValueType::Uuid,
+                cardinality: FieldCardinality::One,
+                nullable: false,
+                selectable: true,
+                filterable: true,
+                sortable: true,
+            }],
+            links: Vec::new(),
+        }
+    }
+
+    fn key(entity_id: u128) -> EntityKey {
+        EntityKey {
+            tenant_id: Uuid::from_u128(1),
+            schema: schema().reference,
+            entity_id: Uuid::from_u128(entity_id),
+            locale: None,
+        }
+    }
+
+    fn executor(mode: SourceMode) -> IndexReplayTargetedExecutor<RecordingSink> {
+        let mut extensions = ModuleRuntimeExtensions::default();
+        let schema = schema();
+        register_index_schema_source(&mut extensions, "targeted_owner", schema.clone()).unwrap();
+        register_index_source(
+            &mut extensions,
+            "targeted_owner",
+            "targeted-owner-primary",
+            [schema.reference.clone()],
+            TargetedSource { mode },
+        )
+        .unwrap();
+        let schemas = materialize_index_schema_registry(&extensions)
+            .unwrap()
+            .expect("schema registry");
+        let sources = materialize_index_source_registry(&extensions)
+            .unwrap()
+            .expect("source registry");
+        IndexReplayTargetedExecutor::new(sources, schemas.shared(), RecordingSink::default())
+    }
+
+    #[tokio::test]
+    async fn targeted_load_applies_only_returned_mutations_and_reports_missing_keys() {
+        let executor = executor(SourceMode::MissingSecond);
+        let outcome = executor
+            .run(IndexReplayModeSelection::targeted(vec![key(10), key(11)]).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.source_name(), "targeted-owner-primary");
+        assert_eq!(outcome.requested_count(), 2);
+        assert_eq!(outcome.mutation_count(), 1);
+        assert_eq!(outcome.missing_count(), 1);
+        assert_eq!(outcome.applied_count(), 1);
+        assert_eq!(outcome.duplicate_count(), 0);
+        assert_eq!(outcome.stale_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn targeted_rejects_other_modes_without_source_or_mutation_execution() {
+        let executor = executor(SourceMode::Valid);
+        let error = executor
+            .run(IndexReplayModeSelection::full())
+            .await
+            .expect_err("Full must not alias Targeted execution");
+        assert!(matches!(
+            error,
+            IndexReplayTargetedError::WrongMode {
+                actual: IndexReplayMode::Full
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn targeted_preflights_nil_duplicate_and_schema_invalid_batches_before_writes() {
+        for (mode, expected) in [
+            (SourceMode::NilEvent, "nil"),
+            (SourceMode::DuplicateEvent, "duplicate"),
+            (SourceMode::InvalidRecord, "schema"),
+        ] {
+            let executor = executor(mode);
+            let error = executor
+                .run(IndexReplayModeSelection::targeted(vec![key(10), key(11)]).unwrap())
+                .await
+                .expect_err("invalid Targeted batch must fail closed");
+            match expected {
+                "nil" => assert!(matches!(error, IndexReplayTargetedError::NilEventId { .. })),
+                "duplicate" => assert!(matches!(
+                    error,
+                    IndexReplayTargetedError::DuplicateEventId { .. }
+                )),
+                "schema" => assert!(matches!(
+                    error,
+                    IndexReplayTargetedError::InvalidMutation { .. }
+                )),
+                _ => unreachable!(),
+            }
+            assert!(executor.mutation_sink.event_ids.lock().unwrap().is_empty());
+        }
+    }
+}

--- a/crates/rustok-index/src/application/targeted_replay.rs
+++ b/crates/rustok-index/src/application/targeted_replay.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, fmt, sync::Arc};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::{RecordValidationError, SchemaRef, SchemaRegistry};
+use crate::{LocaleMode, RecordValidationError, SchemaRef, SchemaRegistry};
 
 use super::{
     IndexReplayFailure, IndexReplayMode, IndexReplayModeSelection, IndexReplayMutationOutcome,
@@ -58,9 +58,10 @@ impl IndexReplayTargetedOutcome {
 /// Bounded exact-key mutation application for `IndexReplayMode::Targeted`.
 ///
 /// The executor consumes the canonical `IndexSourceLoadRequest` already owned by
-/// `IndexReplayModeSelection::Targeted`, validates the complete returned batch before the first
-/// mutation write, then applies source-owned stable mutation identities sequentially through the
-/// existing replay mutation sink. It deliberately has no scan cursor or durable replay ownership.
+/// `IndexReplayModeSelection::Targeted`, validates requested key shape against the active schema,
+/// validates the complete returned batch before the first mutation write, then applies source-owned
+/// stable mutation identities sequentially through the existing replay mutation sink. It
+/// deliberately has no scan cursor or durable replay ownership.
 pub struct IndexReplayTargetedExecutor<M> {
     sources: SharedIndexSourceRegistry,
     schemas: Arc<SchemaRegistry>,
@@ -96,15 +97,33 @@ where
             }
         };
 
+        let registered = self
+            .schemas
+            .get(request.schema())
+            .ok_or_else(|| IndexReplayTargetedError::SchemaNotRegistered(request.schema().clone()))?;
+        for (position, key) in request.keys().iter().enumerate() {
+            let source = if key.entity_id.is_nil() {
+                Some(RecordValidationError::NilEntityId)
+            } else {
+                match (registered.schema.locale_mode, key.locale.is_some()) {
+                    (LocaleMode::Required, false) => Some(RecordValidationError::LocaleRequired(
+                        request.schema().clone(),
+                    )),
+                    (LocaleMode::None, true) => Some(RecordValidationError::LocaleForbidden(
+                        request.schema().clone(),
+                    )),
+                    _ => None,
+                }
+            };
+            if let Some(source) = source {
+                return Err(IndexReplayTargetedError::InvalidTarget { position, source });
+            }
+        }
+
         let descriptor = self
             .sources
             .source_for_schema(request.schema())
             .ok_or_else(|| IndexReplayTargetedError::UnknownSchemaSource(request.schema().clone()))?;
-        if self.schemas.get(request.schema()).is_none() {
-            return Err(IndexReplayTargetedError::SchemaNotRegistered(
-                request.schema().clone(),
-            ));
-        }
         let source_name = descriptor.source_name().to_owned();
         let requested_count = request.keys().len();
         let batch = self
@@ -177,6 +196,12 @@ pub enum IndexReplayTargetedError {
     UnknownSchemaSource(SchemaRef),
     #[error("Index replay Targeted schema is not registered in the active runtime: {0}")]
     SchemaNotRegistered(SchemaRef),
+    #[error("Index replay Targeted key at position {position} is invalid")]
+    InvalidTarget {
+        position: usize,
+        #[source]
+        source: RecordValidationError,
+    },
     #[error("Index replay Targeted source load failed")]
     Source(#[source] IndexSourceError),
     #[error("Index replay Targeted mutation at position {position} has a nil event id")]
@@ -212,9 +237,9 @@ mod tests {
     use crate::{
         EntityKey, EntityName, FieldCardinality, FieldName, IndexField, IndexMutation, IndexRecord,
         IndexSchema, IndexSource, IndexSourceFailure, IndexSourceLoadBatch, IndexSourceLoadRequest,
-        IndexSourcePage, IndexSourceScanRequest, IndexValue, IndexValueType, LocaleMode, ModuleName,
-        SchemaVersion, materialize_index_schema_registry, materialize_index_source_registry,
-        register_index_schema_source, register_index_source,
+        IndexSourcePage, IndexSourceScanRequest, IndexValue, IndexValueType, LocaleKey, LocaleMode,
+        ModuleName, SchemaVersion, materialize_index_schema_registry,
+        materialize_index_source_registry, register_index_schema_source, register_index_source,
     };
 
     use super::*;
@@ -336,14 +361,14 @@ mod tests {
         }
     }
 
-    fn schema() -> IndexSchema {
+    fn schema(locale_mode: LocaleMode) -> IndexSchema {
         IndexSchema {
             reference: SchemaRef {
                 module: ModuleName::new("targeted-owner").unwrap(),
                 entity: EntityName::new("item").unwrap(),
                 version: SchemaVersion::INITIAL,
             },
-            locale_mode: LocaleMode::Optional,
+            locale_mode,
             fields: vec![IndexField {
                 name: FieldName::new("id").unwrap(),
                 value_type: IndexValueType::Uuid,
@@ -360,15 +385,29 @@ mod tests {
     fn key(entity_id: u128) -> EntityKey {
         EntityKey {
             tenant_id: Uuid::from_u128(1),
-            schema: schema().reference,
+            schema: schema(LocaleMode::Optional).reference,
             entity_id: Uuid::from_u128(entity_id),
             locale: None,
         }
     }
 
+    fn localized_key(entity_id: u128, locale: &str) -> EntityKey {
+        EntityKey {
+            locale: Some(LocaleKey::new(locale).unwrap()),
+            ..key(entity_id)
+        }
+    }
+
     fn executor(mode: SourceMode) -> IndexReplayTargetedExecutor<RecordingSink> {
+        executor_with_locale_mode(mode, LocaleMode::Optional)
+    }
+
+    fn executor_with_locale_mode(
+        mode: SourceMode,
+        locale_mode: LocaleMode,
+    ) -> IndexReplayTargetedExecutor<RecordingSink> {
         let mut extensions = ModuleRuntimeExtensions::default();
-        let schema = schema();
+        let schema = schema(locale_mode);
         register_index_schema_source(&mut extensions, "targeted_owner", schema.clone()).unwrap();
         register_index_source(
             &mut extensions,
@@ -420,6 +459,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn targeted_rejects_invalid_requested_entity_and_locale_scope_before_load() {
+        let none_executor = executor_with_locale_mode(SourceMode::Valid, LocaleMode::None);
+        let forbidden_locale = none_executor
+            .run(
+                IndexReplayModeSelection::targeted(vec![localized_key(10, "en-US")]).unwrap(),
+            )
+            .await
+            .expect_err("non-localized schema must reject locale Targeted key");
+        assert!(matches!(
+            forbidden_locale,
+            IndexReplayTargetedError::InvalidTarget {
+                position: 0,
+                source: RecordValidationError::LocaleForbidden(_),
+            }
+        ));
+        assert!(none_executor.mutation_sink.event_ids.lock().unwrap().is_empty());
+
+        let required_executor = executor_with_locale_mode(SourceMode::Valid, LocaleMode::Required);
+        let missing_locale = required_executor
+            .run(IndexReplayModeSelection::targeted(vec![key(10)]).unwrap())
+            .await
+            .expect_err("localized schema must require locale Targeted key");
+        assert!(matches!(
+            missing_locale,
+            IndexReplayTargetedError::InvalidTarget {
+                position: 0,
+                source: RecordValidationError::LocaleRequired(_),
+            }
+        ));
+        assert!(required_executor.mutation_sink.event_ids.lock().unwrap().is_empty());
+
+        let optional_executor = executor(SourceMode::Valid);
+        let mut nil_key = key(10);
+        nil_key.entity_id = Uuid::nil();
+        let nil_entity = optional_executor
+            .run(IndexReplayModeSelection::targeted(vec![nil_key]).unwrap())
+            .await
+            .expect_err("Targeted entity id must be non-nil before load");
+        assert!(matches!(
+            nil_entity,
+            IndexReplayTargetedError::InvalidTarget {
+                position: 0,
+                source: RecordValidationError::NilEntityId,
+            }
+        ));
+        assert!(optional_executor.mutation_sink.event_ids.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn targeted_preflights_nil_duplicate_and_schema_invalid_batches_before_writes() {
         for (mode, expected) in [
             (SourceMode::NilEvent, "nil"),
@@ -455,9 +543,7 @@ mod tests {
             template.schemas.clone(),
             RetryOnceSink::new(Uuid::from_u128(901)),
         );
-        let selection = || {
-            IndexReplayModeSelection::targeted(vec![key(10), key(11)]).unwrap()
-        };
+        let selection = || IndexReplayModeSelection::targeted(vec![key(10), key(11)]).unwrap();
 
         let error = executor
             .run(selection())
@@ -468,7 +554,14 @@ mod tests {
             IndexReplayTargetedError::Mutation { position: 1, .. }
         ));
         assert_eq!(
-            executor.mutation_sink.applied.lock().unwrap().iter().copied().collect::<Vec<_>>(),
+            executor
+                .mutation_sink
+                .applied
+                .lock()
+                .unwrap()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
             vec![Uuid::from_u128(900)]
         );
 

--- a/scripts/verify/verify-index-query-contract.mjs
+++ b/scripts/verify/verify-index-query-contract.mjs
@@ -70,6 +70,7 @@ const scripts = [
   'verify-index-reconciliation-dead-letter-requeue.mjs',
   'verify-index-replay-dry-run.mjs',
   'verify-index-replay-mode-contract.mjs',
+  'verify-index-replay-targeted-application.mjs',
   'verify-index-replay-shadow-host-dispatch.mjs',
   'verify-index-replay-shadow-graphql-transport.mjs',
   'verify-index-replay-page-interruption.mjs',

--- a/scripts/verify/verify-index-replay-mode-contract.mjs
+++ b/scripts/verify/verify-index-replay-mode-contract.mjs
@@ -55,12 +55,43 @@ for (const forbidden of [
 
 requireMarkers('crates/rustok-index/src/application/mod.rs', [
   'mod replay_mode;',
+  'mod targeted_replay;',
   'IndexReplayExecutionSurface, IndexReplayMode, IndexReplayModeSelection',
+  'IndexReplayTargetedError, IndexReplayTargetedExecutor, IndexReplayTargetedOutcome',
 ]);
+
+const targetedPath = 'crates/rustok-index/src/application/targeted_replay.rs';
+const targeted = requireMarkers(targetedPath, [
+  'pub struct IndexReplayTargetedExecutor<M>',
+  'IndexReplayModeSelection::Targeted(request) => request',
+  '.load(request)',
+  'let mut event_ids = BTreeSet::<Uuid>::new();',
+  'self.schemas.validate_mutation(mutation)',
+  '.apply_replay_mutation(self.schemas.as_ref(), &source_name, mutation)',
+  'missing_count: requested_count - mutation_count',
+]);
+for (const forbidden of [
+  'PostgresIndexReplayJobStore',
+  'PostgresIndexReplayCheckpointStore',
+  'DatabaseConnection',
+  'request_cancel(',
+  'tokio::spawn',
+  'partition_key',
+]) {
+  if (targeted.includes(forbidden)) {
+    fail(`${targetedPath} must stay bounded and independent of durable Full ownership: ${forbidden}`);
+  }
+}
 
 const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
 const runner = read(runnerPath);
-for (const forbidden of ['IndexReplayMode::Targeted', 'IndexReplayMode::Shadow', 'TargetedLoad', 'SideEffectFreeScan']) {
+for (const forbidden of [
+  'IndexReplayMode::Targeted',
+  'IndexReplayMode::Shadow',
+  'IndexReplayTargetedExecutor',
+  'TargetedLoad',
+  'SideEffectFreeScan',
+]) {
   if (runner.includes(forbidden)) {
     fail(`${runnerPath} must remain the durable Full-scan runner: ${forbidden}`);
   }
@@ -109,18 +140,19 @@ requireMarkers('apps/server/src/graphql/index_replay.rs', [
 ]);
 
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_locale_transport_execution_pending`.',
+  'Status: `source_complete_targeted_application_host_guard_pending`.',
   '`Full` — cursor-based durable source scan',
   '`Targeted` — bounded exact-key source load',
   '`Shadow` — side-effect-free cursor scan',
-  'Mode is not locale scope and is not future partition scope.',
   'returns true only for `Full`',
-  'must not alias the Full durable job/checkpoint identity',
+  '## Targeted mutation application',
+  '`IndexReplayTargetedExecutor`',
+  'Missing requested keys are allowed',
   '`Shadow` host dispatch is source-complete',
   '`runIndexReplayShadow` is a dedicated transport',
   'Locale-safe continuation and dry-run execution',
   'one current unversioned envelope',
-  'bounded mutation-application',
+  'PostgreSQL/runtime composition plus request-bound server host dispatch',
   'Execution/admission remains maintainer-owned.',
 ]);
 
@@ -131,7 +163,8 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
   'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
+  'Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.',
   'Add partition replay scope only after a real partition-capable source contract exists.',
 ]);
 
-console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted stays bounded-load-only, and Shadow executes schema-wide or exact-locale only through the no-write sealed surface');
+console.log('[verify-index-replay-mode-contract] Full stays durable, Targeted has bounded exact-key mutation application without durable ownership, and Shadow remains no-write/sealed');

--- a/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
+++ b/scripts/verify/verify-index-replay-shadow-graphql-transport.mjs
@@ -184,14 +184,15 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
   '`runIndexReplayShadow`',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_locale_transport_execution_pending`.',
+  'Status: `source_complete_targeted_application_host_guard_pending`.',
   '`runIndexReplayShadow`',
   'Locale-safe continuation and dry-run execution',
-  'bounded mutation-application',
+  '## Targeted mutation application',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
   'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
+  'Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.',
 ]);
 
-console.log('[verify-index-replay-shadow-graphql-transport] Shadow GraphQL is authorization-first, locale-scoped, sealed and no-write without a parallel transport or token format');
+console.log('[verify-index-replay-shadow-graphql-transport] Shadow GraphQL remains authorization-first/locale-scoped/sealed while Targeted application advances without reusing this transport');

--- a/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
+++ b/scripts/verify/verify-index-replay-shadow-host-dispatch.mjs
@@ -87,11 +87,12 @@ requireMarkers('crates/rustok-index/docs/m6-bounded-replay-dry-run.md', [
   'schema-wide or exact-locale invocation',
 ]);
 requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
-  'Status: `source_complete_shadow_locale_transport_execution_pending`.',
+  'Status: `source_complete_targeted_application_host_guard_pending`.',
   '`Shadow` host dispatch is source-complete',
   '`IndexReplayOperatorRuntime::run_shadow`',
   '`runIndexReplayShadow` is a dedicated transport',
   'Locale-safe continuation and dry-run execution',
+  '## Targeted mutation application',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Guard the existing side-effect-free Shadow replay runtime behind the request-bound `modules:manage` operator boundary.',
@@ -99,6 +100,7 @@ requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.
   'Make Shadow continuation identity locale-safe before exposing exact-locale Shadow GraphQL transport.',
   'Add exact-locale Shadow dry-run/runtime/GraphQL execution using the canonical locale-safe continuation scope.',
   'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
+  'Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.',
 ]);
 
-console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded/no-write while the sealed adapter carries one canonical schema-wide or exact-locale scope');
+console.log('[verify-index-replay-shadow-host-dispatch] Shadow host dispatch remains modules:manage-guarded/no-write while Targeted application advances independently toward its own guarded host boundary');

--- a/scripts/verify/verify-index-replay-targeted-application.mjs
+++ b/scripts/verify/verify-index-replay-targeted-application.mjs
@@ -140,13 +140,12 @@ requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
   'Status: `source_complete_targeted_application_host_guard_pending`.',
   '## Targeted mutation application',
   '`IndexReplayTargetedExecutor`',
-  'requested keys against the active schema',
+  'validates requested keys against the active schema',
   'Missing requested keys are allowed',
   'PostgreSQL/runtime materialization and request-bound server host',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
-  'requested Targeted keys against the active schema before source load',
   'Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [

--- a/scripts/verify/verify-index-replay-targeted-application.mjs
+++ b/scripts/verify/verify-index-replay-targeted-application.mjs
@@ -36,6 +36,9 @@ const targeted = requireMarkers(targetedPath, [
   'targeted_load_applies_only_returned_mutations_and_reports_missing_keys',
   'targeted_rejects_other_modes_without_source_or_mutation_execution',
   'targeted_preflights_nil_duplicate_and_schema_invalid_batches_before_writes',
+  'targeted_exact_retry_replays_stable_event_ids_after_partial_failure',
+  'RetryOnceSink::new(Uuid::from_u128(901))',
+  'assert_eq!(retry.duplicate_count(), 1);',
 ]);
 for (const forbidden of [
   'DatabaseConnection',
@@ -125,4 +128,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-targeted-application.mjs'",
 ]);
 
-console.log('[verify-index-replay-targeted-application] Targeted uses canonical bounded load plus stable replay mutation application without Full job/checkpoint ownership');
+console.log('[verify-index-replay-targeted-application] Targeted uses canonical bounded load plus stable replay mutation application and exact retry convergence without Full job/checkpoint ownership');

--- a/scripts/verify/verify-index-replay-targeted-application.mjs
+++ b/scripts/verify/verify-index-replay-targeted-application.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fail = (message) => {
+  console.error(`[verify-index-replay-targeted-application] ${message}`);
+  process.exit(1);
+};
+const requireMarkers = (relative, markers) => {
+  const source = read(relative);
+  for (const marker of markers) {
+    if (!source.includes(marker)) fail(`${relative} is missing ${marker}`);
+  }
+  return source;
+};
+
+const targetedPath = 'crates/rustok-index/src/application/targeted_replay.rs';
+const targeted = requireMarkers(targetedPath, [
+  'pub struct IndexReplayTargetedOutcome',
+  'pub struct IndexReplayTargetedExecutor<M>',
+  'IndexReplayModeSelection::Targeted(request) => request',
+  'IndexReplayTargetedError::WrongMode',
+  'source_for_schema(request.schema())',
+  'self.schemas.get(request.schema()).is_none()',
+  '.load(request)',
+  'let mut event_ids = BTreeSet::<Uuid>::new();',
+  'event_id.is_nil()',
+  'IndexReplayTargetedError::DuplicateEventId',
+  'self.schemas.validate_mutation(mutation)',
+  '.apply_replay_mutation(self.schemas.as_ref(), &source_name, mutation)',
+  'missing_count: requested_count - mutation_count',
+  'targeted_load_applies_only_returned_mutations_and_reports_missing_keys',
+  'targeted_rejects_other_modes_without_source_or_mutation_execution',
+  'targeted_preflights_nil_duplicate_and_schema_invalid_batches_before_writes',
+]);
+for (const forbidden of [
+  'DatabaseConnection',
+  'PostgresMutationStore',
+  'PostgresIndexReplayRunner',
+  'PostgresIndexReplayJobStore',
+  'PostgresIndexReplayCheckpointStore',
+  'index_jobs',
+  'index_checkpoints',
+  'request_cancel(',
+  'tokio::spawn',
+  'tokio::time::sleep',
+  'partition_key',
+  'worker_id',
+  'lease_duration',
+  'heartbeat',
+]) {
+  if (targeted.includes(forbidden)) {
+    fail(`${targetedPath} must remain a bounded application executor without durable scan ownership: ${forbidden}`);
+  }
+}
+
+const mode = requireMarkers('crates/rustok-index/src/application/replay_mode.rs', [
+  'Targeted(IndexSourceLoadRequest)',
+  'IndexSourceLoadRequest::new(keys)?',
+  'IndexReplayExecutionSurface::TargetedLoad',
+  'matches!(self, Self::Full)',
+]);
+if (mode.includes('PostgresMutationStore')) {
+  fail('replay_mode.rs must remain storage-neutral');
+}
+
+requireMarkers('crates/rustok-index/src/application/source_registry.rs', [
+  'const MAX_LOAD_KEYS: usize = 256;',
+  'pub struct IndexSourceLoadRequest',
+  'IndexSourceError::EmptyLoadKeys',
+  'IndexSourceError::TooManyLoadKeys',
+  'IndexSourceError::MixedLoadScope',
+  'IndexSourceError::DuplicateLoadKey',
+  'pub async fn load(',
+  'validate_load_batch(&request, &batch)?;',
+  'IndexSourceError::LoadMutationNotRequested',
+  'IndexSourceError::DuplicateLoadMutationKey',
+]);
+requireMarkers('crates/rustok-index/src/application/mod.rs', [
+  'mod targeted_replay;',
+  'IndexReplayTargetedError, IndexReplayTargetedExecutor, IndexReplayTargetedOutcome',
+]);
+
+const runnerPath = 'crates/rustok-index/src/infrastructure/postgres/source_replay_runner.rs';
+const runner = read(runnerPath);
+for (const forbidden of [
+  'IndexReplayTargetedExecutor',
+  'IndexReplayMode::Targeted',
+  'IndexReplayModeSelection::Targeted',
+  'TargetedLoad',
+]) {
+  if (runner.includes(forbidden)) {
+    fail(`${runnerPath} must stay the durable Full scan runner: ${forbidden}`);
+  }
+}
+
+requireMarkers('crates/rustok-index/docs/m6-targeted-replay-mutation-application.md', [
+  'Status: `source_complete_host_guard_pending`.',
+  '`IndexReplayTargetedExecutor`',
+  'Missing requested keys',
+  'does not infer deletion',
+  'source-owned mutation event UUID',
+  'does not add a checkpoint for partial progress',
+  'PostgreSQL/runtime composition plus request-bound server host dispatch',
+]);
+requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
+  'Status: `source_complete_targeted_application_host_guard_pending`.',
+  '## Targeted mutation application',
+  '`IndexReplayTargetedExecutor`',
+  'Missing requested keys are allowed',
+  'PostgreSQL/runtime materialization and request-bound server host',
+]);
+requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
+  'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
+  'Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.',
+]);
+requireMarkers('crates/rustok-index/docs/README.md', [
+  '[M6 Targeted Replay Mutation Application](./m6-targeted-replay-mutation-application.md)',
+]);
+requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
+  "'verify-index-replay-targeted-application.mjs'",
+]);
+
+console.log('[verify-index-replay-targeted-application] Targeted uses canonical bounded load plus stable replay mutation application without Full job/checkpoint ownership');

--- a/scripts/verify/verify-index-replay-targeted-application.mjs
+++ b/scripts/verify/verify-index-replay-targeted-application.mjs
@@ -24,8 +24,14 @@ const targeted = requireMarkers(targetedPath, [
   'pub struct IndexReplayTargetedExecutor<M>',
   'IndexReplayModeSelection::Targeted(request) => request',
   'IndexReplayTargetedError::WrongMode',
+  'let registered = self',
+  '.get(request.schema())',
+  'for (position, key) in request.keys().iter().enumerate()',
+  'key.entity_id.is_nil()',
+  '(LocaleMode::Required, false)',
+  '(LocaleMode::None, true)',
+  'IndexReplayTargetedError::InvalidTarget',
   'source_for_schema(request.schema())',
-  'self.schemas.get(request.schema()).is_none()',
   '.load(request)',
   'let mut event_ids = BTreeSet::<Uuid>::new();',
   'event_id.is_nil()',
@@ -35,11 +41,30 @@ const targeted = requireMarkers(targetedPath, [
   'missing_count: requested_count - mutation_count',
   'targeted_load_applies_only_returned_mutations_and_reports_missing_keys',
   'targeted_rejects_other_modes_without_source_or_mutation_execution',
+  'targeted_rejects_invalid_requested_entity_and_locale_scope_before_load',
   'targeted_preflights_nil_duplicate_and_schema_invalid_batches_before_writes',
   'targeted_exact_retry_replays_stable_event_ids_after_partial_failure',
   'RetryOnceSink::new(Uuid::from_u128(901))',
   'assert_eq!(retry.duplicate_count(), 1);',
 ]);
+const modeSelection = targeted.indexOf('IndexReplayModeSelection::Targeted(request) => request');
+const schemaAdmission = targeted.indexOf('let registered = self', modeSelection);
+const keyAdmission = targeted.indexOf('for (position, key) in request.keys().iter().enumerate()', schemaAdmission);
+const sourceResolution = targeted.indexOf('source_for_schema(request.schema())', keyAdmission);
+const load = targeted.indexOf('.load(request)', sourceResolution);
+const batchPreflight = targeted.indexOf('let mut event_ids = BTreeSet::<Uuid>::new();', load);
+const mutationWrite = targeted.indexOf('.apply_replay_mutation(self.schemas.as_ref(), &source_name, mutation)', batchPreflight);
+if (
+  modeSelection < 0 ||
+  schemaAdmission <= modeSelection ||
+  keyAdmission <= schemaAdmission ||
+  sourceResolution <= keyAdmission ||
+  load <= sourceResolution ||
+  batchPreflight <= load ||
+  mutationWrite <= batchPreflight
+) {
+  fail('Targeted order must remain mode -> active schema/key admission -> source -> load -> full batch preflight -> mutation writes');
+}
 for (const forbidden of [
   'DatabaseConnection',
   'PostgresMutationStore',
@@ -104,6 +129,7 @@ for (const forbidden of [
 requireMarkers('crates/rustok-index/docs/m6-targeted-replay-mutation-application.md', [
   'Status: `source_complete_host_guard_pending`.',
   '`IndexReplayTargetedExecutor`',
+  'requested key admission',
   'Missing requested keys',
   'does not infer deletion',
   'source-owned mutation event UUID',
@@ -114,11 +140,13 @@ requireMarkers('crates/rustok-index/docs/m6-replay-mode-contract.md', [
   'Status: `source_complete_targeted_application_host_guard_pending`.',
   '## Targeted mutation application',
   '`IndexReplayTargetedExecutor`',
+  'requested keys against the active schema',
   'Missing requested keys are allowed',
   'PostgreSQL/runtime materialization and request-bound server host',
 ]);
 requireMarkers('crates/rustok-index/docs/implementation-plan-current-2026-08-08.md', [
   'Define a bounded Targeted mutation-application contract over `IndexSource::load` without aliasing durable scan ownership.',
+  'requested Targeted keys against the active schema before source load',
   'Materialize the bounded Targeted replay executor with `PostgresMutationStore` and guard host dispatch behind request-bound `modules:manage`.',
 ]);
 requireMarkers('crates/rustok-index/docs/README.md', [
@@ -128,4 +156,4 @@ requireMarkers('scripts/verify/verify-index-query-contract.mjs', [
   "'verify-index-replay-targeted-application.mjs'",
 ]);
 
-console.log('[verify-index-replay-targeted-application] Targeted uses canonical bounded load plus stable replay mutation application and exact retry convergence without Full job/checkpoint ownership');
+console.log('[verify-index-replay-targeted-application] Targeted validates exact keys before load, preflights the whole batch, and converges exact retry without Full job/checkpoint ownership');


### PR DESCRIPTION
## Summary

- add `IndexReplayTargetedExecutor` as the bounded application execution surface for `IndexReplayModeSelection::Targeted`;
- reuse the canonical `IndexSourceLoadRequest` unchanged for its 1..=256 unique-key, non-nil-tenant and exact-schema-set bounds;
- before source resolution/load, validate every requested key against the active schema: non-nil entity UUID, locale required for `LocaleMode::Required`, locale forbidden for `LocaleMode::None`;
- perform exactly one frozen source-registry `load`, then preflight the complete returned batch before the first mutation write: non-nil event UUIDs, invocation-local event UUID uniqueness and full `SchemaRegistry::validate_mutation` validity;
- apply only returned source mutations sequentially through the existing `IndexReplayMutationSink`, preserving source-owned stable event UUIDs as delivery identity;
- treat admitted-but-missing requested keys as a count only; do not synthesize delete mutations;
- retain source evidence for the partial-apply window: after mutation 1 is applied and mutation 2 fails once, an exact retry converges as `Duplicate + Applied` without a Targeted checkpoint;
- keep Targeted out of `PostgresIndexReplayRunner` and out of Full jobs/checkpoints/leases/cancellation/retry/scheduler state;
- keep this slice storage-neutral: no `PostgresMutationStore`, database handle, server operator or public transport is materialized here;
- actualize M6 docs/guards and advance the next source boundary to PostgreSQL/runtime composition plus request-bound `modules:manage` host dispatch, with public Targeted transport still separate.

## Mainline recheck

The branch started from `main@532d293d2bc6ad7f77362970d38469ba5db8e59d`. During implementation/final review `main` advanced through Translation/Modules/Groups/Pages work to `f9f51db8b0deb71f4802830ce4edf70fb9bd4100`. Path-level compares found no overlap with this PR's `rustok-index` application/docs/verify files; the latest drift is Modules/Product lifecycle only.

## Validation

Static GitHub source/diff inspection only. Per maintainer instruction, no Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.