### PR TITLE
feat(modules): retain staged lifecycle recovery intent

### DIFF
--- a/apps/server/docs/module-lifecycle-retry-compensation-runbook.md
+++ b/apps/server/docs/module-lifecycle-retry-compensation-runbook.md
@@ -1,6 +1,8 @@
 # Runbook: retry/compensation for module lifecycle post-hook failures
 
-This document establishes the operational contract for the situation when `ModuleLifecycleService` has already committed tenant state (`enabled=true/false`), but post-hook (`post_enable`/`post_disable`) ended with an error. This is **not a rollback scenario**: module state is considered committed, and the error is handled as retry/compensation flow through `module_operations`.
+This document establishes the operational contract for the situation when `ModuleLifecycleService` has already committed tenant module intent, but post-hook (`post_enable`/`post_disable`) ended with an error. This is **not an automatic rollback scenario**: the requested tenant override is committed first, and the error is handled as retry/compensation flow through `module_operations` plus its immutable selected-intent recovery state.
+
+Effective serving availability is not the recovery predecessor. Availability can legitimately differ from tenant intent while Product co-requisites are staged, channel/maintenance policy is applied, or node readiness changes.
 
 ## When to apply
 
@@ -8,16 +10,30 @@ Use this runbook if in telemetry/logs or admin lifecycle surface you see:
 
 - `module_operations.status = failed`;
 - `error` contains `post-hook` marker;
-- tenant state already corresponds to requested transition.
+- the exact current tenant override still corresponds to the override target recorded for that operation.
 
-Pre-hook errors (before commit) are not covered here: for them committed state does not change and normal toggle retry after fixing the cause is needed.
+Pre-hook errors (before commit) are not covered here: for them committed tenant intent does not change and normal toggle retry after fixing the cause is needed.
+
+## Selected-intent states
+
+Lifecycle recovery distinguishes three exact tenant override states:
+
+- `inherit` — there is no `tenant_modules` row for the module (`None` in the owner contract);
+- `enabled` — an explicit `tenant_modules.enabled = true` override exists;
+- `disabled` — an explicit `tenant_modules.enabled = false` override exists.
+
+For new lifecycle operations the owner stores the exact predecessor and requested override in `module_operation_override_states`. The side-table row itself is the recorded-state marker, so nullable booleans can represent `inherit` without confusing it with a legacy operation that predates this contract.
+
+Legacy failed operations without a `module_operation_override_states` row fail closed for post-hook retry/compensation with `selected_intent_state_unavailable`; do not infer their predecessor from `previous_effective_enabled`.
 
 ## Invariants
 
-1. **Committed state is not rolled back automatically.**
-2. **`module_operations` remains the source of truth for audit trail** (including `correlation_id`, `requested_by`, `requested_enabled`).
-3. **Retry is performed through the module-owned recovery operation**, exposed by `ModuleLifecycleService::retry_failed_post_hook_operation(...)`, to repeat only post-hook for already committed target-state and create a new journal attempt.
-4. **Compensation is performed by separate conscious operation** via `ModuleLifecycleService::compensate_failed_operation(...)` or equivalent canonical toggle in reverse direction, not by hidden rollback inside failed post-hook path.
+1. **Committed tenant intent is not rolled back automatically.**
+2. **`module_operations` remains the audit trail** for operation direction, correlation, actor and historical effective availability. `previous_effective_enabled` is an availability fact, not the selected-intent recovery predecessor.
+3. **`module_operation_override_states` is immutable recovery evidence** for the exact explicit-override predecessor and target.
+4. **Retry repeats only the post-hook** after proving the current explicit override still equals the original requested override. It does not require serving availability to equal `requested_enabled`.
+5. **Compensation is a new canonical lifecycle operation** in the inverse hook/dependency-order direction. Its state target is the exact recorded predecessor; `inherit` removes the explicit tenant override row.
+6. **Policy revision remains canonical and co-requisite-aware.** Compensation computes the next policy from the exact restored override set and publishes the normal owner policy transition/outbox revision.
 
 ## Basic diagnostics
 
@@ -30,10 +46,11 @@ SELECT id,
        tenant_id,
        module_slug,
        requested_enabled,
+       previous_effective_enabled,
        status,
        correlation_id,
        requested_by,
-       error,
+       error_message,
        created_at,
        updated_at
 FROM module_operations
@@ -42,18 +59,31 @@ WHERE tenant_id = '<TENANT_UUID>'
 ORDER BY created_at DESC;
 ```
 
-Check: latest failed record should have non-null `correlation_id`, and current `tenant_modules.enabled` should already be in requested state.
-
-### 2) Check actual tenant state
+For an operation created under the current recovery contract, inspect its exact selected-intent evidence:
 
 ```sql
