### PR TITLE
feat(commerce): route admin refunds through owner port

### DIFF
--- a/crates/rustok-commerce/docs/admin-refund-owner-command-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/admin-refund-owner-command-cutover-2026-08-09.md
@@ -1,0 +1,100 @@
+# Commerce admin refund owner-command cutover — 2026-08-09
+
+Status: source-complete for the mounted admin refund create/complete/cancel routes; execution evidence pending and unvalidated.
+
+## Scope
+
+This slice advances the canonical ecommerce topology P0 without closing it. The mounted admin refund mutations now call a Payment-owned command capability instead of constructing Commerce `PaymentOrchestrationService`:
+
+- `POST /admin/payment-collections/{id}/refunds`;
+- `POST /admin/refunds/{id}/complete`;
+- `POST /admin/refunds/{id}/cancel`.
+
+Together with the preceding admin Payment read and collection-command cutovers, the mounted admin Payment REST surface no longer needs concrete Payment service/orchestration construction for these routes. Other Commerce Payment workflows and the broader Product/Order/Fulfillment/GraphQL topology remain separate work.
+
+## Payment owner capability
+
+`rustok-payment` publishes `PaymentAdminRefundCommandPort` and `PaymentAdminRefundCommandRuntime`. The built-in owner adapter owns:
+
+- refund creation reservation and replay through `PaymentRefundCreationService`;
+- caller creation-key validation at the durable Payment reservation boundary;
+- collection lifecycle admission before a new/replayed provider refund attempt;
+- provider selection from the host-selected `PaymentProviderRegistry`;
+- `PaymentProviderOperationJournal` access;
+- provider refund execution;
+- durable provider-result adoption;
+- provider-payment identity recovery from the authorize journal;
+- provider success/error/reconciliation checkpointing;
+- refund completion and cancellation through Payment-owned lifecycle persistence.
+
+`PaymentService`, `PaymentRefundCreationService`, provider journal construction, and provider execution remain inside `rustok-payment` for this mounted path.
+
+## Two idempotency identities remain distinct
+
+Refund creation intentionally retains two different durable identities.
+
+The caller-supplied `Idempotency-Key` remains the refund creation identity passed to `PaymentRefundCreationService::create_or_replay`. It protects reservation identity and request-hash replay. The HTTP adapter also carries that same stable caller key in `PortContext` so the generic write-port admission contract does not replace or weaken the owner creation identity.
+
+After a refund has an owner-generated `refund_id`, provider execution continues to use the existing provider journal key:
+
+`payment_refund:{refund_id}`
+
+These identities are not interchangeable: the first identifies the caller-visible refund reservation, while the second identifies the external provider refund attempt for that reserved refund.
+
+## Provider request compatibility
+
+The owner command preserves the pre-cutover provider request structure:
+
+- operation is `refund`;
+- `refund_id` remains recorded both in the provider journal relation and provider metadata;
+- `commerce_orchestration.operation` remains `create_refund`;
+- the reserved `refund_id` and requested reason remain in the `commerce_orchestration` metadata;
+- non-manual providers still recover `provider_payment_id` from the durable authorize operation when it is not already present;
+- the authorize lookup key remains `payment_collection:{collection_id}:authorize`.
+
+A retry after upgrade therefore targets the same refund reservation and provider journal rows rather than introducing a new provider identity.
+
+## Reserved-refund reconciliation semantics
+
+A provider failure can happen after the refund reservation has already been durably created. The owner port therefore retains distinct bounded outcomes for the two public cases that previously had refund-specific envelopes:
+
+- unknown/invalid provider outcome after reservation -> `commerce_admin_refund_reconciliation_required` / HTTP 409;
+- provider unavailable after reservation -> `commerce_admin_refund_provider_unavailable` / HTTP 503.
+
+Other provider/payment failures retain the existing admin Payment public families. Provider or database error text is not exposed through the new public port errors; owner diagnostics retain structural identity/failure facts instead.
+
+## Complete and cancel
+
+Refund completion and cancellation remain Payment-owned lifecycle writes. They do not introduce a new provider operation in this cutover; the owner command delegates to the existing Payment lifecycle methods exactly as the previous Commerce orchestration wrapper did.
+
+The transport supplies transition-scoped write-admission identities for complete/cancel. No new durable command-receipt or lost-response replay guarantee is claimed for those transition keys.
+
+## Transport compatibility
+
+The mounted handlers preserve:
+
+- `PAYMENTS_UPDATE` admission;
+- the required `Idempotency-Key` header and 191-byte maximum for create-refund;
+- the existing `CreateRefundInput`, `CompleteRefundInput`, and `CancelRefundInput` request bodies;
+- HTTP 201 for create/replay and HTTP 200 for complete/cancel;
+- `RefundResponse` payloads;
+- validation/not-found/state-conflict/provider-unavailable/provider-invalid-response/reconciliation-required/provider-not-configured/storage-unavailable families;
+- tenant, authenticated user actor, locale, optional channel, and bounded deadline in `PortContext`.
+
+## Runtime composition
+
+`CommerceHttpRuntime` first accepts a host-selected `PaymentAdminRefundCommandRuntime`. If no external adapter was supplied, the built-in Payment owner adapter is composed with the host database and the same host-selected `PaymentProviderRegistry` already used by the admin collection command path.
+
+External adapters therefore retain precedence while the built-in path remains provider-consistent with the host runtime.
+
+## Remaining topology work
+
+The canonical broad item “Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports” remains open.
+
+Admin Payment REST is substantially cut over, but other mounted Commerce workflows still construct or own concrete Payment/Fulfillment orchestration, including post-order/change/return flows and remaining GraphQL/provider-operation surfaces. Fulfillment admin lifecycle construction is also a natural next focused owner-boundary slice.
+
+## Validation status
+
+`scripts/verify/verify-commerce-admin-refund-owner-command-cutover.mjs` is added as a source guard but is intentionally not executed here.
+
+No tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart evidence, lost-response evidence, or external-provider execution evidence are claimed in this slice.

