### PR TITLE
feat(forum): observe storefront topic-list locale outcomes

### DIFF
--- a/crates/rustok-forum/src/graphql/storefront_audience_topics.rs
+++ b/crates/rustok-forum/src/graphql/storefront_audience_topics.rs
@@ -1,4 +1,13 @@
+use std::{
+    sync::{
+        OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
+
 use async_graphql::{Context, ErrorExtensions, FieldError, Object, Result};
+use prometheus::{IntCounterVec, Opts};
 use rustok_api::{
     AuthContext, RequestContext, TenantContext,
     graphql::{GraphQLError, PaginationInput, require_module_enabled, resolve_graphql_locale},
@@ -7,7 +16,6 @@ use rustok_channel::ChannelService;
 use rustok_outbox::TransactionalEventBus;
 use rustok_telemetry::metrics;
 use sea_orm::DatabaseConnection;
-use std::time::Instant;
 use uuid::Uuid;
 
 use crate::{ForumTopicAudienceListService, TopicListItem};
@@ -15,6 +23,14 @@ use crate::{ForumTopicAudienceListService, TopicListItem};
 use super::types::*;
 
 const MODULE_SLUG: &str = "forum";
+const STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_EXACT: &str = "exact";
+const STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_FALLBACK: &str = "fallback";
+const STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_MISSING: &str = "missing";
+
+static FORUM_GRAPHQL_STOREFRONT_TOPIC_LIST_LOCALE_RESOLUTION_TOTAL: OnceLock<IntCounterVec> =
+    OnceLock::new();
+static FORUM_GRAPHQL_STOREFRONT_TOPIC_LIST_LOCALE_RESOLUTION_REGISTERED: AtomicBool =
+    AtomicBool::new(false);
 
 #[derive(Default)]
 pub struct ForumStorefrontAudienceTopicsQuery;
@@ -68,6 +84,7 @@ impl ForumStorefrontAudienceTopicsQuery {
             list_started_at.elapsed().as_secs_f64(),
             page.total,
         );
+        observe_storefront_topic_list_locale_resolution(&page.items);
 
         let items = page
             .items
@@ -88,6 +105,60 @@ impl ForumStorefrontAudienceTopicsQuery {
             offset,
             limit,
         ))
+    }
+}
+
+fn storefront_topic_list_locale_resolution_outcome(
+    requested_locale: &str,
+    effective_locale: &str,
+    available_locale_count: usize,
+) -> &'static str {
+    if available_locale_count == 0 {
+        STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_MISSING
+    } else if requested_locale == effective_locale {
+        STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_EXACT
+    } else {
+        STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_FALLBACK
+    }
+}
+
+fn forum_graphql_storefront_topic_list_locale_resolution_counter() -> Option<&'static IntCounterVec> {
+    let counter = FORUM_GRAPHQL_STOREFRONT_TOPIC_LIST_LOCALE_RESOLUTION_TOTAL.get_or_init(|| {
+        IntCounterVec::new(
+            Opts::new(
+                "rustok_forum_graphql_storefront_topic_list_locale_resolution_total",
+                "Forum GraphQL storefront topic-list items by fixed locale resolution outcome",
+            ),
+            &["outcome"],
+        )
+        .expect("Forum GraphQL storefront topic-list locale metric descriptor must be valid")
+    });
+
+    if FORUM_GRAPHQL_STOREFRONT_TOPIC_LIST_LOCALE_RESOLUTION_REGISTERED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+        && rustok_telemetry::register_runtime_collector(Box::new(counter.clone())).is_err()
+    {
+        FORUM_GRAPHQL_STOREFRONT_TOPIC_LIST_LOCALE_RESOLUTION_REGISTERED
+            .store(false, Ordering::Release);
+        return None;
+    }
+
+    Some(counter)
+}
+
+fn observe_storefront_topic_list_locale_resolution(items: &[TopicListItem]) {
+    let Some(counter) = forum_graphql_storefront_topic_list_locale_resolution_counter() else {
+        return;
+    };
+
+    for item in items {
+        let outcome = storefront_topic_list_locale_resolution_outcome(
+            &item.requested_locale,
+            &item.effective_locale,
+            item.available_locales.len(),
+        );
+        counter.with_label_values(&[outcome]).inc();
     }
 }
 
