### PR TITLE
feat(commerce): route admin payment reads through owner port

### DIFF
--- a/crates/rustok-commerce/docs/admin-payment-read-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/admin-payment-read-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,79 @@
+# Commerce admin Payment read owner-port cutover — 2026-08-09
+
+Status: source-complete for mounted admin Payment/refund GET routes; execution evidence pending and unvalidated.
+
+## Scope
+
+This slice advances the canonical ecommerce topology P0 without closing it. The four mounted admin read routes now cross a Payment-owned read capability instead of constructing `PaymentService` in Commerce:
+
+- `GET /admin/payment-collections`;
+- `GET /admin/payment-collections/{id}`;
+- `GET /admin/refunds`;
+- `GET /admin/refunds/{id}`.
+
+Payment lifecycle/provider mutations are intentionally out of scope. The existing Commerce payment orchestration source remains mounted for authorize, capture, cancel, refund creation, refund completion, and refund cancellation and requires a separate owner-boundary slice.
+
+## Owner contract
+
+`rustok-payment` publishes `PaymentAdminReadPort` and `PaymentAdminReadRuntime` with complete projection operations for:
+
+- filtered/paginated payment collection list plus total;
+- payment collection detail;
+- filtered/paginated refund list plus total;
+- refund detail.
+
+The in-process adapter is the only new source in this slice that constructs `PaymentService`; persistence, validation, filter normalization, ordering, response construction, and tenant-scoped owner reads stay inside `rustok-payment`.
+
+## Mounted adapter
+
+`crates/rustok-commerce/src/controllers/admin/mod.rs` now mounts `payments_owner_reads.rs` as the public `payments` module and loads the prior `payments.rs` as private `payments_legacy` compatibility source.
+
+The mounted module owns the four read handlers and wildcard-reexports the legacy public compatibility surface so existing mutation handlers and generated OpenAPI path symbols remain available. Its local GET handlers shadow the legacy GET names, so mounted payment/refund reads execute only through the new owner port while mutation execution remains unchanged.
+
+The mounted read adapter preserves:
+
+- `PAYMENTS_READ` admission;
+- the existing list query shapes and pagination behavior;
+- payment collection `status`, `order_id`, `cart_id`, and `customer_id` filters;
+- refund `payment_collection_id`, `order_id`, and `status` filters;
+- existing payment/refund DTOs and totals;
+- stable public validation/not-found/conflict/unavailable/internal error families.
+
+## Context
+
+Commerce translates trusted `TenantContext`, `AuthContext`, and `RequestContext` into `PortContext` with:
+
+- tenant id;
+- authenticated user actor;
+- effective locale;
+- optional resolved channel;
+- deterministic correlation scope;
+- bounded two-second read deadline.
+
+The Payment owner enforces `PortCallPolicy::read()` and tenant UUID admission before storage access.
+
+## Runtime selection
+
+`CommerceHttpRuntime` first accepts a host-injected `PaymentAdminReadRuntime`. When the host has not selected an external adapter, it creates the built-in in-process Payment owner runtime from the host database connection. Commerce never constructs `PaymentService` for the mounted read routes.
+
+This keeps an explicit external-adapter injection point without coupling this focused read cutover to the larger payment mutation/provider-runtime composition work.
+
+## Source guard
+
+`scripts/verify/verify-commerce-admin-payment-read-owner-port-cutover.mjs` source-locks:
+
+- the mounted/legacy module split;
+- Payment owner read port/runtime exports;
+- all four mounted owner read calls;
+- trusted context and deadline propagation;
+- absence of `PaymentService` construction in the mounted adapter;
+- host-injected runtime preference with in-process owner fallback;
+- legacy mutation/OpenAPI compatibility re-exports.
+
+The verifier is added but intentionally not executed in this slice.
+
+## Remaining topology work
+
+The canonical broad item “Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports” remains open. The next Payment source slice should move the mounted authorize/capture/cancel/refund lifecycle orchestration behind Payment-owned execution capabilities while retaining current provider journal identities, reconciliation behavior, caller idempotency, permissions, and public envelopes.
+
+No tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, or external-provider execution evidence are claimed here.