--- a/crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs
+++ b/crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use rustok_api::{
     AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
@@ -9,9 +9,9 @@ use rustok_api::{
 };
 use rustok_payment::{
     AuthorizeAdminPaymentCollectionRequest, CancelAdminPaymentCollectionRequest,
-    CaptureAdminPaymentCollectionRequest, ListPaymentCollectionProjectionsRequest,
-    ListRefundProjectionsRequest, ReadPaymentCollectionProjectionRequest,
-    ReadRefundProjectionRequest,
+    CancelAdminRefundRequest, CaptureAdminPaymentCollectionRequest, CompleteAdminRefundRequest,
+    CreateAdminRefundRequest, ListPaymentCollectionProjectionsRequest, ListRefundProjectionsRequest,
+    ReadPaymentCollectionProjectionRequest, ReadRefundProjectionRequest,
 };
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
@@ -23,14 +23,17 @@ use super::{
     ListPaymentCollectionsParams, ListRefundsParams,
 };
 use crate::dto::{
-    AuthorizePaymentInput, CancelPaymentInput, CapturePaymentInput, PaymentCollectionResponse,
-    RefundResponse,
+    AuthorizePaymentInput, CancelPaymentInput, CancelRefundInput, CapturePaymentInput,
+    CompleteRefundInput, CreateRefundInput, PaymentCollectionResponse, RefundResponse,
 };
 
+const MAX_REFUND_CREATION_KEY_LENGTH: usize = 191;
 const ADMIN_PAYMENT_READ_OWNER: &str = "rustok_payment.admin_read";
 const ADMIN_PAYMENT_READ_BOUNDARY: &str = "commerce_admin_payment_read_http";
 const ADMIN_PAYMENT_COMMAND_OWNER: &str = "rustok_payment.admin_collection_command";
 const ADMIN_PAYMENT_COMMAND_BOUNDARY: &str = "commerce_admin_payment_collection_command_http";
+const ADMIN_REFUND_COMMAND_OWNER: &str = "rustok_payment.admin_refund_command";
+const ADMIN_REFUND_COMMAND_BOUNDARY: &str = "commerce_admin_refund_command_http";
 
 type AdminPaymentReadHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
 type AdminPaymentCommandHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
@@ -72,6 +75,48 @@ fn admin_payment_collection_command_context(
     .with_idempotency_key(format!(
         "admin-payment-collection:{collection_id}:{operation}"
     ))
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn admin_refund_create_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    collection_id: Uuid,
+    creation_key: &str,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-refund-command:create:{collection_id}"),
+    )
+    .with_idempotency_key(creation_key.to_string())
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn admin_refund_transition_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    refund_id: Uuid,
+    operation: &'static str,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-refund-command:{operation}:{refund_id}"),
+    )
+    .with_idempotency_key(format!("admin-refund:{refund_id}:{operation}"))
     .with_deadline(std::time::Duration::from_secs(2));
     match request_context.channel_slug.as_deref() {
         Some(channel) => context.with_channel(channel),
@@ -122,6 +167,18 @@ fn payment_read_error_policy(error: &PortError) -> AdminPaymentReadHttpPolicy {
 
 fn payment_command_error_policy(error: &PortError) -> AdminPaymentCommandHttpPolicy {
     match error.code.as_str() {
+        "payment.refund_reserved_reconciliation_required" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_refund_reconciliation_required",
+            "Refund remains reserved while the provider outcome is reconciled",
+            "refund_reconciliation_required",
+        ),
+        "payment.refund_reserved_provider_unavailable" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_refund_provider_unavailable",
+            "Refund remains reserved and the provider operation may be retried safely",
+            "refund_provider_unavailable",
+        ),
         "payment.provider_unavailable" => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_admin_payment_provider_unavailable",
@@ -250,6 +307,37 @@ fn map_payment_command_error(
         status = %status,
         boundary = ADMIN_PAYMENT_COMMAND_BOUNDARY,
         "commerce admin payment owner command failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_refund_command_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    collection_id: Option<Uuid>,
+    refund_id: Option<Uuid>,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = payment_command_error_policy(&error);
+    tracing::error!(
+        owner = ADMIN_REFUND_COMMAND_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        collection_id_present = collection_id.is_some(),
+        collection_id_non_nil = collection_id.map(|value| !value.is_nil()).unwrap_or(false),
+        refund_id_present = refund_id.is_some(),
+        refund_id_non_nil = refund_id.map(|value| !value.is_nil()).unwrap_or(false),
+        operation,
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_REFUND_COMMAND_BOUNDARY,
+        "commerce admin refund owner command failed"
     );
     HttpError::new(status, code, message)
 }
@@ -515,6 +603,69 @@ pub async fn cancel_payment_collection(
 }
 
 #[utoipa::path(
+    post,
+    path = "/admin/payment-collections/{id}/refunds",
+    tag = "admin",
+    params(
+        ("id" = Uuid, Path, description = "Payment collection ID"),
+        ("Idempotency-Key" = String, Header, description = "Stable refund creation identity, maximum 191 bytes")
+    ),
+    request_body = CreateRefundInput,
+    responses(
+        (status = 201, description = "Refund created or replayed", body = RefundResponse),
+        (status = 400, description = "Missing, invalid, or conflicting idempotency key"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Payment collection not found")
+    )
+)]
+pub async fn create_refund(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    Json(input): Json<CreateRefundInput>,
+) -> HttpResult<(StatusCode, Json<RefundResponse>)> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_UPDATE],
+        "Permission denied: payments:update required",
+    )?;
+    let creation_key = refund_creation_key(&headers)?;
+    let context = admin_refund_create_context(
+        &tenant,
+        &auth,
+        &request_context,
+        id,
+        creation_key.as_str(),
+    );
+    let refund = runtime
+        .payment_admin_refund_command_port()
+        .create_refund(
+            context.clone(),
+            CreateAdminRefundRequest {
+                collection_id: id,
+                creation_key,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_refund_command_error(
+                tenant.id,
+                auth.user_id,
+                Some(id),
+                None,
+                "create_refund",
+                &context,
+                error,
+            )
+        })?;
+    Ok((StatusCode::CREATED, Json(refund)))
+}
+
+#[utoipa::path(
     get,
     path = "/admin/refunds",
     tag = "admin",
