### PR TITLE
feat(commerce): route admin payment collection commands through owner port

### DIFF
--- a/crates/rustok-commerce/docs/admin-payment-collection-owner-command-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/admin-payment-collection-owner-command-cutover-2026-08-09.md
@@ -1,0 +1,84 @@
+# Commerce admin Payment collection owner-command cutover — 2026-08-09
+
+Status: source-complete for mounted admin payment-collection authorize/capture/cancel routes; execution evidence pending and unvalidated.
+
+## Scope
+
+This slice advances the canonical ecommerce topology P0 without closing it. Three mounted admin payment-collection mutation routes now call a Payment-owned command capability instead of constructing Commerce `PaymentOrchestrationService` for their execution:
+
+- `POST /admin/payment-collections/{id}/authorize`;
+- `POST /admin/payment-collections/{id}/capture`;
+- `POST /admin/payment-collections/{id}/cancel`.
+
+Refund creation/completion/cancellation are intentionally out of scope and remain on the existing compatibility orchestration source for a separate owner-boundary slice.
+
+## Payment owner capability
+
+`rustok-payment` publishes `PaymentAdminCollectionCommandPort` and `PaymentAdminCollectionCommandRuntime` with authorize, capture, and cancel commands. The built-in adapter owns:
+
+- payment collection lifecycle admission;
+- provider selection;
+- `PaymentProviderOperationJournal` access;
+- provider execution through `PaymentProviderRegistry`;
+- durable provider-result adoption;
+- provider-payment identity recovery from the authorize journal;
+- local Payment persistence after provider success;
+- reconciliation-required checkpointing when provider outcome or local persistence is uncertain.
+
+`PaymentService`, provider journal construction, and provider execution remain inside `rustok-payment` for this mounted path.
+
+## Durable replay compatibility
+
+The cutover preserves the existing provider journal identities exactly:
+
+- `payment_collection:{collection_id}:authorize`;
+- `payment_collection:{collection_id}:capture`;
+- `payment_collection:{collection_id}:cancel`.
+
+It also preserves the request payload metadata used by the pre-cutover Commerce orchestration:
+
+- authorization keeps `commerce_orchestration.operation = authorize_payment_collection` plus `requested_provider_payment_id`;
+- capture keeps `commerce_orchestration.operation = capture_payment_collection`;
+- cancel keeps `commerce_orchestration.operation = cancel_payment_collection` plus the requested cancellation reason;
+- capture/cancel continue to recover `provider_payment_id` from the durable authorize operation when the provider requires it.
+
+Therefore upgraded retries target the same Payment-owned provider journal rows instead of changing provider operation identity.
+
+## Port write identity
+
+The mounted HTTP adapter supplies a bounded write `PortContext` containing tenant, authenticated user actor, locale, optional channel, a two-second deadline, and a stable transition-scoped admission identity:
+
+`admin-payment-collection:{collection_id}:{operation}`
+
+This key satisfies the generic write-port admission contract. It is not a newly claimed durable command receipt. Durable provider replay remains the existing Payment-owned journal and lifecycle behavior described above.
+
+## Public transport compatibility
+
+The mounted handlers preserve:
+
+- `PAYMENTS_UPDATE` admission;
+- the existing `AuthorizePaymentInput`, `CapturePaymentInput`, and `CancelPaymentInput` request bodies;
+- `PaymentCollectionResponse` responses;
+- validation/not-found/state-conflict/provider-unavailable/provider-invalid-response/reconciliation-required/provider-not-configured/storage-unavailable public HTTP families.
+
+Internal Payment failures are mapped to bounded `PortError` categories and structural diagnostics. The new owner path does not place raw provider or database error text into public errors.
+
+## Runtime composition
+
+`CommerceHttpRuntime` first accepts a host-selected `PaymentAdminCollectionCommandRuntime`. When no external command runtime was injected, the built-in owner adapter is composed from the host database and the same host-selected `PaymentProviderRegistry` used by Commerce payment provider integration.
+
+External command adapters therefore retain precedence while the built-in profile keeps provider selection consistent with the host registry.
+
+## Remaining topology work
+
+The canonical broad item “Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports” remains open.
+
+For Payment admin HTTP specifically, the next source slice is refund command ownership: refund reservation/create replay, provider refund execution, refund completion, and refund cancellation. That follow-up must retain `payment_refund:{refund_id}` provider identity, caller refund creation idempotency, reserved-refund reconciliation semantics, and current public envelopes.
+
+Other remaining Commerce Payment/Fulfillment/GraphQL concrete-service construction also keeps the broad P0 open.
+
+## Validation status
+
+`scripts/verify/verify-commerce-admin-payment-collection-owner-command-cutover.mjs` is added as a source guard but is intentionally not executed here.
+
+No tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart evidence, or external-provider execution evidence are claimed in this slice.

--- a/crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs
+++ b/crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs
@@ -8,8 +8,10 @@ use rustok_api::{
     TenantContext,
 };
 use rustok_payment::{
-    ListPaymentCollectionProjectionsRequest, ListRefundProjectionsRequest,
-    ReadPaymentCollectionProjectionRequest, ReadRefundProjectionRequest,
+    AuthorizeAdminPaymentCollectionRequest, CancelAdminPaymentCollectionRequest,
+    CaptureAdminPaymentCollectionRequest, ListPaymentCollectionProjectionsRequest,
+    ListRefundProjectionsRequest, ReadPaymentCollectionProjectionRequest,
+    ReadRefundProjectionRequest,
 };
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
@@ -20,12 +22,18 @@ use super::{
     super::common::{PaginatedResponse, ensure_permissions},
     ListPaymentCollectionsParams, ListRefundsParams,
 };
-use crate::dto::{PaymentCollectionResponse, RefundResponse};
+use crate::dto::{
+    AuthorizePaymentInput, CancelPaymentInput, CapturePaymentInput, PaymentCollectionResponse,
+    RefundResponse,
+};
 
 const ADMIN_PAYMENT_READ_OWNER: &str = "rustok_payment.admin_read";
 const ADMIN_PAYMENT_READ_BOUNDARY: &str = "commerce_admin_payment_read_http";
+const ADMIN_PAYMENT_COMMAND_OWNER: &str = "rustok_payment.admin_collection_command";
+const ADMIN_PAYMENT_COMMAND_BOUNDARY: &str = "commerce_admin_payment_collection_command_http";
 
 type AdminPaymentReadHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