-SELECT tenant_id, module_slug, enabled, updated_at
+SELECT operation_id,
+       previous_override_enabled,
+       requested_override_enabled,
+       created_at
+FROM module_operation_override_states
+WHERE operation_id = '<OPERATION_UUID>';
+```
+
+Interpret nullable override values only when this row exists. `NULL` then means `inherit`.
+
+### 2) Check actual tenant override
+
+```sql
+SELECT tenant_id, module_slug, enabled, settings, updated_at
 FROM tenant_modules
 WHERE tenant_id = '<TENANT_UUID>'
   AND module_slug = '<MODULE_SLUG>';
 ```
 
-If state does not match expectation, this is not a standard post-hook issue and requires separate incident triage.
+No row means current selected intent is `inherit`. A row means explicit `enabled` or `disabled`. If this exact state does not match the operation's `requested_override_enabled`, retry/compensation must fail with a state mismatch and the incident needs separate triage.
+
+Do not substitute `EffectiveModulePolicyService` availability for this check: Product may be explicitly enabled while intentionally unavailable until Inventory/Pricing co-requisites are also selected.
 
 ### 3) Correlate with application logs/traces
 
@@ -61,40 +91,53 @@ Look for `correlation_id` from `module_operations` in structured logs and tracin
 
 ## Retry flow (preferred)
 
-Use if cause is transient and hook is idempotent.
+Use if cause is transient and the post-hook is idempotent.
 
-1. Ensure root-cause is fixed.
-2. Get `ModuleOperationRecoveryPlan` via GraphQL query `moduleOperationRecoveryPlan(operationId: ...)`, list of failed candidates via `failedModuleOperationRecoveryPlans(moduleSlug: ..., limit: ...)` or directly via `ModuleLifecycleService::module_operation_recovery_plan(...)` / `failed_module_operation_recovery_plans(...)`.
-3. If `recommended_action = retry_post_hook`, call GraphQL mutation `retryFailedModuleOperationPostHook(operationId: ...)` or `ModuleLifecycleService::retry_failed_post_hook_operation(...)` for failed operation id. Service will check that current effective state still matches `requested_enabled`, and will not re-execute pre-hook or commit tenant state again.
-4. Verify that GraphQL mutation returned recovery plan of new operation record with status `committed` (or `failed` if post-hook problem repeated) and new `correlation_id`.
+1. Ensure root cause is fixed.
+2. Get `ModuleOperationRecoveryPlan` via GraphQL query `moduleOperationRecoveryPlan(operationId: ...)`, the failed candidate list, or the service owner API.
+3. Confirm the plan is retryable. Operations without recorded selected-intent state are deliberately not retryable through this contract.
+4. Call `retryFailedModuleOperationPostHook` or `ModuleLifecycleService::retry_failed_post_hook_operation(...)`.
+5. The owner verifies the exact current override equals the original requested override, creates a new journal attempt, copies the original selected-intent predecessor/target recovery evidence, and dispatches only the post-hook. It does not re-run pre-hook or persist tenant state again.
+6. Verify the new operation record is `committed`, or `failed` with a new post-hook error and correlation id.
 
-Expected result: successful retry **should not** create duplicate side effects, and journal should show new attempt with new `correlation_id` and same target-state.
+Expected result: successful retry **should not** create duplicate side effects, and the new journal attempt retains enough selected-intent evidence to be compensated later if its own post-hook fails.
 
 ## Compensation flow (when retry is impossible)
 
 Use if:
 
-- post-hook side effect partially executed and requires targeted compensation;
-- business decision requires returning module to previous state.
+- the post-hook side effect partially executed and requires a deliberate reverse lifecycle operation; or
+- business decision requires restoring the exact selected intent that existed before the failed operation.
 
 Steps:
 
-1. Record decision in incident ticket/change log.
-2. Get recovery plan and check `previous_effective_enabled`.
-3. Execute GraphQL mutation `compensateFailedModuleOperation(operationId: ...)` or `ModuleLifecycleService::compensate_failed_operation(...)`; service will create new lifecycle operation via canonical toggle to `previous_effective_enabled`.
-4. Ensure dependent modules/policy-invariants are not violated before compensating toggle.
-5. Check new `module_operations` trail (failed/success) and current `tenant_modules` state.
+1. Record the decision in the incident ticket/change log.
+2. Get the recovery plan and verify selected-intent evidence was recorded. Do **not** use `previous_effective_enabled` as the compensation target.
+3. Confirm the current explicit override still equals the original operation's requested override.
+4. Execute `compensateFailedModuleOperation` or `ModuleLifecycleService::compensate_failed_operation(...)`.
+5. The owner runs the inverse lifecycle hook/dependency-order direction and restores `previous_override_enabled` exactly:
+   - `Some(true)` -> explicit enabled row;
+   - `Some(false)` -> explicit disabled row;
+   - `None` -> remove the explicit row and return to inherited/default selection.
+6. The owner computes/publishes the resulting canonical effective-policy revision from that exact restored override set.
+7. Check the new `module_operations` trail and the current `tenant_modules` row/absence. Serving availability may still differ from selected intent because co-requisites or other policy context can make the module unavailable.
 
 ## Minimum post-incident checklist
 
 - [ ] For each failed post-hook case, `correlation_id` and root cause are recorded.
-- [ ] Retry or compensation performed via canonical lifecycle entrypoint (`retryFailedModuleOperationPostHook` / `compensateFailedModuleOperation` GraphQL mutations or service-level `retry_failed_post_hook_operation`/`compensate_failed_operation`, not via bypass/SQL).
-- [ ] Journal contains final operation record explaining final state.
-- [ ] If failure is systemic/recurring, task created for module owner with reference to failed operations.
+- [ ] Recovery plan has selected-intent evidence; legacy rows without it were not guessed from effective availability.
+- [ ] Retry or compensation was performed through the canonical lifecycle entrypoint, not bypass SQL.
+- [ ] The exact explicit override after recovery is correct, including expected row absence for inherited selection.
+- [ ] Canonical effective-policy revision/outbox reflects the resulting selection.
+- [ ] Journal contains the final operation record explaining final lifecycle direction and result.
+- [ ] If failure is systemic/recurring, a task exists for the module owner with references to failed operations.
 
 ## Related contracts
 
+- `crates/rustok-modules/src/recovery.rs`
+- `crates/rustok-modules/src/executor.rs`
+- `crates/rustok-modules/src/lifecycle_writer.rs`
+- `crates/rustok-migrations/src/m20260808_000099_create_module_operation_override_states.rs`
 - `apps/server/src/services/module_lifecycle.rs`
-- `apps/server/src/models/_entities/module_operations.rs`
 - `docs/architecture/modules.md`
 - `DECISIONS/2026-05-22-module-lifecycle-hook-phases-and-retry-contract.md`

--- a/apps/server/src/services/module_lifecycle.rs
+++ b/apps/server/src/services/module_lifecycle.rs
@@ -17,6 +17,13 @@ use crate::services::platform_composition::PlatformCompositionService;
 
 pub struct ModuleLifecycleService;
 
+#[derive(Clone, Debug)]
+pub struct ModuleLifecycleStateSnapshot {
+    pub module_slug: String,
+    pub enabled: bool,
+    pub settings: serde_json::Value,
+}
+
 #[derive(Debug, Error)]
 pub enum ModuleOperationRecoveryError {
     #[error("Module operation not found")]
@@ -26,11 +33,11 @@ pub enum ModuleOperationRecoveryError {
     #[error("Module operation is not retryable: {0}")]
     NotRetryable(String),
     #[error(
-        "Module operation state mismatch: requested enabled={requested_enabled}, current enabled={current_enabled}"
+        "Module operation override state mismatch: requested={requested_enabled}, current={current_enabled}"
     )]
     StateMismatch {
-        requested_enabled: bool,
-        current_enabled: bool,
+        requested_enabled: String,
+        current_enabled: String,
     },
     #[error("Module post-hook retry failed: {0}")]
     PostHookFailed(String),
@@ -114,7 +121,12 @@ impl ModuleLifecycleService {
             .toggle(tenant_id, module_slug, enabled, requested_by)
             .await
             .map_err(map_lifecycle_writer_error)?;
-        Ok(TenantModulesEntity::find_by_id(result.state.id)
+        let state = result.state.ok_or_else(|| {
+            ToggleModuleError::Policy(
+                "explicit module toggle did not persist a tenant override row".to_string(),
+            )
+        })?;
+        Ok(TenantModulesEntity::find_by_id(state.id)
             .one(db)
             .await?
             .ok_or_else(|| DbErr::RecordNotFound("tenant_modules.toggle_state".to_string()))?)
@@ -170,26 +182,45 @@ impl ModuleLifecycleService {
         operation_id: uuid::Uuid,
         requested_by: Option<String>,
         idempotency_key: uuid::Uuid,
-    ) -> Result<tenant_modules::Model, ModuleOperationRecoveryError> {
+    ) -> Result<ModuleLifecycleStateSnapshot, ModuleOperationRecoveryError> {
+        let plan = module_operation_recovery_plan(db, operation_id)
+            .await
+            .map_err(map_module_recovery_error)?;
         let manifest = PlatformCompositionService::active_manifest(db)
             .await
             .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
         let co_requisites = ManifestManager::module_policy_corequisites(&manifest)
             .map_err(|error| ModuleOperationRecoveryError::Policy(error.to_string()))?;
-        let result = ModuleControlPlane::new(db.clone())
+        let writer = ModuleControlPlane::new(db.clone())
             .lifecycle(registry, manifest.settings.default_enabled)
-            .with_corequisites(co_requisites)
+            .with_corequisites(co_requisites);
+        let result = writer
             .compensate_failed_operation(operation_id, requested_by, idempotency_key)
             .await
             .map_err(map_lifecycle_writer_recovery_error)?;
-        TenantModulesEntity::find_by_id(result.state.id)
-            .one(db)
-            .await?
-            .ok_or_else(|| {
-                ModuleOperationRecoveryError::Database(DbErr::RecordNotFound(
-                    "tenant_modules.compensation_state".to_string(),
-                ))
-            })
+        let policy = writer
+            .effective_policy(plan.tenant_id)
+            .await
+            .map_err(map_lifecycle_writer_recovery_error)?;
+        let (enabled, settings) = match result.state {
+            Some(state) => {
+                let state = TenantModulesEntity::find_by_id(state.id)
+                    .one(db)
+                    .await?
+                    .ok_or_else(|| {
+                        ModuleOperationRecoveryError::Database(DbErr::RecordNotFound(
+                            "tenant_modules.compensation_state".to_string(),
+                        ))
+                    })?;
+                (state.enabled, state.settings)
+            }
+            None => (policy.contains(&plan.module_slug), serde_json::json!({})),
+        };
+        Ok(ModuleLifecycleStateSnapshot {
+            module_slug: plan.module_slug,
+            enabled,
+            settings,
+        })
     }
 
     pub async fn update_module_settings(
@@ -399,11 +430,11 @@ fn map_module_recovery_error(error: ModulesRecoveryError) -> ModuleOperationReco
             ModuleOperationRecoveryError::NotRetryable(reason)
         }
         ModulesRecoveryError::StateMismatch {
-            requested_enabled,
-            current_enabled,
+            requested_override_enabled,
+            current_override_enabled,
         } => ModuleOperationRecoveryError::StateMismatch {
-            requested_enabled,
-            current_enabled,
+            requested_enabled: override_state_label(requested_override_enabled).to_string(),
+            current_enabled: override_state_label(current_override_enabled).to_string(),
         },
         ModulesRecoveryError::PostHookFailed(error) => {
             ModuleOperationRecoveryError::PostHookFailed(error)
@@ -414,6 +445,14 @@ fn map_module_recovery_error(error: ModulesRecoveryError) -> ModuleOperationReco
         ModulesRecoveryError::Persistence(error) => {
             ModuleOperationRecoveryError::Database(DbErr::Custom(error))
         }
+    }
+}
+
+fn override_state_label(value: Option<bool>) -> &'static str {
+    match value {
+        None => "inherit",
+        Some(true) => "enabled",
+        Some(false) => "disabled",
     }
 }
 

--- a/crates/rustok-migrations/src/lib.rs
+++ b/crates/rustok-migrations/src/lib.rs
@@ -51,6 +51,7 @@ mod m20260718_000001_add_module_operation_idempotency_key;
 mod m20260718_000002_add_registry_publication_idempotency;
 mod m20260723_000001_create_event_delivery_settings;
 mod m20260803_000001_create_owner_operation_receipts;
+mod m20260808_000099_create_module_operation_override_states;
 
 #[cfg(test)]
 mod rbac_system_role_repair_tests;
@@ -77,6 +78,7 @@ const APPEND_ONLY_MIGRATION_TAIL: &[&str] = &[
     "m20260803_000017_add_translation_target_support",
     "m20260803_000001_canonicalize_artifact_permissions",
     "m20260806_000014_add_translation_target_support",
+    "m20260808_000099_create_module_operation_override_states",
 ];
 
 struct ModuleMigrationSource {
@@ -353,6 +355,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260717_000003_add_registry_artifact_origin_and_external_staging::Migration),
             Box::new(m20260723_000001_create_event_delivery_settings::Migration),
             Box::new(m20260803_000001_create_owner_operation_receipts::Migration),
+            Box::new(m20260808_000099_create_module_operation_override_states::Migration),
         ];
 
         // Pull module-owned migrations from the domain crates and merge them into

--- a/crates/rustok-migrations/src/m20260808_000099_create_module_operation_override_states.rs
+++ b/crates/rustok-migrations/src/m20260808_000099_create_module_operation_override_states.rs
@@ -1,0 +1,75 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ModuleOperationOverrideStates::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ModuleOperationOverrideStates::OperationId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ModuleOperationOverrideStates::PreviousOverrideEnabled)
+                            .boolean()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(ModuleOperationOverrideStates::RequestedOverrideEnabled)
+                            .boolean()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(ModuleOperationOverrideStates::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_module_operation_override_states_operation_id")
+                            .from(
+                                ModuleOperationOverrideStates::Table,
+                                ModuleOperationOverrideStates::OperationId,
+                            )
+                            .to(ModuleOperations::Table, ModuleOperations::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(ModuleOperationOverrideStates::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum ModuleOperationOverrideStates {
+    Table,
+    OperationId,
+    PreviousOverrideEnabled,
+    RequestedOverrideEnabled,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ModuleOperations {
+    Table,
+    Id,
+}

--- a/crates/rustok-modules/src/executor.rs
+++ b/crates/rustok-modules/src/executor.rs
@@ -3,12 +3,16 @@ use std::collections::HashSet;
 use sea_orm::{DatabaseConnection, TransactionTrait};
 use thiserror::Error;
 
+use crate::recovery::{
+    apply_tenant_override_enabled, read_tenant_override_enabled,
+    record_operation_override_state,
+};
 use crate::{
     ControlPlaneInfrastructure, ModuleEffectivePolicyTransitionCoordinator,
     ModuleExecutionDispatcher, ModuleLifecycleHookPhase, ModuleOperationJournal,
-    ModuleOperationRecordOutcome, ModuleOperationRequest, ModuleOperationSnapshot,
-    ModuleOperationStatus, ModulePolicyRevisionTransition, ModuleToggleValidationError,
-    TenantModuleStateRecord, TenantModuleStateRequest, TenantModuleStateStore,
+    ModuleOperationRecord, ModuleOperationRecordOutcome, ModuleOperationRequest,
+    ModuleOperationSnapshot, ModuleOperationStatus, ModulePolicyRevisionTransition,
+    ModuleToggleValidationError, TenantModuleStateRecord, TenantModuleStateStore,
     validate_module_toggle,
 };
 
@@ -16,6 +20,8 @@ use crate::{
 pub struct ModuleLifecycleToggleRequest {
     pub tenant_id: uuid::Uuid,
     pub module_slug: String,
+    /// Lifecycle hook direction for this command. Recovery may restore an
+    /// inherited override while still running the inverse hook phase.
     pub enabled: bool,
     pub requested_by: Option<String>,
     pub correlation_id: Option<String>,
@@ -25,13 +31,20 @@ pub struct ModuleLifecycleToggleRequest {
     /// Ordinary dependency-order selection used only to validate sequential
     /// lifecycle transitions. Co-requisites must not create a second ordering graph.
     pub ordering_enabled_modules: HashSet<String>,
+    /// Exact tenant override before this command. `None` means inherit defaults.
+    pub previous_override_enabled: Option<bool>,
+    /// Exact tenant override to persist. `None` removes the explicit override.
+    pub requested_override_enabled: Option<bool>,
     pub current_settings: serde_json::Value,
     pub policy_transition: Option<ModulePolicyRevisionTransition>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModuleLifecycleToggleResult {
-    pub state: TenantModuleStateRecord,
+    /// Current explicit tenant row after the state commit. `None` means the
+    /// operation restored inherited/default selection by removing the row.
+    pub state: Option<TenantModuleStateRecord>,
+    pub override_enabled: Option<bool>,
     pub operation_id: Option<uuid::Uuid>,
 }
 
@@ -74,6 +87,7 @@ pub async fn execute_module_toggle(
         requested_by: request.requested_by.clone(),
         correlation_id: request
             .correlation_id
+            .clone()
             .unwrap_or_else(|| infrastructure.new_id().to_string()),
         idempotency_key: request.idempotency_key,
     };
@@ -92,18 +106,17 @@ pub async fn execute_module_toggle(
         request.enabled,
     )?;
     if previous_effective_enabled == request.enabled && request.policy_transition.is_none() {
-        let state = TenantModuleStateStore::persist(
+        let state = apply_tenant_override_enabled(
             db,
-            TenantModuleStateRequest {
-                tenant_id: request.tenant_id,
-                module_slug: request.module_slug,
-                enabled: request.enabled,
-            },
+            request.tenant_id,
+            &request.module_slug,
+            request.requested_override_enabled,
         )
         .await
         .map_err(|error| ModuleLifecycleExecutionError::Persistence(error.to_string()))?;
         return Ok(ModuleLifecycleToggleResult {
             state,
+            override_enabled: request.requested_override_enabled,
             operation_id: None,
         });
     }
@@ -137,6 +150,13 @@ pub async fn execute_module_toggle(
             .await
             .map_err(|error| ModuleLifecycleExecutionError::Persistence(error.to_string()))?
     };
+    record_override_state_or_fail(
+        db,
+        operation.id,
+        request.previous_override_enabled,
+        request.requested_override_enabled,
+    )
+    .await?;
     ModuleOperationJournal::mark_running(db, operation.id)
         .await
         .map_err(|error| ModuleLifecycleExecutionError::Persistence(error.to_string()))?;
@@ -163,44 +183,48 @@ pub async fn execute_module_toggle(
         return Err(ModuleLifecycleExecutionError::PreHook(message));
     }
 
-    let state_request = TenantModuleStateRequest {
-        tenant_id: request.tenant_id,
-        module_slug: request.module_slug.clone(),
-        enabled: request.enabled,
-    };
+    let requested_override_enabled = request.requested_override_enabled;
+    let module_slug = request.module_slug.clone();
     let policy_transition = request.policy_transition.clone();
     let tenant_id = request.tenant_id;
     let coordinator = policy_transition_coordinator;
     let state = match db
-        .transaction::<_, TenantModuleStateRecord, ModuleLifecycleExecutionError>(|transaction| {
-            Box::pin(async move {
-                let state = TenantModuleStateStore::persist(transaction, state_request)
+        .transaction::<_, Option<TenantModuleStateRecord>, ModuleLifecycleExecutionError>(
+            |transaction| {
+                Box::pin(async move {
+                    let state = apply_tenant_override_enabled(
+                        transaction,
+                        tenant_id,
+                        &module_slug,
+                        requested_override_enabled,
+                    )
                     .await
                     .map_err(|error| {
                         ModuleLifecycleExecutionError::Persistence(error.to_string())
                     })?;
-                ModuleOperationJournal::mark_committed(transaction, operation.id)
-                    .await
-                    .map_err(|error| {
-                        ModuleLifecycleExecutionError::Persistence(error.to_string())
-                    })?;
-                if let (Some(coordinator), Some(transition)) = (coordinator, policy_transition) {
-                    coordinator
-                        .publish_and_advance(
-                            transaction,
-                            tenant_id,
-                            None,
-                            "module.lifecycle",
-                            &transition,
-                        )
+                    ModuleOperationJournal::mark_committed(transaction, operation.id)
                         .await
                         .map_err(|error| {
-                            ModuleLifecycleExecutionError::PolicyTransition(error.to_string())
+                            ModuleLifecycleExecutionError::Persistence(error.to_string())
                         })?;
-                }
-                Ok(state)
-            })
-        })
+                    if let (Some(coordinator), Some(transition)) = (coordinator, policy_transition) {
+                        coordinator
+                            .publish_and_advance(
+                                transaction,
+                                tenant_id,
+                                None,
+                                "module.lifecycle",
+                                &transition,
+                            )
+                            .await
+                            .map_err(|error| {
+                                ModuleLifecycleExecutionError::PolicyTransition(error.to_string())
+                            })?;
+                    }
+                    Ok(state)
+                })
+            },
+        )
         .await
     {
         Ok(state) => state,
@@ -244,8 +268,30 @@ pub async fn execute_module_toggle(
 
     Ok(ModuleLifecycleToggleResult {
         state,
+        override_enabled: request.requested_override_enabled,
         operation_id: Some(operation.id),
     })
+}
+
+async fn record_override_state_or_fail(
+    db: &DatabaseConnection,
+    operation_id: uuid::Uuid,
+    previous_override_enabled: Option<bool>,
+    requested_override_enabled: Option<bool>,
+) -> Result<(), ModuleLifecycleExecutionError> {
+    if let Err(error) = record_operation_override_state(
+        db,
+        operation_id,
+        previous_override_enabled,
+        requested_override_enabled,
+    )
+    .await
+    {
+        let message = format!("recovery-state: {error}");
+        let _ = ModuleOperationJournal::mark_failed(db, operation_id, &message).await;
+        return Err(ModuleLifecycleExecutionError::Persistence(error.to_string()));
+    }
+    Ok(())
 }
 
 fn map_idempotency_store_error(
@@ -266,16 +312,25 @@ async fn replay_lifecycle_operation(
 ) -> Result<ModuleLifecycleToggleResult, ModuleLifecycleExecutionError> {
     match operation.status {
         ModuleOperationStatus::Committed => {
-            let state = TenantModuleStateStore::read(db, request.tenant_id, &request.module_slug)
-                .await
-                .map_err(|error| ModuleLifecycleExecutionError::Persistence(error.to_string()))?
-                .ok_or_else(|| {
-                    ModuleLifecycleExecutionError::Persistence(
-                        "committed lifecycle operation has no tenant state".to_string(),
-                    )
-                })?;
+            let override_enabled = read_tenant_override_enabled(
+                db,
+                request.tenant_id,
+                &request.module_slug,
+            )
+            .await
+            .map_err(|error| ModuleLifecycleExecutionError::Persistence(error.to_string()))?;
+            let state = if override_enabled.is_some() {
+                TenantModuleStateStore::read(db, request.tenant_id, &request.module_slug)
+                    .await
+                    .map_err(|error| {
+                        ModuleLifecycleExecutionError::Persistence(error.to_string())
+                    })?
+            } else {
+                None
+            };
             Ok(ModuleLifecycleToggleResult {
                 state,
+                override_enabled,
                 operation_id: Some(operation.id),
             })
         }
@@ -364,6 +419,18 @@ mod tests {
             .await
             .expect("module operations table");
         database
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "CREATE TABLE module_operation_override_states (\
+                    operation_id TEXT PRIMARY KEY NOT NULL, \
+                    previous_override_enabled BOOLEAN, \
+                    requested_override_enabled BOOLEAN\
+                 )"
+                .to_string(),
+            ))
+            .await
+            .expect("module operation override states table");
+        database
     }
 
     #[tokio::test]
@@ -388,6 +455,8 @@ mod tests {
                 idempotency_key: None,
                 effective_enabled_modules: HashSet::new(),
                 ordering_enabled_modules: HashSet::new(),
+                previous_override_enabled: None,
+                requested_override_enabled: Some(true),
                 current_settings: serde_json::json!({}),
                 policy_transition: None,
             },

--- a/crates/rustok-modules/src/lifecycle_writer.rs
+++ b/crates/rustok-modules/src/lifecycle_writer.rs
@@ -172,10 +172,11 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         enabled: bool,
         requested_by: Option<String>,
     ) -> Result<crate::ModuleLifecycleToggleResult, ModuleLifecycleDbWriterError> {
-        self.toggle_with_operation_context(
+        self.apply_override_with_operation_context(
             tenant_id,
             module_slug,
             enabled,
+            Some(enabled),
             requested_by,
             None,
             None,
@@ -183,11 +184,12 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         .await
     }
 
-    async fn toggle_with_operation_context(
+    async fn apply_override_with_operation_context(
         &self,
         tenant_id: Uuid,
         module_slug: &str,
         enabled: bool,
+        requested_override_enabled: Option<bool>,
         requested_by: Option<String>,
         correlation_id: Option<String>,
         idempotency_key: Option<Uuid>,
@@ -196,10 +198,11 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             catalog,
             effective_enabled_modules,
             ordering_enabled_modules,
+            previous_override_enabled,
             current_settings,
             policy_transition,
         ) = self
-            .toggle_execution_context(tenant_id, module_slug, enabled)
+            .override_execution_context(tenant_id, module_slug, requested_override_enabled)
             .await?;
         let dispatcher = match (self.static_registry, self.artifact_executor) {
             (Some(registry), Some(executor)) => {
@@ -230,6 +233,8 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
                 idempotency_key,
                 effective_enabled_modules,
                 ordering_enabled_modules,
+                previous_override_enabled,
+                requested_override_enabled,
                 current_settings,
                 policy_transition,
             },
@@ -238,8 +243,9 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         .map_err(ModuleLifecycleDbWriterError::Lifecycle)
     }
 
-    /// Retries only a post-hook failure using the same owner-owned effective
-    /// policy, catalog, and dispatcher assembly as a normal lifecycle toggle.
+    /// Retries only a post-hook failure using the exact persisted tenant
+    /// override state committed by the original operation. Serving availability
+    /// may differ while Product co-requisites are staged and is not a retry gate.
     pub async fn retry_post_hook(
         &self,
         operation_id: Uuid,
@@ -249,8 +255,8 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         let plan = module_operation_recovery_plan(&self.db, operation_id)
             .await
             .map_err(ModuleLifecycleDbWriterError::Recovery)?;
-        let (catalog, effective_enabled_modules, current_settings) = self
-            .execution_context(plan.tenant_id, &plan.module_slug)
+        let (catalog, current_override_enabled, current_settings) = self
+            .recovery_execution_context(plan.tenant_id, &plan.module_slug)
             .await?;
         let dispatcher = match (self.static_registry, self.artifact_executor) {
             (Some(registry), Some(executor)) => {
@@ -271,7 +277,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
                 operation_id,
                 requested_by,
                 idempotency_key,
-                effective_enabled_modules,
+                current_override_enabled,
                 current_settings,
             },
         )
@@ -279,10 +285,10 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         .map_err(ModuleLifecycleDbWriterError::Recovery)
     }
 
-    /// Compensates a committed operation only after the recovery contract
-    /// confirms that it failed in its post-hook and remains at the requested
-    /// effective state. The resulting reverse transition is a normal owner
-    /// lifecycle operation with its own journal record.
+    /// Compensates a post-hook failure only while the exact committed tenant
+    /// override still matches the original requested intent. The reverse
+    /// transition restores the original explicit override, including removing
+    /// the row when the predecessor was inherited/default selection.
     pub async fn compensate_failed_operation(
         &self,
         operation_id: Uuid,
@@ -302,15 +308,28 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
                 ModuleOperationRecoveryError::NotRetryable(plan.issue.as_str().to_string()),
             ));
         }
-        let (_, effective_enabled_modules, _) = self
-            .execution_context(plan.tenant_id, &plan.module_slug)
+        if !plan.override_state_recorded {
+            return Err(ModuleLifecycleDbWriterError::Recovery(
+                ModuleOperationRecoveryError::NotRetryable(
+                    "selected_intent_state_unavailable".to_string(),
+                ),
+            ));
+        }
+        let (
+            _,
+            current_override_enabled,
+            effective_enabled_modules,
+            _,
+        ) = self
+            .recovery_policy_context(plan.tenant_id, &plan.module_slug)
             .await?;
-        let current_enabled = effective_enabled_modules.contains(&plan.module_slug);
+        let current_effective_enabled = effective_enabled_modules.contains(&plan.module_slug);
+        let reverse_enabled = !plan.requested_enabled;
         let replay_request = ModuleOperationRequest {
             tenant_id: plan.tenant_id,
             module_slug: plan.module_slug.clone(),
-            requested_enabled: plan.previous_effective_enabled,
-            previous_effective_enabled: current_enabled,
+            requested_enabled: reverse_enabled,
+            previous_effective_enabled: current_effective_enabled,
             requested_by: requested_by.clone(),
             correlation_id: plan.operation_id.to_string(),
             idempotency_key: Some(idempotency_key),
@@ -321,28 +340,30 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             .is_some()
         {
             return self
-                .toggle_with_operation_context(
+                .apply_override_with_operation_context(
                     plan.tenant_id,
                     &plan.module_slug,
-                    plan.previous_effective_enabled,
+                    reverse_enabled,
+                    plan.previous_override_enabled,
                     requested_by,
                     Some(plan.operation_id.to_string()),
                     Some(idempotency_key),
                 )
                 .await;
         }
-        if current_enabled != plan.requested_enabled {
+        if current_override_enabled != plan.requested_override_enabled {
             return Err(ModuleLifecycleDbWriterError::Recovery(
                 ModuleOperationRecoveryError::StateMismatch {
-                    requested_enabled: plan.requested_enabled,
-                    current_enabled,
+                    requested_override_enabled: plan.requested_override_enabled,
+                    current_override_enabled,
                 },
             ));
         }
-        self.toggle_with_operation_context(
+        self.apply_override_with_operation_context(
             plan.tenant_id,
             &plan.module_slug,
-            plan.previous_effective_enabled,
+            reverse_enabled,
+            plan.previous_override_enabled,
             requested_by,
             Some(plan.operation_id.to_string()),
             Some(idempotency_key),
@@ -709,30 +730,60 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
         inputs
     }
 
-    async fn execution_context(
+    async fn recovery_execution_context(
         &self,
         tenant_id: Uuid,
         module_slug: &str,
     ) -> Result<
-        (ModuleDefinitionCatalog, HashSet<String>, serde_json::Value),
+        (ModuleDefinitionCatalog, Option<bool>, serde_json::Value),
         ModuleLifecycleDbWriterError,
     > {
         let catalog = self.definition_catalog()?;
-        let effective_enabled_modules = self.effective_enabled_modules(tenant_id).await?;
+        let overrides = self.overrides(tenant_id).await?;
+        let current_override_enabled = override_enabled(&overrides, module_slug);
         let current_settings = self.settings(tenant_id, module_slug).await?;
-        Ok((catalog, effective_enabled_modules, current_settings))
+        Ok((catalog, current_override_enabled, current_settings))
     }
 
-    async fn toggle_execution_context(
+    async fn recovery_policy_context(
         &self,
         tenant_id: Uuid,
         module_slug: &str,
-        requested_enabled: bool,
+    ) -> Result<
+        (
+            ModuleDefinitionCatalog,
+            Option<bool>,
+            HashSet<String>,
+            serde_json::Value,
+        ),
+        ModuleLifecycleDbWriterError,
+    > {
+        let catalog = self.definition_catalog()?;
+        let overrides = self.overrides(tenant_id).await?;
+        let current_override_enabled = override_enabled(&overrides, module_slug);
+        let current_policy = self
+            .effective_policy_from_overrides(tenant_id, &catalog, overrides)
+            .await?;
+        let current_settings = self.settings(tenant_id, module_slug).await?;
+        Ok((
+            catalog,
+            current_override_enabled,
+            current_policy.into_enabled_modules(),
+            current_settings,
+        ))
+    }
+
+    async fn override_execution_context(
+        &self,
+        tenant_id: Uuid,
+        module_slug: &str,
+        requested_override_enabled: Option<bool>,
     ) -> Result<
         (
             ModuleDefinitionCatalog,
             HashSet<String>,
             HashSet<String>,
+            Option<bool>,
             serde_json::Value,
             Option<ModulePolicyRevisionTransition>,
         ),
@@ -740,6 +791,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
     > {
         let catalog = self.definition_catalog()?;
         let overrides = self.overrides(tenant_id).await?;
+        let previous_override_enabled = override_enabled(&overrides, module_slug);
         let current_policy = self
             .effective_policy_from_overrides(tenant_id, &catalog, overrides.clone())
             .await?;
@@ -747,16 +799,21 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             .ordering_policy_from_overrides(tenant_id, &catalog, overrides.clone())
             .await?;
         let mut next_overrides = overrides;
-        if let Some(override_value) = next_overrides
-            .iter_mut()
-            .find(|value| value.module_slug == module_slug)
-        {
-            override_value.enabled = requested_enabled;
-        } else {
-            next_overrides.push(TenantModuleOverride {
-                module_slug: module_slug.to_string(),
-                enabled: requested_enabled,
-            });
+        match requested_override_enabled {
+            Some(enabled) => {
+                if let Some(override_value) = next_overrides
+                    .iter_mut()
+                    .find(|value| value.module_slug == module_slug)
+                {
+                    override_value.enabled = enabled;
+                } else {
+                    next_overrides.push(TenantModuleOverride {
+                        module_slug: module_slug.to_string(),
+                        enabled,
+                    });
+                }
+            }
+            None => next_overrides.retain(|value| value.module_slug != module_slug),
         }
         let next_policy = self
             .effective_policy_from_overrides(tenant_id, &catalog, next_overrides)
@@ -781,6 +838,7 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             catalog,
             current_policy.into_enabled_modules(),
             ordering_policy.into_enabled_modules(),
+            previous_override_enabled,
             current_settings,
             policy_transition,
         ))
@@ -855,6 +913,13 @@ impl<'a> ModuleLifecycleDbWriter<'a> {
             .transpose()
             .map(|settings| settings.unwrap_or_else(|| serde_json::json!({})))
     }
+}
+
+fn override_enabled(overrides: &[TenantModuleOverride], module_slug: &str) -> Option<bool> {
+    overrides
+        .iter()
+        .find(|value| value.module_slug == module_slug)
+        .map(|value| value.enabled)
 }
 
 #[derive(Debug, Error)]

--- a/crates/rustok-modules/src/recovery.rs
+++ b/crates/rustok-modules/src/recovery.rs
@@ -1,14 +1,19 @@
-use std::collections::HashSet;
-
-use sea_orm::DatabaseConnection;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
 use thiserror::Error;
 
 use crate::{
     ModuleExecutionDispatcher, ModuleLifecycleHookPhase, ModuleOperationIssue,
     ModuleOperationJournal, ModuleOperationRecord, ModuleOperationRecordOutcome,
     ModuleOperationRecoveryAction, ModuleOperationRequest, ModuleOperationSnapshot,
-    ModuleOperationStatus,
+    ModuleOperationStatus, ModuleOperationStoreError, TenantModuleStateRecord,
+    TenantModuleStateRequest, TenantModuleStateStore,
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ModuleOperationOverrideState {
+    pub previous_enabled: Option<bool>,
+    pub requested_enabled: Option<bool>,
+}
 
 /// Transport-neutral recovery view of a failed lifecycle operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +23,9 @@ pub struct ModuleOperationRecoveryPlan {
     pub module_slug: String,
     pub requested_enabled: bool,
     pub previous_effective_enabled: bool,
+    pub override_state_recorded: bool,
+    pub previous_override_enabled: Option<bool>,
+    pub requested_override_enabled: Option<bool>,
     pub status: ModuleOperationStatus,
     pub issue: ModuleOperationIssue,
     pub retryable: bool,
@@ -28,13 +36,17 @@ pub struct ModuleOperationRecoveryPlan {
 }
 
 impl ModuleOperationRecoveryPlan {
-    fn from_snapshot(operation: ModuleOperationSnapshot) -> Self {
+    fn from_snapshot(
+        operation: ModuleOperationSnapshot,
+        override_state: Option<ModuleOperationOverrideState>,
+    ) -> Self {
         let issue = match (operation.status, operation.error_message.as_deref()) {
             (ModuleOperationStatus::Failed, Some(message)) if message.starts_with("post-hook:") => {
                 ModuleOperationIssue::PostHookFailed
             }
             (ModuleOperationStatus::Failed, Some(message))
-                if message.starts_with("state-commit:") =>
+                if message.starts_with("state-commit:")
+                    || message.starts_with("recovery-state:") =>
             {
                 ModuleOperationIssue::OtherFailed
             }
@@ -44,7 +56,8 @@ impl ModuleOperationRecoveryPlan {
             (ModuleOperationStatus::Failed, _) => ModuleOperationIssue::OtherFailed,
             _ => ModuleOperationIssue::None,
         };
-        let retryable = issue.retryable();
+        let override_state_recorded = override_state.is_some();
+        let retryable = issue.retryable() && override_state_recorded;
         let recommended_action = if retryable {
             ModuleOperationRecoveryAction::RetryPostHook
         } else if issue == ModuleOperationIssue::PreHookFailed {
@@ -58,6 +71,9 @@ impl ModuleOperationRecoveryPlan {
             module_slug: operation.module_slug,
             requested_enabled: operation.requested_enabled,
             previous_effective_enabled: operation.previous_effective_enabled,
+            override_state_recorded,
+            previous_override_enabled: override_state.and_then(|state| state.previous_enabled),
+            requested_override_enabled: override_state.and_then(|state| state.requested_enabled),
             status: operation.status,
             issue,
             retryable,
@@ -74,7 +90,9 @@ pub struct ModulePostHookRetryRequest {
     pub operation_id: uuid::Uuid,
     pub requested_by: Option<String>,
     pub idempotency_key: uuid::Uuid,
-    pub effective_enabled_modules: HashSet<String>,
+    /// Exact persisted tenant override after the original state commit.
+    /// `None` means that no explicit tenant override row exists.
+    pub current_override_enabled: Option<bool>,
     pub current_settings: serde_json::Value,
 }
 
@@ -89,11 +107,11 @@ pub enum ModuleOperationRecoveryError {
     #[error("module operation is not retryable: {0}")]
     NotRetryable(String),
     #[error(
-        "module operation state mismatch: requested enabled={requested_enabled}, current enabled={current_enabled}"
+        "module operation override state mismatch: requested={requested_override_enabled:?}, current={current_override_enabled:?}"
     )]
     StateMismatch {
-        requested_enabled: bool,
-        current_enabled: bool,
+        requested_override_enabled: Option<bool>,
+        current_override_enabled: Option<bool>,
     },
     #[error("module post-hook retry failed: {0}")]
     PostHookFailed(String),
@@ -105,11 +123,17 @@ pub async fn module_operation_recovery_plan(
     db: &DatabaseConnection,
     operation_id: uuid::Uuid,
 ) -> Result<ModuleOperationRecoveryPlan, ModuleOperationRecoveryError> {
-    ModuleOperationJournal::find(db, operation_id)
+    let operation = ModuleOperationJournal::find(db, operation_id)
         .await
         .map_err(|error| ModuleOperationRecoveryError::Persistence(error.to_string()))?
-        .map(ModuleOperationRecoveryPlan::from_snapshot)
-        .ok_or(ModuleOperationRecoveryError::OperationNotFound)
+        .ok_or(ModuleOperationRecoveryError::OperationNotFound)?;
+    let override_state = operation_override_state(db, operation_id)
+        .await
+        .map_err(|error| ModuleOperationRecoveryError::Persistence(error.to_string()))?;
+    Ok(ModuleOperationRecoveryPlan::from_snapshot(
+        operation,
+        override_state,
+    ))
 }
 
 pub async fn failed_module_operation_recovery_plans(
@@ -117,15 +141,20 @@ pub async fn failed_module_operation_recovery_plans(
     tenant_id: uuid::Uuid,
     module_slug: Option<&str>,
 ) -> Result<Vec<ModuleOperationRecoveryPlan>, ModuleOperationRecoveryError> {
-    ModuleOperationJournal::failed_for_tenant(db, tenant_id, module_slug)
+    let operations = ModuleOperationJournal::failed_for_tenant(db, tenant_id, module_slug)
         .await
-        .map_err(|error| ModuleOperationRecoveryError::Persistence(error.to_string()))
-        .map(|operations| {
-            operations
-                .into_iter()
-                .map(ModuleOperationRecoveryPlan::from_snapshot)
-                .collect()
-        })
+        .map_err(|error| ModuleOperationRecoveryError::Persistence(error.to_string()))?;
+    let mut plans = Vec::with_capacity(operations.len());
+    for operation in operations {
+        let override_state = operation_override_state(db, operation.id)
+            .await
+            .map_err(|error| ModuleOperationRecoveryError::Persistence(error.to_string()))?;
+        plans.push(ModuleOperationRecoveryPlan::from_snapshot(
+            operation,
+            override_state,
+        ));
+    }
+    Ok(plans)
 }
 
 fn retry_operation_request(
@@ -166,6 +195,11 @@ pub async fn retry_failed_post_hook_operation(
     {
         return Ok(operation);
     }
+    if !plan.override_state_recorded {
+        return Err(ModuleOperationRecoveryError::NotRetryable(
+            "selected_intent_state_unavailable".to_string(),
+        ));
+    }
     if !plan.retryable {
         return Err(ModuleOperationRecoveryError::NotRetryable(
             plan.issue.to_string(),
@@ -176,13 +210,10 @@ pub async fn retry_failed_post_hook_operation(
             "unknown_module".to_string(),
         ));
     }
-    let current_enabled = request
-        .effective_enabled_modules
-        .contains(&plan.module_slug);
-    if current_enabled != plan.requested_enabled {
+    if request.current_override_enabled != plan.requested_override_enabled {
         return Err(ModuleOperationRecoveryError::StateMismatch {
-            requested_enabled: plan.requested_enabled,
-            current_enabled,
+            requested_override_enabled: plan.requested_override_enabled,
+            current_override_enabled: request.current_override_enabled,
         });
     }
 
@@ -194,7 +225,21 @@ pub async fn retry_failed_post_hook_operation(
             }
             error => ModuleOperationRecoveryError::Persistence(error.to_string()),
         })? {
-        ModuleOperationRecordOutcome::Recorded(operation) => operation,
+        ModuleOperationRecordOutcome::Recorded(operation) => {
+            if let Err(error) = record_operation_override_state(
+                db,
+                operation.id,
+                plan.previous_override_enabled,
+                plan.requested_override_enabled,
+            )
+            .await
+            {
+                let message = format!("recovery-state: {error}");
+                let _ = ModuleOperationJournal::mark_failed(db, operation.id, &message).await;
+                return Err(ModuleOperationRecoveryError::Persistence(error.to_string()));
+            }
+            operation
+        }
         ModuleOperationRecordOutcome::Replayed(operation) => return Ok(operation),
     };
     ModuleOperationJournal::mark_running(db, operation.id)
@@ -228,6 +273,139 @@ pub async fn retry_failed_post_hook_operation(
     Ok(operation)
 }
 
+pub(crate) async fn operation_override_state<C: ConnectionTrait>(
+    db: &C,
+    operation_id: uuid::Uuid,
+) -> Result<Option<ModuleOperationOverrideState>, ModuleOperationStoreError> {
+    let backend = db.get_database_backend();
+    let sql = match backend {
+        DbBackend::Postgres => {
+            "SELECT previous_override_enabled, requested_override_enabled \
+             FROM module_operation_override_states WHERE operation_id = $1 LIMIT 1"
+        }
+        _ => {
+            "SELECT previous_override_enabled, requested_override_enabled \
+             FROM module_operation_override_states WHERE operation_id = ?1 LIMIT 1"
+        }
+    };
+    db.query_one(Statement::from_sql_and_values(
+        backend,
+        sql,
+        vec![operation_id.into()],
+    ))
+    .await
+    .map_err(store_database_error)?
+    .map(|row| {
+        Ok(ModuleOperationOverrideState {
+            previous_enabled: row
+                .try_get("", "previous_override_enabled")
+                .map_err(store_database_error)?,
+            requested_enabled: row
+                .try_get("", "requested_override_enabled")
+                .map_err(store_database_error)?,
+        })
+    })
+    .transpose()
+}
+
+pub(crate) async fn record_operation_override_state<C: ConnectionTrait>(
+    db: &C,
+    operation_id: uuid::Uuid,
+    previous_override_enabled: Option<bool>,
+    requested_override_enabled: Option<bool>,
+) -> Result<(), ModuleOperationStoreError> {
+    let backend = db.get_database_backend();
+    let sql = match backend {
+        DbBackend::Postgres => {
+            "INSERT INTO module_operation_override_states \
+             (operation_id, previous_override_enabled, requested_override_enabled) \
+             VALUES ($1, $2, $3)"
+        }
+        _ => {
+            "INSERT INTO module_operation_override_states \
+             (operation_id, previous_override_enabled, requested_override_enabled) \
+             VALUES (?1, ?2, ?3)"
+        }
+    };
+    db.execute(Statement::from_sql_and_values(
+        backend,
+        sql,
+        vec![
+            operation_id.into(),
+            previous_override_enabled.into(),
+            requested_override_enabled.into(),
+        ],
+    ))
+    .await
+    .map_err(store_database_error)?;
+    Ok(())
+}
+
+pub(crate) async fn read_tenant_override_enabled<C: ConnectionTrait>(
+    db: &C,
+    tenant_id: uuid::Uuid,
+    module_slug: &str,
+) -> Result<Option<bool>, ModuleOperationStoreError> {
+    let backend = db.get_database_backend();
+    let sql = match backend {
+        DbBackend::Postgres => {
+            "SELECT enabled FROM tenant_modules WHERE tenant_id = $1 AND module_slug = $2 LIMIT 1"
+        }
+        _ => {
+            "SELECT enabled FROM tenant_modules WHERE tenant_id = ?1 AND module_slug = ?2 LIMIT 1"
+        }
+    };
+    db.query_one(Statement::from_sql_and_values(
+        backend,
+        sql,
+        vec![tenant_id.into(), module_slug.into()],
+    ))
+    .await
+    .map_err(store_database_error)?
+    .map(|row| row.try_get("", "enabled").map_err(store_database_error))
+    .transpose()
+}
+
+pub(crate) async fn apply_tenant_override_enabled<C: ConnectionTrait>(
+    db: &C,
+    tenant_id: uuid::Uuid,
+    module_slug: &str,
+    requested_override_enabled: Option<bool>,
+) -> Result<Option<TenantModuleStateRecord>, ModuleOperationStoreError> {
+    let Some(enabled) = requested_override_enabled else {
+        let backend = db.get_database_backend();
+        let sql = match backend {
+            DbBackend::Postgres => {
+                "DELETE FROM tenant_modules WHERE tenant_id = $1 AND module_slug = $2"
+            }
+            _ => "DELETE FROM tenant_modules WHERE tenant_id = ?1 AND module_slug = ?2",
+        };
+        db.execute(Statement::from_sql_and_values(
+            backend,
+            sql,
+            vec![tenant_id.into(), module_slug.into()],
+        ))
+        .await
+        .map_err(store_database_error)?;
+        return Ok(None);
+    };
+
+    TenantModuleStateStore::persist(
+        db,
+        TenantModuleStateRequest {
+            tenant_id,
+            module_slug: module_slug.to_string(),
+            enabled,
+        },
+    )
+    .await
+    .map(Some)
+}
+
+fn store_database_error(error: impl std::fmt::Display) -> ModuleOperationStoreError {
+    ModuleOperationStoreError::Database(error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
@@ -251,19 +429,41 @@ mod tests {
         }
     }
 
+    fn override_state() -> ModuleOperationOverrideState {
+        ModuleOperationOverrideState {
+            previous_enabled: Some(false),
+            requested_enabled: Some(true),
+        }
+    }
+
     #[test]
-    fn only_post_hook_failures_are_retryable() {
-        let post_hook =
-            ModuleOperationRecoveryPlan::from_snapshot(snapshot(Some("post-hook: timeout")));
+    fn only_post_hook_failures_with_selected_state_are_retryable() {
+        let post_hook = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("post-hook: timeout")),
+            Some(override_state()),
+        );
         assert_eq!(post_hook.issue, ModuleOperationIssue::PostHookFailed);
         assert!(post_hook.retryable);
+        assert!(post_hook.override_state_recorded);
         assert_eq!(
             post_hook.recommended_action,
             ModuleOperationRecoveryAction::RetryPostHook
         );
 
-        let pre_hook =
-            ModuleOperationRecoveryPlan::from_snapshot(snapshot(Some("pre-hook: denied")));
+        let legacy_post_hook =
+            ModuleOperationRecoveryPlan::from_snapshot(snapshot(Some("post-hook: timeout")), None);
+        assert_eq!(legacy_post_hook.issue, ModuleOperationIssue::PostHookFailed);
+        assert!(!legacy_post_hook.retryable);
+        assert!(!legacy_post_hook.override_state_recorded);
+        assert_eq!(
+            legacy_post_hook.recommended_action,
+            ModuleOperationRecoveryAction::None
+        );
+
+        let pre_hook = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("pre-hook: denied")),
+            Some(override_state()),
+        );
         assert_eq!(pre_hook.issue, ModuleOperationIssue::PreHookFailed);
         assert!(!pre_hook.retryable);
         assert_eq!(
@@ -271,20 +471,35 @@ mod tests {
             ModuleOperationRecoveryAction::RepeatToggle
         );
 
-        let state_commit = ModuleOperationRecoveryPlan::from_snapshot(snapshot(Some(
-            "state-commit: module lifecycle persistence failed",
-        )));
+        let state_commit = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("state-commit: module lifecycle persistence failed")),
+            Some(override_state()),
+        );
         assert_eq!(state_commit.issue, ModuleOperationIssue::OtherFailed);
         assert!(!state_commit.retryable);
         assert_eq!(
             state_commit.recommended_action,
             ModuleOperationRecoveryAction::None
         );
+
+        let recovery_state = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("recovery-state: persistence failed")),
+            Some(override_state()),
+        );
+        assert_eq!(recovery_state.issue, ModuleOperationIssue::OtherFailed);
+        assert!(!recovery_state.retryable);
+        assert_eq!(
+            recovery_state.recommended_action,
+            ModuleOperationRecoveryAction::None
+        );
     }
 
     #[test]
-    fn retry_attempt_preserves_original_previous_state_for_compensation() {
-        let plan = ModuleOperationRecoveryPlan::from_snapshot(snapshot(Some("post-hook: timeout")));
+    fn retry_attempt_preserves_original_selected_predecessor_for_compensation() {
+        let plan = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("post-hook: timeout")),
+            Some(override_state()),
+        );
         let request =
             retry_operation_request(&plan, Some("retry-operator".to_string()), Uuid::new_v4());
 
@@ -293,10 +508,27 @@ mod tests {
             request.previous_effective_enabled,
             plan.previous_effective_enabled
         );
-        assert_ne!(
-            request.previous_effective_enabled,
-            request.requested_enabled
-        );
+        assert_eq!(plan.previous_override_enabled, Some(false));
+        assert_eq!(plan.requested_override_enabled, Some(true));
         assert_eq!(request.correlation_id, plan.operation_id.to_string());
+    }
+
+    #[test]
+    fn missing_override_state_is_distinct_from_inherited_predecessor() {
+        let legacy = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("post-hook: timeout")),
+            None,
+        );
+        let inherited = ModuleOperationRecoveryPlan::from_snapshot(
+            snapshot(Some("post-hook: timeout")),
+            Some(ModuleOperationOverrideState {
+                previous_enabled: None,
+                requested_enabled: Some(true),
+            }),
+        );
+
+        assert!(!legacy.override_state_recorded);
+        assert!(inherited.override_state_recorded);
+        assert_eq!(inherited.previous_override_enabled, None);
     }
 }

--- a/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
+++ b/crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json
@@ -1,23 +1,14 @@
 {
   "schema_version": 1,
   "generated_at": "2026-08-08",
-  "status": "product_lifecycle_owner_corequisite_policy_identity_source_complete_unvalidated",
-  "source_base_revision": "d7eb11aa73e41bd7ada51c03cb798dc332a10a2b",
+  "status": "product_lifecycle_staged_recovery_source_complete_unvalidated",
+  "source_base_revision": "457edd0861710daea39ea28652b167926b1fdd82",
   "scope": "Product create/delete transaction collaboration with Inventory and Pricing owners",
   "module_topology": {
-    "product_dependencies": [
-      "taxonomy"
-    ],
-    "product_co_requisites": [
-      "inventory",
-      "pricing"
-    ],
-    "inventory_dependencies": [
-      "product"
-    ],
-    "pricing_dependencies": [
-      "product"
-    ],
+    "product_dependencies": ["taxonomy"],
+    "product_co_requisites": ["inventory", "pricing"],
+    "inventory_dependencies": ["product"],
+    "pricing_dependencies": ["product"],
     "ordinary_reverse_dependencies_forbidden": true,
     "co_requisites_are_ordering_dependencies": false,
     "static_default_selection_enforcement_source_complete": true,
@@ -26,15 +17,13 @@
     "canonical_policy_revision_corequisite_identity_source_complete": true,
     "owner_corequisite_decision_explanation_source_complete": true,
     "lifecycle_ordering_separated_from_corequisite_availability_source_complete": true,
-    "staged_intent_recovery_semantics_source_complete": false,
+    "staged_intent_recovery_semantics_source_complete": true,
+    "inherited_override_recovery_source_complete": true,
+    "legacy_recovery_without_selected_state_fails_closed": true,
     "co_requisite_control_plane_execution_proven": false,
     "tenant_lifecycle_corequisite_execution_proven": false,
-    "reason": "The modules owner now hashes normalized Product co-requisites into canonical effective-policy revision/cache identity and explains availability separately from ordinary lifecycle ordering; staged retry/compensation predecessor semantics remain open",
-    "default_enabled_bundle": [
-      "product",
-      "pricing",
-      "inventory"
-    ],
+    "reason": "The modules owner keeps Product co-requisite availability in canonical policy identity while lifecycle recovery now persists exact tri-state tenant override predecessor/target evidence, restores inherited no-row state exactly, and rejects legacy recovery without selected-intent evidence; execution remains open",
+    "default_enabled_bundle": ["product", "pricing", "inventory"],
     "standalone_product_write_activation_proven": false
   },
   "inventory_collaboration": {
@@ -79,14 +68,16 @@
     "canonical_policy_revision_corequisite_identity_source_complete": true,
     "owner_corequisite_decision_explanation_source_complete": true,
     "lifecycle_ordering_separated_from_corequisite_availability_source_complete": true,
-    "dependency_contract_resolved": false,
-    "next_slice": "Separate persisted tenant selected-intent predecessor/current state from effective availability in post-hook retry and compensation while retaining canonical co-requisite-aware policy revision identity",
+    "staged_intent_recovery_semantics_source_complete": true,
+    "dependency_contract_resolved": true,
+    "next_slice": "Retain maintainer-run execution evidence for staged Product/Inventory/Pricing activation and teardown, co-requisite policy/cache revisions, exact post-hook retry/compensation across enabled/disabled/inherited overrides, append-only migration execution, and Product cross-owner transaction rollback",
     "do_not": [
       "add inventory or pricing to Product ordinary module dependencies",
       "move Inventory or Pricing ORM entities into Product",
       "replace atomic owner collaboration with unproven best-effort post-commit writes",
       "claim standalone Product write activation",
-      "reuse effective availability as the staged tenant-intent recovery predecessor"
+      "reuse effective availability as the staged tenant-intent recovery predecessor",
+      "infer legacy recovery predecessor state when module_operation_override_states evidence is absent"
     ]
   },
   "validation": {
@@ -101,6 +92,7 @@
     "effective_policy_guard_execution_proven": false,
     "policy_cache_identity_execution_proven": false,
     "staged_intent_recovery_execution_proven": false,
+    "migration_execution_proven": false,
     "standalone_activation_proven": false,
     "non_default_deployment_selection_proven": false,
     "transaction_rollback_proven": false

--- a/crates/rustok-product/docs/product-lifecycle-collaboration.md
+++ b/crates/rustok-product/docs/product-lifecycle-collaboration.md
@@ -1,6 +1,6 @@
 # Product lifecycle owner collaboration
 
-Status: deployment selection and canonical owner effective-policy co-requisite identity source-complete, staged lifecycle recovery semantics and execution evidence pending, unvalidated.
+Status: deployment selection, canonical owner co-requisite policy identity, and staged lifecycle recovery source-complete; execution evidence pending, unvalidated.
 
 ## Problem
 
@@ -29,7 +29,7 @@ Deployment co-requisite validation remains separate from `ManifestManager::valid
 
 ## Canonical tenant effective-policy identity
 
