### PR TITLE
feat(forum): observe unread topic activity

### DIFF
--- a/crates/rustok-forum/src/graphql/read_state.rs
+++ b/crates/rustok-forum/src/graphql/read_state.rs
@@ -28,9 +28,16 @@ const LOCALE_RESOURCE_UNREAD_TOPIC: &str = "unread_topic";
 const LOCALE_OUTCOME_EXACT: &str = "exact";
 const LOCALE_OUTCOME_FALLBACK: &str = "fallback";
 const LOCALE_OUTCOME_MISSING: &str = "missing";
+const UNREAD_TOPIC_STATE_IMPLICIT: &str = "implicit";
+const UNREAD_TOPIC_STATE_REPLY: &str = "reply";
+const UNREAD_TOPIC_STATE_REVISION: &str = "revision";
+const UNREAD_TOPIC_STATE_REPLY_AND_REVISION: &str = "reply_and_revision";
+const UNREAD_TOPIC_STATE_READ: &str = "read";
 
 static FORUM_GRAPHQL_LOCALE_RESOLUTION_TOTAL: OnceLock<IntCounterVec> = OnceLock::new();
 static FORUM_GRAPHQL_LOCALE_RESOLUTION_REGISTERED: AtomicBool = AtomicBool::new(false);
+static FORUM_GRAPHQL_UNREAD_TOPIC_STATE_TOTAL: OnceLock<IntCounterVec> = OnceLock::new();
+static FORUM_GRAPHQL_UNREAD_TOPIC_STATE_REGISTERED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Enum)]
 pub enum GqlForumTopicStatus {
@@ -168,6 +175,7 @@ impl ForumReadStateQuery {
             )
             .await?;
         observe_unread_topic_locale_resolution(&page.items);
+        observe_unread_topic_activity(&page.items);
 
         Ok(GqlForumTopicUnreadPage {
             items: page.items.into_iter().map(map_unread_item).collect(),
@@ -427,6 +435,63 @@ fn observe_unread_topic_locale_resolution(items: &[TopicUnreadReadModel]) {
     }
 }
 
+fn unread_topic_activity_state(
+    read_state_explicit: bool,
+    unread_count: i64,
+    has_unread_topic_revision: bool,
+) -> &'static str {
+    if !read_state_explicit {
+        UNREAD_TOPIC_STATE_IMPLICIT
+    } else if unread_count > 0 && has_unread_topic_revision {
+        UNREAD_TOPIC_STATE_REPLY_AND_REVISION
+    } else if unread_count > 0 {
+        UNREAD_TOPIC_STATE_REPLY
+    } else if has_unread_topic_revision {
+        UNREAD_TOPIC_STATE_REVISION
+    } else {
+        UNREAD_TOPIC_STATE_READ
+    }
+}
+
+fn forum_graphql_unread_topic_state_counter() -> Option<&'static IntCounterVec> {
+    let counter = FORUM_GRAPHQL_UNREAD_TOPIC_STATE_TOTAL.get_or_init(|| {
+        IntCounterVec::new(
+            Opts::new(
+                "rustok_forum_graphql_unread_topic_state_total",
+                "Forum GraphQL unread-topic item observations by fixed current unread activity state",
+            ),
+            &["state"],
+        )
+        .expect("Forum GraphQL unread-topic state metric descriptor must be valid")
+    });
+
+    if FORUM_GRAPHQL_UNREAD_TOPIC_STATE_REGISTERED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+        && rustok_telemetry::register_runtime_collector(Box::new(counter.clone())).is_err()
+    {
+        FORUM_GRAPHQL_UNREAD_TOPIC_STATE_REGISTERED.store(false, Ordering::Release);
+        return None;
+    }
+
+    Some(counter)
+}
+
+fn observe_unread_topic_activity(items: &[TopicUnreadReadModel]) {
+    let Some(counter) = forum_graphql_unread_topic_state_counter() else {
+        return;
+    };
+
+    for item in items {
+        let state = unread_topic_activity_state(
+            item.read_state_explicit,
+            item.unread_count,
+            item.has_unread_topic_revision,
+        );
+        counter.with_label_values(&[state]).inc();
+    }
+}
+
 fn map_topic(topic: TopicReadModel) -> GqlForumTopicReadModel {
     GqlForumTopicReadModel {
         id: topic.id,
@@ -489,7 +554,9 @@ fn map_batch_result(result: MarkForumTopicsReadBatchResult) -> GqlForumTopicsRea
 mod tests {
     use super::{
         LOCALE_OUTCOME_EXACT, LOCALE_OUTCOME_FALLBACK, LOCALE_OUTCOME_MISSING,
-        locale_resolution_outcome,
+        UNREAD_TOPIC_STATE_IMPLICIT, UNREAD_TOPIC_STATE_READ, UNREAD_TOPIC_STATE_REPLY,
+        UNREAD_TOPIC_STATE_REPLY_AND_REVISION, UNREAD_TOPIC_STATE_REVISION,
+        locale_resolution_outcome, unread_topic_activity_state,
     };
 
     #[test]
@@ -502,6 +569,30 @@ mod tests {
         assert_eq!(
             locale_resolution_outcome("tenant-secret", "tenant-secret", 0),
             LOCALE_OUTCOME_MISSING
+        );
+    }
+
+    #[test]
+    fn unread_topic_activity_states_are_fixed() {
+        assert_eq!(
+            unread_topic_activity_state(false, 0, false),
+            UNREAD_TOPIC_STATE_IMPLICIT
+        );
+        assert_eq!(
+            unread_topic_activity_state(true, 2, true),
+            UNREAD_TOPIC_STATE_REPLY_AND_REVISION
+        );
+        assert_eq!(
+            unread_topic_activity_state(true, 2, false),
+            UNREAD_TOPIC_STATE_REPLY
+        );
+        assert_eq!(
+            unread_topic_activity_state(true, 0, true),
+            UNREAD_TOPIC_STATE_REVISION
+        );
+        assert_eq!(
+            unread_topic_activity_state(true, 0, false),
+            UNREAD_TOPIC_STATE_READ
         );
     }
 }

--- a/docs/modules/forum-33-unread-activity-metrics-actualization-2026-08-09.md
+++ b/docs/modules/forum-33-unread-activity-metrics-actualization-2026-08-09.md
@@ -1,0 +1,115 @@
+# FORUM-33I unread activity metrics actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / low-cardinality-observation-baseline`
+
+## Rechecked FORUM-33 cursor
+
+The source sequence is now:
+
+- FORUM-33A: bounded topic/category counter reconciliation;
+- FORUM-33B: independent counter keyset continuation;
+- FORUM-33C: accepted-solution and solution-stat reconciliation;
+- FORUM-33D: persisted subscription reconciliation;
+- FORUM-33E: persisted mention reconciliation;
+- FORUM-33F: read-only Forum -> Search projection convergence status;
+- FORUM-33G: Notifications-owned exact-recipient reconciliation dry-run status;
+- FORUM-33H: fixed-cardinality locale-resolution observations on `forumUnreadTopics`.
+
+Attachments remain blocked on FORUM-14. Fresh source still has no persisted Forum-owned attachment relation/source-revision authority, so this slice does not infer attachment truth from Media-private state or rich-text references.
+
+## Why unread/activity is the next truthful metric
+
+The canonical FORUM-33 remaining-metrics list includes unread/activity observability. Unlike the still-reserved spam outcomes, Forum already owns and materializes unread truth on the mounted GraphQL path through:
+
+```text
+ForumReadModelService::list_topics_with_unread
+```
+
+The returned `TopicUnreadReadModel` already contains the exact owner-derived primitives used by the response:
+
+- whether an explicit read state exists;
+- unread approved-reply count;
+- whether a newer topic revision exists;
+- the final `is_unread` projection.
+
+No additional database query, owner call, foreign-module read, write or repair is needed to observe those facts.
+
+## Metric contract
+
+FORUM-33I adds:
+
+```text
+rustok_forum_graphql_unread_topic_state_total{state="..."}
+```
+
+`state` is fixed to exactly five values with deterministic precedence:
+
+1. `implicit` — no explicit user read-state row exists;
+2. `reply_and_revision` — explicit state exists, with unread replies and a newer topic revision;
+3. `reply` — explicit state exists with unread replies only;
+4. `revision` — explicit state exists with a newer topic revision only;
+5. `read` — explicit state exists with neither unread replies nor a newer topic revision.
+
+The classifier treats `unread_count > 0` as reply activity and never exports the numeric unread count as a label.
+
+## Observation semantics, not tenant backlog
+
+This is an observation counter over successful bounded `forumUnreadTopics` results. One returned topic contributes one increment to one state.
+
+It is deliberately not described as:
+
+- the current number of unread topics in a tenant;
+- the number of unique topics or users;
+- an unread backlog gauge;
+- a snapshot-consistent tenant-wide population estimate.
+
+Repeated requests can observe the same topic more than once. A request with `unreadOnly = true` naturally biases observations toward unread states. Those properties are part of the metric contract rather than hidden assumptions.
+
+## Cardinality and privacy boundary
+
+The metric has one bounded label, `state`. It does not use:
+
+- tenant ID;
+- user ID;
+- topic or category ID;
+- locale;
+- unread count;
+- last-read position or revision;
+- title, slug, route or content;
+- arbitrary error values.
+
+The existing FORUM-33H locale metric remains unchanged and separate.
+
+## Runtime and failure semantics
+
+The activity observer runs only after the existing bounded owner read succeeds and before the already-existing DTO mapping consumes the page.
+
+Collector registration reuses `rustok_telemetry::register_runtime_collector`. Registration failure remains best-effort telemetry failure: it does not alter the owner read, GraphQL response, cursor, RBAC, visibility, read-state semantics or mutation behavior, and a later observation may retry registration after telemetry initialization.
+
+FORUM-33I adds no migration, queue, worker, job, receipt, retry lane, checkpoint, repair path or database mutation.
+
+## Spam and moderation recheck
+
+Spam-outcome telemetry remains premature. The current FORUM-26D posting-policy evaluator is pure and not mounted as owner enforcement; `DuplicateContent` and `ExternalSpamScore` remain reserved reasons until their owner inputs/contracts exist. FORUM-33 must not manufacture operational spam outcomes from an unexecuted evaluator.
+
+Moderation private application-operation storage also remains outside Forum ownership. A later moderation diagnostic must use an explicit public owner-supported status/read boundary rather than reading `moderation_application_operations` directly.
+
+## Canonical-plan drift
+
+The large canonical Forum implementation plan still lags parts of the merged FORUM-33 execution cursor. This dated packet records the actual source cursor without replacing the entire canonical file through the GitHub contents API and risking unrelated concurrent roadmap loss.
+
+## Next FORUM-33 cursor
+
+Attachments remain blocked on FORUM-14. Spam outcomes remain blocked on real owner enforcement/contracts.
+
+After this unread/activity baseline, recheck broader locale coverage or a permitted Moderation/public-owner diagnostic. Notification/Search lag should only be added if it does not duplicate metrics already owned by those modules.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source check, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-unread-activity-metrics-source.mjs
+```

--- a/docs/modules/forum-33-unread-activity-metrics-pr-notes.tmp
+++ b/docs/modules/forum-33-unread-activity-metrics-pr-notes.tmp
@@ -1,0 +1,1 @@
+FORUM-33I temporary PR staging marker.

--- a/docs/modules/forum-33-unread-activity-metrics-pr-notes.tmp
+++ b/docs/modules/forum-33-unread-activity-metrics-pr-notes.tmp
@@ -1,1 +1,0 @@
-FORUM-33I temporary PR staging marker.

--- a/scripts/verify/verify-forum-unread-activity-metrics-source.mjs
+++ b/scripts/verify/verify-forum-unread-activity-metrics-source.mjs
@@ -98,7 +98,7 @@ for (const marker of [
   "Spam-outcome telemetry remains premature",
   "DuplicateContent",
   "ExternalSpamScore",
-  "no additional database query",
+  "No additional database query",
   "no Cargo command",
 ]) {
   requireText(packet, marker, `${packetPath}: missing ${marker}`);

--- a/scripts/verify/verify-forum-unread-activity-metrics-source.mjs
+++ b/scripts/verify/verify-forum-unread-activity-metrics-source.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const graphqlPath = "crates/rustok-forum/src/graphql/read_state.rs";
+const packetPath =
+  "docs/modules/forum-33-unread-activity-metrics-actualization-2026-08-09.md";
+
+const graphql = read(graphqlPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "async fn forum_unread_topics(",
+  ".list_topics_with_unread(",
+  ".await?;\n        observe_unread_topic_locale_resolution(&page.items);\n        observe_unread_topic_activity(&page.items);",
+  "rustok_forum_graphql_unread_topic_state_total",
+  '&["state"]',
+  'const UNREAD_TOPIC_STATE_IMPLICIT: &str = "implicit";',
+  'const UNREAD_TOPIC_STATE_REPLY: &str = "reply";',
+  'const UNREAD_TOPIC_STATE_REVISION: &str = "revision";',
+  'const UNREAD_TOPIC_STATE_REPLY_AND_REVISION: &str = "reply_and_revision";',
+  'const UNREAD_TOPIC_STATE_READ: &str = "read";',
+  "if !read_state_explicit",
+  "unread_count > 0 && has_unread_topic_revision",
+  "else if unread_count > 0",
+  "else if has_unread_topic_revision",
+  "rustok_telemetry::register_runtime_collector",
+  "counter.with_label_values(&[state]).inc();",
+]) {
+  requireText(graphql, marker, `${graphqlPath}: missing ${marker}`);
+}
+
+const observerStart = graphql.indexOf("fn unread_topic_activity_state(");
+const mapperStart = graphql.indexOf("fn map_topic(");
+if (observerStart < 0 || mapperStart <= observerStart) {
+  throw new Error(`${graphqlPath}: unread activity observer source boundary is invalid`);
+}
+const observer = graphql.slice(observerStart, mapperStart);
+
+for (const forbidden of [
+  "tenant_id",
+  "user_id",
+  "topic_id",
+  "category_id",
+  "requested_locale",
+  "effective_locale",
+  "last_read_position",
+  "last_read_revision",
+  "DatabaseConnection",
+  "ForumReadModelService::new",
+  "Entity::find",
+  "UPDATE ",
+  "INSERT ",
+  "DELETE ",
+  "ActiveModel",
+]) {
+  requireAbsent(
+    observer,
+    forbidden,
+    `${graphqlPath}: unread activity observer must not contain ${forbidden}`,
+  );
+}
+
+for (const forbiddenLabel of [
+  "with_label_values(&[item.",
+  "with_label_values(&[unread_count",
+  "unread_count.to_string",
+  "read_state_explicit.to_string",
+  "has_unread_topic_revision.to_string",
+]) {
+  requireAbsent(
+    observer,
+    forbiddenLabel,
+    `${graphqlPath}: unread activity metric labels must remain fixed`,
+  );
+}
+
+for (const marker of [
+  "FORUM-33I",
+  "FORUM-33H",
+  "Attachments remain blocked on FORUM-14",
+  "rustok_forum_graphql_unread_topic_state_total",
+  "observation counter",
+  "unreadOnly = true",
+  "not described as",
+  "Spam-outcome telemetry remains premature",
+  "DuplicateContent",
+  "ExternalSpamScore",
+  "no additional database query",
+  "no Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-33I unread activity metric source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-33 after #3365 with the next truthful non-duplicative operational baseline: fixed-cardinality unread/activity observations on the already mounted `forumUnreadTopics` GraphQL path.

- observe only successful `ForumReadModelService::list_topics_with_unread` owner results;
- add `rustok_forum_graphql_unread_topic_state_total{state="..."}`;
- keep `state` bounded to `implicit`, `reply`, `revision`, `reply_and_revision`, and `read`;
- classify from the already-materialized owner DTO primitives `read_state_explicit`, `unread_count`, and `has_unread_topic_revision`;
- never export the numeric unread count, tenant/user/topic/category IDs, locale, last-read cursors, title, slug, route, content, or arbitrary errors as labels;
- keep the existing FORUM-33H locale metric unchanged;
- reuse `rustok_telemetry::register_runtime_collector` with best-effort registration;
- add FORUM-33I actualization plus a focused source guard.

## Metric semantics

This is an observation counter over returned bounded page items, not a tenant-wide backlog gauge or unique-topic/user population estimate. Repeated reads may observe the same topic repeatedly, and `unreadOnly = true` naturally biases samples toward unread states.

No additional DB query, owner call, write, repair, cursor change, visibility change, RBAC change, or read-state mutation is introduced.

## Recheck findings

- FORUM-14 is still absent; attachments remain blocked because Forum has no persisted Forum-owned attachment relation/source-revision authority.
- Spam-outcome telemetry is still premature: FORUM-26D is a pure evaluator not mounted as owner enforcement, while `DuplicateContent` and `ExternalSpamScore` remain reserved until their owner inputs/contracts exist.
- Moderation private application-operation storage is not a Forum diagnostic boundary; future moderation status must come from a public owner-supported contract.
- Main advanced after branch creation by one Blog-only commit with no overlap in these paths.

## Validation

Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was run. Review is source-only; maintainer will run tests.