+type AdminPaymentCommandHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
 
 fn admin_payment_read_context(
     tenant: &TenantContext,
@@ -41,6 +49,29 @@ fn admin_payment_read_context(
         request_context.locale.as_str(),
         format!("commerce-admin-payment-read:{operation}:{scope}"),
     )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn admin_payment_collection_command_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    collection_id: Uuid,
+    operation: &'static str,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-payment-command:{operation}:{collection_id}"),
+    )
+    .with_idempotency_key(format!(
+        "admin-payment-collection:{collection_id}:{operation}"
+    ))
     .with_deadline(std::time::Duration::from_secs(2));
     match request_context.channel_slug.as_deref() {
         Some(channel) => context.with_channel(channel),
@@ -89,6 +120,85 @@ fn payment_read_error_policy(error: &PortError) -> AdminPaymentReadHttpPolicy {
     }
 }
 
+fn payment_command_error_policy(error: &PortError) -> AdminPaymentCommandHttpPolicy {
+    match error.code.as_str() {
+        "payment.provider_unavailable" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_unavailable",
+            "Payment provider is temporarily unavailable",
+            "provider_unavailable",
+        ),
+        "payment.provider_invalid_response" => (
+            StatusCode::BAD_GATEWAY,
+            "commerce_admin_payment_provider_invalid_response",
+            "Payment provider returned an invalid response; reconciliation may be required",
+            "provider_invalid_response",
+        ),
+        "payment.provider_outcome_unknown" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_reconciliation_required",
+            "Payment provider outcome is unknown and requires reconciliation",
+            "provider_outcome_unknown",
+        ),
+        "payment.provider_not_configured" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_provider_not_configured",
+            "Payment provider is not configured for this tenant",
+            "provider_configuration",
+        ),
+        "payment.provider_rejected" | "payment.invalid_transition" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_payment_state_conflict",
+            "Payment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        "payment.database_unavailable" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_payment_storage_unavailable",
+            "Payment storage is temporarily unavailable",
+            "database",
+        ),
+        _ => match &error.kind {
+            PortErrorKind::Validation => (
+                StatusCode::BAD_REQUEST,
+                "commerce_admin_payment_invalid",
+                "Payment request is invalid",
+                "validation",
+            ),
+            PortErrorKind::NotFound => (
+                StatusCode::NOT_FOUND,
+                "commerce_admin_not_found",
+                "Commerce resource not found",
+                "not_found",
+            ),
+            PortErrorKind::Conflict => (
+                StatusCode::CONFLICT,
+                "commerce_admin_payment_state_conflict",
+                "Payment operation conflicts with the current state",
+                "state_conflict",
+            ),
+            PortErrorKind::Forbidden => (
+                StatusCode::UNAUTHORIZED,
+                "commerce_permission_denied",
+                "Permission denied",
+                "forbidden",
+            ),
+            PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "commerce_admin_payment_storage_unavailable",
+                "Payment storage is temporarily unavailable",
+                "unavailable",
+            ),
+            PortErrorKind::InvariantViolation => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "commerce_admin_payment_failed",
+                "Payment operation could not be completed safely",
+                "invariant_violation",
+            ),
+        },
+    }
+}
+
 fn map_payment_read_error(
     tenant_id: Uuid,
     actor_id: Uuid,
@@ -113,6 +223,33 @@ fn map_payment_read_error(
         status = %status,
         boundary = ADMIN_PAYMENT_READ_BOUNDARY,
         "commerce admin payment owner read failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_payment_command_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    collection_id: Uuid,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = payment_command_error_policy(&error);
+    tracing::error!(
+        owner = ADMIN_PAYMENT_COMMAND_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        collection_id_non_nil = !collection_id.is_nil(),
+        operation,
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_PAYMENT_COMMAND_BOUNDARY,
+        "commerce admin payment owner command failed"
     );
     HttpError::new(status, code, message)
 }
@@ -217,6 +354,159 @@ pub async fn show_payment_collection(
                 auth.user_id,
                 Some(id),
                 "show_payment_collection",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(collection))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/payment-collections/{id}/authorize",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Payment collection ID")),
+    request_body = AuthorizePaymentInput,
+    responses((status = 200, description = "Payment collection authorized", body = PaymentCollectionResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Payment collection not found"))
+)]
+pub async fn authorize_payment_collection(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<AuthorizePaymentInput>,
+) -> HttpResult<Json<PaymentCollectionResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_UPDATE],
+        "Permission denied: payments:update required",
+    )?;
+    let context = admin_payment_collection_command_context(
+        &tenant,
+        &auth,
+        &request_context,
+        id,
+        "authorize",
+    );
+    let collection = runtime
+        .payment_admin_collection_command_port()
+        .authorize_payment_collection(
+            context.clone(),
+            AuthorizeAdminPaymentCollectionRequest {
+                collection_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "authorize_payment_collection",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(collection))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/payment-collections/{id}/capture",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Payment collection ID")),
+    request_body = CapturePaymentInput,
+    responses((status = 200, description = "Payment collection captured", body = PaymentCollectionResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Payment collection not found"))
+)]
+pub async fn capture_payment_collection(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CapturePaymentInput>,
+) -> HttpResult<Json<PaymentCollectionResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_UPDATE],
+        "Permission denied: payments:update required",
+    )?;
+    let context = admin_payment_collection_command_context(
+        &tenant,
+        &auth,
+        &request_context,
+        id,
+        "capture",
+    );
+    let collection = runtime
+        .payment_admin_collection_command_port()
+        .capture_payment_collection(
+            context.clone(),
+            CaptureAdminPaymentCollectionRequest {
+                collection_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "capture_payment_collection",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(collection))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/payment-collections/{id}/cancel",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Payment collection ID")),
+    request_body = CancelPaymentInput,
+    responses((status = 200, description = "Payment collection cancelled", body = PaymentCollectionResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Payment collection not found"))
+)]
+pub async fn cancel_payment_collection(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CancelPaymentInput>,
+) -> HttpResult<Json<PaymentCollectionResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_UPDATE],
+        "Permission denied: payments:update required",
+    )?;
+    let context = admin_payment_collection_command_context(
+        &tenant,
+        &auth,
+        &request_context,
+        id,
+        "cancel",
+    );
+    let collection = runtime
+        .payment_admin_collection_command_port()
+        .cancel_payment_collection(
+            context.clone(),
+            CancelAdminPaymentCollectionRequest {
+                collection_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_payment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "cancel_payment_collection",
                 &context,
                 error,
             )

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -30,6 +30,7 @@ pub struct CommerceHttpRuntime {
     order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
     payment_admin_read_runtime: rustok_payment::PaymentAdminReadRuntime,
+    payment_admin_collection_command_runtime: rustok_payment::PaymentAdminCollectionCommandRuntime,
     product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
     product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime,
     #[cfg(feature = "marketplace-financial")]
@@ -92,6 +93,12 @@ impl CommerceHttpRuntime {
         self.payment_admin_read_runtime.read_port()
     }
 
+    fn payment_admin_collection_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_payment::PaymentAdminCollectionCommandPort> {
+        self.payment_admin_collection_command_runtime.command_port()
+    }
+
     fn product_catalog_read_port(
         &self,
     ) -> std::sync::Arc<dyn rustok_product::ProductCatalogReadPort> {
@@ -126,6 +133,9 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require TransactionalEventBus in HostRuntimeContext"
                 )
             })?;
