### PR TITLE
test(blog): retain category Translation PostgreSQL evidence

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-09",
+  "status": "blog_category_translation_postgres_source_unvalidated",
+  "owner": "rustok-blog",
+  "provider": "blog/category",
+  "scope": "PostgreSQL migration, concurrent exact-locale CAS and durable change-cursor recovery for the Blog category Translation target pilot",
+  "source_contract": {
+    "postgres_environment_gated_harness_added": true,
+    "isolated_postgres_schema_per_scenario": true,
+    "search_path_excludes_public": true,
+    "real_outbox_migrations_used": true,
+    "real_taxonomy_migrations_used": true,
+    "real_blog_migrations_used": true,
+    "translation_target_migration_up_down_up_covered": true,
+    "reapplied_revision_columns_exercised_through_category_service": true,
+    "reapplied_change_journal_exercised_through_provider": true,
+    "concurrent_apply_uses_independent_database_connections": true,
+    "concurrent_apply_uses_same_source_snapshot_and_expected_revisions": true,
+    "concurrent_apply_uses_distinct_idempotency_keys": true,
+    "concurrent_apply_requires_exactly_one_success": true,
+    "concurrent_apply_requires_closed_conflict_loser": true,
+    "concurrent_apply_requires_one_target_revision": true,
+    "concurrent_apply_requires_one_winning_change_fact": true,
+    "concurrent_apply_requires_one_reindex_outbox_event": true,
+    "cursor_recovery_starts_from_source_create_cursor": true,
+    "cursor_recovery_reconstructs_provider_before_apply": true,
+    "cursor_recovery_resumes_exactly_one_apply_change": true,
+    "cursor_recovery_reconstructs_owner_before_delete": true,
+    "cursor_recovery_reconstructs_provider_after_delete": true,
+    "cursor_recovery_resumes_deleted_lifecycle_change": true,
+    "cursor_recovery_drains_after_latest_cursor": true,
+    "progress_cursor_matches_latest_deleted_change": true,
+    "ulid_cursor_generation_is_separated_for_deterministic_recovery_fixture": true,
+    "concurrent_cursor_commit_order_claimed": false,
+    "production_blog_behavior_changed": false,
+    "production_translation_contract_changed": false,
+    "database_schema_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "postgres_execution_observed": false
+  },
+  "harness": {
+    "path": "crates/rustok-blog/tests/category_translation_target_postgres_test.rs",
+    "database_env": "RUSTOK_BLOG_TRANSLATION_TEST_DATABASE_URL",
+    "fallback_database_envs": [
+      "RUSTOK_BLOG_TEST_DATABASE_URL",
+      "DATABASE_URL"
+    ],
+    "tests": [
+      "category_translation_target_migration_supports_postgres_up_down_up",
+      "concurrent_same_revision_translation_applies_commit_once",
+      "change_cursor_resumes_after_provider_reconstruction_and_delete"
+    ]
+  },
+  "linked_sources": {
+    "provider": "crates/rustok-blog/src/translation_target.rs",
+    "category_owner": "crates/rustok-blog/src/services/category.rs",
+    "change_writer": "crates/rustok-blog/src/translation_evidence.rs",
+    "change_entity": "crates/rustok-blog/src/entities/translation_change.rs",
+    "translation_target_migration": "crates/rustok-blog/src/migrations/m20260803_000016_add_blog_category_translation_target_support.rs",
+    "sqlite_pilot_tests": "crates/rustok-blog/src/translation_target_tests.rs",
+    "translation_plan": "docs/modules/translation-implementation-plan.md",
+    "blog_plan": "crates/rustok-blog/docs/implementation-plan.md"
+  },
+  "suggested_execution": [
+    "node scripts/verify/verify-blog-category-translation-postgres-source.mjs",
+    "RUSTOK_BLOG_TRANSLATION_TEST_DATABASE_URL=postgres://... cargo test -p rustok-blog --test category_translation_target_postgres_test -- --nocapture --test-threads=1"
+  ],
+  "execution": [],
+  "validation": {
+    "cargo_run": false,
+    "tests_run": false,
+    "verifier_run": false,
+    "postgres_run": false,
+    "migration_up_down_up_observed": false,
+    "concurrent_cas_observed": false,
+    "cursor_recovery_observed": false,
+    "workflow_checks_run": false,
+    "ci_run": false,
+    "runtime_proven": false
+  }
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-98.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-98.md
@@ -1,0 +1,111 @@
+# rustok-blog implementation plan — slice 98 continuation
+
+Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.
+
+This slice is an independent continuation of the Blog category Translation target pilot recorded in `crates/rustok-blog/docs/implementation-plan.md` and the active cross-module Translation plan. It does not bypass the separate slice-97 Comments audit relay execution boundary.
+
+## Re-audit
+
+The current `blog/category` owner target already has the production source required for the pilot:
+
+- migration `m20260803_000016_add_blog_category_translation_target_support` adds resource and exact-locale revisions plus `blog_translation_changes`;
+- `CategoryService::apply_exact_translation_in_tx` checks resource, source and target revisions and performs conditional target/resource writes;
+- the target adapter uses the shared durable owner-operation receipt before applying and completes that receipt inside the owner transaction;
+- category create/update/delete and exact Translation apply append Blog-owned change facts;
+- `read_changes` exposes the owner cursor and `read_progress` binds aggregate progress to a stable before/after cursor observation;
+- the SQLite pilot already covers up/down/up, exact apply, replay, stale validation, progress and owner cursor basics.
+
+The root Blog plan correctly left three production-database results open: PostgreSQL migration behavior, concurrent CAS, and change-cursor recovery. No additional production write path is required to retain those source targets.
+
+## Slice 98 — PostgreSQL pilot evidence source
+
+New harness:
+
+`crates/rustok-blog/tests/category_translation_target_postgres_test.rs`
+
+The harness is environment-gated by `RUSTOK_BLOG_TRANSLATION_TEST_DATABASE_URL`, then falls back to `RUSTOK_BLOG_TEST_DATABASE_URL` and PostgreSQL `DATABASE_URL`. Every scenario creates a unique schema and sets `search_path` to that schema only; `public` is deliberately excluded.
+
+### PostgreSQL migration up/down/up
+
+The migration scenario applies the real Outbox and Taxonomy dependency migrations, applies all Blog migrations preceding `000016`, then executes the real Translation target migration as `up -> down -> up`.
+
+After reapplication it uses the production `CategoryService::create` path and the production `BlogCategoryTranslationTargetProvider::read_changes` path. The retained assertions require resource revision one, source-locale revision one, one active change fact and a non-empty resume cursor.
+
+The scenario does not create a parallel test schema or hand-written substitute for the owner migration.
+
+### Concurrent same-revision apply
+
+The concurrency scenario creates one source category and one exact source snapshot. Two independent PostgreSQL connections receive patches derived from the same resource/source/target revision facts but use distinct owner idempotency keys and distinct target values.
+
+Both calls enter through the public `TranslationTargetProvider::apply_patch` contract. A barrier releases them together. The retained outcome is:
+
+- exactly one successful apply;
+- exactly one closed `Conflict` loser;
+- final resource revision two;
+- final target revision one;
+- the exact target value belongs to the winning request;
+- the journal contains only source creation plus one winning apply fact;
+- `sys_events` contains one Blog reindex request from the winner.
+
+This proves the public provider plus Category owner CAS converges without a duplicate target commit. The harness does not claim which caller wins and does not add locking or retry behavior to production.
+
+### Change-cursor recovery after reconstruction
+
+The recovery scenario retains a source-create cursor, drops the first provider, opens a new connection/provider, applies one exact target, resumes from the retained cursor, and captures the next cursor. It then reconstructs the owner again, deletes the category, reconstructs the provider again, and resumes from the apply cursor.
+
+The retained assertions require:
+
+- exactly one active apply change after the source cursor;
+- exactly one deleted lifecycle change after the apply cursor;
+- resource revisions `1 -> 2 -> 3` across source, apply and delete facts;
+- an empty page after the final cursor;
+- zero active resources after deletion;
+- `read_progress.owner_change_cursor` equal to the final deleted change cursor.
+
+Blog change IDs are generated through `rustok_core::generate_id`, which stores ULID bytes in a UUID. The recovery fixture separates its independent retained writes by two milliseconds so the test deterministically exercises ordinary resume semantics. It deliberately does **not** claim that the current cursor contract proves arbitrary concurrent transaction commit ordering; that is a separate contract question and is not promoted by this slice.
+
+## Machine evidence and guard
+
+Source evidence:
+
+`crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json`
+
+Fail-closed source guard:
+
+`scripts/verify/verify-blog-category-translation-postgres-source.mjs`
+
+The evidence remains unvalidated until maintainers run the PostgreSQL target and verifier at an exact revision.
+
+## Preserved boundaries
+
+This slice does not change:
+
+- Blog category storage or Translation target schema;
+- `CategoryService` mutation or CAS behavior;
+- Translation target request/response contracts;
+- owner-operation receipt semantics;
+- Search reindex publication behavior;
+- Translation inventory/checkpoint ownership;
+- FFA/FBA status;
+- Blog Comments audit relay execution status from slice 97.
+
+No new endpoint, worker, retry lane, queue, provider capability or cross-module SQL path is added.
+
+## Maintainer execution
+
+```bash
+node scripts/verify/verify-blog-category-translation-postgres-source.mjs
+
+RUSTOK_BLOG_TRANSLATION_TEST_DATABASE_URL=postgres://... \
+  cargo test -p rustok-blog \
+  --test category_translation_target_postgres_test \
+  -- --nocapture --test-threads=1
+```
+
+No tests, Cargo commands, Node verifiers, PostgreSQL scenarios, formatting, Clippy, workflows, CI, browser targets or runtime validation were executed by the implementation agent.
+
+## Next cursor
+
+After successful maintainer execution, the Blog category pilot may record the PostgreSQL migration/concurrent-CAS/change-recovery result in the active Translation readiness view. The broader Translation plan still retains production enablement and live provider evidence as separate owner/maintainer work.
+
+The Comments audit track remains independently blocked on maintainer execution of its retained slices before source-row/recovery-audit retention is advanced.

