### PR TITLE
feat(commerce): route admin fulfillment create through owner ports

### DIFF
--- a/crates/rustok-commerce/docs/admin-fulfillment-create-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/admin-fulfillment-create-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,113 @@
+# Commerce admin Fulfillment create owner-port cutover — 2026-08-09
+
+## Status
+
+Source-complete for the mounted `POST /admin/fulfillments` route. Execution evidence remains pending and unvalidated.
+
+This slice intentionally keeps manual-fulfillment policy orchestration in Commerce while removing direct Order ORM, concrete Fulfillment service, and direct provider execution from the mounted create path.
+
+## Mounted route
+
+The mounted admin route remains:
+
+- `POST /admin/fulfillments`
+- permission: `FULFILLMENTS_CREATE`
+- request: existing `CreateFulfillmentInput`
+- success: HTTP 201 with existing `FulfillmentResponse`
+
+The mounted `fulfillments_owner_commands.rs` adapter now defines a local `create_fulfillment` handler. That local item shadows the compatibility re-export from `fulfillments_legacy`, preserving router/OpenAPI names without changing the large admin router.
+
+## Cross-owner policy remains in Commerce
+
+`AdminManualFulfillmentOrchestrationService` owns the cross-owner policy composition. It uses only typed owner capabilities:
+
+- `rustok_order::OrderReadPort`
+- `rustok_fulfillment::FulfillmentReadPort`
+- `rustok_fulfillment::ShippingOptionReadPort`
+- `rustok_fulfillment::FulfillmentAdminCreateCommandPort`
+
+The orchestration retains the pre-cutover rules:
+
+- the order must exist in the tenant;
+- manual fulfillment requires typed non-empty `items[]`;
+- an explicitly supplied customer must match the order customer;
+- requested line items must belong to the order;
+- already fulfilled non-cancelled quantities are subtracted before admission;
+- legacy fulfillments without typed items fail closed;
+- all requested items must belong to one seller-aware delivery group;
+- shipping-profile slugs use the existing Commerce normalization/fallback policy;
+- seller identity still falls back to legacy line-item metadata when the typed field is absent;
+- a selected shipping option must match the order currency and required shipping profile;
+- prepared fulfillment item/delivery-group metadata retains the existing `post_order.manual = true` facts.
+
+The service does not import SeaORM Order entities and does not construct `FulfillmentService`.
+
+## Fulfillment-owned create execution
+
+`rustok-fulfillment` now publishes:
+
+- `FulfillmentAdminCreateCommandPort`
+- `FulfillmentAdminCreateCommandRuntime`
+- `InProcessFulfillmentAdminCreateCommandPort`
+- `CreateAdminFulfillmentRequest`
+
+The in-process owner adapter owns:
+
+- `FulfillmentService` construction;
+- selected shipping-option/provider consistency validation;
+- fulfillment persistence;
+- `FulfillmentProviderOperationJournal` construction;
+- create-label provider execution through the host-selected `FulfillmentProviderRegistry`.
+
+The owner does not import Commerce or Order.
+
+## Create-label replay identity
+
+The durable provider operation identity remains exactly:
+
+```text
+fulfillment:{fulfillment_id}:create_label
+```
+
+The provider operation kind remains `create_label`, and provider request metadata retains:
+
+```text
+commerce_orchestration.operation = "create_label"
+```
+
+Existing committed/provider-succeeded journal rows are adopted rather than re-executed. Reconciliation rows with a valid persisted provider result remain adoptable; unresolved/invalid provider outcome state returns the existing reconciliation-required public family.
+
+Provider-result serialization failure is hardened in the owner path: it explicitly records reconciliation-required state instead of leaving the journal in an unresolved executing state. This does not change the public 409 reconciliation envelope.
+
+## Transport write identity is not a durable create receipt
+
+The mounted route supplies a stable input-sensitive `PortContext` idempotency key based on the public create request and the existing dual FNV-1a offset pattern. This satisfies generic write-port admission and gives host-injected adapters stable transport identity.
+
+It is **not** a newly claimed durable manual-fulfillment creation receipt. The in-process durable replay boundary in this slice remains the Fulfillment-owned create-label provider journal after the fulfillment row has been created.
+
+Retained lost-response/restart evidence for the whole create command is still required before claiming end-to-end durable command idempotency.
+
+## Runtime composition
+
+`CommerceHttpRuntime` prefers a host-injected `FulfillmentAdminCreateCommandRuntime`. If absent, the built-in in-process Fulfillment owner adapter is composed with the same host-selected `FulfillmentProviderRegistry` already used by the other admin Fulfillment command runtime.
+
+## Public error compatibility
+
+The mounted route keeps the existing public families:
+
+- validation -> 400 `commerce_admin_fulfillment_invalid`;
+- missing Order/Fulfillment/ShippingOption resource -> 404 `commerce_admin_not_found`;
+- create-label/provider outcome requiring reconciliation after fulfillment persistence -> 409 `commerce_admin_fulfillment_reconciliation_required`;
+- storage/unavailable -> 503 `commerce_admin_fulfillment_storage_unavailable`;
+- forbidden -> existing permission-denied family;
+- invariant failure -> 500 `commerce_admin_fulfillment_failed`.
+
+## Still open
+
+The canonical broad Commerce topology P0 remains open. This slice does not remove concrete owner construction from remaining post-order/change/return, GraphQL/provider-operation, checkout, reconciliation, or other Commerce surfaces.
+
+The legacy Commerce fulfillment orchestration files are retained because other workflows still reference them and because they document compatibility behavior. They are not evidence that the mounted admin create route still uses direct concrete construction.
+
+## Validation status
+
+Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart/lost-response evidence, and external-provider execution were intentionally not run.

