### PR TITLE
fix(blog): bound tag list pagination

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "module": "blog",
   "surface": "canonical_implementation_cursor",
   "status": "source_verified_no_compile",
@@ -9,8 +9,8 @@
   "canonical_current_cursor": "crates/rustok-blog/docs/implementation-plan-current.md",
   "actualization_slice": "crates/rustok-blog/docs/implementation-plan-slice-101.md",
   "historical_baseline_last_embedded_slice": 67,
-  "latest_behavior_slice": 100,
-  "current_recorded_slice": 101,
+  "latest_behavior_slice": 102,
+  "current_recorded_slice": 102,
   "source_tracks": {
     "remote_comments_transport": {
       "status": "source_implemented_maintainer_execution_pending",
@@ -40,13 +40,27 @@
       "slice": "crates/rustok-blog/docs/implementation-plan-slice-100.md",
       "evidence": "crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json",
       "must_not_reopen_as_source_gap": true
+    },
+    "tag_list_pagination": {
+      "status": "source_ready_maintainer_execution_pending",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-102.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json",
+      "maximum_page_size": 100,
+      "offset_overflow_safe": true,
+      "database_side_pagination_claimed": false,
+      "must_not_reopen_as_source_gap": true
+    },
+    "tag_mutation_projection_consistency": {
+      "status": "re_audit_required",
+      "must_define_canonical_search_visible_tag_source": true,
+      "must_define_atomic_reindex_ownership_before_mutation_change": true
     }
   },
   "planning_result": {
     "independent_production_source_gap_identified": false,
     "future_autonomous_source_work_requires_fresh_audit": true,
     "historical_stale_phrases_are_live_instructions": false,
-    "production_behavior_changed": false,
+    "production_behavior_changed_since_slice_101": true,
     "ffa_or_fba_promoted": false
   },
   "execution": [],
@@ -54,6 +68,7 @@
     "no_rust_test_result",
     "no_javascript_verifier_result",
     "no_compile_result",
+    "no_database_side_tag_pagination_result",
     "no_postgresql_result",
     "no_redis_result",
     "no_tcp_runtime_result",