--- a/crates/rustok-blog/tests/category_translation_target_postgres_test.rs
+++ b/crates/rustok-blog/tests/category_translation_target_postgres_test.rs
@@ -1,0 +1,526 @@
+use std::{env, error::Error as StdError, sync::Arc, time::Duration};
+
+use rustok_api::{PortActor, PortContext, PortErrorKind, TenantLocale};
+use rustok_blog::{
+    BlogCategory, BlogCategoryTranslation, BlogCategoryTranslationTargetProvider, BlogModule,
+    BlogTranslationChange, CategoryService, CreateCategoryInput,
+    entities::{
+        blog_category, blog_category_translation, translation_change,
+    },
+};
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_outbox::{OutboxModule, OutboxTransport, SysEvents, TransactionalEventBus};
+use rustok_taxonomy::TaxonomyModule;
+use rustok_translation_targets::{
+    FieldKey, OpaqueCursor, ReadTranslationResourceRequest, TranslationFieldPatch,
+    TranslationPatchRequest, TranslationResourceLifecycle, TranslationResourceSnapshot,
+    TranslationTargetChangesRequest, TranslationTargetProgressRequest, TranslationTargetProvider,
+};
+use sea_orm::{
+    ColumnTrait, ConnectOptions, ConnectionTrait, Database, DatabaseConnection, EntityTrait,
+    QueryFilter,
+};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use tokio::sync::Barrier;
+use uuid::Uuid;
+
+const DATABASE_ENV: &str = "RUSTOK_BLOG_TRANSLATION_TEST_DATABASE_URL";
+
+type TestResult<T> = Result<T, Box<dyn StdError + Send + Sync>>;
+
+struct PostgresBlogTranslationTestDb {
+    control: DatabaseConnection,
+    db: DatabaseConnection,
+    database_url: String,
+    schema_name: String,
+}
+
+impl PostgresBlogTranslationTestDb {
+    async fn empty(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(database_url) = postgres_database_url() else {
+            eprintln!(
+                "{DATABASE_ENV} is not set to a PostgreSQL URL; skipping Blog category translation evidence"
+            );
+            return Ok(None);
+        };
+        let control = connect(&database_url).await?;
+        let schema_name = format!(
+            "rustok_blog_translation_{}_{}",
+            sanitize_identifier(prefix),
+            Uuid::new_v4().simple()
+        );
+        control
+            .execute_unprepared(&format!(r#"CREATE SCHEMA "{schema_name}""#))
+            .await?;
+        let db = scoped_connection(&database_url, &schema_name).await?;
+        Ok(Some(Self {
+            control,
+            db,
+            database_url,
+            schema_name,
+        }))
+    }
+
+    async fn setup(prefix: &str) -> TestResult<Option<Self>> {
+        let Some(test_db) = Self::empty(prefix).await? else {
+            return Ok(None);
+        };
+        apply_dependency_migrations(&test_db.db).await?;
+        let manager = SchemaManager::new(&test_db.db);
+        for migration in BlogModule.migrations() {
+            migration.up(&manager).await?;
+        }
+        Ok(Some(test_db))
+    }
+
+    async fn isolated_connection(&self) -> TestResult<DatabaseConnection> {
+        scoped_connection(&self.database_url, &self.schema_name).await
+    }
+
+    async fn cleanup(self) -> TestResult<()> {
+        self.control
+            .execute_unprepared(&format!(
+                r#"DROP SCHEMA IF EXISTS "{}" CASCADE"#,
+                self.schema_name
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn category_translation_target_migration_supports_postgres_up_down_up() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogTranslationTestDb::empty("migration").await? else {
+        return Ok(());
+    };
+    apply_dependency_migrations(&test_db.db).await?;
+    let manager = SchemaManager::new(&test_db.db);
+    let mut blog_migrations = BlogModule.migrations();
+    let translation_target_migration = blog_migrations
+        .pop()
+        .expect("Blog translation target migration must remain registered last");
+    for migration in blog_migrations {
+        migration.up(&manager).await?;
+    }
+
+    translation_target_migration.up(&manager).await?;
+    translation_target_migration.down(&manager).await?;
+    translation_target_migration.up(&manager).await?;
+
+    let tenant_id = Uuid::new_v4();
+    let service = category_service(test_db.db.clone());
+    let category_id = service
+        .create(
+            tenant_id,
+            admin(),
+            category_input("PostgreSQL migration", "postgres-migration"),
+        )
+        .await?;
+
+    let category = BlogCategory::find_by_id(category_id)
+        .filter(blog_category::Column::TenantId.eq(tenant_id))
+        .one(&test_db.db)
+        .await?
+        .expect("reapplied migration must retain category revision storage");
+    assert_eq!(category.revision, 1);
+    let source = BlogCategoryTranslation::find()
+        .filter(blog_category_translation::Column::TenantId.eq(tenant_id))
+        .filter(blog_category_translation::Column::CategoryId.eq(category_id))
+        .filter(blog_category_translation::Column::Locale.eq("en"))
+        .one(&test_db.db)
+        .await?
+        .expect("reapplied migration must retain exact-locale revision storage");
+    assert_eq!(source.revision, 1);
+
+    let provider = BlogCategoryTranslationTargetProvider::new(service);
+    let changes = provider
+        .read_changes(
+            read_context(tenant_id, "blog-translation-postgres-migration"),
+            TranslationTargetChangesRequest {
+                after: None,
+                limit: 10,
+            },
+        )
+        .await?;
+    assert_eq!(changes.changes.len(), 1);
+    assert_eq!(changes.changes[0].resource_revision.as_str(), "1");
+    assert_eq!(changes.changes[0].lifecycle, TranslationResourceLifecycle::Active);
+    assert!(changes.next_cursor.is_some());
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn concurrent_same_revision_translation_applies_commit_once() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogTranslationTestDb::setup("concurrent_cas").await? else {
+        return Ok(());
+    };
+    let tenant_id = Uuid::new_v4();
+    let service = category_service(test_db.db.clone());
+    let category_id = service
+        .create(
+            tenant_id,
+            admin(),
+            category_input("Systems", "systems"),
+        )
+        .await?;
+    let provider = BlogCategoryTranslationTargetProvider::new(service);
+    let snapshot = provider
+        .read_resource(
+            read_context(tenant_id, "blog-translation-concurrent-snapshot"),
+            resource_request(category_id),
+        )
+        .await?;
+
+    let candidates = [
+        ("Systemes alpha", "systemes-alpha", "candidate-alpha"),
+        ("Systemes beta", "systemes-beta", "candidate-beta"),
+    ];
+    let barrier = Arc::new(Barrier::new(candidates.len()));
+    let mut tasks = Vec::with_capacity(candidates.len());
+    for (name, slug, label) in candidates {
+        let db = test_db.isolated_connection().await?;
+        let provider = BlogCategoryTranslationTargetProvider::new(category_service(db));
+        let barrier = Arc::clone(&barrier);
+        let patch = translation_patch(&snapshot, name, slug, label);
+        let context = apply_context(
+            tenant_id,
+            &format!("blog-translation-{label}"),
+            &format!("blog-translation-idempotency-{label}"),
+        );
+        let expected_name = name.to_string();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            (expected_name, provider.apply_patch(context, patch).await)
+        }));
+    }
+
+    let mut successes = Vec::new();
+    let mut failures = Vec::new();
+    for task in tasks {
+        let (name, result) = task.await?;
+        match result {
+            Ok(receipt) => successes.push((name, receipt)),
+            Err(error) => failures.push(error),
+        }
+    }
+    assert_eq!(successes.len(), 1, "exactly one same-revision apply must commit");
+    assert_eq!(failures.len(), 1, "the competing stale apply must close");
+    assert_eq!(failures[0].kind, PortErrorKind::Conflict);
+
+    let final_provider = BlogCategoryTranslationTargetProvider::new(category_service(
+        test_db.isolated_connection().await?,
+    ));
+    let final_snapshot = final_provider
+        .read_resource(
+            read_context(tenant_id, "blog-translation-concurrent-final"),
+            resource_request(category_id),
+        )
+        .await?;
+    assert_eq!(final_snapshot.summary.resource_revision.as_str(), "2");
+    assert_eq!(
+        final_snapshot
+            .target_revision
+            .as_ref()
+            .map(|revision| revision.as_str()),
+        Some("1")
+    );
+    assert_eq!(
+        exact_target_value(&final_snapshot, "name"),
+        Some(successes[0].0.as_str())
+    );
+
+    let changes = BlogTranslationChange::find()
+        .filter(translation_change::Column::TenantId.eq(tenant_id))
+        .all(&test_db.db)
+        .await?;
+    assert_eq!(changes.len(), 2, "source create plus one winning apply only");
+    let outbox = SysEvents::find().all(&test_db.db).await?;
+    assert_eq!(outbox.len(), 1, "only the winning apply may publish reindex");
+    assert_eq!(outbox[0].event_type, "index.reindex_requested");
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
+async fn change_cursor_resumes_after_provider_reconstruction_and_delete() -> TestResult<()> {
+    let Some(test_db) = PostgresBlogTranslationTestDb::setup("cursor_recovery").await? else {
+        return Ok(());
+    };
+    let tenant_id = Uuid::new_v4();
+    let service = category_service(test_db.db.clone());
+    let category_id = service
+        .create(
+            tenant_id,
+            admin(),
+            category_input("Recovery", "recovery"),
+        )
+        .await?;
+    let provider = BlogCategoryTranslationTargetProvider::new(service);
+    let first_page = provider
+        .read_changes(
+            read_context(tenant_id, "blog-translation-cursor-first"),
+            TranslationTargetChangesRequest {
+                after: None,
+                limit: 10,
+            },
+        )
+        .await?;
+    assert_eq!(first_page.changes.len(), 1);
+    assert_eq!(first_page.changes[0].resource_revision.as_str(), "1");
+    let first_cursor = first_page
+        .next_cursor
+        .expect("source creation must publish a resume cursor");
+    drop(provider);
+
+    // Blog change IDs are ULID-backed UUIDs. Keep independent retained writes in
+    // distinct milliseconds so this recovery target is deterministic without
+    // claiming a concurrent commit-order guarantee from the cursor itself.
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    let apply_provider = BlogCategoryTranslationTargetProvider::new(category_service(
+        test_db.isolated_connection().await?,
+    ));
+    let snapshot = apply_provider
+        .read_resource(
+            read_context(tenant_id, "blog-translation-cursor-apply-read"),
+            resource_request(category_id),
+        )
+        .await?;
+    let receipt = apply_provider
+        .apply_patch(
+            apply_context(
+                tenant_id,
+                "blog-translation-cursor-apply",
+                "blog-translation-cursor-apply-1",
+            ),
+            translation_patch(&snapshot, "Recuperation", "recuperation", "cursor-recovery"),
+        )
+        .await?;
+    assert_eq!(receipt.resource_revision.as_str(), "2");
+    assert_eq!(receipt.target_revision.as_str(), "1");
+
+    let second_page = apply_provider
+        .read_changes(
+            read_context(tenant_id, "blog-translation-cursor-second"),
+            TranslationTargetChangesRequest {
+                after: Some(first_cursor.clone()),
+                limit: 10,
+            },
+        )
+        .await?;
+    assert_eq!(second_page.changes.len(), 1);
+    assert_eq!(second_page.changes[0].resource_revision.as_str(), "2");
+    assert_eq!(second_page.changes[0].lifecycle, TranslationResourceLifecycle::Active);
+    let second_cursor = second_page
+        .next_cursor
+        .expect("translation apply must advance the resume cursor");
+    assert_ne!(second_cursor, first_cursor);
+    drop(apply_provider);
+
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    let delete_service = category_service(test_db.isolated_connection().await?);
+    delete_service
+        .delete(tenant_id, category_id, admin())
+        .await?;
+    drop(delete_service);
+
+    let recovered_provider = BlogCategoryTranslationTargetProvider::new(category_service(
+        test_db.isolated_connection().await?,
+    ));
+    let deleted_page = recovered_provider
+        .read_changes(
+            read_context(tenant_id, "blog-translation-cursor-deleted"),
+            TranslationTargetChangesRequest {
+                after: Some(second_cursor.clone()),
+                limit: 10,
+            },
+        )
+        .await?;
+    assert_eq!(deleted_page.changes.len(), 1);
+    assert_eq!(deleted_page.changes[0].resource_revision.as_str(), "3");
+    assert_eq!(deleted_page.changes[0].lifecycle, TranslationResourceLifecycle::Deleted);
+    let deleted_cursor = deleted_page
+        .next_cursor
+        .expect("delete must advance the durable Blog change cursor");
+    assert_ne!(deleted_cursor, second_cursor);
+
+    let drained = recovered_provider
+        .read_changes(
+            read_context(tenant_id, "blog-translation-cursor-drained"),
+            TranslationTargetChangesRequest {
+                after: Some(deleted_cursor.clone()),
+                limit: 10,
+            },
+        )
+        .await?;
+    assert!(drained.changes.is_empty());
+    assert!(drained.next_cursor.is_none());
+
+    let progress = recovered_provider
+        .read_progress(
+            read_context(tenant_id, "blog-translation-cursor-progress"),
+            TranslationTargetProgressRequest {
+                source_locale: TenantLocale::new("en")?,
+                target_locale: TenantLocale::new("fr")?,
+            },
+        )
+        .await?;
+    assert_eq!(progress.resources, 0);
+    assert_eq!(progress.owner_change_cursor, Some(deleted_cursor));
+
+    test_db.cleanup().await
+}
+
+async fn apply_dependency_migrations(db: &DatabaseConnection) -> TestResult<()> {
+    let manager = SchemaManager::new(db);
+    for migration in OutboxModule.migrations() {
+        migration.up(&manager).await?;
+    }
+    for migration in TaxonomyModule.migrations() {
+        migration.up(&manager).await?;
+    }
+    Ok(())
+}
+
+fn category_service(db: DatabaseConnection) -> Arc<CategoryService> {
+    let event_bus = TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())));
+    Arc::new(CategoryService::new(db, event_bus))
+}
+
+fn admin() -> SecurityContext {
+    SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()))
+}
+
+fn category_input(name: &str, slug: &str) -> CreateCategoryInput {
+    CreateCategoryInput {
+        locale: "en".to_string(),
+        name: name.to_string(),
+        slug: Some(slug.to_string()),
+        description: Some(format!("{name} description")),
+        parent_id: None,
+        position: None,
+        settings: serde_json::json!({}),
+    }
+}
+
+fn read_context(tenant_id: Uuid, correlation_id: &str) -> PortContext {
+    PortContext::new(
+        tenant_id.to_string(),
+        PortActor::system(),
+        "en",
+        correlation_id,
+    )
+    .with_deadline(Duration::from_secs(5))
+}
+
+fn apply_context(tenant_id: Uuid, correlation_id: &str, idempotency_key: &str) -> PortContext {
+    read_context(tenant_id, correlation_id).with_idempotency_key(idempotency_key)
+}
+
+fn resource_request(category_id: Uuid) -> ReadTranslationResourceRequest {
+    ReadTranslationResourceRequest {
+        identity: rustok_translation_targets::TranslationResourceIdentity {
+            owner_slug: rustok_translation_targets::OwnerSlug::new("blog")
+                .expect("static owner slug"),
+            resource_kind: rustok_translation_targets::ResourceKind::new("category")
+                .expect("static resource kind"),
+            resource_id: rustok_translation_targets::ResourceId::new(category_id.to_string())
+                .expect("category UUID resource id"),
+            subresource_id: None,
+        },
+        source_locale: TenantLocale::new("en").expect("static source locale"),
+        target_locale: TenantLocale::new("fr").expect("static target locale"),
+    }
+}
+
+fn translation_patch(
+    snapshot: &TranslationResourceSnapshot,
+    name: &str,
+    slug: &str,
+    suffix: &str,
+) -> TranslationPatchRequest {
+    TranslationPatchRequest {
+        identity: snapshot.summary.identity.clone(),
+        source_locale: snapshot.source_locale.clone(),
+        target_locale: snapshot.target_locale.clone(),
+        expected_resource_revision: snapshot.summary.resource_revision.clone(),
+        expected_source_revision: snapshot.source_revision.clone(),
+        expected_target_revision: snapshot.target_revision.clone(),
+        fields: vec![
+            field_patch(snapshot, "name", name),
+            field_patch(snapshot, "slug", slug),
+            field_patch(snapshot, "description", &format!("description-{suffix}")),
+        ],
+        proposal_id: format!("blog-proposal-{suffix}"),
+        approval_receipt_id: format!("blog-approval-{suffix}"),
+    }
+}
+
+fn field_patch(
+    snapshot: &TranslationResourceSnapshot,
+    key: &str,
+    value: &str,
+) -> TranslationFieldPatch {
+    let field = snapshot
+        .fields
+        .iter()
+        .find(|field| field.descriptor.key.as_str() == key)
+        .expect("requested Blog category field must be exposed");
+    TranslationFieldPatch {
+        key: FieldKey::new(key).expect("static field key"),
+        value: value.to_string(),
+        expected_source_hash: field.source_hash.clone(),
+    }
+}
+
+fn exact_target_value<'a>(
+    snapshot: &'a TranslationResourceSnapshot,
+    key: &str,
+) -> Option<&'a str> {
+    snapshot
+        .fields
+        .iter()
+        .find(|field| field.descriptor.key.as_str() == key)
+        .and_then(|field| field.exact_target_value.as_deref())
+}
+
+fn postgres_database_url() -> Option<String> {
+    env::var(DATABASE_ENV)
+        .or_else(|_| env::var("RUSTOK_BLOG_TEST_DATABASE_URL"))
+        .or_else(|_| env::var("DATABASE_URL"))
+        .ok()
+        .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+}
+
+async fn connect(database_url: &str) -> TestResult<DatabaseConnection> {
+    let mut options = ConnectOptions::new(database_url.to_owned());
+    options
+        .max_connections(1)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Ok(Database::connect(options).await?)
+}
+
+async fn scoped_connection(
+    database_url: &str,
+    schema_name: &str,
+) -> TestResult<DatabaseConnection> {
+    let db = connect(database_url).await?;
+    db.execute_unprepared(&format!(r#"SET search_path TO "{schema_name}""#))
+        .await?;
+    Ok(db)
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '_' {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/scripts/verify/verify-blog-category-translation-postgres-source.mjs
+++ b/scripts/verify/verify-blog-category-translation-postgres-source.mjs
@@ -190,11 +190,10 @@ for (const marker of [
   "translation_target_applies_replays_and_tracks_an_exact_category_locale"
 ]) need(sqlitePilot, marker, "SQLite pilot baseline");
 
-need(
-  rootPlan,
-  "Retained PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement",
-  "Blog root plan open pilot result",
-);
+for (const marker of [
+  "PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are",
+  "still required before production inventory enablement"
+]) need(rootPlan, marker, "Blog root plan open pilot result");
 for (const marker of [
   "category_translation_postgres_evidence_source_ready_maintainer_execution_pending",
   "PostgreSQL migration up/down/up",

--- a/scripts/verify/verify-blog-category-translation-postgres-source.mjs
+++ b/scripts/verify/verify-blog-category-translation-postgres-source.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const files = {
+  evidence: "crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json",
+  harness: "crates/rustok-blog/tests/category_translation_target_postgres_test.rs",
+  migration: "crates/rustok-blog/src/migrations/m20260803_000016_add_blog_category_translation_target_support.rs",
+  migrations: "crates/rustok-blog/src/migrations/mod.rs",
+  owner: "crates/rustok-blog/src/services/category.rs",
+  provider: "crates/rustok-blog/src/translation_target.rs",
+  changeWriter: "crates/rustok-blog/src/translation_evidence.rs",
+  coreId: "crates/rustok-core/src/id.rs",
+  sqlitePilot: "crates/rustok-blog/src/translation_target_tests.rs",
+  rootPlan: "crates/rustok-blog/docs/implementation-plan.md",
+  plan: "crates/rustok-blog/docs/implementation-plan-slice-98.md",
+  translationPlan: "docs/modules/translation-implementation-plan.md",
+};
+
+const failures = [];
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+
+if (failures.length) {
+  console.error("[verify-blog-category-translation-postgres-source] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+const evidence = JSON.parse(read(files.evidence));
+const harness = read(files.harness);
+const migration = read(files.migration);
+const migrations = read(files.migrations);
+const owner = read(files.owner);
+const provider = read(files.provider);
+const changeWriter = read(files.changeWriter);
+const coreId = read(files.coreId);
+const sqlitePilot = read(files.sqlitePilot);
+const rootPlan = read(files.rootPlan);
+const plan = read(files.plan);
+const translationPlan = read(files.translationPlan);
+
+if (
+  evidence.schema_version !== 1 ||
+  evidence.status !== "blog_category_translation_postgres_source_unvalidated" ||
+  evidence.owner !== "rustok-blog" ||
+  evidence.provider !== "blog/category"
+) {
+  failures.push("evidence identity/status/owner/provider drifted");
+}
+
+for (const key of [
+  "postgres_environment_gated_harness_added",
+  "isolated_postgres_schema_per_scenario",
+  "search_path_excludes_public",
+  "real_outbox_migrations_used",
+  "real_taxonomy_migrations_used",
+  "real_blog_migrations_used",
+  "translation_target_migration_up_down_up_covered",
+  "reapplied_revision_columns_exercised_through_category_service",
+  "reapplied_change_journal_exercised_through_provider",
+  "concurrent_apply_uses_independent_database_connections",
+  "concurrent_apply_uses_same_source_snapshot_and_expected_revisions",
+  "concurrent_apply_uses_distinct_idempotency_keys",
+  "concurrent_apply_requires_exactly_one_success",
+  "concurrent_apply_requires_closed_conflict_loser",
+  "concurrent_apply_requires_one_target_revision",
+  "concurrent_apply_requires_one_winning_change_fact",
+  "concurrent_apply_requires_one_reindex_outbox_event",
+  "cursor_recovery_starts_from_source_create_cursor",
+  "cursor_recovery_reconstructs_provider_before_apply",
+  "cursor_recovery_resumes_exactly_one_apply_change",
+  "cursor_recovery_reconstructs_owner_before_delete",
+  "cursor_recovery_reconstructs_provider_after_delete",
+  "cursor_recovery_resumes_deleted_lifecycle_change",
+  "cursor_recovery_drains_after_latest_cursor",
+  "progress_cursor_matches_latest_deleted_change",
+  "ulid_cursor_generation_is_separated_for_deterministic_recovery_fixture"
+]) {
+  if (evidence.source_contract?.[key] !== true) {
+    failures.push(`source_contract.${key} must be true`);
+  }
+}
+for (const key of [
+  "concurrent_cursor_commit_order_claimed",
+  "production_blog_behavior_changed",
+  "production_translation_contract_changed",
+  "database_schema_changed",
+  "ffa_promoted",
+  "fba_promoted",
+  "postgres_execution_observed"
+]) {
+  if (evidence.source_contract?.[key] !== false) {
+    failures.push(`source_contract.${key} must remain false`);
+  }
+}
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("evidence.execution must remain empty before maintainer execution");
+}
+for (const [key, value] of Object.entries(evidence.validation ?? {})) {
+  if (value !== false) failures.push(`validation.${key} must remain false`);
+}
+
+for (const marker of [
+  "RUSTOK_BLOG_TRANSLATION_TEST_DATABASE_URL",
+  'SET search_path TO "{schema_name}"',
+  "for migration in OutboxModule.migrations()",
+  "for migration in TaxonomyModule.migrations()",
+  "for migration in BlogModule.migrations()",
+  "category_translation_target_migration_supports_postgres_up_down_up",
+  "translation_target_migration.up(&manager).await?",
+  "translation_target_migration.down(&manager).await?",
+  "concurrent_same_revision_translation_applies_commit_once",
+  "Barrier::new(candidates.len())",
+  "exactly one same-revision apply must commit",
+  "PortErrorKind::Conflict",
+  "source create plus one winning apply only",
+  "only the winning apply may publish reindex",
+  "change_cursor_resumes_after_provider_reconstruction_and_delete",
+  "after: Some(first_cursor.clone())",
+  "after: Some(second_cursor.clone())",
+  "TranslationResourceLifecycle::Deleted",
+  "assert!(drained.changes.is_empty())",
+  "assert_eq!(progress.owner_change_cursor, Some(deleted_cursor))",
+  "tokio::time::sleep(Duration::from_millis(2))",
+  "does not claim a concurrent commit-order guarantee"
+]) need(harness, marker, "PostgreSQL harness");
+for (const marker of [
+  "CREATE TABLE blog_translation_changes",
+  "INSERT INTO blog_translation_changes",
+  "UPDATE blog_translation_changes",
+  "DELETE FROM blog_translation_changes",
+  "SET search_path TO public",
+  "SET search_path TO \"public\""
+]) forbid(harness, marker, "PostgreSQL harness");
+
+for (const marker of [
+  "m20260803_000016_add_blog_category_translation_target_support",
+  "BlogTranslationChanges::Table",
+  "BlogCategories::Revision",
+  "BlogCategoryTranslations::Revision",
+  "idx_blog_translation_changes_tenant_id"
+]) need(migration + migrations, marker, "Blog translation migration");
+
+for (const marker of [
+  "apply_exact_translation_in_tx",
+  "blog category resource revision does not match the translation proposal",
+  "source locale revision does not match the translation proposal",
+  "target locale revision does not match the translation proposal",
+  ".filter(blog_category_translation::Column::Revision.eq(target.revision))",
+  ".filter(blog_category::Column::Revision.eq(category.revision))",
+  "record_translation_change_in_tx",
+  "publish_blog_reindex_in_tx"
+]) need(owner, marker, "Category owner CAS");
+
+for (const marker of [
+  "idempotency::admit",
+  "apply_exact_translation_in_tx",
+  "async fn read_changes",
+  "order_by_asc(TranslationChangeColumn::Id)",
+  "filter(TranslationChangeColumn::Id.gt(after))",
+  "PROGRESS_STABILITY_ATTEMPTS",
+  "owner_change_cursor"
+]) need(provider, marker, "Blog Translation provider");
+
+need(changeWriter, "id: Set(generate_id())", "Blog change writer");
+need(coreId, "Uuid::from_bytes(Ulid::r#gen().to_bytes())", "ULID-backed core id");
+for (const marker of [
+  "translation_target_schema_supports_up_down_up",
+  "translation_target_applies_replays_and_tracks_an_exact_category_locale"
+]) need(sqlitePilot, marker, "SQLite pilot baseline");
+
+need(
+  rootPlan,
+  "Retained PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement",
+  "Blog root plan open pilot result",
+);
+for (const marker of [
+  "category_translation_postgres_evidence_source_ready_maintainer_execution_pending",
+  "PostgreSQL migration up/down/up",
+  "Concurrent same-revision apply",
+  "Change-cursor recovery after reconstruction",
+  "does **not** claim that the current cursor contract proves arbitrary concurrent transaction commit ordering",
+  "No tests, Cargo commands, Node verifiers"
+]) need(plan, marker, "slice 98 plan");
+for (const marker of [
+  "Blog's",
+  "`blog/category` provider",
+  "records an append-only Blog change cursor"
+]) need(translationPlan, marker, "Translation owner plan");
+
+if (failures.length) {
+  console.error("[verify-blog-category-translation-postgres-source] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "[verify-blog-category-translation-postgres-source] PASS source_ready=true execution=not_run provider=blog/category",
+);


### PR DESCRIPTION
## Summary

Continue the Blog improvement plan with the independent `blog/category` Translation pilot gap that remained after the Comments audit relay slice.

This PR adds source-only PostgreSQL evidence for the existing production owner behavior; it does not change Blog or Translation production Rust.

## Retained PostgreSQL scenarios

1. **Migration `up -> down -> up`**
   - uses the real Outbox and Taxonomy dependency migrations;
   - applies all Blog migrations preceding `m20260803_000016_add_blog_category_translation_target_support`;
   - executes the real Translation target migration up/down/up;
   - creates a category through `CategoryService` afterward;
   - requires resource/source revisions and one active provider change cursor.

2. **Concurrent same-revision exact-locale apply**
   - one source snapshot feeds two distinct patches;
   - two independent PostgreSQL connections and distinct idempotency keys are released together;
   - exactly one public `TranslationTargetProvider::apply_patch` succeeds;
   - the loser closes as `Conflict`;
   - final state contains target revision 1, one winning change fact, and one reindex outbox event.

3. **Change cursor recovery across owner reconstruction**
   - retain source-create cursor;
   - reconstruct provider/connection and apply an exact target;
   - resume exactly one active change;
   - reconstruct owner again and delete the category;
   - reconstruct provider again and resume exactly one deleted lifecycle change;
   - drain after the final cursor and require `read_progress.owner_change_cursor` to equal that deleted change cursor.

The recovery fixture separates ULID-backed change generation by two milliseconds for deterministic ordinary resume ordering. It explicitly does not claim arbitrary concurrent transaction commit-order guarantees for the cursor.

## Evidence and plan

- `crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json`
- `scripts/verify/verify-blog-category-translation-postgres-source.mjs`
- `crates/rustok-blog/docs/implementation-plan-slice-98.md`

Slice 98 status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, PostgreSQL scenarios, formatting, Clippy, workflows, CI, builds, browser targets, or runtime validation were executed. Source/diff review only.