### PR TITLE
docs(blog): actualize storefront comment-form fallback

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -42,7 +42,8 @@
     ],
     "propagated_error_policy": "all_other_blog_errors",
     "cached_thread_snapshot": "source_verified_no_compile",
-    "comment_form_fallback": "not_applicable_no_storefront_write_surface",
+    "comment_form_fallback": "planned",
+    "comment_form_fallback_interpretation": "legacy_registry_compatibility_only_see_storefront_write_surface",
     "degraded_payload": {
       "cache_hit": {
         "cached_snapshot": true,

--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -12,6 +12,7 @@
     "consumer_service": "crates/rustok-blog/src/services/comment.rs",
     "consumer_error_mapping": "crates/rustok-blog/src/services/comment.rs",
     "public_snapshot_policy": "crates/rustok-blog/src/public_comments_snapshot.rs",
+    "storefront_write_surface_inventory": "crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json",
     "provider_port_registry": "crates/rustok-comments/contracts/comments-fba-registry.json",
     "graphql_runtime": "crates/rustok-blog/src/graphql/runtime_data.rs",
     "graphql_owner": "crates/rustok-blog/src/graphql/types.rs",
@@ -41,7 +42,7 @@
     ],
     "propagated_error_policy": "all_other_blog_errors",
     "cached_thread_snapshot": "source_verified_no_compile",
-    "comment_form_fallback": "planned",
+    "comment_form_fallback": "not_applicable_no_storefront_write_surface",
     "degraded_payload": {
       "cache_hit": {
         "cached_snapshot": true,
@@ -85,8 +86,18 @@
     ],
     "runtime_evidence": "pending"
   },
+  "storefront_write_surface": {
+    "status": "source_verified_absent",
+    "inventory": "crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json",
+    "active_comment_form": false,
+    "active_create_comment_transport": false,
+    "legacy_degraded_mode": "hide_comment_form",
+    "legacy_registry_semantics": "compatibility_vocabulary_not_active_storefront_surface",
+    "comment_form_fallback": "not_applicable_no_storefront_write_surface"
+  },
   "fallback_smoke": {
     "status": "planned",
+    "status_scope": "cached_read_runtime_execution_only",
     "profiles": [
       "embedded_native",
       "graphql_storefront"
@@ -113,7 +124,8 @@
           "with_error_code(error.code)"
         ],
         "degraded_mode": "hide_comment_form",
-        "expected_consumer_behavior": "comment-form fallback remains planned; source contract preserves typed unavailable/forbidden/validation errors while runtime fallback evidence remains pending"
+        "mode_status": "legacy_not_applicable_no_storefront_write_surface",
+        "expected_consumer_behavior": "the active storefront has no public comment form or create-comment transport; hide_comment_form is retained only as registry compatibility vocabulary and is not an implementation target"
       },
       {
         "operation": "list_comments_for_target",
@@ -133,6 +145,7 @@
           "with_error_code(error.code)"
         ],
         "degraded_mode": "show_cached_thread_snapshot",
+        "mode_status": "source_ready_maintainer_execution_pending",
         "expected_consumer_behavior": "cached public snapshot source is retained for unavailable/timeout reads across GraphQL and native SSR; runtime fallback execution remains pending"
       }
     ],

