### PR TITLE
feat(forum): reconcile persisted mentions

### DIFF
--- a/crates/rustok-forum/src/graphql/mention_reconciliation_query.rs
+++ b/crates/rustok-forum/src/graphql/mention_reconciliation_query.rs
@@ -1,0 +1,212 @@
+use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled},
+    has_any_effective_permission,
+};
+use rustok_core::SecurityContext;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::services::mention_reconciliation::{
+    ForumMentionDrift, ForumMentionReconciliationReport, ForumMentionReconciliationService,
+};
+
+const MODULE_SLUG: &str = "forum";
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumMentionDrift {
+    pub kind: String,
+    pub revision_id: String,
+    pub source_kind: String,
+    pub source_id: Uuid,
+    pub source_locale: String,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct GqlForumMentionReconciliationReport {
+    pub requested_limit: Option<i32>,
+    pub effective_limit: i32,
+    pub inspected_relation_revisions: i32,
+    pub inspected_mention_revisions: i32,
+    pub has_more_relation_revisions: bool,
+    /// Decimal relation-revision keyset cursor. It is a string because owner revision IDs are i64
+    /// while GraphQL Int is intentionally not used as the durable cursor representation.
+    pub relation_cursor: Option<String>,
+    pub drift_count: i32,
+    /// True only when the current bounded relation-revision page has no detected mention drift.
+    /// Whole-tenant clean requires exhausting the cursor chain with every page clean.
+    pub clean: bool,
+    pub drifts: Vec<GqlForumMentionDrift>,
+}
+
+#[derive(Default)]
+pub struct ForumMentionReconciliationQuery;
+
+#[Object]
+impl ForumMentionReconciliationQuery {
+    /// Read-only FORUM-33 mention projection drift report for the current tenant.
+    ///
+    /// `relation_after` is a positive decimal relation-revision ID returned by the previous page.
+    /// The report uses Forum-owned relation/mention rows only; it does not re-resolve Profiles or
+    /// inspect Notifications-owned delivery state and performs no repair.
+    async fn forum_mention_reconciliation_report(
+        &self,
+        ctx: &Context<'_>,
+        limit: Option<i32>,
+        relation_after: Option<String>,
+    ) -> Result<GqlForumMentionReconciliationReport> {
+        let (tenant_id, security, requested_limit, relation_after, db) =
+            reconciliation_context(ctx, limit, relation_after).await?;
+        let report = ForumMentionReconciliationService::new(db)
+            .report_page(tenant_id, &security, requested_limit, relation_after)
+            .await?;
+        Ok(map_report(report))
+    }
+}
+
+async fn reconciliation_context(
+    ctx: &Context<'_>,
+    limit: Option<i32>,
+    relation_after: Option<String>,
+) -> Result<(
+    Uuid,
+    SecurityContext,
+    Option<u64>,
+    Option<i64>,
+    DatabaseConnection,
+)> {
+    require_module_enabled(ctx, MODULE_SLUG).await?;
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    require_operations_permissions(auth)?;
+    let tenant = ctx.data::<TenantContext>()?;
+    if auth.tenant_id != tenant.id {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: tenant scope mismatch",
+        ));
+    }
+    let requested_limit = normalize_limit(limit)?;
+    let relation_after = normalize_relation_cursor(relation_after)?;
+    let db = ctx.data::<DatabaseConnection>()?.clone();
+    let security =
+        SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions);
+    Ok((tenant.id, security, requested_limit, relation_after, db))
+}
+
+fn require_operations_permissions(auth: &AuthContext) -> Result<()> {
+    let categories_manage = has_any_effective_permission(
+        &auth.permissions,
+        &[Permission::FORUM_CATEGORIES_MANAGE],
+    );
+    let topics_manage =
+        has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_MANAGE]);
+    if categories_manage && topics_manage {
+        Ok(())
+    } else {
+        Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_categories:manage and forum_topics:manage required",
+        ))
+    }
+}
+
+fn normalize_limit(limit: Option<i32>) -> Result<Option<u64>> {
+    match limit {
+        None => Ok(None),
+        Some(value) if value > 0 => Ok(Some(value as u64)),
+        Some(_) => Err(async_graphql::Error::new(
+            "Forum reconciliation limit must be positive",
+        )),
+    }
+}
+
+fn normalize_relation_cursor(cursor: Option<String>) -> Result<Option<i64>> {
+    match cursor {
+        None => Ok(None),
+        Some(value) => value
+            .parse::<i64>()
+            .ok()
+            .filter(|value| *value > 0)
+            .map(Some)
+            .ok_or_else(|| {
+                async_graphql::Error::new(
+                    "Forum mention reconciliation cursor must be a positive decimal revision ID",
+                )
+            }),
+    }
+}
+
+fn map_report(report: ForumMentionReconciliationReport) -> GqlForumMentionReconciliationReport {
+    GqlForumMentionReconciliationReport {
+        requested_limit: report.requested_limit.map(saturating_i32),
+        effective_limit: saturating_i32(report.effective_limit),
+        inspected_relation_revisions: saturating_i32(report.inspected_relation_revisions),
+        inspected_mention_revisions: saturating_i32(report.inspected_mention_revisions),
+        has_more_relation_revisions: report.has_more_relation_revisions,
+        relation_cursor: report.relation_cursor.map(|value| value.to_string()),
+        drift_count: saturating_i32(report.drift_count() as u64),
+        clean: report.is_clean(),
+        drifts: report.drifts.into_iter().map(map_drift).collect(),
+    }
+}
+
+fn map_drift(drift: ForumMentionDrift) -> GqlForumMentionDrift {
+    GqlForumMentionDrift {
+        kind: drift.kind.as_str().to_string(),
+        revision_id: drift.revision_id.to_string(),
+        source_kind: drift.source_kind,
+        source_id: drift.source_id,
+        source_locale: drift.source_locale,
+        stored: drift.stored,
+        expected: drift.expected,
+    }
+}
+
+fn saturating_i32(value: u64) -> i32 {
+    value.min(i32::MAX as u64) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_api::{Action, Resource};
+
+    fn auth(permissions: Vec<Permission>) -> AuthContext {
+        let tenant_id = Uuid::new_v4();
+        AuthContext {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            tenant_id,
+            permissions,
+            client_id: None,
+            scopes: Vec::new(),
+            grant_type: "direct".to_string(),
+        }
+    }
+
+    #[test]
+    fn mention_report_requires_both_effective_manage_permissions() {
+        let both = auth(vec![
+            Permission::new(Resource::ForumCategories, Action::Manage),
+            Permission::new(Resource::ForumTopics, Action::Manage),
+        ]);
+        assert!(require_operations_permissions(&both).is_ok());
+
+        let topics_only = auth(vec![Permission::new(Resource::ForumTopics, Action::Manage)]);
+        assert!(require_operations_permissions(&topics_only).is_err());
+    }
+
+    #[test]
+    fn relation_cursor_is_positive_decimal_i64() {
+        assert_eq!(normalize_relation_cursor(None).unwrap(), None);
+        assert_eq!(
+            normalize_relation_cursor(Some("9223372036854775807".to_string())).unwrap(),
+            Some(i64::MAX)
+        );
+        assert!(normalize_relation_cursor(Some("0".to_string())).is_err());
+        assert!(normalize_relation_cursor(Some("not-a-cursor".to_string())).is_err());
+    }
+}

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -6,6 +6,7 @@ mod category_tree_query;
 mod connection;
 mod content_commands;
 mod error_extension;
