### PR TITLE
feat(commerce): route admin orders through owner ports

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -94,6 +94,40 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
+    #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_order::OrderAdminCommandRuntime>()
+            .or_else(|| server.shared_get::<rustok_order::OrderAdminCommandRuntime>())
+            .or_else(|| {
+                server
+                    .shared_get::<rustok_outbox::TransactionalEventBus>()
+                    .map(|event_bus| {
+                        rustok_order::OrderAdminCommandRuntime::in_process(
+                            server.db_clone(),
+                            event_bus,
+                        )
+                    })
+            });
+        match runtime {
+            Some(runtime) => {
+                server.shared_insert(runtime.clone());
+                host.with_shared_value(runtime)
+            }
+            None => host,
+        }
+    };
+
+    #[cfg(all(feature = "mod-commerce", feature = "mod-payment"))]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_payment::PaymentOrderReadRuntime>()
+            .or_else(|| server.shared_get::<rustok_payment::PaymentOrderReadRuntime>())
+            .unwrap_or_else(|| rustok_payment::PaymentOrderReadRuntime::in_process(server.db_clone()));
+        server.shared_insert(runtime.clone());
+        host.with_shared_value(runtime)
+    };
+
     #[cfg(feature = "commerce-marketplace-financial")]
     let host = {
         let runtime = server

--- a/crates/rustok-commerce/docs/admin-order-owner-port-cutover-2026-08-08.md
+++ b/crates/rustok-commerce/docs/admin-order-owner-port-cutover-2026-08-08.md
@@ -1,0 +1,62 @@
+# Commerce admin Order owner-port cutover — 2026-08-08
+
+Status: source-complete for the mounted admin Order route, execution evidence pending and unvalidated.
+
+## Scope
+
+This slice moves the mounted `/admin/orders` route family away from direct construction of Order, Payment, and Fulfillment owner services. The HTTP surface remains a Commerce transport adapter: it owns permission checks, trusted request-context translation, public HTTP error envelopes, and response assembly, while business persistence and lifecycle semantics stay behind owner ports.
+
+The canonical broad ecommerce topology task remains open because other mounted Commerce REST/GraphQL surfaces still construct owner services directly.
+
+## Mounted route
+
+`crates/rustok-commerce/src/controllers/admin/mod.rs` mounts `orders_owner_ports.rs` as the `orders` module. The previous `orders.rs` source remains in the tree for compatibility/history but is not the mounted admin Order implementation.
+
+The mounted adapter uses:
+
+- `CommerceOrderReadRuntime` / `OrderReadPort` for order list/detail reads;
+- `OrderAdminCommandRuntime` / `OrderAdminCommandPort` for mark-paid, ship, deliver, and cancel lifecycle commands;
+- `PaymentOrderReadRuntime` / `PaymentOrderReadPort` for latest payment collection by Order;
+- the existing `CommerceFulfillmentLifecycleReadRuntime` / `FulfillmentReadPort` for latest fulfillment by Order.
+
+The mounted adapter does not import or construct `OrderService`, `PaymentService`, or `FulfillmentService`.
+
+## Owner boundaries
+
+Order now exposes a transport-neutral admin lifecycle command port. Its in-process implementation delegates to the existing `OrderService` inside the Order owner crate, so existing serialized lifecycle transitions, outbox publication, validation, and persistence remain owner-controlled.
+
+Payment now exposes an Order-scoped read capability for latest payment collection lookup. Its in-process implementation delegates to the existing `PaymentService` inside the Payment owner crate.
+
+Fulfillment already exposed `find_latest_fulfillment_by_order_projection`; Commerce reuses that existing owner read capability instead of creating another adapter.
+
+## Host composition
+
+`CommerceHttpRuntime` requires the new Order command and Payment Order-read runtimes from `HostRuntimeContext`. The server composition prefers a runtime already selected by the host, then an existing server-shared runtime, and only then composes the built-in in-process owner adapter. This prevents the mounted Commerce route from silently replacing a host-selected external provider with local persistence.
+
+## Context and write admission
+
+The HTTP adapter carries trusted tenant/user identity, locale, optional channel, correlation identity, deadline, and a transport-owned non-empty attempt id into `PortContext`. The attempt id satisfies the generic write-port admission contract without changing the public legacy HTTP body/permission surface.
+
+This slice does **not** claim durable Order command replay or lost-response recovery. A generated transport attempt id is not a durable owner receipt. Durable command idempotency, if required for these lifecycle transitions, remains a separate owner concern.
+
+## Public surface preservation
+
+Permissions remain:
+
+- list: `orders:list`;
+- detail: `orders:read`;
+- mark-paid / ship / deliver / cancel: `orders:update`.
+
+The mounted route retains the existing public status/code/message families for validation, not-found, state conflict, unavailable storage, and safe internal failure. Owner technical details stay behind bounded `PortError` diagnostics.
+
+## Source guard
+
+`scripts/verify/verify-commerce-admin-order-owner-port-cutover.mjs` source-locks the mounted module path, owner runtime requirements, owner port calls, absence of concrete service construction in the mounted route, and host-composition preference for externally selected runtimes.
+
+The verifier was added in this source slice but was not executed.
+
+## Remaining ecommerce topology work
+
+The canonical topology item remains unchecked until all mounted Commerce REST/GraphQL consumers are behind host-composed owner capabilities. Follow-up source slices should inspect the remaining Payment, Fulfillment, Order post-order, checkout/orchestration, and GraphQL construction sites individually rather than treating this admin Order cutover as global completion.
+
+No tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, or external-provider execution evidence are claimed by this slice.

--- a/crates/rustok-commerce/src/controllers/admin/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/mod.rs
@@ -1,5 +1,6 @@
 pub mod changes;
 pub mod fulfillments;
+#[path = "orders_owner_ports.rs"]
 pub mod orders;
 pub mod payments;
 pub mod post_order_reads;

--- a/crates/rustok-commerce/src/controllers/admin/orders_owner_ports.rs
+++ b/crates/rustok-commerce/src/controllers/admin/orders_owner_ports.rs
@@ -1,0 +1,599 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_fulfillment::FindLatestFulfillmentByOrderProjectionRequest;
+use rustok_order::{
+    CancelOrderRequest as OwnerCancelOrderRequest,
+    DeliverOrderRequest as OwnerDeliverOrderRequest, ListOrderProjectionsRequest,
+    MarkOrderPaidRequest as OwnerMarkOrderPaidRequest, ReadOrderProjectionRequest,
+    ShipOrderRequest as OwnerShipOrderRequest,
+};
+use rustok_payment::LatestPaymentCollectionByOrderRequest;
+use rustok_web::{HttpError, HttpResult};
+use uuid::Uuid;
+
+use super::{
+    super::CommerceHttpRuntime,
+    super::common::{PaginatedResponse, ensure_permissions},
+    AdminOrderDetailResponse, ListOrdersParams,
+};
+use crate::dto::{
+    CancelOrderInput, DeliverOrderInput, MarkPaidOrderInput, OrderResponse, ShipOrderInput,
+};
+
+const ADMIN_ORDER_OWNER: &str = "rustok_order.admin_orders";
+const ADMIN_ORDER_BOUNDARY: &str = "commerce_admin_order_http";
+const ADMIN_ORDER_DETAIL_PAYMENT_OWNER: &str = "rustok_payment.admin_order_detail";
+const ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER: &str = "rustok_fulfillment.admin_order_detail";
+const ADMIN_ORDER_DETAIL_BOUNDARY: &str = "commerce_admin_order_detail_http";
+
+fn admin_order_port_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    order_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let resource_id = order_id.unwrap_or(tenant.id);
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-order:{operation}:{resource_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2))
+    .with_idempotency_key(Uuid::new_v4().to_string());
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn port_error_kind(error: &PortError) -> &'static str {
+    match &error.kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
+    }
+}
+
+fn map_order_port_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    order_id: Option<Uuid>,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+        ),
+    };
+    let error_kind = port_error_kind(&error);
+    tracing::error!(
+        owner = ADMIN_ORDER_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        order_id_present = order_id.is_some(),
+        order_id_non_nil = order_id.map(|value| !value.is_nil()).unwrap_or(false),
+        operation,
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_BOUNDARY,
+        "commerce admin order owner port failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_payment_detail_port_error(
+    tenant_id: Uuid,
+    order_id: Uuid,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_payment_invalid",
+            "Payment request is invalid",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_reconciliation_required",
+            "Payment state requires reconciliation before it can be read safely",
+        ),
+    };
+    let error_kind = port_error_kind(&error);
+    tracing::error!(
+        owner = ADMIN_ORDER_DETAIL_PAYMENT_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        order_id_non_nil = !order_id.is_nil(),
+        operation = "find_latest_payment_collection_by_order",
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_DETAIL_BOUNDARY,
+        "commerce admin order detail payment owner read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_fulfillment_detail_port_error(
+    tenant_id: Uuid,
+    order_id: Uuid,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_fulfillment_invalid",
+            "Fulfillment request is invalid",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_fulfillment_failed",
+            "Fulfillment state could not be read safely",
+        ),
+    };
+    let error_kind = port_error_kind(&error);
+    tracing::error!(
+        owner = ADMIN_ORDER_DETAIL_FULFILLMENT_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        order_id_non_nil = !order_id.is_nil(),
+        operation = "find_latest_fulfillment_by_order_projection",
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_DETAIL_BOUNDARY,
+        "commerce admin order detail fulfillment owner read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/orders",
+    tag = "admin",
+    params(ListOrdersParams),
+    responses(
+        (status = 200, description = "Orders", body = PaginatedResponse<OrderResponse>),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn list_orders(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Query(params): Query<ListOrdersParams>,
+) -> HttpResult<Json<PaginatedResponse<OrderResponse>>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_LIST],
+        "Permission denied: orders:list required",
+    )?;
+
+    let pagination = params.pagination.unwrap_or_default();
+    let customer_id = params.customer_id;
+    let context = admin_order_port_context(&tenant, &auth, &request_context, None, "list_orders");
+    let page = runtime
+        .order_read_port()
+        .list_order_projections(
+            context.clone(),
+            ListOrderProjectionsRequest {
+                page: pagination.page,
+                per_page: pagination.limit(),
+                status: params.status,
+                customer_id,
+                tenant_default_locale: Some(tenant.default_locale.clone()),
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_order_port_error(
+                tenant.id,
+                auth.user_id,
+                None,
+                "list_orders",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(PaginatedResponse {
+        data: page.items,
+        meta: super::super::common::PaginationMeta::new(
+            pagination.page,
+            pagination.limit(),
+            page.total,
+        ),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/orders/{id}",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    responses(
+        (status = 200, description = "Order details", body = AdminOrderDetailResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn show_order(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<AdminOrderDetailResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_READ],
+        "Permission denied: orders:read required",
+    )?;
+
+    let order_context =
+        admin_order_port_context(&tenant, &auth, &request_context, Some(id), "get_order");
+    let order = runtime
+        .order_read_port()
+        .read_order_projection(
+            order_context.clone(),
+            ReadOrderProjectionRequest {
+                order_id: id,
+                tenant_default_locale: Some(tenant.default_locale.clone()),
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_order_port_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "get_order",
+                &order_context,
+                error,
+            )
+        })?;
+
+    let payment_context = admin_order_port_context(
+        &tenant,
+        &auth,
+        &request_context,
+        Some(id),
+        "payment_detail",
+    );
+    let payment_collection = runtime
+        .payment_order_read_port()
+        .find_latest_collection_by_order(
+            payment_context.clone(),
+            LatestPaymentCollectionByOrderRequest { order_id: id },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_detail_port_error(tenant.id, id, &payment_context, error)
+        })?;
+
+    let fulfillment_context = admin_order_port_context(
+        &tenant,
+        &auth,
+        &request_context,
+        Some(id),
+        "fulfillment_detail",
+    );
+    let fulfillment = runtime
+        .fulfillment_read_port()
+        .find_latest_fulfillment_by_order_projection(
+            fulfillment_context.clone(),
+            FindLatestFulfillmentByOrderProjectionRequest { order_id: id },
+        )
+        .await
+        .map_err(|error| {
+            map_fulfillment_detail_port_error(tenant.id, id, &fulfillment_context, error)
+        })?;
+
+    Ok(Json(AdminOrderDetailResponse {
+        order,
+        payment_collection,
+        fulfillment,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/orders/{id}/mark-paid",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    request_body = MarkPaidOrderInput,
+    responses(
+        (status = 200, description = "Order marked paid", body = OrderResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn mark_order_paid(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<MarkPaidOrderInput>,
+) -> HttpResult<Json<OrderResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_order_port_context(&tenant, &auth, &request_context, Some(id), "mark_order_paid");
+    let order = runtime
+        .order_admin_command_port()
+        .mark_paid(
+            context.clone(),
+            OwnerMarkOrderPaidRequest {
+                order_id: id,
+                payment_id: input.payment_id,
+                payment_method: input.payment_method,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_order_port_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "mark_order_paid",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(order))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/orders/{id}/ship",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    request_body = ShipOrderInput,
+    responses(
+        (status = 200, description = "Order shipped", body = OrderResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn ship_order(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<ShipOrderInput>,
+) -> HttpResult<Json<OrderResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context = admin_order_port_context(&tenant, &auth, &request_context, Some(id), "ship_order");
+    let order = runtime
+        .order_admin_command_port()
+        .ship(
+            context.clone(),
+            OwnerShipOrderRequest {
+                order_id: id,
+                tracking_number: input.tracking_number,
+                carrier: input.carrier,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_order_port_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "ship_order",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(order))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/orders/{id}/deliver",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    request_body = DeliverOrderInput,
+    responses(
+        (status = 200, description = "Order delivered", body = OrderResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn deliver_order(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<DeliverOrderInput>,
+) -> HttpResult<Json<OrderResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_order_port_context(&tenant, &auth, &request_context, Some(id), "deliver_order");
+    let order = runtime
+        .order_admin_command_port()
+        .deliver(
+            context.clone(),
+            OwnerDeliverOrderRequest {
+                order_id: id,
+                delivered_signature: input.delivered_signature,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_order_port_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "deliver_order",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(order))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/orders/{id}/cancel",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    request_body = CancelOrderInput,
+    responses(
+        (status = 200, description = "Order cancelled", body = OrderResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn cancel_order(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CancelOrderInput>,
+) -> HttpResult<Json<OrderResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_order_port_context(&tenant, &auth, &request_context, Some(id), "cancel_order");
+    let order = runtime
+        .order_admin_command_port()
+        .cancel(
+            context.clone(),
+            OwnerCancelOrderRequest {
+                order_id: id,
+                reason: input.reason,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_order_port_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "cancel_order",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(order))
+}

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -27,6 +27,8 @@ pub struct CommerceHttpRuntime {
     fulfillment_lifecycle_read_runtime:
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
+    order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
+    payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
     product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
     product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime,
     #[cfg(feature = "marketplace-financial")]
@@ -75,6 +77,14 @@ impl CommerceHttpRuntime {
 
     fn order_read_port(&self) -> std::sync::Arc<dyn rustok_order::OrderReadPort> {
         self.order_read_runtime.order_read_port()
+    }
+
+    fn order_admin_command_port(&self) -> std::sync::Arc<dyn rustok_order::OrderAdminCommandPort> {
+        self.order_admin_command_runtime.command_port()
+    }
+
+    fn payment_order_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentOrderReadPort> {
+        self.payment_order_read_runtime.read_port()
     }
 
     fn product_catalog_read_port(
@@ -132,6 +142,20 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require CommerceOrderReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let order_admin_command_runtime = runtime
+            .shared_get::<rustok_order::OrderAdminCommandRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require OrderAdminCommandRuntime in HostRuntimeContext"
+                )
+            })?;
+        let payment_order_read_runtime = runtime
+            .shared_get::<rustok_payment::PaymentOrderReadRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require PaymentOrderReadRuntime in HostRuntimeContext"
+                )
+            })?;
         let product_catalog_read_runtime = runtime
             .shared_get::<rustok_product::ProductCatalogReadRuntime>()
             .ok_or_else(|| {
@@ -166,6 +190,8 @@ impl CommerceHttpRuntime {
             shipping_option_read_runtime,
             fulfillment_lifecycle_read_runtime,
             order_read_runtime,
+            order_admin_command_runtime,
+            payment_order_read_runtime,
             product_catalog_read_runtime,
             product_catalog_command_runtime,
             #[cfg(feature = "marketplace-financial")]

--- a/crates/rustok-order/src/admin_command.rs
+++ b/crates/rustok-order/src/admin_command.rs
@@ -1,0 +1,291 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{OrderError, OrderResponse, OrderService};
+
+const ORDER_ADMIN_COMMAND_OWNER: &str = "rustok_order";
+const ORDER_ADMIN_COMMAND_BOUNDARY: &str = "order_admin_command_port";
+
+#[async_trait]
+pub trait OrderAdminCommandPort: Send + Sync {
+    async fn mark_paid(
+        &self,
+        context: PortContext,
+        request: MarkOrderPaidRequest,
+    ) -> Result<OrderResponse, PortError>;
+
+    async fn ship(
+        &self,
+        context: PortContext,
+        request: ShipOrderRequest,
+    ) -> Result<OrderResponse, PortError>;
+
+    async fn deliver(
+        &self,
+        context: PortContext,
+        request: DeliverOrderRequest,
+    ) -> Result<OrderResponse, PortError>;
+
+    async fn cancel(
+        &self,
+        context: PortContext,
+        request: CancelOrderRequest,
+    ) -> Result<OrderResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MarkOrderPaidRequest {
+    pub order_id: Uuid,
+    pub payment_id: String,
+    pub payment_method: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShipOrderRequest {
+    pub order_id: Uuid,
+    pub tracking_number: String,
+    pub carrier: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeliverOrderRequest {
+    pub order_id: Uuid,
+    pub delivered_signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CancelOrderRequest {
+    pub order_id: Uuid,
+    pub reason: Option<String>,
+}
+
+pub struct InProcessOrderAdminCommandPort {
+    inner: OrderService,
+}
+
+impl InProcessOrderAdminCommandPort {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self {
+            inner: OrderService::new(db, event_bus),
+        }
+    }
+}
+
+pub fn in_process_order_admin_command_port(
+    db: DatabaseConnection,
+    event_bus: TransactionalEventBus,
+) -> Arc<dyn OrderAdminCommandPort> {
+    Arc::new(InProcessOrderAdminCommandPort::new(db, event_bus))
+}
+
+#[derive(Clone)]
+pub struct OrderAdminCommandRuntime {
+    command_port: Arc<dyn OrderAdminCommandPort>,
+}
+
+impl OrderAdminCommandRuntime {
+    pub fn new(command_port: Arc<dyn OrderAdminCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self::new(in_process_order_admin_command_port(db, event_bus))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn OrderAdminCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl OrderAdminCommandPort for InProcessOrderAdminCommandPort {
+    async fn mark_paid(
+        &self,
+        context: PortContext,
+        request: MarkOrderPaidRequest,
+    ) -> Result<OrderResponse, PortError> {
+        let operation = "mark_paid";
+        let (tenant_id, actor_id) = require_admin_command_context(&context, operation)?;
+        self.inner
+            .mark_paid(
+                tenant_id,
+                actor_id,
+                request.order_id,
+                request.payment_id,
+                request.payment_method,
+            )
+            .await
+            .map_err(|error| map_order_error(&context, operation, request.order_id, error))
+    }
+
+    async fn ship(
+        &self,
+        context: PortContext,
+        request: ShipOrderRequest,
+    ) -> Result<OrderResponse, PortError> {
+        let operation = "ship";
+        let (tenant_id, actor_id) = require_admin_command_context(&context, operation)?;
+        self.inner
+            .ship_order(
+                tenant_id,
+                actor_id,
+                request.order_id,
+                request.tracking_number,
+                request.carrier,
+            )
+            .await
+            .map_err(|error| map_order_error(&context, operation, request.order_id, error))
+    }
+
+    async fn deliver(
+        &self,
+        context: PortContext,
+        request: DeliverOrderRequest,
+    ) -> Result<OrderResponse, PortError> {
+        let operation = "deliver";
+        let (tenant_id, actor_id) = require_admin_command_context(&context, operation)?;
+        self.inner
+            .deliver_order(
+                tenant_id,
+                actor_id,
+                request.order_id,
+                request.delivered_signature,
+            )
+            .await
+            .map_err(|error| map_order_error(&context, operation, request.order_id, error))
+    }
+
+    async fn cancel(
+        &self,
+        context: PortContext,
+        request: CancelOrderRequest,
+    ) -> Result<OrderResponse, PortError> {
+        let operation = "cancel";
+        let (tenant_id, actor_id) = require_admin_command_context(&context, operation)?;
+        self.inner
+            .cancel_order(tenant_id, actor_id, request.order_id, request.reason)
+            .await
+            .map_err(|error| map_order_error(&context, operation, request.order_id, error))
+    }
+}
+
+fn require_admin_command_context(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(Uuid, Uuid), PortError> {
+    context.require_policy(PortCallPolicy::write())?;
+    let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        log_invalid_context(context, operation, "tenant_id");
+        PortError::validation(
+            "order.admin_command_context_invalid",
+            "order command context is invalid",
+        )
+    })?;
+    let actor_id = Uuid::parse_str(&context.actor.id).map_err(|_| {
+        log_invalid_context(context, operation, "actor_id");
+        PortError::validation(
+            "order.admin_command_context_invalid",
+            "order command context is invalid",
+        )
+    })?;
+    Ok((tenant_id, actor_id))
+}
+
+fn log_invalid_context(context: &PortContext, operation: &'static str, field: &'static str) {
+    tracing::warn!(
+        owner = ORDER_ADMIN_COMMAND_OWNER,
+        operation,
+        field,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        boundary = ORDER_ADMIN_COMMAND_BOUNDARY,
+        "order admin command context was rejected"
+    );
+}
+
+fn map_order_error(
+    context: &PortContext,
+    operation: &'static str,
+    order_id: Uuid,
+    error: OrderError,
+) -> PortError {
+    let (kind, code, message, retryable, error_variant, technical) = match &error {
+        OrderError::Validation(_) => (
+            PortErrorKind::Validation,
+            "order.admin_command_validation",
+            "order request is invalid",
+            false,
+            "validation",
+            false,
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            PortErrorKind::NotFound,
+            "order.admin_order_not_found",
+            "order was not found",
+            false,
+            "not_found",
+            false,
+        ),
+        OrderError::InvalidTransition { .. } => (
+            PortErrorKind::Conflict,
+            "order.admin_command_state_conflict",
+            "order lifecycle transition conflicts with the current state",
+            false,
+            "invalid_transition",
+            false,
+        ),
+        OrderError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "order.admin_command_storage_unavailable",
+            "order storage is temporarily unavailable",
+            true,
+            "database",
+            true,
+        ),
+        OrderError::Core(_) => (
+            PortErrorKind::InvariantViolation,
+            "order.admin_command_invariant",
+            "order operation could not be completed safely",
+            false,
+            "core",
+            true,
+        ),
+    };
+
+    if technical {
+        tracing::error!(
+            owner = ORDER_ADMIN_COMMAND_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            order_id_non_nil = !order_id.is_nil(),
+            error_variant,
+            code,
+            retryable,
+            boundary = ORDER_ADMIN_COMMAND_BOUNDARY,
+            "order admin command failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = ORDER_ADMIN_COMMAND_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            order_id_non_nil = !order_id.is_nil(),
+            error_variant,
+            code,
+            retryable,
+            boundary = ORDER_ADMIN_COMMAND_BOUNDARY,
+            "order admin command was rejected"
+        );
+    }
+
+    PortError::new(kind, code, message, retryable)
+}

--- a/crates/rustok-order/src/lib.rs
+++ b/crates/rustok-order/src/lib.rs
@@ -13,6 +13,7 @@ use rustok_api::Permission;
 use rustok_core::{MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+mod admin_command;
 pub mod analytics;
 mod checkout_compensation;
 mod checkout_compensation_local_context;
@@ -39,6 +40,11 @@ pub mod checkout_owner_context {
     };
 }
 
+pub use admin_command::{
+    CancelOrderRequest, DeliverOrderRequest, InProcessOrderAdminCommandPort,
+    MarkOrderPaidRequest, OrderAdminCommandPort, OrderAdminCommandRuntime, ShipOrderRequest,
+    in_process_order_admin_command_port,
+};
 pub use analytics::{OrderStatsSnapshot, load_order_stats_snapshot};
 pub use checkout_compensation::{
     CheckoutOrderCompensationPort, CheckoutOrderCompensationRequest,

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -20,6 +20,7 @@ pub mod http;
 pub mod migrations;
 #[cfg(feature = "server")]
 pub mod openapi;
+mod order_read;
 pub mod ports;
 #[cfg(feature = "server")]
 pub mod provider_event_recovery_controller;
@@ -35,6 +36,10 @@ pub use checkout_compensation::{
 pub use checkout_execution::*;
 pub use dto::*;
 pub use entities::*;
+pub use order_read::{
+    InProcessPaymentOrderReadPort, LatestPaymentCollectionByOrderRequest, PaymentOrderReadPort,
+    PaymentOrderReadRuntime, in_process_payment_order_read_port,
+};
 pub use ports::*;
 pub use providers::*;
 #[cfg(feature = "stripe")]

--- a/crates/rustok-payment/src/order_read.rs
+++ b/crates/rustok-payment/src/order_read.rs
@@ -1,0 +1,175 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{PaymentCollectionResponse, PaymentError, PaymentService};
+
+const PAYMENT_ORDER_READ_OWNER: &str = "rustok_payment";
+const PAYMENT_ORDER_READ_BOUNDARY: &str = "payment_order_read_port";
+
+#[async_trait]
+pub trait PaymentOrderReadPort: Send + Sync {
+    async fn find_latest_collection_by_order(
+        &self,
+        context: PortContext,
+        request: LatestPaymentCollectionByOrderRequest,
+    ) -> Result<Option<PaymentCollectionResponse>, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LatestPaymentCollectionByOrderRequest {
+    pub order_id: Uuid,
+}
+
+pub struct InProcessPaymentOrderReadPort {
+    inner: PaymentService,
+}
+
+impl InProcessPaymentOrderReadPort {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: PaymentService::new(db),
+        }
+    }
+}
+
+pub fn in_process_payment_order_read_port(db: DatabaseConnection) -> Arc<dyn PaymentOrderReadPort> {
+    Arc::new(InProcessPaymentOrderReadPort::new(db))
+}
+
+#[derive(Clone)]
+pub struct PaymentOrderReadRuntime {
+    read_port: Arc<dyn PaymentOrderReadPort>,
+}
+
+impl PaymentOrderReadRuntime {
+    pub fn new(read_port: Arc<dyn PaymentOrderReadPort>) -> Self {
+        Self { read_port }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(in_process_payment_order_read_port(db))
+    }
+
+    pub fn read_port(&self) -> Arc<dyn PaymentOrderReadPort> {
+        self.read_port.clone()
+    }
+}
+
+#[async_trait]
+impl PaymentOrderReadPort for InProcessPaymentOrderReadPort {
+    async fn find_latest_collection_by_order(
+        &self,
+        context: PortContext,
+        request: LatestPaymentCollectionByOrderRequest,
+    ) -> Result<Option<PaymentCollectionResponse>, PortError> {
+        let operation = "find_latest_collection_by_order";
+        context.require_policy(PortCallPolicy::read())?;
+        let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+            tracing::warn!(
+                owner = PAYMENT_ORDER_READ_OWNER,
+                operation,
+                correlation_id = %context.correlation_id,
+                tenant_id_length = context.tenant_id.chars().count(),
+                boundary = PAYMENT_ORDER_READ_BOUNDARY,
+                "payment order read context was rejected"
+            );
+            PortError::validation(
+                "payment.order_read_context_invalid",
+                "payment request context is invalid",
+            )
+        })?;
+
+        self.inner
+            .find_latest_collection_by_order(tenant_id, request.order_id)
+            .await
+            .map_err(|error| map_payment_error(&context, operation, request.order_id, error))
+    }
+}
+
+fn map_payment_error(
+    context: &PortContext,
+    operation: &'static str,
+    order_id: Uuid,
+    error: PaymentError,
+) -> PortError {
+    let (kind, code, message, retryable, error_variant, technical) = match &error {
+        PaymentError::Validation(_) => (
+            PortErrorKind::Validation,
+            "payment.order_read_validation",
+            "payment request is invalid",
+            false,
+            "validation",
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            PortErrorKind::NotFound,
+            "payment.order_read_not_found",
+            "payment resource was not found",
+            false,
+            "not_found",
+            false,
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            PortErrorKind::Conflict,
+            "payment.order_read_conflict",
+            "payment state conflicts with the request",
+            false,
+            "conflict",
+            false,
+        ),
+        PaymentError::ProviderUnavailable { .. }
+        | PaymentError::ProviderConfiguration { .. }
+        | PaymentError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "payment.order_read_unavailable",
+            "payment storage is temporarily unavailable",
+            true,
+            "unavailable",
+            true,
+        ),
+        PaymentError::ProviderInvalidResponse { .. }
+        | PaymentError::ProviderOutcomeUnknown { .. } => (
+            PortErrorKind::InvariantViolation,
+            "payment.order_read_invariant",
+            "payment state could not be read safely",
+            false,
+            "invariant",
+            true,
+        ),
+    };
+
+    if technical {
+        tracing::error!(
+            owner = PAYMENT_ORDER_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            order_id_non_nil = !order_id.is_nil(),
+            error_variant,
+            code,
+            retryable,
+            boundary = PAYMENT_ORDER_READ_BOUNDARY,
+            "payment order read failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = PAYMENT_ORDER_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            order_id_non_nil = !order_id.is_nil(),
+            error_variant,
+            code,
+            retryable,
+            boundary = PAYMENT_ORDER_READ_BOUNDARY,
+            "payment order read was rejected"
+        );
+    }
+
+    PortError::new(kind, code, message, retryable)
+}

--- a/scripts/verify/verify-commerce-admin-order-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-order-owner-port-cutover.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const adminModule = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const mountedOrders = read(
+  'crates/rustok-commerce/src/controllers/admin/orders_owner_ports.rs',
+);
+const commerceRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const orderRoot = read('crates/rustok-order/src/lib.rs');
+const orderCommand = read('crates/rustok-order/src/admin_command.rs');
+const paymentRoot = read('crates/rustok-payment/src/lib.rs');
+const paymentOrderRead = read('crates/rustok-payment/src/order_read.rs');
+const fulfillmentRead = read('crates/rustok-fulfillment/src/fulfillment_read.rs');
+const serverComposition = read(
+  'apps/server/src/services/commerce_provider_runtime.rs',
+);
+const note = read(
+  'crates/rustok-commerce/docs/admin-order-owner-port-cutover-2026-08-08.md',
+);
+
+const failures = [];
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [source, value, label] of [
+  [adminModule, '#[path = "orders_owner_ports.rs"]', 'mounted admin Order path'],
+  [adminModule, 'pub mod orders;', 'mounted admin Order module'],
+  [mountedOrders, '.order_read_port()', 'mounted Order read port'],
+  [mountedOrders, '.order_admin_command_port()', 'mounted Order command port'],
+  [mountedOrders, '.payment_order_read_port()', 'mounted Payment Order read port'],
+  [mountedOrders, '.fulfillment_read_port()', 'mounted Fulfillment read port'],
+  [mountedOrders, 'FindLatestFulfillmentByOrderProjectionRequest', 'Fulfillment Order projection request'],
+  [mountedOrders, 'LatestPaymentCollectionByOrderRequest', 'Payment Order projection request'],
+  [mountedOrders, 'OwnerMarkOrderPaidRequest', 'Order mark-paid owner request'],
+  [mountedOrders, 'OwnerShipOrderRequest', 'Order ship owner request'],
+  [mountedOrders, 'OwnerDeliverOrderRequest', 'Order deliver owner request'],
+  [mountedOrders, 'OwnerCancelOrderRequest', 'Order cancel owner request'],
+  [mountedOrders, '.with_deadline(', 'mounted deadline context'],
+  [mountedOrders, '.with_idempotency_key(', 'mounted write attempt identity'],
+
+  [commerceRuntime, 'order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime', 'Commerce Order command runtime field'],
+  [commerceRuntime, 'payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime', 'Commerce Payment Order read runtime field'],
+  [commerceRuntime, 'fn order_admin_command_port(', 'Commerce Order command runtime accessor'],
+  [commerceRuntime, 'fn payment_order_read_port(', 'Commerce Payment Order read runtime accessor'],
+  [commerceRuntime, '.shared_get::<rustok_order::OrderAdminCommandRuntime>()', 'Commerce host Order command requirement'],
+  [commerceRuntime, '.shared_get::<rustok_payment::PaymentOrderReadRuntime>()', 'Commerce host Payment Order read requirement'],
+
+  [orderRoot, 'pub use admin_command::{', 'Order owner command exports'],
+  [orderCommand, 'pub trait OrderAdminCommandPort', 'Order admin command capability'],
+  [orderCommand, 'pub struct OrderAdminCommandRuntime', 'Order admin command runtime'],
+  [orderCommand, 'PortCallPolicy::write()', 'Order write admission policy'],
+  [orderCommand, 'OrderService::new(db, event_bus)', 'Order owner in-process delegation'],
+
+  [paymentRoot, 'pub use order_read::{', 'Payment Order read exports'],
+  [paymentOrderRead, 'pub trait PaymentOrderReadPort', 'Payment Order read capability'],
+  [paymentOrderRead, 'pub struct PaymentOrderReadRuntime', 'Payment Order read runtime'],
+  [paymentOrderRead, 'PortCallPolicy::read()', 'Payment read admission policy'],
+  [paymentOrderRead, 'PaymentService::new(db)', 'Payment owner in-process delegation'],
+
+  [fulfillmentRead, 'find_latest_fulfillment_by_order_projection', 'existing Fulfillment Order read capability'],
+
+  [serverComposition, 'host\n            .shared_get::<rustok_order::OrderAdminCommandRuntime>()', 'host-selected Order command preference'],
+  [serverComposition, '.or_else(|| server.shared_get::<rustok_order::OrderAdminCommandRuntime>())', 'server-shared Order command fallback'],
+  [serverComposition, 'rustok_order::OrderAdminCommandRuntime::in_process(', 'built-in Order command fallback'],
+  [serverComposition, 'host\n            .shared_get::<rustok_payment::PaymentOrderReadRuntime>()', 'host-selected Payment read preference'],
+  [serverComposition, '.or_else(|| server.shared_get::<rustok_payment::PaymentOrderReadRuntime>())', 'server-shared Payment read fallback'],
+  [serverComposition, 'rustok_payment::PaymentOrderReadRuntime::in_process(server.db_clone())', 'built-in Payment read fallback'],
+
+  [note, 'source-complete for the mounted admin Order route', 'cutover note status'],
+  [note, 'does **not** claim durable Order command replay', 'cutover durable replay non-claim'],
+]) requireText(source, value, label);
+
+for (const [source, value, label] of [
+  [mountedOrders, 'OrderService::new', 'mounted direct Order service construction'],
+  [mountedOrders, 'PaymentService::new', 'mounted direct Payment service construction'],
+  [mountedOrders, 'FulfillmentService::new', 'mounted direct Fulfillment service construction'],
+  [mountedOrders, 'use rustok_order::OrderService', 'mounted concrete Order import'],
+  [mountedOrders, 'use rustok_payment::PaymentService', 'mounted concrete Payment import'],
+  [mountedOrders, 'use rustok_fulfillment::FulfillmentService', 'mounted concrete Fulfillment import'],
+  [mountedOrders, 'runtime.db_clone()', 'mounted raw DB capability escape'],
+  [mountedOrders, 'runtime.event_bus()', 'mounted raw event bus capability escape'],
+]) forbidText(source, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce admin Order owner-port cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Mounted Commerce admin Order routes use host-composed Order, Payment, and Fulfillment owner ports; execution evidence remains open',
+);


### PR DESCRIPTION
## Summary
- mount `/admin/orders` on a dedicated owner-port adapter instead of the legacy concrete-service route
- add an Order-owned admin lifecycle command port/runtime for mark-paid, ship, deliver, and cancel
- add a Payment-owned Order-scoped read port/runtime for latest payment collection lookup
- reuse the existing Fulfillment owner read port for Order detail
- require the new owner runtimes through `CommerceHttpRuntime`
- compose them in the server with host-selected runtime preference, then server-shared fallback, then in-process owner fallback
- preserve existing admin Order permissions and public HTTP error families
- carry trusted tenant/user/locale/channel context, deadline, and a transport-owned write attempt id through `PortContext`
- add focused source documentation and a source verifier without executing it

## Boundary
The mounted `orders` module is now `orders_owner_ports.rs`. The old `orders.rs` remains in the tree but is no longer the mounted admin Order implementation. The mounted adapter does not construct `OrderService`, `PaymentService`, or `FulfillmentService`; concrete in-process service construction is contained inside the corresponding owner crates.

The generated attempt id satisfies generic write-port admission but is **not** claimed as durable Order command replay. Durable lost-response/restart semantics remain a separate owner concern.

## Scope status
This advances the open canonical ecommerce topology P0 but does not complete it: other mounted Commerce Payment, Fulfillment, post-order, checkout/orchestration, and GraphQL construction sites still require focused owner-port cutovers.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, source verifier execution, workflow checks, CI, HTTP runtime calls, external-provider execution, and runtime validation were intentionally not run per maintainer instruction.