-The active composition still derives package co-requisites through `ManifestManager::module_policy_corequisites`, but the manifest layer is now only the trusted parser/translator. Availability semantics are owned by `rustok-modules`:
+The active composition derives package co-requisites through `ManifestManager::module_policy_corequisites`, but the manifest layer is only the trusted parser/translator. Availability semantics are owned by `rustok-modules`:
 
 - `ModuleLifecycleDbWriter::with_corequisites` accepts the normalized `consumer -> provider -> version requirement` map separately from the definition catalog's ordinary dependencies;
 - `ModuleEffectivePolicyQuery` normalizes the co-requisite input against the active catalog, rejects self-references, dependency/co-requisite overlap, unknown consumers/providers, conflicting duplicates, and malformed version requirements;
@@ -37,7 +37,7 @@ The active composition still derives package co-requisites through `ManifestMana
 - the owner fixed point applies ordinary dependencies and co-requisites as distinct constraints. A missing effective owner produces `CoRequisiteUnavailable`; a selected but incompatible owner version produces `CoRequisiteVersionMismatch`;
 - each Product decision carries `CoRequisite` facts with the admitted owner version, declared requirement, compatibility result, and final owner availability.
 
-The server no longer post-validates a returned `ModuleEffectivePolicy`. Base, channel, maintenance, node-readiness, lifecycle, recovery, and settings adapters supply the active package co-requisite map to the same modules-owner writer and consume its canonical policy result.
+The server does not post-validate a returned `ModuleEffectivePolicy`. Base, channel, maintenance, node-readiness, lifecycle, recovery, and settings adapters supply the active package co-requisite map to the same modules-owner writer and consume its canonical policy result.
 
 ## Tenant intent ordering
 
@@ -45,16 +45,33 @@ Canonical availability cannot also be the lifecycle ordering graph. Inventory an
 
 The modules owner therefore keeps two explicit signals during normal lifecycle toggles:
 
-- **effective availability** is co-requisite-aware and is used for serving decisions, cache identity, operation effective-state reporting, and current/next policy revision;
+- **effective availability** is co-requisite-aware and is used for serving decisions, cache identity, historical operation availability, and current/next policy revision;
 - **ordinary ordering selection** resolves the same tenant intent without co-requisites and is used only by `validate_module_toggle` for the existing dependency-order rules.
 
 This lets a tenant stage Product intent first, then Inventory/Pricing, while Product remains unavailable until the complete owner set satisfies the canonical co-requisite policy. Teardown remains governed by the ordinary dependency topology; co-requisites never become a second ordering graph.
 
-## Remaining staged recovery debt
+## Exact staged lifecycle recovery
 
-The legacy lifecycle recovery contract persists `previous_effective_enabled` in the operation journal and uses effective availability for retry/compensation state matching. Once tenant intent and serving availability are intentionally distinct, a staged Product row can be selected while Product is effectively unavailable. In that state, `previous_effective_enabled` is not a sufficient predecessor for restoring the exact tenant intent after a post-hook failure.
+Recovery now treats tenant selection and serving availability as separate owner facts. The exact explicit tenant override has three states:
 
-This slice therefore does **not** claim staged lifecycle recovery source-complete. The next source task is to give retry/compensation an explicit selected-intent predecessor/current-state contract while retaining the co-requisite-aware policy revision for serving and outbox identity. That change must not reintroduce a second dependency-order graph.
+- `None` — no `tenant_modules` row; selection inherits platform/default policy;
+- `Some(true)` — explicit enabled override;
+- `Some(false)` — explicit disabled override.
+
+A plain boolean predecessor is insufficient because `None` and `Some(false)` have different future behavior when defaults change. New lifecycle operations therefore persist an immutable `module_operation_override_states` side record keyed by `module_operations.id`. Its row presence proves that exact selected-intent recovery evidence was recorded; nullable predecessor/target booleans can then represent inherited state without conflating it with legacy operations.
+
+The recovery contract is fail-closed:
+
+- legacy operations without that side record report no recorded selected-intent state and cannot be retried/compensated by guessing from `previous_effective_enabled`;
+- post-hook retry proves the current explicit override still equals the operation's recorded requested override, then repeats only the post-hook. It does not require Product to be effectively available, so staged Product intent remains recoverable before Inventory/Pricing make the full set available;
+- a retry attempt copies the original selected-intent predecessor/target into its own journal recovery state, preserving later compensation semantics if the retried hook fails again;
+- compensation uses the inverse lifecycle hook/ordinary-order direction from the original command, but its persistence target is the exact recorded predecessor;
+- when that predecessor is `None`, compensation removes the explicit `tenant_modules` row instead of manufacturing `enabled=false`;
+- current/next policy revision for compensation is still computed from the exact resulting override set through the canonical co-requisite-aware owner policy, so serving/cache/outbox identity remains one source of truth.
+
+`previous_effective_enabled` remains in the journal as historical availability evidence. It is deliberately not used as the selected-intent predecessor.
+
+The recovery side table is introduced by a new append-only platform migration. Existing migration files and the published migration prefix are not rewritten.
 
 ## Current contained boundary
 
@@ -92,30 +109,32 @@ This is a native transaction collaboration contract, not a GraphQL, REST, gRPC, 
 - Product declares Inventory and Pricing as package co-requisites with bounded version requirements;
 - Inventory and Pricing continue to depend ordinarily on Product;
 - the default deployment bundle contains Product, Pricing, and Inventory;
-- the server owns a separate deployment co-requisite preflight and invokes it from startup manifest/registry validation;
-- built-in installation remains on ordinary `ManifestManager::validate` and does not invoke the co-requisite preflight;
-- the active manifest supplies package co-requisite metadata to the modules owner without copying it into ordinary dependency ordering;
+- static deployment selection rejects incomplete/incompatible co-requisite bundles without changing ordinary install/migration ordering;
 - canonical effective-policy revision input includes normalized co-requisites under the v2 contract;
 - Product decisions expose explicit co-requisite facts and unavailable/version-mismatch denial reasons;
 - lifecycle current/next revisions use the same co-requisite-aware owner query as policy reads;
 - normal lifecycle validation uses a separate ordinary ordering selection so Product/Inventory/Pricing activation remains sequentially orderable;
-- host-level duplicate effective-policy/toggle co-requisite validation is absent;
-- Product uses the exact owner bootstrap services and operations;
-- Product does not import foreign owner entities or query known foreign tables directly;
-- the owner services remain explicitly transaction-aware;
-- staged retry/compensation predecessor semantics and runtime rollback evidence remain unvalidated.
+- lifecycle operations persist exact nullable predecessor/target override state in a dedicated recovery side table;
+- side-table row presence distinguishes inherited `None` from legacy operations with unknown predecessor state;
+- post-hook retry compares exact current override state instead of effective availability and retains the original predecessor/target for the retry attempt;
+- compensation runs the inverse lifecycle direction but restores the exact recorded override predecessor, including row deletion for inherited state;
+- `previous_effective_enabled` is not used as the compensation target;
+- the recovery migration extends the append-only migration tail;
+- Product uses the exact owner bootstrap services and operations and does not take ownership of Inventory/Pricing persistence.
 
 ## Next implementation slice
 
-Separate persisted tenant selected-intent predecessor/current state from effective availability in module operation recovery. Post-hook retry and compensation must prove the exact committed tenant intent they are recovering while continuing to publish the canonical co-requisite-aware policy revision. Do not change ordinary dependency ordering or turn co-requisites into toggle dependencies.
+The Product dependency/collaboration contract is source-resolved. The remaining gate is maintainer-run execution and retained evidence, not another ownership/topology redesign.
 
-After that recovery source gap closes, retain maintainer-run evidence for:
+Retain execution evidence for:
 
 - default and non-default tenant module selections;
 - co-requisite-aware policy/cache revision changes;
 - staged Product -> Inventory -> Pricing activation and reverse teardown;
-- post-hook retry/compensation across staged intent;
-- clean migration ordering;
+- post-hook retry while Product intent is selected but Product availability is still false;
+- compensation restoring explicit true, explicit false, and inherited/no-row predecessors;
+- fail-closed behavior for a legacy operation without selected-intent recovery state;
+- clean append-only migration ordering;
 - Product create/delete rollback across all three owners;
 - no silent post-commit partial state;
 - no ordinary cyclic dependency;
@@ -129,4 +148,4 @@ Source evidence is stored at:
 
 `crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json`
 
-No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, policy-cache execution, staged recovery, or transaction rollback execution evidence are claimed by this source wave.
+No tests, Cargo commands, formatting, verifier execution, workflow checks, tenant activation, non-default selection, policy-cache execution, staged recovery execution, migration execution, or transaction rollback execution evidence are claimed by this source wave.

--- a/scripts/verify/verify-product-lifecycle-collaboration.mjs
+++ b/scripts/verify/verify-product-lifecycle-collaboration.mjs
@@ -28,6 +28,11 @@ const ownerPolicy = read('crates/rustok-modules/src/policy.rs');
 const lifecycleWriter = read('crates/rustok-modules/src/lifecycle_writer.rs');
 const lifecycleExecutor = read('crates/rustok-modules/src/executor.rs');
 const recovery = read('crates/rustok-modules/src/recovery.rs');
+const recoveryMigration = read(
+  'crates/rustok-migrations/src/m20260808_000099_create_module_operation_override_states.rs',
+);
+const platformMigrator = read('crates/rustok-migrations/src/lib.rs');
+const runbook = read('apps/server/docs/module-lifecycle-retry-compensation-runbook.md');
 const note = read('crates/rustok-product/docs/product-lifecycle-collaboration.md');
 const evidence = JSON.parse(
   read('crates/rustok-product/contracts/evidence/product-lifecycle-collaboration-source.json'),
@@ -93,11 +98,11 @@ const registryValidationBlock = between(
 const startupValidationBlock = manifestManager.slice(
   manifestManager.indexOf('pub fn validate_registry_vs_manifest'),
 );
-const lifecycleToggleBlock = between(
-  tenantLifecycle,
-  'pub async fn toggle_module_with_actor(',
-  '\n    pub async fn module_operation_recovery_plan(',
-  'tenant lifecycle toggle block',
+const compensationBlock = between(
+  lifecycleWriter,
+  'pub async fn compensate_failed_operation(',
+  '\n    /// Persists a static module settings value',
+  'owner compensation block',
 );
 
 for (const [source, value, label] of [
@@ -123,51 +128,62 @@ for (const [source, value, label] of [
   [commands, 'BootstrapService::delete_records_for_variants_in_tx(&txn, &variant_ids)', 'inventory cleanup collaboration'],
   [commands, 'PricingBootstrapService::delete_prices_for_variants_in_tx(&txn, &variant_ids)', 'price cleanup collaboration'],
   [inventoryBootstrap, 'Owner-owned, transaction-aware inventory bootstrap operations.', 'Inventory owner contract'],
-  [inventoryBootstrap, 'C: ConnectionTrait', 'Inventory transaction connection'],
   [pricingBootstrap, 'Pricing-owned transaction-aware operations required by Product lifecycle writes.', 'Pricing owner contract'],
-  [pricingBootstrap, 'C: ConnectionTrait', 'Pricing transaction connection'],
 
-  [manifestCorequisites, 'co_requisites: BTreeMap<String, PackageCoRequisiteSpec>', 'typed package co-requisite parser'],
   [manifestCorequisites, 'pub(crate) fn module_policy_corequisites', 'owner co-requisite input entrypoint'],
   [manifestCorequisites, 'pub(super) fn validate_default_corequisite_selection', 'deployment selection preflight'],
   [manifestCorequisites, 'module.ordinary_dependencies.contains(co_requisite)', 'dependency/co-requisite separation'],
-  [manifestCorequisites, '!selected.contains(co_requisite)', 'missing selected co-requisite rejection'],
-  [manifestCorequisites, 'VersionReq::parse(requirement)', 'deployment co-requisite version validation'],
-  [manifestCorequisites, 'requirement.matches(&installed_version)', 'deployment selected version validation'],
   [manifestManager, 'pub fn validate_deployment_selection(', 'manifest deployment selection API'],
   [startupValidationBlock, '.and_then(|_| ManifestManager::validate_deployment_selection(&manifest))', 'startup co-requisite preflight'],
   [registryValidationBlock, 'dependencies: resolved_spec.depends_on.iter().cloned().collect()', 'ordinary registry dependency source'],
   [installBuiltinBlock, 'Self::validate(manifest)?;', 'ordinary install validation'],
 
   [ownerPolicy, 'pub struct ModuleEffectivePolicyCoRequisite', 'owner co-requisite input'],
-  [ownerPolicy, 'CoRequisite {', 'owner co-requisite decision fact'],
   [ownerPolicy, 'CoRequisiteUnavailable { module_slug: String }', 'owner unavailable denial'],
   [ownerPolicy, 'CoRequisiteVersionMismatch { module_slug: String }', 'owner version denial'],
-  [ownerPolicy, 'co_requisites: Vec<ModuleEffectivePolicyCoRequisite>', 'owner query co-requisite state'],
-  [ownerPolicy, 'co_requisites: &\'a [ModuleEffectivePolicyCoRequisite]', 'revisioned co-requisite input'],
   [ownerPolicy, 'contract: "rustok.module_effective_policy.v2"', 'effective policy v2 identity'],
   [ownerPolicy, 'normalize_corequisites(self.catalog, self.co_requisites)', 'owner co-requisite normalization'],
-  [ownerPolicy, 'corequisite_version_compatible(self.catalog, co_requisite)', 'owner version decision'],
-  [ownerPolicy, 'corequisites_are_revisioned_explainable_availability_not_dependency_edges', 'owner policy source test'],
-
-  [lifecycleWriter, 'pub fn with_corequisites(', 'lifecycle writer co-requisite input'],
-  [lifecycleWriter, '.with_corequisites(self.co_requisites.iter().cloned())', 'canonical lifecycle policy co-requisites'],
   [lifecycleWriter, 'ordering_policy_from_overrides', 'ordinary ordering projection'],
-  [lifecycleWriter, 'ordering_policy.into_enabled_modules()', 'ordinary ordering selection output'],
-  [lifecycleExecutor, 'pub ordering_enabled_modules: HashSet<String>', 'lifecycle ordering input'],
   [lifecycleExecutor, '&request.ordering_enabled_modules', 'ordinary toggle validation input'],
-  [recovery, 'previous_effective_enabled', 'legacy recovery predecessor debt'],
-
-  [lifecycleToggleBlock, 'ManifestManager::module_policy_corequisites(&manifest)', 'lifecycle package contract load'],
-  [lifecycleToggleBlock, '.with_corequisites(co_requisites)', 'lifecycle owner policy binding'],
-  [effectivePolicy, 'ManifestManager::module_policy_corequisites(&manifest)', 'effective-policy package contract load'],
   [effectivePolicy, '.with_corequisites(co_requisites)', 'effective-policy owner binding'],
   [effectivePolicy, '.cache_identity(tenant_id)', 'canonical cache identity'],
 
-  [note, 'canonical owner effective-policy co-requisite identity source-complete', 'focused note status'],
-  [note, 'rustok.module_effective_policy.v2', 'focused note revision identity'],
-  [note, '**ordinary ordering selection**', 'focused note ordering split'],
-  [note, 'previous_effective_enabled', 'focused note staged recovery debt'],
+  [recovery, 'pub override_state_recorded: bool', 'recorded selected-intent marker'],
+  [recovery, 'pub previous_override_enabled: Option<bool>', 'nullable override predecessor'],
+  [recovery, 'pub requested_override_enabled: Option<bool>', 'nullable override target'],
+  [recovery, 'FROM module_operation_override_states', 'selected-intent recovery read'],
+  [recovery, 'INSERT INTO module_operation_override_states', 'selected-intent recovery write'],
+  [recovery, 'selected_intent_state_unavailable', 'legacy recovery fail-closed reason'],
+  [recovery, 'request.current_override_enabled != plan.requested_override_enabled', 'retry exact override state match'],
+  [recovery, 'plan.previous_override_enabled,\n                plan.requested_override_enabled', 'retry predecessor retention'],
+  [recovery, 'DELETE FROM tenant_modules', 'inherited override restoration'],
+  [lifecycleExecutor, 'pub previous_override_enabled: Option<bool>', 'executor exact override predecessor'],
+  [lifecycleExecutor, 'pub requested_override_enabled: Option<bool>', 'executor exact override target'],
+  [lifecycleExecutor, 'record_operation_override_state(', 'executor recovery-state retention'],
+  [lifecycleExecutor, 'apply_tenant_override_enabled(', 'executor tri-state persistence'],
+  [lifecycleWriter, 'Some(enabled),', 'normal toggle explicit override target'],
+  [lifecycleWriter, 'None => next_overrides.retain(|value| value.module_slug != module_slug)', 'policy inherited override projection'],
+  [compensationBlock, 'let reverse_enabled = !plan.requested_enabled;', 'inverse compensation lifecycle direction'],
+  [compensationBlock, 'plan.previous_override_enabled', 'exact compensation target'],
+  [compensationBlock, 'current_override_enabled != plan.requested_override_enabled', 'compensation exact current-state match'],
+  [tenantLifecycle, 'explicit module toggle did not persist a tenant override row', 'normal explicit-row server assertion'],
+  [tenantLifecycle, '(state.enabled, state.settings)', 'explicit compensation response state'],
+  [tenantLifecycle, 'None => (policy.contains(&plan.module_slug), serde_json::json!({}))', 'inherited compensation availability fallback'],
+
+  [recoveryMigration, 'module_operation_override_states', 'recovery side-table migration'],
+  [recoveryMigration, 'PreviousOverrideEnabled', 'nullable predecessor migration column'],
+  [recoveryMigration, 'RequestedOverrideEnabled', 'nullable target migration column'],
+  [recoveryMigration, 'ForeignKeyAction::Cascade', 'recovery side-table operation ownership'],
+  [platformMigrator, 'mod m20260808_000099_create_module_operation_override_states;', 'migration module registration'],
+  [platformMigrator, '"m20260808_000099_create_module_operation_override_states",', 'append-only migration tail registration'],
+  [platformMigrator, 'Box::new(m20260808_000099_create_module_operation_override_states::Migration)', 'migration execution registration'],
+
+  [runbook, '`inherit`', 'operational inherited-state contract'],
+  [runbook, 'selected_intent_state_unavailable', 'operational legacy fail-closed contract'],
+  [runbook, 'Do **not** use `previous_effective_enabled` as the compensation target.', 'operational availability/predecessor separation'],
+  [note, 'staged lifecycle recovery source-complete', 'focused note status'],
+  [note, '`module_operation_override_states`', 'focused recovery evidence'],
+  [note, '`previous_effective_enabled` remains in the journal as historical availability evidence', 'focused legacy fact role'],
 ]) requireText(source, value, label);
 
 for (const [source, value, label] of [
@@ -183,8 +199,8 @@ for (const [source, value, label] of [
   [manifestCorequisites, 'validate_corequisite_toggle', 'duplicate host lifecycle guard'],
   [tenantLifecycle, 'validate_corequisite_toggle', 'server lifecycle duplicate guard'],
   [effectivePolicy, 'validate_effective_policy_corequisites', 'server effective-policy duplicate guard'],
+  [compensationBlock, 'plan.previous_effective_enabled,', 'effective availability reused as compensation target'],
   [catalog, 'rustok_commerce_foundation::entities', 'foreign foundation entity import'],
-  [commands, 'rustok_commerce_foundation::entities', 'foreign foundation entity import in commands'],
   [commands, 'inventory_item::Entity', 'direct Inventory entity access'],
   [commands, 'inventory_level::Entity', 'direct Inventory level access'],
   [commands, 'stock_location::Entity', 'direct stock location access'],
@@ -196,7 +212,7 @@ for (const [source, value, label] of [
   [commands, 'INTO prices', 'direct Pricing SQL write'],
 ]) forbidText(source, value, label);
 
-if (evidence.status !== 'product_lifecycle_owner_corequisite_policy_identity_source_complete_unvalidated') {
+if (evidence.status !== 'product_lifecycle_staged_recovery_source_complete_unvalidated') {
   failures.push(`evidence status mismatch: ${evidence.status}`);
 }
 const coRequisites = [...(evidence.module_topology?.product_co_requisites ?? [])].sort();
@@ -212,7 +228,9 @@ for (const [key, expected] of [
   ['canonical_policy_revision_corequisite_identity_source_complete', true],
   ['owner_corequisite_decision_explanation_source_complete', true],
   ['lifecycle_ordering_separated_from_corequisite_availability_source_complete', true],
-  ['staged_intent_recovery_semantics_source_complete', false],
+  ['staged_intent_recovery_semantics_source_complete', true],
+  ['inherited_override_recovery_source_complete', true],
+  ['legacy_recovery_without_selected_state_fails_closed', true],
   ['co_requisite_control_plane_execution_proven', false],
   ['tenant_lifecycle_corequisite_execution_proven', false],
   ['standalone_product_write_activation_proven', false],
@@ -233,13 +251,14 @@ for (const key of [
   'canonical_policy_revision_corequisite_identity_source_complete',
   'owner_corequisite_decision_explanation_source_complete',
   'lifecycle_ordering_separated_from_corequisite_availability_source_complete',
+  'staged_intent_recovery_semantics_source_complete',
 ]) {
   if (evidence.decision?.[key] !== true) failures.push(`evidence decision.${key} must be true`);
 }
 if (evidence.decision?.containment_complete !== true ||
     evidence.decision?.corequisite_contract_declared !== true ||
-    evidence.decision?.dependency_contract_resolved !== false) {
-  failures.push('evidence decision must close owner policy identity while keeping staged recovery open');
+    evidence.decision?.dependency_contract_resolved !== true) {
+  failures.push('evidence decision must mark the Product dependency/collaboration source contract resolved');
 }
 for (const key of [
   'tests_run',
@@ -253,6 +272,7 @@ for (const key of [
   'effective_policy_guard_execution_proven',
   'policy_cache_identity_execution_proven',
   'staged_intent_recovery_execution_proven',
+  'migration_execution_proven',
   'standalone_activation_proven',
   'non_default_deployment_selection_proven',
   'transaction_rollback_proven',
@@ -269,5 +289,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Product co-requisites are canonical owner effective-policy identity/explanation inputs and remain separate from ordinary lifecycle ordering; staged recovery and execution evidence remain open',
+  '✔ Product co-requisite policy identity, ordinary ordering separation, and exact staged tenant-intent recovery are source-locked; maintainer execution evidence remains open',
 );


### PR DESCRIPTION
## Summary
- separate exact tenant selected intent from effective availability in module lifecycle recovery
- persist immutable tri-state (`inherit` / explicit enabled / explicit disabled) predecessor and target evidence in `module_operation_override_states`
- keep `previous_effective_enabled` only as historical availability evidence, never as the compensation predecessor
- make post-hook retry prove the current explicit override matches the recorded requested override, so staged Product intent remains retryable even while co-requisite-aware serving availability is false
- copy the original selected-intent predecessor/target onto retry attempts so a failed retry remains safely compensatable
- make compensation run the inverse ordinary lifecycle direction while restoring the exact recorded predecessor, including deleting the tenant override row for inherited/default state
- fail closed for legacy operations without selected-intent recovery evidence instead of guessing from effective availability
- preserve canonical co-requisite-aware current/next policy revision and transition outbox identity
- append the recovery side-table migration to the immutable platform migration tail without rewriting the published prefix
- actualize Product lifecycle docs, evidence, runbook, and source verifier

## Source invariants
Product continues to depend ordinarily only on Taxonomy. Inventory and Pricing continue to depend ordinarily on Product. Product co-requisites remain availability constraints and do not become dependency, migration, or toggle-order edges.

Normal lifecycle no-op semantics remain effective-policy based: writing an explicit override that does not change effective state or policy revision does not manufacture lifecycle hooks/operations solely because the row representation changed.

## Validation status
Source and GitHub diff inspection only. Tests, Cargo commands, formatting, source verifier execution, workflow checks, CI, migration execution, tenant activation, retry/compensation execution, and runtime rollback validation were intentionally not run per maintainer instruction.

## Remaining gate
The Product dependency/collaboration contract is source-resolved. Maintainer-run retained execution evidence remains open for staged Product/Inventory/Pricing activation/teardown, co-requisite policy/cache revisions, exact retry/compensation across explicit and inherited overrides, append-only migration execution, and Product cross-owner transaction rollback.