@@ -606,4 +757,129 @@ pub async fn show_refund(
             )
         })?;
     Ok(Json(refund))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/refunds/{id}/complete",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Refund ID")),
+    request_body = CompleteRefundInput,
+    responses((status = 200, description = "Refund completed", body = RefundResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Refund not found"))
+)]
+pub async fn complete_refund(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CompleteRefundInput>,
+) -> HttpResult<Json<RefundResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_UPDATE],
+        "Permission denied: payments:update required",
+    )?;
+    let context = admin_refund_transition_context(
+        &tenant,
+        &auth,
+        &request_context,
+        id,
+        "complete",
+    );
+    let refund = runtime
+        .payment_admin_refund_command_port()
+        .complete_refund(
+            context.clone(),
+            CompleteAdminRefundRequest {
+                refund_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_refund_command_error(
+                tenant.id,
+                auth.user_id,
+                None,
+                Some(id),
+                "complete_refund",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(refund))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/refunds/{id}/cancel",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Refund ID")),
+    request_body = CancelRefundInput,
+    responses((status = 200, description = "Refund cancelled", body = RefundResponse), (status = 401, description = "Unauthorized"), (status = 404, description = "Refund not found"))
+)]
+pub async fn cancel_refund(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CancelRefundInput>,
+) -> HttpResult<Json<RefundResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::PAYMENTS_UPDATE],
+        "Permission denied: payments:update required",
+    )?;
+    let context = admin_refund_transition_context(
+        &tenant,
+        &auth,
+        &request_context,
+        id,
+        "cancel",
+    );
+    let refund = runtime
+        .payment_admin_refund_command_port()
+        .cancel_refund(
+            context.clone(),
+            CancelAdminRefundRequest {
+                refund_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_refund_command_error(
+                tenant.id,
+                auth.user_id,
+                None,
+                Some(id),
+                "cancel_refund",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(refund))
+}
+
+fn refund_creation_key(headers: &HeaderMap) -> HttpResult<String> {
+    let value = headers
+        .get("idempotency-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            HttpError::bad_request(
+                "refund_idempotency_key_required",
+                "Idempotency-Key header is required",
+            )
+        })?;
+    if value.len() > MAX_REFUND_CREATION_KEY_LENGTH {
+        return Err(HttpError::bad_request(
+            "refund_idempotency_key_invalid",
+            format!("Idempotency-Key must contain at most {MAX_REFUND_CREATION_KEY_LENGTH} bytes"),
+        ));
+    }
+    Ok(value.to_string())
 }

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -31,6 +31,7 @@ pub struct CommerceHttpRuntime {
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
     payment_admin_read_runtime: rustok_payment::PaymentAdminReadRuntime,
     payment_admin_collection_command_runtime: rustok_payment::PaymentAdminCollectionCommandRuntime,
+    payment_admin_refund_command_runtime: rustok_payment::PaymentAdminRefundCommandRuntime,
     product_catalog_read_runtime: rustok_product::ProductCatalogReadRuntime,
     product_catalog_command_runtime: rustok_product::ProductCatalogCommandRuntime,
     #[cfg(feature = "marketplace-financial")]
@@ -97,6 +98,12 @@ impl CommerceHttpRuntime {
         &self,
     ) -> std::sync::Arc<dyn rustok_payment::PaymentAdminCollectionCommandPort> {
         self.payment_admin_collection_command_runtime.command_port()
+    }
+
+    fn payment_admin_refund_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_payment::PaymentAdminRefundCommandPort> {
+        self.payment_admin_refund_command_runtime.command_port()
     }
 
     fn product_catalog_read_port(
@@ -182,6 +189,14 @@ impl CommerceHttpRuntime {
                     payment_provider_registry.clone(),
                 )
             });