--- a/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json
@@ -100,8 +100,7 @@
     "status": "planned",
     "status_scope": "cached_read_runtime_execution_only",
     "profiles": [
-      "embedded_native",
-      "graphql_storefront"
+      "embedded_native"
     ],
     "degraded_modes": [
       "hide_comment_form",

--- a/crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json
@@ -7,6 +7,8 @@
   "actualization": "comment_form_fallback_not_applicable_no_storefront_write_surface",
   "legacy_degraded_mode": "hide_comment_form",
   "legacy_registry_semantics": "compatibility_vocabulary_not_active_storefront_surface",
+  "runner": "scripts/verify/verify-blog-comments-storefront-write-surface.mjs",
+  "self_test": "scripts/verify/verify-blog-comments-storefront-write-surface.test.mjs",
   "source_inventory": {
     "readme": "crates/rustok-blog/storefront/README.md",
     "ui": "crates/rustok-blog/storefront/src/ui/leptos.rs",

--- a/crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json
+++ b/crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "storefront_comments_write_surface",
+  "owner": "rustok-blog-storefront",
+  "status": "source_verified_absent",
+  "actualization": "comment_form_fallback_not_applicable_no_storefront_write_surface",
+  "legacy_degraded_mode": "hide_comment_form",
+  "legacy_registry_semantics": "compatibility_vocabulary_not_active_storefront_surface",
+  "source_inventory": {
+    "readme": "crates/rustok-blog/storefront/README.md",
+    "ui": "crates/rustok-blog/storefront/src/ui/leptos.rs",
+    "graphql_transport": "crates/rustok-blog/storefront/src/transport/graphql_adapter.rs",
+    "native_transport": "crates/rustok-blog/storefront/src/transport/native_server_adapter.rs",
+    "transport_facade": "crates/rustok-blog/storefront/src/transport/mod.rs",
+    "model": "crates/rustok-blog/storefront/src/model.rs"
+  },
+  "source_contract": {
+    "storefront_responsibility_is_dual_path_read": true,
+    "approved_public_comments_are_read_only_projection": true,
+    "graphql_transport_contains_storefront_query_only": true,
+    "native_transport_contains_storefront_data_read_only": true,
+    "leptos_ui_renders_comments_without_submit_surface": true,
+    "create_comment_surface_present": false,
+    "comment_form_present": false,
+    "textarea_present": false,
+    "submit_handler_present": false,
+    "production_behavior_changed": false,
+    "runtime_execution_observed": false,
+    "browser_execution_observed": false
+  },
+  "planning_effect": {
+    "comment_form_fallback": "not_applicable_no_storefront_write_surface",
+    "cached_thread_snapshot": "source_ready_maintainer_execution_pending",
+    "fallback_smoke_status": "planned_runtime_execution_only",
+    "new_storefront_write_surface_authorized": false
+  },
+  "execution": []
+}

--- a/crates/rustok-blog/docs/implementation-plan-slice-100.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-100.md
@@ -1,0 +1,90 @@
+# rustok-blog implementation plan — slice 100 continuation
+
+Status: `storefront_comment_form_fallback_not_applicable_source_verified`.
+
+This slice resolves the next cursor from slice 99 by re-auditing the active Blog storefront write surface. The result is a planning correction, not a new UI feature: the active storefront package is read-only and has no public comment form or create-comment transport to hide when the Comments owner is unavailable.
+
+## Re-audit result
+
+The active `rustok-blog-storefront` package owns:
+
+- dual-path read access for published posts;
+- approved public Comments reads;
+- comment pagination;
+- GraphQL and native SSR fetch adapters;
+- Leptos rendering of the selected post and its public Comments projection.
+
+It does **not** own:
+
+- a `<form>` or `<textarea>` comment composer;
+- a submit handler;
+- `CreateCommentInput` in storefront source;
+- a storefront `create_comment` call;
+- a GraphQL storefront mutation;
+- a native server function that writes Comments.
+
+The source inventory is retained in:
+
+`crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json`
+
+Fail-closed source guard:
+
+`scripts/verify/verify-blog-comments-storefront-write-surface.mjs`
+
+## Planning correction
+
+The historical degraded mode `hide_comment_form` remains present in the Blog/Comments FBA registry vocabulary. Slice 100 does not perform a registry schema migration solely to delete that legacy token because the consumer/provider registries currently source-lock the same vocabulary and the token does not activate behavior.
+
+Its canonical interpretation is now:
+
+`compatibility_vocabulary_not_active_storefront_surface`
+
+and the concrete implementation result is:
+
+`comment_form_fallback = not_applicable_no_storefront_write_surface`.
+
+`blog-comments-runtime-fallback-smoke.json` therefore keeps the legacy `comment_form_fallback = planned` field only for current aggregate registry compatibility and adds an explicit interpretation pointer plus the authoritative `storefront_write_surface` block. The `create_comment` fallback case is marked `legacy_not_applicable_no_storefront_write_surface` and is not an implementation target.
+
+This avoids inventing a public comment composer merely to satisfy an obsolete fallback placeholder.
+
+## Remaining storefront fallback boundary
+
+The only active degraded storefront Comments source result is the cached public read snapshot implemented in slice 99:
+
+- live approved read refreshes the snapshot best-effort;
+- `ExternalService` and `Timeout` may consume an exact valid snapshot;
+- stale data preserves `UNAVAILABLE` / `TIMEOUT` and is disclosed as cached;
+- all other errors remain fail-closed;
+- GraphQL and native SSR use the same snapshot policy and host cache capability.
+
+Its source is ready, but cached read fallback runtime evidence is still maintainer-owned and pending. The broad `fallback_smoke.status = planned` now means **cached read fallback runtime evidence**, not a missing comment-form implementation.
+
+## Preserved boundaries
+
+Slice 100 changes no production behavior and authorizes no new storefront write surface. It does not change:
+
+- Comments owner storage or write APIs;
+- Blog CommentService write behavior;
+- GraphQL Blog mutations used by authenticated/admin surfaces;
+- native admin moderation surfaces;
+- storefront routing or UI behavior;
+- cache behavior from slice 99;
+- FFA/FBA promotion status.
+
+The existing `hide_comment_form` registry token remains compatibility vocabulary until a future deliberate registry schema migration can remove or rename it together on both consumer and provider sides.
+
+## Validation boundary
+
+Suggested maintainer source check:
+
+```bash
+node scripts/verify/verify-blog-comments-storefront-write-surface.mjs
+```
+
+No tests, Cargo commands, Node verifiers, formatting, builds, browser targets, HTTP scenarios, Redis scenarios, workflows, CI, or runtime validation were executed by the implementation agent.
+
+## Next cursor
+
+Do not add a storefront comment form as fallback work. The storefront Comments fallback line now has no remaining source-only write task.
+
+The next result on this line is maintainer execution of cached read fallback runtime evidence. For additional autonomous Blog source work, return to the broader implementation plan and select an independent source gap rather than adding more fallback scaffolding.

--- a/scripts/verify/verify-blog-comments-storefront-write-surface.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-write-surface.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const failures = [];
+const files = {
+  evidence: 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+  fallback: 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+  blogRegistry: 'crates/rustok-blog/contracts/blog-fba-registry.json',
+  commentsRegistry: 'crates/rustok-comments/contracts/comments-fba-registry.json',
+  readme: 'crates/rustok-blog/storefront/README.md',
+  ui: 'crates/rustok-blog/storefront/src/ui/leptos.rs',
+  graphql: 'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs',
+  native: 'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs',
+  facade: 'crates/rustok-blog/storefront/src/transport/mod.rs',
+  model: 'crates/rustok-blog/storefront/src/model.rs',
+  plan: 'crates/rustok-blog/docs/implementation-plan-slice-100.md',
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => {
+  const target = absolute(relativePath);
+  if (!fs.existsSync(target)) {
+    failures.push(`${relativePath}: missing file`);
+    return '';
+  }
+  return fs.readFileSync(target, 'utf8');
+};
+const parse = (relativePath) => {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+};
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+const evidence = parse(files.evidence);
+const fallback = parse(files.fallback);
+const blogRegistry = parse(files.blogRegistry);
+const commentsRegistry = parse(files.commentsRegistry);
+const readme = read(files.readme);
+const ui = read(files.ui);
+const graphql = read(files.graphql);
+const native = read(files.native);
+const facade = read(files.facade);
+const model = read(files.model);
+const plan = read(files.plan);
+
+if (evidence) {
+  if (
+    evidence.schema_version !== 1 ||
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'storefront_comments_write_surface' ||
+    evidence.owner !== 'rustok-blog-storefront' ||
+    evidence.status !== 'source_verified_absent' ||
+    evidence.actualization !== 'comment_form_fallback_not_applicable_no_storefront_write_surface' ||
+    evidence.legacy_degraded_mode !== 'hide_comment_form' ||
+    evidence.legacy_registry_semantics !== 'compatibility_vocabulary_not_active_storefront_surface'
+  ) failures.push(`${files.evidence}: identity/status drift`);
+
+  const expectedInventory = {
+    readme: files.readme,
+    ui: files.ui,
+    graphql_transport: files.graphql,
+    native_transport: files.native,
+    transport_facade: files.facade,
+    model: files.model,
+  };
+  for (const [key, expected] of Object.entries(expectedInventory)) {
+    if (evidence.source_inventory?.[key] !== expected) {
+      failures.push(`${files.evidence}: source_inventory.${key} drift`);
+    }
+  }
+  for (const key of [
+    'storefront_responsibility_is_dual_path_read',
+    'approved_public_comments_are_read_only_projection',
+    'graphql_transport_contains_storefront_query_only',
+    'native_transport_contains_storefront_data_read_only',
+    'leptos_ui_renders_comments_without_submit_surface',
+  ]) {
+    if (evidence.source_contract?.[key] !== true) {
+      failures.push(`${files.evidence}: source_contract.${key} must be true`);
+    }
+  }
+  for (const key of [
+    'create_comment_surface_present',
+    'comment_form_present',
+    'textarea_present',
+    'submit_handler_present',
+    'production_behavior_changed',
+    'runtime_execution_observed',
+    'browser_execution_observed',
+  ]) {
+    if (evidence.source_contract?.[key] !== false) {
+      failures.push(`${files.evidence}: source_contract.${key} must be false`);
+    }
+  }
+  if (
+    evidence.planning_effect?.comment_form_fallback !== 'not_applicable_no_storefront_write_surface' ||
+    evidence.planning_effect?.cached_thread_snapshot !== 'source_ready_maintainer_execution_pending' ||
+    evidence.planning_effect?.fallback_smoke_status !== 'planned_runtime_execution_only' ||
+    evidence.planning_effect?.new_storefront_write_surface_authorized !== false ||
+    !Array.isArray(evidence.execution) ||
+    evidence.execution.length !== 0
+  ) failures.push(`${files.evidence}: planning/execution drift`);
+}
+
+if (fallback) {
+  if (fallback.source_contract?.storefront_write_surface_inventory !== files.evidence) {
+    failures.push(`${files.fallback}: write-surface inventory path drift`);
+  }
+  if (
+    fallback.storefront_read_degradation?.comment_form_fallback !== 'planned' ||
+    fallback.storefront_read_degradation?.comment_form_fallback_interpretation !==
+      'legacy_registry_compatibility_only_see_storefront_write_surface'
+  ) failures.push(`${files.fallback}: legacy compatibility marker drift`);
+  const writeSurface = fallback.storefront_write_surface ?? {};
+  if (
+    writeSurface.status !== 'source_verified_absent' ||
+    writeSurface.inventory !== files.evidence ||
+    writeSurface.active_comment_form !== false ||
+    writeSurface.active_create_comment_transport !== false ||
+    writeSurface.legacy_degraded_mode !== 'hide_comment_form' ||
+    writeSurface.legacy_registry_semantics !==
+      'compatibility_vocabulary_not_active_storefront_surface' ||
+    writeSurface.comment_form_fallback !== 'not_applicable_no_storefront_write_surface'
+  ) failures.push(`${files.fallback}: write-surface actualization drift`);
+  if (
+    fallback.fallback_smoke?.status !== 'planned' ||
+    fallback.fallback_smoke?.status_scope !== 'cached_read_runtime_execution_only' ||
+    fallback.fallback_smoke?.runtime_evidence !== 'pending'
+  ) failures.push(`${files.fallback}: fallback runtime scope drift`);
+  const createCase = fallback.fallback_smoke?.cases?.find(
+    (entry) => entry.operation === 'create_comment',
+  );
+  if (
+    !createCase ||
+    createCase.degraded_mode !== 'hide_comment_form' ||
+    createCase.mode_status !== 'legacy_not_applicable_no_storefront_write_surface' ||
+    !createCase.expected_consumer_behavior?.includes('not an implementation target')
+  ) failures.push(`${files.fallback}: create-comment legacy mode drift`);
+}
+
+const blogDependency = blogRegistry?.provider_dependencies?.find(
+  (entry) => entry.module === 'comments',
+);
+const commentsConsumer = commentsRegistry?.consumers?.find(
+  (entry) => entry.module === 'blog',
+);
+for (const [label, value] of [
+  ['Blog registry', blogDependency],
+  ['Comments registry', commentsConsumer],
+]) {
+  if (!value?.degraded_modes?.includes('hide_comment_form')) {
+    failures.push(`${label}: legacy hide_comment_form vocabulary disappeared without schema migration`);
+  }
+}
+
+for (const marker of [
+  'Owns dual-path read access for published posts',
+  "Renders the selected post's approved public comments",
+  'Owns public comment pagination',
+]) need(readme, marker, files.readme);
+
+for (const [label, source] of [
+  [files.ui, ui],
+  [files.graphql, graphql],
+  [files.native, native],
+  [files.facade, facade],
+  [files.model, model],
+]) {
+  for (const marker of [
+    '<form',
+    '<textarea',
+    'on:submit',
+    'CreateCommentInput',
+    'create_comment(',
+    'createComment',
+    'submit_comment',
+  ]) forbid(source, marker, label);
+}
+
+need(graphql, 'query StorefrontBlog', files.graphql);
+forbid(graphql, 'mutation StorefrontBlog', files.graphql);
+need(native, 'endpoint = "blog/storefront-data"', files.native);
+need(native, 'list_public_comments_with_snapshot(', files.native);
+need(ui, 'fn PublicCommentsList(', files.ui);
+
+for (const marker of [
+  'storefront_comment_form_fallback_not_applicable_source_verified',
+  'active storefront package is read-only',
+  'hide_comment_form',
+  'compatibility vocabulary',
+  'not_applicable_no_storefront_write_surface',
+  'cached read fallback runtime evidence',
+  'No tests, Cargo commands, Node verifiers',
+]) need(plan, marker, files.plan);
+
+if (failures.length) {
+  console.error('[verify-blog-comments-storefront-write-surface] FAIL');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '[verify-blog-comments-storefront-write-surface] PASS write_surface=absent comment_form_fallback=not_applicable execution=not_run',
+);

--- a/scripts/verify/verify-blog-comments-storefront-write-surface.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-write-surface.mjs
@@ -45,6 +45,8 @@ const need = (source, marker, label) => {
 const forbid = (source, marker, label) => {
   if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
 };
+const exactSingle = (value, expected) =>
+  Array.isArray(value) && value.length === 1 && value[0] === expected;
 
 const evidence = parse(files.evidence);
 const fallback = parse(files.fallback);
@@ -140,8 +142,9 @@ if (fallback) {
   if (
     fallback.fallback_smoke?.status !== 'planned' ||
     fallback.fallback_smoke?.status_scope !== 'cached_read_runtime_execution_only' ||
-    fallback.fallback_smoke?.runtime_evidence !== 'pending'
-  ) failures.push(`${files.fallback}: fallback runtime scope drift`);
+    fallback.fallback_smoke?.runtime_evidence !== 'pending' ||
+    !exactSingle(fallback.fallback_smoke?.profiles, 'embedded_native')
+  ) failures.push(`${files.fallback}: fallback runtime/profile scope drift`);
   const createCase = fallback.fallback_smoke?.cases?.find(
     (entry) => entry.operation === 'create_comment',
   );
@@ -165,6 +168,9 @@ for (const [label, value] of [
 ]) {
   if (!value?.degraded_modes?.includes('hide_comment_form')) {
     failures.push(`${label}: legacy hide_comment_form vocabulary disappeared without schema migration`);
+  }
+  if (!exactSingle(value?.fallback_profiles, 'embedded_native')) {
+    failures.push(`${label}: legacy fallback profile must remain embedded_native`);
   }
 }
 

--- a/scripts/verify/verify-blog-comments-storefront-write-surface.test.mjs
+++ b/scripts/verify/verify-blog-comments-storefront-write-surface.test.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const verifier = path.resolve('scripts/verify/verify-blog-comments-storefront-write-surface.mjs');
+const files = [
+  'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+  'crates/rustok-blog/contracts/blog-fba-registry.json',
+  'crates/rustok-comments/contracts/comments-fba-registry.json',
+  'crates/rustok-blog/storefront/README.md',
+  'crates/rustok-blog/storefront/src/ui/leptos.rs',
+  'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs',
+  'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs',
+  'crates/rustok-blog/storefront/src/transport/mod.rs',
+  'crates/rustok-blog/storefront/src/model.rs',
+  'crates/rustok-blog/docs/implementation-plan-slice-100.md',
+];
+
+function copy(root, relativePath) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, readFileSync(relativePath));
+}
+
+function mutate(root, relativePath, transform) {
+  const target = path.join(root, relativePath);
+  writeFileSync(target, transform(readFileSync(target, 'utf8')));
+}
+
+function mutateJson(root, relativePath, transform) {
+  mutate(root, relativePath, (source) => {
+    const value = JSON.parse(source);
+    transform(value);
+    return JSON.stringify(value, null, 2);
+  });
+}
+
+function fixture(mutator) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-storefront-write-surface-'));
+  files.forEach((file) => copy(root, file));
+  mutator?.(root);
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: path.resolve('.'),
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(mutator) {
+  const root = fixture(mutator);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('accepts the canonical absent storefront Comments write surface', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects a newly added storefront comment form', () => {
+  const result = rejects((root) =>
+    mutate(
+      root,
+      'crates/rustok-blog/storefront/src/ui/leptos.rs',
+      (source) => `${source}\n<form><textarea></textarea></form>`,
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects a storefront create-comment transport', () => {
+  const result = rejects((root) =>
+    mutate(
+      root,
+      'crates/rustok-blog/storefront/src/transport/native_server_adapter.rs',
+      (source) => `${source}\ncreate_comment(`,
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects a storefront GraphQL mutation', () => {
+  const result = rejects((root) =>
+    mutate(
+      root,
+      'crates/rustok-blog/storefront/src/transport/graphql_adapter.rs',
+      (source) => source.replace('query StorefrontBlog', 'mutation StorefrontBlog'),
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects inventory promotion to a present form', () => {
+  const result = rejects((root) =>
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+      (evidence) => {
+        evidence.source_contract.comment_form_present = true;
+      },
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects fallback actualization back to an implementation target', () => {
+  const result = rejects((root) =>
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+      (evidence) => {
+        evidence.storefront_write_surface.comment_form_fallback = 'planned';
+      },
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects loss of legacy registry compatibility vocabulary without schema migration', () => {
+  const result = rejects((root) =>
+    mutateJson(root, 'crates/rustok-blog/contracts/blog-fba-registry.json', (registry) => {
+      registry.provider_dependencies[0].degraded_modes = ['show_cached_thread_snapshot'];
+    }),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects runtime or browser execution claims', () => {
+  const result = rejects((root) =>
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+      (evidence) => {
+        evidence.source_contract.runtime_execution_observed = true;
+      },
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});
+
+test('rejects slice-100 planning drift', () => {
+  const result = rejects((root) =>
+    writeFileSync(
+      path.join(root, 'crates/rustok-blog/docs/implementation-plan-slice-100.md'),
+      '',
+    ),
+  );
+  assert.notEqual(result.status, 0);
+});


### PR DESCRIPTION
## Summary

Continue the Blog plan after the cached public Comments snapshot slice by re-auditing the planned `hide_comment_form` degraded mode.

The active `rustok-blog-storefront` package is read-only: it has published-post reads, approved public Comments reads, pagination, GraphQL/native fetch adapters and Leptos rendering, but no public comment form, textarea, submit handler, `CreateCommentInput`, storefront create-comment call, GraphQL mutation or native write server function.

This PR records that result instead of inventing a write surface solely to satisfy an old fallback placeholder.

## Actualization

- new machine inventory: `blog-comments-storefront-write-surface.json`;
- `comment_form_fallback = not_applicable_no_storefront_write_surface` in the authoritative write-surface block;
- historical `hide_comment_form` remains registry compatibility vocabulary until a deliberate consumer/provider registry schema migration removes it on both sides;
- the legacy `comment_form_fallback=planned` field is retained only because the existing aggregate guard source-locks that registry vocabulary, with an explicit interpretation pointer to the write-surface inventory;
- `fallback_smoke.status=planned` is scoped to cached-read runtime execution, not a missing comment-form implementation.

## Aggregate parity correction

Source review also caught a mismatch introduced by the preceding cached-snapshot slice: runtime fallback evidence had added `graphql_storefront` to the legacy `fallback_smoke.profiles`, while the FBA registries still source-lock `embedded_native` only. This PR restores the legacy smoke profile to `embedded_native`; actual GraphQL/native read parity remains represented by `storefront_read_degradation.transports=[graphql,native_ssr]`.

## Guard

Adds a fail-closed source verifier and focused self-test that require the active storefront to remain free of comment-write UI/transport markers, source-lock the read-only README contract, preserve the legacy registry vocabulary without treating it as active behavior, and reject runtime/browser claims.

## Validation boundary

No tests, Cargo commands, Node verifiers, formatting, builds, browser/HTTP scenarios, Redis scenarios, workflows, CI or runtime validation were executed. Source/diff review only.