+mod mention_reconciliation_query;
 mod mutation;
 #[path = "query_runtime.rs"]
 mod query;
@@ -47,6 +48,9 @@ pub use content_commands::{
     UpdateForumReplyWithQuotesInput, UpdateForumTopicWithQuotesInput,
 };
 pub use error_extension::ForumGraphqlErrorExtension;
+pub use mention_reconciliation_query::{
+    GqlForumMentionDrift, GqlForumMentionReconciliationReport,
+};
 pub use quote_commands::{
     GqlForumQuoteReferenceInput, GqlForumQuoteTargetKind, GqlForumRelationQuote,
     GqlForumRelationSnapshot, SetForumQuoteRelationsInput,
@@ -91,6 +95,7 @@ pub struct ForumQuery(
     read_state::ForumReadStateQuery,
     reconciliation_query::ForumReconciliationQuery,
     subscription_reconciliation_query::ForumSubscriptionReconciliationQuery,
+    mention_reconciliation_query::ForumMentionReconciliationQuery,
     reply_audience_query::ForumReplyAudienceQuery,
     storefront_read_state::ForumStorefrontReadStateQuery,
     storefront_audience_topic::ForumStorefrontAudienceTopicQuery,

--- a/crates/rustok-forum/src/services/mention_reconciliation.rs
+++ b/crates/rustok-forum/src/services/mention_reconciliation.rs
@@ -1,0 +1,590 @@
+use std::time::Instant;
+
+use rustok_api::{Action, Resource, normalize_locale_tag};
+use rustok_core::SecurityContext;
+use sea_orm::{
+    AccessMode, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction,
+    IsolationLevel, Statement, TransactionTrait,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::{
+    counter_reconciliation::{
+        DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT,
+    },
+    rbac::enforce_scope,
+};
+use crate::error::{ForumError, ForumResult};
+use crate::mentions::FORUM_MAX_MENTION_TARGETS_PER_REVISION;
+
+const FORUM_MENTION_RECONCILIATION_OPERATION: &str = "forum.mention_reconciliation_report";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumMentionDriftKind {
+    SourceUnavailable,
+    ChildSourceMismatch,
+    TargetLimitExceeded,
+    LocaleInvalid,
+    ProjectionFingerprintInvalid,
+}
+
+impl ForumMentionDriftKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SourceUnavailable => "source_unavailable",
+            Self::ChildSourceMismatch => "child_source_mismatch",
+            Self::TargetLimitExceeded => "target_limit_exceeded",
+            Self::LocaleInvalid => "locale_invalid",
+            Self::ProjectionFingerprintInvalid => "projection_fingerprint_invalid",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumMentionDrift {
+    pub kind: ForumMentionDriftKind,
+    pub revision_id: i64,
+    pub source_kind: String,
+    pub source_id: Uuid,
+    pub source_locale: String,
+    pub stored: i64,
+    pub expected: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForumMentionReconciliationReport {
+    pub requested_limit: Option<u64>,
+    pub effective_limit: u64,
+    pub inspected_relation_revisions: u64,
+    pub inspected_mention_revisions: u64,
+    pub has_more_relation_revisions: bool,
+    pub relation_cursor: Option<i64>,
+    pub drifts: Vec<ForumMentionDrift>,
+}
+
+impl ForumMentionReconciliationReport {
+    pub fn drift_count(&self) -> usize {
+        self.drifts.len()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.drifts.is_empty()
+    }
+}
+
+/// Read-only FORUM-33 reconciliation for persisted Forum mention snapshots.
+///
+/// Relation revisions are the Forum-owned immutable source identity for user/audience mention
+/// snapshots. This report does not re-resolve handles through Profiles and does not inspect
+/// Notifications delivery state. It checks only persisted Forum-owned invariants: exact source
+/// availability, child/source identity agreement, the established 32-target bound, canonical
+/// locale identity and the owner projection fingerprint shape.
+///
+/// Traversal is bounded by relation revision ID with strict keyset continuation. Each page is one
+/// database snapshot: PostgreSQL uses `REPEATABLE READ READ ONLY`; SQLite uses one transaction.
+/// Multi-page scans are page-local diagnostics and deliberately perform no repair.
+pub struct ForumMentionReconciliationService {
+    db: DatabaseConnection,
+}
+
+impl ForumMentionReconciliationService {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    pub async fn report_page(
+        &self,
+        tenant_id: Uuid,
+        security: &SecurityContext,
+        requested_limit: Option<u64>,
+        relation_after: Option<i64>,
+    ) -> ForumResult<ForumMentionReconciliationReport> {
+        rustok_telemetry::metrics::record_module_entrypoint_call(
+            "forum",
+            "mention_reconciliation_report",
+            "library",
+        );
+        let started_at = Instant::now();
+        let result = match enforce_operations_scope(security) {
+            Ok(()) => self.report_inner(tenant_id, requested_limit, relation_after).await,
+            Err(error) => Err(error),
+        };
+        rustok_telemetry::metrics::record_span_duration(
+            FORUM_MENTION_RECONCILIATION_OPERATION,
+            started_at.elapsed().as_secs_f64(),
+        );
+        if result.is_err() {
+            rustok_telemetry::metrics::record_span_error(
+                FORUM_MENTION_RECONCILIATION_OPERATION,
+                "owner_report",
+            );
+            rustok_telemetry::metrics::record_module_error(
+                "forum",
+                "mention_reconciliation",
+                "error",
+            );
+        }
+        result
+    }
+
+    async fn report_inner(
+        &self,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+        relation_after: Option<i64>,
+    ) -> ForumResult<ForumMentionReconciliationReport> {
+        if relation_after.is_some_and(|value| value <= 0) {
+            return Err(ForumError::Validation(
+                "Forum mention reconciliation cursor must be positive".to_string(),
+            ));
+        }
+        let backend = self.db.get_database_backend();
+        let transaction = match backend {
+            DatabaseBackend::Postgres => {
+                self.db
+                    .begin_with_config(
+                        Some(IsolationLevel::RepeatableRead),
+                        Some(AccessMode::ReadOnly),
+                    )
+                    .await?
+            }
+            DatabaseBackend::Sqlite => self.db.begin().await?,
+            other => {
+                return Err(ForumError::Validation(format!(
+                    "Forum mention reconciliation does not support database backend {other:?}"
+                )));
+            }
+        };
+
+        let report = self
+            .report_in_transaction(
+                &transaction,
+                backend,
+                tenant_id,
+                requested_limit,
+                relation_after,
+            )
+            .await;
+        match report {
+            Ok(report) => {
+                transaction.commit().await?;
+                Ok(report)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn report_in_transaction(
+        &self,
+        transaction: &DatabaseTransaction,
+        backend: DatabaseBackend,
+        tenant_id: Uuid,
+        requested_limit: Option<u64>,
+        relation_after: Option<i64>,
+    ) -> ForumResult<ForumMentionReconciliationReport> {
+        let effective_limit = requested_limit
+            .unwrap_or(DEFAULT_FORUM_COUNTER_RECONCILIATION_LIMIT)
+            .clamp(1, MAX_FORUM_COUNTER_RECONCILIATION_LIMIT);
+        let fetch_limit = effective_limit.saturating_add(1);
+        let rows = transaction
+            .query_all(mention_statement(
+                backend,
+                tenant_id,
+                relation_after,
+                fetch_limit,
+            )?)
+            .await?;
+
+        let has_more_relation_revisions = rows.len() > effective_limit as usize;
+        let mut relation_cursor = relation_after;
+        let mut inspected_mention_revisions = 0_u64;
+        let mut drifts = Vec::new();
+
+        for row in rows.iter().take(effective_limit as usize) {
+            let revision_id: i64 = row.try_get("", "revision_id")?;
+            relation_cursor = Some(revision_id);
+            let source_kind: String = row.try_get("", "target_kind")?;
+            let source_id: Uuid = row.try_get("", "target_id")?;
+            let source_locale: String = row.try_get("", "locale")?;
+            let projection_fingerprint: String = row.try_get("", "projection_fingerprint")?;
+            let source_exists: i64 = row.try_get("", "source_exists")?;
+            let user_count: i64 = row.try_get("", "user_count")?;
+            let audience_count: i64 = row.try_get("", "audience_count")?;
+            let child_source_mismatch_count: i64 =
+                row.try_get("", "child_source_mismatch_count")?;
+            let mention_count = user_count.saturating_add(audience_count);
+
+            if mention_count == 0 {
+                continue;
+            }
+            inspected_mention_revisions = inspected_mention_revisions.saturating_add(1);
+
+            if source_exists != 1 {
+                drifts.push(ForumMentionDrift {
+                    kind: ForumMentionDriftKind::SourceUnavailable,
+                    revision_id,
+                    source_kind: source_kind.clone(),
+                    source_id,
+                    source_locale: source_locale.clone(),
+                    stored: source_exists,
+                    expected: 1,
+                });
+            }
+            if child_source_mismatch_count != 0 {
+                drifts.push(ForumMentionDrift {
+                    kind: ForumMentionDriftKind::ChildSourceMismatch,
+                    revision_id,
+                    source_kind: source_kind.clone(),
+                    source_id,
+                    source_locale: source_locale.clone(),
+                    stored: child_source_mismatch_count,
+                    expected: 0,
+                });
+            }
+            if mention_count > FORUM_MAX_MENTION_TARGETS_PER_REVISION as i64 {
+                drifts.push(ForumMentionDrift {
+                    kind: ForumMentionDriftKind::TargetLimitExceeded,
+                    revision_id,
+                    source_kind: source_kind.clone(),
+                    source_id,
+                    source_locale: source_locale.clone(),
+                    stored: mention_count,
+                    expected: FORUM_MAX_MENTION_TARGETS_PER_REVISION as i64,
+                });
+            }
+            if normalize_locale_tag(&source_locale).as_deref() != Some(source_locale.as_str()) {
+                drifts.push(ForumMentionDrift {
+                    kind: ForumMentionDriftKind::LocaleInvalid,
+                    revision_id,
+                    source_kind: source_kind.clone(),
+                    source_id,
+                    source_locale: source_locale.clone(),
+                    stored: 0,
+                    expected: 1,
+                });
+            }
+            if !valid_projection_fingerprint(&projection_fingerprint) {
+                drifts.push(ForumMentionDrift {
+                    kind: ForumMentionDriftKind::ProjectionFingerprintInvalid,
+                    revision_id,
+                    source_kind,
+                    source_id,
+                    source_locale,
+                    stored: projection_fingerprint.len() as i64,
+                    expected: 64,
+                });
+            }
+        }
+
+        Ok(ForumMentionReconciliationReport {
+            requested_limit,
+            effective_limit,
+            inspected_relation_revisions: rows.len().min(effective_limit as usize) as u64,
+            inspected_mention_revisions,
+            has_more_relation_revisions,
+            relation_cursor,
+            drifts,
+        })
+    }
+}
+
+fn enforce_operations_scope(security: &SecurityContext) -> ForumResult<()> {
+    enforce_scope(security, Resource::ForumCategories, Action::Manage)?;
+    enforce_scope(security, Resource::ForumTopics, Action::Manage)
+}
+
+fn valid_projection_fingerprint(value: &str) -> bool {
+    value == "legacy"
+        || (value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')))
+}
+
+fn mention_statement(
+    backend: DatabaseBackend,
+    tenant_id: Uuid,
+    after: Option<i64>,
+    limit: u64,
+) -> ForumResult<Statement> {
+    match (backend, after) {
+        (DatabaseBackend::Sqlite, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            MENTIONS_SQLITE,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Sqlite, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            MENTIONS_AFTER_SQLITE,
+            vec![tenant_id.into(), after.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, None) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            MENTIONS_POSTGRES,
+            vec![tenant_id.into(), (limit as i64).into()],
+        )),
+        (DatabaseBackend::Postgres, Some(after)) => Ok(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            MENTIONS_AFTER_POSTGRES,
+            vec![tenant_id.into(), after.into(), (limit as i64).into()],
+        )),
+        (other, _) => Err(ForumError::Validation(format!(
+            "Forum mention reconciliation does not support database backend {other:?}"
+        ))),
+    }
+}
+
+const MENTIONS_SQLITE: &str = r#"
+WITH bounded AS (
+    SELECT revision_id, target_kind, target_id, locale, projection_fingerprint
+    FROM forum_relation_revisions
+    WHERE tenant_id = ?1
+    ORDER BY revision_id
+    LIMIT ?2
+), user_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(u.source_revision_id) AS user_count,
+        COALESCE(SUM(CASE WHEN u.source_revision_id IS NOT NULL AND (
+            u.source_kind <> b.target_kind
+            OR u.source_id <> b.target_id
+            OR u.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0) AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_user_mentions u
+      ON u.tenant_id = ?1
+     AND u.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+), audience_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(a.source_revision_id) AS audience_count,
+        COALESCE(SUM(CASE WHEN a.source_revision_id IS NOT NULL AND (
+            a.source_kind <> b.target_kind
+            OR a.source_id <> b.target_id
+            OR a.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0) AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_audience_mentions a
+      ON a.tenant_id = ?1
+     AND a.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+)
+SELECT
+    b.revision_id,
+    b.target_kind,
+    b.target_id,
+    b.locale,
+    b.projection_fingerprint,
+    CASE WHEN (
+        b.target_kind = 'topic' AND EXISTS (
+            SELECT 1 FROM forum_topic_translations t
+            WHERE t.tenant_id = ?1 AND t.topic_id = b.target_id AND t.locale = b.locale
+        )
+    ) OR (
+        b.target_kind = 'reply' AND EXISTS (
+            SELECT 1 FROM forum_reply_bodies r
+            WHERE r.tenant_id = ?1 AND r.reply_id = b.target_id AND r.locale = b.locale
+        )
+    ) THEN 1 ELSE 0 END AS source_exists,
+    CAST(u.user_count AS INTEGER) AS user_count,
+    CAST(a.audience_count AS INTEGER) AS audience_count,
+    CAST(u.mismatch_count + a.mismatch_count AS INTEGER) AS child_source_mismatch_count
+FROM bounded b
+JOIN user_summary u ON u.revision_id = b.revision_id
+JOIN audience_summary a ON a.revision_id = b.revision_id
+ORDER BY b.revision_id
+"#;
+
+const MENTIONS_AFTER_SQLITE: &str = r#"
+WITH bounded AS (
+    SELECT revision_id, target_kind, target_id, locale, projection_fingerprint
+    FROM forum_relation_revisions
+    WHERE tenant_id = ?1
+      AND revision_id > ?2
+    ORDER BY revision_id
+    LIMIT ?3
+), user_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(u.source_revision_id) AS user_count,
+        COALESCE(SUM(CASE WHEN u.source_revision_id IS NOT NULL AND (
+            u.source_kind <> b.target_kind
+            OR u.source_id <> b.target_id
+            OR u.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0) AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_user_mentions u
+      ON u.tenant_id = ?1
+     AND u.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+), audience_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(a.source_revision_id) AS audience_count,
+        COALESCE(SUM(CASE WHEN a.source_revision_id IS NOT NULL AND (
+            a.source_kind <> b.target_kind
+            OR a.source_id <> b.target_id
+            OR a.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0) AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_audience_mentions a
+      ON a.tenant_id = ?1
+     AND a.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+)
+SELECT
+    b.revision_id,
+    b.target_kind,
+    b.target_id,
+    b.locale,
+    b.projection_fingerprint,
+    CASE WHEN (
+        b.target_kind = 'topic' AND EXISTS (
+            SELECT 1 FROM forum_topic_translations t
+            WHERE t.tenant_id = ?1 AND t.topic_id = b.target_id AND t.locale = b.locale
+        )
+    ) OR (
+        b.target_kind = 'reply' AND EXISTS (
+            SELECT 1 FROM forum_reply_bodies r
+            WHERE r.tenant_id = ?1 AND r.reply_id = b.target_id AND r.locale = b.locale
+        )
+    ) THEN 1 ELSE 0 END AS source_exists,
+    CAST(u.user_count AS INTEGER) AS user_count,
+    CAST(a.audience_count AS INTEGER) AS audience_count,
+    CAST(u.mismatch_count + a.mismatch_count AS INTEGER) AS child_source_mismatch_count
+FROM bounded b
+JOIN user_summary u ON u.revision_id = b.revision_id
+JOIN audience_summary a ON a.revision_id = b.revision_id
+ORDER BY b.revision_id
+"#;
+
+const MENTIONS_POSTGRES: &str = r#"
+WITH bounded AS (
+    SELECT revision_id, target_kind, target_id, locale, projection_fingerprint
+    FROM forum_relation_revisions
+    WHERE tenant_id = $1
+    ORDER BY revision_id
+    LIMIT $2
+), user_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(u.source_revision_id)::BIGINT AS user_count,
+        COALESCE(SUM(CASE WHEN u.source_revision_id IS NOT NULL AND (
+            u.source_kind <> b.target_kind
+            OR u.source_id <> b.target_id
+            OR u.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0)::BIGINT AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_user_mentions u
+      ON u.tenant_id = $1
+     AND u.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+), audience_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(a.source_revision_id)::BIGINT AS audience_count,
+        COALESCE(SUM(CASE WHEN a.source_revision_id IS NOT NULL AND (
+            a.source_kind <> b.target_kind
+            OR a.source_id <> b.target_id
+            OR a.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0)::BIGINT AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_audience_mentions a
+      ON a.tenant_id = $1
+     AND a.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+)
+SELECT
+    b.revision_id,
+    b.target_kind,
+    b.target_id,
+    b.locale,
+    b.projection_fingerprint,
+    CASE WHEN (
+        b.target_kind = 'topic' AND EXISTS (
+            SELECT 1 FROM forum_topic_translations t
+            WHERE t.tenant_id = $1 AND t.topic_id = b.target_id AND t.locale = b.locale
+        )
+    ) OR (
+        b.target_kind = 'reply' AND EXISTS (
+            SELECT 1 FROM forum_reply_bodies r
+            WHERE r.tenant_id = $1 AND r.reply_id = b.target_id AND r.locale = b.locale
+        )
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS source_exists,
+    u.user_count,
+    a.audience_count,
+    (u.mismatch_count + a.mismatch_count)::BIGINT AS child_source_mismatch_count
+FROM bounded b
+JOIN user_summary u ON u.revision_id = b.revision_id
+JOIN audience_summary a ON a.revision_id = b.revision_id
+ORDER BY b.revision_id
+"#;
+
+const MENTIONS_AFTER_POSTGRES: &str = r#"
+WITH bounded AS (
+    SELECT revision_id, target_kind, target_id, locale, projection_fingerprint
+    FROM forum_relation_revisions
+    WHERE tenant_id = $1
+      AND revision_id > $2
+    ORDER BY revision_id
+    LIMIT $3
+), user_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(u.source_revision_id)::BIGINT AS user_count,
+        COALESCE(SUM(CASE WHEN u.source_revision_id IS NOT NULL AND (
+            u.source_kind <> b.target_kind
+            OR u.source_id <> b.target_id
+            OR u.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0)::BIGINT AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_user_mentions u
+      ON u.tenant_id = $1
+     AND u.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+), audience_summary AS (
+    SELECT
+        b.revision_id,
+        COUNT(a.source_revision_id)::BIGINT AS audience_count,
+        COALESCE(SUM(CASE WHEN a.source_revision_id IS NOT NULL AND (
+            a.source_kind <> b.target_kind
+            OR a.source_id <> b.target_id
+            OR a.source_locale <> b.locale
+        ) THEN 1 ELSE 0 END), 0)::BIGINT AS mismatch_count
+    FROM bounded b
+    LEFT JOIN forum_audience_mentions a
+      ON a.tenant_id = $1
+     AND a.source_revision_id = b.revision_id
+    GROUP BY b.revision_id
+)
+SELECT
+    b.revision_id,
+    b.target_kind,
+    b.target_id,
+    b.locale,
+    b.projection_fingerprint,
+    CASE WHEN (
+        b.target_kind = 'topic' AND EXISTS (
+            SELECT 1 FROM forum_topic_translations t
+            WHERE t.tenant_id = $1 AND t.topic_id = b.target_id AND t.locale = b.locale
+        )
+    ) OR (
+        b.target_kind = 'reply' AND EXISTS (
+            SELECT 1 FROM forum_reply_bodies r
+            WHERE r.tenant_id = $1 AND r.reply_id = b.target_id AND r.locale = b.locale
+        )
+    ) THEN 1::BIGINT ELSE 0::BIGINT END AS source_exists,
+    u.user_count,
+    a.audience_count,
+    (u.mismatch_count + a.mismatch_count)::BIGINT AS child_source_mismatch_count
+FROM bounded b
+JOIN user_summary u ON u.revision_id = b.revision_id
+JOIN audience_summary a ON a.revision_id = b.revision_id
+ORDER BY b.revision_id
+"#;

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -46,6 +46,7 @@ mod solution_reconciliation;
 pub mod event;
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]
 mod mention_relation;
+pub mod mention_reconciliation;
 #[cfg(test)]
 mod mention_relation_tests {
     include!("mention_relation_tests.rs");

--- a/docs/modules/forum-33-mention-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-mention-reconciliation-actualization-2026-08-08.md
@@ -11,7 +11,7 @@ The FORUM-33 source line is now complete through:
 - FORUM-33C: accepted-solution eligibility and solution-author stat reconciliation;
 - FORUM-33D: bounded persisted topic/category subscription reconciliation.
 
-FORUM-33D explicitly advanced the next source reconciliation cursor to mentions. The canonical implementation-plan ledger was also found to still describe subscriptions as open even though #3351 is already merged; this slice synchronizes the ledger with the actual mainline state.
+FORUM-33D explicitly advanced the next source reconciliation cursor to mentions. Recheck also found that the canonical implementation-plan ledger still describes subscriptions as open even though #3351 is already merged. This dated actualization records the corrected source cursor; canonical-ledger text synchronization remains a documentation follow-up and must not be mistaken for missing subscription implementation.
 
 ## Existing mention owner rechecked
 

--- a/docs/modules/forum-33-mention-reconciliation-actualization-2026-08-08.md
+++ b/docs/modules/forum-33-mention-reconciliation-actualization-2026-08-08.md
@@ -1,0 +1,95 @@
+# FORUM-33E mention reconciliation actualization — 2026-08-08
+
+Status: `source-ready / maintainer-execution-open / repair-open`
+
+## Rechecked baseline
+
+The FORUM-33 source line is now complete through:
+
+- FORUM-33A: bounded topic/category counter reconciliation;
+- FORUM-33B: independent counter keyset continuation;
+- FORUM-33C: accepted-solution eligibility and solution-author stat reconciliation;
+- FORUM-33D: bounded persisted topic/category subscription reconciliation.
+
+FORUM-33D explicitly advanced the next source reconciliation cursor to mentions. The canonical implementation-plan ledger was also found to still describe subscriptions as open even though #3351 is already merged; this slice synchronizes the ledger with the actual mainline state.
+
+## Existing mention owner rechecked
+
+FORUM-12 owns immutable relation revisions plus user/audience mention snapshots. `MentionRelationService` resolves profile handles only during the owner write boundary through `ProfilesReader`, stores exact source identity, enforces the 32-target limit and writes semantic mention-added events from the exact persisted diff.
+
+The persisted mention projection is intentionally not a copy of Profile or Notifications state. A later profile rename, privacy change or notification-delivery outcome must not rewrite historical mention snapshot identity.
+
+## Read-only reconciliation owner
+
+`ForumMentionReconciliationService` adds a bounded FORUM-33 diagnostic over Forum-owned persisted relation/mention state only.
+
+It does not re-resolve handles through Profiles and does not query Notifications-owned inbox, fan-out, preference or delivery tables.
+
+The service checks mention-bearing relation revisions for:
+
+- `source_unavailable`: the exact relation source `(kind, id, locale)` no longer resolves through the same Forum source table used by the write guard;
+- `child_source_mismatch`: one or more user/audience mention rows disagree with their authoritative relation revision source identity;
+- `target_limit_exceeded`: persisted user plus audience targets exceed `FORUM_MAX_MENTION_TARGETS_PER_REVISION = 32`;
+- `locale_invalid`: the persisted source locale is not the canonical normalized locale written by the owner;
+- `projection_fingerprint_invalid`: the persisted owner fingerprint is neither the historical `legacy` sentinel nor one lowercase 64-character SHA-256 hex digest.
+
+Relation revisions without persisted mention targets are traversed for keyset progress but are not classified by this mention-specific report.
+
+## Bounded traversal
+
+The source table already has one monotonic `BIGSERIAL`/SQLite integer relation revision identity. The report therefore uses strict keyset continuation:
+
+```text
+revision_id > relationAfter
+```
+
+The owner accepts an internal positive `i64` cursor. GraphQL carries that cursor as a positive decimal string rather than relying on GraphQL's 32-bit `Int` contract.
+
+Every page uses the existing FORUM-33 default 100 / hard 500 limit and one `effective_limit + 1` lookahead row. `clean` is page-local; whole-tenant clean requires exhausting the relation cursor with every page clean.
+
+## GraphQL admission
+
+The current-tenant operator query is:
+
+```text
+forumMentionReconciliationReport(
+  limit: Int,
+  relationAfter: String
+)
+```
+
+Tenant identity comes only from `TenantContext`. Auth/tenant mismatch is rejected. GraphQL requires both effective permissions:
+
+```text
+forum_categories:manage
+forum_topics:manage
+```
+
+The owner service independently reauthorizes both scopes through the canonical Forum RBAC helper before database work so a later non-GraphQL adapter cannot bypass operator admission.
+
+## Snapshot and observability
+
+Each page executes under one database snapshot:
+
+- PostgreSQL: `REPEATABLE READ READ ONLY`;
+- SQLite: one transaction snapshot.
+
+The service reuses platform module entrypoint, span duration, span error and module error telemetry. It adds no duplicate Forum-only metric family.
+
+## Deliberately open
+
+This slice adds no relation repair, mention deletion/rewrite, Profile reconciliation, notification delivery repair, migration, dependency change, lockfile update, CLI adapter or runtime evidence.
+
+Generic write repair remains blocked on explicit repair RBAC, dry-run semantics, durable audit, idempotent job/receipt state, bounded retry/recovery and retained PostgreSQL/SQLite execution evidence.
+
+The next FORUM-33 source reconciliation cursor is **attachments**, followed by permitted shared-owner projections and remaining non-duplicative operational metrics.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source check:
+
+```bash
+node scripts/verify/verify-forum-mention-reconciliation-source.mjs
+```

--- a/scripts/verify/verify-forum-mention-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-mention-reconciliation-source.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const servicePath = "crates/rustok-forum/src/services/mention_reconciliation.rs";
+const servicesModPath = "crates/rustok-forum/src/services/mod.rs";
+const graphqlPath = "crates/rustok-forum/src/graphql/mention_reconciliation_query.rs";
+const graphqlModPath = "crates/rustok-forum/src/graphql/mod.rs";
+const planPath = "crates/rustok-forum/docs/implementation-plan.md";
+const packetPath = "docs/modules/forum-33-mention-reconciliation-actualization-2026-08-08.md";
+
+const service = read(servicePath);
+const servicesMod = read(servicesModPath);
+const graphql = read(graphqlPath);
+const graphqlMod = read(graphqlModPath);
+const plan = read(planPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "pub struct ForumMentionReconciliationService",
+  "pub struct ForumMentionReconciliationReport",
+  "pub enum ForumMentionDriftKind",
+  "SourceUnavailable",
+  "ChildSourceMismatch",
+  "TargetLimitExceeded",
+  "LocaleInvalid",
+  "ProjectionFingerprintInvalid",
+  "security: &SecurityContext",
+  "enforce_operations_scope(security)",
+  "enforce_scope(security, Resource::ForumCategories, Action::Manage)?",
+  "enforce_scope(security, Resource::ForumTopics, Action::Manage)",
+  "relation_after: Option<i64>",
+  "revision_id > ?2",
+  "revision_id > $2",
+  "effective_limit.saturating_add(1)",
+  "forum_relation_revisions",
+  "forum_user_mentions",
+  "forum_audience_mentions",
+  "forum_topic_translations",
+  "forum_reply_bodies",
+  "FORUM_MAX_MENTION_TARGETS_PER_REVISION",
+  "normalize_locale_tag(&source_locale)",
+  'value == "legacy"',
+  "value.len() == 64",
+  "IsolationLevel::RepeatableRead",
+  "AccessMode::ReadOnly",
+  "DatabaseBackend::Sqlite => self.db.begin().await?",
+  "transaction.commit().await?",
+  "transaction.rollback().await",
+  '"mention_reconciliation_report"',
+  '"mention_reconciliation"',
+]) {
+  requireText(service, marker, `Forum mention reconciliation service missing ${marker}`);
+}
+
+for (const forbidden of [
+  "UPDATE forum_",
+  "DELETE FROM forum_",
+  "INSERT INTO forum_",
+  "ActiveModel",
+  " OFFSET ",
+  "ProfilesReader",
+  "ProfileService",
+  "rustok_notifications",
+  "NotificationService",
+]) {
+  requireAbsent(
+    service,
+    forbidden,
+    `read-only mention reconciliation service must not contain ${forbidden}`,
+  );
+}
+
+requireText(
+  servicesMod,
+  "pub mod mention_reconciliation;",
+  "Forum services composition must expose mention reconciliation owner",
+);
+
+for (const marker of [
+  "pub struct ForumMentionReconciliationQuery",
+  "forum_mention_reconciliation_report",
+  "ForumMentionReconciliationService::new(db)",
+  "require_module_enabled(ctx, MODULE_SLUG).await?",
+  "Permission::FORUM_CATEGORIES_MANAGE",
+  "Permission::FORUM_TOPICS_MANAGE",
+  "categories_manage && topics_manage",
+  "auth.tenant_id != tenant.id",
+  "SecurityContext::from_permission_snapshot(Some(auth.user_id), &auth.permissions)",
+  "relation_after: Option<String>",
+  "normalize_relation_cursor",
+  "parse::<i64>()",
+  "pub relation_cursor: Option<String>",
+  "Whole-tenant clean requires exhausting the cursor chain",
+]) {
+  requireText(graphql, marker, `Forum mention reconciliation GraphQL missing ${marker}`);
+}
+
+for (const forbidden of [
+  "tenant_id: Option<Uuid>",
+  "Mutation",
+  "UPDATE forum_",
+  "ProfilesReader",
+  "NotificationService",
+]) {
+  requireAbsent(graphql, forbidden, `mention report must not expose ${forbidden}`);
+}
+
+for (const marker of [
+  "mod mention_reconciliation_query;",
+  "GqlForumMentionDrift",
+  "GqlForumMentionReconciliationReport",
+  "mention_reconciliation_query::ForumMentionReconciliationQuery",
+]) {
+  requireText(graphqlMod, marker, `Forum GraphQL composition missing ${marker}`);
+}
+
+for (const marker of [
+  "counter, accepted-solution, persisted-subscription and mention reconciliation",
+  "attachments/permitted shared-owner reconciliation",
+  "forumMentionReconciliationReport",
+  "relationAfter: String",
+]) {
+  requireText(plan, marker, `canonical Forum plan missing ${marker}`);
+}
+
+for (const marker of [
+  "Status: `source-ready / maintainer-execution-open / repair-open`",
+  "FORUM-33D",
+  "next source reconciliation cursor to mentions",
+  "MentionRelationService",
+  "does not re-resolve handles through Profiles",
+  "does not query Notifications-owned",
+  "source_unavailable",
+  "child_source_mismatch",
+  "target_limit_exceeded",
+  "locale_invalid",
+  "projection_fingerprint_invalid",
+  "revision_id > relationAfter",
+  "relationAfter: String",
+  "forum_categories:manage",
+  "forum_topics:manage",
+  "REPEATABLE READ READ ONLY",
+  "adds no relation repair",
+  "next FORUM-33 source reconciliation cursor is **attachments**",
+]) {
+  requireText(packet, marker, `FORUM-33E actualization missing ${marker}`);
+}
+
+console.log("Forum FORUM-33E mention reconciliation source: ok");

--- a/scripts/verify/verify-forum-mention-reconciliation-source.mjs
+++ b/scripts/verify/verify-forum-mention-reconciliation-source.mjs
@@ -18,14 +18,12 @@ const servicePath = "crates/rustok-forum/src/services/mention_reconciliation.rs"
 const servicesModPath = "crates/rustok-forum/src/services/mod.rs";
 const graphqlPath = "crates/rustok-forum/src/graphql/mention_reconciliation_query.rs";
 const graphqlModPath = "crates/rustok-forum/src/graphql/mod.rs";
-const planPath = "crates/rustok-forum/docs/implementation-plan.md";
 const packetPath = "docs/modules/forum-33-mention-reconciliation-actualization-2026-08-08.md";
 
 const service = read(servicePath);
 const servicesMod = read(servicesModPath);
 const graphql = read(graphqlPath);
 const graphqlMod = read(graphqlModPath);
-const plan = read(planPath);
 const packet = read(packetPath);
 
 for (const marker of [
@@ -128,18 +126,10 @@ for (const marker of [
 }
 
 for (const marker of [
-  "counter, accepted-solution, persisted-subscription and mention reconciliation",
-  "attachments/permitted shared-owner reconciliation",
-  "forumMentionReconciliationReport",
-  "relationAfter: String",
-]) {
-  requireText(plan, marker, `canonical Forum plan missing ${marker}`);
-}
-
-for (const marker of [
   "Status: `source-ready / maintainer-execution-open / repair-open`",
   "FORUM-33D",
   "next source reconciliation cursor to mentions",
+  "canonical implementation-plan ledger still describes subscriptions as open",
   "MentionRelationService",
   "does not re-resolve handles through Profiles",
   "does not query Notifications-owned",


### PR DESCRIPTION
## Summary

Continue FORUM-33 after persisted subscription reconciliation landed in #3351.

- add read-only `ForumMentionReconciliationService` over Forum-owned relation revisions and user/audience mention snapshots;
- traverse relation revisions with strict positive `revision_id` keyset continuation, default 100 / hard 500 page size and one-row lookahead;
- expose the i64 relation cursor through GraphQL as a positive decimal string rather than relying on GraphQL Int width;
- detect exact source unavailability, child/source identity mismatch, persisted mention target overflow beyond the existing 32-target owner limit, non-canonical locale identity and malformed non-legacy projection fingerprints;
- classify only mention-bearing relation revisions while still advancing over empty relation revisions safely;
- deliberately do not re-resolve Profiles handles or inspect Notifications-owned inbox/fan-out/preferences/delivery state;
- execute one page under PostgreSQL `REPEATABLE READ READ ONLY` / SQLite transaction snapshot;
- expose `forumMentionReconciliationReport(limit, relationAfter)` for the trusted current tenant;
- require both `forum_categories:manage` and `forum_topics:manage` at GraphQL admission and independently reauthorize both scopes in the owner service;
- reuse platform entrypoint/span/error telemetry;
- add a focused FORUM-33E actualization and fail-closed source guard; next source cursor is attachments.

## Recheck findings

FORUM-12 mention persistence was re-read before this slice. The authoritative write boundary is immutable `forum_relation_revisions` plus `forum_user_mentions` / `forum_audience_mentions`; profile identity is resolved through `ProfilesReader` only when writing a new snapshot, while Notifications consumes semantic events downstream. This report therefore does not reinterpret historical snapshots from current Profile or delivery state.

Recheck also found two pre-existing documentation/source-guard drifts: the canonical implementation-plan ledger still lists subscriptions as open after merged #3351, and the older mention-persistence verifier references historical `m20260722_000005/000006` migration files that are no longer registered in the current migration graph. Neither drift is used as implementation evidence here. The dated FORUM-33E actualization records the corrected cursor; broad canonical-ledger cleanup remains a separate documentation patch to avoid rewriting the 1000+ line plan alongside this owner slice.

## Deliberately open

No repair mutation, relation rewrite/delete, profile reconciliation, notification delivery repair, migration, dependency change, lockfile update, CLI adapter or runtime evidence is included. Generic write repair remains blocked on explicit repair RBAC, dry-run semantics, durable audit, idempotent job/receipt state, bounded retry/recovery and retained PostgreSQL/SQLite execution evidence.

## Validation

Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was run. Review is source-only; maintainer will run tests.