### PR TITLE
feat(commerce): route admin Fulfillment commands through owner port

### DIFF
--- a/crates/rustok-commerce/docs/admin-fulfillment-owner-command-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/admin-fulfillment-owner-command-cutover-2026-08-09.md
@@ -1,0 +1,95 @@
+# Commerce admin Fulfillment owner-command cutover — 2026-08-09
+
+Status: source-complete for mounted admin Fulfillment ship/deliver/reopen/reship/cancel routes; execution evidence pending and unvalidated.
+
+## Scope
+
+This slice advances the canonical ecommerce topology P0 without closing it. Five mounted admin Fulfillment lifecycle routes now call a Fulfillment-owned command capability:
+
+- `POST /admin/fulfillments/{id}/ship`;
+- `POST /admin/fulfillments/{id}/deliver`;
+- `POST /admin/fulfillments/{id}/reopen`;
+- `POST /admin/fulfillments/{id}/reship`;
+- `POST /admin/fulfillments/{id}/cancel`.
+
+`POST /admin/fulfillments` is intentionally out of scope. Manual fulfillment creation is a cross-owner Commerce workflow: it validates Order ownership and remaining quantities, applies seller-aware shipping-profile grouping, persists the Fulfillment, and then creates a provider label. Moving that entire workflow into `rustok-fulfillment` would incorrectly make Fulfillment own Order/Commerce policy.
+
+## Fulfillment owner capability
+
+`rustok-fulfillment` now publishes `FulfillmentAdminCommandPort` and `FulfillmentAdminCommandRuntime` with typed ship, deliver, reopen, reship, and cancel commands. The built-in adapter owns:
+
+- `FulfillmentService` construction and lifecycle persistence;
+- shipping-option provider resolution;
+- `FulfillmentProviderOperationJournal` construction and replay adoption;
+- provider execution through the host-selected `FulfillmentProviderRegistry` for ship/reship/cancel;
+- provider-result metadata adoption;
+- reconciliation checkpointing when a provider side effect succeeded but local persistence failed.
+
+Mounted Commerce HTTP does not construct `FulfillmentService` or `FulfillmentOrchestrationService` for these five routes.
+
+## Provider replay compatibility
+
+The owner command adapter preserves the pre-cutover immutable provider request payload and exact payload-sensitive key algorithm:
+
+`fulfillment:{fulfillment_id}:{operation}:{fnv128}`
+
+The two FNV-1a 64-bit passes retain the existing offset bases and concatenate into the same 32-hex-character suffix. Provider request metadata also remains compatible:
+
+- ship: `commerce_orchestration.operation = ship` plus carrier, tracking number, and item adjustments;
+- reship: `commerce_orchestration.operation = reship` plus carrier, tracking number, and item adjustments;
+- cancel: `commerce_orchestration.operation = cancel` plus the requested reason.
+
+The existing local `provider_operation` metadata is also retained when provider results are committed to Fulfillment state.
+
+## Lifecycle replay compatibility
+
+The owner path retains two compatibility behaviors from the previous Commerce facade:
+
+- a completed reship replay returns the already-shipped Fulfillment when `metadata.provider_operation.operation == "reship"`;
+- cancelling an already-cancelled Fulfillment returns the current projection instead of re-running the provider operation.
+
+Ship continues to adopt already-committed provider journal state. Provider operations already marked `reconciliation_required` remain a validation-class replay result, matching the pre-cutover mounted HTTP family.
+
+## Reconciliation semantics
+
+When ship/reship/cancel provider execution succeeds but the subsequent local Fulfillment persistence fails, the owner adapter marks the provider operation `reconciliation_required` and returns the existing public reconciliation family:
+
+- HTTP 409;
+- `commerce_admin_fulfillment_reconciliation_required`;
+- `Fulfillment operation requires reconciliation`.
+
+Ordinary validation, not-found, invalid-transition, and storage failures keep their existing public HTTP families. Internal provider/database text is not copied into owner `PortError` messages.
+
+## Port write identity
+
+Mounted HTTP supplies tenant, authenticated user actor, locale, optional channel, a two-second deadline, and a stable transition-scoped admission identity:
+
+`admin-fulfillment:{fulfillment_id}:{operation}`
+
+This identity satisfies the generic write-port admission contract. It is not a newly claimed durable command receipt. Durable provider replay for ship/reship/cancel remains the Fulfillment-owned payload-sensitive provider journal described above. Deliver/reopen do not gain a durable replay receipt in this slice.
+
+## Runtime composition
+
+`CommerceHttpRuntime` prefers a host-injected `FulfillmentAdminCommandRuntime`. When none is supplied, it composes the public in-process Fulfillment owner runtime using the same host-selected `FulfillmentProviderRegistry` already used by Commerce provider integration.
+
+This preserves external adapter precedence without constructing concrete Fulfillment services in the mounted command adapter.
+
+## Mounted compatibility strategy
+
+The existing `controllers/admin/fulfillments.rs` remains a private compatibility module. `fulfillments_owner_commands.rs` wildcard-reexports its unaffected list/show/create and generated Utoipa compatibility symbols, while local definitions shadow the five mounted lifecycle commands.
+
+This follows the already-established Payment cutover pattern and avoids changing public route/OpenAPI symbol names.
+
+## Remaining topology work
+
+The canonical broad item “Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports” remains open.
+
+The next Fulfillment-specific boundary is manual admin fulfillment creation. That work should keep Order and seller/shipping-profile policy in Commerce while replacing cross-owner concrete access with typed owner capabilities and keeping create-label durability/recovery intact.
+
+Post-order/change/return workflows and remaining GraphQL/provider-operation construction also keep the broad P0 open.
+
+## Validation status
+
+`scripts/verify/verify-commerce-admin-fulfillment-owner-command-cutover.mjs` is added as a source guard but is intentionally not executed here.
+
+No tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart/lost-response evidence, or external-provider execution evidence are claimed in this slice.

