### PR TITLE
docs(parity): synchronize Pages Page Builder rollout plan

### DIFF
--- a/crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
@@ -12,6 +12,8 @@ const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
 const sharedPlanPath = "docs/modules/pages-page-builder-parity-continuation-plan.md";
 const localPlanPath = "crates/rustok-page-builder/docs/implementation-plan.md";
 const centralPlanPath = "docs/modules/page-builder-implementation-plan.md";
+const parityActualizationPath = "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md";
+const rolloutActualizationPath = "docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md";
 const gatePath = "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json";
 const forumManifestPath = "crates/rustok-forum/rustok-module.toml";
 const forumWavePath = "crates/rustok-forum/contracts/evidence/forum-wave1-rollout-evidence.json";
@@ -21,6 +23,11 @@ function read(relativePath) {
   const absolutePath = path.join(repoRoot, relativePath);
   if (!fs.existsSync(absolutePath)) {
     failures.push(`${relativePath}: required file is missing`);
+    return "";
+  }
+  const stats = fs.lstatSync(absolutePath);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${relativePath}: required source must be a regular non-symlink file`);
     return "";
   }
   return fs.readFileSync(absolutePath, "utf8");
@@ -53,6 +60,8 @@ function section(source, startMarker, endMarker) {
 const sharedPlan = read(sharedPlanPath);
 const localPlan = read(localPlanPath);
 const centralPlan = read(centralPlanPath);
+const parityActualization = read(parityActualizationPath);
+const rolloutActualization = read(rolloutActualizationPath);
 const gate = parseJson(read(gatePath), gatePath);
 const forumManifest = read(forumManifestPath);
 const forumWave = parseJson(read(forumWavePath), forumWavePath);
@@ -69,9 +78,7 @@ for (const marker of [
   "forum-runtime-composition-source-ready",
   "forum-evidence-harness-source-ready",
   "pages-reference-consumer-gate-source-ready",
-]) {
-  requireText(sharedPlan, marker, `${sharedPlanPath}: status`);
-}
+]) requireText(sharedPlan, marker, `${sharedPlanPath}: status`);
 forbidText(sharedPlan, "forum-fly-adapter-open", `${sharedPlanPath}: status`);
 
 for (const marker of [
@@ -86,35 +93,27 @@ for (const marker of [
   "preview_data_state = \"owner_preview_transport_ready\"",
   "property_data_state = \"owner_property_editor_ready\"",
   "acceptance remains `false`",
-]) {
-  requireText(sharedCurrent, marker, `${sharedPlanPath}: current reconciliation`);
-}
+]) requireText(sharedCurrent, marker, `${sharedPlanPath}: current reconciliation`);
 
 for (const stale of [
   "adapter_state = \"pending\"",
   "because Forum has no real Fly component registry or `ContributionAdapter` yet",
   "The next contribution source cursor is the real Forum Fly adapter/component-registry slice",
-]) {
-  forbidText(sharedCurrent, stale, `${sharedPlanPath}: current reconciliation`);
-}
+]) forbidText(sharedCurrent, stale, `${sharedPlanPath}: current reconciliation`);
 
 for (const marker of [
   "Maintainer executes and accepts `pages_reference_consumer_gate`",
   "execute the retained Forum browser/runtime/deployment-attestation packets",
   "health remains `unobserved`",
   "Promote FFA/FBA only after",
-]) {
-  requireText(sharedNext, marker, `${sharedPlanPath}: next cursor`);
-}
+]) requireText(sharedNext, marker, `${sharedPlanPath}: next cursor`);
 
 for (const marker of [
   "Forum is the second production consumer",
   "pages_reference_consumer_gate",
   "accepted = false",
   "execute the retained Forum browser/runtime/deployment-attestation",
-]) {
-  requireText(localPlan, marker, localPlanPath);
-}
+]) requireText(localPlan, marker, localPlanPath);
 forbidText(
   localOpen,
   "Connect the next production consumer's concrete tenant-scoped store",
@@ -125,9 +124,43 @@ for (const marker of [
   "Forum Fly adapter/component registry: source-ready",
   "Forum owner preview transport/Pages host composition: source-ready",
   "Forum owner-backed property editing: source-ready",
-]) {
-  requireText(centralPlan, marker, centralPlanPath);
-}
+]) requireText(centralPlan, marker, centralPlanPath);
+
+for (const marker of [
+  "pages-reference-consumer-rollout-source-ready",
+  "docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md",
+  "server-owned rollout state",
+  "FLY_CAPABILITY_DENIED",
+  "FEATURE_DISABLED",
+  "artifact/HTTP",
+  "rollout runtime matrix",
+  "owner sign-off + explicit rollback decision",
+  "No additional Pages/Page Builder rollout architecture slice",
+]) requireText(parityActualization, marker, parityActualizationPath);
+
+for (const marker of [
+  "source-parity-current",
+  "PR #3333",
+  "PR #3337",
+  "PR #3345",
+  "PR #3353",
+  "server-owned persisted rollout state",
+  "FLY_CAPABILITY_DENIED",
+  "feature-disabled / FEATURE_DISABLED",
+  "artifact/HTTP",
+  "rollout runtime matrix",
+  "canonical rollout feature preflight",
+  "reference-consumer candidate",
+  "There is no additional source-only rollout architecture task",
+  "pages_reference_consumer_gate` remains `accepted = false`",
+  "Forum Wave remains blocked",
+  "FFA/FBA promotion remains unclaimed",
+]) requireText(rolloutActualization, marker, rolloutActualizationPath);
+forbidText(
+  rolloutActualization,
+  "FLY_CAPABILITY_DENIED` is accepted as evidence for the provider `FEATURE_DISABLED",
+  rolloutActualizationPath,
+);
 
 if (gate.artifact !== "pages_reference_consumer_gate_source") {
   failures.push(`${gatePath}: gate artifact identity drifted`);
@@ -152,6 +185,34 @@ if (gate.current_boundary?.provider_health !== "unobserved") {
 if (gate.current_boundary?.forum_wave_blocker !== "pages_reference_consumer_gate") {
   failures.push(`${gatePath}: Forum Wave blocker drifted`);
 }
+if (
+  gate.current_boundary?.four_profile_runtime_matrix !==
+  "harness_source_ready_maintainer_execution_pending"
+) failures.push(`${gatePath}: rollout matrix cursor drifted`);
+if (
+  gate.current_boundary?.canonical_feature_preflight !==
+  "harness_source_ready_maintainer_execution_pending_FEATURE_DISABLED"
+) failures.push(`${gatePath}: canonical feature-preflight cursor drifted`);
+if (
+  gate.current_boundary?.reference_candidate_rollout_matrix_input !==
+    "source_ready_required_before_candidate" ||
+  gate.current_boundary?.reference_candidate_feature_preflight_input !==
+    "source_ready_required_before_candidate"
+) failures.push(`${gatePath}: reference candidate rollout-input cursor drifted`);
+if (
+  gate.execution_harness?.required_inputs?.rollout_matrix !==
+    "pages_builder_rollout_runtime_matrix_v1" ||
+  gate.execution_harness?.required_inputs?.rollout_feature_preflight !==
+    "pages_builder_rollout_feature_preflight_v1" ||
+  gate.execution_harness?.canonical_feature_disabled_code_required !== "FEATURE_DISABLED"
+) failures.push(`${gatePath}: reference candidate rollout contract drifted`);
+if (gate.rollout_matrix_harness?.browser_intent_denial_code !== "FLY_CAPABILITY_DENIED") {
+  failures.push(`${gatePath}: browser-intent denial contract drifted`);
+}
+if (
+  gate.rollout_feature_preflight_harness?.feature_disabled_kind !== "feature-disabled" ||
+  gate.rollout_feature_preflight_harness?.feature_disabled_code !== "FEATURE_DISABLED"
+) failures.push(`${gatePath}: provider feature-disabled contract drifted`);
 
 for (const marker of [
   'id = "rustok.forum.widget-catalog"',
@@ -161,9 +222,7 @@ for (const marker of [
   'property_data_state = "owner_property_editor_ready"',
   'persistence_owner = "forum"',
   'authorization_owner = "forum"',
-]) {
-  requireText(forumManifest, marker, forumManifestPath);
-}
+]) requireText(forumManifest, marker, forumManifestPath);
 
 if (forumWave.mode !== "source_ready" || forumWave.execution_status !== "not_run_by_implementation_agent") {
   failures.push(`${forumWavePath}: Forum Wave must remain source_ready and unexecuted`);

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,31 +1,53 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-gate-source-ready / execution-acceptance-pending`
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / execution-acceptance-pending`.
 
-Base rechecked: `main@bb65b7f0d3b6d2663519260841097c0e0f5f6cb8`.
+## Current authority
 
-## Why this slice exists
+This parity packet now has two source actualizations:
 
-PR #3320 made `pages_reference_consumer_gate` explicit and recorded the current Pages/Forum evidence boundary, but two canonical planning surfaces still carried older source cursors:
+- the earlier Forum composition reconciliation through PR #3320;
+- `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353.
 
-- `docs/modules/pages-page-builder-parity-continuation-plan.md` still advertised `forum-fly-adapter-open` and a discovery-only Forum state;
-- `crates/rustok-page-builder/docs/implementation-plan.md` still listed connecting the next production consumer as open work.
-
-Those statements were stale relative to merged Forum Page Builder source through PRs #3239, #3247 and #3254 and retained evidence harness source through #3264, #3266 and #3274.
+The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor.
 
 ## Current source truth
 
-The synchronized plans now record:
+The synchronized source boundary is now:
 
 - Pages source architecture remains complete with execution evidence open;
 - Forum is the second production Page Builder consumer;
 - Forum canonical metadata, Fly adapter/component registry, owner preview and owner-backed property editing are source-ready;
 - Forum persistence, visibility, widget schemas, validation and authorization remain Forum-owned;
-- Forum browser/runtime/deployment-attestation harnesses are source-ready but unexecuted;
-- `pages_reference_consumer_gate` is source-ready but remains `accepted = false` and `execution_gate = pending`;
+- Pages rollout settings are server-owned and persisted per tenant;
+- Pages UI provider status, authoritative Preview/Publish SSR composition and standalone browser-intent preflight consume server-owned rollout state;
+- the four canonical rollout profiles have a bounded real-consumer runtime-matrix harness with production settings writes, Pages reads, UI/SSR/bypass checks and verified settings restoration;
+- standalone browser-intent denial remains the distinct `FLY_CAPABILITY_DENIED` security contract;
+- the canonical provider degraded error catalog is separately proved through a non-mutating server-owned `feature-disabled / FEATURE_DISABLED` capability preflight;
+- the reference candidate requires artifact/HTTP, browser, runtime-matrix and canonical feature-preflight packets bound to one exact source/deployment chain;
+- `pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`;
 - provider health remains `unobserved` until a real SLO source exists;
-- the next cursor is maintainer acceptance evidence for the Pages gate, followed by Forum evidence/Wave execution, not another Forum adapter architecture slice;
+- Forum browser/runtime/deployment evidence and observed Wave remain blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
+
+## Current next cursor
+
+No additional Pages/Page Builder rollout architecture slice is identified by the source reconciliation.
+
+The next cursor is maintainer execution in this order:
+
+```text
+artifact/HTTP
+-> browser
+-> rollout runtime matrix
+-> canonical FEATURE_DISABLED preflight
+-> reference-consumer candidate
+-> owner sign-off + explicit rollback decision
+-> Pages gate acceptance
+-> Forum browser/runtime/deployment evidence and observed Wave
+```
+
+Source inspection alone must not mark any of those execution or acceptance steps complete.
 
 ## Anti-drift guard
 
@@ -34,17 +56,19 @@ The synchronized plans now record:
 - the shared Pages/Page Builder parity plan;
 - the local Page Builder implementation plan;
 - the central Page Builder plan;
+- the rollout-specific current actualization;
 - the Pages reference-consumer gate source packet;
+- the matrix/feature-preflight candidate registration;
 - the current Forum contribution manifest;
 - the Forum Wave source packet.
 
-The guard rejects the former `forum-fly-adapter-open`/discovery-only cursor, the old local `next production consumer` task, an accepted Pages gate without evidence, fabricated provider health, and Forum Wave promotion while the Pages gate remains pending.
+The guard rejects the former `forum-fly-adapter-open`/discovery-only cursor, an accepted Pages gate without execution evidence, fabricated provider health, Forum Wave promotion while the Pages gate remains pending, and any plan wording that treats `FLY_CAPABILITY_DENIED` as equivalent to the canonical provider `FEATURE_DISABLED` contract.
 
-The Pages reference-consumer gate now lists this plan-parity verifier as a required source guard.
+The Pages reference-consumer gate continues to list this plan-parity verifier as a required source guard.
 
 ## Execution boundary
 
-No tests, Node verifiers, Cargo commands, formatting, builds, HTTP requests, browsers, workflows, CI or runtime evidence were executed by this slice.
+No tests, Node verifiers, Cargo commands, formatting, builds, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
 
 Suggested maintainer command, intentionally not run:
 

--- a/docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md
@@ -1,0 +1,101 @@
+# Pages / Page Builder rollout plan actualization — 2026-08-08
+
+Status: `source-parity-current / rollout-owner-source-ready / four-profile-matrix-source-ready / canonical-feature-preflight-source-ready / reference-candidate-source-ready / execution-acceptance-pending`.
+
+This packet is the current rollout/evidence overlay for the larger Pages/Page Builder plans. Where older 2026-08-08 plan text still describes a hardcoded `pages_builder_capability_flags()` helper, rollout wiring as pending, the matrix as merely executable, or the reference candidate as accepting only artifact/browser evidence, this packet supersedes that rollout-specific wording.
+
+## Rechecked merged source
+
+The current source sequence is:
+
+- PR #3333 — Pages UI provider status and authoritative Preview/Publish SSR composition consume a persisted tenant rollout snapshot instead of hardcoded all-on flags;
+- PR #3337 — rollout settings authority is owned by Pages GraphQL, standalone admin remains stateless, and direct `/builder/intents` requests are narrowed by the same server-owned persisted flags before draft mutation;
+- PR #3345 — the four canonical profiles (`all_on`, `publish_off`, `preview_off`, `builder_off`) have a bounded exact-source runtime-matrix harness using production `tenantModules` / `updateModuleSettings`, real admin UI, Preview SSR, standalone browser-intent preflight, Pages-owned reads and mandatory settings restoration;
+- PR #3353 — Pages exposes a tenant-bound non-mutating canonical capability preflight and the reference candidate requires artifact/HTTP, browser, rollout-matrix and canonical feature-preflight packets as one exact-source chain.
+
+No tests or runtime evidence are claimed by these source statements.
+
+## Current ownership and error contracts
+
+Persisted rollout settings remain owned by the Pages server. Admin consumers never supply rollout flags as request authority.
+
+The two degraded-path error contracts are deliberately distinct:
+
+- standalone browser-intent bypass prevention returns `FLY_CAPABILITY_DENIED`;
+- canonical Page Builder provider rollout preflight returns `feature-disabled / FEATURE_DISABLED`.
+
+`FLY_CAPABILITY_DENIED` is not accepted as evidence for the provider `FEATURE_DISABLED` catalog.
+
+The canonical non-mutating capability preflight uses the same Pages permission mapping source-locked against `PageBuilderCapabilityPermissions`:
+
+```text
+Preview / Tree -> pages:read
+Properties     -> pages:update
+Publish        -> pages:publish
+```
+
+It evaluates `rustok_page_builder::rollout::ensure_capability` after RBAC and before any Preview renderer or Publish persistence path.
+
+## Four-profile execution chain
+
+The accepted execution order is now source-defined as:
+
+```text
+artifact/HTTP
+-> browser
+-> rollout runtime matrix
+-> canonical rollout feature preflight
+-> reference-consumer candidate
+-> maintainer owner sign-off + rollback decision
+```
+
+The runtime matrix proves real UI/SSR/read/bypass behavior and restores original tenant settings. The feature-preflight packet separately proves the canonical provider error catalog and performs its own settings snapshot/restore cycle. The reference candidate independently rechecks both packets and their predecessor hashes, source commit, API deployment RepoDigest and origin bindings before executing its bounded source guards/focused tests.
+
+## Canonical profile outcomes
+
+| Profile | Preview | Properties | Publish dry | Pages reads |
+| --- | --- | --- | --- | --- |
+| `all_on` | pass | pass | pass | pass |
+| `publish_off` | pass | pass | `feature-disabled / FEATURE_DISABLED` | pass |
+| `preview_off` | `feature-disabled / FEATURE_DISABLED` | pass | `feature-disabled / FEATURE_DISABLED` | pass |
+| `builder_off` | `feature-disabled / FEATURE_DISABLED` | read-only/hidden plus browser bypass denial | `feature-disabled / FEATURE_DISABLED` | pass |
+
+The standalone browser-intent matrix additionally retains typed `FLY_CAPABILITY_DENIED` evidence for disabled mutating intents.
+
+## Current source boundary
+
+Source architecture for this Pages reference-consumer rollout slice is complete. The repository now has source for:
+
+- server-owned persisted rollout state;
+- UI and authoritative SSR binding;
+- standalone browser-intent narrowing;
+- four-profile real-consumer runtime matrix;
+- canonical non-mutating `FEATURE_DISABLED` preflight;
+- exact predecessor/source/deployment correlation into the reference candidate;
+- fail-closed source guards and bounded retained evidence formats.
+
+Provider health remains `unobserved`; no live SLO source exists in this slice.
+
+`pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`.
+
+Forum Wave remains blocked by `pages_reference_consumer_gate`.
+
+FFA/FBA promotion remains unclaimed.
+
+## Next cursor
+
+There is no additional source-only rollout architecture task identified by this reconciliation. The next required work is maintainer execution on one exact source/deployment chain:
+
+1. produce accepted artifact/HTTP evidence;
+2. produce accepted browser evidence;
+3. execute and retain the four-profile rollout matrix;
+4. execute and retain the canonical feature-preflight packet;
+5. execute the reference-candidate runner;
+6. review the candidate and record owner sign-off plus explicit rollback decision;
+7. only then change gate acceptance and proceed to Forum browser/runtime/deployment evidence and observed tenant Wave.
+
+The implementation agent must not mark any of those execution steps complete from source inspection alone.
+
+## Validation boundary
+
+No tests, Node verifiers, Cargo commands, formatting, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, builds, migrations or `git diff --check` were executed by this plan actualization.


### PR DESCRIPTION
## Summary

Synchronizes the Pages / Page Builder planning cursor after merged rollout source work through #3353.

The large implementation plans still contain older rollout-specific wording in places (for example the former hardcoded Pages rollout helper). Rather than risky whole-file replacement of those long historical plans, this PR adds a current authoritative rollout overlay and makes the existing plan-parity actualization/guard require it.

## Current source cursor recorded

The overlay records:
- #3333: persisted tenant rollout flags bound into Pages UI provider status and authoritative SSR composition;
- #3337: Pages GraphQL owns rollout state, standalone admin stays stateless, direct browser intents are narrowed by server-owned flags;
- #3345: bounded four-profile runtime matrix source with production settings ownership, real UI/SSR/bypass/Pages-read checks and verified settings restore;
- #3353: canonical non-mutating `feature-disabled / FEATURE_DISABLED` preflight and four-packet reference-candidate correlation.

It explicitly keeps the two degraded-path contracts separate:
- `FLY_CAPABILITY_DENIED` = standalone browser-intent bypass resistance;
- `feature-disabled / FEATURE_DISABLED` = canonical Page Builder provider rollout catalog.

## Plan boundary

The current source-only sequence is now documented as:

`artifact/HTTP -> browser -> rollout runtime matrix -> canonical FEATURE_DISABLED preflight -> reference candidate -> owner sign-off + rollback decision -> Pages gate acceptance -> Forum evidence/Wave`.

No additional Pages/Page Builder rollout architecture task is identified by this reconciliation. Provider health remains `unobserved`, the Pages gate remains unaccepted/pending, Forum Wave remains blocked, and FFA/FBA remain unclaimed.

## Anti-drift

`verify-pages-page-builder-plan-parity.mjs` now source-locks the rollout overlay plus the live gate fields for matrix/preflight/candidate registration and rejects any collapse of `FLY_CAPABILITY_DENIED` into `FEATURE_DISABLED` evidence.

## Validation boundary

Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting, builds, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or `git diff --check` were executed. Source/diff review only.