### PR TITLE
feat(blog): cache degraded storefront Comments snapshots

### DIFF
--- a/apps/server/src/services/blog_public_comments_snapshot.rs
+++ b/apps/server/src/services/blog_public_comments_snapshot.rs
@@ -31,9 +31,7 @@ impl ServerBlogPublicCommentsSnapshotStore {
     async fn backend(&self) -> Arc<dyn CacheBackend> {
         self.backend
             .get_or_init(|| async {
-                self.cache
-                    .backend(CACHE_PREFIX, SNAPSHOT_TTL, MAX_SNAPSHOT_KEYS)
-                    .await
+                self.cache.backend(CACHE_PREFIX, SNAPSHOT_TTL, MAX_SNAPSHOT_KEYS).await
             })
             .await
             .clone()

--- a/apps/server/src/services/blog_public_comments_snapshot.rs
+++ b/apps/server/src/services/blog_public_comments_snapshot.rs
@@ -1,0 +1,82 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use rustok_blog::PublicCommentsSnapshotStore;
+use rustok_cache::CacheService;
+use rustok_core::{CacheBackend, ModuleRuntimeExtensions};
+use tokio::sync::OnceCell;
+
+use crate::services::{
+    cache_runtime::ensure_cache_service, server_runtime_context::ServerRuntimeContext,
+};
+
+const CACHE_PREFIX: &str = "blog-public-comments-snapshot-v1";
+const SNAPSHOT_TTL: Duration = Duration::from_secs(15 * 60);
+const MAX_SNAPSHOT_KEYS: u64 = 10_000;
+
+#[derive(Clone)]
+struct ServerBlogPublicCommentsSnapshotStore {
+    cache: CacheService,
+    backend: Arc<OnceCell<Arc<dyn CacheBackend>>>,
+}
+
+impl ServerBlogPublicCommentsSnapshotStore {
+    fn new(cache: CacheService) -> Self {
+        Self {
+            cache,
+            backend: Arc::new(OnceCell::new()),
+        }
+    }
+
+    async fn backend(&self) -> Arc<dyn CacheBackend> {
+        self.backend
+            .get_or_init(|| async {
+                self.cache
+                    .backend(CACHE_PREFIX, SNAPSHOT_TTL, MAX_SNAPSHOT_KEYS)
+                    .await
+            })
+            .await
+            .clone()
+    }
+}
+
+#[async_trait]
+impl PublicCommentsSnapshotStore for ServerBlogPublicCommentsSnapshotStore {
+    async fn load(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+        self.backend()
+            .await
+            .get(key)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn store(&self, key: String, value: Vec<u8>) -> Result<(), String> {
+        self.backend()
+            .await
+            .set_with_ttl(key, value, SNAPSHOT_TTL)
+            .await
+            .map_err(|error| error.to_string())
+    }
+}
+
+pub(super) fn register(
+    extensions: &mut ModuleRuntimeExtensions,
+    runtime_ctx: &ServerRuntimeContext,
+) {
+    let cache = ensure_cache_service(runtime_ctx);
+    let store: Arc<dyn PublicCommentsSnapshotStore> =
+        Arc::new(ServerBlogPublicCommentsSnapshotStore::new(cache));
+    extensions.insert(store);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adapter_contract_is_bounded_and_lazy() {
+        assert_eq!(CACHE_PREFIX, "blog-public-comments-snapshot-v1");
+        assert_eq!(SNAPSHOT_TTL, Duration::from_secs(900));
+        assert_eq!(MAX_SNAPSHOT_KEYS, 10_000);
+    }
+}

--- a/apps/server/src/services/module_event_dispatcher.rs
+++ b/apps/server/src/services/module_event_dispatcher.rs
@@ -13,6 +13,10 @@ use crate::error::{Error, Result};
 use crate::services::event_transport_factory::EventRuntime;
 use crate::services::server_runtime_context::ServerRuntimeContext;
 
+#[cfg(feature = "mod-blog")]
+#[path = "blog_public_comments_snapshot.rs"]
+mod blog_public_comments_snapshot;
+
 pub fn spawn_module_event_dispatcher(
     ctx: &ServerRuntimeContext,
     registry: &ModuleRegistry,
@@ -235,6 +239,7 @@ pub fn build_shared_runtime_extensions_with_host_providers(
 
     #[cfg(feature = "mod-blog")]
     {
+        blog_public_comments_snapshot::register(&mut extensions, &runtime_ctx);
         let event_bus = rustok_outbox::TransactionalEventBus::new(Arc::new(
             rustok_outbox::OutboxTransport::new(db.clone()),
         ));

--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "module": "blog",
   "role": "consumer",
   "provider": "comments",
@@ -11,12 +11,16 @@
   "source_contract": {
     "consumer_service": "crates/rustok-blog/src/services/comment.rs",
     "consumer_error_mapping": "crates/rustok-blog/src/services/comment.rs",
+    "public_snapshot_policy": "crates/rustok-blog/src/public_comments_snapshot.rs",
     "provider_port_registry": "crates/rustok-comments/contracts/comments-fba-registry.json",
+    "graphql_runtime": "crates/rustok-blog/src/graphql/runtime_data.rs",
     "graphql_owner": "crates/rustok-blog/src/graphql/types.rs",
     "storefront_model": "crates/rustok-blog/storefront/src/model.rs",
     "storefront_graphql": "crates/rustok-blog/storefront/src/transport/graphql_adapter.rs",
     "storefront_native": "crates/rustok-blog/storefront/src/transport/native_server_adapter.rs",
-    "storefront_ui": "crates/rustok-blog/storefront/src/ui/leptos.rs"
+    "storefront_ui": "crates/rustok-blog/storefront/src/ui/leptos.rs",
+    "host_snapshot_adapter": "apps/server/src/services/blog_public_comments_snapshot.rs",
+    "host_runtime_composition": "apps/server/src/services/module_event_dispatcher.rs"
   },
   "storefront_read_degradation": {
     "status": "source_verified_no_compile",
@@ -36,22 +40,56 @@
       "Timeout"
     ],
     "propagated_error_policy": "all_other_blog_errors",
+    "cached_thread_snapshot": "source_verified_no_compile",
+    "comment_form_fallback": "planned",
     "degraded_payload": {
-      "items": [],
-      "total": 0
+      "cache_hit": {
+        "cached_snapshot": true,
+        "availability": "preserve_unavailable_or_timeout",
+        "items": "last_valid_approved_public_page",
+        "total": "last_valid_public_total"
+      },
+      "cache_miss": {
+        "cached_snapshot": false,
+        "items": [],
+        "total": 0
+      }
+    },
+    "cache_contract": {
+      "source_of_truth": "comments_owner_only",
+      "write_policy": "successful_public_read_best_effort",
+      "read_policy": "external_service_or_timeout_only",
+      "key_identity": [
+        "tenant_id",
+        "post_id",
+        "requested_locale",
+        "fallback_locale",
+        "page",
+        "per_page"
+      ],
+      "key_encoding": "sha256_of_schema_bound_identity",
+      "envelope_schema_version": 1,
+      "visibility_validation": "exact_identity_same_post_approved_only",
+      "maximum_payload_bytes": 262144,
+      "host_cache_prefix": "blog-public-comments-snapshot-v1",
+      "host_ttl_seconds": 900,
+      "host_max_keys": 10000,
+      "host_cache_owner": "rustok-cache CacheService",
+      "cache_failures": "best_effort_do_not_change_owner_response"
     },
     "ui_states": [
       "comments_temporarily_unavailable_article_still_available",
-      "comments_timeout_article_still_available"
+      "comments_timeout_article_still_available",
+      "comments_unavailable_cached_snapshot_visible",
+      "comments_timeout_cached_snapshot_visible"
     ],
-    "cached_thread_snapshot": "planned",
-    "comment_form_fallback": "planned",
     "runtime_evidence": "pending"
   },
   "fallback_smoke": {
     "status": "planned",
     "profiles": [
-      "embedded_native"
+      "embedded_native",
+      "graphql_storefront"
     ],
     "degraded_modes": [
       "hide_comment_form",
@@ -75,7 +113,7 @@
           "with_error_code(error.code)"
         ],
         "degraded_mode": "hide_comment_form",
-        "expected_consumer_behavior": "planned UI branch; source contract preserves typed unavailable/forbidden/validation errors while runtime fallback evidence remains pending"
+        "expected_consumer_behavior": "comment-form fallback remains planned; source contract preserves typed unavailable/forbidden/validation errors while runtime fallback evidence remains pending"
       },
       {
         "operation": "list_comments_for_target",
@@ -95,7 +133,7 @@
           "with_error_code(error.code)"
         ],
         "degraded_mode": "show_cached_thread_snapshot",
-        "expected_consumer_behavior": "typed unavailable/timeout storefront state is source-verified; cached snapshot runtime fallback remains planned and not executed"
+        "expected_consumer_behavior": "cached public snapshot source is retained for unavailable/timeout reads across GraphQL and native SSR; runtime fallback execution remains pending"
       }
     ],
     "runtime_evidence": "pending"

--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 2,
   "module": "blog",
   "role": "consumer",
   "provider": "comments",

--- a/crates/rustok-blog/docs/implementation-plan-slice-99.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-99.md
@@ -14,7 +14,7 @@ The platform already has the correct cache owner:
 - server runtime initialization retains one process-wide `CacheService`;
 - `ModuleRuntimeExtensions` transfers typed host capabilities into both GraphQL and server-function `HostRuntimeContext` composition.
 
-A second Comments table, queue, relay, Redis client, or storefront-only cache owner is therefore unnecessary.
+A second Comments table, queue, relay, Redis client, or storefront-only cache owner is therefore unnecessary. The machine ownership invariant for this slice is `comments_owner_only`: the snapshot is a disposable public read projection and never becomes an alternate Comments authority.
 
 ## Slice 99 — one Blog snapshot policy for both storefront transports
 

--- a/crates/rustok-blog/docs/implementation-plan-slice-99.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-99.md
@@ -107,7 +107,7 @@ Stale Comments are therefore visible but never presented as live.
 
 The existing fail-closed source boundary remains authoritative:
 
-- `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json` is advanced to schema v3;
+- `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json` remains schema v2 and is extended additively with the cached-snapshot contract;
 - `scripts/verify/verify-blog-comments-port-boundary.mjs` source-locks the shared snapshot policy, host cache bounds, GraphQL/native parity, UI stale disclosure, and preserved fail-closed error policy.
 
 The broader fallback smoke remains `planned` because comment-form fallback is still a separate unfinished result.

--- a/crates/rustok-blog/docs/implementation-plan-slice-99.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-99.md
@@ -1,0 +1,136 @@
+# rustok-blog implementation plan — slice 99 continuation
+
+Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.
+
+This slice closes the remaining source-only cached public Comments snapshot gap that followed the typed `AVAILABLE` / `UNAVAILABLE` / `TIMEOUT` storefront state. It does not claim Comments provider runtime execution, browser evidence, Redis execution, or comment-form fallback completion.
+
+## Re-audit
+
+Before this slice, GraphQL and native SSR both preserved the selected article when the Comments owner returned only `ExternalService` or `Timeout`, but they replaced the Comments page with an empty degraded payload. The active Blog plan and `blog-comments-runtime-fallback-smoke.json` still marked `show_cached_thread_snapshot` as planned.
+
+The platform already has the correct cache owner:
+
+- `rustok-cache::CacheService` owns Redis lifecycle and bounded in-memory fallback;
+- server runtime initialization retains one process-wide `CacheService`;
+- `ModuleRuntimeExtensions` transfers typed host capabilities into both GraphQL and server-function `HostRuntimeContext` composition.
+
+A second Comments table, queue, relay, Redis client, or storefront-only cache owner is therefore unnecessary.
+
+## Slice 99 — one Blog snapshot policy for both storefront transports
+
+New source:
+
+`crates/rustok-blog/src/public_comments_snapshot.rs`
+
+`list_public_comments_with_snapshot` remains downstream of the canonical `CommentService::list_for_post_with_locale_fallback` public-read path. It never queries or mutates Comments persistence directly.
+
+### Live success
+
+A successful approved public Comments read remains authoritative and returns:
+
+- `availability = AVAILABLE`;
+- `cached_snapshot = false`;
+- the live items and total.
+
+When a snapshot store is present, the same successful page is written best-effort after source validation. Cache write failure cannot replace or fail the owner response.
+
+### Degraded owner read
+
+Only the existing two degradable Blog error kinds are eligible:
+
+- `ExternalService -> UNAVAILABLE`;
+- `Timeout -> TIMEOUT`.
+
+For every other `BlogError`, the helper returns the original error and does not consult the snapshot cache.
+
+On an eligible error:
+
+1. an exact valid cache hit returns the original degraded availability plus `cached_snapshot = true` and the retained items/total;
+2. a miss, cache failure, oversized entry, invalid JSON, schema drift, identity mismatch, cross-post row, or non-approved row returns the original degraded availability with `cached_snapshot = false`, empty items and total zero.
+
+The availability signal is never rewritten to `AVAILABLE` when stale data is shown.
+
+## Snapshot identity and bounds
+
+The cache identity contains:
+
+- tenant id;
+- post id;
+- requested locale;
+- fallback locale;
+- page;
+- page size.
+
+The serialized identity is bound to the `blog-public-comments-snapshot-v1` schema prefix and SHA-256 hashed before it becomes a backend key. The cached envelope repeats the complete identity and schema version, so a digest collision or corrupt/misrouted backend value still has to pass exact identity validation before use.
+
+Both writes and reads enforce:
+
+- schema version 1;
+- exact identity equality;
+- same post id for every item;
+- `approved` status for every retained item;
+- item count not greater than requested page size;
+- total not lower than retained item count;
+- maximum encoded payload size of 256 KiB.
+
+This is a bounded stale public projection, not an ownership transfer from Comments.
+
+## Host cache composition
+
+New adapter:
+
+`apps/server/src/services/blog_public_comments_snapshot.rs`
+
+The server adapter reuses the canonical `CacheService` from `ensure_cache_service` and lazily materializes one backend with:
+
+- prefix `blog-public-comments-snapshot-v1`;
+- TTL 900 seconds;
+- maximum 10,000 keys.
+
+Redis is reused automatically when configured by the existing cache runtime; otherwise the same cache capability provides its bounded in-memory fallback. The Blog adapter never resolves a Redis URL or creates a Redis client directly.
+
+The adapter is registered as `Arc<dyn PublicCommentsSnapshotStore>` in the existing host-provider `ModuleRuntimeExtensions`, so GraphQL schema data and native server-function runtime receive the same typed store.
+
+## Transport and UI parity
+
+GraphQL `publicComments` now exposes `cachedSnapshot` alongside the existing availability state. Native SSR maps the same shared helper result into the same storefront DTO.
+
+The Leptos storefront behavior is:
+
+- live `AVAILABLE`: render the ordinary list;
+- `UNAVAILABLE` / `TIMEOUT` without snapshot: retain the existing message-only degraded state;
+- `UNAVAILABLE` / `TIMEOUT` with `cachedSnapshot = true`: render a warning that a recent cached snapshot is being shown, then render the retained list and pagination.
+
+Stale Comments are therefore visible but never presented as live.
+
+## Machine evidence
+
+The existing fail-closed source boundary remains authoritative:
+
+- `crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json` is advanced to schema v3;
+- `scripts/verify/verify-blog-comments-port-boundary.mjs` source-locks the shared snapshot policy, host cache bounds, GraphQL/native parity, UI stale disclosure, and preserved fail-closed error policy.
+
+The broader fallback smoke remains `planned` because comment-form fallback is still a separate unfinished result.
+
+## Preserved boundaries
+
+This slice does not add or change:
+
+- Comments storage, moderation, lifecycle, visibility, counters, threads, or event ownership;
+- Blog database schema or migrations;
+- a queue, worker, relay, retry lane, or DLQ;
+- a direct Redis dependency in Blog;
+- moderation Comments caching;
+- fallback for validation, forbidden, not-found, conflict, invariant, or other non-availability errors;
+- comment submission behavior;
+- FFA/FBA promotion.
+
+## Maintainer validation boundary
+
+Suggested source/runtime validation remains maintainer-owned. No tests, Cargo commands, Node verifiers, formatting, builds, browser targets, Redis scenarios, workflows, CI, HTTP execution, or runtime validation were executed by the implementation agent.
+
+## Next cursor
+
+Re-audit the storefront write surface for the planned `hide_comment_form` degraded mode. If a public comment form is still absent from the active storefront, actualize the plan instead of inventing a fallback for a nonexistent surface. If the form exists, keep its write fallback separate from this read snapshot and preserve typed Comments write errors.
+
+Browser/runtime evidence for cached-snapshot behavior remains a separate maintainer-execution result after the source boundary is retained.

--- a/crates/rustok-blog/src/graphql/runtime_data.rs
+++ b/crates/rustok-blog/src/graphql/runtime_data.rs
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn graphql_runtime_data_exposes_comments_port_and_snapshot_selection() {
+    fn graphql_runtime_data_exposes_comments_port_selection() {
         let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String> =
             attach_schema_data;
         let selector: fn(

--- a/crates/rustok-blog/src/graphql/runtime_data.rs
+++ b/crates/rustok-blog/src/graphql/runtime_data.rs
@@ -5,21 +5,24 @@ use rustok_comments::CommentsThreadPort;
 use rustok_outbox::TransactionalEventBus;
 use sea_orm::DatabaseConnection;
 
-use crate::CommentService;
+use crate::{CommentService, PublicCommentsSnapshotStore};
 
 /// Manifest-attached Blog GraphQL runtime capabilities.
 ///
-/// A host may publish a transport-neutral Comments port through
-/// `HostRuntimeContext`. Its absence preserves the existing in-process Blog
-/// compatibility profile.
+/// A host may publish transport-neutral Comments and public snapshot capabilities
+/// through `HostRuntimeContext`. Their absence preserves the existing in-process
+/// Blog compatibility profile and empty degraded payload behavior.
 #[derive(Clone, Default)]
 pub struct BlogGraphqlRuntimeData {
     comments_thread_port: Option<Arc<dyn CommentsThreadPort>>,
+    public_comments_snapshot_store: Option<Arc<dyn PublicCommentsSnapshotStore>>,
 }
 
 pub fn attach_schema_data(inputs: &GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String> {
     Ok(BlogGraphqlRuntimeData {
         comments_thread_port: inputs.shared_get::<Arc<dyn CommentsThreadPort>>(),
+        public_comments_snapshot_store: inputs
+            .shared_get::<Arc<dyn PublicCommentsSnapshotStore>>(),
     })
 }
 
@@ -36,6 +39,12 @@ impl BlogGraphqlRuntimeData {
             None => CommentService::new(db, event_bus),
         }
     }
+
+    pub(crate) fn public_comments_snapshot_store(
+        &self,
+    ) -> Option<&Arc<dyn PublicCommentsSnapshotStore>> {
+        self.public_comments_snapshot_store.as_ref()
+    }
 }
 
 #[cfg(test)]
@@ -43,7 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn graphql_runtime_data_exposes_comments_port_selection() {
+    fn graphql_runtime_data_exposes_comments_port_and_snapshot_selection() {
         let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String> =
             attach_schema_data;
         let selector: fn(
@@ -51,6 +60,10 @@ mod tests {
             DatabaseConnection,
             TransactionalEventBus,
         ) -> CommentService = BlogGraphqlRuntimeData::comment_service;
-        let _ = (factory, selector);
+        let snapshot_selector: fn(
+            &BlogGraphqlRuntimeData,
+        ) -> Option<&Arc<dyn PublicCommentsSnapshotStore>> =
+            BlogGraphqlRuntimeData::public_comments_snapshot_store;
+        let _ = (factory, selector, snapshot_selector);
     }
 }

--- a/crates/rustok-blog/src/graphql/types.rs
+++ b/crates/rustok-blog/src/graphql/types.rs
@@ -3,17 +3,18 @@ use rustok_api::{
     AuthContext, Permission, RichTextDocument, RichTextView, TenantContext, graphql::GraphQLError,
     has_any_effective_permission,
 };
-use rustok_core::{SecurityContext, error::ErrorKind};
+use rustok_core::SecurityContext;
 use rustok_outbox::TransactionalEventBus;
 use rustok_profiles::graphql::GqlProfileSummary;
 use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
 use crate::{
-    BlogError, BlogPostStatus, CommentListItem as DomainCommentListItem,
+    BlogPostStatus, CommentListItem as DomainCommentListItem,
     CreatePostInput as DomainCreatePostInput, ListCommentsFilter,
     ModerateCommentStatus as DomainModerateCommentStatus, PostResponse, PostSummary,
-    UpdatePostInput as DomainUpdatePostInput,
+    PublicCommentsAvailability, UpdatePostInput as DomainUpdatePostInput,
+    list_public_comments_with_snapshot,
 };
 
 use super::runtime_data::BlogGraphqlRuntimeData;
@@ -78,6 +79,16 @@ pub enum GqlBlogCommentsAvailability {
     Timeout,
 }
 
+impl From<PublicCommentsAvailability> for GqlBlogCommentsAvailability {
+    fn from(availability: PublicCommentsAvailability) -> Self {
+        match availability {
+            PublicCommentsAvailability::Available => Self::Available,
+            PublicCommentsAvailability::Unavailable => Self::Unavailable,
+            PublicCommentsAvailability::Timeout => Self::Timeout,
+        }
+    }
+}
+
 #[derive(SimpleObject)]
 #[graphql(complex)]
 pub struct GqlPost {
@@ -118,6 +129,7 @@ pub struct GqlPublicCommentListItem {
 #[derive(SimpleObject)]
 pub struct GqlPublicCommentList {
     pub availability: GqlBlogCommentsAvailability,
+    pub cached_snapshot: bool,
     pub items: Vec<GqlPublicCommentListItem>,
     pub total: u64,
 }
@@ -157,34 +169,24 @@ impl GqlPost {
         let requested_locale = comment_locale(locale.as_deref(), &self.effective_locale);
         let fallback_locale = post_comment_fallback_locale(request_tenant, self);
         let service = runtime.comment_service(db.clone(), event_bus.clone());
-
-        let (items, total, availability) = match service
-            .list_for_post_with_locale_fallback(
-                self.tenant_id,
-                SecurityContext::public_read(),
-                self.id,
-                ListCommentsFilter {
-                    locale: Some(requested_locale),
-                    page: page.unwrap_or(1).max(1),
-                    per_page: per_page.unwrap_or(20).clamp(1, 100),
-                },
-                Some(fallback_locale),
-            )
-            .await
-        {
-            Ok((items, total)) => (items, total, GqlBlogCommentsAvailability::Available),
-            Err(error) => {
-                let Some(availability) = graphql_comments_read_availability(&error) else {
-                    return Err(async_graphql::Error::new(error.to_string()));
-                };
-                (Vec::new(), 0, availability)
-            }
-        };
+        let read = list_public_comments_with_snapshot(
+            &service,
+            runtime.public_comments_snapshot_store(),
+            self.tenant_id,
+            self.id,
+            requested_locale.as_str(),
+            Some(fallback_locale),
+            page.unwrap_or(1),
+            per_page.unwrap_or(20),
+        )
+        .await
+        .map_err(|error| async_graphql::Error::new(error.to_string()))?;
 
         Ok(GqlPublicCommentList {
-            availability,
-            items: items.into_iter().map(Into::into).collect(),
-            total,
+            availability: read.availability.into(),
+            cached_snapshot: read.cached_snapshot,
+            items: read.items.into_iter().map(Into::into).collect(),
+            total: read.total,
         })
     }
 
@@ -225,17 +227,6 @@ impl GqlPost {
             items: items.into_iter().map(Into::into).collect(),
             total,
         })
-    }
-}
-
-fn graphql_comments_read_availability(error: &BlogError) -> Option<GqlBlogCommentsAvailability> {
-    let BlogError::Rich(error) = error else {
-        return None;
-    };
-    match error.kind {
-        ErrorKind::ExternalService => Some(GqlBlogCommentsAvailability::Unavailable),
-        ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout),
-        _ => None,
     }
 }
 

--- a/crates/rustok-blog/src/lib.rs
+++ b/crates/rustok-blog/src/lib.rs
@@ -57,6 +57,7 @@ pub mod graphql;
 pub mod locale;
 pub mod migrations;
 pub mod openapi;
+pub mod public_comments_snapshot;
 mod reaction_subject;
 pub mod richtext;
 mod seo_targets;
@@ -81,6 +82,10 @@ pub use dto::{
 pub use entities::*;
 pub use error::{BlogError, BlogResult};
 pub use graphql::{BlogMutation, BlogQuery};
+pub use public_comments_snapshot::{
+    PublicCommentsAvailability, PublicCommentsRead, PublicCommentsSnapshotStore,
+    list_public_comments_with_snapshot,
+};
 pub use reaction_subject::{
     BLOG_POST_REACTION_KIND, BLOG_REACTION_SOURCE, BLOG_REACTION_V1_KEY,
     BlogReactionSubjectProviderFactory,

--- a/crates/rustok-blog/src/public_comments_snapshot.rs
+++ b/crates/rustok-blog/src/public_comments_snapshot.rs
@@ -1,0 +1,320 @@
+use std::{fmt::Write as _, sync::Arc};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use rustok_api::sha256_digest;
+use rustok_core::error::ErrorKind;
+
+use crate::{
+    BlogError, BlogResult, CommentListItem, CommentService, ListCommentsFilter,
+};
+
+const SNAPSHOT_SCHEMA_VERSION: u16 = 1;
+pub const MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES: usize = 256 * 1024;
+
+#[async_trait]
+pub trait PublicCommentsSnapshotStore: Send + Sync {
+    async fn load(&self, key: &str) -> Result<Option<Vec<u8>>, String>;
+    async fn store(&self, key: String, value: Vec<u8>) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicCommentsAvailability {
+    Available,
+    Unavailable,
+    Timeout,
+}
+
+#[derive(Debug, Clone)]
+pub struct PublicCommentsRead {
+    pub availability: PublicCommentsAvailability,
+    pub cached_snapshot: bool,
+    pub items: Vec<CommentListItem>,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PublicCommentsSnapshotIdentity {
+    tenant_id: Uuid,
+    post_id: Uuid,
+    requested_locale: String,
+    fallback_locale: Option<String>,
+    page: u64,
+    per_page: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PublicCommentsSnapshotEnvelope {
+    schema_version: u16,
+    identity: PublicCommentsSnapshotIdentity,
+    items: Vec<CommentListItem>,
+    total: u64,
+}
+
+pub async fn list_public_comments_with_snapshot(
+    service: &CommentService,
+    snapshot_store: Option<&Arc<dyn PublicCommentsSnapshotStore>>,
+    tenant_id: Uuid,
+    post_id: Uuid,
+    requested_locale: &str,
+    fallback_locale: Option<&str>,
+    page: u64,
+    per_page: u64,
+) -> BlogResult<PublicCommentsRead> {
+    let page = page.max(1);
+    let per_page = per_page.clamp(1, 100);
+    let identity = PublicCommentsSnapshotIdentity {
+        tenant_id,
+        post_id,
+        requested_locale: requested_locale.to_string(),
+        fallback_locale: fallback_locale.map(str::to_string),
+        page,
+        per_page,
+    };
+
+    match service
+        .list_for_post_with_locale_fallback(
+            tenant_id,
+            rustok_core::SecurityContext::public_read(),
+            post_id,
+            ListCommentsFilter {
+                locale: Some(requested_locale.to_string()),
+                page,
+                per_page,
+            },
+            fallback_locale,
+        )
+        .await
+    {
+        Ok((items, total)) => {
+            if let Some(store) = snapshot_store {
+                store_snapshot_best_effort(store.as_ref(), &identity, &items, total).await;
+            }
+            Ok(PublicCommentsRead {
+                availability: PublicCommentsAvailability::Available,
+                cached_snapshot: false,
+                items,
+                total,
+            })
+        }
+        Err(error) => {
+            let Some(availability) = degraded_availability(&error) else {
+                return Err(error);
+            };
+
+            if let Some(store) = snapshot_store {
+                if let Some(snapshot) = load_snapshot_best_effort(store.as_ref(), &identity).await {
+                    return Ok(PublicCommentsRead {
+                        availability,
+                        cached_snapshot: true,
+                        items: snapshot.items,
+                        total: snapshot.total,
+                    });
+                }
+            }
+
+            Ok(PublicCommentsRead {
+                availability,
+                cached_snapshot: false,
+                items: Vec::new(),
+                total: 0,
+            })
+        }
+    }
+}
+
+async fn store_snapshot_best_effort(
+    store: &dyn PublicCommentsSnapshotStore,
+    identity: &PublicCommentsSnapshotIdentity,
+    items: &[CommentListItem],
+    total: u64,
+) {
+    let envelope = PublicCommentsSnapshotEnvelope {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        identity: identity.clone(),
+        items: items.to_vec(),
+        total,
+    };
+    let bytes = match serde_json::to_vec(&envelope) {
+        Ok(bytes) if bytes.len() <= MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES => bytes,
+        Ok(bytes) => {
+            tracing::warn!(
+                encoded_bytes = bytes.len(),
+                maximum_bytes = MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES,
+                "Blog public comments snapshot exceeded the bounded payload size"
+            );
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(%error, "Blog public comments snapshot serialization failed");
+            return;
+        }
+    };
+
+    if let Err(error) = store.store(snapshot_key(identity), bytes).await {
+        tracing::warn!(%error, "Blog public comments snapshot cache write failed");
+    }
+}
+
+async fn load_snapshot_best_effort(
+    store: &dyn PublicCommentsSnapshotStore,
+    identity: &PublicCommentsSnapshotIdentity,
+) -> Option<PublicCommentsSnapshotEnvelope> {
+    let bytes = match store.load(snapshot_key(identity).as_str()).await {
+        Ok(Some(bytes)) if bytes.len() <= MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES => bytes,
+        Ok(Some(bytes)) => {
+            tracing::warn!(
+                encoded_bytes = bytes.len(),
+                maximum_bytes = MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES,
+                "Blog public comments snapshot cache payload exceeded the bounded size"
+            );
+            return None;
+        }
+        Ok(None) => return None,
+        Err(error) => {
+            tracing::warn!(%error, "Blog public comments snapshot cache read failed");
+            return None;
+        }
+    };
+
+    let snapshot: PublicCommentsSnapshotEnvelope = match serde_json::from_slice(&bytes) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(%error, "Blog public comments snapshot cache payload was invalid");
+            return None;
+        }
+    };
+    if !snapshot_matches(&snapshot, identity) {
+        tracing::warn!("Blog public comments snapshot cache identity or visibility check failed");
+        return None;
+    }
+    Some(snapshot)
+}
+
+fn snapshot_matches(
+    snapshot: &PublicCommentsSnapshotEnvelope,
+    identity: &PublicCommentsSnapshotIdentity,
+) -> bool {
+    snapshot.schema_version == SNAPSHOT_SCHEMA_VERSION
+        && snapshot.identity == *identity
+        && snapshot.items.len() <= identity.per_page as usize
+        && snapshot.total >= snapshot.items.len() as u64
+        && snapshot
+            .items
+            .iter()
+            .all(|item| item.post_id == identity.post_id && item.status == "approved")
+}
+
+fn snapshot_key(identity: &PublicCommentsSnapshotIdentity) -> String {
+    let encoded = serde_json::to_vec(identity)
+        .expect("public comments snapshot identity must remain serializable");
+    let digest = sha256_digest(&[b"blog-public-comments-snapshot-v1\0", encoded.as_slice()]);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut hex, "{byte:02x}").expect("hex encoding into String cannot fail");
+    }
+    format!("snapshot:{hex}")
+}
+
+fn degraded_availability(error: &BlogError) -> Option<PublicCommentsAvailability> {
+    let BlogError::Rich(error) = error else {
+        return None;
+    };
+    match error.kind {
+        ErrorKind::ExternalService => Some(PublicCommentsAvailability::Unavailable),
+        ErrorKind::Timeout => Some(PublicCommentsAvailability::Timeout),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustok_core::error::RichError;
+
+    fn identity(tenant_id: Uuid, post_id: Uuid, page: u64) -> PublicCommentsSnapshotIdentity {
+        PublicCommentsSnapshotIdentity {
+            tenant_id,
+            post_id,
+            requested_locale: "fr".to_string(),
+            fallback_locale: Some("en".to_string()),
+            page,
+            per_page: 20,
+        }
+    }
+
+    fn approved_item(post_id: Uuid) -> CommentListItem {
+        CommentListItem {
+            id: Uuid::new_v4(),
+            locale: "fr".to_string(),
+            effective_locale: "fr".to_string(),
+            post_id,
+            author_id: Some(Uuid::new_v4()),
+            content_preview: "cached".to_string(),
+            status: "approved".to_string(),
+            parent_comment_id: None,
+            created_at: "2026-08-09T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn snapshot_key_is_tenant_post_and_page_scoped() {
+        let tenant_id = Uuid::new_v4();
+        let post_id = Uuid::new_v4();
+        assert_ne!(
+            snapshot_key(&identity(tenant_id, post_id, 1)),
+            snapshot_key(&identity(tenant_id, post_id, 2))
+        );
+        assert_ne!(
+            snapshot_key(&identity(tenant_id, post_id, 1)),
+            snapshot_key(&identity(Uuid::new_v4(), post_id, 1))
+        );
+    }
+
+    #[test]
+    fn snapshot_validation_rejects_cross_post_and_non_approved_rows() {
+        let tenant_id = Uuid::new_v4();
+        let post_id = Uuid::new_v4();
+        let identity = identity(tenant_id, post_id, 1);
+        let valid = PublicCommentsSnapshotEnvelope {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            identity: identity.clone(),
+            items: vec![approved_item(post_id)],
+            total: 1,
+        };
+        assert!(snapshot_matches(&valid, &identity));
+
+        let mut cross_post = valid.clone();
+        cross_post.items[0].post_id = Uuid::new_v4();
+        assert!(!snapshot_matches(&cross_post, &identity));
+
+        let mut pending = valid;
+        pending.items[0].status = "pending".to_string();
+        assert!(!snapshot_matches(&pending, &identity));
+    }
+
+    #[test]
+    fn only_external_service_and_timeout_errors_degrade() {
+        let unavailable = BlogError::Rich(Box::new(RichError::new(
+            ErrorKind::ExternalService,
+            "unavailable",
+        )));
+        let timeout = BlogError::Rich(Box::new(RichError::new(ErrorKind::Timeout, "timeout")));
+        let validation = BlogError::Rich(Box::new(RichError::new(
+            ErrorKind::Validation,
+            "validation",
+        )));
+
+        assert_eq!(
+            degraded_availability(&unavailable),
+            Some(PublicCommentsAvailability::Unavailable)
+        );
+        assert_eq!(
+            degraded_availability(&timeout),
+            Some(PublicCommentsAvailability::Timeout)
+        );
+        assert_eq!(degraded_availability(&validation), None);
+    }
+}

--- a/crates/rustok-blog/src/public_comments_snapshot.rs
+++ b/crates/rustok-blog/src/public_comments_snapshot.rs
@@ -137,6 +137,10 @@ async fn store_snapshot_best_effort(
         items: items.to_vec(),
         total,
     };
+    if !snapshot_matches(&envelope, identity) {
+        tracing::warn!("Blog public comments live response failed snapshot visibility checks");
+        return;
+    }
     let bytes = match serde_json::to_vec(&envelope) {
         Ok(bytes) if bytes.len() <= MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES => bytes,
         Ok(bytes) => {

--- a/crates/rustok-blog/storefront/src/model.rs
+++ b/crates/rustok-blog/storefront/src/model.rs
@@ -39,6 +39,8 @@ pub enum BlogCommentsAvailability {
 pub struct BlogCommentList {
     #[serde(default)]
     pub availability: BlogCommentsAvailability,
+    #[serde(default, rename = "cachedSnapshot")]
+    pub cached_snapshot: bool,
     pub items: Vec<BlogCommentListItem>,
     pub total: u64,
 }

--- a/crates/rustok-blog/storefront/src/transport/graphql_adapter.rs
+++ b/crates/rustok-blog/storefront/src/transport/graphql_adapter.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{ApiError, configured_tenant_slug};
 
-const STOREFRONT_BLOG_QUERY: &str = "query StorefrontBlog($postSlug: String!, $filter: PostsFilter, $locale: String, $commentsPage: Int!, $commentsPerPage: Int!) { selectedPost: postBySlug(slug: $postSlug, locale: $locale) { id effectiveLocale title slug excerpt content { document html } contentPlainText status publishedAt tags featuredImageUrl publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability total items { id effectiveLocale authorId contentPreview parentCommentId createdAt } } } posts(filter: $filter) { total items { id title effectiveLocale slug excerpt status publishedAt } } }";
+const STOREFRONT_BLOG_QUERY: &str = "query StorefrontBlog($postSlug: String!, $filter: PostsFilter, $locale: String, $commentsPage: Int!, $commentsPerPage: Int!) { selectedPost: postBySlug(slug: $postSlug, locale: $locale) { id effectiveLocale title slug excerpt content { document html } contentPlainText status publishedAt tags featuredImageUrl publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability cachedSnapshot total items { id effectiveLocale authorId contentPreview parentCommentId createdAt } } } posts(filter: $filter) { total items { id title effectiveLocale slug excerpt status publishedAt } } }";
 
 #[derive(Debug, Deserialize)]
 struct StorefrontBlogResponse {

--- a/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
+++ b/crates/rustok-blog/storefront/src/transport/native_server_adapter.rs
@@ -53,7 +53,10 @@ async fn storefront_blog_native(
     {
         use leptos::prelude::expect_context;
         use rustok_api::HostRuntimeContext;
-        use rustok_blog::{BlogPostStatus, ListCommentsFilter, PostListQuery, PostService};
+        use rustok_blog::{
+            BlogPostStatus, PostListQuery, PostService, PublicCommentsSnapshotStore,
+            list_public_comments_with_snapshot,
+        };
         use rustok_channel::ChannelService;
         use rustok_core::SecurityContext;
         use rustok_outbox::TransactionalEventBus;
@@ -141,35 +144,30 @@ async fn storefront_blog_native(
             });
 
         let selected_post = if let Some(post) = selected_post {
-            let public_comments = match comment_service(&runtime_ctx, event_bus.clone())
-                .list_for_post_with_locale_fallback(
-                    tenant_id,
-                    SecurityContext::public_read(),
-                    post.id,
-                    ListCommentsFilter {
-                        locale: Some(requested_locale.clone()),
-                        page: comments_page.max(1),
-                        per_page: COMMENTS_PAGE_SIZE,
-                    },
-                    Some(fallback_locale.as_str()),
-                )
-                .await
-            {
-                Ok((comments, total)) => BlogCommentList {
-                    availability: BlogCommentsAvailability::Available,
-                    items: comments.into_iter().map(map_comment_list_item).collect(),
-                    total,
-                },
-                Err(error) => {
-                    let Some(availability) = comments_read_availability(&error) else {
-                        return Err(ServerFnError::new(error));
-                    };
-                    BlogCommentList {
-                        availability,
-                        items: Vec::new(),
-                        total: 0,
-                    }
-                }
+            let comments = comment_service(&runtime_ctx, event_bus.clone());
+            let snapshot_store =
+                runtime_ctx.shared_get::<Arc<dyn PublicCommentsSnapshotStore>>();
+            let public_comments = list_public_comments_with_snapshot(
+                &comments,
+                snapshot_store.as_ref(),
+                tenant_id,
+                post.id,
+                requested_locale.as_str(),
+                Some(fallback_locale.as_str()),
+                comments_page,
+                COMMENTS_PAGE_SIZE,
+            )
+            .await
+            .map_err(ServerFnError::new)?;
+            let public_comments = BlogCommentList {
+                availability: map_comments_availability(public_comments.availability),
+                cached_snapshot: public_comments.cached_snapshot,
+                items: public_comments
+                    .items
+                    .into_iter()
+                    .map(map_comment_list_item)
+                    .collect(),
+                total: public_comments.total,
             };
             Some(map_post_detail(post, public_comments))
         } else {
@@ -232,18 +230,15 @@ fn comment_service(
 }
 
 #[cfg(feature = "ssr")]
-fn comments_read_availability(
-    error: &rustok_blog::BlogError,
-) -> Option<BlogCommentsAvailability> {
-    let rustok_blog::BlogError::Rich(error) = error else {
-        return None;
-    };
-    match error.kind {
-        rustok_core::error::ErrorKind::ExternalService => {
-            Some(BlogCommentsAvailability::Unavailable)
+fn map_comments_availability(
+    availability: rustok_blog::PublicCommentsAvailability,
+) -> BlogCommentsAvailability {
+    match availability {
+        rustok_blog::PublicCommentsAvailability::Available => BlogCommentsAvailability::Available,
+        rustok_blog::PublicCommentsAvailability::Unavailable => {
+            BlogCommentsAvailability::Unavailable
         }
-        rustok_core::error::ErrorKind::Timeout => Some(BlogCommentsAvailability::Timeout),
-        _ => None,
+        rustok_blog::PublicCommentsAvailability::Timeout => BlogCommentsAvailability::Timeout,
     }
 }
 
@@ -339,6 +334,9 @@ mod tests {
             &rustok_api::HostRuntimeContext,
             rustok_outbox::TransactionalEventBus,
         ) -> rustok_blog::CommentService = comment_service;
-        let _ = selector;
+        let mapper: fn(
+            rustok_blog::PublicCommentsAvailability,
+        ) -> BlogCommentsAvailability = map_comments_availability;
+        let _ = (selector, mapper);
     }
 }

--- a/crates/rustok-blog/storefront/src/ui/leptos.rs
+++ b/crates/rustok-blog/storefront/src/ui/leptos.rs
@@ -244,20 +244,32 @@ fn PublicCommentsList(comments: BlogCommentList, comments_page: u64) -> impl Int
     let query_writer = use_route_query_writer();
     let title = t(locale.as_deref(), "blog.comments.title", "Comments");
 
-    if comments.availability != BlogCommentsAvailability::Available {
-        let message = match comments.availability {
-            BlogCommentsAvailability::Unavailable => t(
-                locale.as_deref(),
-                "blog.comments.unavailable",
-                "Comments are temporarily unavailable. The article is still available.",
-            ),
-            BlogCommentsAvailability::Timeout => t(
-                locale.as_deref(),
-                "blog.comments.timeout",
-                "Comments took too long to load. The article is still available.",
-            ),
-            BlogCommentsAvailability::Available => unreachable!(),
-        };
+    let degraded_message = match comments.availability {
+        BlogCommentsAvailability::Available => None,
+        BlogCommentsAvailability::Unavailable if comments.cached_snapshot => Some(t(
+            locale.as_deref(),
+            "blog.comments.unavailableCached",
+            "Comments are temporarily unavailable. Showing a recent cached snapshot.",
+        )),
+        BlogCommentsAvailability::Unavailable => Some(t(
+            locale.as_deref(),
+            "blog.comments.unavailable",
+            "Comments are temporarily unavailable. The article is still available.",
+        )),
+        BlogCommentsAvailability::Timeout if comments.cached_snapshot => Some(t(
+            locale.as_deref(),
+            "blog.comments.timeoutCached",
+            "Comments took too long to load. Showing a recent cached snapshot.",
+        )),
+        BlogCommentsAvailability::Timeout => Some(t(
+            locale.as_deref(),
+            "blog.comments.timeout",
+            "Comments took too long to load. The article is still available.",
+        )),
+    };
+
+    if comments.availability != BlogCommentsAvailability::Available && !comments.cached_snapshot {
+        let message = degraded_message.expect("degraded comments without a snapshot need a message");
         return view! {
             <section class="mt-8 border-t border-border pt-6">
                 <h4 class="text-lg font-semibold text-foreground">{title}</h4>
@@ -275,12 +287,18 @@ fn PublicCommentsList(comments: BlogCommentList, comments_page: u64) -> impl Int
     );
 
     if comments.total == 0 {
+        let degraded_message = degraded_message.clone();
         return view! {
             <section class="mt-8 border-t border-border pt-6">
                 <div class="flex items-center justify-between gap-3">
                     <h4 class="text-lg font-semibold text-foreground">{title}</h4>
                     <span class="text-xs text-muted-foreground">{total_label}</span>
                 </div>
+                {degraded_message.map(|message| view! {
+                    <p class="mt-3 rounded-xl border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+                        {message}
+                    </p>
+                })}
                 <p class="mt-3 rounded-xl border border-dashed border-border p-4 text-sm text-muted-foreground">
                     {t(
                         locale.as_deref(),
@@ -315,6 +333,11 @@ fn PublicCommentsList(comments: BlogCommentList, comments_page: u64) -> impl Int
                     </span>
                 </div>
             </div>
+            {degraded_message.map(|message| view! {
+                <p class="mt-3 rounded-xl border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+                    {message}
+                </p>
+            })}
             {if core::has_items(comments.items.as_slice()) {
                 view! {
                     <div class="mt-4 space-y-3">

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -49,14 +49,19 @@ function sameSet(actual, expected) {
 const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
 const fallbackEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
 const servicePath = 'crates/rustok-blog/src/services/comment.rs';
+const snapshotPolicyPath = 'crates/rustok-blog/src/public_comments_snapshot.rs';
+const graphqlRuntimePath = 'crates/rustok-blog/src/graphql/runtime_data.rs';
 const graphqlOwnerPath = 'crates/rustok-blog/src/graphql/types.rs';
 const storefrontModelPath = 'crates/rustok-blog/storefront/src/model.rs';
 const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
 const storefrontNativePath = 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
 const storefrontUiPath = 'crates/rustok-blog/storefront/src/ui/leptos.rs';
+const hostSnapshotAdapterPath = 'apps/server/src/services/blog_public_comments_snapshot.rs';
+const hostRuntimeCompositionPath = 'apps/server/src/services/module_event_dispatcher.rs';
 const providerRegistryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
 const consumerRegistryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
+const slice99Path = 'crates/rustok-blog/docs/implementation-plan-slice-99.md';
 const injectionConstructor = 'CommentService::with_comments_thread_port';
 const injectionSignature = 'fn(DatabaseConnection, Arc<dyn CommentsThreadPort>) -> CommentService';
 const injectionTest =
@@ -78,12 +83,17 @@ const fallbackEvidence = json(fallbackEvidencePath);
 const providerRegistry = json(providerRegistryPath);
 const consumerRegistry = json(consumerRegistryPath);
 const service = read(servicePath);
+const snapshotPolicy = read(snapshotPolicyPath);
+const graphqlRuntime = read(graphqlRuntimePath);
 const graphqlOwner = read(graphqlOwnerPath);
 const storefrontModel = read(storefrontModelPath);
 const storefrontGraphql = read(storefrontGraphqlPath);
 const storefrontNative = read(storefrontNativePath);
 const storefrontUi = read(storefrontUiPath);
+const hostSnapshotAdapter = read(hostSnapshotAdapterPath);
+const hostRuntimeComposition = read(hostRuntimeCompositionPath);
 const plan = read(planPath);
+const slice99 = read(slice99Path);
 
 if (evidence) {
   if (evidence.schema_version !== 3) failures.push(`${evidencePath}: schema_version drift`);
@@ -134,7 +144,7 @@ if (evidence) {
 }
 
 if (fallbackEvidence) {
-  if (fallbackEvidence.schema_version !== 2) failures.push(`${fallbackEvidencePath}: schema_version drift`);
+  if (fallbackEvidence.schema_version !== 3) failures.push(`${fallbackEvidencePath}: schema_version drift`);
   if (
     fallbackEvidence.module !== 'blog' ||
     fallbackEvidence.role !== 'consumer' ||
@@ -150,12 +160,16 @@ if (fallbackEvidence) {
   const expectedSources = {
     consumer_service: servicePath,
     consumer_error_mapping: servicePath,
+    public_snapshot_policy: snapshotPolicyPath,
     provider_port_registry: providerRegistryPath,
+    graphql_runtime: graphqlRuntimePath,
     graphql_owner: graphqlOwnerPath,
     storefront_model: storefrontModelPath,
     storefront_graphql: storefrontGraphqlPath,
     storefront_native: storefrontNativePath,
     storefront_ui: storefrontUiPath,
+    host_snapshot_adapter: hostSnapshotAdapterPath,
+    host_runtime_composition: hostRuntimeCompositionPath,
   };
   for (const [key, expected] of Object.entries(expectedSources)) {
     if (fallbackEvidence.source_contract?.[key] !== expected) {
@@ -168,7 +182,7 @@ if (fallbackEvidence) {
     readDegradation.runtime_status !== 'not_run' ||
     readDegradation.operation !== 'list_public_comments_for_target' ||
     readDegradation.propagated_error_policy !== 'all_other_blog_errors' ||
-    readDegradation.cached_thread_snapshot !== 'planned' ||
+    readDegradation.cached_thread_snapshot !== 'source_verified_no_compile' ||
     readDegradation.comment_form_fallback !== 'planned' ||
     readDegradation.runtime_evidence !== 'pending'
   ) failures.push(`${fallbackEvidencePath}: storefront read degradation status drift`);
@@ -181,11 +195,38 @@ if (fallbackEvidence) {
   if (!sameSet(readDegradation.degraded_error_kinds ?? [], ['ExternalService', 'Timeout'])) {
     failures.push(`${fallbackEvidencePath}: degraded error-kind drift`);
   }
+  const cacheHit = readDegradation.degraded_payload?.cache_hit ?? {};
+  const cacheMiss = readDegradation.degraded_payload?.cache_miss ?? {};
   if (
-    !Array.isArray(readDegradation.degraded_payload?.items) ||
-    readDegradation.degraded_payload.items.length !== 0 ||
-    readDegradation.degraded_payload?.total !== 0
-  ) failures.push(`${fallbackEvidencePath}: degraded payload drift`);
+    cacheHit.cached_snapshot !== true ||
+    cacheHit.availability !== 'preserve_unavailable_or_timeout' ||
+    cacheHit.items !== 'last_valid_approved_public_page' ||
+    cacheHit.total !== 'last_valid_public_total'
+  ) failures.push(`${fallbackEvidencePath}: cache-hit degraded payload drift`);
+  if (
+    cacheMiss.cached_snapshot !== false ||
+    !Array.isArray(cacheMiss.items) ||
+    cacheMiss.items.length !== 0 ||
+    cacheMiss.total !== 0
+  ) failures.push(`${fallbackEvidencePath}: cache-miss degraded payload drift`);
+  const cacheContract = readDegradation.cache_contract ?? {};
+  if (
+    cacheContract.source_of_truth !== 'comments_owner_only' ||
+    cacheContract.write_policy !== 'successful_public_read_best_effort' ||
+    cacheContract.read_policy !== 'external_service_or_timeout_only' ||
+    cacheContract.key_encoding !== 'sha256_of_schema_bound_identity' ||
+    cacheContract.envelope_schema_version !== 1 ||
+    cacheContract.visibility_validation !== 'exact_identity_same_post_approved_only' ||
+    cacheContract.maximum_payload_bytes !== 262144 ||
+    cacheContract.host_cache_prefix !== 'blog-public-comments-snapshot-v1' ||
+    cacheContract.host_ttl_seconds !== 900 ||
+    cacheContract.host_max_keys !== 10000 ||
+    cacheContract.host_cache_owner !== 'rustok-cache CacheService' ||
+    cacheContract.cache_failures !== 'best_effort_do_not_change_owner_response'
+  ) failures.push(`${fallbackEvidencePath}: cache contract drift`);
+  if (!sameSet(cacheContract.key_identity ?? [], [
+    'tenant_id', 'post_id', 'requested_locale', 'fallback_locale', 'page', 'per_page',
+  ])) failures.push(`${fallbackEvidencePath}: cache identity drift`);
   if (
     fallbackEvidence.fallback_smoke?.status !== 'planned' ||
     fallbackEvidence.fallback_smoke?.runtime_evidence !== 'pending'
@@ -252,53 +293,99 @@ for (const marker of [
 ]) requireMarker(service, marker, servicePath);
 
 for (const marker of [
-  'pub enum BlogCommentsAvailability',
-  '#[serde(rename_all = "SCREAMING_SNAKE_CASE")]',
-  'Available,',
-  'Unavailable,',
-  'Timeout,',
-  'pub availability: BlogCommentsAvailability',
-]) requireMarker(storefrontModel, marker, storefrontModelPath);
+  'pub trait PublicCommentsSnapshotStore: Send + Sync',
+  'pub async fn list_public_comments_with_snapshot(',
+  'SecurityContext::public_read()',
+  'PublicCommentsAvailability::Available',
+  'PublicCommentsAvailability::Unavailable',
+  'PublicCommentsAvailability::Timeout',
+  'cached_snapshot: true',
+  'cached_snapshot: false',
+  'store_snapshot_best_effort',
+  'load_snapshot_best_effort',
+  'MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES: usize = 256 * 1024',
+  'snapshot.schema_version == SNAPSHOT_SCHEMA_VERSION',
+  'snapshot.identity == *identity',
+  'item.post_id == identity.post_id && item.status == "approved"',
+  'sha256_digest(&[b"blog-public-comments-snapshot-v1\\0", encoded.as_slice()])',
+  'ErrorKind::ExternalService => Some(PublicCommentsAvailability::Unavailable)',
+  'ErrorKind::Timeout => Some(PublicCommentsAvailability::Timeout)',
+  'return Err(error);',
+  'live response failed snapshot visibility checks',
+]) requireMarker(snapshotPolicy, marker, snapshotPolicyPath);
+for (const marker of ['Redis', 'redis::', 'DatabaseConnection', 'sys_events']) {
+  requireNoMarker(snapshotPolicy, marker, snapshotPolicyPath);
+}
 
 for (const marker of [
-  'fn comments_read_availability(',
-  'rustok_core::error::ErrorKind::ExternalService',
-  'Some(BlogCommentsAvailability::Unavailable)',
-  'rustok_core::error::ErrorKind::Timeout',
-  'Some(BlogCommentsAvailability::Timeout)',
-  'let Some(availability) = comments_read_availability(&error) else',
-  'return Err(ServerFnError::new(error));',
-  'availability: BlogCommentsAvailability::Available',
-  'items: Vec::new()',
-  'total: 0',
-]) requireMarker(storefrontNative, marker, storefrontNativePath);
-requireNoMarker(storefrontNative, 'Err(_) => BlogCommentList', storefrontNativePath);
+  'public_comments_snapshot_store: Option<Arc<dyn PublicCommentsSnapshotStore>>',
+  'shared_get::<Arc<dyn PublicCommentsSnapshotStore>>()',
+  'pub(crate) fn public_comments_snapshot_store(',
+]) requireMarker(graphqlRuntime, marker, graphqlRuntimePath);
 
 for (const marker of [
   'pub enum GqlBlogCommentsAvailability',
   'pub availability: GqlBlogCommentsAvailability',
-  'fn graphql_comments_read_availability(error: &BlogError)',
-  'ErrorKind::ExternalService => Some(GqlBlogCommentsAvailability::Unavailable)',
-  'ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout)',
-  'let Some(availability) = graphql_comments_read_availability(&error) else',
-  'return Err(async_graphql::Error::new(error.to_string()));',
-  'GqlBlogCommentsAvailability::Available',
+  'pub cached_snapshot: bool',
+  'list_public_comments_with_snapshot(',
+  'runtime.public_comments_snapshot_store()',
+  'availability: read.availability.into()',
+  'cached_snapshot: read.cached_snapshot',
+  '.map_err(|error| async_graphql::Error::new(error.to_string()))?',
 ]) requireMarker(graphqlOwner, marker, graphqlOwnerPath);
-requireNoMarker(graphqlOwner, 'Err(_) => (Vec::new(), 0', graphqlOwnerPath);
+requireNoMarker(graphqlOwner, 'fn graphql_comments_read_availability(', graphqlOwnerPath);
+
+for (const marker of [
+  'pub enum BlogCommentsAvailability',
+  '#[serde(rename_all = "SCREAMING_SNAKE_CASE")]',
+  'pub availability: BlogCommentsAvailability',
+  '#[serde(default, rename = "cachedSnapshot")]',
+  'pub cached_snapshot: bool',
+]) requireMarker(storefrontModel, marker, storefrontModelPath);
 
 requireMarker(
   storefrontGraphql,
-  'publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability total items',
+  'publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability cachedSnapshot total items',
   storefrontGraphqlPath,
 );
 
 for (const marker of [
-  'comments.availability != BlogCommentsAvailability::Available',
-  'BlogCommentsAvailability::Unavailable',
-  'BlogCommentsAvailability::Timeout',
+  'list_public_comments_with_snapshot(',
+  'shared_get::<Arc<dyn PublicCommentsSnapshotStore>>()',
+  'availability: map_comments_availability(public_comments.availability)',
+  'cached_snapshot: public_comments.cached_snapshot',
+  'map_comments_availability(',
+]) requireMarker(storefrontNative, marker, storefrontNativePath);
+requireNoMarker(storefrontNative, 'fn comments_read_availability(', storefrontNativePath);
+
+for (const marker of [
+  'comments.availability != BlogCommentsAvailability::Available && !comments.cached_snapshot',
+  'BlogCommentsAvailability::Unavailable if comments.cached_snapshot',
+  'BlogCommentsAvailability::Timeout if comments.cached_snapshot',
+  'Showing a recent cached snapshot.',
   'Comments are temporarily unavailable. The article is still available.',
   'Comments took too long to load. The article is still available.',
 ]) requireMarker(storefrontUi, marker, storefrontUiPath);
+
+for (const marker of [
+  'CACHE_PREFIX: &str = "blog-public-comments-snapshot-v1"',
+  'SNAPSHOT_TTL: Duration = Duration::from_secs(15 * 60)',
+  'MAX_SNAPSHOT_KEYS: u64 = 10_000',
+  'cache.backend(CACHE_PREFIX, SNAPSHOT_TTL, MAX_SNAPSHOT_KEYS)',
+  '.set_with_ttl(key, value, SNAPSHOT_TTL)',
+  'ensure_cache_service(runtime_ctx)',
+  'Arc<dyn PublicCommentsSnapshotStore>',
+  'extensions.insert(store)',
+]) requireMarker(hostSnapshotAdapter, marker, hostSnapshotAdapterPath);
+for (const marker of ['redis::Client', 'RUSTOK_REDIS_URL', 'REDIS_URL']) {
+  requireNoMarker(hostSnapshotAdapter, marker, hostSnapshotAdapterPath);
+}
+
+for (const marker of [
+  '#[path = "blog_public_comments_snapshot.rs"]',
+  'mod blog_public_comments_snapshot;',
+  'blog_public_comments_snapshot::register(&mut extensions, &runtime_ctx);',
+]) requireMarker(hostRuntimeComposition, marker, hostRuntimeCompositionPath);
 
 const directBypasses = [...service.matchAll(/\.comments\s*\.\s*([a-z_]+)\s*\(/g)].map((match) => match[1]);
 if (directBypasses.length > 0) {
@@ -322,9 +409,18 @@ for (const marker of [
   'source_verified_no_compile',
   'typed storefront comments availability',
   'CommentService::with_comments_thread_port',
-  'remote transport remains pending',
-  'cached snapshot and comment-form fallback remain planned',
 ]) requireMarker(plan, marker, planPath);
+
+for (const marker of [
+  'storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending',
+  'one Blog snapshot policy for both storefront transports',
+  'comments_owner_only',
+  'TTL 900 seconds',
+  'maximum 10,000 keys',
+  'cachedSnapshot',
+  'comment-form fallback is still a separate unfinished result',
+  'No tests, Cargo commands, Node verifiers',
+]) requireMarker(slice99, marker, slice99Path);
 
 if (failures.length > 0) {
   console.error('Blog Comments port boundary verification failed:');
@@ -332,4 +428,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog Comments consumer port, injection seam, and storefront read-degradation source boundary is consistent');
+console.log('Blog Comments consumer, shared cached snapshot fallback, and storefront transport boundary is consistent');

--- a/scripts/verify/verify-blog-comments-port-boundary.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.mjs
@@ -144,7 +144,7 @@ if (evidence) {
 }
 
 if (fallbackEvidence) {
-  if (fallbackEvidence.schema_version !== 3) failures.push(`${fallbackEvidencePath}: schema_version drift`);
+  if (fallbackEvidence.schema_version !== 2) failures.push(`${fallbackEvidencePath}: schema_version drift`);
   if (
     fallbackEvidence.module !== 'blog' ||
     fallbackEvidence.role !== 'consumer' ||

--- a/scripts/verify/verify-blog-comments-port-boundary.test.mjs
+++ b/scripts/verify/verify-blog-comments-port-boundary.test.mjs
@@ -6,709 +6,75 @@ import './verify-blog-comments-storefront-native-port-injection.test.mjs';
 import './verify-blog-comments-admin-native-port-injection.test.mjs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const verifier = path.resolve('scripts/verify/verify-blog-comments-port-boundary.mjs');
-const operations = [
-  'create_comment',
-  'get_comment',
-  'list_comments_for_target',
-  'list_public_comments_for_target',
-  'update_comment',
-  'set_comment_status',
-  'delete_comment',
-];
-const injectionConstructor = 'CommentService::with_comments_thread_port';
-const injectionSignature = 'fn(DatabaseConnection, Arc<dyn CommentsThreadPort>) -> CommentService';
-const injectionTest =
-  'services::comment::port_injection_tests::comment_service_accepts_an_injected_comments_thread_port';
-const injectionCommand =
-  `cargo test -p rustok-blog --lib ${injectionTest} -- --exact`;
-const httpHarnessTest = 'controllers::tests::blog_http_runtime_exposes_comments_port_selection';
-const httpHarnessCommand = `cargo test -p rustok-blog --lib ${httpHarnessTest} -- --exact`;
-const graphqlHarnessTest =
-  'graphql::runtime_data::tests::graphql_runtime_data_exposes_comments_port_selection';
-const graphqlHarnessCommand =
-  `cargo test -p rustok-blog --lib ${graphqlHarnessTest} -- --exact`;
-const storefrontHarnessTest =
-  'transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection';
-const storefrontHarnessCommand =
-  `cargo test -p rustok-blog-storefront --features ssr ${storefrontHarnessTest} -- --exact`;
-const adminHarnessTest =
-  'transport::native_server_adapter::tests::admin_native_runtime_exposes_comments_port_selection';
-const adminHarnessCommand =
-  `cargo test -p rustok-blog-admin --features ssr ${adminHarnessTest} -- --exact`;
+const files = {
+  matrix: 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json',
+  fallback: 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+  httpEvidence: 'crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json',
+  graphqlEvidence: 'crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json',
+  storefrontEvidence:
+    'crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json',
+  adminEvidence: 'crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json',
+  providerRegistry: 'crates/rustok-comments/contracts/comments-fba-registry.json',
+  consumerRegistry: 'crates/rustok-blog/contracts/blog-fba-registry.json',
+  facade: 'crates/rustok-blog/src/lib.rs',
+  service: 'crates/rustok-blog/src/services/comment.rs',
+  snapshot: 'crates/rustok-blog/src/public_comments_snapshot.rs',
+  httpRuntime: 'crates/rustok-blog/src/controllers/mod.rs',
+  httpController: 'crates/rustok-blog/src/controllers/comments.rs',
+  manifest: 'crates/rustok-blog/rustok-module.toml',
+  graphqlModule: 'crates/rustok-blog/src/graphql/mod.rs',
+  graphqlRuntime: 'crates/rustok-blog/src/graphql/runtime_data.rs',
+  graphqlTypes: 'crates/rustok-blog/src/graphql/types.rs',
+  graphqlMutation: 'crates/rustok-blog/src/graphql/mutation.rs',
+  storefrontModel: 'crates/rustok-blog/storefront/src/model.rs',
+  storefrontGraphql: 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs',
+  storefrontNative: 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs',
+  storefrontUi: 'crates/rustok-blog/storefront/src/ui/leptos.rs',
+  adminNative: 'crates/rustok-blog/admin/src/transport/native_server_adapter.rs',
+  hostSnapshot: 'apps/server/src/services/blog_public_comments_snapshot.rs',
+  hostComposition: 'apps/server/src/services/module_event_dispatcher.rs',
+  serverBuild: 'apps/server/build.rs',
+  serverSchema: 'apps/server/src/graphql/schema.rs',
+  plan: 'crates/rustok-blog/docs/implementation-plan.md',
+  slice99: 'crates/rustok-blog/docs/implementation-plan-slice-99.md',
+};
 
-function write(root, relativePath, content) {
+function copy(root, relativePath) {
   const target = path.join(root, relativePath);
   mkdirSync(path.dirname(target), { recursive: true });
-  writeFileSync(target, content);
+  writeFileSync(target, readFileSync(relativePath));
 }
 
-function fixture({
-  directBypass = false,
-  missingDeadline = false,
-  missingIdempotency = false,
-  missingPublicRead = false,
-  missingAvailabilityField = false,
-  broadNativeFallback = false,
-  missingGraphqlAvailability = false,
-  missingUiState = false,
-  missingInjectionConstructor = false,
-  missingInjectionHarness = false,
-  injectionRuntimePromoted = false,
-  statusDrift = false,
-  fallbackPromoted = false,
-} = {}) {
+function mutate(root, relativePath, transform) {
+  const target = path.join(root, relativePath);
+  const source = readFileSync(target, 'utf8');
+  writeFileSync(target, transform(source));
+}
+
+function mutateJson(root, relativePath, transform) {
+  mutate(root, relativePath, (source) => {
+    const value = JSON.parse(source);
+    transform(value);
+    return JSON.stringify(value, null, 2);
+  });
+}
+
+function fixture(mutator) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-comments-port-'));
-  const evidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-consumer-static-matrix.json';
-  const fallbackEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
-  const httpEvidencePath = 'crates/rustok-blog/contracts/evidence/blog-comments-http-port-injection.json';
-  const graphqlEvidencePath =
-    'crates/rustok-blog/contracts/evidence/blog-comments-graphql-port-injection.json';
-  const storefrontEvidencePath =
-    'crates/rustok-blog/contracts/evidence/blog-comments-storefront-native-port-injection.json';
-  const adminEvidencePath =
-    'crates/rustok-blog/contracts/evidence/blog-comments-admin-native-port-injection.json';
-  const facadePath = 'crates/rustok-blog/src/lib.rs';
-  const servicePath = 'crates/rustok-blog/src/services/comment.rs';
-  const httpRuntimePath = 'crates/rustok-blog/src/controllers/mod.rs';
-  const httpControllerPath = 'crates/rustok-blog/src/controllers/comments.rs';
-  const manifestPath = 'crates/rustok-blog/rustok-module.toml';
-  const graphqlModulePath = 'crates/rustok-blog/src/graphql/mod.rs';
-  const graphqlRuntimeDataPath = 'crates/rustok-blog/src/graphql/runtime_data.rs';
-  const graphqlOwnerPath = 'crates/rustok-blog/src/graphql/types.rs';
-  const graphqlMutationPath = 'crates/rustok-blog/src/graphql/mutation.rs';
-  const serverCodegenPath = 'apps/server/build.rs';
-  const serverSchemaPath = 'apps/server/src/graphql/schema.rs';
-  const storefrontModelPath = 'crates/rustok-blog/storefront/src/model.rs';
-  const storefrontGraphqlPath = 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs';
-  const storefrontNativePath = 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs';
-  const storefrontUiPath = 'crates/rustok-blog/storefront/src/ui/leptos.rs';
-  const adminNativePath = 'crates/rustok-blog/admin/src/transport/native_server_adapter.rs';
-  const providerRegistryPath = 'crates/rustok-comments/contracts/comments-fba-registry.json';
-  const consumerRegistryPath = 'crates/rustok-blog/contracts/blog-fba-registry.json';
-
-  write(root, facadePath, 'pub use rustok_comments::CommentsThreadPort;');
-
-  write(
-    root,
-    servicePath,
-    `
-comments_thread_port: Arc<dyn CommentsThreadPort>
-${missingInjectionConstructor ? '' : `
-let comments_thread_port = in_process_comments_thread_port(db.clone(), event_bus);
-Self::with_comments_thread_port(db, comments_thread_port)
-pub fn with_comments_thread_port(
-comments_thread_port: Arc<dyn CommentsThreadPort>,
-Self {
-            db,
-            comments_thread_port,
-        }
-`}
-${missingInjectionHarness ? '' : `
-mod port_injection_tests
-fn comment_service_accepts_an_injected_comments_thread_port()
-) -> CommentService = CommentService::with_comments_thread_port;
-`}
-.comments_thread_port
-.create_comment(
-.get_comment(
-.list_comments_for_target(
-${missingPublicRead ? '' : '.list_public_comments_for_target('}
-.update_comment(
-.set_comment_status(
-.delete_comment(
-comments_write_port_context(
-comments_read_port_context(
-comments_public_read_port_context(
-PortActor::service(PUBLIC_COMMENTS_PORT_ACTOR)
-${missingDeadline ? '' : '.with_deadline(std::time::Duration::from_secs(2))'}
-${missingIdempotency ? '' : '.with_idempotency_key(format!("{correlation_id}:command:{command_id}"))'}
-PortErrorKind::NotFound => rustok_core::error::ErrorKind::NotFound
-PortErrorKind::Forbidden => rustok_core::error::ErrorKind::Forbidden
-PortErrorKind::Validation => rustok_core::error::ErrorKind::Validation
-PortErrorKind::Unavailable => rustok_core::error::ErrorKind::ExternalService
-PortErrorKind::Timeout => rustok_core::error::ErrorKind::Timeout
-BlogError::Rich(Box::new(
-.with_error_code(error.code)
-body: input.content
-content: record.body
-content_text: record.body_text
-Self::ensure_blog_target(&existing)?
-ensure_post_exists
-DomainCreateCommentInput
-TARGET_TYPE_BLOG_POST
-post_id
-${directBypass ? '.comments.get_comment(' : ''}
-`,
-  );
-
-  write(
-    root,
-    httpRuntimePath,
-    `
-use rustok_comments::CommentsThreadPort;
-use std::sync::Arc;
-comments_thread_port: Option<Arc<dyn CommentsThreadPort>>
-fn comment_service(&self) -> CommentService {
-if let Some(comments_thread_port) = self.comments_thread_port.clone() {
-CommentService::with_comments_thread_port(self.db_clone(), comments_thread_port)
-} else {
-CommentService::new(self.db_clone(), self.event_bus())
-}
-}
-comments_thread_port: runtime.shared_get::<Arc<dyn CommentsThreadPort>>()
-mod tests
-fn blog_http_runtime_exposes_comments_port_selection()
-let selector: fn(&BlogHttpRuntime) -> CommentService = BlogHttpRuntime::comment_service;
-`,
-  );
-  write(root, httpControllerPath, 'let service = runtime.comment_service();');
-
-  write(
-    root,
-    manifestPath,
-    '[provides.graphql]\nquery = "graphql::BlogQuery"\nmutation = "graphql::BlogMutation"\nruntime_data_factory = "graphql::attach_schema_data"',
-  );
-  write(
-    root,
-    graphqlModulePath,
-    'mod runtime_data;\npub use runtime_data::{BlogGraphqlRuntimeData, attach_schema_data};',
-  );
-  write(
-    root,
-    serverCodegenPath,
-    'graphql_runtime_data_factory: Option<String> graphql_runtime_data_factory_expr builder = builder.data({factory}(inputs)?);',
-  );
-  write(
-    root,
-    serverSchemaPath,
-    'schema_codegen::attach_module_graphql_data(builder, &graphql_runtime_inputs)',
-  );
-  write(
-    root,
-    graphqlRuntimeDataPath,
-    `
-use rustok_api::graphql::GraphqlRuntimeInputs;
-use rustok_comments::CommentsThreadPort;
-comments_thread_port: Option<Arc<dyn CommentsThreadPort>>
-pub fn attach_schema_data(
-inputs.shared_get::<Arc<dyn CommentsThreadPort>>()
-pub(crate) fn comment_service(
-match self.comments_thread_port.clone()
-Some(comments_thread_port)
-CommentService::with_comments_thread_port(db, comments_thread_port)
-None => CommentService::new(db, event_bus)
-fn graphql_runtime_data_exposes_comments_port_selection()
-let factory: fn(&GraphqlRuntimeInputs) -> Result<BlogGraphqlRuntimeData, String>
-BlogGraphqlRuntimeData::comment_service;
-`,
-  );
-
-  write(
-    root,
-    storefrontModelPath,
-    `
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum BlogCommentsAvailability {
-Available,
-Unavailable,
-Timeout,
-}
-${missingAvailabilityField ? '' : 'pub availability: BlogCommentsAvailability'}
-`,
-  );
-  write(
-    root,
-    storefrontNativePath,
-    `
-use std::sync::Arc;
-#[server(prefix = "/api/fn", endpoint = "blog/storefront-data")]
-let runtime_ctx = expect_context::<HostRuntimeContext>();
-fn comment_service(
-runtime_ctx: &rustok_api::HostRuntimeContext,
-runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()
-rustok_blog::CommentService::with_comments_thread_port(
-rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)
-comment_service(&runtime_ctx, event_bus.clone())
-.list_for_post_with_locale_fallback(
-SecurityContext::public_read()
-fn comments_read_availability(
-rustok_core::error::ErrorKind::ExternalService
-Some(BlogCommentsAvailability::Unavailable)
-rustok_core::error::ErrorKind::Timeout
-Some(BlogCommentsAvailability::Timeout)
-let Some(availability) = comments_read_availability(&error) else
-return Err(ServerFnError::new(error));
-availability: BlogCommentsAvailability::Available
-items: Vec::new()
-total: 0
-${broadNativeFallback ? 'Err(_) => BlogCommentList' : ''}
-fn storefront_native_runtime_exposes_comments_port_selection()
-) -> rustok_blog::CommentService = comment_service;
-`,
-  );
-  write(
-    root,
-    graphqlOwnerPath,
-    `
-use super::runtime_data::BlogGraphqlRuntimeData;
-async fn public_comments(
-let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
-let service = runtime.comment_service(db.clone(), event_bus.clone());
-async fn moderation_comments(
-let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
-let service = runtime.comment_service(db.clone(), event_bus.clone());
-pub enum GqlBlogCommentsAvailability
-pub availability: GqlBlogCommentsAvailability
-fn graphql_comments_read_availability(error: &BlogError)
-ErrorKind::ExternalService => Some(GqlBlogCommentsAvailability::Unavailable)
-ErrorKind::Timeout => Some(GqlBlogCommentsAvailability::Timeout)
-${missingGraphqlAvailability ? '' : 'let Some(availability) = graphql_comments_read_availability(&error) else'}
-return Err(async_graphql::Error::new(error.to_string()));
-GqlBlogCommentsAvailability::Available
-`,
-  );
-  write(
-    root,
-    graphqlMutationPath,
-    `
-use super::runtime_data::BlogGraphqlRuntimeData;
-async fn moderate_comment(
-let runtime = ctx.data::<BlogGraphqlRuntimeData>()?;
-runtime
-.comment_service(db.clone(), event_bus.clone())
-`,
-  );
-  write(
-    root,
-    storefrontGraphqlPath,
-    'publicComments(locale: $locale, page: $commentsPage, perPage: $commentsPerPage) { availability total items',
-  );
-  write(
-    root,
-    storefrontUiPath,
-    missingUiState
-      ? ''
-      : `
-comments.availability != BlogCommentsAvailability::Available
-BlogCommentsAvailability::Unavailable
-BlogCommentsAvailability::Timeout
-Comments are temporarily unavailable. The article is still available.
-Comments took too long to load. The article is still available.
-`,
-  );
-
-  write(
-    root,
-    adminNativePath,
-    `
-use std::sync::Arc;
-struct NativeContext {
-comments_thread_port: Option<Arc<dyn rustok_blog::CommentsThreadPort>>
-}
-let runtime = expect_context::<HostRuntimeContext>();
-if auth.tenant_id != tenant.id
-runtime.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()
-fn comment_service(context: &NativeContext) -> rustok_blog::CommentService {
-context.comments_thread_port.clone()
-rustok_blog::CommentService::with_comments_thread_port(
-rustok_blog::CommentService::new(context.db.clone(), context.event_bus.clone())
-}
-fn require_manage_permission(
-&[rustok_api::Permission::BLOG_POSTS_MANAGE]
-"Permission denied: blog_posts:manage required"
-#[server(prefix = "/api/fn", endpoint = "blog/admin/moderation-comments")]
-require_manage_permission(&context.auth)?;
-comment_service(&context)
-page: page.max(1)
-per_page: per_page.clamp(1, 100)
-.list_for_post_with_locale_fallback(
-.map_err(ServerFnError::new)?;
-#[server(prefix = "/api/fn", endpoint = "blog/admin/moderate-comment")]
-require_manage_permission(&context.auth)?;
-comment_service(&context)
-.moderate_comment(
-.map_err(ServerFnError::new)?;
-#[cfg(feature = "ssr")]
-fn optional_text
-fn admin_native_runtime_exposes_comments_port_selection()
-let selector: fn(&NativeContext) -> rustok_blog::CommentService = comment_service;
-`,
-  );
-
-  const cases = operations.map((operation) => ({
-    operation,
-    assertions: ['typed_port_error_mapping', 'context_deadline_preserved'],
-    runtime_evidence: 'pending',
-  }));
-  write(
-    root,
-    evidencePath,
-    JSON.stringify({
-      schema_version: 3,
-      module: 'blog',
-      surface: 'comments_port_boundary',
-      role: 'consumer',
-      provider: 'comments',
-      generated_from: consumerRegistryPath,
-      status: statusDrift ? 'runtime_verified' : 'source_verified_no_compile',
-      compile_policy: 'not_run_by_request',
-      source_contract: {
-        consumer_service: servicePath,
-        provider_registry: providerRegistryPath,
-        consumer_registry: consumerRegistryPath,
-        injection_constructor: injectionConstructor,
-      },
-      profiles: {
-        source_verified: ['in_process'],
-        pending: ['remote_adapter_placeholder'],
-      },
-      adapter_injection: {
-        status: 'executable_no_run',
-        runtime_status: injectionRuntimePromoted ? 'passed' : 'not_run',
-        source: servicePath,
-        constructor: injectionConstructor,
-        signature: injectionSignature,
-        test: injectionTest,
-        command: injectionCommand,
-        default_profile: 'in_process',
-        remote_transport_implementation: 'pending',
-      },
-      cases,
-      fallback_smoke: {
-        status: 'planned',
-        profiles: ['embedded_native'],
-        degraded_modes: ['hide_comment_form', 'show_cached_thread_snapshot'],
-        runtime_evidence: 'pending',
-      },
-    }),
-  );
-
-  write(
-    root,
-    httpEvidencePath,
-    JSON.stringify({
-      schema_version: 1,
-      module: 'blog',
-      surface: 'comments_http_port_injection',
-      role: 'consumer',
-      provider: 'comments',
-      status: 'source_verified_no_compile',
-      compile_policy: 'not_run_by_request',
-      runtime_status: 'not_run',
-      source_contract: {
-        http_runtime: httpRuntimePath,
-        moderation_controller: httpControllerPath,
-        consumer_service: servicePath,
-        consumer_matrix: evidencePath,
-      },
-      profiles: {
-        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
-        pending: ['remote_transport_implementation'],
-      },
-      composition: {
-        host_context: 'rustok_api::HostRuntimeContext',
-        shared_value: 'Arc<dyn CommentsThreadPort>',
-        lookup: 'HostRuntimeContext::shared_get',
-        selector: 'BlogHttpRuntime::comment_service',
-        injected_constructor: 'CommentService::with_comments_thread_port',
-        fallback_constructor: 'CommentService::new',
-        http_operation: 'moderate_comment',
-      },
-      harness: {
-        status: 'executable_no_run',
-        runtime_status: 'not_run',
-        source: httpRuntimePath,
-        test: httpHarnessTest,
-        command: httpHarnessCommand,
-      },
-      non_claims: [],
-    }),
-  );
-
-  write(
-    root,
-    graphqlEvidencePath,
-    JSON.stringify({
-      schema_version: 1,
-      module: 'blog',
-      surface: 'comments_graphql_port_injection',
-      role: 'consumer',
-      provider: 'comments',
-      status: 'source_verified_no_compile',
-      compile_policy: 'not_run_by_request',
-      runtime_status: 'not_run',
-      source_contract: {
-        module_manifest: manifestPath,
-        graphql_module: graphqlModulePath,
-        runtime_data: graphqlRuntimeDataPath,
-        comment_reads: graphqlOwnerPath,
-        comment_mutation: graphqlMutationPath,
-        consumer_service: servicePath,
-        consumer_matrix: evidencePath,
-        server_codegen: serverCodegenPath,
-        server_schema: serverSchemaPath,
-      },
-      profiles: {
-        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
-        pending: ['remote_transport_implementation'],
-      },
-      composition: {
-        host_inputs: 'rustok_api::graphql::GraphqlRuntimeInputs',
-        manifest_factory: 'graphql::attach_schema_data',
-        schema_attachment: 'schema_codegen::attach_module_graphql_data',
-        schema_data: 'BlogGraphqlRuntimeData',
-        shared_value: 'Arc<dyn CommentsThreadPort>',
-        lookup: 'GraphqlRuntimeInputs::shared_get',
-        selector: 'BlogGraphqlRuntimeData::comment_service',
-        injected_constructor: 'CommentService::with_comments_thread_port',
-        fallback_constructor: 'CommentService::new',
-        graphql_operations: ['public_comments', 'moderation_comments', 'moderate_comment'],
-      },
-      harness: {
-        status: 'executable_no_run',
-        runtime_status: 'not_run',
-        source: graphqlRuntimeDataPath,
-        test: graphqlHarnessTest,
-        command: graphqlHarnessCommand,
-      },
-      registration: {
-        standalone_verifier:
-          'scripts/verify/verify-blog-comments-graphql-port-injection.mjs',
-        focused_fixture:
-          'scripts/verify/verify-blog-comments-graphql-port-injection.test.mjs',
-        blog_fba_package_chain: 'pending',
-      },
-    }),
-  );
-
-  write(
-    root,
-    storefrontEvidencePath,
-    JSON.stringify({
-      schema_version: 1,
-      module: 'blog',
-      surface: 'comments_storefront_native_port_injection',
-      role: 'consumer',
-      provider: 'comments',
-      status: 'source_verified_no_compile',
-      compile_policy: 'not_run_by_request',
-      runtime_status: 'not_run',
-      source_contract: {
-        blog_facade: facadePath,
-        native_adapter: storefrontNativePath,
-        consumer_service: servicePath,
-        consumer_matrix: evidencePath,
-        fallback_evidence: fallbackEvidencePath,
-      },
-      profiles: {
-        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
-        pending: ['remote_transport_implementation'],
-      },
-      composition: {
-        host_context: 'rustok_api::HostRuntimeContext',
-        shared_value: 'Arc<dyn rustok_blog::CommentsThreadPort>',
-        facade_reexport: 'pub use rustok_comments::CommentsThreadPort;',
-        lookup: 'HostRuntimeContext::shared_get',
-        selector: 'comment_service',
-        injected_constructor: 'CommentService::with_comments_thread_port',
-        fallback_constructor: 'CommentService::new',
-        native_endpoint: 'blog/storefront-data',
-        operation: 'list_public_comments_for_target',
-      },
-      availability: {
-        states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
-        degraded_error_kinds: ['ExternalService', 'Timeout'],
-        propagated_error_policy: 'all_other_blog_errors',
-      },
-      harness: {
-        status: 'executable_no_run',
-        runtime_status: 'not_run',
-        source: storefrontNativePath,
-        test: storefrontHarnessTest,
-        command: storefrontHarnessCommand,
-      },
-      registration: {
-        standalone_verifier:
-          'scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs',
-        focused_fixture:
-          'scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs',
-        blog_fba_package_chain: 'pending',
-      },
-      non_claims: [
-        'no remote network transport is implemented',
-        'no Rust or JavaScript test was run',
-        'no compile, database, browser, workflow, CI, or production result is recorded',
-      ],
-    }),
-  );
-
-  write(
-    root,
-    adminEvidencePath,
-    JSON.stringify({
-      schema_version: 1,
-      module: 'blog',
-      surface: 'comments_admin_native_port_injection',
-      role: 'consumer',
-      provider: 'comments',
-      status: 'source_verified_no_compile',
-      compile_policy: 'not_run_by_request',
-      runtime_status: 'not_run',
-      source_contract: {
-        admin_adapter: adminNativePath,
-        consumer_service: servicePath,
-        consumer_matrix: evidencePath,
-      },
-      profiles: {
-        source_verified: ['in_process_fallback', 'host_injected_port_selection'],
-        pending: ['remote_transport_implementation'],
-      },
-      composition: {
-        host_context: 'rustok_api::HostRuntimeContext',
-        native_context: 'NativeContext',
-        shared_value: 'Arc<dyn rustok_blog::CommentsThreadPort>',
-        lookup: 'HostRuntimeContext::shared_get',
-        selector: 'comment_service',
-        injected_constructor: 'CommentService::with_comments_thread_port',
-        fallback_constructor: 'CommentService::new',
-        native_endpoints: [
-          'blog/admin/moderation-comments',
-          'blog/admin/moderate-comment',
-        ],
-        port_operations: [
-          'list_comments_for_target',
-          'get_comment',
-          'set_comment_status',
-        ],
-      },
-      authorization: {
-        tenant_binding: 'AuthContext.tenant_id == TenantContext.id',
-        permission: 'blog_posts:manage',
-        checked_before_port_call: true,
-      },
-      moderation_policy: {
-        read_pagination: 'page >= 1; 1 <= per_page <= 100',
-        error_policy: 'all_blog_errors_propagated',
-        storefront_degradation_reused: false,
-      },
-      harness: {
-        status: 'executable_no_run',
-        runtime_status: 'not_run',
-        source: adminNativePath,
-        test: adminHarnessTest,
-        command: adminHarnessCommand,
-      },
-      registration: {
-        standalone_verifier:
-          'scripts/verify/verify-blog-comments-admin-native-port-injection.mjs',
-        focused_fixture:
-          'scripts/verify/verify-blog-comments-admin-native-port-injection.test.mjs',
-        blog_fba_package_chain: 'pending',
-      },
-      non_claims: [
-        'no remote network transport is implemented',
-        'no admin moderation error is degraded to an empty success payload',
-        'no Rust or JavaScript test was run',
-        'no compile, database, browser, workflow, CI, or production result is recorded',
-      ],
-    }),
-  );
-
-  write(
-    root,
-    fallbackEvidencePath,
-    JSON.stringify({
-      schema_version: 2,
-      module: 'blog',
-      role: 'consumer',
-      provider: 'comments',
-      generated_from: consumerRegistryPath,
-      status: 'source_verified_no_compile',
-      runner: 'scripts/verify/verify-blog-comments-port-boundary.mjs',
-      compile_policy: 'not_run_by_request',
-      runtime_status: 'not_run',
-      source_contract: {
-        consumer_service: servicePath,
-        consumer_error_mapping: servicePath,
-        provider_port_registry: providerRegistryPath,
-        graphql_owner: graphqlOwnerPath,
-        storefront_model: storefrontModelPath,
-        storefront_graphql: storefrontGraphqlPath,
-        storefront_native: storefrontNativePath,
-        storefront_ui: storefrontUiPath,
-      },
-      storefront_read_degradation: {
-        status: 'source_verified_no_compile',
-        runtime_status: 'not_run',
-        operation: 'list_public_comments_for_target',
-        transports: ['graphql', 'native_ssr'],
-        availability_states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
-        degraded_error_kinds: ['ExternalService', 'Timeout'],
-        propagated_error_policy: 'all_other_blog_errors',
-        degraded_payload: { items: [], total: 0 },
-        cached_thread_snapshot: 'planned',
-        comment_form_fallback: 'planned',
-        runtime_evidence: 'pending',
-      },
-      fallback_smoke: {
-        status: 'planned',
-        profiles: ['embedded_native'],
-        degraded_modes: ['hide_comment_form', 'show_cached_thread_snapshot'],
-        cases: [
-          {
-            operation: 'create_comment',
-            source_markers: ['ensure_post_exists', 'DomainCreateCommentInput', 'comments_thread_port', 'comments_write_port_context'],
-            typed_error_markers: ['PortErrorKind::Forbidden', 'PortErrorKind::Validation', 'PortErrorKind::Unavailable', 'ErrorKind::ExternalService', 'with_error_code(error.code)'],
-            degraded_mode: 'hide_comment_form',
-          },
-          {
-            operation: 'list_comments_for_target',
-            source_markers: ['list_comments_for_target', 'TARGET_TYPE_BLOG_POST', 'post_id', 'comments_read_port_context'],
-            typed_error_markers: ['PortErrorKind::NotFound', 'PortErrorKind::Unavailable', 'PortErrorKind::Timeout', 'ErrorKind::ExternalService', 'ErrorKind::Timeout', 'with_error_code(error.code)'],
-            degraded_mode: 'show_cached_thread_snapshot',
-          },
-        ],
-        runtime_evidence: 'pending',
-      },
-    }),
-  );
-
-  write(root, providerRegistryPath, JSON.stringify({ ports: [{ name: 'CommentsThreadPort', operations }] }));
-  write(
-    root,
-    consumerRegistryPath,
-    JSON.stringify({
-      provider_dependencies: [{ module: 'comments', port: 'CommentsThreadPort', operations }],
-      contract_tests: {
-        status: 'source_verified_no_compile',
-        runtime_status: 'pending',
-        adapter_injection: {
-          status: 'executable_no_run',
-          runtime_status: injectionRuntimePromoted ? 'passed' : 'not_run',
-          source: servicePath,
-          constructor: injectionConstructor,
-          signature: injectionSignature,
-          test: injectionTest,
-          command: injectionCommand,
-          remote_transport_implementation: 'pending',
-        },
-        cases: operations.map((operation) => ({ operation })),
-        fallback_smoke: { status: fallbackPromoted ? 'source_verified_no_compile' : 'planned' },
-      },
-    }),
-  );
-  write(
-    root,
-    'crates/rustok-blog/docs/implementation-plan.md',
-    'blog-comments-consumer-static-matrix.json blog-comments-runtime-fallback-smoke.json blog-comments-http-port-injection.json verify-blog-comments-http-port-injection.mjs verify-blog-comments-http-port-injection.test.mjs blog-comments-graphql-port-injection.json verify-blog-comments-graphql-port-injection.mjs verify-blog-comments-graphql-port-injection.test.mjs blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs blog-comments-admin-native-port-injection.json verify-blog-comments-admin-native-port-injection.mjs verify-blog-comments-admin-native-port-injection.test.mjs BlogGraphqlRuntimeData graphql::attach_schema_data schema_codegen::attach_module_graphql_data GraphQL Comments host selection is source-locked storefront native SSR Comments host selection is source-locked admin native SSR Comments host selection is source-locked Blog FBA package-chain registration remains pending verify:blog:comments-port-boundary test:verify:blog:comments-port-boundary source_verified_no_compile typed storefront comments availability CommentService::with_comments_thread_port BlogHttpRuntime::comment_service HTTP moderation remote transport remains pending remote network transport remains pending cached snapshot and comment-form fallback remain planned Slice 59 Slice 60 Slice 61 Slice 62 Slice 63 Slice 64 Slice 65 Slice 66',
-  );
-
+  for (const relativePath of Object.values(files)) copy(root, relativePath);
+  mutator?.(root);
   return root;
 }
 
@@ -720,8 +86,8 @@ function run(root) {
   });
 }
 
-function rejects(options) {
-  const root = fixture(options);
+function rejects(mutator) {
+  const root = fixture(mutator);
   try {
     return run(root);
   } finally {
@@ -729,7 +95,11 @@ function rejects(options) {
   }
 }
 
-test('accepts the canonical Blog Comments consumer port boundary', () => {
+function removeMarker(file, marker) {
+  return (root) => mutate(root, file, (source) => source.replace(marker, ''));
+}
+
+test('accepts the canonical Blog Comments consumer and cached snapshot boundary', () => {
   const root = fixture();
   try {
     const result = run(root);
@@ -739,66 +109,103 @@ test('accepts the canonical Blog Comments consumer port boundary', () => {
   }
 });
 
-test('rejects a direct CommentsService bypass', () => {
-  assert.notEqual(rejects({ directBypass: true }).status, 0);
-});
-
-test('rejects a port context without deadline', () => {
-  assert.notEqual(rejects({ missingDeadline: true }).status, 0);
-});
-
-test('rejects writes without idempotency keys', () => {
-  assert.notEqual(rejects({ missingIdempotency: true }).status, 0);
-});
-
-test('rejects removal of the approved public-read port operation', () => {
-  assert.notEqual(rejects({ missingPublicRead: true }).status, 0);
-});
-
-test('rejects removal of the Comments port injection constructor', () => {
-  const result = rejects({ missingInjectionConstructor: true });
+test('rejects a direct Comments service bypass', () => {
+  const result = rejects((root) =>
+    mutate(root, files.service, (source) => `${source}\nself.comments.get_comment(`),
+  );
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /with_comments_thread_port/);
 });
 
-test('rejects removal of the compile-only injection harness', () => {
-  const result = rejects({ missingInjectionHarness: true });
+test('rejects removal of the approved-only snapshot validation', () => {
+  const result = rejects(
+    removeMarker(files.snapshot, 'item.post_id == identity.post_id && item.status == "approved"'),
+  );
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /port_injection_tests|injected_comments_thread_port/);
 });
 
-test('rejects runtime promotion of the unexecuted injection harness', () => {
-  const result = rejects({ injectionRuntimePromoted: true });
+test('rejects removal of the bounded snapshot payload limit', () => {
+  const result = rejects(
+    removeMarker(files.snapshot, 'MAX_PUBLIC_COMMENTS_SNAPSHOT_BYTES: usize = 256 * 1024'),
+  );
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /base injection seam drift/);
 });
 
-test('rejects a storefront model without typed availability', () => {
-  assert.notEqual(rejects({ missingAvailabilityField: true }).status, 0);
-});
-
-test('rejects broad native fallback for every error', () => {
-  const result = rejects({ broadNativeFallback: true });
+test('rejects snapshot fallback for non-availability errors', () => {
+  const result = rejects(
+    removeMarker(files.snapshot, 'return Err(error);'),
+  );
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /forbidden Err\(_\) => BlogCommentList/);
 });
 
-test('rejects GraphQL degradation without typed classification', () => {
-  assert.notEqual(rejects({ missingGraphqlAvailability: true }).status, 0);
+test('rejects removal of GraphQL cached-snapshot disclosure', () => {
+  const result = rejects(
+    removeMarker(files.graphqlTypes, 'cached_snapshot: read.cached_snapshot'),
+  );
+  assert.notEqual(result.status, 0);
 });
 
-test('rejects removal of the storefront unavailable and timeout state', () => {
-  assert.notEqual(rejects({ missingUiState: true }).status, 0);
+test('rejects removal of the native snapshot store lookup', () => {
+  const result = rejects(
+    removeMarker(
+      files.storefrontNative,
+      'shared_get::<Arc<dyn PublicCommentsSnapshotStore>>()',
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects removal of stale snapshot UI disclosure', () => {
+  const result = rejects(
+    removeMarker(files.storefrontUi, 'Showing a recent cached snapshot.'),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects a host snapshot adapter that creates a Redis client directly', () => {
+  const result = rejects((root) =>
+    mutate(root, files.hostSnapshot, (source) => `${source}\nredis::Client::open("redis://example")`),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects removal of host runtime snapshot registration', () => {
+  const result = rejects(
+    removeMarker(
+      files.hostComposition,
+      'blog_public_comments_snapshot::register(&mut extensions, &runtime_ctx);',
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects fallback evidence that demotes cached snapshot to planned', () => {
+  const result = rejects((root) =>
+    mutateJson(root, files.fallback, (evidence) => {
+      evidence.storefront_read_degradation.cached_thread_snapshot = 'planned';
+    }),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects fallback evidence that claims comment-form completion', () => {
+  const result = rejects((root) =>
+    mutateJson(root, files.fallback, (evidence) => {
+      evidence.storefront_read_degradation.comment_form_fallback = 'source_verified_no_compile';
+    }),
+  );
+  assert.notEqual(result.status, 0);
 });
 
 test('rejects runtime status promotion without execution', () => {
-  const result = rejects({ statusDrift: true });
+  const result = rejects((root) =>
+    mutateJson(root, files.fallback, (evidence) => {
+      evidence.runtime_status = 'passed';
+    }),
+  );
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /status drift/);
 });
 
-test('rejects source promotion of planned cached snapshot and form fallback', () => {
-  const result = rejects({ fallbackPromoted: true });
+test('rejects cached snapshot plan drift', () => {
+  const result = rejects((root) => writeFileSync(path.join(root, files.slice99), ''));
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /contract-test status drift/);
 });

--- a/scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs
@@ -160,6 +160,8 @@ if (
   fallbackEvidence?.schema_version !== 2 ||
   fallbackEvidence?.status !== 'source_verified_no_compile' ||
   fallbackEvidence?.runtime_status !== 'not_run' ||
+  fallbackEvidence?.storefront_read_degradation?.cached_thread_snapshot !==
+    'source_verified_no_compile' ||
   !sameSet(
     fallbackEvidence?.storefront_read_degradation?.availability_states ?? [],
     ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
@@ -183,16 +185,16 @@ for (const marker of [
   'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()',
   'rustok_blog::CommentService::with_comments_thread_port(',
   'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)',
-  'comment_service(&runtime_ctx, event_bus.clone())',
-  '.list_for_post_with_locale_fallback(',
-  'SecurityContext::public_read()',
-  'fn comments_read_availability(',
-  'ErrorKind::ExternalService',
+  'let comments = comment_service(&runtime_ctx, event_bus.clone());',
+  'runtime_ctx.shared_get::<Arc<dyn PublicCommentsSnapshotStore>>()',
+  'list_public_comments_with_snapshot(',
+  'availability: map_comments_availability(public_comments.availability)',
+  'cached_snapshot: public_comments.cached_snapshot',
+  'fn map_comments_availability(',
+  'PublicCommentsAvailability::Unavailable',
   'BlogCommentsAvailability::Unavailable',
-  'ErrorKind::Timeout',
+  'PublicCommentsAvailability::Timeout',
   'BlogCommentsAvailability::Timeout',
-  'let Some(availability) = comments_read_availability(&error) else',
-  'return Err(ServerFnError::new(error));',
   'fn storefront_native_runtime_exposes_comments_port_selection()',
   ') -> rustok_blog::CommentService = comment_service;',
 ]) requireMarker(nativeAdapter, marker, nativeAdapterPath);
@@ -208,6 +210,7 @@ if (countMarker(nativeAdapter, 'comment_service(&runtime_ctx, event_bus.clone())
 }
 requireNoMarker(nativeAdapter, 'rustok_comments::CommentsThreadPort', nativeAdapterPath);
 requireNoMarker(nativeAdapter, 'Err(_) => BlogCommentList', nativeAdapterPath);
+requireNoMarker(nativeAdapter, 'fn comments_read_availability(', nativeAdapterPath);
 
 const lookupIndex = nativeAdapter.indexOf(
   'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()',
@@ -245,4 +248,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log('Blog storefront native Comments host selection and typed degradation source boundary is consistent');
+console.log('Blog storefront native Comments host selection and shared cached-snapshot degradation boundary is consistent');

--- a/scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs
@@ -2,7 +2,13 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -21,192 +27,40 @@ const consumerMatrixPath =
 const fallbackEvidencePath =
   'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json';
 const planPath = 'crates/rustok-blog/docs/implementation-plan.md';
-const harnessTest =
-  'transport::native_server_adapter::tests::storefront_native_runtime_exposes_comments_port_selection';
-const harnessCommand =
-  `cargo test -p rustok-blog-storefront --features ssr ${harnessTest} -- --exact`;
+const fixtureFiles = [
+  evidencePath,
+  facadePath,
+  nativeAdapterPath,
+  servicePath,
+  consumerMatrixPath,
+  fallbackEvidencePath,
+  planPath,
+];
 
-function write(root, relativePath, content) {
+function copy(root, relativePath) {
   const target = path.join(root, relativePath);
   mkdirSync(path.dirname(target), { recursive: true });
-  writeFileSync(target, content);
+  writeFileSync(target, readFileSync(relativePath));
 }
 
-function fixture({
-  missingFacade = false,
-  missingLookup = false,
-  missingInjected = false,
-  missingFallback = false,
-  directReadConstruction = false,
-  missingSelectorHandoff = false,
-  missingPublicRead = false,
-  broadFallback = false,
-  missingAvailability = false,
-  missingHarness = false,
-  runtimePromoted = false,
-  adminStillPending = false,
-  remotePromoted = false,
-  registrationPromoted = false,
-  planDrift = false,
-} = {}) {
+function mutate(root, relativePath, transform) {
+  const target = path.join(root, relativePath);
+  const source = readFileSync(target, 'utf8');
+  writeFileSync(target, transform(source));
+}
+
+function mutateJson(root, relativePath, transform) {
+  mutate(root, relativePath, (source) => {
+    const value = JSON.parse(source);
+    transform(value);
+    return JSON.stringify(value, null, 2);
+  });
+}
+
+function fixture(mutator) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-storefront-native-comments-'));
-
-  write(
-    root,
-    facadePath,
-    missingFacade ? '' : 'pub use rustok_comments::CommentsThreadPort;',
-  );
-
-  write(
-    root,
-    nativeAdapterPath,
-    `
-use std::sync::Arc;
-#[server(prefix = "/api/fn", endpoint = "blog/storefront-data")]
-let runtime_ctx = expect_context::<HostRuntimeContext>();
-fn comment_service(
-runtime_ctx: &rustok_api::HostRuntimeContext,
-${missingLookup ? '' : 'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()'}
-${missingInjected ? '' : 'rustok_blog::CommentService::with_comments_thread_port('}
-${missingFallback ? '' : 'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)'}
-${
-  missingSelectorHandoff
-    ? ''
-    : 'comment_service(&runtime_ctx, event_bus.clone())'
-}
-${directReadConstruction ? 'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus.clone())' : ''}
-.list_for_post_with_locale_fallback(
-SecurityContext::public_read()
-fn comments_read_availability(
-ErrorKind::ExternalService
-${missingAvailability ? '' : 'BlogCommentsAvailability::Unavailable'}
-ErrorKind::Timeout
-${missingAvailability ? '' : 'BlogCommentsAvailability::Timeout'}
-let Some(availability) = comments_read_availability(&error) else
-return Err(ServerFnError::new(error));
-${broadFallback ? 'Err(_) => BlogCommentList' : ''}
-${
-  missingHarness
-    ? ''
-    : `
-fn storefront_native_runtime_exposes_comments_port_selection()
-) -> rustok_blog::CommentService = comment_service;
-`
-}
-`,
-  );
-
-  write(
-    root,
-    servicePath,
-    `
-pub fn with_comments_thread_port(
-${missingPublicRead ? '' : '.list_public_comments_for_target('}
-comments_public_read_port_context(
-PortActor::service(PUBLIC_COMMENTS_PORT_ACTOR)
-`,
-  );
-
-  write(
-    root,
-    consumerMatrixPath,
-    JSON.stringify({
-      schema_version: 3,
-      status: 'source_verified_no_compile',
-      profiles: {
-        source_verified: ['in_process'],
-        pending: ['remote_adapter_placeholder'],
-      },
-    }),
-  );
-
-  write(
-    root,
-    fallbackEvidencePath,
-    JSON.stringify({
-      schema_version: 2,
-      status: 'source_verified_no_compile',
-      runtime_status: 'not_run',
-      storefront_read_degradation: {
-        availability_states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
-        degraded_error_kinds: ['ExternalService', 'Timeout'],
-        propagated_error_policy: 'all_other_blog_errors',
-      },
-    }),
-  );
-
-  const sourceVerified = ['in_process_fallback', 'host_injected_port_selection'];
-  const pending = ['remote_transport_implementation'];
-  if (adminStillPending) pending.unshift('admin_native_ssr_composition');
-  if (remotePromoted) {
-    sourceVerified.push('remote_transport_implementation');
-    pending.splice(pending.indexOf('remote_transport_implementation'), 1);
-  }
-
-  write(
-    root,
-    evidencePath,
-    JSON.stringify({
-      schema_version: 1,
-      module: 'blog',
-      surface: 'comments_storefront_native_port_injection',
-      role: 'consumer',
-      provider: 'comments',
-      status: 'source_verified_no_compile',
-      compile_policy: 'not_run_by_request',
-      runtime_status: runtimePromoted ? 'passed' : 'not_run',
-      source_contract: {
-        blog_facade: facadePath,
-        native_adapter: nativeAdapterPath,
-        consumer_service: servicePath,
-        consumer_matrix: consumerMatrixPath,
-        fallback_evidence: fallbackEvidencePath,
-      },
-      profiles: {
-        source_verified: sourceVerified,
-        pending,
-      },
-      composition: {
-        host_context: 'rustok_api::HostRuntimeContext',
-        shared_value: 'Arc<dyn rustok_blog::CommentsThreadPort>',
-        facade_reexport: 'pub use rustok_comments::CommentsThreadPort;',
-        lookup: 'HostRuntimeContext::shared_get',
-        selector: 'comment_service',
-        injected_constructor: 'CommentService::with_comments_thread_port',
-        fallback_constructor: 'CommentService::new',
-        native_endpoint: 'blog/storefront-data',
-        operation: 'list_public_comments_for_target',
-      },
-      availability: {
-        states: ['AVAILABLE', 'UNAVAILABLE', 'TIMEOUT'],
-        degraded_error_kinds: ['ExternalService', 'Timeout'],
-        propagated_error_policy: 'all_other_blog_errors',
-      },
-      harness: {
-        status: 'executable_no_run',
-        runtime_status: 'not_run',
-        source: nativeAdapterPath,
-        test: harnessTest,
-        command: harnessCommand,
-      },
-      registration: {
-        standalone_verifier:
-          'scripts/verify/verify-blog-comments-storefront-native-port-injection.mjs',
-        focused_fixture:
-          'scripts/verify/verify-blog-comments-storefront-native-port-injection.test.mjs',
-        blog_fba_package_chain: registrationPromoted ? 'registered' : 'pending',
-      },
-    }),
-  );
-
-  write(
-    root,
-    planPath,
-    planDrift
-      ? ''
-      : 'blog-comments-storefront-native-port-injection.json verify-blog-comments-storefront-native-port-injection.mjs verify-blog-comments-storefront-native-port-injection.test.mjs storefront native SSR Comments host selection is source-locked Blog FBA package-chain registration remains pending remote network transport remains pending Slice 63',
-  );
-
+  for (const file of fixtureFiles) copy(root, file);
+  mutator?.(root);
   return root;
 }
 
@@ -218,13 +72,17 @@ function run(root) {
   });
 }
 
-function rejects(options) {
-  const root = fixture(options);
+function rejects(mutator) {
+  const root = fixture(mutator);
   try {
     return run(root);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+}
+
+function removeMarker(file, marker) {
+  return (root) => mutate(root, file, (source) => source.replace(marker, ''));
 }
 
 test('accepts the canonical storefront native Comments composition boundary', () => {
@@ -238,61 +96,187 @@ test('accepts the canonical storefront native Comments composition boundary', ()
 });
 
 test('rejects removal of the Blog facade port re-export', () => {
-  assert.notEqual(rejects({ missingFacade: true }).status, 0);
+  assert.notEqual(
+    rejects(removeMarker(facadePath, 'pub use rustok_comments::CommentsThreadPort;')).status,
+    0,
+  );
 });
 
-test('rejects removal of the host shared-value lookup', () => {
-  assert.notEqual(rejects({ missingLookup: true }).status, 0);
+test('rejects removal of the host Comments port lookup', () => {
+  assert.notEqual(
+    rejects(
+      removeMarker(
+        nativeAdapterPath,
+        'runtime_ctx.shared_get::<Arc<dyn rustok_blog::CommentsThreadPort>>()',
+      ),
+    ).status,
+    0,
+  );
 });
 
 test('rejects removal of the injected selector branch', () => {
-  assert.notEqual(rejects({ missingInjected: true }).status, 0);
+  assert.notEqual(
+    rejects(
+      removeMarker(
+        nativeAdapterPath,
+        'rustok_blog::CommentService::with_comments_thread_port(',
+      ),
+    ).status,
+    0,
+  );
 });
 
 test('rejects removal of the in-process fallback branch', () => {
-  assert.notEqual(rejects({ missingFallback: true }).status, 0);
+  assert.notEqual(
+    rejects(
+      removeMarker(
+        nativeAdapterPath,
+        'rustok_blog::CommentService::new(runtime_ctx.db_clone(), event_bus)',
+      ),
+    ).status,
+    0,
+  );
 });
 
-test('rejects direct provider construction in the storefront public read', () => {
-  assert.notEqual(rejects({ directReadConstruction: true }).status, 0);
+test('rejects direct extra provider construction in the storefront read', () => {
+  assert.notEqual(
+    rejects((root) =>
+      mutate(root, nativeAdapterPath, (source) => `${source}\nrustok_blog::CommentService::new(`),
+    ).status,
+    0,
+  );
 });
 
 test('rejects removal of the storefront selector handoff', () => {
-  assert.notEqual(rejects({ missingSelectorHandoff: true }).status, 0);
+  assert.notEqual(
+    rejects(
+      removeMarker(
+        nativeAdapterPath,
+        'let comments = comment_service(&runtime_ctx, event_bus.clone());',
+      ),
+    ).status,
+    0,
+  );
 });
 
 test('rejects removal of the approved-only public port operation', () => {
-  assert.notEqual(rejects({ missingPublicRead: true }).status, 0);
+  assert.notEqual(
+    rejects(removeMarker(servicePath, '.list_public_comments_for_target(')).status,
+    0,
+  );
+});
+
+test('rejects removal of the shared snapshot store lookup', () => {
+  assert.notEqual(
+    rejects(
+      removeMarker(
+        nativeAdapterPath,
+        'runtime_ctx.shared_get::<Arc<dyn PublicCommentsSnapshotStore>>()',
+      ),
+    ).status,
+    0,
+  );
+});
+
+test('rejects removal of the shared snapshot helper handoff', () => {
+  assert.notEqual(
+    rejects(removeMarker(nativeAdapterPath, 'list_public_comments_with_snapshot(')).status,
+    0,
+  );
+});
+
+test('rejects removal of cached-snapshot disclosure', () => {
+  assert.notEqual(
+    rejects(removeMarker(nativeAdapterPath, 'cached_snapshot: public_comments.cached_snapshot')).status,
+    0,
+  );
 });
 
 test('rejects broad storefront degradation for every error', () => {
-  assert.notEqual(rejects({ broadFallback: true }).status, 0);
+  assert.notEqual(
+    rejects((root) =>
+      mutate(root, nativeAdapterPath, (source) => `${source}\nErr(_) => BlogCommentList`),
+    ).status,
+    0,
+  );
 });
 
-test('rejects removal of typed unavailable and timeout states', () => {
-  assert.notEqual(rejects({ missingAvailability: true }).status, 0);
+test('rejects removal of typed timeout mapping', () => {
+  assert.notEqual(
+    rejects(removeMarker(nativeAdapterPath, 'PublicCommentsAvailability::Timeout')).status,
+    0,
+  );
 });
 
 test('rejects removal of the compile-only selector harness', () => {
-  assert.notEqual(rejects({ missingHarness: true }).status, 0);
+  assert.notEqual(
+    rejects(
+      removeMarker(
+        nativeAdapterPath,
+        'fn storefront_native_runtime_exposes_comments_port_selection()',
+      ),
+    ).status,
+    0,
+  );
+});
+
+test('rejects fallback evidence that demotes cached snapshot to planned', () => {
+  const result = rejects((root) =>
+    mutateJson(root, fallbackEvidencePath, (evidence) => {
+      evidence.storefront_read_degradation.cached_thread_snapshot = 'planned';
+    }),
+  );
+  assert.notEqual(result.status, 0);
 });
 
 test('rejects runtime promotion without execution', () => {
-  assert.notEqual(rejects({ runtimePromoted: true }).status, 0);
+  assert.notEqual(
+    rejects((root) =>
+      mutateJson(root, evidencePath, (evidence) => {
+        evidence.runtime_status = 'passed';
+      }),
+    ).status,
+    0,
+  );
 });
 
 test('rejects stale admin native SSR pending status after composition', () => {
-  assert.notEqual(rejects({ adminStillPending: true }).status, 0);
+  assert.notEqual(
+    rejects((root) =>
+      mutateJson(root, evidencePath, (evidence) => {
+        evidence.profiles.pending.unshift('admin_native_ssr_composition');
+      }),
+    ).status,
+    0,
+  );
 });
 
 test('rejects remote transport promotion without implementation', () => {
-  assert.notEqual(rejects({ remotePromoted: true }).status, 0);
+  assert.notEqual(
+    rejects((root) =>
+      mutateJson(root, evidencePath, (evidence) => {
+        evidence.profiles.source_verified.push('remote_transport_implementation');
+        evidence.profiles.pending = [];
+      }),
+    ).status,
+    0,
+  );
 });
 
 test('rejects unearned Blog FBA package-chain registration', () => {
-  assert.notEqual(rejects({ registrationPromoted: true }).status, 0);
+  assert.notEqual(
+    rejects((root) =>
+      mutateJson(root, evidencePath, (evidence) => {
+        evidence.registration.blog_fba_package_chain = 'registered';
+      }),
+    ).status,
+    0,
+  );
 });
 
 test('rejects canonical-plan drift', () => {
-  assert.notEqual(rejects({ planDrift: true }).status, 0);
+  assert.notEqual(
+    rejects((root) => writeFileSync(path.join(root, planPath), '')) .status,
+    0,
+  );
 });


### PR DESCRIPTION
## Summary

Continue the Blog improvement plan by closing the source-only cached public Comments snapshot gap for storefront reads.

This PR adds one Blog-owned fallback policy shared by GraphQL and native SSR. Comments remains the sole source of truth; the cache is only a bounded stale public projection used after `ExternalService` or `Timeout` owner failures.

## Behavior

- successful approved public reads remain authoritative and best-effort refresh the snapshot;
- snapshot identity includes tenant, post, requested/fallback locale, page and page size and is SHA-256 keyed;
- schema/identity/same-post/approved-only/page-size/total and 256 KiB payload bounds are checked before write and on load;
- only `ExternalService` and `Timeout` may consult the snapshot;
- every other Blog error remains fail-closed and bypasses the cache;
- cache hits preserve `UNAVAILABLE` / `TIMEOUT` and expose `cachedSnapshot=true` rather than pretending stale data is live;
- cache miss/corruption/cache failure preserves the existing empty degraded response.

## Host cache ownership

The server adapter reuses the canonical `rustok-cache::CacheService` through `ModuleRuntimeExtensions` with a lazy backend:

- prefix `blog-public-comments-snapshot-v1`;
- TTL 900 seconds;
- maximum 10,000 keys;
- Redis reuse when configured, bounded in-memory fallback otherwise.

No Blog Redis client, queue, worker, database table, migration, retry lane or alternate Comments storage is introduced.

## Transport/UI parity

- GraphQL `publicComments` adds `cachedSnapshot`;
- native SSR uses the same shared snapshot helper/store;
- storefront DTO carries the same flag;
- Leptos renders cached comments with an explicit stale-data warning while preserving the degraded availability state.

## Evidence

- `blog-comments-runtime-fallback-smoke.json` remains schema v2 and is extended additively;
- slice 99 records `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`;
- parent and storefront-native source guards/self-tests are updated to source-lock the shared snapshot path while preserving existing GraphQL/HTTP/admin harness identities.

The broader fallback smoke remains `planned` because comment-form fallback is still a separate unresolved result.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, builds, browser/HTTP targets, Redis scenarios, workflows, CI or runtime validation were executed. Source/diff review only.