--- a/crates/rustok-commerce/src/controllers/admin/fulfillments_owner_commands.rs
+++ b/crates/rustok-commerce/src/controllers/admin/fulfillments_owner_commands.rs
@@ -1,0 +1,383 @@
+use axum::{Json, extract::{Path, State}, http::StatusCode};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_fulfillment::{
+    CancelAdminFulfillmentRequest, DeliverAdminFulfillmentRequest, ReopenAdminFulfillmentRequest,
+    ReshipAdminFulfillmentRequest, ShipAdminFulfillmentRequest,
+};
+use rustok_web::{HttpError, HttpResult};
+use uuid::Uuid;
+
+pub use super::fulfillments_legacy::*;
+use super::{super::CommerceHttpRuntime, super::common::ensure_permissions};
+use crate::dto::{
+    CancelFulfillmentInput, DeliverFulfillmentInput, FulfillmentResponse, ReopenFulfillmentInput,
+    ReshipFulfillmentInput, ShipFulfillmentInput,
+};
+
+const ADMIN_FULFILLMENT_COMMAND_OWNER: &str = "rustok_fulfillment.admin_command";
+const ADMIN_FULFILLMENT_COMMAND_BOUNDARY: &str = "commerce_admin_fulfillment_command_http";
+
+type AdminFulfillmentCommandHttpPolicy =
+    (StatusCode, &'static str, &'static str, &'static str);
+
+fn admin_fulfillment_command_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    fulfillment_id: Uuid,
+    operation: &'static str,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-fulfillment-command:{operation}:{fulfillment_id}"),
+    )
+    .with_idempotency_key(format!("admin-fulfillment:{fulfillment_id}:{operation}"))
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn fulfillment_command_error_policy(error: &PortError) -> AdminFulfillmentCommandHttpPolicy {
+    match error.code.as_str() {
+        "fulfillment.reconciliation_required" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_reconciliation_required",
+            "Fulfillment operation requires reconciliation",
+            "reconciliation_required",
+        ),
+        "fulfillment.database_unavailable" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_fulfillment_storage_unavailable",
+            "Fulfillment storage is temporarily unavailable",
+            "database",
+        ),
+        "fulfillment.invalid_transition" => (
+            StatusCode::CONFLICT,
+            "commerce_admin_fulfillment_state_conflict",
+            "Fulfillment operation conflicts with the current state",
+            "state_conflict",
+        ),
+        _ => match &error.kind {
+            PortErrorKind::Validation => (
+                StatusCode::BAD_REQUEST,
+                "commerce_admin_fulfillment_invalid",
+                "Fulfillment request is invalid",
+                "validation",
+            ),
+            PortErrorKind::NotFound => (
+                StatusCode::NOT_FOUND,
+                "commerce_admin_not_found",
+                "Commerce resource not found",
+                "not_found",
+            ),
+            PortErrorKind::Conflict => (
+                StatusCode::CONFLICT,
+                "commerce_admin_fulfillment_state_conflict",
+                "Fulfillment operation conflicts with the current state",
+                "state_conflict",
+            ),
+            PortErrorKind::Forbidden => (
+                StatusCode::UNAUTHORIZED,
+                "commerce_permission_denied",
+                "Permission denied",
+                "forbidden",
+            ),
+            PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "commerce_admin_fulfillment_storage_unavailable",
+                "Fulfillment storage is temporarily unavailable",
+                "unavailable",
+            ),
+            PortErrorKind::InvariantViolation => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "commerce_admin_fulfillment_failed",
+                "Fulfillment operation could not be completed safely",
+                "invariant_violation",
+            ),
+        },
+    }
+}
+
+fn map_fulfillment_command_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    fulfillment_id: Uuid,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = fulfillment_command_error_policy(&error);
+    tracing::error!(
+        owner = ADMIN_FULFILLMENT_COMMAND_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        fulfillment_id_non_nil = !fulfillment_id.is_nil(),
+        operation,
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_FULFILLMENT_COMMAND_BOUNDARY,
+        "commerce admin fulfillment owner command failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/fulfillments/{id}/ship",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Fulfillment ID")),
+    request_body = ShipFulfillmentInput,
+    responses(
+        (status = 200, description = "Fulfillment shipped", body = FulfillmentResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Fulfillment not found")
+    )
+)]
+pub async fn ship_fulfillment(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<ShipFulfillmentInput>,
+) -> HttpResult<Json<FulfillmentResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::FULFILLMENTS_UPDATE],
+        "Permission denied: fulfillments:update required",
+    )?;
+    let context =
+        admin_fulfillment_command_context(&tenant, &auth, &request_context, id, "ship");
+    let fulfillment = runtime
+        .fulfillment_admin_command_port()
+        .ship_fulfillment(
+            context.clone(),
+            ShipAdminFulfillmentRequest {
+                fulfillment_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_fulfillment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "ship_fulfillment",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(fulfillment))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/fulfillments/{id}/deliver",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Fulfillment ID")),
+    request_body = DeliverFulfillmentInput,
+    responses(
+        (status = 200, description = "Fulfillment delivered", body = FulfillmentResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Fulfillment not found")
+    )
+)]
+pub async fn deliver_fulfillment(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<DeliverFulfillmentInput>,
+) -> HttpResult<Json<FulfillmentResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::FULFILLMENTS_UPDATE],
+        "Permission denied: fulfillments:update required",
+    )?;
+    let context =
+        admin_fulfillment_command_context(&tenant, &auth, &request_context, id, "deliver");
+    let fulfillment = runtime
+        .fulfillment_admin_command_port()
+        .deliver_fulfillment(
+            context.clone(),
+            DeliverAdminFulfillmentRequest {
+                fulfillment_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_fulfillment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "deliver_fulfillment",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(fulfillment))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/fulfillments/{id}/reopen",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Fulfillment ID")),
+    request_body = ReopenFulfillmentInput,
+    responses(
+        (status = 200, description = "Fulfillment reopened", body = FulfillmentResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Fulfillment not found")
+    )
+)]
+pub async fn reopen_fulfillment(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<ReopenFulfillmentInput>,
+) -> HttpResult<Json<FulfillmentResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::FULFILLMENTS_UPDATE],
+        "Permission denied: fulfillments:update required",
+    )?;
+    let context =
+        admin_fulfillment_command_context(&tenant, &auth, &request_context, id, "reopen");
+    let fulfillment = runtime
+        .fulfillment_admin_command_port()
+        .reopen_fulfillment(
+            context.clone(),
+            ReopenAdminFulfillmentRequest {
+                fulfillment_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_fulfillment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "reopen_fulfillment",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(fulfillment))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/fulfillments/{id}/reship",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Fulfillment ID")),
+    request_body = ReshipFulfillmentInput,
+    responses(
+        (status = 200, description = "Fulfillment marked for reship", body = FulfillmentResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Fulfillment not found")
+    )
+)]
+pub async fn reship_fulfillment(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<ReshipFulfillmentInput>,
+) -> HttpResult<Json<FulfillmentResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::FULFILLMENTS_UPDATE],
+        "Permission denied: fulfillments:update required",
+    )?;
+    let context =
+        admin_fulfillment_command_context(&tenant, &auth, &request_context, id, "reship");
+    let fulfillment = runtime
+        .fulfillment_admin_command_port()
+        .reship_fulfillment(
+            context.clone(),
+            ReshipAdminFulfillmentRequest {
+                fulfillment_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_fulfillment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "reship_fulfillment",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(fulfillment))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/fulfillments/{id}/cancel",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Fulfillment ID")),
+    request_body = CancelFulfillmentInput,
+    responses(
+        (status = 200, description = "Fulfillment cancelled", body = FulfillmentResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Fulfillment not found")
+    )
+)]
+pub async fn cancel_fulfillment(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CancelFulfillmentInput>,
+) -> HttpResult<Json<FulfillmentResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::FULFILLMENTS_UPDATE],
+        "Permission denied: fulfillments:update required",
+    )?;
+    let context =
+        admin_fulfillment_command_context(&tenant, &auth, &request_context, id, "cancel");
+    let fulfillment = runtime
+        .fulfillment_admin_command_port()
+        .cancel_fulfillment(
+            context.clone(),
+            CancelAdminFulfillmentRequest {
+                fulfillment_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_fulfillment_command_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "cancel_fulfillment",
+                &context,
+                error,
+            )
+        })?;
+    Ok(Json(fulfillment))
+}