+        let payment_admin_refund_command_runtime = runtime
+            .shared_get::<rustok_payment::PaymentAdminRefundCommandRuntime>()
+            .unwrap_or_else(|| {
+                rustok_payment::PaymentAdminRefundCommandRuntime::in_process(
+                    runtime.db_clone(),
+                    payment_provider_registry.clone(),
+                )
+            });
         let product_catalog_read_runtime = runtime
             .shared_get::<rustok_product::ProductCatalogReadRuntime>()
             .ok_or_else(|| {
@@ -218,6 +233,7 @@ impl CommerceHttpRuntime {
             payment_order_read_runtime,
             payment_admin_read_runtime,
             payment_admin_collection_command_runtime,
+            payment_admin_refund_command_runtime,
             product_catalog_read_runtime,
             product_catalog_command_runtime,
             #[cfg(feature = "marketplace-financial")]

--- a/crates/rustok-payment/src/admin_refund_command.rs
+++ b/crates/rustok-payment/src/admin_refund_command.rs
@@ -1,0 +1,748 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::dto::{
+    CancelRefundInput, CompleteRefundInput, CreateRefundInput, PaymentCollectionResponse,
+    PaymentCollectionStatusKind, RefundResponse,
+};
+use crate::providers::{
+    MANUAL_PAYMENT_PROVIDER_ID, PaymentProviderOperationRequest, PaymentProviderOperationResult,
+    PaymentProviderRegistry,
+};
+use crate::{
+    BeginProviderOperation, PROVIDER_OPERATION_COMMITTED, PROVIDER_OPERATION_EXECUTING,
+    PROVIDER_OPERATION_RECONCILIATION_REQUIRED, PROVIDER_OPERATION_SUCCEEDED, PaymentError,
+    PaymentProviderOperationJournal, PaymentRefundCreationService, PaymentService,
+};
+
+const ADMIN_REFUND_COMMAND_BOUNDARY: &str = "payment_admin_refund_command_port";
+const UNKNOWN_PROVIDER_ID: &str = "payment-provider";
+
+#[async_trait]
+pub trait PaymentAdminRefundCommandPort: Send + Sync {
+    async fn create_refund(
+        &self,
+        context: PortContext,
+        request: CreateAdminRefundRequest,
+    ) -> Result<RefundResponse, PortError>;
+
+    async fn complete_refund(
+        &self,
+        context: PortContext,
+        request: CompleteAdminRefundRequest,
+    ) -> Result<RefundResponse, PortError>;
+
+    async fn cancel_refund(
+        &self,
+        context: PortContext,
+        request: CancelAdminRefundRequest,
+    ) -> Result<RefundResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateAdminRefundRequest {
+    pub collection_id: Uuid,
+    pub creation_key: String,
+    pub input: CreateRefundInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompleteAdminRefundRequest {
+    pub refund_id: Uuid,
+    pub input: CompleteRefundInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelAdminRefundRequest {
+    pub refund_id: Uuid,
+    pub input: CancelRefundInput,
+}
+
+pub struct InProcessPaymentAdminRefundCommandPort {
+    payment_service: PaymentService,
+    refund_creation_service: PaymentRefundCreationService,
+    operation_journal: PaymentProviderOperationJournal,
+    provider_registry: PaymentProviderRegistry,
+}
+
+impl InProcessPaymentAdminRefundCommandPort {
+    pub fn new(db: DatabaseConnection, provider_registry: PaymentProviderRegistry) -> Self {
+        Self {
+            payment_service: PaymentService::new(db.clone()),
+            refund_creation_service: PaymentRefundCreationService::new(db.clone()),
+            operation_journal: PaymentProviderOperationJournal::new(db),
+            provider_registry,
+        }
+    }
+}
+
+pub fn in_process_payment_admin_refund_command_port(
+    db: DatabaseConnection,
+    provider_registry: PaymentProviderRegistry,
+) -> Arc<dyn PaymentAdminRefundCommandPort> {
+    Arc::new(InProcessPaymentAdminRefundCommandPort::new(
+        db,
+        provider_registry,
+    ))
+}
+
+#[derive(Clone)]
+pub struct PaymentAdminRefundCommandRuntime {
+    command_port: Arc<dyn PaymentAdminRefundCommandPort>,
+}
+
+impl PaymentAdminRefundCommandRuntime {
+    pub fn new(command_port: Arc<dyn PaymentAdminRefundCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        provider_registry: PaymentProviderRegistry,
+    ) -> Self {
+        Self::new(in_process_payment_admin_refund_command_port(
+            db,
+            provider_registry,
+        ))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn PaymentAdminRefundCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl PaymentAdminRefundCommandPort for InProcessPaymentAdminRefundCommandPort {
+    async fn create_refund(
+        &self,
+        context: PortContext,
+        request: CreateAdminRefundRequest,
+    ) -> Result<RefundResponse, PortError> {
+        const OPERATION: &str = "create_admin_refund";
+        require_refund_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+
+        let collection = self
+            .payment_service
+            .get_collection(tenant_id, request.collection_id)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))?;
+        if collection.status_kind() != PaymentCollectionStatusKind::Captured {
+            return Err(map_payment_error(
+                &context,
+                OPERATION,
+                PaymentError::InvalidTransition {
+                    from: collection.status,
+                    to: "pending".to_string(),
+                },
+            ));
+        }
+        let provider_id = provider_id_for_collection(&collection);
+        let refund = self
+            .refund_creation_service
+            .create_or_replay(
+                tenant_id,
+                request.collection_id,
+                request.creation_key,
+                request.input.clone(),
+            )
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))?;
+
+        let provider_request = PaymentProviderOperationRequest {
+            tenant_id,
+            collection_id: request.collection_id,
+            amount: refund.amount,
+            currency_code: refund.currency_code.clone(),
+            idempotency_key: Some(format!("payment_refund:{}", refund.id)),
+            metadata: merge_provider_context(
+                request.input.metadata,
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "create_refund",
+                        "refund_id": refund.id,
+                        "reason": request.input.reason,
+                    }
+                }),
+            ),
+        };
+        let journaled = self
+            .execute_refund_provider_operation(
+                &context,
+                OPERATION,
+                refund.id,
+                provider_id.as_str(),
+                provider_request,
+            )
+            .await?;
+        self.mark_refund_journal_committed(
+            &context,
+            OPERATION,
+            refund.id,
+            journaled.operation_id,
+        )
+        .await?;
+        Ok(refund)
+    }
+
+    async fn complete_refund(
+        &self,
+        context: PortContext,
+        request: CompleteAdminRefundRequest,
+    ) -> Result<RefundResponse, PortError> {
+        const OPERATION: &str = "complete_admin_refund";
+        require_refund_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.payment_service
+            .complete_refund(tenant_id, request.refund_id, request.input)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))
+    }
+
+    async fn cancel_refund(
+        &self,
+        context: PortContext,
+        request: CancelAdminRefundRequest,
+    ) -> Result<RefundResponse, PortError> {
+        const OPERATION: &str = "cancel_admin_refund";
+        require_refund_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.payment_service
+            .cancel_refund(tenant_id, request.refund_id, request.input)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, error))
+    }
+}
+
+struct JournaledRefundProviderResult {
+    operation_id: Uuid,
+    #[allow(dead_code)]
+    result: PaymentProviderOperationResult,
+}
+
+impl InProcessPaymentAdminRefundCommandPort {
+    async fn execute_refund_provider_operation(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        refund_id: Uuid,
+        provider_id: &str,
+        request: PaymentProviderOperationRequest,
+    ) -> Result<JournaledRefundProviderResult, PortError> {
+        let request = self
+            .enrich_refund_provider_request(
+                context,
+                owner_operation,
+                refund_id,
+                provider_id,
+                request,
+            )
+            .await?;
+        let idempotency_key = request
+            .idempotency_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                PortError::validation(
+                    "payment.provider_idempotency_key_missing",
+                    "payment provider operation requires idempotency identity",
+                )
+            })?
+            .to_string();
+        let request_payload = serde_json::to_value(&request).map_err(|_| {
+            PortError::validation(
+                "payment.provider_request_invalid",
+                "payment provider request could not be normalized",
+            )
+        })?;
+        let journal_operation = self
+            .operation_journal
+            .begin(BeginProviderOperation {
+                tenant_id: request.tenant_id,
+                payment_collection_id: request.collection_id,
+                refund_id: Some(refund_id),
+                operation: "refund".to_string(),
+                provider_id: provider_id.to_string(),
+                idempotency_key,
+                request_payload,
+            })
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?;
+
+        if let Some(result) = persisted_provider_result(&journal_operation)
+            .map_err(|error| map_payment_error(context, owner_operation, error))?
+        {
+            return Ok(JournaledRefundProviderResult {
+                operation_id: journal_operation.id,
+                result,
+            });
+        }
+
+        let claimed = self
+            .operation_journal
+            .claim_execution(journal_operation.id)
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?;
+        if claimed.is_none() {
+            let current = self
+                .operation_journal
+                .get(journal_operation.id)
+                .await
+                .map_err(|error| map_payment_error(context, owner_operation, error))?;
+            if let Some(result) = persisted_provider_result(&current)
+                .map_err(|error| map_payment_error(context, owner_operation, error))?
+            {
+                return Ok(JournaledRefundProviderResult {
+                    operation_id: current.id,
+                    result,
+                });
+            }
+            return Err(PortError::validation(
+                "payment.provider_operation_in_progress",
+                "payment provider operation is already in progress",
+            ));
+        }
+
+        let provider_result = match self.provider_registry.execute_refund(provider_id, request).await {
+            Ok(result) => result,
+            Err(error) => {
+                let checkpoint = if error.requires_provider_reconciliation() {
+                    self.operation_journal
+                        .mark_reconciliation_required(
+                            journal_operation.id,
+                            "payment.refund_provider_outcome_requires_reconciliation",
+                        )
+                        .await
+                } else {
+                    self.operation_journal
+                        .mark_provider_error(
+                            journal_operation.id,
+                            "payment.refund_provider_operation_failed",
+                        )
+                        .await
+                };
+                if checkpoint.is_err() {
+                    return Err(map_reserved_refund_error(
+                        context,
+                        owner_operation,
+                        PaymentError::provider_outcome_unknown(provider_id, "refund"),
+                    ));
+                }
+                return Err(map_reserved_refund_error(context, owner_operation, error));
+            }
+        };
+
+        let result_payload = match serde_json::to_value(&provider_result) {
+            Ok(payload) => payload,
+            Err(_) => {
+                let _ = self
+                    .operation_journal
+                    .mark_reconciliation_required(
+                        journal_operation.id,
+                        "payment.refund_provider_result_serialization_failed",
+                    )
+                    .await;
+                return Err(map_reserved_refund_error(
+                    context,
+                    owner_operation,
+                    PaymentError::provider_outcome_unknown(provider_id, "refund"),
+                ));
+            }
+        };
+        if self
+            .operation_journal
+            .mark_provider_succeeded(
+                journal_operation.id,
+                provider_result.external_reference.clone(),
+                result_payload,
+            )
+            .await
+            .is_err()
+        {
+            let _ = self
+                .operation_journal
+                .mark_reconciliation_required(
+                    journal_operation.id,
+                    "payment.refund_provider_success_checkpoint_failed",
+                )
+                .await;
+            return Err(map_reserved_refund_error(
+                context,
+                owner_operation,
+                PaymentError::provider_outcome_unknown(provider_id, "refund"),
+            ));
+        }
+
+        Ok(JournaledRefundProviderResult {
+            operation_id: journal_operation.id,
+            result: provider_result,
+        })
+    }
+
+    async fn enrich_refund_provider_request(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        refund_id: Uuid,
+        provider_id: &str,
+        mut request: PaymentProviderOperationRequest,
+    ) -> Result<PaymentProviderOperationRequest, PortError> {
+        insert_metadata_string(&mut request.metadata, "refund_id", refund_id.to_string())
+            .map_err(|error| map_payment_error(context, owner_operation, error))?;
+        if provider_id == MANUAL_PAYMENT_PROVIDER_ID {
+            return Ok(request);
+        }
+        if metadata_string(&request.metadata, "provider_payment_id").is_some() {
+            return Ok(request);
+        }
+
+        let authorize_key = format!("payment_collection:{}:authorize", request.collection_id);
+        let authorize = self
+            .operation_journal
+            .find_by_key(request.tenant_id, provider_id, authorize_key.as_str())
+            .await
+            .map_err(|error| map_payment_error(context, owner_operation, error))?
+            .ok_or_else(|| {
+                map_payment_error(
+                    context,
+                    owner_operation,
+                    PaymentError::Validation(
+                        "provider refund requires a completed authorize operation".to_string(),
+                    ),
+                )
+            })?;
+        if !matches!(
+            authorize.status.as_str(),
+            PROVIDER_OPERATION_COMMITTED
+                | PROVIDER_OPERATION_SUCCEEDED
+                | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+        ) {
+            return Err(map_payment_error(
+                context,
+                owner_operation,
+                PaymentError::Validation(
+                    "provider refund requires a completed authorize operation".to_string(),
+                ),
+            ));
+        }
+        let provider_payment_id = authorize
+            .provider_reference
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                authorize
+                    .provider_result
+                    .as_ref()
+                    .and_then(|result| result.get("external_reference"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+            })
+            .ok_or_else(|| {
+                map_payment_error(
+                    context,
+                    owner_operation,
+                    PaymentError::provider_outcome_unknown(provider_id, "authorize"),
+                )
+            })?;
+        insert_metadata_string(
+            &mut request.metadata,
+            "provider_payment_id",
+            provider_payment_id,
+        )
+        .map_err(|error| map_payment_error(context, owner_operation, error))?;
+        Ok(request)
+    }
+
+    async fn mark_refund_journal_committed(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        refund_id: Uuid,
+        operation_id: Uuid,
+    ) -> Result<(), PortError> {
+        if self.operation_journal.mark_committed(operation_id).await.is_err() {
+            let _ = self
+                .operation_journal
+                .mark_reconciliation_required(
+                    operation_id,
+                    "payment.refund_local_commit_checkpoint_failed",
+                )
+                .await;
+            tracing::error!(
+                owner = "rustok_payment",
+                operation = owner_operation,
+                refund_id_non_nil = !refund_id.is_nil(),
+                operation_id_non_nil = !operation_id.is_nil(),
+                correlation_id = %context.correlation_id,
+                code = "payment.refund_commit_checkpoint_failed",
+                boundary = ADMIN_REFUND_COMMAND_BOUNDARY,
+                "refund provider success could not be committed locally"
+            );
+            return Err(map_reserved_refund_error(
+                context,
+                owner_operation,
+                PaymentError::provider_outcome_unknown(UNKNOWN_PROVIDER_ID, "refund"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn require_refund_write_admission(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::write()).inspect_err(|error| {
+        log_port_error(context, operation, "policy", error);
+    })
+}
+
+fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let error = PortError::validation(
+            "payment.tenant_id_invalid",
+            "payment refund command tenant context is invalid",
+        );
+        log_port_error(context, operation, "tenant_id", &error);
+        error
+    })
+}
+
+fn map_reserved_refund_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PaymentError,
+) -> PortError {
+    match error {
+        PaymentError::ProviderOutcomeUnknown { .. }
+        | PaymentError::ProviderInvalidResponse { .. } => {
+            let mapped = PortError::conflict(
+                "payment.refund_reserved_reconciliation_required",
+                "refund remains reserved while provider outcome is reconciled",
+            );
+            log_mapped_error(context, operation, "reserved_refund_provider_outcome", &mapped);
+            mapped
+        }
+        PaymentError::ProviderUnavailable { .. } => {
+            let mapped = PortError::unavailable(
+                "payment.refund_reserved_provider_unavailable",
+                "refund remains reserved and provider operation may be retried safely",
+            );
+            log_mapped_error(context, operation, "reserved_refund_provider_unavailable", &mapped);
+            mapped
+        }
+        other => map_payment_error(context, operation, other),
+    }
+}
+
+fn map_payment_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: PaymentError,
+) -> PortError {
+    let error_variant = payment_error_variant(&error);
+    let mapped = match error {
+        PaymentError::Validation(_) => {
+            PortError::validation("payment.validation", "payment request is invalid")
+        }
+        PaymentError::PaymentCollectionNotFound(_) => PortError::not_found(
+            "payment.collection_not_found",
+            "payment collection was not found",
+        ),
+        PaymentError::PaymentNotFound(_) => {
+            PortError::not_found("payment.payment_not_found", "payment was not found")
+        }
+        PaymentError::RefundNotFound(_) => {
+            PortError::not_found("payment.refund_not_found", "refund was not found")
+        }
+        PaymentError::InvalidTransition { .. } => PortError::conflict(
+            "payment.invalid_transition",
+            "payment lifecycle conflicts with the requested operation",
+        ),
+        PaymentError::ProviderUnavailable { .. } => PortError::unavailable(
+            "payment.provider_unavailable",
+            "payment provider is temporarily unavailable",
+        ),
+        PaymentError::ProviderRejected { .. } => PortError::conflict(
+            "payment.provider_rejected",
+            "payment provider rejected the requested operation",
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => PortError::new(
+            PortErrorKind::InvariantViolation,
+            "payment.provider_invalid_response",
+            "payment provider response could not be applied safely",
+            false,
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => PortError::conflict(
+            "payment.provider_outcome_unknown",
+            "payment provider outcome requires reconciliation",
+        ),
+        PaymentError::ProviderConfiguration { .. } => PortError::new(
+            PortErrorKind::InvariantViolation,
+            "payment.provider_not_configured",
+            "payment provider is not configured for the requested operation",
+            false,
+        ),
+        PaymentError::Database(_) => PortError::unavailable(
+            "payment.database_unavailable",
+            "payment storage is temporarily unavailable",
+        ),
+    };
+    log_mapped_error(context, operation, error_variant, &mapped);
+    mapped
+}
+
+fn payment_error_variant(error: &PaymentError) -> &'static str {
+    match error {
+        PaymentError::Validation(_) => "validation",
+        PaymentError::PaymentCollectionNotFound(_) => "payment_collection_not_found",
+        PaymentError::PaymentNotFound(_) => "payment_not_found",
+        PaymentError::RefundNotFound(_) => "refund_not_found",
+        PaymentError::InvalidTransition { .. } => "invalid_transition",
+        PaymentError::ProviderUnavailable { .. } => "provider_unavailable",
+        PaymentError::ProviderRejected { .. } => "provider_rejected",
+        PaymentError::ProviderInvalidResponse { .. } => "provider_invalid_response",
+        PaymentError::ProviderOutcomeUnknown { .. } => "provider_outcome_unknown",
+        PaymentError::ProviderConfiguration { .. } => "provider_configuration",
+        PaymentError::Database(_) => "database",
+    }
+}
+
+fn log_port_error(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = "rustok_payment",
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = ADMIN_REFUND_COMMAND_BOUNDARY,
+        "payment admin refund command admission failed"
+    );
+}
+
+fn log_mapped_error(
+    context: &PortContext,
+    operation: &'static str,
+    error_variant: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = "rustok_payment",
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        error_variant,
+        public_code = %error.code,
+        retryable = error.retryable,
+        boundary = ADMIN_REFUND_COMMAND_BOUNDARY,
+        "payment admin refund command returned a bounded owner error"
+    );
+}
+
+fn persisted_provider_result(
+    journal_operation: &crate::entities::provider_operation::Model,
+) -> Result<Option<PaymentProviderOperationResult>, PaymentError> {
+    if journal_operation.status == PROVIDER_OPERATION_EXECUTING {
+        return Ok(None);
+    }
+    if !matches!(
+        journal_operation.status.as_str(),
+        PROVIDER_OPERATION_COMMITTED
+            | PROVIDER_OPERATION_SUCCEEDED
+            | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+    ) {
+        return Ok(None);
+    }
+    let Some(value) = journal_operation.provider_result.clone() else {
+        return Err(PaymentError::provider_outcome_unknown(
+            journal_operation.provider_id.as_str(),
+            journal_operation.operation.as_str(),
+        ));
+    };
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|_| {
+            PaymentError::provider_outcome_unknown(
+                journal_operation.provider_id.as_str(),
+                journal_operation.operation.as_str(),
+            )
+        })
+}
+
+fn insert_metadata_string(metadata: &mut Value, key: &str, value: String) -> Result<(), PaymentError> {
+    if !metadata.is_object() {
+        if metadata.is_null() {
+            *metadata = serde_json::json!({});
+        } else {
+            return Err(PaymentError::Validation(
+                "payment provider operation metadata must be an object".to_string(),
+            ));
+        }
+    }
+    let object = metadata.as_object_mut().ok_or_else(|| {
+        PaymentError::Validation("payment provider operation metadata must be an object".to_string())
+    })?;
+    if let Some(existing) = object.get(key).and_then(Value::as_str) {
+        if existing != value {
+            return Err(PaymentError::Validation(
+                "payment provider identity conflicts with owner identity".to_string(),
+            ));
+        }
+        return Ok(());
+    }
+    object.insert(key.to_string(), Value::String(value));
+    Ok(())
+}
+
+fn metadata_string<'a>(metadata: &'a Value, key: &str) -> Option<&'a str> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn provider_id_for_collection(collection: &PaymentCollectionResponse) -> String {
+    collection
+        .provider_id
+        .clone()
+        .unwrap_or_else(|| MANUAL_PAYMENT_PROVIDER_ID.to_string())
+}
+
+fn merge_provider_context(current: Value, patch: Value) -> Value {
+    match (current, patch) {
+        (Value::Object(mut current), Value::Object(patch)) => {
+            for (key, value) in patch {
+                current.insert(key, value);
+            }
+            Value::Object(current)
+        }
+        (_, patch) => patch,
+    }
+}

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -5,6 +5,7 @@ use sea_orm_migration::MigrationTrait;
 
 mod admin_collection_command;
 mod admin_read;
