### PR TITLE
docs(index): refresh post-targeted implementation cursor

### DIFF
--- a/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
+++ b/crates/rustok-index/docs/implementation-plan-current-2026-08-08.md
@@ -1,9 +1,16 @@
 # Current `rustok-index` implementation plan — 2026-08-08
 
-Status overlay rechecked at `main@d0557dbeb34c86184b4eeae83f93145ebd53c558` and continued on
-`agent/index-replay-targeted-graphql-transport-20260809`.
+Status overlay rechecked at `main@97c01e2df66156f449b796f1349252da67a94bc3` and continued on
+`agent/index-plan-post-targeted-recheck-20260809`.
 
 `implementation-plan.md` remains historical architecture context. This file is the current execution cursor.
+
+Post-Targeted recheck: #3360 merged `runIndexReplayTargeted` at
+`e7b6a135692047398b95966491dbcbb06347da31`. Main then advanced to
+`97c01e2df66156f449b796f1349252da67a94bc3` through Forum notification reconciliation, Blog Translation
+PostgreSQL evidence, and Commerce Payment owner-port work only. The compare from the Targeted merge to current
+`main` contains no `rustok-index` path and no Index replay transport path, so it opens no new Index source-code
+boundary and does not relax any execution/admission gate below.
 
 ## Current primary owner gate
 


### PR DESCRIPTION
## Summary

- actualize the current `rustok-index` execution cursor after merged Targeted GraphQL PR #3360;
- move the plan recheck marker to `main@97c01e2df66156f449b796f1349252da67a94bc3` and the current recheck branch;
- record the post-Targeted compare from merge SHA `e7b6a135692047398b95966491dbcbb06347da31` through current `main`;
- explicitly note that the intervening Forum/Blog/Commerce mainline work changes no `rustok-index` or Index replay transport paths and therefore opens no new source-code boundary;
- retain the existing gates unchanged: M6 requires maintainer execution/admission, M5 typed Product events require canonical event-contract digest admission, M7 Storefront cutover requires evidence admission, and partition replay remains blocked on a real partition-filtering source contract.

## Static review

The branch is one commit and changes exactly one documentation file: `crates/rustok-index/docs/implementation-plan-current-2026-08-08.md` (+10/-3). No production, test, verifier, schema, migration, GraphQL, replay runtime, or source contract file changes.

## Validation

Static GitHub source/compare inspection only. No Rust tests, Node verifiers, Cargo checks, formatting, migrations, SQLite/PostgreSQL scenarios, workflows, CI, or `git diff --check` were executed.