--- a/crates/rustok-commerce/src/controllers/admin/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/mod.rs
@@ -1,4 +1,7 @@
 pub mod changes;
+#[path = "fulfillments.rs"]
+mod fulfillments_legacy;
+#[path = "fulfillments_owner_commands.rs"]
 pub mod fulfillments;
 #[path = "orders_owner_ports.rs"]
 pub mod orders;

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -26,6 +26,7 @@ pub struct CommerceHttpRuntime {
     shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime:
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
+    fulfillment_admin_command_runtime: rustok_fulfillment::FulfillmentAdminCommandRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
@@ -76,6 +77,12 @@ impl CommerceHttpRuntime {
     fn fulfillment_read_port(&self) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentReadPort> {
         self.fulfillment_lifecycle_read_runtime
             .fulfillment_read_port()
+    }
+
+    fn fulfillment_admin_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentAdminCommandPort> {
+        self.fulfillment_admin_command_runtime.command_port()
     }
 
     fn order_read_port(&self) -> std::sync::Arc<dyn rustok_order::OrderReadPort> {
@@ -143,6 +150,9 @@ impl CommerceHttpRuntime {
         let payment_provider_registry = runtime
             .shared_get::<PaymentProviderRegistry>()
             .unwrap_or_else(PaymentProviderRegistry::with_manual_provider);
+        let fulfillment_provider_registry = runtime
+            .shared_get::<FulfillmentProviderRegistry>()
+            .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider);
         let shipping_option_read_runtime = runtime
             .shared_get::<crate::graphql_runtime::CommerceShippingOptionReadRuntime>()
             .ok_or_else(|| {
@@ -157,6 +167,14 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require CommerceFulfillmentLifecycleReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let fulfillment_admin_command_runtime = runtime
+            .shared_get::<rustok_fulfillment::FulfillmentAdminCommandRuntime>()
+            .unwrap_or_else(|| {
+                rustok_fulfillment::FulfillmentAdminCommandRuntime::in_process(
+                    runtime.db_clone(),
+                    fulfillment_provider_registry.clone(),
+                )
+            });
         let order_read_runtime = runtime
             .shared_get::<crate::graphql_runtime::CommerceOrderReadRuntime>()
             .ok_or_else(|| {
@@ -223,11 +241,10 @@ impl CommerceHttpRuntime {
             db: runtime.db_clone(),
             event_bus,
             payment_provider_registry,
-            fulfillment_provider_registry: runtime
-                .shared_get::<FulfillmentProviderRegistry>()
-                .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider),
+            fulfillment_provider_registry,
             shipping_option_read_runtime,
             fulfillment_lifecycle_read_runtime,
+            fulfillment_admin_command_runtime,
             order_read_runtime,
             order_admin_command_runtime,
             payment_order_read_runtime,

--- a/crates/rustok-fulfillment/src/admin_command.rs
+++ b/crates/rustok-fulfillment/src/admin_command.rs
@@ -1,0 +1,953 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+use validator::Validate;
+
+use crate::dto::{
+    CancelFulfillmentInput, DeliverFulfillmentInput, FulfillmentResponse, ReopenFulfillmentInput,
+    ReshipFulfillmentInput, ShipFulfillmentInput,
+};
+use crate::entities::provider_operation;
+use crate::error::FulfillmentError;
+use crate::providers::{
+    FulfillmentProviderOperationRequest, FulfillmentProviderOperationResult,
+    FulfillmentProviderRegistry, MANUAL_FULFILLMENT_PROVIDER_ID,
+};
+use crate::services::{
+    BeginProviderOperation, FulfillmentProviderOperationJournal, FulfillmentService,
+    PROVIDER_OPERATION_COMMITTED, PROVIDER_OPERATION_EXECUTING,
+    PROVIDER_OPERATION_RECONCILIATION_REQUIRED, PROVIDER_OPERATION_SUCCEEDED,
+};
+
+const ADMIN_COMMAND_BOUNDARY: &str = "fulfillment_admin_command_port";
+
+#[async_trait]
+pub trait FulfillmentAdminCommandPort: Send + Sync {
+    async fn ship_fulfillment(
+        &self,
+        context: PortContext,
+        request: ShipAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+
+    async fn deliver_fulfillment(
+        &self,
+        context: PortContext,
+        request: DeliverAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+
+    async fn reopen_fulfillment(
+        &self,
+        context: PortContext,
+        request: ReopenAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+
+    async fn reship_fulfillment(
+        &self,
+        context: PortContext,
+        request: ReshipAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+
+    async fn cancel_fulfillment(
+        &self,
+        context: PortContext,
+        request: CancelAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShipAdminFulfillmentRequest {
+    pub fulfillment_id: Uuid,
+    pub input: ShipFulfillmentInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeliverAdminFulfillmentRequest {
+    pub fulfillment_id: Uuid,
+    pub input: DeliverFulfillmentInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReopenAdminFulfillmentRequest {
+    pub fulfillment_id: Uuid,
+    pub input: ReopenFulfillmentInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReshipAdminFulfillmentRequest {
+    pub fulfillment_id: Uuid,
+    pub input: ReshipFulfillmentInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelAdminFulfillmentRequest {
+    pub fulfillment_id: Uuid,
+    pub input: CancelFulfillmentInput,
+}
+
+pub struct InProcessFulfillmentAdminCommandPort {
+    service: FulfillmentService,
+    operation_journal: FulfillmentProviderOperationJournal,
+    provider_registry: FulfillmentProviderRegistry,
+}
+
+impl InProcessFulfillmentAdminCommandPort {
+    pub fn new(db: DatabaseConnection, provider_registry: FulfillmentProviderRegistry) -> Self {
+        Self {
+            service: FulfillmentService::new(db.clone()),
+            operation_journal: FulfillmentProviderOperationJournal::new(db),
+            provider_registry,
+        }
+    }
+}
+
+pub fn in_process_fulfillment_admin_command_port(
+    db: DatabaseConnection,
+    provider_registry: FulfillmentProviderRegistry,
+) -> Arc<dyn FulfillmentAdminCommandPort> {
+    Arc::new(InProcessFulfillmentAdminCommandPort::new(
+        db,
+        provider_registry,
+    ))
+}
+
+#[derive(Clone)]
+pub struct FulfillmentAdminCommandRuntime {
+    command_port: Arc<dyn FulfillmentAdminCommandPort>,
+}
+
+impl FulfillmentAdminCommandRuntime {
+    pub fn new(command_port: Arc<dyn FulfillmentAdminCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        provider_registry: FulfillmentProviderRegistry,
+    ) -> Self {
+        Self::new(in_process_fulfillment_admin_command_port(
+            db,
+            provider_registry,
+        ))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn FulfillmentAdminCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl FulfillmentAdminCommandPort for InProcessFulfillmentAdminCommandPort {
+    async fn ship_fulfillment(
+        &self,
+        context: PortContext,
+        request: ShipAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        const OPERATION: &str = "ship_admin_fulfillment";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        request.input.validate().map_err(|_| {
+            PortError::validation(
+                "fulfillment.validation",
+                "fulfillment shipment request is invalid",
+            )
+        })?;
+
+        let current = self
+            .service
+            .get_fulfillment(tenant_id, request.fulfillment_id)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))?;
+        if !matches!(current.status.as_str(), "pending" | "shipped") {
+            return Err(map_fulfillment_error(
+                &context,
+                OPERATION,
+                FulfillmentError::InvalidTransition {
+                    from: current.status,
+                    to: "shipped".to_string(),
+                },
+            ));
+        }
+
+        let provider_id = self
+            .provider_id_for_fulfillment(&context, OPERATION, tenant_id, &current)
+            .await?;
+        let ShipFulfillmentInput {
+            carrier,
+            tracking_number,
+            items,
+            metadata,
+        } = request.input;
+        let provider_request = operation_request(
+            tenant_id,
+            request.fulfillment_id,
+            "ship",
+            provider_id.as_str(),
+            merge_metadata(
+                metadata.clone(),
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "ship",
+                        "carrier": carrier,
+                        "tracking_number": tracking_number,
+                        "items": items
+                    }
+                }),
+            ),
+        )?;
+        let journaled = self
+            .execute_provider_operation(
+                &context,
+                OPERATION,
+                provider_id.as_str(),
+                "ship",
+                provider_request,
+            )
+            .await?;
+        if journaled.committed {
+            return Ok(current);
+        }
+
+        let updated = self
+            .service
+            .ship_fulfillment(
+                tenant_id,
+                request.fulfillment_id,
+                ShipFulfillmentInput {
+                    carrier,
+                    tracking_number: journaled
+                        .result
+                        .tracking_number
+                        .clone()
+                        .unwrap_or(tracking_number),
+                    items,
+                    metadata: local_commit_metadata(
+                        metadata,
+                        journaled.result.metadata.clone(),
+                        journaled.operation_id,
+                        "ship",
+                    ),
+                },
+            )
+            .await;
+        match updated {
+            Ok(updated) => {
+                self.ensure_committed(&context, OPERATION, journaled.operation_id, "ship")
+                    .await?;
+                Ok(updated)
+            }
+            Err(error) => {
+                self.mark_local_persistence_reconciliation(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "ship",
+                )
+                .await;
+                Err(reconciliation_error(&context, OPERATION, "ship", &error))
+            }
+        }
+    }
+
+    async fn deliver_fulfillment(
+        &self,
+        context: PortContext,
+        request: DeliverAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        const OPERATION: &str = "deliver_admin_fulfillment";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.service
+            .deliver_fulfillment(tenant_id, request.fulfillment_id, request.input)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))
+    }
+
+    async fn reopen_fulfillment(
+        &self,
+        context: PortContext,
+        request: ReopenAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        const OPERATION: &str = "reopen_admin_fulfillment";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.service
+            .reopen_fulfillment(tenant_id, request.fulfillment_id, request.input)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))
+    }
+
+    async fn reship_fulfillment(
+        &self,
+        context: PortContext,
+        request: ReshipAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        const OPERATION: &str = "reship_admin_fulfillment";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        request.input.validate().map_err(|_| {
+            PortError::validation(
+                "fulfillment.validation",
+                "fulfillment reship request is invalid",
+            )
+        })?;
+
+        let current = self
+            .service
+            .get_fulfillment(tenant_id, request.fulfillment_id)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))?;
+        if current.status == "shipped"
+            && current
+                .metadata
+                .get("provider_operation")
+                .and_then(|value| value.get("operation"))
+                .and_then(Value::as_str)
+                == Some("reship")
+        {
+            return Ok(current);
+        }
+        if current.status != "delivered" {
+            return Err(map_fulfillment_error(
+                &context,
+                OPERATION,
+                FulfillmentError::InvalidTransition {
+                    from: current.status,
+                    to: "shipped".to_string(),
+                },
+            ));
+        }
+
+        let provider_id = self
+            .provider_id_for_fulfillment(&context, OPERATION, tenant_id, &current)
+            .await?;
+        let ReshipFulfillmentInput {
+            carrier,
+            tracking_number,
+            items,
+            metadata,
+        } = request.input;
+        let provider_request = operation_request(
+            tenant_id,
+            request.fulfillment_id,
+            "reship",
+            provider_id.as_str(),
+            merge_metadata(
+                metadata.clone(),
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "reship",
+                        "carrier": carrier,
+                        "tracking_number": tracking_number,
+                        "items": items
+                    }
+                }),
+            ),
+        )?;
+        let journaled = self
+            .execute_provider_operation(
+                &context,
+                OPERATION,
+                provider_id.as_str(),
+                "reship",
+                provider_request,
+            )
+            .await?;
+        if journaled.committed {
+            return Ok(current);
+        }
+
+        let updated = self
+            .service
+            .reship_fulfillment(
+                tenant_id,
+                request.fulfillment_id,
+                ReshipFulfillmentInput {
+                    carrier,
+                    tracking_number: journaled
+                        .result
+                        .tracking_number
+                        .clone()
+                        .unwrap_or(tracking_number),
+                    items,
+                    metadata: local_commit_metadata(
+                        metadata,
+                        journaled.result.metadata.clone(),
+                        journaled.operation_id,
+                        "reship",
+                    ),
+                },
+            )
+            .await;
+        match updated {
+            Ok(updated) => {
+                self.ensure_committed(&context, OPERATION, journaled.operation_id, "reship")
+                    .await?;
+                Ok(updated)
+            }
+            Err(error) => {
+                self.mark_local_persistence_reconciliation(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "reship",
+                )
+                .await;
+                Err(reconciliation_error(&context, OPERATION, "reship", &error))
+            }
+        }
+    }
+
+    async fn cancel_fulfillment(
+        &self,
+        context: PortContext,
+        request: CancelAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        const OPERATION: &str = "cancel_admin_fulfillment";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        let current = self
+            .service
+            .get_fulfillment(tenant_id, request.fulfillment_id)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))?;
+        if current.status == "cancelled" {
+            return Ok(current);
+        }
+        if current.status == "delivered" {
+            return Err(map_fulfillment_error(
+                &context,
+                OPERATION,
+                FulfillmentError::InvalidTransition {
+                    from: current.status,
+                    to: "cancelled".to_string(),
+                },
+            ));
+        }
+
+        let provider_id = self
+            .provider_id_for_fulfillment(&context, OPERATION, tenant_id, &current)
+            .await?;
+        let CancelFulfillmentInput { reason, metadata } = request.input;
+        let provider_request = operation_request(
+            tenant_id,
+            request.fulfillment_id,
+            "cancel",
+            provider_id.as_str(),
+            merge_metadata(
+                metadata.clone(),
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "cancel",
+                        "reason": reason
+                    }
+                }),
+            ),
+        )?;
+        let journaled = self
+            .execute_provider_operation(
+                &context,
+                OPERATION,
+                provider_id.as_str(),
+                "cancel",
+                provider_request,
+            )
+            .await?;
+        if journaled.committed {
+            return Ok(current);
+        }
+
+        let updated = self
+            .service
+            .cancel_fulfillment(
+                tenant_id,
+                request.fulfillment_id,
+                CancelFulfillmentInput {
+                    reason,
+                    metadata: local_commit_metadata(
+                        metadata,
+                        journaled.result.metadata.clone(),
+                        journaled.operation_id,
+                        "cancel",
+                    ),
+                },
+            )
+            .await;
+        match updated {
+            Ok(updated) => {
+                self.ensure_committed(&context, OPERATION, journaled.operation_id, "cancel")
+                    .await?;
+                Ok(updated)
+            }
+            Err(error) => {
+                self.mark_local_persistence_reconciliation(
+                    &context,
+                    OPERATION,
+                    journaled.operation_id,
+                    "cancel",
+                )
+                .await;
+                Err(reconciliation_error(&context, OPERATION, "cancel", &error))
+            }
+        }
+    }
+}
+
+struct JournaledProviderResult {
+    operation_id: Uuid,
+    result: FulfillmentProviderOperationResult,
+    committed: bool,
+}
+
+impl InProcessFulfillmentAdminCommandPort {
+    async fn execute_provider_operation(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        provider_id: &str,
+        operation: &'static str,
+        request: FulfillmentProviderOperationRequest,
+    ) -> Result<JournaledProviderResult, PortError> {
+        let idempotency_key = request
+            .idempotency_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                PortError::validation(
+                    "fulfillment.provider_idempotency_key_missing",
+                    "fulfillment provider operation requires idempotency identity",
+                )
+            })?
+            .to_string();
+        let request_payload = serde_json::to_value(&request).map_err(|_| {
+            PortError::validation(
+                "fulfillment.provider_request_invalid",
+                "fulfillment provider request could not be normalized",
+            )
+        })?;
+        let journal_operation = self
+            .operation_journal
+            .begin(BeginProviderOperation {
+                tenant_id: request.tenant_id,
+                fulfillment_id: request.fulfillment_id,
+                operation: operation.to_string(),
+                provider_id: provider_id.to_string(),
+                idempotency_key,
+                request_payload,
+            })
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+
+        if matches!(
+            journal_operation.status.as_str(),
+            PROVIDER_OPERATION_COMMITTED
+                | PROVIDER_OPERATION_SUCCEEDED
+                | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+        ) {
+            let result = deserialize_provider_result(&journal_operation)
+                .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+            if journal_operation.status == PROVIDER_OPERATION_RECONCILIATION_REQUIRED {
+                return Err(PortError::validation(
+                    "fulfillment.provider_reconciliation_pending",
+                    "fulfillment provider operation requires reconciliation",
+                ));
+            }
+            return Ok(JournaledProviderResult {
+                operation_id: journal_operation.id,
+                result,
+                committed: journal_operation.status == PROVIDER_OPERATION_COMMITTED,
+            });
+        }
+        if journal_operation.status == PROVIDER_OPERATION_EXECUTING {
+            return Err(PortError::validation(
+                "fulfillment.provider_operation_in_progress",
+                "fulfillment provider operation is already executing",
+            ));
+        }
+
+        if self
+            .operation_journal
+            .claim_execution(journal_operation.id)
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?
+            .is_none()
+        {
+            let current = self
+                .operation_journal
+                .get(journal_operation.id)
+                .await
+                .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+            if matches!(
+                current.status.as_str(),
+                PROVIDER_OPERATION_COMMITTED
+                    | PROVIDER_OPERATION_SUCCEEDED
+                    | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+            ) {
+                let result = deserialize_provider_result(&current)
+                    .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+                if current.status == PROVIDER_OPERATION_RECONCILIATION_REQUIRED {
+                    return Err(PortError::validation(
+                        "fulfillment.provider_reconciliation_pending",
+                        "fulfillment provider operation requires reconciliation",
+                    ));
+                }
+                return Ok(JournaledProviderResult {
+                    operation_id: current.id,
+                    result,
+                    committed: current.status == PROVIDER_OPERATION_COMMITTED,
+                });
+            }
+            return Err(PortError::validation(
+                "fulfillment.provider_operation_in_progress",
+                "fulfillment provider operation is already executing",
+            ));
+        }
+
+        let provider_result = match operation {
+            "ship" | "reship" => self.provider_registry.execute_ship(provider_id, request).await,
+            "cancel" => self.provider_registry.execute_cancel(provider_id, request).await,
+            _ => Err(FulfillmentError::Validation(
+                "unsupported fulfillment provider operation".to_string(),
+            )),
+        };
+        let provider_result = match provider_result {
+            Ok(result) => result,
+            Err(error) => {
+                if self
+                    .operation_journal
+                    .mark_provider_error(
+                        journal_operation.id,
+                        "fulfillment.provider_operation_failed",
+                    )
+                    .await
+                    .is_err()
+                {
+                    return Err(PortError::validation(
+                        "fulfillment.provider_journal_failed",
+                        "fulfillment provider operation failed and could not be checkpointed",
+                    ));
+                }
+                return Err(map_fulfillment_error(context, owner_operation, error));
+            }
+        };
+
+        let result_payload = serde_json::to_value(&provider_result).map_err(|_| {
+            PortError::validation(
+                "fulfillment.provider_result_invalid",
+                "fulfillment provider result could not be normalized",
+            )
+        })?;
+        self.operation_journal
+            .mark_provider_succeeded(
+                journal_operation.id,
+                provider_result.external_reference.clone(),
+                result_payload,
+            )
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+
+        Ok(JournaledProviderResult {
+            operation_id: journal_operation.id,
+            result: provider_result,
+            committed: false,
+        })
+    }
+
+    async fn provider_id_for_fulfillment(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        tenant_id: Uuid,
+        fulfillment: &FulfillmentResponse,
+    ) -> Result<String, PortError> {
+        match fulfillment.shipping_option_id {
+            Some(shipping_option_id) => self
+                .service
+                .get_shipping_option(tenant_id, shipping_option_id, None, None)
+                .await
+                .map(|option| option.provider_id)
+                .map_err(|error| map_fulfillment_error(context, owner_operation, error)),
+            None => Ok(MANUAL_FULFILLMENT_PROVIDER_ID.to_string()),
+        }
+    }
+
+    async fn mark_local_persistence_reconciliation(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        operation_id: Uuid,
+        operation: &'static str,
+    ) {
+        let checkpoint = self
+            .operation_journal
+            .mark_reconciliation_required(
+                operation_id,
+                format!("fulfillment.local_{operation}_persistence_failed"),
+            )
+            .await;
+        tracing::error!(
+            owner = "rustok_fulfillment",
+            operation = owner_operation,
+            provider_operation = operation,
+            correlation_id = %context.correlation_id,
+            operation_id_non_nil = !operation_id.is_nil(),
+            checkpoint_failed = checkpoint.is_err(),
+            boundary = ADMIN_COMMAND_BOUNDARY,
+            "fulfillment provider operation succeeded but local persistence did not complete"
+        );
+    }
+
+    async fn ensure_committed(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        operation_id: Uuid,
+        operation: &'static str,
+    ) -> Result<(), PortError> {
+        let current = self
+            .operation_journal
+            .get(operation_id)
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+        if current.status == PROVIDER_OPERATION_COMMITTED {
+            return Ok(());
+        }
+        if self
+            .operation_journal
+            .mark_committed(operation_id)
+            .await
+            .is_err()
+        {
+            let _ = self
+                .operation_journal
+                .mark_reconciliation_required(
+                    operation_id,
+                    format!("fulfillment.local_{operation}_journal_commit_failed"),
+                )
+                .await;
+            return Err(PortError::validation(
+                "fulfillment.journal_commit_failed",
+                "fulfillment operation completed but its journal could not be committed",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn require_write_admission(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::write()).inspect_err(|error| {
+        log_port_error(context, operation, "policy", error);
+    })?;
+    context.require_write_semantics().inspect_err(|error| {
+        log_port_error(context, operation, "write_semantics", error);
+    })
+}
+
+fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let error = PortError::validation(
+            "fulfillment.tenant_id_invalid",
+            "fulfillment command tenant context is invalid",
+        );
+        log_port_error(context, operation, "tenant_id", &error);
+        error
+    })
+}
+
+fn map_fulfillment_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: FulfillmentError,
+) -> PortError {
+    let error_variant = fulfillment_error_variant(&error);
+    let mapped = match error {
+        FulfillmentError::Validation(_) => {
+            PortError::validation("fulfillment.validation", "fulfillment request is invalid")
+        }
+        FulfillmentError::ShippingOptionNotFound(_) => PortError::not_found(
+            "fulfillment.shipping_option_not_found",
+            "shipping option was not found",
+        ),
+        FulfillmentError::FulfillmentNotFound(_) => PortError::not_found(
+            "fulfillment.not_found",
+            "fulfillment was not found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => PortError::conflict(
+            "fulfillment.invalid_transition",
+            "fulfillment lifecycle conflicts with the requested operation",
+        ),
+        FulfillmentError::Database(_) => PortError::unavailable(
+            "fulfillment.database_unavailable",
+            "fulfillment storage is temporarily unavailable",
+        ),
+    };
+    tracing::warn!(
+        owner = "rustok_fulfillment",
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        error_variant,
+        public_code = %mapped.code,
+        retryable = mapped.retryable,
+        boundary = ADMIN_COMMAND_BOUNDARY,
+        "fulfillment admin command returned a bounded owner error"
+    );
+    mapped
+}
+
+fn reconciliation_error(
+    context: &PortContext,
+    owner_operation: &'static str,
+    provider_operation: &'static str,
+    error: &FulfillmentError,
+) -> PortError {
+    tracing::error!(
+        owner = "rustok_fulfillment",
+        operation = owner_operation,
+        provider_operation,
+        correlation_id = %context.correlation_id,
+        error_variant = fulfillment_error_variant(error),
+        boundary = ADMIN_COMMAND_BOUNDARY,
+        "fulfillment provider operation requires reconciliation after local persistence failure"
+    );
+    PortError::conflict(
+        "fulfillment.reconciliation_required",
+        "fulfillment operation requires reconciliation",
+    )
+}
+
+fn fulfillment_error_variant(error: &FulfillmentError) -> &'static str {
+    match error {
+        FulfillmentError::Validation(_) => "validation",
+        FulfillmentError::ShippingOptionNotFound(_) => "shipping_option_not_found",
+        FulfillmentError::FulfillmentNotFound(_) => "fulfillment_not_found",
+        FulfillmentError::InvalidTransition { .. } => "invalid_transition",
+        FulfillmentError::Database(_) => "database",
+    }
+}
+
+fn log_port_error(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = "rustok_fulfillment",
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = ADMIN_COMMAND_BOUNDARY,
+        "fulfillment admin command admission failed"
+    );
+}
+
+fn operation_request(
+    tenant_id: Uuid,
+    fulfillment_id: Uuid,
+    operation: &'static str,
+    provider_id: &str,
+    metadata: Value,
+) -> Result<FulfillmentProviderOperationRequest, PortError> {
+    let immutable_payload = serde_json::json!({
+        "tenant_id": tenant_id,
+        "fulfillment_id": fulfillment_id,
+        "operation": operation,
+        "provider_id": provider_id,
+        "metadata": metadata,
+    });
+    let key = stable_operation_key(fulfillment_id, operation, &immutable_payload)?;
+    Ok(FulfillmentProviderOperationRequest {
+        tenant_id,
+        fulfillment_id,
+        idempotency_key: Some(key),
+        metadata,
+    })
+}
+
+fn stable_operation_key(
+    fulfillment_id: Uuid,
+    operation: &str,
+    payload: &Value,
+) -> Result<String, PortError> {
+    let bytes = serde_json::to_vec(payload).map_err(|_| {
+        PortError::validation(
+            "fulfillment.provider_identity_invalid",
+            "fulfillment provider identity could not be normalized",
+        )
+    })?;
+    let first = fnv1a64(&bytes, 0xcbf29ce484222325);
+    let second = fnv1a64(&bytes, 0x84222325cbf29ce4);
+    Ok(format!(
+        "fulfillment:{fulfillment_id}:{operation}:{first:016x}{second:016x}"
+    ))
+}
+
+fn fnv1a64(bytes: &[u8], offset_basis: u64) -> u64 {
+    bytes.iter().fold(offset_basis, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
+fn deserialize_provider_result(
+    operation: &provider_operation::Model,
+) -> Result<FulfillmentProviderOperationResult, FulfillmentError> {
+    let value = operation.provider_result.clone().ok_or_else(|| {
+        FulfillmentError::Validation(
+            "fulfillment provider operation has no persisted provider result".to_string(),
+        )
+    })?;
+    serde_json::from_value(value).map_err(|_| {
+        FulfillmentError::Validation(
+            "fulfillment provider operation has an invalid persisted provider result".to_string(),
+        )
+    })
+}
+
+fn local_commit_metadata(
+    input_metadata: Value,
+    provider_metadata: Value,
+    operation_id: Uuid,
+    operation: &'static str,
+) -> Value {
+    merge_metadata(
+        merge_metadata(input_metadata, provider_metadata),
+        serde_json::json!({
+            "provider_operation": {
+                "id": operation_id,
+                "operation": operation
+            }
+        }),
+    )
+}
+
+fn merge_metadata(current: Value, patch: Value) -> Value {
+    match (current, patch) {
+        (Value::Object(mut current), Value::Object(patch)) => {
+            for (key, value) in patch {
+                current.insert(key, value);
+            }
+            Value::Object(current)
+        }
+        (_, patch) => patch,
+    }
+}

--- a/crates/rustok-fulfillment/src/lib.rs
+++ b/crates/rustok-fulfillment/src/lib.rs
@@ -3,6 +3,7 @@ use rustok_api::Permission;
 use rustok_core::{MigrationDependencyDescriptor, MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
+mod admin_command;
 pub mod checkout_execution;
 mod checkout_execution_typed;
 pub mod dto;
@@ -16,6 +17,12 @@ pub mod services;
 mod shipping_option_read;
 pub mod status;
 
+pub use admin_command::{
+    CancelAdminFulfillmentRequest, DeliverAdminFulfillmentRequest, FulfillmentAdminCommandPort,
+    FulfillmentAdminCommandRuntime, InProcessFulfillmentAdminCommandPort,
+    ReopenAdminFulfillmentRequest, ReshipAdminFulfillmentRequest, ShipAdminFulfillmentRequest,
+    in_process_fulfillment_admin_command_port,
+};
 pub use checkout_execution::{
     CheckoutFulfillmentCommand, CheckoutFulfillmentExecutionPort, CheckoutFulfillmentItemCommand,
     EnsureCheckoutFulfillmentsRequest, InProcessCheckoutFulfillmentExecutionPort,

--- a/scripts/verify/verify-commerce-admin-fulfillment-owner-command-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-fulfillment-owner-command-cutover.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) throw new Error(`missing ${label}: ${text}`);
+};
+const forbidText = (source, text, label) => {
+  if (source.includes(text)) throw new Error(`forbidden ${label}: ${text}`);
+};
+
+const adminMod = read("crates/rustok-commerce/src/controllers/admin/mod.rs");
+const mounted = read("crates/rustok-commerce/src/controllers/admin/fulfillments_owner_commands.rs");
+const legacy = read("crates/rustok-commerce/src/controllers/admin/fulfillments.rs");
+const httpRuntime = read("crates/rustok-commerce/src/controllers/mod.rs");
+const fulfillmentLib = read("crates/rustok-fulfillment/src/lib.rs");
+const ownerCommand = read("crates/rustok-fulfillment/src/admin_command.rs");
+const openapi = read("crates/rustok-commerce/src/openapi.rs");
+const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+const doc = read("crates/rustok-commerce/docs/admin-fulfillment-owner-command-cutover-2026-08-09.md");
+
+requireText(adminMod, '#[path = "fulfillments.rs"]\nmod fulfillments_legacy;', "private legacy Fulfillment module");
+requireText(adminMod, '#[path = "fulfillments_owner_commands.rs"]\npub mod fulfillments;', "mounted Fulfillment owner adapter");
+requireText(mounted, "pub use super::fulfillments_legacy::*;", "legacy/Utoipa compatibility re-export");
+
+requireText(fulfillmentLib, "mod admin_command;", "Fulfillment admin command module");
+requireText(fulfillmentLib, "FulfillmentAdminCommandPort", "Fulfillment admin command export");
+requireText(fulfillmentLib, "FulfillmentAdminCommandRuntime", "Fulfillment admin runtime export");
+requireText(ownerCommand, "pub trait FulfillmentAdminCommandPort", "Fulfillment owner command trait");
+requireText(ownerCommand, "pub struct FulfillmentAdminCommandRuntime", "Fulfillment owner command runtime");
+requireText(ownerCommand, "context.require_policy(PortCallPolicy::write())", "write policy admission");
+requireText(ownerCommand, "context.require_write_semantics()", "write semantics admission");
+requireText(ownerCommand, "FulfillmentService::new(db.clone())", "owner-local Fulfillment service construction");
+requireText(ownerCommand, "FulfillmentProviderOperationJournal::new(db)", "owner-local provider journal construction");
+requireText(ownerCommand, "self.provider_registry.execute_ship", "owner ship provider execution");
+requireText(ownerCommand, "self.provider_registry.execute_cancel", "owner cancel provider execution");
+requireText(ownerCommand, '"fulfillment:{fulfillment_id}:{operation}:{first:016x}{second:016x}"', "canonical payload-sensitive provider key");
+requireText(ownerCommand, "0xcbf29ce484222325", "first legacy FNV offset basis");
+requireText(ownerCommand, "0x84222325cbf29ce4", "second legacy FNV offset basis");
+requireText(ownerCommand, '"operation": "ship"', "ship provider metadata");
+requireText(ownerCommand, '"operation": "reship"', "reship provider metadata");
+requireText(ownerCommand, '"operation": "cancel"', "cancel provider metadata");
+requireText(ownerCommand, '== Some("reship")', "reship replay shortcut");
+requireText(ownerCommand, 'if current.status == "cancelled"', "cancel replay shortcut");
+requireText(ownerCommand, '"fulfillment.reconciliation_required"', "bounded reconciliation error");
+forbidText(ownerCommand, "source.to_string()", "raw provider error persistence");
+
+for (const operation of ["ship", "deliver", "reopen", "reship", "cancel"]) {
+  requireText(mounted, `pub async fn ${operation}_fulfillment`, `mounted ${operation} handler`);
+  requireText(mounted, `.fulfillment_admin_command_port()`, "mounted Fulfillment command runtime access");
+  requireText(mounted, `.${operation}_fulfillment(`, `mounted owner ${operation} call`);
+}
+requireText(mounted, "Permission::FULFILLMENTS_UPDATE", "Fulfillment update permission");
+requireText(mounted, 'format!("admin-fulfillment:{fulfillment_id}:{operation}")', "stable transport write identity");
+requireText(mounted, ".with_deadline(std::time::Duration::from_secs(2))", "bounded command deadline");
+requireText(mounted, "request_context.channel_slug.as_deref()", "channel propagation");
+requireText(mounted, '"commerce_admin_fulfillment_reconciliation_required"', "reconciliation public envelope");
+forbidText(mounted, "FulfillmentService::new", "concrete Fulfillment construction in mounted adapter");
+forbidText(mounted, "FulfillmentOrchestrationService::new", "Commerce orchestration construction for mounted five commands");
+forbidText(mounted, "runtime.db_clone()", "direct Commerce DB access in mounted command adapter");
+
+requireText(legacy, "pub async fn create_fulfillment", "cross-owner create remains compatibility source");
+requireText(legacy, "FulfillmentOrchestrationService::new(runtime.db_clone())", "manual create remains cross-owner orchestration");
+
+requireText(httpRuntime, "fulfillment_admin_command_runtime: rustok_fulfillment::FulfillmentAdminCommandRuntime", "Commerce Fulfillment command runtime field");
+requireText(httpRuntime, "fn fulfillment_admin_command_port(", "Commerce Fulfillment command accessor");
+requireText(httpRuntime, ".shared_get::<rustok_fulfillment::FulfillmentAdminCommandRuntime>()", "host-selected Fulfillment command runtime preference");
+requireText(httpRuntime, "rustok_fulfillment::FulfillmentAdminCommandRuntime::in_process(", "built-in Fulfillment owner fallback");
+requireText(httpRuntime, "fulfillment_provider_registry.clone()", "host Fulfillment provider registry reuse");
+
+for (const symbol of [
+  "ship_fulfillment",
+  "deliver_fulfillment",
+  "reopen_fulfillment",
+  "reship_fulfillment",
+  "cancel_fulfillment",
+]) {
+  requireText(openapi, `crate::controllers::admin::${symbol}`, `OpenAPI root symbol ${symbol}`);
+}
+
+requireText(plan, "- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,", "canonical topology item remains open");
+requireText(plan, "Payment, and Fulfillment concrete services behind host-composed owner ports.", "canonical topology continuation remains open");
+requireText(doc, "Manual fulfillment creation is a cross-owner Commerce workflow", "create follow-up boundary");
+requireText(doc, "execution evidence pending and unvalidated", "unvalidated source status");
+requireText(doc, "It is not a newly claimed durable command receipt", "transport/durable replay distinction");
+
+console.log("commerce admin Fulfillment owner-command cutover source guard: OK");


### PR DESCRIPTION
## Summary
- publish Fulfillment-owned `FulfillmentAdminCommandPort` / `FulfillmentAdminCommandRuntime`
- move mounted admin Fulfillment ship/deliver/reopen/reship/cancel execution behind the owner command port
- keep `FulfillmentService`, provider journal construction, provider selection, and ship/reship/cancel provider execution inside `rustok-fulfillment`
- preserve exact payload-sensitive provider replay identity `fulfillment:{fulfillment_id}:{operation}:{hash}` with the existing dual FNV-1a offsets
- preserve ship/reship/cancel provider request metadata and local `provider_operation` metadata adoption
- preserve completed-reship and already-cancelled replay shortcuts
- preserve local-after-provider reconciliation checkpointing and the existing 409 reconciliation public family
- keep `FULFILLMENTS_UPDATE`, existing request/response DTOs, route paths, and OpenAPI root symbols
- carry tenant/user/locale/channel plus bounded deadline and stable transport write admission identity through `PortContext`
- prefer a host-injected `FulfillmentAdminCommandRuntime`; otherwise compose the in-process Fulfillment owner adapter using the host-selected `FulfillmentProviderRegistry`
- add focused actualization and a source guard without executing it

## Out of scope
`POST /admin/fulfillments` remains on the existing cross-owner Commerce orchestration path. Manual fulfillment creation reads Order-owned state and applies Commerce seller/shipping-profile grouping before persisting Fulfillment and creating a provider label; moving that entire workflow into `rustok-fulfillment` would assign the wrong ownership. A follow-up should keep that orchestration in Commerce while replacing cross-owner concrete access with typed owner capabilities and retaining create-label durability/recovery.

The canonical broad Commerce topology P0 remains open for manual fulfillment creation, remaining post-order/change/return workflows, GraphQL/provider-operation construction, and other concrete-owner paths.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart/lost-response evidence, and external-provider execution were intentionally not run per maintainer instruction.