--- a/crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "tag_list_pagination",
+  "owner": "rustok-blog",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "source_contract": {
+    "service": "crates/rustok-blog/src/services/tag.rs",
+    "dto": "crates/rustok-blog/src/dto/tag.rs",
+    "maximum_page_size": 100,
+    "minimum_page_size": 1,
+    "owner_service_clamps_page_size": true,
+    "dto_documents_minimum_page": true,
+    "dto_documents_page_size_bounds": true,
+    "page_offset_uses_saturating_arithmetic": true,
+    "page_offset_uses_checked_usize_conversion": true,
+    "extreme_page_cannot_overflow_offset_arithmetic": true,
+    "total_count_semantics_changed": false,
+    "sort_order_changed": false,
+    "tag_visibility_scope_changed": false,
+    "database_side_pagination_claimed": false,
+    "production_behavior_changed": true,
+    "database_schema_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "source_harness": {
+    "path": "crates/rustok-blog/src/services/tag.rs",
+    "module": "services::tag::pagination_tests",
+    "tests": [
+      "tag_page_size_is_bounded_by_owner_service",
+      "tag_page_offset_saturates_without_arithmetic_overflow"
+    ],
+    "status": "executable_no_run",
+    "runtime_status": "not_run"
+  },
+  "open_follow_up": {
+    "tag_mutation_projection_consistency": "re_audit_required",
+    "reason": "TagService update/delete mutate Taxonomy or Blog relations while Search currently projects tag text from blog_posts.metadata.tags; this slice deliberately does not redefine that ownership boundary"
+  },
+  "execution": [],
+  "explicit_non_claims": [
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_compile_result",
+    "no_database_side_pagination_result",
+    "no_postgresql_result",
+    "no_browser_result",
+    "no_http_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -1,22 +1,23 @@
 # rustok-blog canonical implementation cursor
 
-Status: `canonical_source_cursor_actualized_through_slice_100`.
+Status: `canonical_source_cursor_actualized_through_slice_102`.
 
 This document is the canonical **current** source cursor for `rustok-blog`.
 `crates/rustok-blog/docs/implementation-plan.md` remains the long historical baseline and embedded implementation log, but its inline `Current state`, completed-slice list, and `Next results` stop before the later continuation series and must not be used as the live cursor without this file.
 
-The continuation series is authoritative for source work after the historical baseline. Slice 101 records this actualization; the latest production/source behavior slice before this plan-only correction is slice 100.
+The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 102 is the latest production/source behavior slice.
 
 ## Re-audit basis
 
-Fresh `main` was re-audited after slices 98–100. The retained continuation artifacts show that several phrases still present in the historical baseline are stale as current instructions:
+The source continuation through slice 102 retains the following planning corrections and independent Blog source result:
 
 - the remote Comments transport is no longer an unimplemented source item;
 - the cached public Comments snapshot is no longer merely planned;
 - the storefront comment-form fallback is not an implementation target because the active storefront has no public Comments write surface;
-- Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution.
+- Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution;
+- Blog tag list pagination is now owner-bounded and overflow-safe after a fresh audit outside those execution-gated tracks.
 
-These are planning corrections only. They do not promote runtime evidence.
+None of these source states promote runtime evidence.
 
 ## Current source tracks
 
@@ -66,17 +67,41 @@ Canonical interpretation:
 
 The legacy `hide_comment_form` token remains compatibility vocabulary in the existing FBA registries; it is not authorization to invent a new storefront write surface.
 
+### Blog tag list pagination
+
+A fresh source audit after slice 101 found that `TagService::list_tags` accepted an arbitrarily large `per_page` and used unchecked page-offset multiplication, unlike the already bounded Blog category list contract.
+
+Slice 102 makes the owner service authoritative for the response bound and arithmetic safety:
+
+`tag_list_pagination = source_ready_maintainer_execution_pending`
+
+The retained contract is:
+
+- `1 <= per_page <= 100` in the owner service;
+- matching Utoipa parameter metadata in `ListTagsFilter`;
+- saturating `u64` page-offset arithmetic plus checked `usize` conversion;
+- unchanged visibility, usage-count ordering, locale resolution and total-count semantics.
+
+This does **not** claim database-side pagination. Eligible tag terms, usage counts and translations are still materialized before the existing usage-count sort/page slice.
+
+The same audit exposed a separate cross-owner question rather than resolving it implicitly:
+
+`tag_mutation_projection_consistency = re_audit_required`
+
+Post reads resolve current tag names through `blog_post_tags -> rustok-taxonomy`, while Blog Search currently projects tag text from `blog_posts.metadata.tags`. Any update/delete fix must first define the canonical source and atomic/reindex ownership instead of adding direct cross-module SQL.
+
 ## Remaining execution-owned results
 
-The source re-audit identifies no independent production source gap inside the tracks above. The remaining concrete results are maintainer execution or explicitly execution-gated follow-ups:
+The concrete retained execution results remain maintainer-owned:
 
 1. Execute the retained Comments transport/composition, PostgreSQL, restart/ambiguity, canonical relay, and cached-snapshot evidence at an exact revision.
 2. Execute slices 95–97 before defining terminal Blog source-row and immutable recovery-audit retention.
 3. Execute slice 98 PostgreSQL evidence before advancing the Blog category Translation readiness result.
-4. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
-5. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
+4. Execute slice 102 tag pagination source/unit evidence before promoting runtime validation.
+5. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
+6. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
 
-A future autonomous source slice must start from a fresh repository audit and identify a genuinely new independent source gap. It must not manufacture work by reopening a source-complete or not-applicable cursor.
+A future source implementation must still start from a fresh ownership audit. It must not manufacture work by reopening a source-complete or not-applicable cursor.
 
 ## Superseded historical cursor phrases
 
@@ -87,14 +112,12 @@ The following phrases may remain in the historical baseline as records of earlie
 - `PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement`;
 - `then implement the remote network transport`.
 
-The continuation slice files and machine evidence remain the source of detailed ownership/non-claim history. This file only defines the current planning cursor.
+The continuation slice files and machine evidence remain the source of detailed ownership/non-claim history. This file defines the current planning cursor.
 
 ## Validation boundary
 
-No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent while producing this actualization.
+No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–102.
 
 ## Next cursor
 
-No independent production source gap is claimed by this actualization.
-
-Continue only after a fresh repository audit finds a new source gap outside the execution-gated tracks above, or after maintainers provide execution results that unlock one of their explicit follow-ups.
+Re-audit Blog tag mutation/projection consistency as a separate ownership problem. Determine the canonical Search-visible tag source and the atomic/reindex behavior required for `TagService::update_tag/delete_tag` before changing those production mutation semantics.

--- a/crates/rustok-blog/docs/implementation-plan-slice-102.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-102.md
@@ -1,0 +1,101 @@
+# rustok-blog implementation plan — slice 102 continuation
+
+Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.
+
+This slice continues the canonical current cursor established by slice 101.
+
+## Fresh audit
+
+After the plan actualization, a fresh audit moved outside the execution-gated Comments, category Translation, and storefront fallback tracks and rechecked Blog-owned posts/categories/tags source.
+
+`CategoryService` and `ListCategoriesFilter` already retain an explicit `1..=100` pagination contract. The public Blog tag list did not:
+
+- `ListTagsFilter.per_page` documented no upper bound;
+- `TagService::list_tags` used `filter.per_page.max(1)`, allowing arbitrarily large requested page sizes;
+- the in-memory offset used `(page - 1) * per_page`, so an extreme `u64` page could overflow arithmetic before `skip`.
+
+This is an owner-service contract gap independent of the execution-gated tracks in the current cursor.
+
+## Slice 102 — owner-bounded tag list pagination
+
+`TagService` now owns the effective tag page-size limit:
+
+```text
+1 <= per_page <= 100
+```
+
+The service does not trust transport validation. Every direct caller is bounded by `bounded_tag_page_size`, including programmatic callers that construct `ListTagsFilter` without serde/OpenAPI.
+
+`ListTagsFilter` now documents the same contract through Utoipa parameter metadata:
+
+```text
+page >= 1
+1 <= per_page <= 100
+```
+
+This is descriptive transport/schema metadata; the service clamp remains authoritative.
+
+## Overflow-safe page offset
+
+The tag list keeps the existing page normalization (`page >= 1`) but computes the in-memory skip with saturating arithmetic:
+
+```text
+page.saturating_sub(1).saturating_mul(per_page)
+```
+
+The result is converted to `usize` with a checked conversion and falls back to `usize::MAX` if the platform cannot represent the offset. An extreme page therefore produces an empty page instead of an arithmetic panic/wrap.
+
+## Preserved list semantics
+
+The slice intentionally preserves:
+
+- Blog module-owned tags plus attached global tags visibility;
+- usage-count descending order;
+- canonical-key tie breaking;
+- locale resolution behavior;
+- total count before page slicing;
+- Taxonomy ownership of tag terms/translations;
+- `Resource::Tags` authorization.
+
+It does **not** claim database-side pagination. `list_visible_terms`, usage counts, and translation loading still materialize the eligible tag inventory before sorting/page slicing. The change bounds the returned page and makes offset arithmetic safe; a future DB-side optimization must preserve the current global/module visibility and usage-count ordering exactly.
+
+## Source harness
+
+Two pure unit targets are retained in `services::tag::pagination_tests`:
+
+- `tag_page_size_is_bounded_by_owner_service`;
+- `tag_page_offset_saturates_without_arithmetic_overflow`.
+
+They cover zero/default/oversized page sizes plus ordinary and extreme page offsets. They were not executed by the implementation agent.
+
+Machine evidence:
+
+`crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json`
+
+Fail-closed source guard:
+
+`scripts/verify/verify-blog-tag-pagination-source.mjs`
+
+Focused negative fixture:
+
+`scripts/verify/verify-blog-tag-pagination-source.test.mjs`
+
+## Separate mutation/projection audit
+
+The fresh tag audit also found a distinct ownership question that is deliberately not folded into this pagination fix:
+
+- post reads resolve current tag names through `blog_post_tags -> rustok-taxonomy`;
+- Blog Search projection currently derives tag text from `blog_posts.metadata.tags`;
+- `TagService::update_tag` changes the module-owned Taxonomy term;
+- `TagService::delete_tag` removes Blog relations and then deletes the Taxonomy term;
+- neither mutation currently defines how the denormalized Search tag text is refreshed.
+
+That is a separate cross-owner consistency problem involving Blog, Taxonomy, and Search. Solving it requires an explicit canonical source/projection decision; this slice does not copy Taxonomy-private state into Search or add direct cross-module SQL.
+
+## Validation boundary
+
+No tests, Cargo commands, Node verifiers, formatting, builds, PostgreSQL scenarios, browser/HTTP requests, workflows, CI, `git diff --check`, or runtime/production validation were executed.
+
+## Next cursor
+
+Re-audit Blog tag mutation/projection consistency as a separate ownership slice. Determine the canonical source for Search-visible tag text and the atomic/reindex behavior required for `TagService::update_tag/delete_tag` before changing production mutation semantics.

--- a/crates/rustok-blog/src/dto/tag.rs
+++ b/crates/rustok-blog/src/dto/tag.rs
@@ -48,8 +48,10 @@ pub struct TagListItem {
 pub struct ListTagsFilter {
     pub locale: Option<String>,
     #[serde(default = "default_page")]
+    #[param(minimum = 1)]
     pub page: u64,
     #[serde(default = "default_per_page")]
+    #[param(minimum = 1, maximum = 100)]
     pub per_page: u64,
 }
 

--- a/crates/rustok-blog/src/services/tag.rs
+++ b/crates/rustok-blog/src/services/tag.rs
@@ -189,7 +189,7 @@ impl TagService {
         });
 
         let total = sortable.len() as u64;
-        let offset = ((page - 1) * per_page) as usize;
+        let offset = tag_page_offset(page, per_page);
         let items = sortable
             .into_iter()
             .skip(offset)
@@ -498,6 +498,11 @@ fn bounded_tag_page_size(value: u64) -> u64 {
     value.clamp(1, MAX_TAGS_PER_PAGE)
 }
 
+fn tag_page_offset(page: u64, per_page: u64) -> usize {
+    let offset = page.saturating_sub(1).saturating_mul(per_page);
+    usize::try_from(offset).unwrap_or(usize::MAX)
+}
+
 fn validate_tag_name(name: &str) -> BlogResult<()> {
     if name.trim().is_empty() {
         return Err(BlogError::validation("Tag name cannot be empty"));
@@ -572,12 +577,19 @@ fn to_tag_response(term: rustok_taxonomy::TaxonomyTermResponse, use_count: i32) 
 
 #[cfg(test)]
 mod pagination_tests {
-    use super::{MAX_TAGS_PER_PAGE, bounded_tag_page_size};
+    use super::{MAX_TAGS_PER_PAGE, bounded_tag_page_size, tag_page_offset};
 
     #[test]
     fn tag_page_size_is_bounded_by_owner_service() {
         assert_eq!(bounded_tag_page_size(0), 1);
         assert_eq!(bounded_tag_page_size(20), 20);
         assert_eq!(bounded_tag_page_size(MAX_TAGS_PER_PAGE + 1), MAX_TAGS_PER_PAGE);
+    }
+
+    #[test]
+    fn tag_page_offset_saturates_without_arithmetic_overflow() {
+        assert_eq!(tag_page_offset(1, 20), 0);
+        assert_eq!(tag_page_offset(2, 20), 20);
+        assert_eq!(tag_page_offset(u64::MAX, MAX_TAGS_PER_PAGE), usize::MAX);
     }
 }

--- a/crates/rustok-blog/src/services/tag.rs
+++ b/crates/rustok-blog/src/services/tag.rs
@@ -24,6 +24,7 @@ use crate::error::{BlogError, BlogResult};
 use crate::services::rbac::{enforce_owned_scope, enforce_scope};
 
 const BLOG_SCOPE_VALUE: &str = "blog";
+const MAX_TAGS_PER_PAGE: u64 = 100;
 
 pub struct TagService {
     db: DatabaseConnection,
@@ -163,7 +164,7 @@ impl TagService {
         let locale =
             normalize_locale(filter.locale.as_deref().unwrap_or(PLATFORM_FALLBACK_LOCALE))?;
         let page = filter.page.max(1);
-        let per_page = filter.per_page.max(1);
+        let per_page = bounded_tag_page_size(filter.per_page);
 
         let terms = self.list_visible_terms(tenant_id).await?;
         if terms.is_empty() {
@@ -405,8 +406,7 @@ pub(crate) async fn find_post_ids_by_tag(
 
     let alias_ids = taxonomy_term_alias::Entity::find()
         .join(
-            JoinType::InnerJoin,
-            taxonomy_term_alias::Relation::Term.def(),
+            JoinType::InnerJoin, taxonomy_term_alias::Relation::Term.def(),
         )
         .filter(taxonomy_term_alias::Column::TenantId.eq(tenant_id))
         .filter(taxonomy_term_alias::Column::Slug.eq(&normalized_slug))
@@ -494,6 +494,10 @@ fn global_scope_condition() -> Condition {
         .add(taxonomy_term::Column::ScopeValue.eq(""))
 }
 
+fn bounded_tag_page_size(value: u64) -> u64 {
+    value.clamp(1, MAX_TAGS_PER_PAGE)
+}
+
 fn validate_tag_name(name: &str) -> BlogResult<()> {
     if name.trim().is_empty() {
         return Err(BlogError::validation("Tag name cannot be empty"));
@@ -563,5 +567,17 @@ fn to_tag_response(term: rustok_taxonomy::TaxonomyTermResponse, use_count: i32) 
         slug: term.slug,
         use_count,
         created_at: term.created_at,
+    }
+}
+
+#[cfg(test)]
+mod pagination_tests {
+    use super::{MAX_TAGS_PER_PAGE, bounded_tag_page_size};
+
+    #[test]
+    fn tag_page_size_is_bounded_by_owner_service() {
+        assert_eq!(bounded_tag_page_size(0), 1);
+        assert_eq!(bounded_tag_page_size(20), 20);
+        assert_eq!(bounded_tag_page_size(MAX_TAGS_PER_PAGE + 1), MAX_TAGS_PER_PAGE);
     }
 }

--- a/scripts/verify/verify-blog-canonical-plan-current.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.mjs
@@ -18,6 +18,7 @@ const files = {
   slice99: 'crates/rustok-blog/docs/implementation-plan-slice-99.md',
   slice100: 'crates/rustok-blog/docs/implementation-plan-slice-100.md',
   slice101: 'crates/rustok-blog/docs/implementation-plan-slice-101.md',
+  slice102: 'crates/rustok-blog/docs/implementation-plan-slice-102.md',
   docsIndex: 'crates/rustok-blog/docs/README.md',
   tcpTransport: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
   tcpServer: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
@@ -25,6 +26,7 @@ const files = {
   translationPostgres: 'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
   fallback: 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
   writeSurface: 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+  tagPagination: 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
 };
 
 function absolute(relativePath) {
@@ -76,6 +78,7 @@ const slice98 = read(files.slice98);
 const slice99 = read(files.slice99);
 const slice100 = read(files.slice100);
 const slice101 = read(files.slice101);
+const slice102 = read(files.slice102);
 const docsIndex = read(files.docsIndex);
 const tcpTransport = json(files.tcpTransport);
 const tcpServer = json(files.tcpServer);
@@ -83,10 +86,11 @@ const tcpListener = json(files.tcpListener);
 const translationPostgres = json(files.translationPostgres);
 const fallback = json(files.fallback);
 const writeSurface = json(files.writeSurface);
+const tagPagination = json(files.tagPagination);
 
 if (evidence) {
   if (
-    evidence.schema_version !== 1 ||
+    evidence.schema_version !== 2 ||
     evidence.module !== 'blog' ||
     evidence.surface !== 'canonical_implementation_cursor' ||
     evidence.status !== 'source_verified_no_compile' ||
@@ -99,8 +103,8 @@ if (evidence) {
     evidence.canonical_current_cursor !== files.current ||
     evidence.actualization_slice !== files.slice101 ||
     evidence.historical_baseline_last_embedded_slice !== 67 ||
-    evidence.latest_behavior_slice !== 100 ||
-    evidence.current_recorded_slice !== 101
+    evidence.latest_behavior_slice !== 102 ||
+    evidence.current_recorded_slice !== 102
   ) failures.push(`${files.evidence}: cursor path/version drift`);
 
   const tracks = evidence.source_tracks ?? {};
@@ -113,8 +117,7 @@ if (evidence) {
   ) failures.push(`${files.evidence}: remote Comments track drift`);
 
   if (
-    tracks.comments_source_retention?.status !==
-      'blocked_until_slices_95_97_execution' ||
+    tracks.comments_source_retention?.status !== 'blocked_until_slices_95_97_execution' ||
     tracks.comments_source_retention?.blocking_slice !== files.slice97 ||
     tracks.comments_source_retention?.must_not_advance_before_execution !== true
   ) failures.push(`${files.evidence}: Comments source-retention gate drift`);
@@ -144,10 +147,26 @@ if (evidence) {
   ) failures.push(`${files.evidence}: storefront write-surface track drift`);
 
   if (
+    tracks.tag_list_pagination?.status !== 'source_ready_maintainer_execution_pending' ||
+    tracks.tag_list_pagination?.slice !== files.slice102 ||
+    tracks.tag_list_pagination?.evidence !== files.tagPagination ||
+    tracks.tag_list_pagination?.maximum_page_size !== 100 ||
+    tracks.tag_list_pagination?.offset_overflow_safe !== true ||
+    tracks.tag_list_pagination?.database_side_pagination_claimed !== false ||
+    tracks.tag_list_pagination?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: tag pagination track drift`);
+
+  if (
+    tracks.tag_mutation_projection_consistency?.status !== 're_audit_required' ||
+    tracks.tag_mutation_projection_consistency?.must_define_canonical_search_visible_tag_source !== true ||
+    tracks.tag_mutation_projection_consistency?.must_define_atomic_reindex_ownership_before_mutation_change !== true
+  ) failures.push(`${files.evidence}: tag mutation/projection cursor drift`);
+
+  if (
     evidence.planning_result?.independent_production_source_gap_identified !== false ||
     evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== true ||
     evidence.planning_result?.historical_stale_phrases_are_live_instructions !== false ||
-    evidence.planning_result?.production_behavior_changed !== false ||
+    evidence.planning_result?.production_behavior_changed_since_slice_101 !== true ||
     evidence.planning_result?.ffa_or_fba_promoted !== false ||
     !Array.isArray(evidence.execution) ||
     evidence.execution.length !== 0
@@ -191,8 +210,7 @@ if (
 ) failures.push(`${files.translationPostgres}: Translation PostgreSQL source status drift`);
 
 if (
-  fallback?.storefront_read_degradation?.cached_thread_snapshot !==
-    'source_verified_no_compile' ||
+  fallback?.storefront_read_degradation?.cached_thread_snapshot !== 'source_verified_no_compile' ||
   fallback?.storefront_read_degradation?.runtime_evidence !== 'pending' ||
   !sameSet(fallback?.storefront_read_degradation?.transports, ['graphql', 'native_ssr']) ||
   fallback?.storefront_write_surface?.comment_form_fallback !==
@@ -201,8 +219,7 @@ if (
 
 if (
   writeSurface?.status !== 'source_verified_absent' ||
-  writeSurface?.actualization !==
-    'comment_form_fallback_not_applicable_no_storefront_write_surface' ||
+  writeSurface?.actualization !== 'comment_form_fallback_not_applicable_no_storefront_write_surface' ||
   writeSurface?.source_contract?.create_comment_surface_present !== false ||
   writeSurface?.source_contract?.comment_form_present !== false ||
   writeSurface?.planning_effect?.new_storefront_write_surface_authorized !== false ||
@@ -210,43 +227,41 @@ if (
   writeSurface.execution.length !== 0
 ) failures.push(`${files.writeSurface}: storefront write-surface evidence drift`);
 
+if (
+  tagPagination?.status !== 'source_verified_no_compile' ||
+  tagPagination?.runtime_status !== 'not_run' ||
+  tagPagination?.source_contract?.maximum_page_size !== 100 ||
+  tagPagination?.source_contract?.owner_service_clamps_page_size !== true ||
+  tagPagination?.source_contract?.extreme_page_cannot_overflow_offset_arithmetic !== true ||
+  tagPagination?.source_contract?.database_side_pagination_claimed !== false ||
+  !Array.isArray(tagPagination?.execution) ||
+  tagPagination.execution.length !== 0
+) failures.push(`${files.tagPagination}: tag pagination source evidence drift`);
+
 for (const [source, marker, label] of [
   [slice97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice97],
   [slice98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice98],
   [slice99, 'Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.', files.slice99],
   [slice100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.', files.slice100],
+  [slice102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.', files.slice102],
 ]) need(source, marker, label);
 
-need(
-  slice97,
-  'After retained maintainer execution of slices 95–97, define bounded lifecycle and',
-  files.slice97,
-);
-need(
-  slice98,
-  'The Comments audit track remains independently blocked on maintainer execution',
-  files.slice98,
-);
-need(
-  slice99,
-  'comment-form fallback is still a separate unfinished result',
-  files.slice99,
-);
-need(
-  slice100,
-  'comment_form_fallback = not_applicable_no_storefront_write_surface',
-  files.slice100,
-);
+need(slice97, 'After retained maintainer execution of slices 95–97, define bounded lifecycle and', files.slice97);
+need(slice98, 'The Comments audit track remains independently blocked on maintainer execution', files.slice98);
+need(slice99, 'comment-form fallback is still a separate unfinished result', files.slice99);
+need(slice100, 'comment_form_fallback = not_applicable_no_storefront_write_surface', files.slice100);
+need(slice102, 'Re-audit Blog tag mutation/projection consistency as a separate ownership slice.', files.slice102);
 
 for (const marker of [
-  'Status: `canonical_source_cursor_actualized_through_slice_100`.',
+  'Status: `canonical_source_cursor_actualized_through_slice_102`.',
   '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
   '`category_translation_postgres = source_ready_maintainer_execution_pending`',
   '`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`',
   '`comment_form_fallback = not_applicable_no_storefront_write_surface`',
+  '`tag_list_pagination = source_ready_maintainer_execution_pending`',
+  '`tag_mutation_projection_consistency = re_audit_required`',
   'do not advance that source work before retained maintainer execution of slices 95–97',
-  'The source re-audit identifies no independent production source gap',
-  'A future autonomous source slice must start from a fresh repository audit',
+  'This does **not** claim database-side pagination.',
   '## Superseded historical cursor phrases',
   'No tests, Cargo commands, Node verifiers',
 ]) need(current, marker, files.current);
@@ -298,5 +313,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '[verify-blog-canonical-plan-current] PASS cursor=slice-101 behavior-through=slice-100 execution=not-run',
+  '[verify-blog-canonical-plan-current] PASS cursor=slice-102 behavior-through=slice-102 execution=not-run',
 );

--- a/scripts/verify/verify-blog-canonical-plan-current.test.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.test.mjs
@@ -26,6 +26,7 @@ const files = [
   'crates/rustok-blog/docs/implementation-plan-slice-99.md',
   'crates/rustok-blog/docs/implementation-plan-slice-100.md',
   'crates/rustok-blog/docs/implementation-plan-slice-101.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-102.md',
   'crates/rustok-blog/docs/README.md',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
@@ -33,6 +34,7 @@ const files = [
   'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
+  'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
 ];
 
 function absolute(root, relativePath) {
@@ -86,7 +88,7 @@ test('accepts the canonical Blog current implementation cursor', () => {
   try {
     const result = run(root);
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(result.stdout, /cursor=slice-101/);
+    assert.match(result.stdout, /cursor=slice-102/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -164,6 +166,34 @@ test('rejects a cached snapshot regression back to planned source work', () => {
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /storefront fallback current-state drift/);
+});
+
+test('rejects reopening the tag pagination source gap', () => {
+  const result = rejects((root) => {
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
+      (value) => {
+        value.source_tracks.tag_list_pagination.status = 'planned';
+      },
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag pagination track drift/);
+});
+
+test('rejects claiming database-side tag pagination', () => {
+  const result = rejects((root) => {
+    mutateJson(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
+      (value) => {
+        value.source_contract.database_side_pagination_claimed = true;
+      },
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag pagination source evidence drift/);
 });
 
 test('rejects listing the historical plan before the canonical current cursor', () => {

--- a/scripts/verify/verify-blog-tag-pagination-source.mjs
+++ b/scripts/verify/verify-blog-tag-pagination-source.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const failures = [];
+const files = {
+  evidence: 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
+  service: 'crates/rustok-blog/src/services/tag.rs',
+  dto: 'crates/rustok-blog/src/dto/tag.rs',
+  slice: 'crates/rustok-blog/docs/implementation-plan-slice-102.md',
+  current: 'crates/rustok-blog/docs/implementation-plan-current.md',
+};
+
+function read(relativePath) {
+  const target = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(target)) {
+    failures.push(`${relativePath}: missing file`);
+    return '';
+  }
+  return fs.readFileSync(target, 'utf8');
+}
+
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function need(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+
+function forbid(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const evidence = json(files.evidence);
+const service = read(files.service);
+const dto = read(files.dto);
+const slice = read(files.slice);
+const current = read(files.current);
+
+if (evidence) {
+  if (
+    evidence.schema_version !== 1 ||
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'tag_list_pagination' ||
+    evidence.owner !== 'rustok-blog' ||
+    evidence.status !== 'source_verified_no_compile' ||
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${files.evidence}: identity/status drift`);
+
+  const contract = evidence.source_contract ?? {};
+  if (
+    contract.service !== files.service ||
+    contract.dto !== files.dto ||
+    contract.maximum_page_size !== 100 ||
+    contract.minimum_page_size !== 1 ||
+    contract.owner_service_clamps_page_size !== true ||
+    contract.dto_documents_minimum_page !== true ||
+    contract.dto_documents_page_size_bounds !== true ||
+    contract.page_offset_uses_saturating_arithmetic !== true ||
+    contract.page_offset_uses_checked_usize_conversion !== true ||
+    contract.extreme_page_cannot_overflow_offset_arithmetic !== true ||
+    contract.total_count_semantics_changed !== false ||
+    contract.sort_order_changed !== false ||
+    contract.tag_visibility_scope_changed !== false ||
+    contract.database_side_pagination_claimed !== false ||
+    contract.production_behavior_changed !== true ||
+    contract.database_schema_changed !== false ||
+    contract.ffa_promoted !== false ||
+    contract.fba_promoted !== false
+  ) failures.push(`${files.evidence}: source contract drift`);
+
+  if (
+    evidence.source_harness?.path !== files.service ||
+    evidence.source_harness?.module !== 'services::tag::pagination_tests' ||
+    evidence.source_harness?.status !== 'executable_no_run' ||
+    evidence.source_harness?.runtime_status !== 'not_run' ||
+    JSON.stringify(evidence.source_harness?.tests) !== JSON.stringify([
+      'tag_page_size_is_bounded_by_owner_service',
+      'tag_page_offset_saturates_without_arithmetic_overflow',
+    ])
+  ) failures.push(`${files.evidence}: source harness drift`);
+
+  if (
+    evidence.open_follow_up?.tag_mutation_projection_consistency !== 're_audit_required' ||
+    !evidence.open_follow_up?.reason?.includes('Search currently projects tag text') ||
+    !Array.isArray(evidence.execution) ||
+    evidence.execution.length !== 0
+  ) failures.push(`${files.evidence}: follow-up/execution drift`);
+}
+
+for (const marker of [
+  'const MAX_TAGS_PER_PAGE: u64 = 100;',
+  'let page = filter.page.max(1);',
+  'let per_page = bounded_tag_page_size(filter.per_page);',
+  'let offset = tag_page_offset(page, per_page);',
+  'fn bounded_tag_page_size(value: u64) -> u64 {',
+  'value.clamp(1, MAX_TAGS_PER_PAGE)',
+  'fn tag_page_offset(page: u64, per_page: u64) -> usize {',
+  'page.saturating_sub(1).saturating_mul(per_page)',
+  'usize::try_from(offset).unwrap_or(usize::MAX)',
+  'mod pagination_tests',
+  'fn tag_page_size_is_bounded_by_owner_service()',
+  'fn tag_page_offset_saturates_without_arithmetic_overflow()',
+  'tag_page_offset(u64::MAX, MAX_TAGS_PER_PAGE)',
+]) need(service, marker, files.service);
+
+for (const marker of [
+  '#[param(minimum = 1)]',
+  '#[param(minimum = 1, maximum = 100)]',
+]) need(dto, marker, files.dto);
+
+for (const marker of [
+  'let per_page = filter.per_page.max(1);',
+  '((page - 1) * per_page) as usize',
+]) forbid(service, marker, files.service);
+
+for (const marker of [
+  'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.',
+  '1 <= per_page <= 100',
+  'saturating arithmetic',
+  'does **not** claim database-side pagination',
+  'TagService::update_tag/delete_tag',
+  'No tests, Cargo commands, Node verifiers',
+  'Re-audit Blog tag mutation/projection consistency',
+]) need(slice, marker, files.slice);
+
+for (const marker of [
+  'tag_list_pagination = source_ready_maintainer_execution_pending',
+  'tag_mutation_projection_consistency = re_audit_required',
+]) need(current, marker, files.current);
+
+if (failures.length > 0) {
+  console.error('[verify-blog-tag-pagination-source] FAIL');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('[verify-blog-tag-pagination-source] PASS max_per_page=100 offset=overflow-safe execution=not-run');

--- a/scripts/verify/verify-blog-tag-pagination-source.test.mjs
+++ b/scripts/verify/verify-blog-tag-pagination-source.test.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const verifier = path.join(repositoryRoot, 'scripts/verify/verify-blog-tag-pagination-source.mjs');
+const files = [
+  'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
+  'crates/rustok-blog/src/services/tag.rs',
+  'crates/rustok-blog/src/dto/tag.rs',
+  'crates/rustok-blog/docs/implementation-plan-slice-102.md',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+];
+
+function target(root, relativePath) {
+  return path.join(root, relativePath);
+}
+
+function write(root, relativePath, content) {
+  const file = target(root, relativePath);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+function fixture(mutator = () => {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-tag-pagination-'));
+  for (const relativePath of files) {
+    const destination = target(root, relativePath);
+    mkdirSync(path.dirname(destination), { recursive: true });
+    cpSync(path.join(repositoryRoot, relativePath), destination);
+  }
+  mutator(root);
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: repositoryRoot,
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function rejects(mutator) {
+  const root = fixture(mutator);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function replace(root, relativePath, from, to) {
+  const source = readFileSync(target(root, relativePath), 'utf8');
+  write(root, relativePath, source.replace(from, to));
+}
+
+test('accepts the canonical Blog tag pagination source boundary', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /max_per_page=100/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects removal of the owner page-size clamp', () => {
+  const result = rejects((root) => {
+    replace(
+      root,
+      'crates/rustok-blog/src/services/tag.rs',
+      'let per_page = bounded_tag_page_size(filter.per_page);',
+      'let per_page = filter.per_page.max(1);',
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /bounded_tag_page_size|forbidden/);
+});
+
+test('rejects unsafe multiplication in the page offset', () => {
+  const result = rejects((root) => {
+    replace(
+      root,
+      'crates/rustok-blog/src/services/tag.rs',
+      'let offset = tag_page_offset(page, per_page);',
+      'let offset = ((page - 1) * per_page) as usize;',
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag_page_offset|forbidden/);
+});
+
+test('rejects removal of the published DTO maximum', () => {
+  const result = rejects((root) => {
+    replace(
+      root,
+      'crates/rustok-blog/src/dto/tag.rs',
+      '#[param(minimum = 1, maximum = 100)]',
+      '#[param(minimum = 1)]',
+    );
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /maximum = 100/);
+});
+
+test('rejects runtime promotion without execution', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json';
+    const value = JSON.parse(readFileSync(target(root, relativePath), 'utf8'));
+    value.runtime_status = 'passed';
+    write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /identity\/status drift/);
+});
+
+test('rejects claiming database-side pagination', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json';
+    const value = JSON.parse(readFileSync(target(root, relativePath), 'utf8'));
+    value.source_contract.database_side_pagination_claimed = true;
+    write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /source contract drift/);
+});


### PR DESCRIPTION
## Summary

Continue the canonical Blog plan with a fresh source audit outside the execution-gated Comments/Translation/storefront tracks.

The audit found that Blog category listing already owns a `1..=100` page-size contract, while `TagService::list_tags` accepted arbitrarily large `per_page` values and computed its in-memory offset with unchecked `u64` multiplication.

## Production fix

- owner `TagService` clamps every tag-list `per_page` to `1..=100`, including direct programmatic callers;
- `ListTagsFilter` publishes matching Utoipa minimum/maximum metadata;
- tag page offsets use saturating subtraction/multiplication plus checked `usize` conversion, so extreme page values produce an empty page instead of arithmetic overflow;
- existing tag visibility, usage-count ordering, locale resolution and total-count semantics are preserved.

This does **not** claim database-side pagination: eligible tag terms/counts/translations are still materialized before the existing usage-count sort and page slice.

## Evidence / current cursor

- adds `blog-tag-pagination-source.json`;
- adds slice 102: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`;
- advances the canonical current cursor/evidence to behavior slice 102;
- adds a fail-closed tag pagination verifier and focused self-test;
- advances the canonical current-cursor guard/self-test through slice 102.

## Separate next audit

The same source review exposed a distinct cross-owner consistency question that is intentionally not mixed into this pagination fix: post reads resolve tag names through `blog_post_tags -> rustok-taxonomy`, while Blog Search currently projects tag text from `blog_posts.metadata.tags`. The next cursor is to re-audit the canonical source and atomic/reindex behavior for `TagService::update_tag/delete_tag` before changing mutation semantics.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, builds, PostgreSQL/browser/HTTP scenarios, workflows, CI, `git diff --check`, or runtime validation were executed. Source/diff review only.