### PR TITLE
docs(blog): add canonical current implementation cursor

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "canonical_implementation_cursor",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "historical_baseline": "crates/rustok-blog/docs/implementation-plan.md",
+  "canonical_current_cursor": "crates/rustok-blog/docs/implementation-plan-current.md",
+  "actualization_slice": "crates/rustok-blog/docs/implementation-plan-slice-101.md",
+  "historical_baseline_last_embedded_slice": 67,
+  "latest_behavior_slice": 100,
+  "current_recorded_slice": 101,
+  "source_tracks": {
+    "remote_comments_transport": {
+      "status": "source_implemented_maintainer_execution_pending",
+      "transport_evidence": "crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json",
+      "latest_audit_relay_slice": "crates/rustok-blog/docs/implementation-plan-slice-97.md",
+      "must_not_reopen_as_source_gap": true
+    },
+    "comments_source_retention": {
+      "status": "blocked_until_slices_95_97_execution",
+      "blocking_slice": "crates/rustok-blog/docs/implementation-plan-slice-97.md",
+      "must_not_advance_before_execution": true
+    },
+    "category_translation_postgres": {
+      "status": "source_ready_maintainer_execution_pending",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-98.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json",
+      "must_not_reopen_as_source_gap": true
+    },
+    "cached_public_comments_snapshot": {
+      "status": "source_ready_maintainer_execution_pending",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-99.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json",
+      "must_not_reopen_as_source_gap": true
+    },
+    "storefront_comment_form_fallback": {
+      "status": "not_applicable_no_storefront_write_surface",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-100.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json",
+      "must_not_reopen_as_source_gap": true
+    }
+  },
+  "planning_result": {
+    "independent_production_source_gap_identified": false,
+    "future_autonomous_source_work_requires_fresh_audit": true,
+    "historical_stale_phrases_are_live_instructions": false,
+    "production_behavior_changed": false,
+    "ffa_or_fba_promoted": false
+  },
+  "execution": [],
+  "explicit_non_claims": [
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_compile_result",
+    "no_postgresql_result",
+    "no_redis_result",
+    "no_tcp_runtime_result",
+    "no_browser_result",
+    "no_http_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/README.md
+++ b/crates/rustok-blog/docs/README.md
@@ -10,6 +10,15 @@ semantics. Comments lifecycle events are consumed by Blog's durable idempotent
 reply-count projection, which publishes `BlogPostUpdated` in the same projection
 transaction.
 
+## Planning cursor
+
+Use [Current Implementation Cursor](./implementation-plan-current.md) for the
+live Blog source status and next autonomous cursor. The long
+[Implementation Plan](./implementation-plan.md) is the historical baseline and
+embedded implementation log; its inline current-state and next-results sections
+predate the later standalone continuation slices and must not be treated as the
+live cursor without the current-cursor document.
+
 ## Purpose
 
 - publish the canonical Blog runtime contract for posts, categories, and tag relations;
@@ -139,7 +148,8 @@ Tests in `tests/contract_surface.rs`, `tests/module.rs`, and `tests/integration.
 ## Related documents
 
 - [README crate](../README.md)
-- [Implementation Plan](./implementation-plan.md)
+- [Current Implementation Cursor](./implementation-plan-current.md)
+- [Historical Implementation Plan](./implementation-plan.md)
 - [CRATE_API](../CRATE_API.md)
 - [Admin package](../admin/README.md)
 - [Storefront package](../storefront/README.md)

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -1,0 +1,100 @@
+# rustok-blog canonical implementation cursor
+
+Status: `canonical_source_cursor_actualized_through_slice_100`.
+
+This document is the canonical **current** source cursor for `rustok-blog`.
+`crates/rustok-blog/docs/implementation-plan.md` remains the long historical baseline and embedded implementation log, but its inline `Current state`, completed-slice list, and `Next results` stop before the later continuation series and must not be used as the live cursor without this file.
+
+The continuation series is authoritative for source work after the historical baseline. Slice 101 records this actualization; the latest production/source behavior slice before this plan-only correction is slice 100.
+
+## Re-audit basis
+
+Fresh `main` was re-audited after slices 98–100. The retained continuation artifacts show that several phrases still present in the historical baseline are stale as current instructions:
+
+- the remote Comments transport is no longer an unimplemented source item;
+- the cached public Comments snapshot is no longer merely planned;
+- the storefront comment-form fallback is not an implementation target because the active storefront has no public Comments write surface;
+- Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution.
+
+These are planning corrections only. They do not promote runtime evidence.
+
+## Current source tracks
+
+### Comments remote transport and host composition
+
+The remote Comments source implementation exists. The retained continuation chain covers the typed transport boundary, `TcpJsonCommentsTransport`, TCP server/listener and host selection, user delegation and authorization, key/keyring lifecycle, schedule persistence/audit, canonical event admission, source retry/dead-letter/recovery ownership, restart/ambiguous-commit evidence sources, and the canonical `rustok-outbox` relay evidence source.
+
+Canonical interpretation:
+
+`remote_comments_transport = source_implemented_maintainer_execution_pending`
+
+Do **not** interpret historical `remote transport remains pending` text as a request to implement another transport, listener, retry lane, or relay.
+
+The latest audit/relay source boundary is slice 97:
+
+`canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.
+
+Source-row and immutable recovery-audit retention remain intentionally gated: do not advance that source work before retained maintainer execution of slices 95–97.
+
+### Blog category Translation target
+
+The `blog/category` target production source is present. Slice 98 adds the isolated PostgreSQL evidence source for:
+
+- real migration `up -> down -> up`;
+- concurrent same-revision CAS with one winner and one conflict;
+- change-cursor recovery across provider/owner reconstruction and delete lifecycle.
+
+Canonical interpretation:
+
+`category_translation_postgres = source_ready_maintainer_execution_pending`
+
+Do **not** reopen PostgreSQL migration, concurrent CAS, or ordinary cursor-recovery source scaffolding. After maintainer execution, record the result in the active Translation readiness view. Broader production enablement remains a separate Translation-owner decision.
+
+### Storefront Comments fallback
+
+Slice 99 implements one Blog-owned cached public Comments snapshot policy shared by GraphQL and native SSR. Successful approved public reads refresh the bounded cache best-effort. Only `ExternalService` and `Timeout` may consume an exact valid stale snapshot; stale hits preserve `UNAVAILABLE` / `TIMEOUT` and expose `cachedSnapshot=true`.
+
+Canonical interpretation:
+
+`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`
+
+Slice 100 re-audits the storefront write surface and proves that the active package is read-only. There is no public comment form, textarea, submit handler, GraphQL storefront mutation, or native create-comment server function.
+
+Canonical interpretation:
+
+`comment_form_fallback = not_applicable_no_storefront_write_surface`
+
+The legacy `hide_comment_form` token remains compatibility vocabulary in the existing FBA registries; it is not authorization to invent a new storefront write surface.
+
+## Remaining execution-owned results
+
+The source re-audit identifies no independent production source gap inside the tracks above. The remaining concrete results are maintainer execution or explicitly execution-gated follow-ups:
+
+1. Execute the retained Comments transport/composition, PostgreSQL, restart/ambiguity, canonical relay, and cached-snapshot evidence at an exact revision.
+2. Execute slices 95–97 before defining terminal Blog source-row and immutable recovery-audit retention.
+3. Execute slice 98 PostgreSQL evidence before advancing the Blog category Translation readiness result.
+4. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
+5. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
+
+A future autonomous source slice must start from a fresh repository audit and identify a genuinely new independent source gap. It must not manufacture work by reopening a source-complete or not-applicable cursor.
+
+## Superseded historical cursor phrases
+
+The following phrases may remain in the historical baseline as records of earlier state, but they are superseded as live instructions:
+
+- `remote transport remains pending`;
+- `cached snapshot and comment-form fallback remain planned`;
+- `PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement`;
+- `then implement the remote network transport`.
+
+The continuation slice files and machine evidence remain the source of detailed ownership/non-claim history. This file only defines the current planning cursor.
+
+## Validation boundary
+
+No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent while producing this actualization.
+
+## Next cursor
+
+No independent production source gap is claimed by this actualization.
+
+Continue only after a fresh repository audit finds a new source gap outside the execution-gated tracks above, or after maintainers provide execution results that unlock one of their explicit follow-ups.

--- a/crates/rustok-blog/docs/implementation-plan-slice-101.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-101.md
@@ -1,0 +1,113 @@
+# rustok-blog implementation plan — slice 101 continuation
+
+Status: `canonical_plan_current_cursor_source_ready_no_runtime_promotion`.
+
+This slice continues `crates/rustok-blog/docs/implementation-plan-slice-100.md`.
+
+## Goal
+
+Repair the planning boundary after the historical root implementation plan fell behind the continuation series.
+
+The repository contains a long `implementation-plan.md` whose inline current-state and completed-slice sections stop before the later slice files. By slice 100, several old phrases in that historical file had become actively misleading: they still described the remote Comments transport and cached snapshot as future implementation work, still treated the nonexistent storefront comment form as a planned fallback surface, and still described Blog category Translation PostgreSQL evidence as source work not yet retained.
+
+Slice 101 does not rewrite the 1,000+ line historical log. Instead it creates one stable canonical current-cursor document and makes the Blog docs index point maintainers and agents to it before the historical baseline.
+
+## Canonical current cursor
+
+New document:
+
+`crates/rustok-blog/docs/implementation-plan-current.md`
+
+It records the following current source interpretations:
+
+```text
+remote_comments_transport = source_implemented_maintainer_execution_pending
+category_translation_postgres = source_ready_maintainer_execution_pending
+cached_public_comments_snapshot = source_ready_maintainer_execution_pending
+comment_form_fallback = not_applicable_no_storefront_write_surface
+```
+
+It also records the execution gate from slice 97:
+
+```text
+source_row_and_recovery_audit_retention = blocked_until_slices_95_97_execution
+```
+
+No runtime or production result is promoted.
+
+## Why the historical root plan is not rewritten wholesale
+
+`implementation-plan.md` is both a current-state document and a chronological record. Its embedded completed-slice list ends before the standalone continuation series that now reaches slice 100. Replacing the whole file through the contents API solely to refresh several live-cursor paragraphs would create a large, review-hostile rewrite with high accidental-history risk.
+
+The safer contract is:
+
+1. preserve the historical file unchanged;
+2. publish one small canonical current cursor;
+3. link it from `docs/README.md` before the historical plan;
+4. retain machine evidence for the exact interpretation;
+5. add a fail-closed verifier and focused self-test so stale phrases cannot silently re-enter the canonical cursor.
+
+Future maintainers may deliberately consolidate the historical log in a separately reviewed documentation migration, but current source work must use the canonical cursor first.
+
+## Re-audited source facts
+
+### Remote Comments
+
+The continuation source chain after the old root cursor includes the typed remote adapter/TCP transport, server adapter/listener, host channel/provider selection, delegated user-write authorization, key/keyring lifecycle, scheduled replacement persistence/audit, canonical event contract and writer, bounded source handoff/retry/dead-letter/recovery, restart/ambiguous-commit evidence sources, and canonical Outbox relay evidence.
+
+Slice 97 is explicitly source-ready for canonical relay PostgreSQL execution. Therefore the old root instruction `then implement the remote network transport` is superseded; another transport or relay would violate the established ownership boundary.
+
+### Category Translation
+
+Slice 98 retains PostgreSQL source targets for real migration up/down/up, same-revision concurrent CAS, and ordinary change-cursor recovery. The correct next result is maintainer execution and readiness recording, not another source harness for those same cases.
+
+### Storefront fallback
+
+Slice 99 retains the shared cached public Comments snapshot source across GraphQL/native SSR and the stale-data UI signal. Slice 100 proves the active storefront has no public Comments write surface. The old combined phrase `cached snapshot and comment-form fallback remain planned` is therefore doubly stale: one half is source-ready and the other is not applicable.
+
+## Machine evidence
+
+Current-cursor evidence:
+
+`crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json`
+
+Fail-closed verifier:
+
+`scripts/verify/verify-blog-canonical-plan-current.mjs`
+
+Focused self-test:
+
+`scripts/verify/verify-blog-canonical-plan-current.test.mjs`
+
+The verifier source-locks the current cursor against slices 97–100 and rejects the stale historical phrases if they appear as live instructions in the current-cursor document.
+
+## Preserved boundaries
+
+Slice 101 changes no production behavior. It does not change:
+
+- Comments transport, listener, authorization, delegation, key lifecycle, replay, schedule state or persistence;
+- Blog source audit, recovery, retry/dead-letter, handoff, or source-row retention;
+- canonical event schema, digests, writer, `sys_events`, Outbox relay, retry or DLQ;
+- Blog category schema, Translation target CAS, receipts, journal or Search reindex behavior;
+- storefront DTOs, cache policy, UI rendering, routes or write surfaces;
+- Blog FBA/FFA status;
+- package scripts or aggregate verification-chain order.
+
+## Explicit non-claims
+
+This slice does not claim:
+
+- any Rust/JavaScript verifier or test execution;
+- compile/check/format/Clippy results;
+- PostgreSQL, Redis, TCP, browser, HTTP, workflow, CI or production execution;
+- execution of slices 95–100;
+- source-row/recovery-audit retention completion;
+- Translation production enablement;
+- cached-snapshot runtime evidence;
+- a newly discovered production source gap.
+
+## Next cursor
+
+The canonical current cursor intentionally names **no independent production source gap** inside the re-audited Comments/Translation/storefront tracks.
+
+The next autonomous source slice must be justified by a fresh repository audit outside those execution-gated tracks. If maintainers execute the retained targets first, continue only from the explicit follow-up unlocked by those results.

--- a/scripts/verify/verify-blog-canonical-plan-current.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const failures = [];
+
+const files = {
+  evidence: 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
+  current: 'crates/rustok-blog/docs/implementation-plan-current.md',
+  historical: 'crates/rustok-blog/docs/implementation-plan.md',
+  slice97: 'crates/rustok-blog/docs/implementation-plan-slice-97.md',
+  slice98: 'crates/rustok-blog/docs/implementation-plan-slice-98.md',
+  slice99: 'crates/rustok-blog/docs/implementation-plan-slice-99.md',
+  slice100: 'crates/rustok-blog/docs/implementation-plan-slice-100.md',
+  slice101: 'crates/rustok-blog/docs/implementation-plan-slice-101.md',
+  docsIndex: 'crates/rustok-blog/docs/README.md',
+  tcpTransport: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
+  tcpServer: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
+  tcpListener: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json',
+  translationPostgres: 'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
+  fallback: 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+  writeSurface: 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+};
+
+function absolute(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function read(relativePath) {
+  const target = absolute(relativePath);
+  if (!fs.existsSync(target)) {
+    failures.push(`${relativePath}: missing file`);
+    return '';
+  }
+  return fs.readFileSync(target, 'utf8');
+}
+
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function need(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function forbid(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden live cursor marker ${marker}`);
+}
+
+function sameSet(actual, expected) {
+  return [...(actual ?? [])].sort().join('|') === [...expected].sort().join('|');
+}
+
+function between(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) return '';
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const evidence = json(files.evidence);
+const current = read(files.current);
+const historical = read(files.historical);
+const slice97 = read(files.slice97);
+const slice98 = read(files.slice98);
+const slice99 = read(files.slice99);
+const slice100 = read(files.slice100);
+const slice101 = read(files.slice101);
+const docsIndex = read(files.docsIndex);
+const tcpTransport = json(files.tcpTransport);
+const tcpServer = json(files.tcpServer);
+const tcpListener = json(files.tcpListener);
+const translationPostgres = json(files.translationPostgres);
+const fallback = json(files.fallback);
+const writeSurface = json(files.writeSurface);
+
+if (evidence) {
+  if (
+    evidence.schema_version !== 1 ||
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'canonical_implementation_cursor' ||
+    evidence.status !== 'source_verified_no_compile' ||
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${files.evidence}: identity/status drift`);
+
+  if (
+    evidence.historical_baseline !== files.historical ||
+    evidence.canonical_current_cursor !== files.current ||
+    evidence.actualization_slice !== files.slice101 ||
+    evidence.historical_baseline_last_embedded_slice !== 67 ||
+    evidence.latest_behavior_slice !== 100 ||
+    evidence.current_recorded_slice !== 101
+  ) failures.push(`${files.evidence}: cursor path/version drift`);
+
+  const tracks = evidence.source_tracks ?? {};
+  if (
+    tracks.remote_comments_transport?.status !==
+      'source_implemented_maintainer_execution_pending' ||
+    tracks.remote_comments_transport?.transport_evidence !== files.tcpTransport ||
+    tracks.remote_comments_transport?.latest_audit_relay_slice !== files.slice97 ||
+    tracks.remote_comments_transport?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: remote Comments track drift`);
+
+  if (
+    tracks.comments_source_retention?.status !==
+      'blocked_until_slices_95_97_execution' ||
+    tracks.comments_source_retention?.blocking_slice !== files.slice97 ||
+    tracks.comments_source_retention?.must_not_advance_before_execution !== true
+  ) failures.push(`${files.evidence}: Comments source-retention gate drift`);
+
+  if (
+    tracks.category_translation_postgres?.status !==
+      'source_ready_maintainer_execution_pending' ||
+    tracks.category_translation_postgres?.slice !== files.slice98 ||
+    tracks.category_translation_postgres?.evidence !== files.translationPostgres ||
+    tracks.category_translation_postgres?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: category Translation track drift`);
+
+  if (
+    tracks.cached_public_comments_snapshot?.status !==
+      'source_ready_maintainer_execution_pending' ||
+    tracks.cached_public_comments_snapshot?.slice !== files.slice99 ||
+    tracks.cached_public_comments_snapshot?.evidence !== files.fallback ||
+    tracks.cached_public_comments_snapshot?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: cached Comments track drift`);
+
+  if (
+    tracks.storefront_comment_form_fallback?.status !==
+      'not_applicable_no_storefront_write_surface' ||
+    tracks.storefront_comment_form_fallback?.slice !== files.slice100 ||
+    tracks.storefront_comment_form_fallback?.evidence !== files.writeSurface ||
+    tracks.storefront_comment_form_fallback?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: storefront write-surface track drift`);
+
+  if (
+    evidence.planning_result?.independent_production_source_gap_identified !== false ||
+    evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== true ||
+    evidence.planning_result?.historical_stale_phrases_are_live_instructions !== false ||
+    evidence.planning_result?.production_behavior_changed !== false ||
+    evidence.planning_result?.ffa_or_fba_promoted !== false ||
+    !Array.isArray(evidence.execution) ||
+    evidence.execution.length !== 0
+  ) failures.push(`${files.evidence}: planning/execution claim drift`);
+}
+
+for (const [label, artifact, expectedSurface] of [
+  [files.tcpTransport, tcpTransport, 'comments_tcp_json_transport'],
+  [files.tcpServer, tcpServer, 'comments_tcp_server_adapter'],
+  [files.tcpListener, tcpListener, 'comments_tcp_listener_lifecycle'],
+]) {
+  if (
+    artifact?.module !== 'blog' ||
+    artifact?.provider !== 'comments' ||
+    artifact?.surface !== expectedSurface ||
+    artifact?.status !== 'source_verified_no_compile' ||
+    artifact?.runtime_status !== 'not_run'
+  ) failures.push(`${label}: remote transport source evidence drift`);
+}
+
+if (
+  !sameSet(tcpServer?.operations, [
+    'create_comment',
+    'get_comment',
+    'list_comments_for_target',
+    'list_public_comments_for_target',
+    'update_comment',
+    'set_comment_status',
+    'delete_comment',
+  ])
+) failures.push(`${files.tcpServer}: seven-operation transport parity drift`);
+
+if (
+  translationPostgres?.status !== 'blog_category_translation_postgres_source_unvalidated' ||
+  translationPostgres?.source_contract?.translation_target_migration_up_down_up_covered !== true ||
+  translationPostgres?.source_contract?.concurrent_apply_requires_exactly_one_success !== true ||
+  translationPostgres?.source_contract?.cursor_recovery_drains_after_latest_cursor !== true ||
+  translationPostgres?.source_contract?.postgres_execution_observed !== false ||
+  !Array.isArray(translationPostgres?.execution) ||
+  translationPostgres.execution.length !== 0
+) failures.push(`${files.translationPostgres}: Translation PostgreSQL source status drift`);
+
+if (
+  fallback?.storefront_read_degradation?.cached_thread_snapshot !==
+    'source_verified_no_compile' ||
+  fallback?.storefront_read_degradation?.runtime_evidence !== 'pending' ||
+  !sameSet(fallback?.storefront_read_degradation?.transports, ['graphql', 'native_ssr']) ||
+  fallback?.storefront_write_surface?.comment_form_fallback !==
+    'not_applicable_no_storefront_write_surface'
+) failures.push(`${files.fallback}: storefront fallback current-state drift`);
+
+if (
+  writeSurface?.status !== 'source_verified_absent' ||
+  writeSurface?.actualization !==
+    'comment_form_fallback_not_applicable_no_storefront_write_surface' ||
+  writeSurface?.source_contract?.create_comment_surface_present !== false ||
+  writeSurface?.source_contract?.comment_form_present !== false ||
+  writeSurface?.planning_effect?.new_storefront_write_surface_authorized !== false ||
+  !Array.isArray(writeSurface?.execution) ||
+  writeSurface.execution.length !== 0
+) failures.push(`${files.writeSurface}: storefront write-surface evidence drift`);
+
+for (const [source, marker, label] of [
+  [slice97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice97],
+  [slice98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice98],
+  [slice99, 'Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.', files.slice99],
+  [slice100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.', files.slice100],
+]) need(source, marker, label);
+
+need(
+  slice97,
+  'After retained maintainer execution of slices 95–97, define bounded lifecycle and',
+  files.slice97,
+);
+need(
+  slice98,
+  'The Comments audit track remains independently blocked on maintainer execution',
+  files.slice98,
+);
+need(
+  slice99,
+  'comment-form fallback is still a separate unfinished result',
+  files.slice99,
+);
+need(
+  slice100,
+  'comment_form_fallback = not_applicable_no_storefront_write_surface',
+  files.slice100,
+);
+
+for (const marker of [
+  'Status: `canonical_source_cursor_actualized_through_slice_100`.',
+  '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
+  '`category_translation_postgres = source_ready_maintainer_execution_pending`',
+  '`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`',
+  '`comment_form_fallback = not_applicable_no_storefront_write_surface`',
+  'do not advance that source work before retained maintainer execution of slices 95–97',
+  'The source re-audit identifies no independent production source gap',
+  'A future autonomous source slice must start from a fresh repository audit',
+  '## Superseded historical cursor phrases',
+  'No tests, Cargo commands, Node verifiers',
+]) need(current, marker, files.current);
+
+const supersededSection = between(
+  current,
+  '## Superseded historical cursor phrases',
+  '## Validation boundary',
+);
+const liveCurrent = current.replace(supersededSection, '');
+for (const marker of [
+  'remote transport remains pending',
+  'cached snapshot and comment-form fallback remain planned',
+  'PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement',
+  'then implement the remote network transport',
+]) forbid(liveCurrent, marker, files.current);
+
+const completed = between(historical, '## Completed implementation slices', '## Next results');
+need(completed, '67. Executed all four Blog Comments projection PostgreSQL targets locally', files.historical);
+if (/\n68\.\s/.test(completed)) {
+  failures.push(`${files.historical}: historical embedded completed-slice list unexpectedly advanced without current-cursor evidence update`);
+}
+
+for (const marker of [
+  '## Planning cursor',
+  '[Current Implementation Cursor](./implementation-plan-current.md)',
+  '[Historical Implementation Plan](./implementation-plan.md)',
+  'must not be treated as the live cursor',
+]) need(docsIndex, marker, files.docsIndex);
+const currentLink = docsIndex.indexOf('[Current Implementation Cursor](./implementation-plan-current.md)');
+const historicalLink = docsIndex.indexOf('[Historical Implementation Plan](./implementation-plan.md)');
+if (currentLink < 0 || historicalLink < 0 || currentLink > historicalLink) {
+  failures.push(`${files.docsIndex}: canonical current cursor must be listed before the historical plan`);
+}
+
+for (const marker of [
+  'Status: `canonical_plan_current_cursor_source_ready_no_runtime_promotion`.',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+  'historical root implementation plan fell behind the continuation series',
+  'remote_comments_transport = source_implemented_maintainer_execution_pending',
+  'source_row_and_recovery_audit_retention = blocked_until_slices_95_97_execution',
+  'The next autonomous source slice must be justified by a fresh repository audit',
+]) need(slice101, marker, files.slice101);
+
+if (failures.length > 0) {
+  console.error('[verify-blog-canonical-plan-current] FAIL');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '[verify-blog-canonical-plan-current] PASS cursor=slice-101 behavior-through=slice-100 execution=not-run',
+);

--- a/scripts/verify/verify-blog-canonical-plan-current.test.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.test.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const verifier = path.join(repositoryRoot, 'scripts/verify/verify-blog-canonical-plan-current.mjs');
+const files = [
+  'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+  'crates/rustok-blog/docs/implementation-plan.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-97.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-98.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-99.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-100.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-101.md',
+  'crates/rustok-blog/docs/README.md',
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json',
+  'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+];
+
+function absolute(root, relativePath) {
+  return path.join(root, relativePath);
+}
+
+function write(root, relativePath, content) {
+  const target = absolute(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+function fixture(mutator = () => {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-current-plan-'));
+  for (const relativePath of files) {
+    const source = path.join(repositoryRoot, relativePath);
+    const target = absolute(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(source, target);
+  }
+  mutator(root);
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: repositoryRoot,
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(mutator) {
+  const root = fixture(mutator);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function mutateJson(root, relativePath, mutator) {
+  const target = absolute(root, relativePath);
+  const value = JSON.parse(readFileSync(target, 'utf8'));
+  mutator(value);
+  write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test('accepts the canonical Blog current implementation cursor', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /cursor=slice-101/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects reopening remote transport as live current-cursor work', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/docs/implementation-plan-current.md';
+    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    write(
+      root,
+      relativePath,
+      source.replace(
+        '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
+        '`remote_comments_transport = remote transport remains pending`',
+      ),
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /remote transport|current/);
+});
+
+test('rejects promoting a new autonomous source gap without a fresh audit', () => {
+  const result = rejects((root) => {
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
+      (value) => {
+        value.planning_result.independent_production_source_gap_identified = true;
+      },
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /planning\/execution claim drift/);
+});
+
+test('rejects Translation PostgreSQL execution promotion without retained execution', () => {
+  const result = rejects((root) => {
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
+      (value) => {
+        value.source_contract.postgres_execution_observed = true;
+      },
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Translation PostgreSQL source status drift/);
+});
+
+test('rejects reviving an active storefront comment form', () => {
+  const result = rejects((root) => {
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+      (value) => {
+        value.source_contract.comment_form_present = true;
+        value.source_contract.create_comment_surface_present = true;
+      },
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /write-surface evidence drift/);
+});
+
+test('rejects a cached snapshot regression back to planned source work', () => {
+  const result = rejects((root) => {
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
+      (value) => {
+        value.storefront_read_degradation.cached_thread_snapshot = 'planned';
+      },
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /storefront fallback current-state drift/);
+});
+
+test('rejects listing the historical plan before the canonical current cursor', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/docs/README.md';
+    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    const current = '[Current Implementation Cursor](./implementation-plan-current.md)';
+    const historical = '[Historical Implementation Plan](./implementation-plan.md)';
+    write(
+      root,
+      relativePath,
+      source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical),
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /canonical current cursor must be listed before/);
+});
+
+test('rejects an unrecorded advance of the historical embedded slice list', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/docs/implementation-plan.md';
+    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    write(
+      root,
+      relativePath,
+      source.replace(
+        '\n## Next results',
+        '\n68. Unrecorded historical-list advance.\n\n## Next results',
+      ),
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /historical embedded completed-slice list unexpectedly advanced/);
+});


### PR DESCRIPTION
## Summary

Actualize the Blog improvement plan after the standalone continuation series reached slice 100 while the historical root `implementation-plan.md` still embeds current-state/completed-slice/next-result text only through slice 67.

This PR avoids a review-hostile rewrite of the 1,000+ line historical log. Instead it adds one canonical current cursor, points the Blog docs index to it before the historical plan, retains machine evidence, and adds a fail-closed verifier plus focused self-test.

## Current cursor corrections

The canonical current cursor records:

- remote Comments transport source implementation exists; retained runtime/DB/TCP evidence remains maintainer-owned;
- source-row/recovery-audit retention remains blocked until retained execution of slices 95–97;
- Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor source evidence is already retained in slice 98 and awaits maintainer execution;
- cached public Comments snapshot source is retained across GraphQL/native SSR in slice 99 and awaits runtime evidence;
- storefront comment-form fallback is not applicable because the active storefront has no public Comments write surface, as recorded by slice 100;
- no new independent production source gap is claimed by this plan-only actualization.

Historical phrases such as `remote transport remains pending`, `cached snapshot and comment-form fallback remain planned`, and `then implement the remote network transport` remain history only and are explicitly superseded as live instructions.

## Guard

Adds `verify-blog-canonical-plan-current.mjs` and a focused self-test. The guard binds the current cursor to slices 97–100 and current machine evidence, rejects reopening source-complete/not-applicable tracks, rejects execution promotion, and requires the docs index to list the canonical cursor before the historical plan.

## Scope

No production source, registry, package script, FFA/FBA status, runtime composition, transport, database schema, cache behavior, or UI behavior changes.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, builds, PostgreSQL/Redis/TCP/browser/HTTP scenarios, workflows, CI, or runtime validation were executed. Source/diff review only.