--- a/crates/rustok-commerce/src/controllers/admin/fulfillments_owner_commands.rs
+++ b/crates/rustok-commerce/src/controllers/admin/fulfillments_owner_commands.rs
@@ -13,11 +13,13 @@ use uuid::Uuid;
 pub use super::fulfillments_legacy::*;
 use super::{super::CommerceHttpRuntime, super::common::ensure_permissions};
 use crate::dto::{
-    CancelFulfillmentInput, DeliverFulfillmentInput, FulfillmentResponse, ReopenFulfillmentInput,
-    ReshipFulfillmentInput, ShipFulfillmentInput,
+    CancelFulfillmentInput, CreateFulfillmentInput, DeliverFulfillmentInput, FulfillmentResponse,
+    ReopenFulfillmentInput, ReshipFulfillmentInput, ShipFulfillmentInput,
 };
+use crate::services::AdminManualFulfillmentOrchestrationService;
 
 const ADMIN_FULFILLMENT_COMMAND_OWNER: &str = "rustok_fulfillment.admin_command";
+const ADMIN_FULFILLMENT_CREATE_OWNER: &str = "rustok_fulfillment.admin_create_command";
 const ADMIN_FULFILLMENT_COMMAND_BOUNDARY: &str = "commerce_admin_fulfillment_command_http";
 
 type AdminFulfillmentCommandHttpPolicy =
@@ -42,6 +44,63 @@ fn admin_fulfillment_command_context(
         Some(channel) => context.with_channel(channel),
         None => context,
     }