@@ -156,5 +227,39 @@ fn map_topic_list_item(topic: TopicListItem) -> GqlForumTopicListItem {
         is_locked: topic.is_locked,
         reply_count: topic.reply_count,
         created_at: topic.created_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_EXACT,
+        STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_FALLBACK,
+        STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_MISSING,
+        storefront_topic_list_locale_resolution_outcome,
+    };
+
+    #[test]
+    fn storefront_topic_list_locale_outcomes_are_fixed_and_hide_locale_values() {
+        assert_eq!(
+            storefront_topic_list_locale_resolution_outcome("ru", "ru", 1),
+            STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_EXACT
+        );
+        assert_eq!(
+            storefront_topic_list_locale_resolution_outcome(
+                "tenant-secret",
+                "different-secret",
+                2,
+            ),
+            STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_FALLBACK
+        );
+        assert_eq!(
+            storefront_topic_list_locale_resolution_outcome(
+                "tenant-secret",
+                "tenant-secret",
+                0,
+            ),
+            STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_MISSING
+        );
     }
 }

--- a/docs/modules/forum-33-storefront-topic-list-locale-metrics-actualization-2026-08-09.md
+++ b/docs/modules/forum-33-storefront-topic-list-locale-metrics-actualization-2026-08-09.md
@@ -1,0 +1,94 @@
+# FORUM-33K storefront topic-list locale metrics actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / locale-baseline-complete`
+
+## Rechecked execution cursor
+
+The merged FORUM-33 source sequence is A through J. FORUM-33H observes locale fallback on bounded `forumUnreadTopics` rows; FORUM-33I observes bounded unread/activity states; FORUM-33J observes locale fallback on bounded `forumCategoryTree` nodes.
+
+Fresh `main` before this slice was `f9b50401f836d97092b21b9f4e4d0b2437ab3fe1`. Changes after FORUM-33J were outside Forum.
+
+Fresh source search still finds no persisted Forum-owned `forum_attachment*`, `ForumAttachment`, or `attachment_id` relation/source-revision authority. Attachments therefore remain blocked on FORUM-14.
+
+Fresh posting-policy search still finds `ForumPostingPolicyEvaluator::decide`, `DuplicateContent`, and `ExternalSpamScore` only in documentation, tests, and source verification rather than mounted production enforcement. Spam-outcome telemetry therefore remains blocked on real owner execution/contracts.
+
+Moderation recovery has public write/recovery commands, but Forum still has no public Moderation application-operation read/status contract suitable for lag/status diagnostics. Forum must not inspect Moderation-private application storage.
+
+## Why this locale surface is useful
+
+`forumStorefrontAudienceTopics` is the public paginated storefront topic-list surface. It is materially different from the authenticated unread page and category tree already covered by H/J: it represents the normal public topic discovery path and can therefore reveal locale fallback behavior that those surfaces do not exercise.
+
+The mounted owner call remains:
+
+```text
+ForumTopicAudienceListService::list_public_storefront_visible_with_locale_fallback
+```
+
+The returned `TopicListItem` values already contain:
+
+- `requested_locale`;
+- `effective_locale`;
+- `available_locales`.
+
+FORUM-33K observes those already-materialized owner DTOs only after the successful owner read. It adds no database query, owner call, fallback pass, authorization decision, channel check, visibility decision, write, repair, cursor, or response-field change.
+
+## Metric contract
+
+The metric is:
+
+```text
+rustok_forum_graphql_storefront_topic_list_locale_resolution_total{outcome="..."}
+```
+
+`outcome` has exactly three values:
+
+- `exact`: at least one localized row exists and effective locale equals requested locale;
+- `fallback`: at least one localized row exists and effective locale differs from requested locale;
+- `missing`: the owner DTO reports no available locale.
+
+Only the normalized page returned by the existing GraphQL pagination path is observed. The metric is an observation counter, not a tenant-wide population gauge or unique-topic estimate; repeated reads can count the same topic again.
+
+## Cardinality and privacy boundary
+
+The only label is fixed `outcome`. No tenant-controlled locale string becomes a label. The observer also exports no tenant ID, user ID, topic/category/author ID, title, slug, route, channel, tag, status, reply/vote count, subscription state, solution ID, metadata, or arbitrary error.
+
+Collector registration is best effort through `rustok_telemetry::register_runtime_collector`; registration failure does not alter the GraphQL result and can be retried on a later successful observation.
+
+## Existing behavior preserved
+
+The existing public module/channel guards, tenant scoping, pagination normalization, owner call, read-path query metric, read-path budget metric, DTO mapping, page total, offset and limit remain authoritative and unchanged.
+
+FORUM-33K does not change the merged H, I, or J collectors. It uses a surface-specific family so each source contract remains explicit and existing guards do not need to be widened or rewritten.
+
+## Locale baseline stopping point
+
+With K, FORUM-33 has representative locale-fallback observations on three materially different bounded mounted GraphQL reads:
+
+1. authenticated unread-topic page;
+2. category tree;
+3. public storefront topic list.
+
+That is sufficient for the baseline requested by FORUM-33. Do not continue adding locale metrics to every single-item/topic/reply/admin/HTTP read merely for coverage. A future locale metric should require a distinct operational question or evidence of a blind spot, not just another localized DTO.
+
+## Remaining FORUM-33 blocks
+
+- attachment reconciliation: blocked on FORUM-14 persisted Forum-owned relation/source-revision authority;
+- spam outcomes: blocked on mounted owner enforcement and real duplicate/external-spam inputs;
+- Moderation application status/lag: blocked on an explicit public Moderation read/status contract;
+- Search/Notifications: already have owner-side reconciliation/diagnostic coverage; avoid duplicate Forum telemetry without a new gap.
+
+The canonical implementation plan still lags portions of the merged FORUM-33 execution ledger. This dated actualization records the live cursor without replacing the large canonical file through the GitHub contents API and risking unrelated concurrent roadmap edits.
+
+## Next cursor
+
+After FORUM-33K, stop locale expansion. On the next continuation, recheck whether FORUM-14, mounted posting-policy enforcement, or a public Moderation diagnostic owner contract has landed. If none has landed, reassess whether FORUM-33 has any truthful remaining source slice rather than manufacturing telemetry from missing authority.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-storefront-topic-list-locale-metrics-source.mjs
+```

--- a/scripts/verify/verify-forum-storefront-topic-list-locale-metrics-source.mjs
+++ b/scripts/verify/verify-forum-storefront-topic-list-locale-metrics-source.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const graphqlPath = "crates/rustok-forum/src/graphql/storefront_audience_topics.rs";
+const packetPath =
+  "docs/modules/forum-33-storefront-topic-list-locale-metrics-actualization-2026-08-09.md";
+
+const graphql = read(graphqlPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "async fn forum_storefront_audience_topics(",
+  ".list_public_storefront_visible_with_locale_fallback(",
+  ".await?;",
+  "observe_storefront_topic_list_locale_resolution(&page.items);",
+  "rustok_forum_graphql_storefront_topic_list_locale_resolution_total",
+  '&["outcome"]',
+  'const STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_EXACT: &str = "exact";',
+  'const STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_FALLBACK: &str = "fallback";',
+  'const STOREFRONT_TOPIC_LIST_LOCALE_OUTCOME_MISSING: &str = "missing";',
+  "available_locale_count == 0",
+  "requested_locale == effective_locale",
+  "rustok_telemetry::register_runtime_collector",
+  "counter.with_label_values(&[outcome]).inc();",
+  'metrics::record_read_path_query(',
+  'metrics::record_read_path_budget(',
+]) {
+  requireText(graphql, marker, `${graphqlPath}: missing ${marker}`);
+}
+
+const ownerCall = graphql.indexOf(
+  ".list_public_storefront_visible_with_locale_fallback(",
+);
+const ownerAwait = graphql.indexOf(".await?;", ownerCall);
+const observation = graphql.indexOf(
+  "observe_storefront_topic_list_locale_resolution(&page.items);",
+  ownerAwait,
+);
+const mapping = graphql.indexOf("let items = page", observation);
+const response = graphql.indexOf("Ok(ForumTopicConnection::new(", mapping);
+if (
+  ownerCall < 0 ||
+  ownerAwait <= ownerCall ||
+  observation <= ownerAwait ||
+  mapping <= observation ||
+  response <= mapping
+) {
+  throw new Error(
+    `${graphqlPath}: expected owner call -> await -> locale observation -> mapping -> response ordering`,
+  );
+}
+
+const observerStart = graphql.indexOf(
+  "fn storefront_topic_list_locale_resolution_outcome(",
+);
+const tenantScopeStart = graphql.indexOf("fn resolve_tenant_scope(", observerStart);
+if (observerStart < 0 || tenantScopeStart <= observerStart) {
+  throw new Error(`${graphqlPath}: storefront locale observer source boundary is invalid`);
+}
+const observer = graphql.slice(observerStart, tenantScopeStart);
+
+for (const forbidden of [
+  "tenant_id",
+  "user_id",
+  "topic.id",
+  "category_id",
+  "author_id",
+  "title",
+  "slug",
+  "channel_slugs",
+  "tags",
+  "status",
+  "reply_count",
+  "vote_score",
+  "is_subscribed",
+  "solution_reply_id",
+  "metadata",
+  "DatabaseConnection",
+  "ForumTopicAudienceListService::new",
+  "Entity::find",
+  "UPDATE ",
+  "INSERT ",
+  "DELETE ",
+  "ActiveModel",
+]) {
+  requireAbsent(
+    observer,
+    forbidden,
+    `${graphqlPath}: storefront locale observer must not contain ${forbidden}`,
+  );
+}
+
+for (const forbiddenLabel of [
+  "with_label_values(&[requested_locale",
+  "with_label_values(&[effective_locale",
+  "with_label_values(&[item.",
+  "requested_locale.to_string",
+  "effective_locale.to_string",
+]) {
+  requireAbsent(
+    observer,
+    forbiddenLabel,
+    `${graphqlPath}: locale or DTO values must not become metric labels`,
+  );
+}
+
+for (const marker of [
+  "FORUM-33K",
+  "FORUM-33J",
+  "locale-baseline-complete",
+  "Attachments therefore remain blocked on FORUM-14",
+  "forumStorefrontAudienceTopics",
+  "rustok_forum_graphql_storefront_topic_list_locale_resolution_total",
+  "observation counter",
+  "no database query",
+  "Tenant-controlled locale string",
+  "Spam-outcome telemetry therefore remains blocked",
+  "public Moderation application-operation read/status contract",
+  "stop locale expansion",
+  "no Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-33K storefront topic-list locale metric source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-33 after #3371 with bounded locale-fallback observations on the mounted public `forumStorefrontAudienceTopics` GraphQL list.

- observe only successful `ForumTopicAudienceListService::list_public_storefront_visible_with_locale_fallback` results;
- add `rustok_forum_graphql_storefront_topic_list_locale_resolution_total{outcome="..."}`;
- keep `outcome` fixed to `exact`, `fallback`, and `missing`;
- observe only already-returned bounded `TopicListItem` page values;
- never export locale strings, tenant/user/topic/category/author IDs, titles/slugs/channels, counts, status or arbitrary errors as labels;
- preserve module/channel guards, tenant scoping, pagination, read-path query/budget metrics, mapping and response shape;
- add FORUM-33K actualization and source guard;
- mark the representative locale baseline complete so future work does not blanket-instrument every localized surface.

## Remaining blocks

Attachments remain blocked on FORUM-14. Spam outcomes remain blocked because posting-policy evaluation is still not mounted as production owner enforcement. Moderation application status/lag remains blocked on an explicit public Moderation read/status contract.

## Validation

Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, DB fixture, migration, build, workflow, CI, lock generation, or `git diff --check` was run. Maintainer will run tests.