### PR TITLE
feat(forum): observe category tree locale outcomes

### DIFF
--- a/crates/rustok-forum/src/graphql/category_tree_query.rs
+++ b/crates/rustok-forum/src/graphql/category_tree_query.rs
@@ -1,4 +1,13 @@
+use std::{
+    sync::{
+        OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
+
 use async_graphql::{Context, FieldError, Object, Result, SimpleObject};
+use prometheus::{IntCounterVec, Opts};
 use rustok_api::Permission;
 use rustok_api::{
     AuthContext, RequestContext, TenantContext,
@@ -7,7 +16,6 @@ use rustok_api::{
 };
 use rustok_telemetry::metrics;
 use sea_orm::DatabaseConnection;
-use std::time::Instant;
 use uuid::Uuid;
 
 use crate::{
@@ -18,6 +26,13 @@ use crate::{
 use super::ForumGraphqlRuntimeData;
 
 const MODULE_SLUG: &str = "forum";
+const CATEGORY_TREE_LOCALE_OUTCOME_EXACT: &str = "exact";
+const CATEGORY_TREE_LOCALE_OUTCOME_FALLBACK: &str = "fallback";
+const CATEGORY_TREE_LOCALE_OUTCOME_MISSING: &str = "missing";
+
+static FORUM_GRAPHQL_CATEGORY_TREE_LOCALE_RESOLUTION_TOTAL: OnceLock<IntCounterVec> = OnceLock::new();
+static FORUM_GRAPHQL_CATEGORY_TREE_LOCALE_RESOLUTION_REGISTERED: AtomicBool =
+    AtomicBool::new(false);
 
 #[derive(Default)]
 pub(crate) struct ForumCategoryTreeQuery;
@@ -82,6 +97,7 @@ impl ForumCategoryTreeQuery {
             MAX_FORUM_CATEGORY_TREE_NODES,
             tree.total_nodes as usize,
         );
+        observe_category_tree_locale_resolution(&tree.roots);
 
         Ok(tree.into())
     }
@@ -111,6 +127,68 @@ fn resolve_tenant_scope(tenant: &TenantContext, requested_tenant_id: Option<Uuid
         }
         Some(requested_tenant_id) => Ok(requested_tenant_id),
         None => Ok(tenant.id),
+    }
+}
+
+fn category_tree_locale_resolution_outcome(
+    requested_locale: &str,
+    effective_locale: &str,
+    available_locale_count: usize,
+) -> &'static str {
+    if available_locale_count == 0 {
+        CATEGORY_TREE_LOCALE_OUTCOME_MISSING
+    } else if requested_locale == effective_locale {
+        CATEGORY_TREE_LOCALE_OUTCOME_EXACT
+    } else {
+        CATEGORY_TREE_LOCALE_OUTCOME_FALLBACK
+    }
+}
+
+fn forum_graphql_category_tree_locale_resolution_counter() -> Option<&'static IntCounterVec> {
+    let counter = FORUM_GRAPHQL_CATEGORY_TREE_LOCALE_RESOLUTION_TOTAL.get_or_init(|| {
+        IntCounterVec::new(
+            Opts::new(
+                "rustok_forum_graphql_category_tree_locale_resolution_total",
+                "Forum GraphQL category-tree nodes by fixed locale resolution outcome",
+            ),
+            &["outcome"],
+        )
+        .expect("Forum GraphQL category-tree locale metric descriptor must be valid")
+    });
+
+    if FORUM_GRAPHQL_CATEGORY_TREE_LOCALE_RESOLUTION_REGISTERED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+        && rustok_telemetry::register_runtime_collector(Box::new(counter.clone())).is_err()
+    {
+        FORUM_GRAPHQL_CATEGORY_TREE_LOCALE_RESOLUTION_REGISTERED
+            .store(false, Ordering::Release);
+        return None;
+    }
+
+    Some(counter)
+}
+
+fn observe_category_tree_locale_resolution(nodes: &[CategoryTreeNode]) {
+    let Some(counter) = forum_graphql_category_tree_locale_resolution_counter() else {
+        return;
+    };
+
+    observe_category_tree_locale_resolution_with_counter(counter, nodes);
+}
+
+fn observe_category_tree_locale_resolution_with_counter(
+    counter: &IntCounterVec,
+    nodes: &[CategoryTreeNode],
+) {
+    for node in nodes {
+        let outcome = category_tree_locale_resolution_outcome(
+            &node.requested_locale,
+            &node.effective_locale,
+            node.available_locales.len(),
+        );
+        counter.with_label_values(&[outcome]).inc();
+        observe_category_tree_locale_resolution_with_counter(counter, &node.children);
     }
 }
 