+        let payment_provider_registry = runtime
+            .shared_get::<PaymentProviderRegistry>()
+            .unwrap_or_else(PaymentProviderRegistry::with_manual_provider);
         let shipping_option_read_runtime = runtime
             .shared_get::<crate::graphql_runtime::CommerceShippingOptionReadRuntime>()
             .ok_or_else(|| {
@@ -164,6 +174,14 @@ impl CommerceHttpRuntime {
         let payment_admin_read_runtime = runtime
             .shared_get::<rustok_payment::PaymentAdminReadRuntime>()
             .unwrap_or_else(|| rustok_payment::PaymentAdminReadRuntime::in_process(runtime.db_clone()));
+        let payment_admin_collection_command_runtime = runtime
+            .shared_get::<rustok_payment::PaymentAdminCollectionCommandRuntime>()
+            .unwrap_or_else(|| {
+                rustok_payment::PaymentAdminCollectionCommandRuntime::in_process(
+                    runtime.db_clone(),
+                    payment_provider_registry.clone(),
+                )
+            });
         let product_catalog_read_runtime = runtime
             .shared_get::<rustok_product::ProductCatalogReadRuntime>()
             .ok_or_else(|| {
@@ -189,9 +207,7 @@ impl CommerceHttpRuntime {
         Ok(Self {
             db: runtime.db_clone(),
             event_bus,
-            payment_provider_registry: runtime
-                .shared_get::<PaymentProviderRegistry>()
-                .unwrap_or_else(PaymentProviderRegistry::with_manual_provider),
+            payment_provider_registry,
             fulfillment_provider_registry: runtime
                 .shared_get::<FulfillmentProviderRegistry>()
                 .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider),
@@ -201,6 +217,7 @@ impl CommerceHttpRuntime {
             order_admin_command_runtime,
             payment_order_read_runtime,
             payment_admin_read_runtime,
+            payment_admin_collection_command_runtime,
             product_catalog_read_runtime,
             product_catalog_command_runtime,
             #[cfg(feature = "marketplace-financial")]

--- a/crates/rustok-payment/src/admin_collection_command.rs
+++ b/crates/rustok-payment/src/admin_collection_command.rs
@@ -1,0 +1,1074 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+use validator::Validate;
+
+use crate::dto::{
+    AuthorizePaymentInput, CancelPaymentInput, CapturePaymentInput, PaymentCollectionResponse,
+    PaymentCollectionStatusKind,
+};
+use crate::providers::{
+    MANUAL_PAYMENT_PROVIDER_ID, PaymentProviderOperationRequest, PaymentProviderOperationResult,
+    PaymentProviderRegistry,
+};
+use crate::{
+    BeginProviderOperation, PROVIDER_OPERATION_COMMITTED, PROVIDER_OPERATION_EXECUTING,
+    PROVIDER_OPERATION_RECONCILIATION_REQUIRED, PROVIDER_OPERATION_SUCCEEDED, PaymentError,
+    PaymentProviderOperationJournal, PaymentService,
+};
+
+const ADMIN_COLLECTION_COMMAND_BOUNDARY: &str = "payment_admin_collection_command_port";
+const UNKNOWN_PROVIDER_ID: &str = "payment-provider";
+
+#[async_trait]
+pub trait PaymentAdminCollectionCommandPort: Send + Sync {
+    async fn authorize_payment_collection(
+        &self,
+        context: PortContext,
+        request: AuthorizeAdminPaymentCollectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError>;
+
+    async fn capture_payment_collection(
+        &self,
+        context: PortContext,
+        request: CaptureAdminPaymentCollectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError>;
+
+    async fn cancel_payment_collection(
+        &self,
+        context: PortContext,
+        request: CancelAdminPaymentCollectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorizeAdminPaymentCollectionRequest {
+    pub collection_id: Uuid,
+    pub input: AuthorizePaymentInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureAdminPaymentCollectionRequest {
+    pub collection_id: Uuid,
+    pub input: CapturePaymentInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelAdminPaymentCollectionRequest {
+    pub collection_id: Uuid,
+    pub input: CancelPaymentInput,
+}
+
+pub struct InProcessPaymentAdminCollectionCommandPort {
+    payment_service: PaymentService,
+    operation_journal: PaymentProviderOperationJournal,
+    provider_registry: PaymentProviderRegistry,
+}
+
+impl InProcessPaymentAdminCollectionCommandPort {
+    pub fn new(db: DatabaseConnection, provider_registry: PaymentProviderRegistry) -> Self {
+        Self {
+            payment_service: PaymentService::new(db.clone()),
+            operation_journal: PaymentProviderOperationJournal::new(db),
+            provider_registry,
+        }
+    }
+}
+
+pub fn in_process_payment_admin_collection_command_port(
+    db: DatabaseConnection,
+    provider_registry: PaymentProviderRegistry,
+) -> Arc<dyn PaymentAdminCollectionCommandPort> {
+    Arc::new(InProcessPaymentAdminCollectionCommandPort::new(
+        db,
+        provider_registry,
+    ))
+}
+
+#[derive(Clone)]
+pub struct PaymentAdminCollectionCommandRuntime {
+    command_port: Arc<dyn PaymentAdminCollectionCommandPort>,
+}
+
+impl PaymentAdminCollectionCommandRuntime {
+    pub fn new(command_port: Arc<dyn PaymentAdminCollectionCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        provider_registry: PaymentProviderRegistry,
+    ) -> Self {
+        Self::new(in_process_payment_admin_collection_command_port(
+            db,
+            provider_registry,
+        ))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn PaymentAdminCollectionCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl PaymentAdminCollectionCommandPort for InProcessPaymentAdminCollectionCommandPort {
+    async fn authorize_payment_collection(
+        &self,
+        context: PortContext,
+        request: AuthorizeAdminPaymentCollectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError> {
+        const OPERATION: &str = "authorize_admin_payment_collection";
+        require_admin_collection_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_admin_collection_tenant_id(&context, OPERATION)?;
+        request.input.validate().map_err(|_| {
+            PortError::validation(
+                "payment.validation",
+                "payment authorization request is invalid",
+            )
+        })?;
+
+        let collection = self
+            .payment_service
+            .get_collection(tenant_id, request.collection_id)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))?;
+        let provider_id = request
+            .input
+            .provider_id
+            .clone()
+            .or_else(|| collection.provider_id.clone())
+            .unwrap_or_else(|| MANUAL_PAYMENT_PROVIDER_ID.to_string());
+        let idempotency_key = format!("payment_collection:{}:authorize", collection.id);
+
+        match collection.status_kind() {
+            PaymentCollectionStatusKind::Authorized | PaymentCollectionStatusKind::Captured => {
+                self.commit_existing_provider_operation(
+                    &context,
+                    OPERATION,
+                    tenant_id,
+                    provider_id.as_str(),
+                    idempotency_key.as_str(),
+                    "authorize",
+                )
+                .await?;
+                return Ok(collection);
+            }
+            PaymentCollectionStatusKind::Pending => {}
+            PaymentCollectionStatusKind::Cancelled | PaymentCollectionStatusKind::Unknown => {
+                return Err(map_payment_error(
+                    &context,
+                    OPERATION,
+                    PaymentError::InvalidTransition {
+                        from: collection.status,
+                        to: "authorized".to_string(),
+                    },
+                ));
+            }
+        }
+
+        let AuthorizePaymentInput {
+            provider_id: _,
+            provider_payment_id,
+            amount,
+            metadata,
+        } = request.input;
+        let requested_amount = amount.unwrap_or(collection.amount);
+        let provider_request = PaymentProviderOperationRequest {
+            tenant_id,
+            collection_id: collection.id,
+            amount: requested_amount,
+            currency_code: collection.currency_code.clone(),
+            idempotency_key: Some(idempotency_key),
+            metadata: merge_provider_context(
+                metadata.clone(),
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "authorize_payment_collection",
+                        "requested_provider_payment_id": provider_payment_id.clone(),
+                    }
+                }),
+            ),
+        };
+        let journaled = self
+            .execute_journaled_provider_operation(
+                &context,
+                OPERATION,
+                "authorize",
+                provider_id.as_str(),
+                provider_request,
+            )
+            .await?;
+        let provider_result = journaled.result;
+
+        match self
+            .payment_service
+            .authorize_collection(
+                tenant_id,
+                collection.id,
+                AuthorizePaymentInput {
+                    provider_id: Some(provider_result.provider_id),
+                    provider_payment_id: provider_result.external_reference.or(provider_payment_id),
+                    amount: Some(provider_result.authorized_amount),
+                    metadata: merge_provider_context(metadata, provider_result.metadata),
+                },
+            )
+            .await
+        {
+            Ok(collection) => {
+                self.mark_journal_committed(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "authorize",
+                )
+                .await?;
+                Ok(collection)
+            }
+            Err(error) => {
+                self.mark_local_persistence_failed(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "authorize",
+                    &error,
+                )
+                .await;
+                Err(self.local_persistence_after_provider_error(
+                    &context,
+                    OPERATION,
+                    "authorize",
+                    error,
+                ))
+            }
+        }
+    }
+
+    async fn capture_payment_collection(
+        &self,
+        context: PortContext,
+        request: CaptureAdminPaymentCollectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError> {
+        const OPERATION: &str = "capture_admin_payment_collection";
+        require_admin_collection_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_admin_collection_tenant_id(&context, OPERATION)?;
+        let collection = self
+            .payment_service
+            .get_collection(tenant_id, request.collection_id)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))?;
+        let provider_id = provider_id_for_collection(&collection);
+        let idempotency_key = format!("payment_collection:{}:capture", collection.id);
+
+        match collection.status_kind() {
+            PaymentCollectionStatusKind::Captured => {
+                self.commit_existing_provider_operation(
+                    &context,
+                    OPERATION,
+                    tenant_id,
+                    provider_id.as_str(),
+                    idempotency_key.as_str(),
+                    "capture",
+                )
+                .await?;
+                return Ok(collection);
+            }
+            PaymentCollectionStatusKind::Authorized => {}
+            PaymentCollectionStatusKind::Pending
+            | PaymentCollectionStatusKind::Cancelled
+            | PaymentCollectionStatusKind::Unknown => {
+                return Err(map_payment_error(
+                    &context,
+                    OPERATION,
+                    PaymentError::InvalidTransition {
+                        from: collection.status,
+                        to: "captured".to_string(),
+                    },
+                ));
+            }
+        }
+
+        let CapturePaymentInput { amount, metadata } = request.input;
+        let requested_amount = amount.unwrap_or(collection.authorized_amount);
+        let provider_request = PaymentProviderOperationRequest {
+            tenant_id,
+            collection_id: collection.id,
+            amount: requested_amount,
+            currency_code: collection.currency_code.clone(),
+            idempotency_key: Some(idempotency_key),
+            metadata: merge_provider_context(
+                metadata.clone(),
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "capture_payment_collection"
+                    }
+                }),
+            ),
+        };
+        let journaled = self
+            .execute_journaled_provider_operation(
+                &context,
+                OPERATION,
+                "capture",
+                provider_id.as_str(),
+                provider_request,
+            )
+            .await?;
+        let provider_result = journaled.result;
+
+        match self
+            .payment_service
+            .capture_collection(
+                tenant_id,
+                collection.id,
+                CapturePaymentInput {
+                    amount: Some(provider_result.captured_amount),
+                    metadata: merge_provider_context(metadata, provider_result.metadata),
+                },
+            )
+            .await
+        {
+            Ok(collection) => {
+                self.mark_journal_committed(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "capture",
+                )
+                .await?;
+                Ok(collection)
+            }
+            Err(error) => {
+                self.mark_local_persistence_failed(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "capture",
+                    &error,
+                )
+                .await;
+                Err(self.local_persistence_after_provider_error(
+                    &context,
+                    OPERATION,
+                    "capture",
+                    error,
+                ))
+            }
+        }
+    }
+
+    async fn cancel_payment_collection(
+        &self,
+        context: PortContext,
+        request: CancelAdminPaymentCollectionRequest,
+    ) -> Result<PaymentCollectionResponse, PortError> {
+        const OPERATION: &str = "cancel_admin_payment_collection";
+        require_admin_collection_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_admin_collection_tenant_id(&context, OPERATION)?;
+        let mut input = request.input;
+        let collection = self
+            .payment_service
+            .get_collection(tenant_id, request.collection_id)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))?;
+        let provider_id = provider_id_for_collection(&collection);
+        let idempotency_key = format!("payment_collection:{}:cancel", collection.id);
+
+        match collection.status_kind() {
+            PaymentCollectionStatusKind::Cancelled => {
+                self.commit_existing_provider_operation(
+                    &context,
+                    OPERATION,
+                    tenant_id,
+                    provider_id.as_str(),
+                    idempotency_key.as_str(),
+                    "cancel",
+                )
+                .await?;
+                return Ok(collection);
+            }
+            PaymentCollectionStatusKind::Pending | PaymentCollectionStatusKind::Authorized => {}
+            PaymentCollectionStatusKind::Captured | PaymentCollectionStatusKind::Unknown => {
+                return Err(map_payment_error(
+                    &context,
+                    OPERATION,
+                    PaymentError::InvalidTransition {
+                        from: collection.status,
+                        to: "cancelled".to_string(),
+                    },
+                ));
+            }
+        }
+
+        let provider_operation_id = if should_cancel_provider(&collection) {
+            let provider_request = PaymentProviderOperationRequest {
+                tenant_id,
+                collection_id: collection.id,
+                amount: executable_payment_amount(&collection),
+                currency_code: collection.currency_code.clone(),
+                idempotency_key: Some(idempotency_key),
+                metadata: merge_provider_context(
+                    input.metadata.clone(),
+                    serde_json::json!({
+                        "commerce_orchestration": {
+                            "operation": "cancel_payment_collection",
+                            "reason": input.reason.clone(),
+                        }
+                    }),
+                ),
+            };
+            let journaled = self
+                .execute_journaled_provider_operation(
+                    &context,
+                    OPERATION,
+                    "cancel",
+                    provider_id.as_str(),
+                    provider_request,
+                )
+                .await?;
+            input.metadata = merge_provider_context(input.metadata, journaled.result.metadata);
+            Some(journaled.operation_id)
+        } else {
+            None
+        };
+
+        match self
+            .payment_service
+            .cancel_collection(tenant_id, collection.id, input)
+            .await
+        {
+            Ok(collection) => {
+                if let Some(operation_id) = provider_operation_id {
+                    self.mark_journal_committed(
+                        &context,
+                        OPERATION,
+                        operation_id,
+                        "cancel",
+                    )
+                    .await?;
+                }
+                Ok(collection)
+            }
+            Err(error) => {
+                if let Some(operation_id) = provider_operation_id {
+                    self.mark_local_persistence_failed(
+                        &context,
+                        OPERATION,
+                        operation_id,
+                        "cancel",
+                        &error,
+                    )
+                    .await;
+                    Err(self.local_persistence_after_provider_error(
+                        &context,
+                        OPERATION,
+                        "cancel",
+                        error,
+                    ))
+                } else {
+                    Err(map_payment_error(&context, OPERATION, error))
+                }
+            }
+        }
+    }
+}
+
+struct JournaledProviderResult {
+    operation_id: Uuid,
+    result: PaymentProviderOperationResult,
+}
+
+impl InProcessPaymentAdminCollectionCommandPort {
+    async fn execute_journaled_provider_operation(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        provider_operation: &'static str,
+        provider_id: &str,
+        request: PaymentProviderOperationRequest,
+    ) -> Result<JournaledProviderResult, PortError> {
+        let request = self
+            .enrich_provider_request(
+                context,
+                owner_operation,
+                provider_operation,
+                provider_id,
+                request,
+            )
+            .await?;
+        let idempotency_key = request
+            .idempotency_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                PortError::validation(
+                    "payment.provider_idempotency_key_missing",
+                    "payment provider operation requires idempotency identity",
+                )
+            })?
+            .to_string();
+        let request_payload = serde_json::to_value(&request).map_err(|_| {
+            PortError::validation(
+                "payment.provider_request_invalid",
+                "payment provider request could not be normalized",
+            )
+        })?;
+        let journal_operation = self
+            .operation_journal
+            .begin(BeginProviderOperation {
+                tenant_id: request.tenant_id,
+                payment_collection_id: request.collection_id,
+                refund_id: None,
+                operation: provider_operation.to_string(),
+                provider_id: provider_id.to_string(),
+                idempotency_key,
+                request_payload,
+            })
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?;
+
+        if let Some(result) = persisted_provider_result(&journal_operation)
+            .map_err(|error| map_payment_error(context, owner_operation, error))?
+        {
+            return Ok(JournaledProviderResult {
+                operation_id: journal_operation.id,
+                result,
+            });
+        }
+
+        let claimed = self
+            .operation_journal
+            .claim_execution(journal_operation.id)
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?;
+        if claimed.is_none() {
+            let current = self
+                .operation_journal
+                .get(journal_operation.id)
+                .await
+                .map_err(|error| map_payment_error(context, owner_operation, error))?;
+            if let Some(result) = persisted_provider_result(&current)
+                .map_err(|error| map_payment_error(context, owner_operation, error))?
+            {
+                return Ok(JournaledProviderResult {
+                    operation_id: current.id,
+                    result,
+                });
+            }
+            return Err(PortError::validation(
+                "payment.provider_operation_in_progress",
+                "payment provider operation is already in progress",
+            ));
+        }
+
+        let provider_result = match provider_operation {
+            "authorize" => self.provider_registry.execute_authorize(provider_id, request).await,
+            "capture" => self.provider_registry.execute_capture(provider_id, request).await,
+            "cancel" => self.provider_registry.execute_cancel(provider_id, request).await,
+            _ => {
+                return Err(PortError::validation(
+                    "payment.provider_operation_invalid",
+                    "payment provider operation is not supported",
+                ));
+            }
+        };
+        let provider_result = match provider_result {
+            Ok(result) => result,
+            Err(error) => {
+                let checkpoint = if error.requires_provider_reconciliation() {
+                    self.operation_journal
+                        .mark_reconciliation_required(
+                            journal_operation.id,
+                            "payment.provider_outcome_requires_reconciliation",
+                        )
+                        .await
+                } else {
+                    self.operation_journal
+                        .mark_provider_error(journal_operation.id, "payment.provider_operation_failed")
+                        .await
+                };
+                if checkpoint.is_err() {
+                    return Err(map_payment_error(
+                        context,
+                        owner_operation,
+                        PaymentError::provider_outcome_unknown(provider_id, provider_operation),
+                    ));
+                }
+                return Err(map_payment_error(context, owner_operation, error));
+            }
+        };
+
+        let result_payload = match serde_json::to_value(&provider_result) {
+            Ok(payload) => payload,
+            Err(_) => {
+                let _ = self
+                    .operation_journal
+                    .mark_reconciliation_required(
+                        journal_operation.id,
+                        "payment.provider_result_serialization_failed",
+                    )
+                    .await;
+                return Err(map_payment_error(
+                    context,
+                    owner_operation,
+                    PaymentError::provider_outcome_unknown(provider_id, provider_operation),
+                ));
+            }
+        };
+        if self
+            .operation_journal
+            .mark_provider_succeeded(
+                journal_operation.id,
+                provider_result.external_reference.clone(),
+                result_payload,
+            )
+            .await
+            .is_err()
+        {
+            let _ = self
+                .operation_journal
+                .mark_reconciliation_required(
+                    journal_operation.id,
+                    "payment.provider_success_checkpoint_failed",
+                )
+                .await;
+            return Err(map_payment_error(
+                context,
+                owner_operation,
+                PaymentError::provider_outcome_unknown(provider_id, provider_operation),
+            ));
+        }
+
+        Ok(JournaledProviderResult {
+            operation_id: journal_operation.id,
+            result: provider_result,
+        })
+    }
+
+    async fn enrich_provider_request(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        provider_operation: &str,
+        provider_id: &str,
+        mut request: PaymentProviderOperationRequest,
+    ) -> Result<PaymentProviderOperationRequest, PortError> {
+        if provider_id == MANUAL_PAYMENT_PROVIDER_ID || provider_operation == "authorize" {
+            return Ok(request);
+        }
+        if metadata_string(&request.metadata, "provider_payment_id").is_some() {
+            return Ok(request);
+        }
+
+        let authorize_key = format!("payment_collection:{}:authorize", request.collection_id);
+        let authorize = self
+            .operation_journal
+            .find_by_key(request.tenant_id, provider_id, authorize_key.as_str())
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?
+            .ok_or_else(|| {
+                map_payment_error(
+                    context,
+                    owner_operation,
+                    PaymentError::Validation(
+                        "provider operation requires a completed authorize operation".to_string(),
+                    ),
+                )
+            })?;
+        if !matches!(
+            authorize.status.as_str(),
+            PROVIDER_OPERATION_COMMITTED
+                | PROVIDER_OPERATION_SUCCEEDED
+                | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+        ) {
+            return Err(map_payment_error(
+                context,
+                owner_operation,
+                PaymentError::Validation(
+                    "provider operation requires a completed authorize operation".to_string(),
+                ),
+            ));
+        }
+        let provider_payment_id = authorize
+            .provider_reference
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                authorize
+                    .provider_result
+                    .as_ref()
+                    .and_then(|result| result.get("external_reference"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+            })
+            .ok_or_else(|| {
+                map_payment_error(
+                    context,
+                    owner_operation,
+                    PaymentError::provider_outcome_unknown(provider_id, "authorize"),
+                )
+            })?;
+        insert_metadata_string(
+            &mut request.metadata,
+            "provider_payment_id",
+            provider_payment_id,
+        )
+        .map_err(|error| map_payment_error(context, owner_operation, error))?;
+        Ok(request)
+    }
+
+    async fn commit_existing_provider_operation(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        tenant_id: Uuid,
+        provider_id: &str,
+        idempotency_key: &str,
+        provider_operation: &'static str,
+    ) -> Result<(), PortError> {
+        if let Some(existing) = self
+            .operation_journal
+            .find_by_key(tenant_id, provider_id, idempotency_key)
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?
+            && matches!(
+                existing.status.as_str(),
+                PROVIDER_OPERATION_SUCCEEDED | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+            )
+        {
+            self.mark_journal_committed(
+                context,
+                owner_operation,
+                existing.id,
+                provider_operation,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn mark_journal_committed(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        operation_id: Uuid,
+        provider_operation: &'static str,
+    ) -> Result<(), PortError> {
+        if self.operation_journal.mark_committed(operation_id).await.is_err() {
+            let _ = self
+                .operation_journal
+                .mark_reconciliation_required(
+                    operation_id,
+                    format!("payment.local_{provider_operation}_commit_checkpoint_failed"),
+                )
+                .await;
+            return Err(map_payment_error(
+                context,
+                owner_operation,
+                PaymentError::provider_outcome_unknown(UNKNOWN_PROVIDER_ID, provider_operation),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn mark_local_persistence_failed(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        operation_id: Uuid,
+        provider_operation: &'static str,
+        error: &PaymentError,
+    ) {
+        let _ = self
+            .operation_journal
+            .mark_reconciliation_required(
+                operation_id,
+                format!("payment.local_{provider_operation}_persistence_failed"),
+            )
+            .await;
+        log_local_persistence_failure(context, owner_operation, provider_operation, error);
+    }
+
+    fn local_persistence_after_provider_error(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        provider_operation: &'static str,
+        error: PaymentError,
+    ) -> PortError {
+        log_local_persistence_failure(context, owner_operation, provider_operation, &error);
+        map_payment_error(
+            context,
+            owner_operation,
+            PaymentError::provider_outcome_unknown(UNKNOWN_PROVIDER_ID, provider_operation),
+        )
+    }
+}
+
+fn require_admin_collection_write_admission(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::write()).inspect_err(|error| {
+        log_port_error(context, operation, "policy", error);
+    })?;
+    context.require_write_semantics().inspect_err(|error| {
+        log_port_error(context, operation, "write_semantics", error);
+    })
+}
+
+fn parse_admin_collection_tenant_id(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let error = PortError::validation(
+            "payment.tenant_id_invalid",
+            "payment command tenant context is invalid",
+        );
+        log_port_error(context, operation, "tenant_id", &error);
+        error
+    })
+}
+
+fn map_payment_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PaymentError,
+) -> PortError {
+    let error_variant = payment_error_variant(&error);
+    let mapped = match error {
+        PaymentError::Validation(_) => {
+            PortError::validation("payment.validation", "payment request is invalid")
+        }
+        PaymentError::PaymentCollectionNotFound(_) => PortError::not_found(
+            "payment.collection_not_found",
+            "payment collection was not found",
+        ),
+        PaymentError::PaymentNotFound(_) => {
+            PortError::not_found("payment.payment_not_found", "payment was not found")
+        }
+        PaymentError::RefundNotFound(_) => {
+            PortError::not_found("payment.refund_not_found", "refund was not found")
+        }
+        PaymentError::InvalidTransition { .. } => PortError::conflict(
+            "payment.invalid_transition",
+            "payment lifecycle conflicts with the requested operation",
+        ),
+        PaymentError::ProviderUnavailable { .. } => PortError::unavailable(
+            "payment.provider_unavailable",
+            "payment provider is temporarily unavailable",
+        ),
+        PaymentError::ProviderRejected { .. } => PortError::conflict(
+            "payment.provider_rejected",
+            "payment provider rejected the requested operation",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => PortError::new(
+            PortErrorKind::InvariantViolation,
+            "payment.provider_invalid_response",
+            "payment provider response could not be applied safely",
+            false,
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => PortError::new(
+            PortErrorKind::Conflict,
+            "payment.provider_outcome_unknown",
+            "payment provider outcome requires reconciliation",
+            false,
+        ),
+        PaymentError::ProviderConfiguration { .. } => PortError::new(
+            PortErrorKind::InvariantViolation,
+            "payment.provider_not_configured",
+            "payment provider is not configured for the requested operation",
+            false,
+        ),
+        PaymentError::Database(_) => PortError::unavailable(
+            "payment.database_unavailable",
+            "payment storage is temporarily unavailable",
+        ),
+    };
+    tracing::warn!(
+        owner = "rustok_payment",
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        error_variant,
+        public_code = %mapped.code,
+        retryable = mapped.retryable,
+        boundary = ADMIN_COLLECTION_COMMAND_BOUNDARY,
+        "payment admin collection command returned a bounded owner error"
+    );
+    mapped
+}
+
+fn payment_error_variant(error: &PaymentError) -> &'static str {
+    match error {
+        PaymentError::Validation(_) => "validation",
+        PaymentError::PaymentCollectionNotFound(_) => "payment_collection_not_found",
+        PaymentError::PaymentNotFound(_) => "payment_not_found",
+        PaymentError::RefundNotFound(_) => "refund_not_found",
+        PaymentError::InvalidTransition { .. } => "invalid_transition",
+        PaymentError::ProviderUnavailable { .. } => "provider_unavailable",
+        PaymentError::ProviderRejected { .. } => "provider_rejected",
+        PaymentError::ProviderInvalidResponse { .. } => "provider_invalid_response",
+        PaymentError::ProviderOutcomeUnknown { .. } => "provider_outcome_unknown",
+        PaymentError::ProviderConfiguration { .. } => "provider_configuration",
+        PaymentError::Database(_) => "database",
+    }
+}
+
+fn log_port_error(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = "rustok_payment",
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = ADMIN_COLLECTION_COMMAND_BOUNDARY,
+        "payment admin collection command admission failed"
+    );
+}
+
+fn persisted_provider_result(
+    journal_operation: &crate::entities::provider_operation::Model,
+) -> Result<Option<PaymentProviderOperationResult>, PaymentError> {
+    if journal_operation.status == PROVIDER_OPERATION_EXECUTING {
+        return Ok(None);
+    }
+    if !matches!(
+        journal_operation.status.as_str(),
+        PROVIDER_OPERATION_COMMITTED
+            | PROVIDER_OPERATION_SUCCEEDED
+            | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+    ) {
+        return Ok(None);
+    }
+    let Some(value) = journal_operation.provider_result.clone() else {
+        return Err(PaymentError::provider_outcome_unknown(
+            journal_operation.provider_id.as_str(),
+            journal_operation.operation.as_str(),
+        ));
+    };
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|_| {
+            PaymentError::provider_outcome_unknown(
+                journal_operation.provider_id.as_str(),
+                journal_operation.operation.as_str(),
+            )
+        })
+}
+
+fn insert_metadata_string(metadata: &mut Value, key: &str, value: String) -> Result<(), PaymentError> {
+    if !metadata.is_object() {
+        if metadata.is_null() {
+            *metadata = serde_json::json!({});
+        } else {
+            return Err(PaymentError::Validation(
+                "payment provider operation metadata must be an object".to_string(),
+            ));
+        }
+    }
+    let object = metadata.as_object_mut().ok_or_else(|| {
+        PaymentError::Validation("payment provider operation metadata must be an object".to_string())
+    })?;
+    if let Some(existing) = object.get(key).and_then(Value::as_str) {
+        if existing != value {
+            return Err(PaymentError::Validation(
+                "payment provider identity conflicts with owner identity".to_string(),
+            ));
+        }
+        return Ok(());
+    }
+    object.insert(key.to_string(), Value::String(value));
+    Ok(())
+}
+
+fn metadata_string<'a>(metadata: &'a Value, key: &str) -> Option<&'a str> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn provider_id_for_collection(collection: &PaymentCollectionResponse) -> String {
+    collection
+        .provider_id
+        .clone()
+        .unwrap_or_else(|| MANUAL_PAYMENT_PROVIDER_ID.to_string())
+}
+
+fn should_cancel_provider(collection: &PaymentCollectionResponse) -> bool {
+    collection.status_kind() == PaymentCollectionStatusKind::Authorized
+        || collection.authorized_amount > Decimal::ZERO
+        || collection.provider_id.is_some()
+}
+
+fn executable_payment_amount(collection: &PaymentCollectionResponse) -> Decimal {
+    if collection.captured_amount > Decimal::ZERO {
+        collection.captured_amount
+    } else if collection.authorized_amount > Decimal::ZERO {
+        collection.authorized_amount
+    } else {
+        collection.amount
+    }
+}
+
+fn merge_provider_context(current: Value, patch: Value) -> Value {
+    match (current, patch) {
+        (Value::Object(mut current), Value::Object(patch)) => {
+            for (key, value) in patch {
+                current.insert(key, value);
+            }
+            Value::Object(current)
+        }
+        (_, patch) => patch,
+    }
+}
+
+fn log_local_persistence_failure(
+    context: &PortContext,
+    owner_operation: &'static str,
+    provider_operation: &'static str,
+    error: &PaymentError,
+) {
+    tracing::error!(
+        owner = "rustok_payment",
+        operation = owner_operation,
+        provider_operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        error_variant = payment_error_variant(error),
+        boundary = ADMIN_COLLECTION_COMMAND_BOUNDARY,
+        "payment provider operation succeeded but local persistence did not complete"
+    );
+}

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -3,6 +3,7 @@ use rustok_api::Permission;
 use rustok_core::{MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+mod admin_collection_command;
 mod admin_read;
 #[path = "checkout_compensation.rs"]
 mod checkout_compensation_persistent;
@@ -30,6 +31,12 @@ pub mod services;
 #[cfg(feature = "stripe")]
 pub mod stripe_provider;
 
+pub use admin_collection_command::{
+    AuthorizeAdminPaymentCollectionRequest, CancelAdminPaymentCollectionRequest,
+    CaptureAdminPaymentCollectionRequest, InProcessPaymentAdminCollectionCommandPort,
+    PaymentAdminCollectionCommandPort, PaymentAdminCollectionCommandRuntime,
+    in_process_payment_admin_collection_command_port,
+};
 pub use admin_read::{
     InProcessPaymentAdminReadPort, ListPaymentCollectionProjectionsRequest,
     ListRefundProjectionsRequest, PaymentAdminReadPort, PaymentAdminReadRuntime,

--- a/scripts/verify/verify-commerce-admin-payment-collection-owner-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-payment-collection-owner-command-cutover.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) {
+    throw new Error(`missing ${label}: ${text}`);
+  }
+};
+const forbidText = (source, text, label) => {
+  if (source.includes(text)) {
+    throw new Error(`forbidden ${label}: ${text}`);
+  }
+};
+
+const mounted = read("crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs");
+const legacy = read("crates/rustok-commerce/src/controllers/admin/payments.rs");
+const httpRuntime = read("crates/rustok-commerce/src/controllers/mod.rs");
+const paymentLib = read("crates/rustok-payment/src/lib.rs");
+const ownerCommand = read("crates/rustok-payment/src/admin_collection_command.rs");
+const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+const doc = read("crates/rustok-commerce/docs/admin-payment-collection-owner-command-cutover-2026-08-09.md");
+
+requireText(paymentLib, "mod admin_collection_command;", "Payment admin collection command module");
+requireText(paymentLib, "PaymentAdminCollectionCommandPort, PaymentAdminCollectionCommandRuntime", "Payment command exports");
+requireText(ownerCommand, "pub trait PaymentAdminCollectionCommandPort", "Payment owner command port");
+requireText(ownerCommand, "pub struct PaymentAdminCollectionCommandRuntime", "Payment owner command runtime");
+requireText(ownerCommand, "context.require_policy(PortCallPolicy::write())", "write-port admission");
+requireText(ownerCommand, "PaymentService::new(db.clone())", "owner-local Payment service construction");
+requireText(ownerCommand, "PaymentProviderOperationJournal::new(db)", "owner-local provider journal construction");
+requireText(ownerCommand, "self.provider_registry.execute_authorize", "owner authorize provider execution");
+requireText(ownerCommand, "self.provider_registry.execute_capture", "owner capture provider execution");
+requireText(ownerCommand, "self.provider_registry.execute_cancel", "owner cancel provider execution");
+
+for (const key of [
+  'format!("payment_collection:{}:authorize", collection.id)',
+  'format!("payment_collection:{}:capture", collection.id)',
+  'format!("payment_collection:{}:cancel", collection.id)',
+]) {
+  requireText(ownerCommand, key, `canonical provider journal key ${key}`);
+}
+for (const operation of [
+  '"operation": "authorize_payment_collection"',
+  '"operation": "capture_payment_collection"',
+  '"operation": "cancel_payment_collection"',
+]) {
+  requireText(ownerCommand, operation, `legacy provider request metadata ${operation}`);
+}
+requireText(ownerCommand, 'format!("payment_collection:{}:authorize", request.collection_id)', "durable authorize identity recovery");
+requireText(ownerCommand, "PROVIDER_OPERATION_RECONCILIATION_REQUIRED", "reconciliation adoption");
+requireText(ownerCommand, ".mark_reconciliation_required(", "reconciliation checkpointing");
+requireText(ownerCommand, "payment provider outcome requires reconciliation", "bounded reconciliation error");
+forbidText(ownerCommand, "source.to_string()", "raw provider error persistence");
+forbidText(ownerCommand, "error.to_string()", "raw owner error persistence");
+
+for (const call of [
+  ".authorize_payment_collection(",
+  ".capture_payment_collection(",
+  ".cancel_payment_collection(",
+]) {
+  requireText(mounted, ".payment_admin_collection_command_port()", "mounted Payment command runtime access");
+  requireText(mounted, call, `mounted Payment owner command ${call}`);
+}
+requireText(mounted, "Permission::PAYMENTS_UPDATE", "payment update permission preservation");
+requireText(mounted, 'format!("admin-payment-collection:{collection_id}:{operation}")', "stable transport write identity");
+requireText(mounted, ".with_deadline(std::time::Duration::from_secs(2))", "bounded command deadline");
+requireText(mounted, "request_context.channel_slug.as_deref()", "channel propagation");
+forbidText(mounted, "PaymentOrchestrationService::new", "Commerce orchestration construction in mounted adapter");
+forbidText(mounted, "PaymentService::new", "concrete Payment service construction in mounted adapter");
+
+requireText(httpRuntime, "payment_admin_collection_command_runtime: rustok_payment::PaymentAdminCollectionCommandRuntime", "Commerce command runtime field");
+requireText(httpRuntime, ".shared_get::<rustok_payment::PaymentAdminCollectionCommandRuntime>()", "host-selected command runtime preference");
+requireText(httpRuntime, "rustok_payment::PaymentAdminCollectionCommandRuntime::in_process(", "built-in owner command fallback");
+requireText(httpRuntime, "payment_provider_registry.clone()", "host provider registry reuse");
+
+for (const refundMutation of ["create_refund", "complete_refund", "cancel_refund"]) {
+  requireText(legacy, `pub async fn ${refundMutation}`, `legacy refund mutation ${refundMutation}`);
+}
+requireText(
+  plan,
+  "- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.",
+  "canonical topology item remains open",
+);
+requireText(doc, "Refund creation/completion/cancellation are intentionally out of scope", "refund follow-up remains explicit");
+requireText(doc, "execution evidence pending and unvalidated", "unvalidated source status");
+requireText(doc, "not a newly claimed durable command receipt", "transport versus durable replay distinction");
+
+console.log("commerce admin Payment collection owner-command cutover source guard: OK");


### PR DESCRIPTION
## Summary
- publish Payment-owned `PaymentAdminCollectionCommandPort` / `PaymentAdminCollectionCommandRuntime`
- move mounted admin payment collection authorize/capture/cancel execution behind the owner command port
- preserve exact durable provider journal keys:
  - `payment_collection:{collection_id}:authorize`
  - `payment_collection:{collection_id}:capture`
  - `payment_collection:{collection_id}:cancel`
- preserve pre-cutover provider request metadata and authorize-provider identity recovery
- retain lifecycle replay, reconciliation-required checkpointing, `PAYMENTS_UPDATE`, request/response DTOs, and existing public provider/storage error families
- carry tenant/user/locale/channel plus bounded deadline and stable transition-scoped write admission identity through `PortContext`
- prefer a host-selected external `PaymentAdminCollectionCommandRuntime`; otherwise compose the in-process Payment owner adapter with the same host-selected `PaymentProviderRegistry`
- keep concrete `PaymentService`, provider journal access, and provider execution inside `rustok-payment`
- add focused actualization and a source guard without executing it

## Out of scope
Refund creation, refund completion, and refund cancellation remain on the existing compatibility `PaymentOrchestrationService` path. Their owner cutover is separate because it must preserve refund reservation/replay, caller `Idempotency-Key`, provider refund identity, and reserved-refund reconciliation semantics.

The canonical broad Commerce topology P0 remains open for refund mutations, remaining Payment/GraphQL construction, Fulfillment, and other concrete-owner paths.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart evidence, and external-provider execution were intentionally not run per maintainer instruction.