### PR TITLE
feat(forum): reconcile persisted subscriptions

### DIFF
--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -17,6 +17,7 @@ mod runtime_data;
 mod storefront_audience_topic;
 mod storefront_audience_topics;
 mod storefront_read_state;
+mod subscription_reconciliation_query;
 mod topic_fork_mutation;
 mod topic_merge_mutation;
 mod topic_reply_range_move_mutation;
@@ -57,6 +58,10 @@ pub use reconciliation_query::{
 };
 pub use runtime_data::{ForumGraphqlRuntimeData, attach_schema_data};
 pub use storefront_read_state::*;
+pub use subscription_reconciliation_query::{
+    GqlForumSubscriptionCursor, GqlForumSubscriptionDrift,
+    GqlForumSubscriptionReconciliationReport,
+};
 pub use topic_fork_mutation::{
     ForkForumTopicReplyBranchGraphqlInput, GqlForumTopicFork,
 };
@@ -85,6 +90,7 @@ pub struct ForumQuery(
     category_route_query::ForumCategoryRouteQuery,
     read_state::ForumReadStateQuery,
     reconciliation_query::ForumReconciliationQuery,
+    subscription_reconciliation_query::ForumSubscriptionReconciliationQuery,
     reply_audience_query::ForumReplyAudienceQuery,
     storefront_read_state::ForumStorefrontReadStateQuery,
     storefront_audience_topic::ForumStorefrontAudienceTopicQuery,

--- a/crates/rustok-forum/src/graphql/subscription_reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/subscription_reconciliation_query.rs
@@ -176,7 +176,6 @@ fn saturating_i32(value: u64) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::subscription::reconciliation::ForumSubscriptionCursor;
     use rustok_api::{Action, Resource};
 
     fn auth(permissions: Vec<Permission>) -> AuthContext {

--- a/crates/rustok-forum/src/graphql/subscription_reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/subscription_reconciliation_query.rs
@@ -1,0 +1,234 @@
+use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use rustok_core::SecurityContext;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::services::subscription::reconciliation::{
+    ForumSubscriptionCursor, ForumSubscriptionDrift, ForumSubscriptionReconciliationReport,
+    ForumSubscriptionReconciliationService,
+};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumSubscriptionCursor {
+    pub target_id: Uuid,
+    pub user_id: Uuid,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumSubscriptionDrift {
+    pub kind: String,
+    pub target_kind: String,
+    pub target_id: Uuid,
+    pub user_id: Uuid,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumSubscriptionReconciliationReport {
+    pub requested_limit: Option<i32>,
+    pub effective_limit: i32,
+    pub inspected_topic_subscriptions: i32,
+    pub inspected_category_subscriptions: i32,
+    pub has_more_topic_subscriptions: bool,
+    pub has_more_category_subscriptions: bool,
+    pub topic_cursor: Option<GqlForumSubscriptionCursor>,
+    pub category_cursor: Option<GqlForumSubscriptionCursor>,
+    pub drift_count: i32,
+    /// True only when the current bounded topic/category subscription page has no detected drift.
+    /// Whole-tenant clean requires exhausting both composite cursor chains with every page clean.
+    pub clean: bool,
+    pub drifts: Vec<GqlForumSubscriptionDrift>,
+}
+
+#[derive(Default)]
+pub struct ForumSubscriptionReconciliationQuery;
+
+#[Object]
+impl ForumSubscriptionReconciliationQuery {
+    /// Read-only FORUM-33 subscription-owner drift report for the current tenant.
+    ///
+    /// Topic and category rows use independent composite `(target_id, user_id)` keyset cursors.
+    /// Callers must echo both components of a returned cursor together on the next page. The report
+    /// does not infer missing subscriptions from participation policy and does not perform repair.
+    #[allow(clippy::too_many_arguments)]
+    async fn forum_subscription_reconciliation_report(
+        &self,
+        ctx: &Context<'_>,
+        limit: Option<i32>,
+        topic_after: Option<Uuid>,
+        topic_user_after: Option<Uuid>,
+        category_after: Option<Uuid>,
+        category_user_after: Option<Uuid>,
+    ) -> Result<GqlForumSubscriptionReconciliationReport> {
+        let (tenant_id, security, requested_limit, db) =
+            reconciliation_context(ctx, limit).await?;
+        let report = ForumSubscriptionReconciliationService::new(db)
+            .report_page(
+                tenant_id,
+                &security,
+                requested_limit,
+                topic_after,
+                topic_user_after,
+                category_after,
+                category_user_after,
+            )
+            .await?;
+        Ok(map_report(report))
+    }
+}
+
+async fn reconciliation_context(
+    ctx: &Context<'_>,
+    limit: Option<i32>,
+) -> Result<(Uuid, SecurityContext, Option<u64>, DatabaseConnection)> {
+    require_module_enabled(ctx, MODULE_SLUG).await?;
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    require_operations_permissions(auth)?;
+    let tenant = ctx.data::<TenantContext>()?;
+    if auth.tenant_id != tenant.id {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: tenant scope mismatch",
+        ));
+    }
+    let requested_limit = normalize_limit(limit)?;
+    let db = ctx.data::<DatabaseConnection>()?.clone();
+    let security =
+        SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
+    Ok((tenant.id, security, requested_limit, db))
+}
+
+fn require_operations_permissions(auth: &AuthContext) -> Result<()> {
+    let categories_manage = has_any_effective_permission(
+        &auth.permissions,
+        &[Permission::FORUM_CATEGORIES_MANAGE],
+    );
+    let topics_manage =
+        has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_MANAGE]);
+    if categories_manage && topics_manage {
+        Ok(())
+    } else {
+        Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_categories:manage and forum_topics:manage required",
+        ))
+    }
+}
+
+fn normalize_limit(limit: Option<i32>) -> Result<Option<u64>> {
+    match limit {
+        None => Ok(None),
+        Some(value) if value > 0 => Ok(Some(value as u64)),
+        Some(_) => Err(async_graphql::Error::new(
+            "Forum reconciliation limit must be positive",
+        )),
+    }
+}
+
+fn map_report(
+    report: ForumSubscriptionReconciliationReport,
+) -> GqlForumSubscriptionReconciliationReport {
+    GqlForumSubscriptionReconciliationReport {
+        requested_limit: report.requested_limit.map(saturating_i32),
+        effective_limit: saturating_i32(report.effective_limit),
+        inspected_topic_subscriptions: saturating_i32(report.inspected_topic_subscriptions),
+        inspected_category_subscriptions: saturating_i32(report.inspected_category_subscriptions),
+        has_more_topic_subscriptions: report.has_more_topic_subscriptions,
+        has_more_category_subscriptions: report.has_more_category_subscriptions,
+        topic_cursor: report.topic_cursor.map(map_cursor),
+        category_cursor: report.category_cursor.map(map_cursor),
+        drift_count: saturating_i32(report.drift_count() as u64),
+        clean: report.is_clean(),
+        drifts: report.drifts.into_iter().map(map_drift).collect(),
+    }
+}
+
+fn map_cursor(cursor: ForumSubscriptionCursor) -> GqlForumSubscriptionCursor {
+    GqlForumSubscriptionCursor {
+        target_id: cursor.target_id,
+        user_id: cursor.user_id,
+    }
+}
+
+fn map_drift(drift: ForumSubscriptionDrift) -> GqlForumSubscriptionDrift {
+    GqlForumSubscriptionDrift {
+        kind: drift.kind.as_str().to_string(),
+        target_kind: drift.target_kind.as_str().to_string(),
+        target_id: drift.target_id,
+        user_id: drift.user_id,
+        stored: drift.stored,
+        expected: drift.expected,
+    }
+}
+
+fn saturating_i32(value: u64) -> i32 {
+    value.min(i32::MAX as u64) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::subscription::reconciliation::ForumSubscriptionCursor;
+    use rustok_api::{Action, Resource};
+
+    fn auth(permissions: Vec<Permission>) -> AuthContext {
+        let tenant_id = Uuid::new_v4();
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    #[test]
+    fn subscription_report_requires_both_effective_manage_permissions() {
+        let both = auth(vec![
+            Permission::new(Resource::ForumCategories, Action::Manage),
+            Permission::new(Resource::ForumTopics, Action::Manage),
+        ]);
+        assert!(require_operations_permissions(&both).is_ok());
+
+        let topics_only = auth(vec![Permission::new(Resource::ForumTopics, Action::Manage)]);
+        assert!(require_operations_permissions(&topics_only).is_err());
+    }
+
+    #[test]
+    fn mapped_subscription_report_preserves_composite_cursors() {
+        let topic_cursor = ForumSubscriptionCursor {
+            target_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let category_cursor = ForumSubscriptionCursor {
+            target_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let mapped = map_report(ForumSubscriptionReconciliationReport {
+            requested_limit: Some(25),
+            effective_limit: 25,
+            inspected_topic_subscriptions: 25,
+            inspected_category_subscriptions: 4,
+            has_more_topic_subscriptions: true,
+            has_more_category_subscriptions: false,
+            topic_cursor: Some(topic_cursor),
+            category_cursor: Some(category_cursor),
+            drifts: Vec::new(),
+        });
+        assert_eq!(mapped.topic_cursor.unwrap().target_id, topic_cursor.target_id);
+        assert_eq!(
+            mapped.category_cursor.unwrap().user_id,
+            category_cursor.user_id
+        );
+    }
+}

--- a/crates/rustok-forum/src/services/subscription.rs
+++ b/crates/rustok-forum/src/services/subscription.rs
@@ -1,6 +1,7 @@
 mod category;
 mod helpers;
 mod policy;
+pub mod reconciliation;
 mod topic;
 
 use sea_orm::DatabaseConnection;

--- a/crates/rustok-forum/src/services/subscription/reconciliation.rs
+++ b/crates/rustok-forum/src/services/subscription/reconciliation.rs
@@ -1,0 +1,633 @@
+use std::time::Instant;
+
+use rustok_api::{Action, Resource};
+use rustok_core::SecurityContext;
+use sea_orm::{
+    AccessMode, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction,
+    IsolationLevel, Statement, TransactionTrait,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{ForumError, ForumResult};
+use crate::services::rbac::enforce_scope;
+use crate::services::{
+    DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
+};
+
+const FORUM_SUBSCRIPTION_RECONCILIATION_OPERATION: &str =
+    "forum.subscription_reconciliation_report";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumSubscriptionTargetKind {
+    Topic,
+    Category,
+}
+
+impl ForumSubscriptionTargetKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Topic => "topic",
+            Self::Category => "category",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumSubscriptionDriftKind {
+    TargetMissing,
+    MergedTopicSourceSubscription,
+    MutedPreferencesInvalid,
+    RevisionInvalid,
+}
+
+impl ForumSubscriptionDriftKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TargetMissing => "target_missing",
+            Self::MergedTopicSourceSubscription => "merged_topic_source_subscription",
+            Self::MutedPreferencesInvalid => "muted_preferences_invalid",
+            Self::RevisionInvalid => "revision_invalid",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumSubscriptionCursor {
+    pub target_id: Uuid,
+    pub user_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumSubscriptionDrift {
+    pub kind: ForumSubscriptionDriftKind,
+    pub target_kind: ForumSubscriptionTargetKind,
+    pub target_id: Uuid,
+    pub user_id: Uuid,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumSubscriptionReconciliationReport {
+    pub requested_limit: Option<u64>,
+    pub effective_limit: u64,
+    pub inspected_topic_subscriptions: u64,
+    pub inspected_category_subscriptions: u64,
+    pub has_more_topic_subscriptions: bool,
+    pub has_more_category_subscriptions: bool,
+    pub topic_cursor: Option<ForumSubscriptionCursor>,
+    pub category_cursor: Option<ForumSubscriptionCursor>,
+    pub drifts: Vec<ForumSubscriptionDrift>,
+}
+
+impl ForumSubscriptionReconciliationReport {
+    pub fn drift_count(&self) -> usize {
+        self.drifts.len()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.drifts.is_empty()
+    }
+}
+
+/// Read-only FORUM-33 reconciliation for persisted Forum subscription owner rows.
+///
+/// Topic and category subscriptions are independent shapes and use composite `(target_id, user_id)`
+/// keyset cursors because neither table has a single row UUID. The report checks only invariants
+/// already owned by Forum: target referential integrity, the schema-enforced muted preference shape,
+/// positive optimistic revisions, and source-topic rows that remain after an immutable topic merge.
+/// It deliberately does not infer missing subscriptions from participation policy and does not read
+/// Profiles/Notifications-owned user or delivery state.
+///
+/// Every page is read-only and snapshot-consistent. PostgreSQL uses `REPEATABLE READ READ ONLY`;
+/// SQLite uses one transaction whose first read establishes the page snapshot. Multi-page scans are
+/// page-local diagnostics, not a serializable repair fence.
+pub struct ForumSubscriptionReconciliationService {
+    db: DatabaseConnection,
+}
+
+impl ForumSubscriptionReconciliationService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn report_page(
+        &self,
+        tenant_id: Uuid,
+        security: &SecurityContext,
+        requested_limit: Option<u64>,
+        topic_after_target: Option<Uuid>,
+        topic_after_user: Option<Uuid>,
+        category_after_target: Option<Uuid>,
+        category_after_user: Option<Uuid>,
+    ) -> ForumResult<ForumSubscriptionReconciliationReport> {
+        rustok_telemetry::metrics::record_module_entrypoint_call(
+            "forum",
+            "subscription_reconciliation_report",
+            "library",
+        );
+        let started_at = Instant::now();
+        let result = match enforce_operations_scope(security) {
+            Ok(()) => {
+                self.report_inner(
+                    tenant_id,
+                    requested_limit,
+                    topic_after_target,
+                    topic_after_user,
+                    category_after_target,
+                    category_after_user,
+                )
+                .await
+            }
+            Err(error) => Err(error),
+        };
+        rustok_telemetry::metrics::record_span_duration(
+            FORUM_SUBSCRIPTION_RECONCILIATION_OPERATION,
+            started_at.elapsed().as_secs_f64(),
+        );
+        if result.is_err() {
+            rustok_telemetry::metrics::record_span_error(
+                FORUM_SUBSCRIPTION_RECONCILIATION_OPERATION,
+                "owner_report",
+            );
+            rustok_telemetry::metrics::record_module_error(
+                "forum",
+                "subscription_reconciliation",
+                "error",
+            );
+        }
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn report_inner(
+        &self,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+        topic_after_target: Option<Uuid>,
+        topic_after_user: Option<Uuid>,
+        category_after_target: Option<Uuid>,
+        category_after_user: Option<Uuid>,
+    ) -> ForumResult<ForumSubscriptionReconciliationReport> {
+        let topic_after = subscription_cursor(
+            topic_after_target,
+            topic_after_user,
+            "topic subscription",
+        )?;
+        let category_after = subscription_cursor(
+            category_after_target,
+            category_after_user,
+            "category subscription",
+        )?;
+
+        let backend = self.db.get_database_backend();
+        let transaction = match backend {
+            DatabaseBackend::Postgres => {
+                self.db
+                    .begin_with_config(
+                        Some(IsolationLevel::RepeatableRead),
+                        Some(AccessMode::ReadOnly),
+                    )
+                    .await?
+            }
+            DatabaseBackend::Sqlite => self.db.begin().await?,
+            other => {
+                return Err(ForumError::Validation(format!(
+                    "Forum subscription reconciliation does not support database backend {other:?}"
+                )));
+            }
+        };
+
+        let report = self
+            .report_in_transaction(
+                &transaction,
+                backend,
+                tenant_id,
+                requested_limit,
+                topic_after,
+                category_after,
+            )
+            .await;
+        match report {
+            Ok(report) => {
+                transaction.commit().await?;
+                Ok(report)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn report_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        backend: DatabaseBackend,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+        topic_after: Option<ForumSubscriptionCursor>,
+        category_after: Option<ForumSubscriptionCursor>,
+    ) -> ForumResult<ForumSubscriptionReconciliationReport> {
+        let effective_limit = requested_limit
+            .unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT)
+            .clamp(1, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT);
+        let fetch_limit = effective_limit.saturating_add(1);
+
+        let topic_rows = transaction
+            .query_all(subscription_statement(
+                backend,
+                TOPIC_SUBSCRIPTIONS_SQLITE,
+                TOPIC_SUBSCRIPTIONS_AFTER_SQLITE,
+                TOPIC_SUBSCRIPTIONS_POSTGRES,
+                TOPIC_SUBSCRIPTIONS_AFTER_POSTGRES,
+                tenant_id,
+                topic_after,
+                fetch_limit,
+            )?)
+            .await?;
+        let category_rows = transaction
+            .query_all(subscription_statement(
+                backend,
+                CATEGORY_SUBSCRIPTIONS_SQLITE,
+                CATEGORY_SUBSCRIPTIONS_AFTER_SQLITE,
+                CATEGORY_SUBSCRIPTIONS_POSTGRES,
+                CATEGORY_SUBSCRIPTIONS_AFTER_POSTGRES,
+                tenant_id,
+                category_after,
+                fetch_limit,
+            )?)
+            .await?;
+
+        let has_more_topic_subscriptions = topic_rows.len() > effective_limit as usize;
+        let has_more_category_subscriptions = category_rows.len() > effective_limit as usize;
+        let mut topic_cursor = topic_after;
+        let mut category_cursor = category_after;
+        let mut drifts = Vec::new();
+
+        for row in topic_rows.iter().take(effective_limit as usize) {
+            let target_id: Uuid = row.try_get("", "target_id")?;
+            let user_id: Uuid = row.try_get("", "user_id")?;
+            topic_cursor = Some(ForumSubscriptionCursor { target_id, user_id });
+            collect_common_drifts(
+                row,
+                ForumSubscriptionTargetKind::Topic,
+                target_id,
+                user_id,
+                &mut drifts,
+            )?;
+            let merged_source: i64 = row.try_get("", "merged_source")?;
+            if merged_source != 0 {
+                drifts.push(ForumSubscriptionDrift {
+                    kind: ForumSubscriptionDriftKind::MergedTopicSourceSubscription,
+                    target_kind: ForumSubscriptionTargetKind::Topic,
+                    target_id,
+                    user_id,
+                    stored: 1,
+                    expected: 0,
+                });
+            }
+        }
+
+        for row in category_rows.iter().take(effective_limit as usize) {
+            let target_id: Uuid = row.try_get("", "target_id")?;
+            let user_id: Uuid = row.try_get("", "user_id")?;
+            category_cursor = Some(ForumSubscriptionCursor { target_id, user_id });
+            collect_common_drifts(
+                row,
+                ForumSubscriptionTargetKind::Category,
+                target_id,
+                user_id,
+                &mut drifts,
+            )?;
+        }
+
+        Ok(ForumSubscriptionReconciliationReport {
+            requested_limit,
+            effective_limit,
+            inspected_topic_subscriptions: topic_rows.len().min(effective_limit as usize) as u64,
+            inspected_category_subscriptions: category_rows.len().min(effective_limit as usize)
+                as u64,
+            has_more_topic_subscriptions,
+            has_more_category_subscriptions,
+            topic_cursor,
+            category_cursor,
+            drifts,
+        })
+    }
+}
+
+fn collect_common_drifts(
+    row: &sea_orm::QueryResult,
+    target_kind: ForumSubscriptionTargetKind,
+    target_id: Uuid,
+    user_id: Uuid,
+    drifts: &mut Vec<ForumSubscriptionDrift>,
+) -> ForumResult<()> {
+    let target_exists: i64 = row.try_get("", "target_exists")?;
+    if target_exists != 1 {
+        drifts.push(ForumSubscriptionDrift {
+            kind: ForumSubscriptionDriftKind::TargetMissing,
+            target_kind,
+            target_id,
+            user_id,
+            stored: target_exists,
+            expected: 1,
+        });
+    }
+
+    let muted_preferences_valid: i64 = row.try_get("", "muted_preferences_valid")?;
+    if muted_preferences_valid != 1 {
+        drifts.push(ForumSubscriptionDrift {
+            kind: ForumSubscriptionDriftKind::MutedPreferencesInvalid,
+            target_kind,
+            target_id,
+            user_id,
+            stored: muted_preferences_valid,
+            expected: 1,
+        });
+    }
+
+    let revision: i64 = row.try_get("", "revision")?;
+    if revision <= 0 {
+        drifts.push(ForumSubscriptionDrift {
+            kind: ForumSubscriptionDriftKind::RevisionInvalid,
+            target_kind,
+            target_id,
+            user_id,
+            stored: revision,
+            expected: 1,
+        });
+    }
+    Ok(())
+}
+
+fn enforce_operations_scope(security: &SecurityContext) -> ForumResult<()> {
+    enforce_scope(security, Resource::ForumCategories, Action::Manage)?;
+    enforce_scope(security, Resource::ForumTopics, Action::Manage)
+}
+
+fn subscription_cursor(
+    target_after: Option<Uuid>,
+    user_after: Option<Uuid>,
+    label: &str,
+) -> ForumResult<Option<ForumSubscriptionCursor>> {
+    match (target_after, user_after) {
+        (None, None) => Ok(None),
+        (Some(target_id), Some(user_id)) => Ok(Some(ForumSubscriptionCursor {
+            target_id,
+            user_id,
+        })),
+        _ => Err(ForumError::Validation(format!(
+            "Forum {label} cursor requires both target and user components"
+        ))),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn subscription_statement(
+    backend: DatabaseBackend,
+    initial_sqlite: &str,
+    after_sqlite: &str,
+    initial_postgres: &str,
+    after_postgres: &str,
+    tenant_id: Uuid,
+    after: Option<ForumSubscriptionCursor>,
+    limit: u64,
+) -> ForumResult<Statement> {
+    match (backend, after) {
+        (DatabaseBackend::Sqlite, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            initial_sqlite,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Sqlite, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            after_sqlite,
+            vec![
+                tenant_id.into(),
+                after.target_id.into(),
+                after.user_id.into(),
+                (limit as i64).into(),
+            ],
+        )),
+        (DatabaseBackend::Postgres, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            initial_postgres,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            after_postgres,
+            vec![
+                tenant_id.into(),
+                after.target_id.into(),
+                after.user_id.into(),
+                (limit as i64).into(),
+            ],
+        )),
+        (other, _) => Err(ForumError::Validation(format!(
+            "Forum subscription reconciliation does not support database backend {other:?}"
+        ))),
+    }
+}
+
+const TOPIC_SUBSCRIPTIONS_SQLITE: &str = r#"
+SELECT
+    s.topic_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN t.id IS NULL THEN 0 ELSE 1 END AS target_exists,
+    CASE WHEN EXISTS (
+        SELECT 1
+        FROM forum_topic_merge_operations merge_operation
+        WHERE merge_operation.tenant_id = s.tenant_id
+          AND merge_operation.source_topic_id = s.topic_id
+    ) THEN 1 ELSE 0 END AS merged_source,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1 ELSE 0 END AS muted_preferences_valid,
+    CAST(s.revision AS INTEGER) AS revision
+FROM forum_topic_subscriptions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+WHERE s.tenant_id = ?1
+ORDER BY s.topic_id, s.user_id
+LIMIT ?2
+"#;
+
+const TOPIC_SUBSCRIPTIONS_AFTER_SQLITE: &str = r#"
+SELECT
+    s.topic_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN t.id IS NULL THEN 0 ELSE 1 END AS target_exists,
+    CASE WHEN EXISTS (
+        SELECT 1
+        FROM forum_topic_merge_operations merge_operation
+        WHERE merge_operation.tenant_id = s.tenant_id
+          AND merge_operation.source_topic_id = s.topic_id
+    ) THEN 1 ELSE 0 END AS merged_source,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1 ELSE 0 END AS muted_preferences_valid,
+    CAST(s.revision AS INTEGER) AS revision
+FROM forum_topic_subscriptions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+WHERE s.tenant_id = ?1
+  AND (s.topic_id > ?2 OR (s.topic_id = ?2 AND s.user_id > ?3))
+ORDER BY s.topic_id, s.user_id
+LIMIT ?4
+"#;
+
+const TOPIC_SUBSCRIPTIONS_POSTGRES: &str = r#"
+SELECT
+    s.topic_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN t.id IS NULL THEN 0::BIGINT ELSE 1::BIGINT END AS target_exists,
+    CASE WHEN EXISTS (
+        SELECT 1
+        FROM forum_topic_merge_operations merge_operation
+        WHERE merge_operation.tenant_id = s.tenant_id
+          AND merge_operation.source_topic_id = s.topic_id
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS merged_source,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS muted_preferences_valid,
+    s.revision::BIGINT AS revision
+FROM forum_topic_subscriptions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+WHERE s.tenant_id = $1
+ORDER BY s.topic_id, s.user_id
+LIMIT $2
+"#;
+
+const TOPIC_SUBSCRIPTIONS_AFTER_POSTGRES: &str = r#"
+SELECT
+    s.topic_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN t.id IS NULL THEN 0::BIGINT ELSE 1::BIGINT END AS target_exists,
+    CASE WHEN EXISTS (
+        SELECT 1
+        FROM forum_topic_merge_operations merge_operation
+        WHERE merge_operation.tenant_id = s.tenant_id
+          AND merge_operation.source_topic_id = s.topic_id
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS merged_source,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS muted_preferences_valid,
+    s.revision::BIGINT AS revision
+FROM forum_topic_subscriptions s
+LEFT JOIN forum_topics t
+    ON t.tenant_id = s.tenant_id
+   AND t.id = s.topic_id
+WHERE s.tenant_id = $1
+  AND (s.topic_id > $2 OR (s.topic_id = $2 AND s.user_id > $3))
+ORDER BY s.topic_id, s.user_id
+LIMIT $4
+"#;
+
+const CATEGORY_SUBSCRIPTIONS_SQLITE: &str = r#"
+SELECT
+    s.category_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN c.id IS NULL THEN 0 ELSE 1 END AS target_exists,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1 ELSE 0 END AS muted_preferences_valid,
+    CAST(s.revision AS INTEGER) AS revision
+FROM forum_category_subscriptions s
+LEFT JOIN forum_categories c
+    ON c.tenant_id = s.tenant_id
+   AND c.id = s.category_id
+WHERE s.tenant_id = ?1
+ORDER BY s.category_id, s.user_id
+LIMIT ?2
+"#;
+
+const CATEGORY_SUBSCRIPTIONS_AFTER_SQLITE: &str = r#"
+SELECT
+    s.category_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN c.id IS NULL THEN 0 ELSE 1 END AS target_exists,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1 ELSE 0 END AS muted_preferences_valid,
+    CAST(s.revision AS INTEGER) AS revision
+FROM forum_category_subscriptions s
+LEFT JOIN forum_categories c
+    ON c.tenant_id = s.tenant_id
+   AND c.id = s.category_id
+WHERE s.tenant_id = ?1
+  AND (s.category_id > ?2 OR (s.category_id = ?2 AND s.user_id > ?3))
+ORDER BY s.category_id, s.user_id
+LIMIT ?4
+"#;
+
+const CATEGORY_SUBSCRIPTIONS_POSTGRES: &str = r#"
+SELECT
+    s.category_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN c.id IS NULL THEN 0::BIGINT ELSE 1::BIGINT END AS target_exists,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS muted_preferences_valid,
+    s.revision::BIGINT AS revision
+FROM forum_category_subscriptions s
+LEFT JOIN forum_categories c
+    ON c.tenant_id = s.tenant_id
+   AND c.id = s.category_id
+WHERE s.tenant_id = $1
+ORDER BY s.category_id, s.user_id
+LIMIT $2
+"#;
+
+const CATEGORY_SUBSCRIPTIONS_AFTER_POSTGRES: &str = r#"
+SELECT
+    s.category_id AS target_id,
+    s.user_id AS user_id,
+    CASE WHEN c.id IS NULL THEN 0::BIGINT ELSE 1::BIGINT END AS target_exists,
+    CASE WHEN s.level <> 'muted' OR (
+        NOT s.notify_mentions
+        AND NOT s.notify_replies
+        AND NOT s.notify_new_topics
+        AND s.digest_mode = 'disabled'
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS muted_preferences_valid,
+    s.revision::BIGINT AS revision
+FROM forum_category_subscriptions s
+LEFT JOIN forum_categories c
+    ON c.tenant_id = s.tenant_id
+   AND c.id = s.category_id
+WHERE s.tenant_id = $1
+  AND (s.category_id > $2 OR (s.category_id = $2 AND s.user_id > $3))
+ORDER BY s.category_id, s.user_id
+LIMIT $4
+"#;

--- a/docs/modules/forum-33-subscription-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-subscription-reconciliation-actualization-2026-08-08.md
@@ -1,0 +1,95 @@
+# FORUM-33D subscription reconciliation actualization — 2026-08-08
+
+Status: `source-ready / maintainer-execution-open / repair-open`
+
+## Rechecked baseline
+
+The merged FORUM-33 sequence is source-complete through:
+
+- FORUM-33A: bounded topic/category counter reconciliation;
+- FORUM-33B: independent UUID keyset continuation for the counter shapes;
+- FORUM-33C: accepted-solution eligibility and `forum_user_stats.solution_count` reconciliation.
+
+The next explicit source cursor recorded by FORUM-33C was subscriptions. Existing FORUM-11 subscription ownership and FORUM-21C topic-merge subscription reconciliation were re-read before selecting this slice.
+
+## Owner boundary
+
+`ForumSubscriptionReconciliationService` is a read-only diagnostic owner under `services::subscription::reconciliation`.
+
+It reconciles persisted Forum-owned rows only. It deliberately does **not** infer that a topic author or reply participant must have a subscription merely because an auto-subscribe policy exists: participation policy controls future owner commands and is not a retroactive projection.
+
+The service also does not read Profiles-owned user lifecycle/privacy facts or Notifications-owned delivery state. Those remain shared-owner or downstream concerns.
+
+## Bounded shapes and cursors
+
+Topic and category subscriptions are independently bounded to the existing FORUM-33 default 100 / hard 500 page size.
+
+Neither subscription table has a single row UUID: each row is identified by tenant plus `(target_id, user_id)`. Continuation therefore uses strict composite keysets rather than OFFSET:
+
+```text
+topic:    (topic_id, user_id) > (topicAfter, topicUserAfter)
+category: (category_id, user_id) > (categoryAfter, categoryUserAfter)
+```
+
+Both components of a supplied cursor are required together. An exhausted shape preserves its previous cursor while the other shape may continue.
+
+GraphQL exposes the current-tenant report as:
+
+```text
+forumSubscriptionReconciliationReport(
+  limit: Int,
+  topicAfter: UUID,
+  topicUserAfter: UUID,
+  categoryAfter: UUID,
+  categoryUserAfter: UUID
+)
+```
+
+The response returns independent composite topic/category cursors, `hasMore*` flags, inspected-row counts, page-local `clean`, and drift rows.
+
+## Drift classes
+
+The report detects only invariants already owned by Forum:
+
+- `target_missing`: a persisted subscription row no longer resolves to its same-tenant Forum target;
+- `merged_topic_source_subscription`: a topic-subscription row remains attached to an immutable topic-merge source identity; actual move/dedup repair remains owned by the existing FORUM-21C reconciliation command;
+- `muted_preferences_invalid`: a `muted` row violates the existing schema/service rule requiring all notification flags off and digest disabled;
+- `revision_invalid`: a persisted optimistic revision is not positive.
+
+A reversible ordinary `archived` topic is intentionally not classified as drift merely because it is archived. FORUM-21 merge-source detection uses immutable merge history instead of assuming all archived topics are permanent tombstones.
+
+## Admission, snapshot, and observability
+
+GraphQL derives tenant identity only from `TenantContext`, rejects auth/tenant mismatch, and requires both effective permissions:
+
+```text
+forum_categories:manage
+forum_topics:manage
+```
+
+The owner service independently reauthorizes the same two Manage scopes through the canonical Forum RBAC helper before database work.
+
+Each report page runs in one database snapshot:
+
+- PostgreSQL: `REPEATABLE READ READ ONLY`;
+- SQLite: one transaction snapshot.
+
+The service reuses platform module-entrypoint/span/error telemetry and adds no duplicate Forum metric family.
+
+## Deliberately open
+
+This slice adds no repair mutation, row deletion, subscription move, deduplication, policy backfill, user/profile inference, delivery repair, schema migration, dependency change, or CLI adapter.
+
+Any generic write repair still requires the FORUM-33 operator boundary: explicit repair RBAC, dry-run semantics, durable audit, idempotent job/receipt state, bounded retry/recovery, and retained PostgreSQL/SQLite execution evidence.
+
+The next source reconciliation cursor is mentions, followed by attachments and shared-owner projections where authoritative contracts permit it.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation, or `git diff --check` was executed while preparing this slice.
+
+Suggested source check:
+
+```bash
+node scripts/verify/verify-forum-subscription-reconciliation-source.mjs
+```

--- a/scripts/verify/verify-forum-subscription-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-subscription-reconciliation-source.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const servicePath = "crates/rustok-forum/src/services/subscription/reconciliation.rs";
+const subscriptionModulePath = "crates/rustok-forum/src/services/subscription.rs";
+const graphqlPath = "crates/rustok-forum/src/graphql/subscription_reconciliation_query.rs";
+const graphqlModulePath = "crates/rustok-forum/src/graphql/mod.rs";
+const packetPath = "docs/modules/forum-33-subscription-reconciliation-actualization-2026-08-08.md";
+
+const service = read(servicePath);
+const subscriptionModule = read(subscriptionModulePath);
+const graphql = read(graphqlPath);
+const graphqlModule = read(graphqlModulePath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "pub struct ForumSubscriptionReconciliationService",
+  "pub struct ForumSubscriptionReconciliationReport",
+  "pub struct ForumSubscriptionCursor",
+  "pub enum ForumSubscriptionDriftKind",
+  "TargetMissing",
+  "MergedTopicSourceSubscription",
+  "MutedPreferencesInvalid",
+  "RevisionInvalid",
+  "security: &SecurityContext",
+  "enforce_operations_scope(security)",
+  "enforce_scope(security, Resource::ForumCategories, Action::Manage)?",
+  "enforce_scope(security, Resource::ForumTopics, Action::Manage)",
+  "topic_after_target: Option<Uuid>",
+  "topic_after_user: Option<Uuid>",
+  "category_after_target: Option<Uuid>",
+  "category_after_user: Option<Uuid>",
+  "subscription_cursor(",
+  "cursor requires both target and user components",
+  "effective_limit.saturating_add(1)",
+  "TOPIC_SUBSCRIPTIONS_AFTER_SQLITE",
+  "TOPIC_SUBSCRIPTIONS_AFTER_POSTGRES",
+  "CATEGORY_SUBSCRIPTIONS_AFTER_SQLITE",
+  "CATEGORY_SUBSCRIPTIONS_AFTER_POSTGRES",
+  "s.topic_id > ?2 OR (s.topic_id = ?2 AND s.user_id > ?3)",
+  "s.topic_id > $2 OR (s.topic_id = $2 AND s.user_id > $3)",
+  "s.category_id > ?2 OR (s.category_id = ?2 AND s.user_id > ?3)",
+  "s.category_id > $2 OR (s.category_id = $2 AND s.user_id > $3)",
+  "FROM forum_topic_merge_operations merge_operation",
+  "merge_operation.source_topic_id = s.topic_id",
+  "s.level <> 'muted'",
+  "s.digest_mode = 'disabled'",
+  "revision <= 0",
+  "begin_with_config(",
+  "IsolationLevel::RepeatableRead",
+  "AccessMode::ReadOnly",
+  "DatabaseBackend::Sqlite => self.db.begin().await?",
+  "transaction.commit().await?",
+  "transaction.rollback().await",
+  '"subscription_reconciliation_report"',
+  '"subscription_reconciliation"',
+]) {
+  requireText(service, marker, `Forum subscription reconciliation service missing ${marker}`);
+}
+
+for (const forbidden of [
+  "UPDATE forum_",
+  "DELETE FROM forum_",
+  "INSERT INTO forum_",
+  "ActiveModel",
+  " OFFSET ",
+]) {
+  requireAbsent(
+    service,
+    forbidden,
+    `read-only subscription reconciliation service must not contain ${forbidden}`,
+  );
+}
+
+requireText(
+  subscriptionModule,
+  "pub mod reconciliation;",
+  "Forum subscription module must expose the reconciliation owner",
+);
+
+for (const marker of [
+  "pub struct ForumSubscriptionReconciliationQuery",
+  "forum_subscription_reconciliation_report",
+  "ForumSubscriptionReconciliationService::new(db)",
+  "require_module_enabled(ctx, MODULE_SLUG).await?",
+  "Permission::FORUM_CATEGORIES_MANAGE",
+  "Permission::FORUM_TOPICS_MANAGE",
+  "categories_manage && topics_manage",
+  "auth.tenant_id != tenant.id",
+  "SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions)",
+  "topic_after: Option<Uuid>",
+  "topic_user_after: Option<Uuid>",
+  "category_after: Option<Uuid>",
+  "category_user_after: Option<Uuid>",
+  "pub topic_cursor: Option<GqlForumSubscriptionCursor>",
+  "pub category_cursor: Option<GqlForumSubscriptionCursor>",
+  "Whole-tenant clean requires exhausting both composite cursor chains",
+]) {
+  requireText(graphql, marker, `Forum subscription reconciliation GraphQL missing ${marker}`);
+}
+
+for (const forbidden of ["tenant_id: Option<Uuid>", "Mutation", "UPDATE forum_"]) {
+  requireAbsent(graphql, forbidden, `subscription report must not expose ${forbidden}`);
+}
+
+for (const marker of [
+  "mod subscription_reconciliation_query;",
+  "GqlForumSubscriptionCursor",
+  "GqlForumSubscriptionDrift",
+  "GqlForumSubscriptionReconciliationReport",
+  "subscription_reconciliation_query::ForumSubscriptionReconciliationQuery",
+]) {
+  requireText(graphqlModule, marker, `Forum GraphQL composition missing ${marker}`);
+}
+
+for (const marker of [
+  "Status: `source-ready / maintainer-execution-open / repair-open`",
+  "FORUM-33C",
+  "The next explicit source cursor recorded by FORUM-33C was subscriptions",
+  "services::subscription::reconciliation",
+  "does **not** infer",
+  "(topic_id, user_id) > (topicAfter, topicUserAfter)",
+  "(category_id, user_id) > (categoryAfter, categoryUserAfter)",
+  "forumSubscriptionReconciliationReport(",
+  "target_missing",
+  "merged_topic_source_subscription",
+  "muted_preferences_invalid",
+  "revision_invalid",
+  "reversible ordinary `archived` topic",
+  "forum_categories:manage",
+  "forum_topics:manage",
+  "REPEATABLE READ READ ONLY",
+  "adds no repair mutation",
+  "next source reconciliation cursor is mentions",
+]) {
+  requireText(packet, marker, `FORUM-33D actualization missing ${marker}`);
+}
+
+console.log("Forum FORUM-33D subscription reconciliation source: ok");


### PR DESCRIPTION
## Summary

Continue the canonical FORUM-33 source line after accepted-solution reconciliation in #3317.

- add read-only `ForumSubscriptionReconciliationService` under the existing subscription owner boundary;
- independently scan topic/category subscription rows with default 100 / hard 500 limits;
- use strict composite `(target_id, user_id)` keyset continuation because subscription rows have no single row UUID;
- reject partial cursors before SQL and preserve an exhausted shape cursor while the other shape continues;
- detect same-tenant target integrity drift, merged-source topic subscriptions that still require the existing FORUM-21C repair owner, invalid muted preference shape, and non-positive revisions;
- deliberately do not infer missing rows from auto-subscribe participation policy and do not read Profiles/Notifications-owned state;
- execute both shapes in one page-local PostgreSQL `REPEATABLE READ READ ONLY` / SQLite transaction snapshot;
- expose `forumSubscriptionReconciliationReport(limit, topicAfter, topicUserAfter, categoryAfter, categoryUserAfter)` through the merged Forum GraphQL query;
- derive tenant only from trusted request context, require both `forum_categories:manage` and `forum_topics:manage` at GraphQL admission, then independently reauthorize both scopes in the owner service;
- reuse platform entrypoint/span/error telemetry;
- add a focused FORUM-33D actualization and fail-closed source verifier; the next source reconciliation cursor is mentions.

## Recheck

The merged FORUM-33A/B/C source was re-read before this change. Existing FORUM-11 subscription policy semantics and FORUM-21C merge-subscription reconciliation were also reviewed so this diagnostic does not redefine their ownership. Ordinary reversible archived topics are not treated as drift solely because they are archived; merged source identity is derived from immutable merge history.

The branch was created from `main@f9f51db8b0deb71f4802830ce4edf70fb9bd4100`. While preparing the PR, `main` advanced by one unrelated Index commit to `e2887c3b1358a6936b3ad2a93775547bb242e37b`; no Forum path overlap was found.

## Deliberately open

No repair mutation, row move/delete/dedup, policy backfill, external user/profile inference, delivery repair, schema migration, dependency change, lockfile update, CLI adapter, or runtime evidence is included. Generic write repair remains blocked on explicit repair RBAC, dry-run semantics, durable audit, idempotent job/receipt state, bounded retry/recovery, and retained PostgreSQL/SQLite execution evidence.

## Validation

Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation, or `git diff --check` was run. Review is source-only; the maintainer will run tests.