@@ -211,6 +289,11 @@ mod tests {
 
     use crate::graphql::ForumQuery;
 
+    use super::{
+        CATEGORY_TREE_LOCALE_OUTCOME_EXACT, CATEGORY_TREE_LOCALE_OUTCOME_FALLBACK,
+        CATEGORY_TREE_LOCALE_OUTCOME_MISSING, category_tree_locale_resolution_outcome,
+    };
+
     #[test]
     fn schema_exposes_recursive_forum_category_tree() {
         let schema =
@@ -225,5 +308,21 @@ mod tests {
         assert!(sdl.contains("isArchived: Boolean!"));
         assert!(sdl.contains("children: [GqlForumCategoryTreeNode!]!"));
         assert!(sdl.contains("breadcrumbs: [GqlForumCategoryBreadcrumb!]!"));
+    }
+
+    #[test]
+    fn category_tree_locale_outcomes_are_fixed_and_hide_locale_values() {
+        assert_eq!(
+            category_tree_locale_resolution_outcome("ru", "ru", 1),
+            CATEGORY_TREE_LOCALE_OUTCOME_EXACT
+        );
+        assert_eq!(
+            category_tree_locale_resolution_outcome("tenant-secret", "different-secret", 2),
+            CATEGORY_TREE_LOCALE_OUTCOME_FALLBACK
+        );
+        assert_eq!(
+            category_tree_locale_resolution_outcome("tenant-secret", "tenant-secret", 0),
+            CATEGORY_TREE_LOCALE_OUTCOME_MISSING
+        );
     }
 }

--- a/docs/modules/forum-33-category-tree-locale-metrics-actualization-2026-08-09.md
+++ b/docs/modules/forum-33-category-tree-locale-metrics-actualization-2026-08-09.md
@@ -1,0 +1,100 @@
+# FORUM-33J category-tree locale metrics actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / bounded-locale-coverage`
+
+## Rechecked FORUM-33 cursor
+
+The executed source sequence is now FORUM-33A through FORUM-33I. The latest two telemetry slices are:
+
+- FORUM-33H: fixed-cardinality locale-resolution observations on successful `forumUnreadTopics` reads;
+- FORUM-33I: fixed-cardinality unread/activity observations on the same bounded owner-backed page.
+
+Fresh `main` still has no persisted Forum-owned attachment relation/source-revision authority. Attachments therefore remain blocked on FORUM-14; this slice does not infer relation truth from rich text or Media-private storage.
+
+## Why category tree is the next truthful locale surface
+
+The canonical FORUM-33 telemetry scope includes locale fallback. `forumCategoryTree` is already a mounted bounded GraphQL read and already resolves localized owner DTOs through the category audience read service.
+
+The authoritative call remains:
+
+```text
+ForumCategoryAudienceReadService::tree_authenticated_owner_visible_with_audience_context
+```
+
+Its `CategoryTreeResponse` contains bounded recursive `CategoryTreeNode` values with the exact locale facts needed for observation:
+
+- `requested_locale`;
+- `effective_locale`;
+- `available_locales`.
+
+FORUM-33J observes only those already-materialized owner nodes after the owner read succeeds. It performs no additional database query, owner call, fallback resolution, permission check, visibility decision, mutation or repair.
+
+## Metric contract
+
+The new metric is:
+
+```text
+rustok_forum_graphql_category_tree_locale_resolution_total{outcome="..."}
+```
+
+`outcome` has exactly three values:
+
+- `exact`: at least one localized row exists and effective locale equals requested locale;
+- `fallback`: at least one localized row exists and effective locale differs from requested locale;
+- `missing`: the owner node reports no available locale.
+
+The tree is already bounded by `MAX_FORUM_CATEGORY_TREE_NODES`; recursive observation walks only returned nodes and adds no separate population scan.
+
+## Why this is a separate surface-scoped family
+
+The merged FORUM-33H collector remains unchanged. FORUM-33J does not refactor or widen that established `forumUnreadTopics` source contract merely to share a private collector implementation.
+
+A category-tree-specific family keeps the new surface explicit and preserves the existing H/I source guards without changing their behavior. It is not duplicate sampling of the same owner result: H observes unread-topic rows, while J observes category-tree nodes.
+
+## Cardinality and privacy boundary
+
+The only label is bounded `outcome`. The metric does not export locale values themselves and contains no:
+
+- tenant ID;
+- user ID;
+- category ID or parent ID;
+- category name or slug;
+- route, icon, color or description;
+- topic/reply counts;
+- arbitrary error or permission values.
+
+Tenant-controlled locale strings therefore cannot create Prometheus series.
+
+## Runtime and failure semantics
+
+Collector registration uses `rustok_telemetry::register_runtime_collector` and is best effort. If the runtime registry is not ready, the GraphQL owner result and response remain unchanged and a later successful observation can retry registration.
+
+The existing category-tree read-path query and budget metrics remain unchanged. FORUM-33J adds no migration, table, queue, worker, job, receipt, checkpoint or write path.
+
+## Remaining ownership blocks
+
+Spam-outcome telemetry remains blocked on real posting-policy owner enforcement/contracts; FORUM-26D is still a pure evaluator and `DuplicateContent` / `ExternalSpamScore` are reserved reasons rather than mounted operational outcomes.
+
+Moderation recovery now has public owner commands and host GraphQL orchestration, but that is a write/recovery boundary, not a Forum-owned application-operation diagnostic read. Forum still must not inspect Moderation private operation storage. A later Moderation diagnostic requires an explicit owner-supported read/status contract.
+
+Search and Notifications already own substantial convergence/reconciliation telemetry and should not receive duplicate Forum metrics without a new gap.
+
+## Canonical-plan drift
+
+The large canonical Forum implementation plan still lags parts of the merged FORUM-33 execution ledger. This dated packet records the actual cursor without whole-file replacement through the GitHub contents API, which could overwrite unrelated concurrent roadmap edits.
+
+## Next FORUM-33 cursor
+
+Attachments remain blocked on FORUM-14. Spam outcomes remain blocked on real owner enforcement. Moderation application status remains blocked on a public read/status owner contract.
+
+After this category-tree locale extension, recheck another mounted localized Forum surface only if it adds useful coverage without turning telemetry into blanket instrumentation. Topic/reply storefront reads are possible candidates. Otherwise stop the locale expansion and wait for one of the blocked owner contracts to land.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source check, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-category-tree-locale-metrics-source.mjs
+```

--- a/scripts/verify/verify-forum-category-tree-locale-metrics-source.mjs
+++ b/scripts/verify/verify-forum-category-tree-locale-metrics-source.mjs
@@ -40,6 +40,26 @@ for (const marker of [
   requireText(graphql, marker, `${graphqlPath}: missing ${marker}`);
 }
 
+const ownerCall = graphql.indexOf(
+  ".tree_authenticated_owner_visible_with_audience_context(",
+);
+const ownerAwait = graphql.indexOf(".await?;", ownerCall);
+const observation = graphql.indexOf(
+  "observe_category_tree_locale_resolution(&tree.roots);",
+  ownerAwait,
+);
+const response = graphql.indexOf("Ok(tree.into())", observation);
+if (
+  ownerCall < 0 ||
+  ownerAwait <= ownerCall ||
+  observation <= ownerAwait ||
+  response <= observation
+) {
+  throw new Error(
+    `${graphqlPath}: expected owner call -> await -> locale observation -> response ordering`,
+  );
+}
+
 const observerStart = graphql.indexOf("fn category_tree_locale_resolution_outcome(");
 const gqlTypeStart = graphql.indexOf("#[derive(SimpleObject)]", observerStart);
 if (observerStart < 0 || gqlTypeStart <= observerStart) {

--- a/scripts/verify/verify-forum-category-tree-locale-metrics-source.mjs
+++ b/scripts/verify/verify-forum-category-tree-locale-metrics-source.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const graphqlPath = "crates/rustok-forum/src/graphql/category_tree_query.rs";
+const packetPath =
+  "docs/modules/forum-33-category-tree-locale-metrics-actualization-2026-08-09.md";
+
+const graphql = read(graphqlPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "async fn forum_category_tree(",
+  ".tree_authenticated_owner_visible_with_audience_context(",
+  ".await?;",
+  "observe_category_tree_locale_resolution(&tree.roots);",
+  "rustok_forum_graphql_category_tree_locale_resolution_total",
+  '&["outcome"]',
+  'const CATEGORY_TREE_LOCALE_OUTCOME_EXACT: &str = "exact";',
+  'const CATEGORY_TREE_LOCALE_OUTCOME_FALLBACK: &str = "fallback";',
+  'const CATEGORY_TREE_LOCALE_OUTCOME_MISSING: &str = "missing";',
+  "available_locale_count == 0",
+  "requested_locale == effective_locale",
+  "rustok_telemetry::register_runtime_collector",
+  "counter.with_label_values(&[outcome]).inc();",
+  "observe_category_tree_locale_resolution_with_counter(counter, &node.children);",
+]) {
+  requireText(graphql, marker, `${graphqlPath}: missing ${marker}`);
+}
+
+const observerStart = graphql.indexOf("fn category_tree_locale_resolution_outcome(");
+const gqlTypeStart = graphql.indexOf("#[derive(SimpleObject)]", observerStart);
+if (observerStart < 0 || gqlTypeStart <= observerStart) {
+  throw new Error(`${graphqlPath}: category-tree locale observer source boundary is invalid`);
+}
+const observer = graphql.slice(observerStart, gqlTypeStart);
+
+for (const forbidden of [
+  "tenant_id",
+  "user_id",
+  "category_id",
+  "parent_id",
+  "name",
+  "slug",
+  "description",
+  "icon",
+  "color",
+  "topic_count",
+  "reply_count",
+  "DatabaseConnection",
+  "category_audience_read_service",
+  "Entity::find",
+  "UPDATE ",
+  "INSERT ",
+  "DELETE ",
+  "ActiveModel",
+]) {
+  requireAbsent(
+    observer,
+    forbidden,
+    `${graphqlPath}: category-tree locale observer must not contain ${forbidden}`,
+  );
+}
+
+for (const forbiddenLabel of [
+  "with_label_values(&[requested_locale",
+  "with_label_values(&[effective_locale",
+  "with_label_values(&[node.",
+  "requested_locale.to_string",
+  "effective_locale.to_string",
+]) {
+  requireAbsent(
+    observer,
+    forbiddenLabel,
+    `${graphqlPath}: locale values must not become metric labels`,
+  );
+}
+
+for (const marker of [
+  "FORUM-33J",
+  "FORUM-33I",
+  "Attachments therefore remain blocked on FORUM-14",
+  "forumCategoryTree",
+  "rustok_forum_graphql_category_tree_locale_resolution_total",
+  "MAX_FORUM_CATEGORY_TREE_NODES",
+  "no additional database query",
+  "Tenant-controlled locale strings",
+  "Spam-outcome telemetry remains blocked",
+  "Moderation recovery now has public owner commands",
+  "no Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-33J category-tree locale metric source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-33 after #3369 with bounded locale-fallback coverage on the already mounted `forumCategoryTree` GraphQL read.

- observe only successful `ForumCategoryAudienceReadService::tree_authenticated_owner_visible_with_audience_context` results;
- add `rustok_forum_graphql_category_tree_locale_resolution_total{outcome="..."}`;
- keep `outcome` fixed to `exact`, `fallback`, and `missing`;
- recursively observe only the already-returned `CategoryTreeNode` values bounded by `MAX_FORUM_CATEGORY_TREE_NODES`;
- never export locale strings, tenant/user/category identifiers, names, slugs, routes, counts, or arbitrary errors as labels;
- keep FORUM-33H and FORUM-33I collectors unchanged;
- use best-effort `rustok_telemetry::register_runtime_collector` registration;
- add FORUM-33J actualization plus a focused source guard.

## Ownership / behavior

No additional DB query, owner call, fallback pass, permission check, visibility decision, write, repair, cursor, GraphQL schema shape, or category-tree mapping change is introduced. The existing owner result remains authoritative.

Attachments remain blocked on FORUM-14. Spam outcomes remain blocked on real posting-policy enforcement/contracts. Moderation recovery now has public command boundaries, but not a public application-operation read/status contract suitable for Forum diagnostics.

## Validation

Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, DB fixture, migration, build, workflow, CI, lock generation, or `git diff --check` was run. Maintainer will run tests.