+mod admin_refund_command;
 #[path = "checkout_compensation.rs"]
 mod checkout_compensation_persistent;
 #[path = "checkout_compensation_api.rs"]
@@ -42,6 +43,11 @@ pub use admin_read::{
     ListRefundProjectionsRequest, PaymentAdminReadPort, PaymentAdminReadRuntime,
     PaymentCollectionProjectionPage, ReadPaymentCollectionProjectionRequest,
     ReadRefundProjectionRequest, RefundProjectionPage, in_process_payment_admin_read_port,
+};
+pub use admin_refund_command::{
+    CancelAdminRefundRequest, CompleteAdminRefundRequest, CreateAdminRefundRequest,
+    InProcessPaymentAdminRefundCommandPort, PaymentAdminRefundCommandPort,
+    PaymentAdminRefundCommandRuntime, in_process_payment_admin_refund_command_port,
 };
 pub use checkout_compensation::{
     CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,

--- a/scripts/verify/verify-commerce-admin-refund-owner-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-refund-owner-command-cutover.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) throw new Error(`missing ${label}: ${text}`);
+};
+const forbidText = (source, text, label) => {
+  if (source.includes(text)) throw new Error(`forbidden ${label}: ${text}`);
+};
+
+const mounted = read("crates/rustok-commerce/src/controllers/admin/payments_owner_reads.rs");
+const adminModule = read("crates/rustok-commerce/src/controllers/admin/mod.rs");
+const httpRuntime = read("crates/rustok-commerce/src/controllers/mod.rs");
+const paymentLib = read("crates/rustok-payment/src/lib.rs");
+const owner = read("crates/rustok-payment/src/admin_refund_command.rs");
+const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+const doc = read("crates/rustok-commerce/docs/admin-refund-owner-command-cutover-2026-08-09.md");
+
+requireText(paymentLib, "mod admin_refund_command;", "Payment refund command module");
+requireText(paymentLib, "PaymentAdminRefundCommandPort", "Payment refund command port export");
+requireText(paymentLib, "PaymentAdminRefundCommandRuntime", "Payment refund command runtime export");
+requireText(owner, "pub trait PaymentAdminRefundCommandPort", "owner refund command trait");
+requireText(owner, "PaymentRefundCreationService::new(db.clone())", "owner-local refund reservation service");
+requireText(owner, "PaymentProviderOperationJournal::new(db)", "owner-local provider journal");
+requireText(owner, "context.require_policy(PortCallPolicy::write())", "write admission");
+requireText(owner, ".create_or_replay(", "durable refund reservation replay");
+requireText(owner, 'idempotency_key: Some(format!("payment_refund:{}", refund.id))', "stable provider refund identity");
+requireText(owner, 'operation: "refund".to_string()', "provider refund operation");
+requireText(owner, "refund_id: Some(refund_id)", "provider journal refund relation");
+requireText(owner, '"operation": "create_refund"', "legacy provider metadata operation");
+requireText(owner, 'format!("payment_collection:{}:authorize", request.collection_id)', "authorize provider identity recovery");
+requireText(owner, "self.provider_registry.execute_refund", "Payment-owned provider execution");
+requireText(owner, "payment.refund_reserved_reconciliation_required", "reserved refund reconciliation outcome");
+requireText(owner, "payment.refund_reserved_provider_unavailable", "reserved refund unavailable outcome");
+requireText(owner, ".complete_refund(tenant_id, request.refund_id, request.input)", "owner refund completion");
+requireText(owner, ".cancel_refund(tenant_id, request.refund_id, request.input)", "owner refund cancellation");
+forbidText(owner, "source.to_string()", "raw provider source persistence");
+forbidText(owner, "error.to_string()", "raw owner error persistence");
+
+for (const symbol of ["create_refund", "complete_refund", "cancel_refund"]) {
+  requireText(mounted, `pub async fn ${symbol}`, `mounted ${symbol} handler`);
+}
+requireText(mounted, ".payment_admin_refund_command_port()", "mounted refund owner runtime access");
+requireText(mounted, "Permission::PAYMENTS_UPDATE", "refund update permission");
+requireText(mounted, 'headers.get("idempotency-key")', "caller refund idempotency header");
+requireText(mounted, "MAX_REFUND_CREATION_KEY_LENGTH: usize = 191", "refund creation key bound");
+requireText(mounted, ".with_idempotency_key(creation_key.to_string())", "caller key write admission propagation");
+requireText(mounted, ".with_deadline(std::time::Duration::from_secs(2))", "bounded refund command deadline");
+requireText(mounted, "request_context.channel_slug.as_deref()", "refund channel propagation");
+requireText(mounted, "payment.refund_reserved_reconciliation_required", "refund-specific reconciliation HTTP mapping");
+requireText(mounted, "commerce_admin_refund_reconciliation_required", "public refund reconciliation envelope");
+requireText(mounted, "commerce_admin_refund_provider_unavailable", "public reserved refund unavailable envelope");
+forbidText(mounted, "PaymentOrchestrationService::new", "mounted Commerce Payment orchestration construction");
+forbidText(mounted, "PaymentService::new", "mounted concrete Payment service construction");
+
+requireText(adminModule, '#[path = "payments_owner_reads.rs"]\npub mod payments;', "owner-mounted admin Payment module");
+requireText(httpRuntime, "payment_admin_refund_command_runtime: rustok_payment::PaymentAdminRefundCommandRuntime", "refund command runtime field");
+requireText(httpRuntime, ".shared_get::<rustok_payment::PaymentAdminRefundCommandRuntime>()", "host-selected refund command runtime preference");
+requireText(httpRuntime, "rustok_payment::PaymentAdminRefundCommandRuntime::in_process(", "built-in Payment refund owner fallback");
+requireText(httpRuntime, "payment_provider_registry.clone()", "host provider registry reuse");
+
+requireText(
+  plan,
+  "- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.",
+  "canonical topology item remains open",
+);
+requireText(doc, "execution evidence pending and unvalidated", "unvalidated source status");
+requireText(doc, "payment_refund:{refund_id}", "provider refund identity documentation");
+requireText(doc, "two different durable identities", "creation versus provider identity distinction");
+requireText(doc, "remains open", "broad topology follow-up");
+
+console.log("commerce admin refund owner-command cutover source guard: OK");