+}
+
+fn admin_fulfillment_create_read_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    order_id: Uuid,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-fulfillment-create-read:{order_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn admin_fulfillment_create_command_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    input: &CreateFulfillmentInput,
+) -> Result<PortContext, HttpError> {
+    let payload = serde_json::to_vec(input).map_err(|_| {
+        HttpError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_fulfillment_failed",
+            "Fulfillment operation could not be completed safely",
+        )
+    })?;
+    let first = fnv1a64(&payload, 0xcbf29ce484222325);
+    let second = fnv1a64(&payload, 0x84222325cbf29ce4);
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-fulfillment-create-command:{}", input.order_id),
+    )
+    .with_idempotency_key(format!(
+        "admin-fulfillment:create:{}:{first:016x}{second:016x}",
+        input.order_id
+    ))
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
+fn fnv1a64(bytes: &[u8], offset_basis: u64) -> u64 {
+    bytes.iter().fold(offset_basis, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
 }
 
 fn fulfillment_command_error_policy(error: &PortError) -> AdminFulfillmentCommandHttpPolicy {
@@ -130,6 +189,81 @@ fn map_fulfillment_command_error(
         "commerce admin fulfillment owner command failed"
     );
     HttpError::new(status, code, message)
+}
+
+fn map_fulfillment_create_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    order_id: Uuid,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = fulfillment_command_error_policy(&error);
+    tracing::error!(
+        owner = ADMIN_FULFILLMENT_CREATE_OWNER,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        order_id_non_nil = !order_id.is_nil(),
+        operation = "create_fulfillment",
+        correlation_id = %context.correlation_id,
+        internal_code = %error.code,
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_FULFILLMENT_COMMAND_BOUNDARY,
+        "commerce admin fulfillment cross-owner create failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/fulfillments",
+    tag = "admin",
+    request_body = CreateFulfillmentInput,
+    responses(
+        (status = 201, description = "Fulfillment created", body = FulfillmentResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn create_fulfillment(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Json(input): Json<CreateFulfillmentInput>,
+) -> HttpResult<(StatusCode, Json<FulfillmentResponse>)> {
+    ensure_permissions(
+        &auth,
+        &[Permission::FULFILLMENTS_CREATE],
+        "Permission denied: fulfillments:create required",
+    )?;
+    let order_id = input.order_id;
+    let read_context =
+        admin_fulfillment_create_read_context(&tenant, &auth, &request_context, order_id);
+    let write_context =
+        admin_fulfillment_create_command_context(&tenant, &auth, &request_context, &input)?;
+    let service = AdminManualFulfillmentOrchestrationService::new(
+        runtime.order_read_port(),
+        runtime.fulfillment_read_port(),
+        runtime.shipping_option_read_port(),
+        runtime.fulfillment_admin_create_command_port(),
+    );
+    let fulfillment = service
+        .create_manual_fulfillment(read_context, write_context.clone(), input)
+        .await
+        .map_err(|error| {
+            map_fulfillment_create_error(
+                tenant.id,
+                auth.user_id,
+                order_id,
+                &write_context,
+                error,
+            )
+        })?;
+    Ok((StatusCode::CREATED, Json(fulfillment)))
 }
 
 #[utoipa::path(

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -27,6 +27,8 @@ pub struct CommerceHttpRuntime {
     fulfillment_lifecycle_read_runtime:
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     fulfillment_admin_command_runtime: rustok_fulfillment::FulfillmentAdminCommandRuntime,
+    fulfillment_admin_create_command_runtime:
+        rustok_fulfillment::FulfillmentAdminCreateCommandRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
@@ -83,6 +85,12 @@ impl CommerceHttpRuntime {
         &self,
     ) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentAdminCommandPort> {
         self.fulfillment_admin_command_runtime.command_port()
+    }
+
+    fn fulfillment_admin_create_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentAdminCreateCommandPort> {
+        self.fulfillment_admin_create_command_runtime.command_port()
     }
 
     fn order_read_port(&self) -> std::sync::Arc<dyn rustok_order::OrderReadPort> {
@@ -175,6 +183,14 @@ impl CommerceHttpRuntime {
                     fulfillment_provider_registry.clone(),
                 )
             });
+        let fulfillment_admin_create_command_runtime = runtime
+            .shared_get::<rustok_fulfillment::FulfillmentAdminCreateCommandRuntime>()
+            .unwrap_or_else(|| {
+                rustok_fulfillment::FulfillmentAdminCreateCommandRuntime::in_process(
+                    runtime.db_clone(),
+                    fulfillment_provider_registry.clone(),
+                )
+            });
         let order_read_runtime = runtime
             .shared_get::<crate::graphql_runtime::CommerceOrderReadRuntime>()
             .ok_or_else(|| {
@@ -245,6 +261,7 @@ impl CommerceHttpRuntime {
             shipping_option_read_runtime,
             fulfillment_lifecycle_read_runtime,
             fulfillment_admin_command_runtime,
+            fulfillment_admin_create_command_runtime,
             order_read_runtime,
             order_admin_command_runtime,
             payment_order_read_runtime,

--- a/crates/rustok-commerce/src/services/admin_manual_fulfillment_orchestration.rs
+++ b/crates/rustok-commerce/src/services/admin_manual_fulfillment_orchestration.rs
@@ -1,0 +1,312 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use rustok_api::{PortContext, PortError};
+use rustok_fulfillment::{
+    CreateAdminFulfillmentRequest, CreateFulfillmentInput, CreateFulfillmentItemInput,
+    FulfillmentAdminCreateCommandPort, FulfillmentReadPort, FulfillmentResponse,
+    ListFulfillmentProjectionsRequest, ReadShippingOptionProjectionRequest, ShippingOptionReadPort,
+    ShippingOptionResponse, MANUAL_FULFILLMENT_PROVIDER_ID,
+};
+use rustok_order::{OrderLineItemResponse, OrderReadPort, ReadOrderProjectionRequest};
+use serde_json::Value;
+use uuid::Uuid;
+use validator::Validate;
+
+use crate::storefront_shipping::{
+    is_shipping_option_compatible_with_profiles, normalize_shipping_profile_slug,
+};
+
+pub(crate) struct AdminManualFulfillmentOrchestrationService {
+    order_read_port: Arc<dyn OrderReadPort>,
+    fulfillment_read_port: Arc<dyn FulfillmentReadPort>,
+    shipping_option_read_port: Arc<dyn ShippingOptionReadPort>,
+    create_command_port: Arc<dyn FulfillmentAdminCreateCommandPort>,
+}
+
+impl AdminManualFulfillmentOrchestrationService {
+    pub(crate) fn new(
+        order_read_port: Arc<dyn OrderReadPort>,
+        fulfillment_read_port: Arc<dyn FulfillmentReadPort>,
+        shipping_option_read_port: Arc<dyn ShippingOptionReadPort>,
+        create_command_port: Arc<dyn FulfillmentAdminCreateCommandPort>,
+    ) -> Self {
+        Self {
+            order_read_port,
+            fulfillment_read_port,
+            shipping_option_read_port,
+            create_command_port,
+        }
+    }
+
+    pub(crate) async fn create_manual_fulfillment(
+        &self,
+        read_context: PortContext,
+        write_context: PortContext,
+        input: CreateFulfillmentInput,
+    ) -> Result<FulfillmentResponse, PortError> {
+        input.validate().map_err(|_| invalid_request())?;
+        let order_id = input.order_id;
+        let order = self
+            .order_read_port
+            .read_order_projection(
+                read_context.clone(),
+                ReadOrderProjectionRequest {
+                    order_id,
+                    tenant_default_locale: None,
+                },
+            )
+            .await?;
+
+        let requested_items = input.items.clone().ok_or_else(invalid_request)?;
+        if requested_items.is_empty() {
+            return Err(invalid_request());
+        }
+        if input.customer_id.is_some() && input.customer_id != order.customer_id {
+            return Err(invalid_request());
+        }
+
+        let order_line_items_by_id = order
+            .line_items
+            .iter()
+            .cloned()
+            .map(|item| (item.id, item))
+            .collect::<BTreeMap<Uuid, OrderLineItemResponse>>();
+        let existing_fulfillments = self
+            .load_all_fulfillments_for_order(read_context.clone(), order_id)
+            .await?;
+        let mut fulfilled_quantities = BTreeMap::<Uuid, i32>::new();
+        for fulfillment in existing_fulfillments {
+            if fulfillment.status == "cancelled" {
+                continue;
+            }
+            if fulfillment.items.is_empty() {
+                return Err(invalid_request());
+            }
+            for item in fulfillment.items {
+                let entry = fulfilled_quantities
+                    .entry(item.order_line_item_id)
+                    .or_insert(0);
+                *entry = entry.checked_add(item.quantity).ok_or_else(invalid_request)?;
+            }
+        }
+
+        let requested_groups = requested_items
+            .iter()
+            .map(|item| {
+                let line_item = order_line_items_by_id
+                    .get(&item.order_line_item_id)
+                    .ok_or_else(invalid_request)?;
+                Ok(DeliveryGroupKey {
+                    shipping_profile_slug: normalize_shipping_profile_slug(
+                        line_item.shipping_profile_slug.as_str(),
+                    )
+                    .unwrap_or_else(|| "default".to_string()),
+                    seller_id: normalize_seller_id(
+                        line_item
+                            .seller_id
+                            .clone()
+                            .or_else(|| seller_id_from_metadata(&line_item.metadata))
+                            .as_deref(),
+                    ),
+                })
+            })
+            .collect::<Result<Vec<_>, PortError>>()?;
+        let canonical_group = requested_groups
+            .first()
+            .cloned()
+            .ok_or_else(invalid_request)?;
+        if requested_groups.iter().any(|group| {
+            group.shipping_profile_slug != canonical_group.shipping_profile_slug
+                || group.seller_id != canonical_group.seller_id
+        }) {
+            return Err(invalid_request());
+        }
+
+        let shipping_option = match input.shipping_option_id {
+            Some(shipping_option_id) => Some(
+                self.shipping_option_read_port
+                    .read_shipping_option_projection(
+                        read_context.clone(),
+                        ReadShippingOptionProjectionRequest {
+                            shipping_option_id,
+                            requested_locale: Some(read_context.locale.clone()),
+                            tenant_default_locale: None,
+                        },
+                    )
+                    .await?,
+            ),
+            None => None,
+        };
+        if let Some(option) = shipping_option.as_ref() {
+            validate_shipping_option_against_order(
+                option,
+                order.currency_code.as_str(),
+                canonical_group.shipping_profile_slug.as_str(),
+            )?;
+        }
+        let provider_id = shipping_option
+            .as_ref()
+            .map(|option| option.provider_id.clone())
+            .unwrap_or_else(|| MANUAL_FULFILLMENT_PROVIDER_ID.to_string());
+
+        let mut items = Vec::with_capacity(requested_items.len());
+        for item in requested_items {
+            let line_item = order_line_items_by_id
+                .get(&item.order_line_item_id)
+                .ok_or_else(invalid_request)?;
+            let already_fulfilled = fulfilled_quantities
+                .get(&item.order_line_item_id)
+                .copied()
+                .unwrap_or_default();
+            let remaining_quantity = line_item
+                .quantity
+                .checked_sub(already_fulfilled)
+                .ok_or_else(invalid_request)?;
+            if remaining_quantity <= 0 || item.quantity > remaining_quantity {
+                return Err(invalid_request());
+            }
+
+            items.push(CreateFulfillmentItemInput {
+                order_line_item_id: item.order_line_item_id,
+                quantity: item.quantity,
+                metadata: merge_metadata(
+                    item.metadata,
+                    serde_json::json!({
+                        "shipping_profile_slug": canonical_group.shipping_profile_slug,
+                        "seller_id": canonical_group.seller_id,
+                        "post_order": {
+                            "manual": true
+                        }
+                    }),
+                ),
+            });
+        }
+
+        let metadata = merge_metadata(
+            input.metadata,
+            serde_json::json!({
+                "delivery_group": {
+                    "shipping_profile_slug": canonical_group.shipping_profile_slug,
+                    "seller_id": canonical_group.seller_id,
+                    "order_line_item_ids": items
+                        .iter()
+                        .map(|item| item.order_line_item_id)
+                        .collect::<Vec<_>>(),
+                },
+                "post_order": {
+                    "manual": true
+                }
+            }),
+        );
+
+        self.create_command_port
+            .create_fulfillment(
+                write_context,
+                CreateAdminFulfillmentRequest {
+                    input: CreateFulfillmentInput {
+                        order_id,
+                        shipping_option_id: input.shipping_option_id,
+                        customer_id: order.customer_id,
+                        carrier: input.carrier,
+                        tracking_number: input.tracking_number,
+                        items: Some(items),
+                        metadata,
+                    },
+                    provider_id,
+                },
+            )
+            .await
+    }
+
+    async fn load_all_fulfillments_for_order(
+        &self,
+        context: PortContext,
+        order_id: Uuid,
+    ) -> Result<Vec<FulfillmentResponse>, PortError> {
+        let mut page = 1_u64;
+        let mut all = Vec::new();
+        loop {
+            let result = self
+                .fulfillment_read_port
+                .list_fulfillment_projections(
+                    context.clone(),
+                    ListFulfillmentProjectionsRequest {
+                        page,
+                        per_page: 100,
+                        status: None,
+                        order_id: Some(order_id),
+                        customer_id: None,
+                    },
+                )
+                .await?;
+            let returned = result.items.len();
+            all.extend(result.items);
+            if returned == 0 || all.len() as u64 >= result.total {
+                return Ok(all);
+            }
+            page = page.checked_add(1).ok_or_else(invalid_request)?;
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DeliveryGroupKey {
+    shipping_profile_slug: String,
+    seller_id: Option<String>,
+}
+
+fn validate_shipping_option_against_order(
+    option: &ShippingOptionResponse,
+    order_currency_code: &str,
+    required_shipping_profile_slug: &str,
+) -> Result<(), PortError> {
+    if !option.currency_code.eq_ignore_ascii_case(order_currency_code) {
+        return Err(invalid_request());
+    }
+    let required_profiles = BTreeSet::from([required_shipping_profile_slug.to_string()]);
+    if !is_shipping_option_compatible_with_profiles(option, &required_profiles) {
+        return Err(invalid_request());
+    }
+    Ok(())
+}
+
+fn normalize_seller_id(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn seller_id_from_metadata(metadata: &Value) -> Option<String> {
+    metadata
+        .get("seller")
+        .and_then(|seller| seller.get("id"))
+        .and_then(Value::as_str)
+        .and_then(|value| normalize_seller_id(Some(value)))
+        .or_else(|| {
+            metadata
+                .get("seller_id")
+                .and_then(Value::as_str)
+                .and_then(|value| normalize_seller_id(Some(value)))
+        })
+}
+
+fn merge_metadata(current: Value, patch: Value) -> Value {
+    match (current, patch) {
+        (Value::Object(mut current), Value::Object(patch)) => {
+            for (key, value) in patch {
+                current.insert(key, value);
+            }
+            Value::Object(current)
+        }
+        (_, patch) => patch,
+    }
+}
+
+fn invalid_request() -> PortError {
+    PortError::validation(
+        "commerce.fulfillment_create_invalid",
+        "manual fulfillment request is invalid",
+    )
+}

--- a/crates/rustok-commerce/src/services/mod.rs
+++ b/crates/rustok-commerce/src/services/mod.rs
@@ -1,3 +1,4 @@
+mod admin_manual_fulfillment_orchestration;
 pub mod checkout;
 #[path = "checkout_compensation_error_safe.rs"]
 mod checkout_compensation;
@@ -72,6 +73,7 @@ mod staged_checkout;
 #[path = "../storefront_staged_checkout_runtime.rs"]
 pub mod storefront_staged_checkout_runtime;
 
+pub(crate) use admin_manual_fulfillment_orchestration::AdminManualFulfillmentOrchestrationService;
 pub use checkout::{CheckoutError, CheckoutResult, CheckoutService};
 pub use checkout_compensation::{
     CheckoutCompensationError, CheckoutCompensationResult, CheckoutCompensationService,

--- a/crates/rustok-fulfillment/src/admin_create_command.rs
+++ b/crates/rustok-fulfillment/src/admin_create_command.rs
@@ -1,0 +1,429 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+
+use crate::dto::{CreateFulfillmentInput, FulfillmentResponse};
+use crate::entities::provider_operation;
+use crate::error::FulfillmentError;
+use crate::providers::{
+    FulfillmentProviderOperationRequest, FulfillmentProviderOperationResult,
+    FulfillmentProviderRegistry, MANUAL_FULFILLMENT_PROVIDER_ID,
+};
+use crate::services::{
+    BeginProviderOperation, FulfillmentProviderOperationJournal, FulfillmentService,
+    PROVIDER_OPERATION_COMMITTED, PROVIDER_OPERATION_EXECUTING,
+    PROVIDER_OPERATION_RECONCILIATION_REQUIRED, PROVIDER_OPERATION_SUCCEEDED,
+};
+
+const ADMIN_CREATE_BOUNDARY: &str = "fulfillment_admin_create_command_port";
+
+#[async_trait]
+pub trait FulfillmentAdminCreateCommandPort: Send + Sync {
+    async fn create_fulfillment(
+        &self,
+        context: PortContext,
+        request: CreateAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateAdminFulfillmentRequest {
+    pub input: CreateFulfillmentInput,
+    pub provider_id: String,
+}
+
+pub struct InProcessFulfillmentAdminCreateCommandPort {
+    service: FulfillmentService,
+    operation_journal: FulfillmentProviderOperationJournal,
+    provider_registry: FulfillmentProviderRegistry,
+}
+
+impl InProcessFulfillmentAdminCreateCommandPort {
+    pub fn new(db: DatabaseConnection, provider_registry: FulfillmentProviderRegistry) -> Self {
+        Self {
+            service: FulfillmentService::new(db.clone()),
+            operation_journal: FulfillmentProviderOperationJournal::new(db),
+            provider_registry,
+        }
+    }
+}
+
+pub fn in_process_fulfillment_admin_create_command_port(
+    db: DatabaseConnection,
+    provider_registry: FulfillmentProviderRegistry,
+) -> Arc<dyn FulfillmentAdminCreateCommandPort> {
+    Arc::new(InProcessFulfillmentAdminCreateCommandPort::new(
+        db,
+        provider_registry,
+    ))
+}
+
+#[derive(Clone)]
+pub struct FulfillmentAdminCreateCommandRuntime {
+    command_port: Arc<dyn FulfillmentAdminCreateCommandPort>,
+}
+
+impl FulfillmentAdminCreateCommandRuntime {
+    pub fn new(command_port: Arc<dyn FulfillmentAdminCreateCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        provider_registry: FulfillmentProviderRegistry,
+    ) -> Self {
+        Self::new(in_process_fulfillment_admin_create_command_port(
+            db,
+            provider_registry,
+        ))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn FulfillmentAdminCreateCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl FulfillmentAdminCreateCommandPort for InProcessFulfillmentAdminCreateCommandPort {
+    async fn create_fulfillment(
+        &self,
+        context: PortContext,
+        request: CreateAdminFulfillmentRequest,
+    ) -> Result<FulfillmentResponse, PortError> {
+        const OPERATION: &str = "create_admin_fulfillment";
+        context.require_policy(PortCallPolicy::write())?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+
+        request.input.validate().map_err(|_| {
+            PortError::validation(
+                "fulfillment.validation",
+                "fulfillment create request is invalid",
+            )
+        })?;
+        let provider_id = request.provider_id.trim().to_string();
+        if provider_id.is_empty() || provider_id.len() > 100 {
+            return Err(PortError::validation(
+                "fulfillment.provider_invalid",
+                "fulfillment provider identity is invalid",
+            ));
+        }
+
+        if let Some(shipping_option_id) = request.input.shipping_option_id {
+            let option = self
+                .service
+                .get_shipping_option(tenant_id, shipping_option_id, None, None)
+                .await
+                .map_err(|error| map_fulfillment_error(&context, OPERATION, error))?;
+            if option.provider_id != provider_id {
+                return Err(PortError::validation(
+                    "fulfillment.provider_mismatch",
+                    "fulfillment provider does not match the selected shipping option",
+                ));
+            }
+        } else if provider_id != MANUAL_FULFILLMENT_PROVIDER_ID {
+            return Err(PortError::validation(
+                "fulfillment.provider_mismatch",
+                "manual fulfillment requires the manual provider",
+            ));
+        }
+
+        let fulfillment = self
+            .service
+            .create_fulfillment(tenant_id, request.input)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))?;
+
+        let provider_request = FulfillmentProviderOperationRequest {
+            tenant_id,
+            fulfillment_id: fulfillment.id,
+            idempotency_key: Some(format!("fulfillment:{}:create_label", fulfillment.id)),
+            metadata: merge_metadata(
+                fulfillment.metadata.clone(),
+                serde_json::json!({
+                    "commerce_orchestration": {
+                        "operation": "create_label"
+                    }
+                }),
+            ),
+        };
+
+        if let Err(error) = self
+            .execute_create_label(&context, OPERATION, provider_id.as_str(), provider_request)
+            .await
+        {
+            tracing::error!(
+                boundary = ADMIN_CREATE_BOUNDARY,
+                owner_operation = OPERATION,
+                fulfillment_id_non_nil = !fulfillment.id.is_nil(),
+                internal_code = %error.code,
+                retryable = error.retryable,
+                "fulfillment create-label execution requires reconciliation"
+            );
+            return Err(PortError::conflict(
+                "fulfillment.reconciliation_required",
+                "fulfillment create-label operation requires reconciliation",
+            ));
+        }
+
+        Ok(fulfillment)
+    }
+}
+
+impl InProcessFulfillmentAdminCreateCommandPort {
+    async fn execute_create_label(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        provider_id: &str,
+        request: FulfillmentProviderOperationRequest,
+    ) -> Result<FulfillmentProviderOperationResult, PortError> {
+        let idempotency_key = request
+            .idempotency_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                PortError::validation(
+                    "fulfillment.provider_idempotency_key_missing",
+                    "create-label operation requires idempotency identity",
+                )
+            })?
+            .to_string();
+        let request_payload = serde_json::to_value(&request).map_err(|_| {
+            PortError::validation(
+                "fulfillment.provider_request_invalid",
+                "create-label provider request is invalid",
+            )
+        })?;
+        let operation = self
+            .operation_journal
+            .begin(BeginProviderOperation {
+                tenant_id: request.tenant_id,
+                fulfillment_id: request.fulfillment_id,
+                operation: "create_label".to_string(),
+                provider_id: provider_id.to_string(),
+                idempotency_key,
+                request_payload,
+            })
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+
+        if matches!(
+            operation.status.as_str(),
+            PROVIDER_OPERATION_COMMITTED
+                | PROVIDER_OPERATION_SUCCEEDED
+                | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+        ) {
+            let result = deserialize_create_label_result(context, owner_operation, &operation)?;
+            if operation.status != PROVIDER_OPERATION_COMMITTED {
+                self.commit_create_label(context, owner_operation, operation.id)
+                    .await?;
+            }
+            return Ok(result);
+        }
+        if operation.status == PROVIDER_OPERATION_EXECUTING {
+            return Err(PortError::conflict(
+                "fulfillment.provider_operation_in_progress",
+                "create-label provider operation is already in progress",
+            ));
+        }
+
+        if self
+            .operation_journal
+            .claim_execution(operation.id)
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?
+            .is_none()
+        {
+            let current = self
+                .operation_journal
+                .get(operation.id)
+                .await
+                .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+            if matches!(
+                current.status.as_str(),
+                PROVIDER_OPERATION_COMMITTED
+                    | PROVIDER_OPERATION_SUCCEEDED
+                    | PROVIDER_OPERATION_RECONCILIATION_REQUIRED
+            ) {
+                let result = deserialize_create_label_result(context, owner_operation, &current)?;
+                if current.status != PROVIDER_OPERATION_COMMITTED {
+                    self.commit_create_label(context, owner_operation, current.id)
+                        .await?;
+                }
+                return Ok(result);
+            }
+            return Err(PortError::conflict(
+                "fulfillment.provider_operation_in_progress",
+                "create-label provider operation is already in progress",
+            ));
+        }
+
+        let result = match self
+            .provider_registry
+            .execute_create_label(provider_id, request)
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = self
+                    .operation_journal
+                    .mark_provider_error(operation.id, "create_label provider execution failed")
+                    .await;
+                return Err(map_fulfillment_error(context, owner_operation, error));
+            }
+        };
+
+        let result_payload = match serde_json::to_value(&result) {
+            Ok(payload) => payload,
+            Err(_) => {
+                let _ = self
+                    .operation_journal
+                    .mark_execution_reconciliation_required(
+                        operation.id,
+                        result.external_reference.clone(),
+                        None,
+                        "create_label provider result could not be serialized",
+                    )
+                    .await;
+                return Err(PortError::conflict(
+                    "fulfillment.reconciliation_required",
+                    "create-label provider result requires reconciliation",
+                ));
+            }
+        };
+
+        self.operation_journal
+            .mark_provider_succeeded(
+                operation.id,
+                result.external_reference.clone(),
+                result_payload,
+            )
+            .await
+            .map_err(|error| map_fulfillment_error(context, owner_operation, error))?;
+        self.commit_create_label(context, owner_operation, operation.id)
+            .await?;
+        Ok(result)
+    }
+
+    async fn commit_create_label(
+        &self,
+        context: &PortContext,
+        owner_operation: &'static str,
+        operation_id: Uuid,
+    ) -> Result<(), PortError> {
+        if let Err(error) = self.operation_journal.mark_committed(operation_id).await {
+            let _ = self
+                .operation_journal
+                .mark_reconciliation_required(
+                    operation_id,
+                    "create_label provider succeeded but journal commit failed",
+                )
+                .await;
+            return Err(map_fulfillment_error(context, owner_operation, error));
+        }
+        Ok(())
+    }
+}
+
+fn deserialize_create_label_result(
+    context: &PortContext,
+    owner_operation: &'static str,
+    operation: &provider_operation::Model,
+) -> Result<FulfillmentProviderOperationResult, PortError> {
+    let value = operation.provider_result.clone().ok_or_else(|| {
+        PortError::conflict(
+            "fulfillment.reconciliation_required",
+            "create-label provider result is not available for safe replay",
+        )
+    })?;
+    serde_json::from_value(value).map_err(|_| {
+        tracing::error!(
+            boundary = ADMIN_CREATE_BOUNDARY,
+            owner_operation,
+            provider_operation_id_non_nil = !operation.id.is_nil(),
+            "fulfillment create-label journal contains invalid provider result"
+        );
+        PortError::conflict(
+            "fulfillment.reconciliation_required",
+            "create-label provider result is invalid and requires reconciliation",
+        )
+    })
+}
+
+fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(context.tenant_id.as_str()).map_err(|_| {
+        tracing::error!(
+            boundary = ADMIN_CREATE_BOUNDARY,
+            owner_operation = operation,
+            tenant_id_length = context.tenant_id.len(),
+            "fulfillment admin create command received invalid tenant identity"
+        );
+        PortError::validation(
+            "fulfillment.tenant_invalid",
+            "fulfillment tenant identity is invalid",
+        )
+    })
+}
+
+fn map_fulfillment_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: FulfillmentError,
+) -> PortError {
+    let (variant, mapped) = match error {
+        FulfillmentError::Validation(_) => (
+            "validation",
+            PortError::validation(
+                "fulfillment.validation",
+                "fulfillment request is invalid",
+            ),
+        ),
+        FulfillmentError::ShippingOptionNotFound(_) | FulfillmentError::FulfillmentNotFound(_) => (
+            "not_found",
+            PortError::not_found(
+                "fulfillment.not_found",
+                "fulfillment resource was not found",
+            ),
+        ),
+        FulfillmentError::InvalidTransition { .. } => (
+            "invalid_transition",
+            PortError::conflict(
+                "fulfillment.invalid_transition",
+                "fulfillment operation conflicts with the current state",
+            ),
+        ),
+        FulfillmentError::Database(_) => (
+            "database",
+            PortError::unavailable(
+                "fulfillment.database_unavailable",
+                "fulfillment storage is temporarily unavailable",
+            ),
+        ),
+    };
+    tracing::error!(
+        boundary = ADMIN_CREATE_BOUNDARY,
+        owner_operation = operation,
+        error_variant = variant,
+        correlation_id_present = !context.correlation_id.is_empty(),
+        "fulfillment admin create owner operation failed"
+    );
+    mapped
+}
+
+fn merge_metadata(current: serde_json::Value, patch: serde_json::Value) -> serde_json::Value {
+    match (current, patch) {
+        (serde_json::Value::Object(mut current), serde_json::Value::Object(patch)) => {
+            for (key, value) in patch {
+                current.insert(key, value);
+            }
+            serde_json::Value::Object(current)
+        }
+        (_, patch) => patch,
+    }
+}

--- a/crates/rustok-fulfillment/src/lib.rs
+++ b/crates/rustok-fulfillment/src/lib.rs
@@ -4,6 +4,7 @@ use rustok_core::{MigrationDependencyDescriptor, MigrationSource, RusToKModule};
 use sea_orm_migration::MigrationTrait;
 
 mod admin_command;
+mod admin_create_command;
 pub mod checkout_execution;
 mod checkout_execution_typed;
 pub mod dto;
@@ -22,6 +23,11 @@ pub use admin_command::{
     FulfillmentAdminCommandRuntime, InProcessFulfillmentAdminCommandPort,
     ReopenAdminFulfillmentRequest, ReshipAdminFulfillmentRequest, ShipAdminFulfillmentRequest,
     in_process_fulfillment_admin_command_port,
+};
+pub use admin_create_command::{
+    CreateAdminFulfillmentRequest, FulfillmentAdminCreateCommandPort,
+    FulfillmentAdminCreateCommandRuntime, InProcessFulfillmentAdminCreateCommandPort,
+    in_process_fulfillment_admin_create_command_port,
 };
 pub use checkout_execution::{
     CheckoutFulfillmentCommand, CheckoutFulfillmentExecutionPort, CheckoutFulfillmentItemCommand,

--- a/scripts/verify/verify-commerce-admin-fulfillment-create-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-fulfillment-create-owner-port-cutover.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const requireText = (source, text, label) => {
+  if (!source.includes(text)) throw new Error(`missing ${label}: ${text}`);
+};
+const forbidText = (source, text, label) => {
+  if (source.includes(text)) throw new Error(`forbidden ${label}: ${text}`);
+};
+
+const adminMod = read("crates/rustok-commerce/src/controllers/admin/mod.rs");
+const mounted = read("crates/rustok-commerce/src/controllers/admin/fulfillments_owner_commands.rs");
+const legacy = read("crates/rustok-commerce/src/controllers/admin/fulfillments.rs");
+const orchestration = read("crates/rustok-commerce/src/services/admin_manual_fulfillment_orchestration.rs");
+const servicesMod = read("crates/rustok-commerce/src/services/mod.rs");
+const httpRuntime = read("crates/rustok-commerce/src/controllers/mod.rs");
+const fulfillmentLib = read("crates/rustok-fulfillment/src/lib.rs");
+const ownerCreate = read("crates/rustok-fulfillment/src/admin_create_command.rs");
+const plan = read("crates/rustok-commerce/docs/implementation-plan.md");
+const doc = read("crates/rustok-commerce/docs/admin-fulfillment-create-owner-port-cutover-2026-08-09.md");
+
+requireText(adminMod, '#[path = "fulfillments.rs"]\nmod fulfillments_legacy;', "private legacy Fulfillment module");
+requireText(adminMod, '#[path = "fulfillments_owner_commands.rs"]\npub mod fulfillments;', "mounted Fulfillment owner adapter");
+requireText(mounted, "pub use super::fulfillments_legacy::*;", "legacy/Utoipa compatibility re-export");
+requireText(mounted, "pub async fn create_fulfillment", "mounted create handler");
+requireText(mounted, "Permission::FULFILLMENTS_CREATE", "create permission");
+requireText(mounted, "AdminManualFulfillmentOrchestrationService::new(", "typed cross-owner orchestration");
+requireText(mounted, "runtime.order_read_port()", "Order owner read capability");
+requireText(mounted, "runtime.fulfillment_read_port()", "Fulfillment owner read capability");
+requireText(mounted, "runtime.shipping_option_read_port()", "ShippingOption owner read capability");
+requireText(mounted, "runtime.fulfillment_admin_create_command_port()", "Fulfillment owner create capability");
+requireText(mounted, '"admin-fulfillment:create:{}:{first:016x}{second:016x}"', "input-sensitive transport write identity");
+requireText(mounted, "0xcbf29ce484222325", "first admission FNV offset");
+requireText(mounted, "0x84222325cbf29ce4", "second admission FNV offset");
+requireText(mounted, ".with_deadline(std::time::Duration::from_secs(2))", "bounded read/write deadline");
+requireText(mounted, "request_context.channel_slug.as_deref()", "channel propagation");
+requireText(mounted, '"commerce_admin_fulfillment_reconciliation_required"', "reconciliation public envelope");
+forbidText(mounted, "FulfillmentService::new", "concrete Fulfillment construction in mounted create path");
+forbidText(mounted, "FulfillmentOrchestrationService::new", "legacy Commerce orchestration construction in mounted create path");
+forbidText(mounted, "runtime.db_clone()", "direct Commerce DB access in mounted create adapter");
+forbidText(mounted, "rustok_order::entities", "Order ORM access in mounted create adapter");
+
+requireText(servicesMod, "mod admin_manual_fulfillment_orchestration;", "manual fulfillment orchestration module");
+requireText(servicesMod, "AdminManualFulfillmentOrchestrationService", "manual fulfillment orchestration export");
+requireText(orchestration, "Arc<dyn OrderReadPort>", "Order owner read port field");
+requireText(orchestration, "Arc<dyn FulfillmentReadPort>", "Fulfillment owner read port field");
+requireText(orchestration, "Arc<dyn ShippingOptionReadPort>", "ShippingOption owner read port field");
+requireText(orchestration, "Arc<dyn FulfillmentAdminCreateCommandPort>", "Fulfillment owner create port field");
+requireText(orchestration, ".read_order_projection(", "Order projection read");
+requireText(orchestration, ".list_fulfillment_projections(", "existing Fulfillment projection reads");
+requireText(orchestration, ".read_shipping_option_projection(", "ShippingOption projection read");
+requireText(orchestration, ".create_fulfillment(", "owner create command call");
+requireText(orchestration, "is_shipping_option_compatible_with_profiles", "existing shipping-profile compatibility policy");
+requireText(orchestration, '"post_order": {\n                            "manual": true', "manual fulfillment item metadata");
+requireText(orchestration, '"delivery_group"', "delivery-group metadata");
+forbidText(orchestration, "sea_orm", "SeaORM in cross-owner orchestration");
+forbidText(orchestration, "rustok_order::entities", "Order ORM in cross-owner orchestration");
+forbidText(orchestration, "FulfillmentService", "concrete Fulfillment service in cross-owner orchestration");
+
+requireText(fulfillmentLib, "mod admin_create_command;", "Fulfillment admin create module");
+requireText(fulfillmentLib, "FulfillmentAdminCreateCommandPort", "Fulfillment create port export");
+requireText(fulfillmentLib, "FulfillmentAdminCreateCommandRuntime", "Fulfillment create runtime export");
+requireText(ownerCreate, "pub trait FulfillmentAdminCreateCommandPort", "Fulfillment create owner trait");
+requireText(ownerCreate, "pub struct FulfillmentAdminCreateCommandRuntime", "Fulfillment create owner runtime");
+requireText(ownerCreate, "context.require_policy(PortCallPolicy::write())", "owner write admission");
+requireText(ownerCreate, "FulfillmentService::new(db.clone())", "owner-local Fulfillment service");
+requireText(ownerCreate, "FulfillmentProviderOperationJournal::new(db)", "owner-local provider journal");
+requireText(ownerCreate, ".execute_create_label(provider_id, request)", "owner create-label provider execution");
+requireText(ownerCreate, 'format!("fulfillment:{}:create_label", fulfillment.id)', "exact durable create-label identity");
+requireText(ownerCreate, 'operation: "create_label".to_string()', "create-label journal operation");
+requireText(ownerCreate, '"operation": "create_label"', "create-label provider metadata");
+requireText(ownerCreate, "PROVIDER_OPERATION_COMMITTED", "committed replay adoption");
+requireText(ownerCreate, "PROVIDER_OPERATION_SUCCEEDED", "provider-succeeded replay adoption");
+requireText(ownerCreate, "PROVIDER_OPERATION_RECONCILIATION_REQUIRED", "reconciliation replay handling");
+requireText(ownerCreate, "mark_execution_reconciliation_required", "provider-result serialization reconciliation checkpoint");
+requireText(ownerCreate, '"fulfillment.reconciliation_required"', "bounded post-persistence reconciliation error");
+forbidText(ownerCreate, "rustok_commerce", "Commerce dependency in Fulfillment owner create");
+forbidText(ownerCreate, "rustok_order", "Order dependency in Fulfillment owner create");
+forbidText(ownerCreate, "source.to_string()", "raw source persistence in Fulfillment owner create");
+forbidText(ownerCreate, "error.to_string()", "raw error persistence in Fulfillment owner create");
+
+requireText(httpRuntime, "fulfillment_admin_create_command_runtime:", "Commerce Fulfillment create runtime field");
+requireText(httpRuntime, "fn fulfillment_admin_create_command_port(", "Commerce Fulfillment create port accessor");
+requireText(httpRuntime, ".shared_get::<rustok_fulfillment::FulfillmentAdminCreateCommandRuntime>()", "host-selected create runtime preference");
+requireText(httpRuntime, "rustok_fulfillment::FulfillmentAdminCreateCommandRuntime::in_process(", "built-in create owner fallback");
+requireText(httpRuntime, "fulfillment_provider_registry.clone()", "host-selected Fulfillment provider registry reuse");
+
+requireText(legacy, "pub async fn create_fulfillment", "legacy create compatibility source retained");
+requireText(legacy, "FulfillmentOrchestrationService::new(runtime.db_clone())", "legacy compatibility orchestration retained");
+
+requireText(plan, "- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,", "canonical topology item remains open");
+requireText(plan, "Payment, and Fulfillment concrete services behind host-composed owner ports.", "canonical topology continuation remains open");
+requireText(doc, "Source-complete for the mounted `POST /admin/fulfillments` route", "focused source-complete status");
+requireText(doc, "It is **not** a newly claimed durable manual-fulfillment creation receipt", "transport/durable replay distinction");
+requireText(doc, "canonical broad Commerce topology P0 remains open", "broad topology remains open");
+requireText(doc, "Execution evidence remains pending and unvalidated", "execution evidence remains open");
+
+console.log("commerce admin Fulfillment create owner-port cutover source guard: OK");


### PR DESCRIPTION
## Summary
- route mounted `POST /admin/fulfillments` through typed Order/Fulfillment/ShippingOption owner reads plus a Fulfillment-owned create command
- keep seller-aware delivery-group, shipping-profile, customer, and remaining-quantity policy composition in Commerce rather than assigning cross-owner policy to Fulfillment
- publish `FulfillmentAdminCreateCommandPort` / `FulfillmentAdminCreateCommandRuntime`
- keep Fulfillment persistence, provider consistency checks, provider journal construction, and create-label execution inside `rustok-fulfillment`
- preserve the exact durable provider identity `fulfillment:{fulfillment_id}:create_label`, operation kind `create_label`, and `commerce_orchestration.operation = "create_label"` metadata
- preserve existing committed/provider-succeeded/reconciliation replay behavior and harden provider-result serialization failure into explicit reconciliation-required state
- keep `FULFILLMENTS_CREATE`, existing DTOs, HTTP 201 success, and existing 400/404/409/503/500 public error families
- carry tenant/user/locale/channel and bounded deadlines through owner contexts; use an input-sensitive transport write identity for generic port admission only, not as a newly claimed durable manual-create receipt
- prefer host-injected `FulfillmentAdminCreateCommandRuntime`; otherwise compose the built-in owner adapter with the host-selected `FulfillmentProviderRegistry`
- add focused actualization and a source guard without executing it

## Out of scope
The broad Commerce topology P0 remains open for remaining post-order/change/return, GraphQL/provider-operation, checkout, reconciliation, and other concrete-owner paths. Legacy fulfillment orchestration sources remain for compatibility and other workflows.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, runtime HTTP calls, restart/lost-response evidence, and external-provider execution were intentionally not run per maintainer instruction.