--- a/crates/rustok-commerce/src/controllers/admin/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/mod.rs
@@ -2,6 +2,9 @@ pub mod changes;
 pub mod fulfillments;
 #[path = "orders_owner_ports.rs"]
 pub mod orders;
+#[path = "payments.rs"]
+mod payments_legacy;
+#[path = "payments_owner_reads.rs"]
 pub mod payments;
 pub mod post_order_reads;
 pub mod products;

--- a/crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs
+++ b/crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs
@@ -1,0 +1,319 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_payment::{
+    ListPaymentCollectionProjectionsRequest, ListRefundProjectionsRequest,
+    ReadPaymentCollectionProjectionRequest, ReadRefundProjectionRequest,
+};
+use rustok_web::{HttpError, HttpResult};
+use uuid::Uuid;
+
+pub use super::payments_legacy::*;
+use super::{
+    super::CommerceHttpRuntime,
+    super::common::{PaginatedResponse, ensure_permissions},
+    ListPaymentCollectionsParams, ListRefundsParams,
+};
+use crate::dto::{PaymentCollectionResponse, RefundResponse};
+
+const ADMIN_PAYMENT_READ_OWNER: &str = "rustok_payment.admin_read";
+const ADMIN_PAYMENT_READ_BOUNDARY: &str = "commerce_admin_payment_read_http";
+
+type AdminPaymentReadHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
+
+fn admin_payment_read_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    resource_id: Option<Uuid>,
+    operation: &'static str,
+) -> PortContext {
+    let scope = resource_id.unwrap_or(tenant.id);
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-payment-read:{operation}:{scope}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn payment_read_error_policy(error: &PortError) -> AdminPaymentReadHttpPolicy {
+    match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_payment_invalid",
+            "Payment request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_payment_failed",
+            "Payment operation could not be completed safely",
+            "invariant_violation",
+        ),
+    }
+}
+
+fn map_payment_read_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    resource_id: Option<Uuid>,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = payment_read_error_policy(&error);
+    tracing::error!(
+        owner = ADMIN_PAYMENT_READ_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        resource_id_present = resource_id.is_some(),
+        resource_id_non_nil = resource_id.map(|value| !value.is_nil()).unwrap_or(false),
+        operation,
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_PAYMENT_READ_BOUNDARY,
+        "commerce admin payment owner read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/payment-collections",
+    tag = "admin",
+    params(ListPaymentCollectionsParams),
+    responses((status = 200, description = "Payment collections", body = PaginatedResponse<PaymentCollectionResponse>), (status = 401, description = "Unauthorized"))
+)]
+pub async fn list_payment_collections(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Query(params): Query<ListPaymentCollectionsParams>,
+) -> HttpResult<Json<PaginatedResponse<PaymentCollectionResponse>>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_READ],
+        "Permission denied: payments:read required",
+    )?;
+    let pagination = params.pagination.unwrap_or_default();
+    let context = admin_payment_read_context(
+        &tenant,
+        &auth,
+        &request_context,
+        None,
+        "list_payment_collections",
+    );
+    let page = runtime
+        .payment_admin_read_port()
+        .list_payment_collection_projections(
+            context.clone(),
+            ListPaymentCollectionProjectionsRequest {
+                page: pagination.page,
+                per_page: pagination.limit(),
+                status: params.status,
+                order_id: params.order_id,
+                cart_id: params.cart_id,
+                customer_id: params.customer_id,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_read_error(
+                tenant.id,
+                auth.user_id,
+                None,
+                "list_payment_collections",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(PaginatedResponse {
+        data: page.items,
+        meta: super::super::common::PaginationMeta::new(
+            pagination.page,
+            pagination.limit(),
+            page.total,
+        ),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/payment-collections/{id}",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Payment collection ID")),
+    responses((status = 200, description = "Payment collection details", body = PaymentCollectionResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Payment collection not found"))
+)]
+pub async fn show_payment_collection(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<PaymentCollectionResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_READ],
+        "Permission denied: payments:read required",
+    )?;
+    let context = admin_payment_read_context(
+        &tenant,
+        &auth,
+        &request_context,
+        Some(id),
+        "show_payment_collection",
+    );
+    let collection = runtime
+        .payment_admin_read_port()
+        .read_payment_collection_projection(
+            context.clone(),
+            ReadPaymentCollectionProjectionRequest { collection_id: id },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_read_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "show_payment_collection",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(collection))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/refunds",
+    tag = "admin",
+    params(ListRefundsParams),
+    responses((status = 200, description = "Refunds", body = PaginatedResponse<RefundResponse>), (status = 401, description = "Unauthorized"))
+)]
+pub async fn list_refunds(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Query(params): Query<ListRefundsParams>,
+) -> HttpResult<Json<PaginatedResponse<RefundResponse>>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_READ],
+        "Permission denied: payments:read required",
+    )?;
+    let pagination = params.pagination.unwrap_or_default();
+    let context = admin_payment_read_context(&tenant, &auth, &request_context, None, "list_refunds");
+    let page = runtime
+        .payment_admin_read_port()
+        .list_refund_projections(
+            context.clone(),
+            ListRefundProjectionsRequest {
+                page: pagination.page,
+                per_page: pagination.limit(),
+                payment_collection_id: params.payment_collection_id,
+                order_id: params.order_id,
+                status: params.status,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_read_error(
+                tenant.id,
+                auth.user_id,
+                None,
+                "list_refunds",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(PaginatedResponse {
+        data: page.items,
+        meta: super::super::common::PaginationMeta::new(
+            pagination.page,
+            pagination.limit(),
+            page.total,
+        ),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/refunds/{id}",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Refund ID")),
+    responses((status = 200, description = "Refund details", body = RefundResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Refund not found"))
+)]
+pub async fn show_refund(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<RefundResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_READ],
+        "Permission denied: payments:read required",
+    )?;
+    let context = admin_payment_read_context(&tenant, &auth, &request_context, Some(id), "show_refund");
+    let refund = runtime
+        .payment_admin_read_port()
+        .read_refund_projection(
+            context.clone(),
+            ReadRefundProjectionRequest { refund_id: id },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_read_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                "show_refund",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(refund))
+}

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -29,6 +29,7 @@ pub struct CommerceHttpRuntime {
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
+    payment_admin_read_runtime: rustok_payment::PaymentAdminReadRuntime,
     product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
     product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime,
     #[cfg(feature = "marketplace-financial")]
@@ -85,6 +86,10 @@ impl CommerceHttpRuntime {
 
     fn payment_order_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentOrderReadPort> {
         self.payment_order_read_runtime.read_port()
+    }
+
+    fn payment_admin_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentAdminReadPort> {
+        self.payment_admin_read_runtime.read_port()
     }
 
     fn product_catalog_read_port(
@@ -156,6 +161,9 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require PaymentOrderReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let payment_admin_read_runtime = runtime
+            .shared_get::<rustok_payment::PaymentAdminReadRuntime>()
+            .unwrap_or_else(|| rustok_payment::PaymentAdminReadRuntime::in_process(runtime.db_clone()));
         let product_catalog_read_runtime = runtime
             .shared_get::<rustok_product::ProductCatalogReadRuntime>()
             .ok_or_else(|| {
@@ -192,6 +200,7 @@ impl CommerceHttpRuntime {
             order_read_runtime,
             order_admin_command_runtime,
             payment_order_read_runtime,
+            payment_admin_read_runtime,
             product_catalog_read_runtime,
             product_catalog_command_runtime,
             #[cfg(feature = "marketplace-financial")]

--- a/crates/rustok-payment/src/admin_read.rs
+++ b/crates/rustok-payment/src/admin_read.rs
@@ -1,0 +1,331 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortActorKind, PortCallPolicy, PortContext, PortError, PortErrorKind};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    ListPaymentCollectionsInput, ListRefundsInput, PaymentCollectionResponse, PaymentError,
+    PaymentService, RefundResponse,
+};
+
+const PAYMENT_ADMIN_READ_OWNER: &str = "rustok_payment";
+const PAYMENT_ADMIN_READ_BOUNDARY: &str = "payment_admin_read_port";
+
+#[async_trait]
+pub trait PaymentAdminReadPort: Send + Sync {
+    async fn list_payment_collection_projections(
+        &self,
+        context: PortContext,
+        request: ListPaymentCollectionProjectionsRequest,
+    ) -> Result<PaymentCollectionProjectionPage, PortError>;
+
+    async fn read_payment_collection_projection(
+        &self,
+        context: PortContext,
+        request: ReadPaymentCollectionProjectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError>;
+
+    async fn list_refund_projections(
+        &self,
+        context: PortContext,
+        request: ListRefundProjectionsRequest,
+    ) -> Result<RefundProjectionPage, PortError>;
+
+    async fn read_refund_projection(
+        &self,
+        context: PortContext,
+        request: ReadRefundProjectionRequest,
+    ) -> Result<RefundResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListPaymentCollectionProjectionsRequest {
+    pub page: u64,
+    pub per_page: u64,
+    pub status: Option<String>,
+    pub order_id: Option<Uuid>,
+    pub cart_id: Option<Uuid>,
+    pub customer_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadPaymentCollectionProjectionRequest {
+    pub collection_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaymentCollectionProjectionPage {
+    pub items: Vec<PaymentCollectionResponse>,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListRefundProjectionsRequest {
+    pub page: u64,
+    pub per_page: u64,
+    pub payment_collection_id: Option<Uuid>,
+    pub order_id: Option<Uuid>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadRefundProjectionRequest {
+    pub refund_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RefundProjectionPage {
+    pub items: Vec<RefundResponse>,
+    pub total: u64,
+}
+
+pub struct InProcessPaymentAdminReadPort {
+    inner: PaymentService,
+}
+
+impl InProcessPaymentAdminReadPort {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: PaymentService::new(db),
+        }
+    }
+}
+
+pub fn in_process_payment_admin_read_port(db: DatabaseConnection) -> Arc<dyn PaymentAdminReadPort> {
+    Arc::new(InProcessPaymentAdminReadPort::new(db))
+}
+
+#[derive(Clone)]
+pub struct PaymentAdminReadRuntime {
+    read_port: Arc<dyn PaymentAdminReadPort>,
+}
+
+impl PaymentAdminReadRuntime {
+    pub fn new(read_port: Arc<dyn PaymentAdminReadPort>) -> Self {
+        Self { read_port }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(in_process_payment_admin_read_port(db))
+    }
+
+    pub fn read_port(&self) -> Arc<dyn PaymentAdminReadPort> {
+        self.read_port.clone()
+    }
+}
+
+#[async_trait]
+impl PaymentAdminReadPort for InProcessPaymentAdminReadPort {
+    async fn list_payment_collection_projections(
+        &self,
+        context: PortContext,
+        request: ListPaymentCollectionProjectionsRequest,
+    ) -> Result<PaymentCollectionProjectionPage, PortError> {
+        let operation = "list_payment_collection_projections";
+        let tenant_id = require_admin_read_context(&context, operation)?;
+        let (items, total) = self
+            .inner
+            .list_collections(
+                tenant_id,
+                ListPaymentCollectionsInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    status: request.status,
+                    order_id: request.order_id,
+                    cart_id: request.cart_id,
+                    customer_id: request.customer_id,
+                },
+            )
+            .await
+            .map_err(|error| map_payment_error(&context, operation, error))?;
+        Ok(PaymentCollectionProjectionPage { items, total })
+    }
+
+    async fn read_payment_collection_projection(
+        &self,
+        context: PortContext,
+        request: ReadPaymentCollectionProjectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError> {
+        let operation = "read_payment_collection_projection";
+        let tenant_id = require_admin_read_context(&context, operation)?;
+        self.inner
+            .get_collection(tenant_id, request.collection_id)
+            .await
+            .map_err(|error| map_payment_error(&context, operation, error))
+    }
+
+    async fn list_refund_projections(
+        &self,
+        context: PortContext,
+        request: ListRefundProjectionsRequest,
+    ) -> Result<RefundProjectionPage, PortError> {
+        let operation = "list_refund_projections";
+        let tenant_id = require_admin_read_context(&context, operation)?;
+        let (items, total) = self
+            .inner
+            .list_refunds(
+                tenant_id,
+                ListRefundsInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    payment_collection_id: request.payment_collection_id,
+                    order_id: request.order_id,
+                    status: request.status,
+                },
+            )
+            .await
+            .map_err(|error| map_payment_error(&context, operation, error))?;
+        Ok(RefundProjectionPage { items, total })
+    }
+
+    async fn read_refund_projection(
+        &self,
+        context: PortContext,
+        request: ReadRefundProjectionRequest,
+    ) -> Result<RefundResponse, PortError> {
+        let operation = "read_refund_projection";
+        let tenant_id = require_admin_read_context(&context, operation)?;
+        self.inner
+            .get_refund(tenant_id, request.refund_id)
+            .await
+            .map_err(|error| map_payment_error(&context, operation, error))
+    }
+}
+
+fn require_admin_read_context(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<Uuid, PortError> {
+    context.require_policy(PortCallPolicy::read()).inspect_err(|error| {
+        log_context_rejection(context, operation, "policy", error);
+    })?;
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let error = PortError::validation(
+            "payment.admin_read_context_invalid",
+            "payment admin read context is invalid",
+        );
+        log_context_rejection(context, operation, "tenant_id", &error);
+        error
+    })
+}
+
+fn map_payment_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PaymentError,
+) -> PortError {
+    let (kind, code, message, retryable, error_variant) = match &error {
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            PortErrorKind::NotFound,
+            "payment.admin_read_not_found",
+            "payment resource was not found",
+            false,
+            "not_found",
+        ),
+        PaymentError::Validation(_) => (
+            PortErrorKind::Validation,
+            "payment.admin_read_validation",
+            "payment read request is invalid",
+            false,
+            "validation",
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            PortErrorKind::Conflict,
+            "payment.admin_read_conflict",
+            "payment state conflicts with the read request",
+            false,
+            "conflict",
+        ),
+        PaymentError::ProviderUnavailable { .. }
+        | PaymentError::ProviderConfiguration { .. }
+        | PaymentError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "payment.admin_read_unavailable",
+            "payment read capability is temporarily unavailable",
+            true,
+            "unavailable",
+        ),
+        PaymentError::ProviderInvalidResponse { .. }
+        | PaymentError::ProviderOutcomeUnknown { .. } => (
+            PortErrorKind::InvariantViolation,
+            "payment.admin_read_invariant",
+            "payment state could not be read safely",
+            false,
+            "invariant_violation",
+        ),
+    };
+    let technical_failure = matches!(
+        &kind,
+        PortErrorKind::Unavailable | PortErrorKind::InvariantViolation
+    );
+    if technical_failure {
+        tracing::error!(
+            owner = PAYMENT_ADMIN_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context.tenant_id.chars().count(),
+            actor_kind = actor_kind(&context.actor.kind),
+            actor_id_length = context.actor.id.chars().count(),
+            channel_present = context.channel.is_some(),
+            locale_length = context.locale.chars().count(),
+            deadline_ms = ?context.deadline_ms,
+            error_variant,
+            boundary = PAYMENT_ADMIN_READ_BOUNDARY,
+            error = ?error,
+            "payment admin read owner operation failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = PAYMENT_ADMIN_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context.tenant_id.chars().count(),
+            actor_kind = actor_kind(&context.actor.kind),
+            actor_id_length = context.actor.id.chars().count(),
+            channel_present = context.channel.is_some(),
+            locale_length = context.locale.chars().count(),
+            deadline_ms = ?context.deadline_ms,
+            error_variant,
+            boundary = PAYMENT_ADMIN_READ_BOUNDARY,
+            "payment admin read owner operation was rejected"
+        );
+    }
+    PortError::new(kind, code, message, retryable)
+}
+
+fn log_context_rejection(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = PAYMENT_ADMIN_READ_OWNER,
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_kind = actor_kind(&context.actor.kind),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = PAYMENT_ADMIN_READ_BOUNDARY,
+        "payment admin read context was rejected"
+    );
+}
+
+fn actor_kind(kind: &PortActorKind) -> &'static str {
+    match kind {
+        PortActorKind::User => "user",
+        PortActorKind::Service => "service",
+        PortActorKind::System => "system",
+    }
+}

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -3,6 +3,7 @@ use rustok_api::Permission;
 use rustok_core::{MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+mod admin_read;
 #[path = "checkout_compensation.rs"]
 mod checkout_compensation_persistent;
 #[path = "checkout_compensation_api.rs"]
@@ -29,6 +30,12 @@ pub mod services;
 #[cfg(feature = "stripe")]
 pub mod stripe_provider;
 
+pub use admin_read::{
+    InProcessPaymentAdminReadPort, ListPaymentCollectionProjectionsRequest,
+    ListRefundProjectionsRequest, PaymentAdminReadPort, PaymentAdminReadRuntime,
+    PaymentCollectionProjectionPage, ReadPaymentCollectionProjectionRequest,
+    ReadRefundProjectionRequest, RefundProjectionPage, in_process_payment_admin_read_port,
+};
 pub use checkout_compensation::{
     CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,
     InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,

--- a/scripts/verify/verify-commerce-admin-payment-read-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-payment-read-owner-port-cutover.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) {
+    throw new Error(`missing ${label}: ${text}`);
+  }
+};
+const forbidText = (source, text, label) => {
+  if (source.includes(text)) {
+    throw new Error(`forbidden ${label}: ${text}`);
+  }
+};
+
+const adminMod = read("crates/rustok-commerce/src/controllers/admin/mod.rs");
+const mounted = read("crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs");
+const legacy = read("crates/rustok-commerce/src/controllers/admin/payments.rs");
+const httpRuntime = read("crates/rustok-commerce/src/controllers/mod.rs");
+const paymentLib = read("crates/rustok-payment/src/lib.rs");
+const ownerRead = read("crates/rustok-payment/src/admin_read.rs");
+const openapi = read("crates/rustok-commerce/src/openapi.rs");
+const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+
+requireText(adminMod, '#[path = "payments.rs"]\nmod payments_legacy;', "legacy payment module alias");
+requireText(adminMod, '#[path = "payments_owner_reads.rs"]\npub mod payments;', "mounted payment owner read module");
+
+requireText(paymentLib, "mod admin_read;", "Payment admin read module registration");
+requireText(paymentLib, "PaymentAdminReadPort, PaymentAdminReadRuntime", "Payment admin read exports");
+requireText(ownerRead, "pub trait PaymentAdminReadPort", "Payment admin read owner port");
+requireText(ownerRead, "pub struct PaymentAdminReadRuntime", "Payment admin read runtime");
+requireText(ownerRead, "context.require_policy(PortCallPolicy::read())", "read deadline policy admission");
+requireText(ownerRead, "PaymentService::new(db)", "owner-local in-process service construction");
+requireText(ownerRead, ".list_collections(", "owner collection list delegation");
+requireText(ownerRead, ".get_collection(", "owner collection detail delegation");
+requireText(ownerRead, ".list_refunds(", "owner refund list delegation");
+requireText(ownerRead, ".get_refund(", "owner refund detail delegation");
+
+requireText(mounted, "pub use super::payments_legacy::*;", "legacy mutation/OpenAPI compatibility re-export");
+requireText(mounted, "runtime\n        .payment_admin_read_port()", "mounted owner read runtime call");
+requireText(mounted, ".list_payment_collection_projections(", "mounted collection list owner call");
+requireText(mounted, ".read_payment_collection_projection(", "mounted collection detail owner call");
+requireText(mounted, ".list_refund_projections(", "mounted refund list owner call");
+requireText(mounted, ".read_refund_projection(", "mounted refund detail owner call");
+requireText(mounted, "RequestContext", "trusted request context extractor");
+requireText(mounted, ".with_deadline(std::time::Duration::from_secs(2))", "bounded read deadline");
+requireText(mounted, "request_context.channel_slug.as_deref()", "resolved channel propagation");
+requireText(mounted, "Permission::PAYMENTS_READ", "read permission preservation");
+forbidText(mounted, "PaymentService", "concrete Payment service in mounted read adapter");
+forbidText(mounted, "runtime.db_clone()", "Commerce DB access in mounted read adapter");
+
+for (const mutation of [
+  "authorize_payment_collection",
+  "capture_payment_collection",
+  "cancel_payment_collection",
+  "create_refund",
+  "complete_refund",
+  "cancel_refund",
+]) {
+  requireText(legacy, `pub async fn ${mutation}`, `legacy mutation source ${mutation}`);
+}
+
+requireText(httpRuntime, "payment_admin_read_runtime: rustok_payment::PaymentAdminReadRuntime", "Commerce payment admin read runtime field");
+requireText(httpRuntime, ".shared_get::<rustok_payment::PaymentAdminReadRuntime>()", "host-selected payment admin read runtime");
+requireText(httpRuntime, "rustok_payment::PaymentAdminReadRuntime::in_process(runtime.db_clone())", "in-process owner runtime fallback");
+requireText(httpRuntime, "fn payment_admin_read_port", "Commerce payment admin read port accessor");
+
+for (const operation of [
+  "crate::controllers::admin::list_payment_collections",
+  "crate::controllers::admin::show_payment_collection",
+  "crate::controllers::admin::list_refunds",
+  "crate::controllers::admin::show_refund",
+]) {
+  requireText(openapi, operation, `OpenAPI root operation ${operation}`);
+}
+
+requireText(
+  plan,
+  "- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.",
+  "canonical broad topology item remains open",
+);
+
+console.log("commerce admin Payment read owner-port cutover source guard: OK");


### PR DESCRIPTION
## Summary
- publish Payment-owned `PaymentAdminReadPort` / `PaymentAdminReadRuntime`
- move the four mounted admin Payment/refund GET routes to that owner capability:
  - `GET /admin/payment-collections`
  - `GET /admin/payment-collections/{id}`
  - `GET /admin/refunds`
  - `GET /admin/refunds/{id}`
- keep filtering, pagination, totals, DTOs, `PAYMENTS_READ`, and stable public error families
- propagate trusted tenant/user/locale/channel context plus a bounded read deadline through `PortContext`
- keep `PaymentService` construction inside the Payment in-process owner adapter
- preserve a host-injected `PaymentAdminReadRuntime` when present, with an in-process owner fallback otherwise
- mount the previous `payments.rs` privately as compatibility source and wildcard-reexport it so mutation handlers and utoipa-generated compatibility symbols remain available
- add focused source documentation and a source guard without executing it

## Out of scope
Payment lifecycle/provider mutations remain on the existing Commerce `PaymentOrchestrationService`: authorize, capture, collection cancel, refund creation, refund completion, and refund cancellation. Moving those effects behind Payment-owned execution capabilities is a separate follow-up slice because it must preserve provider journal identities, reconciliation semantics, and caller idempotency.

The canonical broad ecommerce topology P0 therefore remains open; this PR only completes the mounted admin Payment read portion.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, and external-provider execution were intentionally not run per maintainer instruction.