### PR DESCRIPTION
## Summary
- publish Payment-owned `PaymentAdminRefundCommandPort` / `PaymentAdminRefundCommandRuntime`
- move mounted admin refund create/complete/cancel execution behind the owner command port
- keep caller `Idempotency-Key` as the durable refund reservation identity used by `PaymentRefundCreationService::create_or_replay`
- preserve provider refund journal identity `payment_refund:{refund_id}`
- preserve refund provider metadata, durable authorize-provider identity recovery, replay/adoption, and reconciliation checkpoints
- preserve refund-specific reserved-provider public envelopes for reconciliation-required and provider-unavailable outcomes
- keep `PAYMENTS_UPDATE`, request/response DTOs, create 201, complete/cancel 200, and the existing 191-byte caller key bound
- prefer host-injected `PaymentAdminRefundCommandRuntime`; otherwise compose the built-in Payment owner adapter with the host-selected `PaymentProviderRegistry`
- keep Payment service, refund reservation service, provider journal, and provider execution inside `rustok-payment`
- add focused actualization and a source guard without executing it

## Out of scope
The broad Commerce topology P0 remains open. Other mounted Commerce Payment workflows (including post-order/change/return and remaining GraphQL/provider-operation surfaces) and Fulfillment concrete-service construction still need focused owner-boundary cutovers.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart/lost-response evidence, and external-provider execution were intentionally not run per maintainer instruction.