### PR TITLE
fix(blog): make taxonomy tag projection canonical

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
@@ -9,8 +9,8 @@
   "canonical_current_cursor": "crates/rustok-blog/docs/implementation-plan-current.md",
   "actualization_slice": "crates/rustok-blog/docs/implementation-plan-slice-101.md",
   "historical_baseline_last_embedded_slice": 67,
-  "latest_behavior_slice": 102,
-  "current_recorded_slice": 102,
+  "latest_behavior_slice": 103,
+  "current_recorded_slice": 103,
   "source_tracks": {
     "remote_comments_transport": {
       "status": "source_implemented_maintainer_execution_pending",
@@ -50,15 +50,28 @@
       "database_side_pagination_claimed": false,
       "must_not_reopen_as_source_gap": true
     },
-    "tag_mutation_projection_consistency": {
-      "status": "re_audit_required",
-      "must_define_canonical_search_visible_tag_source": true,
-      "must_define_atomic_reindex_ownership_before_mutation_change": true
+    "tag_canonical_projection": {
+      "status": "source_ready_maintainer_execution_pending",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-103.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json",
+      "attachment_source": "blog_post_tags",
+      "dictionary_source": "rustok-taxonomy",
+      "metadata_tags_are_canonical": false,
+      "legacy_data_audit_pending": true,
+      "must_not_reopen_as_source_gap": true
+    },
+    "tag_mutation_atomic_reindex": {
+      "status": "next_source_gap",
+      "canonical_source_defined": true,
+      "taxonomy_supplied_transaction_api_required": true,
+      "blog_scope_reindex_same_transaction_required": true,
+      "manual_predelete_relation_cleanup_must_be_removed": true
     }
   },
   "planning_result": {
-    "independent_production_source_gap_identified": false,
-    "future_autonomous_source_work_requires_fresh_audit": true,
+    "independent_production_source_gap_identified": true,
+    "next_source_gap": "tag_mutation_atomic_reindex",
+    "future_autonomous_source_work_requires_fresh_audit": false,
     "historical_stale_phrases_are_live_instructions": false,
     "production_behavior_changed_since_slice_101": true,
     "ffa_or_fba_promoted": false
@@ -70,6 +83,9 @@
     "no_compile_result",
     "no_database_side_tag_pagination_result",
     "no_postgresql_result",
+    "no_legacy_data_audit_result",
+    "no_legacy_backfill_result",
+    "no_tag_mutation_atomic_reindex_result",
     "no_redis_result",
     "no_tcp_runtime_result",
     "no_browser_result",

--- a/crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "tag_canonical_read_search_projection",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "ownership": {
+    "dictionary_owner": "rustok-taxonomy",
+    "attachment_owner": "rustok-blog",
+    "attachment_table": "blog_post_tags",
+    "compatibility_mirror": "blog_posts.metadata.tags",
+    "metadata_tags_is_canonical_read_source": false,
+    "metadata_tags_is_search_projection_source": false
+  },
+  "source_contract": {
+    "blog_read_service": "crates/rustok-blog/src/services/tag.rs",
+    "search_projector": "crates/rustok-search/src/blog_projector.rs",
+    "search_postgres_harness": "crates/rustok-search/tests/blog_projection_postgres_test.rs",
+    "search_projection_evidence": "crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json",
+    "requested_post_ids_receive_explicit_empty_tag_entries": true,
+    "empty_relation_set_falls_back_to_metadata": false,
+    "search_requires_blog_post_tags": true,
+    "search_requires_taxonomy_terms": true,
+    "search_requires_taxonomy_term_translations": true,
+    "search_locale_resolution": [
+      "document_locale",
+      "platform_fallback_locale",
+      "canonical_key"
+    ],
+    "taxonomy_joins_are_tenant_constrained": true,
+    "tag_aggregation_is_distinct_and_deterministic": true,
+    "stale_metadata_tags_are_ignored_by_search_harness": true,
+    "tag_mutation_semantics_changed": false,
+    "tag_mutation_atomic_reindex_implemented": false,
+    "production_behavior_changed": true,
+    "database_schema_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "rollout_requirements": [
+    "execute Blog tag read evidence against real owner tables",
+    "execute Search Blog projection PostgreSQL harness",
+    "audit deployed Blog rows for metadata tags without blog_post_tags relations",
+    "backfill metadata-only legacy rows through an owner migration before rollout if such rows exist",
+    "retain evidence that stale metadata tags do not reappear after relation removal"
+  ],
+  "next_source_gap": {
+    "status": "tag_mutation_atomic_reindex_next",
+    "required": [
+      "Taxonomy-owned update/delete term in supplied transaction",
+      "Blog update/delete tag mutation and Blog-scope ReindexRequested in one transaction",
+      "remove manual pre-delete blog_post_tags cleanup and rely on the declared FK cascade"
+    ]
+  },
+  "execution": [],
+  "explicit_non_claims": [
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_compile_result",
+    "no_postgresql_result",
+    "no_legacy_data_audit_result",
+    "no_legacy_backfill_result",
+    "no_tag_mutation_atomic_reindex_result",
+    "no_runtime_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json
@@ -15,11 +15,13 @@
   },
   "source_contract": {
     "blog_read_service": "crates/rustok-blog/src/services/tag.rs",
+    "blog_read_harness": "crates/rustok-blog/tests/taxonomy_tags.rs",
     "search_projector": "crates/rustok-search/src/blog_projector.rs",
     "search_postgres_harness": "crates/rustok-search/tests/blog_projection_postgres_test.rs",
     "search_projection_evidence": "crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json",
     "requested_post_ids_receive_explicit_empty_tag_entries": true,
     "empty_relation_set_falls_back_to_metadata": false,
+    "blog_read_harness_rejects_metadata_resurrection": true,
     "search_requires_blog_post_tags": true,
     "search_requires_taxonomy_terms": true,
     "search_requires_taxonomy_term_translations": true,

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -101,7 +101,7 @@ Blog reads seed an explicit empty tag vector for each requested post ID. Therefo
 
 Blog Search now requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves attached names through document locale -> `PLATFORM_FALLBACK_LOCALE` -> canonical key. Taxonomy joins are tenant-constrained and tag aggregation remains distinct/deterministic. The retained PostgreSQL harness deliberately keeps stale metadata while expecting projection from relation/Taxonomy rows.
 
-Runtime promotion must audit deployed rows for metadata-only legacy tags. If such rows exist, backfill owner relations before rollout. Slice 103 does not claim that the audit or a backfill was executed.
+Runtime promotion must audit deployed data for metadata-only legacy rows. If such rows exist, backfill owner relations before rollout. Slice 103 does not claim that the audit or a backfill was executed.
 
 Mutation semantics intentionally remain separate:
 
@@ -117,7 +117,7 @@ The concrete retained execution results remain maintainer-owned:
 2. Execute slices 95–97 before defining terminal Blog source-row and immutable recovery-audit retention.
 3. Execute slice 98 PostgreSQL evidence before advancing the Blog category Translation readiness result.
 4. Execute slice 102 tag pagination source/unit evidence before promoting runtime validation.
-5. Execute slice 103 Blog read/Search canonical tag projection evidence and audit deployed data for metadata-only legacy tags before runtime promotion.
+5. Execute slice 103 Blog read/Search canonical tag projection evidence and audit deployed data for metadata-only legacy rows before runtime promotion.
 6. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
 7. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
 

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -9,14 +9,14 @@ The continuation series is authoritative for source work after the historical ba
 
 ## Re-audit basis
 
-The source continuation through slice 103 retains these planning corrections/results:
+The source continuation through slice 103 retains the following planning corrections and independent Blog source results:
 
-- remote Comments transport source exists; retained execution evidence remains maintainer-owned;
-- cached public Comments snapshot source exists; runtime evidence remains pending;
-- storefront comment-form fallback is not applicable because the active storefront has no public Comments write surface;
-- Blog category Translation PostgreSQL evidence source exists and waits for maintainer execution;
+- the remote Comments transport is no longer an unimplemented source item;
+- the cached public Comments snapshot is no longer merely planned;
+- the storefront comment-form fallback is not an implementation target because the active storefront has no public Comments write surface;
+- Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution;
 - Blog tag list pagination is owner-bounded and overflow-safe;
-- Blog tag read/Search authority is now `blog_post_tags + rustok-taxonomy`, not `blog_posts.metadata.tags`.
+- Blog tag reads and Search projection now use `blog_post_tags + rustok-taxonomy` as the canonical source rather than `blog_posts.metadata.tags`.
 
 None of these source states promote runtime evidence.
 
@@ -24,84 +24,115 @@ None of these source states promote runtime evidence.
 
 ### Comments remote transport and host composition
 
+The remote Comments source implementation exists. The retained continuation chain covers the typed transport boundary, `TcpJsonCommentsTransport`, TCP server/listener and host selection, user delegation and authorization, key/keyring lifecycle, schedule persistence/audit, canonical event admission, source retry/dead-letter/recovery ownership, restart/ambiguous-commit evidence sources, and the canonical `rustok-outbox` relay evidence source.
+
 Canonical interpretation:
 
 `remote_comments_transport = source_implemented_maintainer_execution_pending`
 
-The latest audit/relay boundary is slice 97. Source-row and immutable recovery-audit retention remain intentionally gated: do not advance that source work before retained maintainer execution of slices 95–97.
-
 Do **not** interpret historical `remote transport remains pending` text as a request to implement another transport, listener, retry lane, or relay.
 
+The latest audit/relay source boundary is slice 97:
+
+`canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.
+
+Source-row and immutable recovery-audit retention remain intentionally gated: do not advance that source work before retained maintainer execution of slices 95–97.
+
 ### Blog category Translation target
+
+The `blog/category` target production source is present. Slice 98 adds the isolated PostgreSQL evidence source for:
+
+- real migration `up -> down -> up`;
+- concurrent same-revision CAS with one winner and one conflict;
+- change-cursor recovery across provider/owner reconstruction and delete lifecycle.
 
 Canonical interpretation:
 
 `category_translation_postgres = source_ready_maintainer_execution_pending`
 
-Slice 98 retains real migration `up -> down -> up`, concurrent same-revision CAS and change-cursor recovery source evidence. Do not reopen that source scaffolding before maintainer execution.
+Do **not** reopen PostgreSQL migration, concurrent CAS, or ordinary cursor-recovery source scaffolding. After maintainer execution, record the result in the active Translation readiness view. Broader production enablement remains a separate Translation-owner decision.
 
 ### Storefront Comments fallback
 
-Canonical interpretations:
-
-`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`
-
-`comment_form_fallback = not_applicable_no_storefront_write_surface`
-
-The legacy `hide_comment_form` token remains compatibility vocabulary only; it is not authorization to invent a storefront write surface.
-
-### Blog tag list pagination
-
-Slice 102 retains:
-
-`tag_list_pagination = source_ready_maintainer_execution_pending`
-
-The owner service enforces `1 <= per_page <= 100`; page-offset arithmetic is overflow-safe; visibility, usage-count ordering, locale resolution and total-count semantics are unchanged. This does **not** claim database-side pagination.
-
-### Blog canonical tag read/Search projection
-
-Slice 103 resolves the source-ownership question exposed by slice 102.
+Slice 99 implements one Blog-owned cached public Comments snapshot policy shared by GraphQL and native SSR. Successful approved public reads refresh the bounded cache best-effort. Only `ExternalService` and `Timeout` may consume an exact valid stale snapshot; stale hits preserve `UNAVAILABLE` / `TIMEOUT` and expose `cachedSnapshot=true`.
 
 Canonical interpretation:
 
+`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`
+
+Slice 100 re-audits the storefront write surface and proves that the active package is read-only. There is no public comment form, textarea, submit handler, GraphQL storefront mutation, or native create-comment server function.
+
+Canonical interpretation:
+
+`comment_form_fallback = not_applicable_no_storefront_write_surface`
+
+The legacy `hide_comment_form` token remains compatibility vocabulary in the existing FBA registries; it is not authorization to invent a new storefront write surface.
+
+### Blog tag list pagination
+
+A fresh source audit after slice 101 found that `TagService::list_tags` accepted an arbitrarily large `per_page` and used unchecked page-offset multiplication, unlike the already bounded Blog category list contract.
+
+Slice 102 makes the owner service authoritative for the response bound and arithmetic safety:
+
+`tag_list_pagination = source_ready_maintainer_execution_pending`
+
+The retained contract is:
+
+- `1 <= per_page <= 100` in the owner service;
+- matching Utoipa parameter metadata in `ListTagsFilter`;
+- saturating `u64` page-offset arithmetic plus checked `usize` conversion;
+- unchanged visibility, usage-count ordering, locale resolution and total-count semantics.
+
+This does **not** claim database-side pagination. Eligible tag terms, usage counts and translations are still materialized before the existing usage-count sort/page slice.
+
+### Blog canonical tag read/Search projection
+
+Slice 103 resolves the cross-owner source question identified by slice 102:
+
 `tag_canonical_projection = source_ready_maintainer_execution_pending`
 
-The retained authority is:
+The accepted ownership boundary is now source-locked:
 
-- `rustok-taxonomy` owns the shared dictionary;
+- `rustok-taxonomy` owns the shared tag dictionary;
 - `rustok-blog` owns post attachments in `blog_post_tags`;
-- `blog_posts.metadata.tags` remains compatibility metadata but is not a canonical read or Search projection source.
+- `blog_posts.metadata.tags` remains compatibility metadata, but is not a canonical Blog read or Search projection source.
 
-Blog reads seed an explicit empty tag vector for every requested post ID, so an empty relation set no longer resurrects stale metadata tags.
+Blog reads seed an explicit empty tag vector for each requested post ID. Therefore an empty relation set no longer becomes a missing map entry that can resurrect stale `metadata.tags` through the existing response fallback path.
 
-Search requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves names using document locale -> `PLATFORM_FALLBACK_LOCALE` -> canonical key. The PostgreSQL source harness deliberately retains stale metadata while proving that projected tags follow attached Taxonomy rows.
+Blog Search now requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves attached names through document locale -> `PLATFORM_FALLBACK_LOCALE` -> canonical key. Taxonomy joins are tenant-constrained and tag aggregation remains distinct/deterministic. The retained PostgreSQL harness deliberately keeps stale metadata while expecting projection from relation/Taxonomy rows.
 
-Runtime promotion must include a deployed-data audit for metadata-only legacy rows. If such rows exist, backfill owner relations before rollout. No legacy-data audit or backfill result is claimed by slice 103.
+Runtime promotion must audit deployed rows for metadata-only legacy tags. If such rows exist, backfill owner relations before rollout. Slice 103 does not claim that the audit or a backfill was executed.
 
-Mutation atomicity remains deliberately separate:
+Mutation semantics intentionally remain separate:
 
 `tag_mutation_atomic_reindex = next_source_gap`
 
-Slice 103 does **not** change `TagService::update_tag/delete_tag`. The next source slice must make dictionary mutation and Blog-scope reindex atomic without violating Taxonomy dictionary ownership, and must remove the redundant manual pre-delete relation cleanup in favor of the declared FK cascade.
+Slice 103 does **not** change `TagService::update_tag/delete_tag`. The next source slice must define a Taxonomy-owned supplied-transaction mutation API, commit the dictionary mutation and Blog-scope reindex together, and remove Blog's redundant manual pre-delete relation cleanup in favor of the declared FK cascade.
 
 ## Remaining execution-owned results
 
-1. Execute retained Comments transport/composition, PostgreSQL, restart/ambiguity, canonical relay and cached-snapshot evidence at an exact revision.
+The concrete retained execution results remain maintainer-owned:
+
+1. Execute the retained Comments transport/composition, PostgreSQL, restart/ambiguity, canonical relay, and cached-snapshot evidence at an exact revision.
 2. Execute slices 95–97 before defining terminal Blog source-row and immutable recovery-audit retention.
-3. Execute slice 98 PostgreSQL evidence before advancing Blog category Translation readiness.
-4. Execute slice 102 tag-pagination evidence.
-5. Execute slice 103 Blog/Search canonical tag projection evidence and audit deployed data for metadata-only legacy tags before runtime promotion.
+3. Execute slice 98 PostgreSQL evidence before advancing the Blog category Translation readiness result.
+4. Execute slice 102 tag pagination source/unit evidence before promoting runtime validation.
+5. Execute slice 103 Blog read/Search canonical tag projection evidence and audit deployed data for metadata-only legacy tags before runtime promotion.
 6. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
-7. Execute Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
+7. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
+
+A future source implementation must follow the explicit current cursor. It must not manufacture work by reopening a source-complete or not-applicable track.
 
 ## Superseded historical cursor phrases
 
-The following historical phrases are not live instructions:
+The following phrases may remain in the historical baseline as records of earlier state, but they are superseded as live instructions:
 
 - `remote transport remains pending`;
 - `cached snapshot and comment-form fallback remain planned`;
 - `PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement`;
 - `then implement the remote network transport`.
+
+The continuation slice files and machine evidence remain the source of detailed ownership/non-claim history. This file defines the current planning cursor.
 
 ## Validation boundary
 
@@ -111,4 +142,4 @@ No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browse
 
 Implement slice 104: `tag_mutation_atomic_reindex`.
 
-Use a Taxonomy-owned supplied-transaction mutation API, then commit Blog tag update/delete and `ReindexRequested { target_type: "blog", target_id: None }` in the same transaction. Remove the manual pre-delete `blog_post_tags` cleanup and rely on the declared FK cascade. Preserve existing Blog `tags:*` authorization semantics and do not promote runtime evidence.
+Use a Taxonomy-owned supplied-transaction update/delete path, then commit Blog tag mutation and `ReindexRequested { target_type: "blog", target_id: None }` in the same transaction. Remove the manual pre-delete `blog_post_tags` cleanup and rely on the declared FK cascade. Preserve existing Blog `tags:*` authorization semantics and do not promote runtime evidence.

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -1,21 +1,22 @@
 # rustok-blog canonical implementation cursor
 
-Status: `canonical_source_cursor_actualized_through_slice_102`.
+Status: `canonical_source_cursor_actualized_through_slice_103`.
 
 This document is the canonical **current** source cursor for `rustok-blog`.
 `crates/rustok-blog/docs/implementation-plan.md` remains the long historical baseline and embedded implementation log, but its inline `Current state`, completed-slice list, and `Next results` stop before the later continuation series and must not be used as the live cursor without this file.
 
-The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 102 is the latest production/source behavior slice.
+The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 103 is the latest production/source behavior slice.
 
 ## Re-audit basis
 
-The source continuation through slice 102 retains the following planning corrections and independent Blog source result:
+The source continuation through slice 103 retains these planning corrections/results:
 
-- the remote Comments transport is no longer an unimplemented source item;
-- the cached public Comments snapshot is no longer merely planned;
-- the storefront comment-form fallback is not an implementation target because the active storefront has no public Comments write surface;
-- Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution;
-- Blog tag list pagination is now owner-bounded and overflow-safe after a fresh audit outside those execution-gated tracks.
+- remote Comments transport source exists; retained execution evidence remains maintainer-owned;
+- cached public Comments snapshot source exists; runtime evidence remains pending;
+- storefront comment-form fallback is not applicable because the active storefront has no public Comments write surface;
+- Blog category Translation PostgreSQL evidence source exists and waits for maintainer execution;
+- Blog tag list pagination is owner-bounded and overflow-safe;
+- Blog tag read/Search authority is now `blog_post_tags + rustok-taxonomy`, not `blog_posts.metadata.tags`.
 
 None of these source states promote runtime evidence.
 
@@ -23,101 +24,91 @@ None of these source states promote runtime evidence.
 
 ### Comments remote transport and host composition
 
-The remote Comments source implementation exists. The retained continuation chain covers the typed transport boundary, `TcpJsonCommentsTransport`, TCP server/listener and host selection, user delegation and authorization, key/keyring lifecycle, schedule persistence/audit, canonical event admission, source retry/dead-letter/recovery ownership, restart/ambiguous-commit evidence sources, and the canonical `rustok-outbox` relay evidence source.
-
 Canonical interpretation:
 
 `remote_comments_transport = source_implemented_maintainer_execution_pending`
 
+The latest audit/relay boundary is slice 97. Source-row and immutable recovery-audit retention remain intentionally gated: do not advance that source work before retained maintainer execution of slices 95–97.
+
 Do **not** interpret historical `remote transport remains pending` text as a request to implement another transport, listener, retry lane, or relay.
 
-The latest audit/relay source boundary is slice 97:
-
-`canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.
-
-Source-row and immutable recovery-audit retention remain intentionally gated: do not advance that source work before retained maintainer execution of slices 95–97.
-
 ### Blog category Translation target
-
-The `blog/category` target production source is present. Slice 98 adds the isolated PostgreSQL evidence source for:
-
-- real migration `up -> down -> up`;
-- concurrent same-revision CAS with one winner and one conflict;
-- change-cursor recovery across provider/owner reconstruction and delete lifecycle.
 
 Canonical interpretation:
 
 `category_translation_postgres = source_ready_maintainer_execution_pending`
 
-Do **not** reopen PostgreSQL migration, concurrent CAS, or ordinary cursor-recovery source scaffolding. After maintainer execution, record the result in the active Translation readiness view. Broader production enablement remains a separate Translation-owner decision.
+Slice 98 retains real migration `up -> down -> up`, concurrent same-revision CAS and change-cursor recovery source evidence. Do not reopen that source scaffolding before maintainer execution.
 
 ### Storefront Comments fallback
 
-Slice 99 implements one Blog-owned cached public Comments snapshot policy shared by GraphQL and native SSR. Successful approved public reads refresh the bounded cache best-effort. Only `ExternalService` and `Timeout` may consume an exact valid stale snapshot; stale hits preserve `UNAVAILABLE` / `TIMEOUT` and expose `cachedSnapshot=true`.
-
-Canonical interpretation:
+Canonical interpretations:
 
 `cached_public_comments_snapshot = source_ready_maintainer_execution_pending`
 
-Slice 100 re-audits the storefront write surface and proves that the active package is read-only. There is no public comment form, textarea, submit handler, GraphQL storefront mutation, or native create-comment server function.
-
-Canonical interpretation:
-
 `comment_form_fallback = not_applicable_no_storefront_write_surface`
 
-The legacy `hide_comment_form` token remains compatibility vocabulary in the existing FBA registries; it is not authorization to invent a new storefront write surface.
+The legacy `hide_comment_form` token remains compatibility vocabulary only; it is not authorization to invent a storefront write surface.
 
 ### Blog tag list pagination
 
-A fresh source audit after slice 101 found that `TagService::list_tags` accepted an arbitrarily large `per_page` and used unchecked page-offset multiplication, unlike the already bounded Blog category list contract.
-
-Slice 102 makes the owner service authoritative for the response bound and arithmetic safety:
+Slice 102 retains:
 
 `tag_list_pagination = source_ready_maintainer_execution_pending`
 
-The retained contract is:
+The owner service enforces `1 <= per_page <= 100`; page-offset arithmetic is overflow-safe; visibility, usage-count ordering, locale resolution and total-count semantics are unchanged. This does **not** claim database-side pagination.
 
-- `1 <= per_page <= 100` in the owner service;
-- matching Utoipa parameter metadata in `ListTagsFilter`;
-- saturating `u64` page-offset arithmetic plus checked `usize` conversion;
-- unchanged visibility, usage-count ordering, locale resolution and total-count semantics.
+### Blog canonical tag read/Search projection
 
-This does **not** claim database-side pagination. Eligible tag terms, usage counts and translations are still materialized before the existing usage-count sort/page slice.
+Slice 103 resolves the source-ownership question exposed by slice 102.
 
-The same audit exposed a separate cross-owner question rather than resolving it implicitly:
+Canonical interpretation:
 
-`tag_mutation_projection_consistency = re_audit_required`
+`tag_canonical_projection = source_ready_maintainer_execution_pending`
 
-Post reads resolve current tag names through `blog_post_tags -> rustok-taxonomy`, while Blog Search currently projects tag text from `blog_posts.metadata.tags`. Any update/delete fix must first define the canonical source and atomic/reindex ownership instead of adding direct cross-module SQL.
+The retained authority is:
+
+- `rustok-taxonomy` owns the shared dictionary;
+- `rustok-blog` owns post attachments in `blog_post_tags`;
+- `blog_posts.metadata.tags` remains compatibility metadata but is not a canonical read or Search projection source.
+
+Blog reads seed an explicit empty tag vector for every requested post ID, so an empty relation set no longer resurrects stale metadata tags.
+
+Search requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves names using document locale -> `PLATFORM_FALLBACK_LOCALE` -> canonical key. The PostgreSQL source harness deliberately retains stale metadata while proving that projected tags follow attached Taxonomy rows.
+
+Runtime promotion must include a deployed-data audit for metadata-only legacy rows. If such rows exist, backfill owner relations before rollout. No legacy-data audit or backfill result is claimed by slice 103.
+
+Mutation atomicity remains deliberately separate:
+
+`tag_mutation_atomic_reindex = next_source_gap`
+
+Slice 103 does **not** change `TagService::update_tag/delete_tag`. The next source slice must make dictionary mutation and Blog-scope reindex atomic without violating Taxonomy dictionary ownership, and must remove the redundant manual pre-delete relation cleanup in favor of the declared FK cascade.
 
 ## Remaining execution-owned results
 
-The concrete retained execution results remain maintainer-owned:
-
-1. Execute the retained Comments transport/composition, PostgreSQL, restart/ambiguity, canonical relay, and cached-snapshot evidence at an exact revision.
+1. Execute retained Comments transport/composition, PostgreSQL, restart/ambiguity, canonical relay and cached-snapshot evidence at an exact revision.
 2. Execute slices 95–97 before defining terminal Blog source-row and immutable recovery-audit retention.
-3. Execute slice 98 PostgreSQL evidence before advancing the Blog category Translation readiness result.
-4. Execute slice 102 tag pagination source/unit evidence before promoting runtime validation.
-5. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
-6. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
-
-A future source implementation must still start from a fresh ownership audit. It must not manufacture work by reopening a source-complete or not-applicable cursor.
+3. Execute slice 98 PostgreSQL evidence before advancing Blog category Translation readiness.
+4. Execute slice 102 tag-pagination evidence.
+5. Execute slice 103 Blog/Search canonical tag projection evidence and audit deployed data for metadata-only legacy tags before runtime promotion.
+6. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
+7. Execute Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
 
 ## Superseded historical cursor phrases
 
-The following phrases may remain in the historical baseline as records of earlier state, but they are superseded as live instructions:
+The following historical phrases are not live instructions:
 
 - `remote transport remains pending`;
 - `cached snapshot and comment-form fallback remain planned`;
 - `PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement`;
 - `then implement the remote network transport`.
 
-The continuation slice files and machine evidence remain the source of detailed ownership/non-claim history. This file defines the current planning cursor.
-
 ## Validation boundary
 
-No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–102.
+No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–103.
 
 ## Next cursor
 
-Re-audit Blog tag mutation/projection consistency as a separate ownership problem. Determine the canonical Search-visible tag source and the atomic/reindex behavior required for `TagService::update_tag/delete_tag` before changing those production mutation semantics.
+Implement slice 104: `tag_mutation_atomic_reindex`.
+
+Use a Taxonomy-owned supplied-transaction mutation API, then commit Blog tag update/delete and `ReindexRequested { target_type: "blog", target_id: None }` in the same transaction. Remove the manual pre-delete `blog_post_tags` cleanup and rely on the declared FK cascade. Preserve existing Blog `tags:*` authorization semantics and do not promote runtime evidence.

--- a/crates/rustok-blog/docs/implementation-plan-slice-103.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-103.md
@@ -1,0 +1,75 @@
+# Blog implementation plan — slice 103
+
+Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.
+
+## Fresh ownership audit
+
+Slice 102 left one explicit ownership question: post reads resolve tags through `blog_post_tags -> rustok-taxonomy`, while Search projected `blog_posts.metadata.tags`.
+
+The fresh audit resolves the canonical source before changing tag mutation semantics:
+
+- `rustok-taxonomy` owns the shared tag dictionary;
+- `rustok-blog` owns post-to-tag attachments in `blog_post_tags`;
+- `blog_posts.metadata.tags` is retained only as compatibility metadata written by existing post paths and is not authoritative for reads or Search projection.
+
+This follows the accepted Taxonomy ADR: dictionary ownership is shared, domain attachments remain module-owned.
+
+## Source change
+
+### Blog reads
+
+`load_post_tags_map` now creates an explicit empty tag vector for every requested post ID before loading relations. Therefore a post with zero attached relations resolves to an empty tag list instead of producing a missing map entry that could fall back to stale `metadata.tags` in `PostService`.
+
+Canonical interpretation:
+
+`blog_tag_read_source = blog_post_tags_plus_taxonomy`
+
+### Search projection
+
+`BlogSearchProjector` now requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` in addition to the existing Blog projection tables.
+
+Search tag names are resolved from attached term IDs with this bounded fallback chain:
+
+1. taxonomy translation for the Blog document locale;
+2. taxonomy translation for `PLATFORM_FALLBACK_LOCALE`;
+3. taxonomy term `canonical_key`.
+
+All Taxonomy joins are constrained by the Blog post tenant. Tag aggregation remains distinct and deterministic. The previous `jsonb_array_elements_text(p.metadata -> 'tags')` source is removed.
+
+The retained PostgreSQL Search harness now stores deliberately stale metadata tags while creating canonical `blog_post_tags` + Taxonomy rows. It also contains a targeted reindex source case where the attached Taxonomy translation changes while metadata remains stale; the expected payload follows Taxonomy, not metadata.
+
+Canonical interpretation:
+
+`blog_search_tag_projection = relation_taxonomy_source_ready_maintainer_execution_pending`
+
+## Deliberate non-scope
+
+This slice does **not** change `TagService::update_tag` or `TagService::delete_tag` transaction semantics.
+
+The audit found two mutation issues, but they remain the next coherent source slice:
+
+- tag update/delete does not yet publish Blog Search reindex in the same transaction as the dictionary mutation;
+- `delete_tag` still manually deletes `blog_post_tags` before `TaxonomyService::delete_term`, even though the declared `blog_post_tags.tag_id -> taxonomy_terms.id` FK already uses `ON DELETE CASCADE`.
+
+Changing those mutations belongs in slice 104 after this canonical-source boundary is retained.
+
+## Rollout caveat
+
+This source change is intentionally fail-closed for legacy data. If deployed rows contain `metadata.tags` without equivalent `blog_post_tags` relations, strict canonical reads/Search will expose no tag attachment for those rows.
+
+Before runtime promotion, maintainers must audit deployed data. If metadata-only rows exist, backfill them through an owner migration or another owner-authorized repair before rollout. Slice 103 does not claim that such legacy rows exist, that an audit was executed, or that a backfill was performed.
+
+## Validation boundary
+
+No tests, Cargo commands, Node verifiers, PostgreSQL scenarios, formatting, builds, Clippy, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent.
+
+Source/harness/verifier changes are retained as executable evidence only.
+
+## Next cursor
+
+Implement `tag_mutation_atomic_reindex` as slice 104:
+
+1. expose Taxonomy-owned update/delete operations that accept a supplied owner transaction while preserving Taxonomy validation, revision/CAS, translation-change evidence, and permission semantics;
+2. make Blog tag update/delete perform the dictionary mutation and `ReindexRequested { target_type: "blog", target_id: None }` in the same transaction;
+3. remove Blog's manual pre-delete relation cleanup and rely on the declared FK cascade;
+4. retain rollback/source evidence without claiming runtime execution.

--- a/crates/rustok-blog/src/services/tag.rs
+++ b/crates/rustok-blog/src/services/tag.rs
@@ -351,6 +351,12 @@ pub(crate) async fn load_post_tags_map(
         return Ok(HashMap::new());
     }
 
+    let mut tags_by_post = post_ids
+        .iter()
+        .copied()
+        .map(|post_id| (post_id, Vec::new()))
+        .collect::<HashMap<_, _>>();
+
     let relations = blog_post_tag::Entity::find()
         .filter(blog_post_tag::Column::PostId.is_in(post_ids.to_vec()))
         .order_by_asc(blog_post_tag::Column::CreatedAt)
@@ -358,7 +364,7 @@ pub(crate) async fn load_post_tags_map(
         .await?;
 
     if relations.is_empty() {
-        return Ok(HashMap::new());
+        return Ok(tags_by_post);
     }
 
     let term_ids = relations.iter().map(|item| item.tag_id).collect::<Vec<_>>();
@@ -366,7 +372,6 @@ pub(crate) async fn load_post_tags_map(
         .resolve_term_names(tenant_id, &term_ids, locale, fallback_locale)
         .await?;
 
-    let mut tags_by_post: HashMap<Uuid, Vec<String>> = HashMap::new();
     for relation in relations {
         if let Some(name) = names.get(&relation.tag_id) {
             tags_by_post

--- a/crates/rustok-blog/tests/taxonomy_tags.rs
+++ b/crates/rustok-blog/tests/taxonomy_tags.rs
@@ -212,3 +212,47 @@ async fn post_tag_sync_reuses_existing_global_taxonomy_term() {
     assert_eq!(blog_scoped_terms.len(), 1);
     assert_eq!(blog_scoped_terms[0].canonical_key, "backend");
 }
+
+#[tokio::test]
+async fn post_read_does_not_resurrect_metadata_tags_after_relations_are_removed() {
+    let (db, event_bus, _events, tenant_id) = setup().await;
+    let post_service = PostService::new(db.clone(), event_bus);
+    let security = admin();
+
+    let post_id = post_service
+        .create_post(
+            tenant_id,
+            security.clone(),
+            CreatePostInput {
+                locale: "en".to_string(),
+                title: "Canonical tag relation".to_string(),
+                content: rustok_blog::richtext::article_document_from_plain_text(
+                    &"Body".to_string(),
+                ),
+                excerpt: None,
+                slug: Some("canonical-tag-relation".to_string()),
+                publish: true,
+                tags: vec!["stale-metadata-tag".to_string()],
+                category_id: None,
+                featured_image_url: None,
+                seo_title: None,
+                seo_description: None,
+                channel_slugs: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("post should be created");
+
+    blog_post_tag::Entity::delete_many()
+        .filter(blog_post_tag::Column::PostId.eq(post_id))
+        .exec(&db)
+        .await
+        .expect("test should remove canonical relations while leaving compatibility metadata intact");
+
+    let post = post_service
+        .get_post(tenant_id, security, post_id, "en")
+        .await
+        .expect("post should load after relation removal");
+    assert!(post.tags.is_empty());
+}

--- a/crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json
+++ b/crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json
@@ -18,7 +18,10 @@
     "event_handler": "crates/rustok-search/src/ingestion.rs",
     "projector": "crates/rustok-search/src/blog_projector.rs",
     "search_migrations": "crates/rustok-search/src/migrations/mod.rs",
-    "source_guardrail": "scripts/verify/verify-search-blog-projection.mjs"
+    "source_guardrail": "scripts/verify/verify-search-blog-projection.mjs",
+    "blog_tag_attachment_source": "blog_post_tags",
+    "tag_dictionary_source": "taxonomy_terms + taxonomy_term_translations",
+    "legacy_metadata_tags_are_projection_source": false
   },
   "cases": [
     {
@@ -27,7 +30,11 @@
     },
     {
       "name": "projected_payload",
-      "expected": "slug, author, tags, channels, publication timestamps, counts, and version are projected from Blog-owned tables"
+      "expected": "slug, author, canonical attached taxonomy tags, channels, publication timestamps, counts, and version are projected from owner tables"
+    },
+    {
+      "name": "canonical_taxonomy_tag_projection",
+      "expected": "Blog tag payload and keywords resolve from blog_post_tags plus tenant-local taxonomy translations for the document locale with platform fallback and canonical-key fallback; stale blog_posts.metadata.tags does not affect projection"
     },
     {
       "name": "full_blog_reindex",
@@ -43,7 +50,7 @@
     },
     {
       "name": "schema_search_path",
-      "expected": "Blog source-table availability and unqualified projector SQL resolve through the same active PostgreSQL search_path"
+      "expected": "Blog, Blog-tag relation, Taxonomy source-table availability and unqualified projector SQL resolve through the same active PostgreSQL search_path"
     },
     {
       "name": "event_routing",
@@ -53,6 +60,8 @@
   "runtime_promotion_requirements": [
     "execute both Rust test targets against PostgreSQL",
     "execute the source guardrail and its fixture target",
+    "retain canonical Blog tag projection evidence proving stale metadata tags are ignored",
+    "audit deployed Blog rows for metadata-only legacy tags and backfill owner relations before rollout if such rows exist",
     "retain migration and pg_trgm permission evidence",
     "retain host event-delivery evidence for disable and enable toggles",
     "retain query visibility evidence for published_only storefront search"

--- a/crates/rustok-search/src/blog_projector.rs
+++ b/crates/rustok-search/src/blog_projector.rs
@@ -5,7 +5,7 @@ use sea_orm::{
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
-use rustok_api::RichTextDocument;
+use rustok_api::{PLATFORM_FALLBACK_LOCALE, RichTextDocument};
 use rustok_content::{RichTextProfile, plain_text};
 use rustok_core::{Error, Result};
 use rustok_telemetry::metrics;
@@ -108,6 +108,9 @@ impl BlogSearchProjector {
                 AND to_regclass('blog_post_translations') IS NOT NULL
                 AND to_regclass('blog_post_channel_visibility') IS NOT NULL
                 AND to_regclass('blog_category_translations') IS NOT NULL
+                AND to_regclass('blog_post_tags') IS NOT NULL
+                AND to_regclass('taxonomy_terms') IS NOT NULL
+                AND to_regclass('taxonomy_term_translations') IS NOT NULL
                 AS available
             "#
             .to_string(),
@@ -174,6 +177,7 @@ impl BlogSearchProjector {
             where_clause.push_str(" AND p.id = $2");
             values.push(post_id.into());
         }
+        let fallback_locale = PLATFORM_FALLBACK_LOCALE;
 
         let sql = format!(
             r#"
@@ -265,14 +269,25 @@ impl BlogSearchProjector {
                     string_agg(tag.tag_name, ' ' ORDER BY tag.tag_name) AS tag_names,
                     COALESCE(jsonb_agg(tag.tag_name ORDER BY tag.tag_name), '[]'::jsonb) AS tag_list
                 FROM (
-                    SELECT DISTINCT BTRIM(tag_value) AS tag_name
-                    FROM jsonb_array_elements_text(
-                        CASE
-                            WHEN jsonb_typeof(p.metadata -> 'tags') = 'array' THEN p.metadata -> 'tags'
-                            ELSE '[]'::jsonb
-                        END
-                    ) AS tag_values(tag_value)
-                    WHERE BTRIM(tag_value) <> ''
+                    SELECT DISTINCT BTRIM(
+                        COALESCE(localized.name, fallback.name, term.canonical_key)
+                    ) AS tag_name
+                    FROM blog_post_tags relation
+                    JOIN taxonomy_terms term
+                      ON term.id = relation.tag_id
+                     AND term.tenant_id = p.tenant_id
+                    LEFT JOIN taxonomy_term_translations localized
+                      ON localized.term_id = term.id
+                     AND localized.tenant_id = p.tenant_id
+                     AND localized.locale = bt.locale
+                    LEFT JOIN taxonomy_term_translations fallback
+                      ON fallback.term_id = term.id
+                     AND fallback.tenant_id = p.tenant_id
+                     AND fallback.locale = '{fallback_locale}'
+                    WHERE relation.post_id = p.id
+                      AND BTRIM(
+                          COALESCE(localized.name, fallback.name, term.canonical_key)
+                      ) <> ''
                 ) tag
             ) tags ON TRUE
             LEFT JOIN LATERAL (

--- a/crates/rustok-search/tests/blog_projection_postgres_test.rs
+++ b/crates/rustok-search/tests/blog_projection_postgres_test.rs
@@ -211,6 +211,72 @@ async fn blog_events_upsert_publish_archive_and_delete_search_document() -> Test
 }
 
 #[tokio::test]
+async fn blog_reindex_projects_attached_taxonomy_tags_not_metadata_snapshot() -> TestResult<()> {
+    let Some(test_db) = PostgresSearchTestDb::setup("blog_taxonomy_tags").await? else {
+        return Ok(());
+    };
+
+    let tenant_id = Uuid::new_v4();
+    let post_id = Uuid::new_v4();
+    let author_id = Uuid::new_v4();
+    insert_blog_post(
+        &test_db.db,
+        tenant_id,
+        post_id,
+        author_id,
+        "published",
+        "taxonomy-tags",
+        "Taxonomy tags",
+    )
+    .await?;
+
+    test_db
+        .db
+        .execute_unprepared(&format!(
+            r#"
+            UPDATE blog_posts
+            SET metadata = '{{"tags":["stale-metadata-only"]}}'::jsonb
+            WHERE id = '{post_id}' AND tenant_id = '{tenant_id}';
+
+            UPDATE taxonomy_term_translations
+            SET name = 'backend', slug = 'backend'
+            WHERE tenant_id = '{tenant_id}'
+              AND locale = 'en'
+              AND term_id IN (
+                  SELECT relation.tag_id
+                  FROM blog_post_tags relation
+                  WHERE relation.post_id = '{post_id}'
+              )
+              AND name = 'rust';
+            "#
+        ))
+        .await?;
+
+    let handler = SearchIngestionHandler::new(test_db.db.clone());
+    handler
+        .handle(&envelope(
+            tenant_id,
+            Some(author_id),
+            DomainEvent::ReindexRequested {
+                target_type: "blog".to_string(),
+                target_id: Some(post_id),
+            },
+        )?)
+        .await?;
+
+    let document = load_blog_document(&test_db.db, tenant_id, post_id)
+        .await?
+        .expect("Blog post should be projected from canonical tag attachments");
+    assert_eq!(document.payload["tags"], serde_json::json!(["backend", "cms"]));
+    assert_ne!(
+        document.payload["tags"],
+        serde_json::json!(["stale-metadata-only"])
+    );
+
+    test_db.cleanup().await
+}
+
+#[tokio::test]
 async fn full_blog_reindex_replaces_only_current_tenant_blog_documents() -> TestResult<()> {
     let Some(test_db) = PostgresSearchTestDb::setup("blog_reindex").await? else {
         return Ok(());
@@ -485,6 +551,26 @@ async fn create_blog_projection_source_tables(
             name TEXT NOT NULL,
             slug TEXT NOT NULL
         );
+
+        CREATE TABLE taxonomy_terms (
+            id UUID PRIMARY KEY,
+            tenant_id UUID NOT NULL,
+            canonical_key TEXT NOT NULL
+        );
+
+        CREATE TABLE taxonomy_term_translations (
+            id UUID PRIMARY KEY,
+            term_id UUID NOT NULL,
+            tenant_id UUID NOT NULL,
+            locale TEXT NOT NULL,
+            name TEXT NOT NULL,
+            slug TEXT NOT NULL
+        );
+
+        CREATE TABLE blog_post_tags (
+            post_id UUID NOT NULL,
+            tag_id UUID NOT NULL
+        );
         "#,
     )
     .await?;
@@ -501,6 +587,10 @@ async fn insert_blog_post(
     title: &str,
 ) -> Result<(), sea_orm::DbErr> {
     let translation_id = Uuid::new_v4();
+    let rust_tag_id = Uuid::new_v4();
+    let rust_translation_id = Uuid::new_v4();
+    let cms_tag_id = Uuid::new_v4();
+    let cms_translation_id = Uuid::new_v4();
     db.execute_unprepared(&format!(
         r#"
         INSERT INTO users (id, name)
@@ -512,7 +602,7 @@ async fn insert_blog_post(
             created_at, updated_at, comment_count, view_count, version
         ) VALUES (
             '{post_id}', '{tenant_id}', '{author_id}', '{status}', '{slug}',
-            '{{"tags":["rust","cms"]}}'::jsonb,
+            '{{"tags":["legacy-metadata-only"]}}'::jsonb,
             CASE WHEN '{status}' = 'published' THEN NOW() ELSE NULL END,
             NOW(), NOW(), 4, 12, 1
         );
@@ -527,6 +617,21 @@ async fn insert_blog_post(
 
         INSERT INTO blog_post_channel_visibility (tenant_id, post_id, channel_slug)
         VALUES ('{tenant_id}', '{post_id}', 'web');
+
+        INSERT INTO taxonomy_terms (id, tenant_id, canonical_key)
+        VALUES
+            ('{rust_tag_id}', '{tenant_id}', 'rust'),
+            ('{cms_tag_id}', '{tenant_id}', 'cms');
+
+        INSERT INTO taxonomy_term_translations (id, term_id, tenant_id, locale, name, slug)
+        VALUES
+            ('{rust_translation_id}', '{rust_tag_id}', '{tenant_id}', 'en', 'rust', 'rust'),
+            ('{cms_translation_id}', '{cms_tag_id}', '{tenant_id}', 'en', 'cms', 'cms');
+
+        INSERT INTO blog_post_tags (post_id, tag_id)
+        VALUES
+            ('{post_id}', '{rust_tag_id}'),
+            ('{post_id}', '{cms_tag_id}');
         "#
     ))
     .await?;

--- a/scripts/verify/verify-blog-canonical-plan-current.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.mjs
@@ -8,7 +8,6 @@ const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const failures = [];
-
 const files = {
   evidence: 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
   current: 'crates/rustok-blog/docs/implementation-plan-current.md',
@@ -19,50 +18,31 @@ const files = {
   slice100: 'crates/rustok-blog/docs/implementation-plan-slice-100.md',
   slice101: 'crates/rustok-blog/docs/implementation-plan-slice-101.md',
   slice102: 'crates/rustok-blog/docs/implementation-plan-slice-102.md',
+  slice103: 'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   docsIndex: 'crates/rustok-blog/docs/README.md',
   tcpTransport: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
-  tcpServer: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
-  tcpListener: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json',
   translationPostgres: 'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
   fallback: 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
   writeSurface: 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
   tagPagination: 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
+  tagProjection: 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
 };
-
-function absolute(relativePath) {
-  return path.join(repoRoot, relativePath);
-}
-
+function absolute(relativePath) { return path.join(repoRoot, relativePath); }
 function read(relativePath) {
   const target = absolute(relativePath);
-  if (!fs.existsSync(target)) {
-    failures.push(`${relativePath}: missing file`);
-    return '';
-  }
+  if (!fs.existsSync(target)) { failures.push(`${relativePath}: missing file`); return ''; }
   return fs.readFileSync(target, 'utf8');
 }
-
 function json(relativePath) {
-  try {
-    return JSON.parse(read(relativePath));
-  } catch (error) {
-    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
-    return null;
-  }
+  try { return JSON.parse(read(relativePath)); }
+  catch (error) { failures.push(`${relativePath}: invalid JSON: ${error.message}`); return null; }
 }
-
 function need(source, marker, label) {
   if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
 }
-
 function forbid(source, marker, label) {
   if (source.includes(marker)) failures.push(`${label}: forbidden live cursor marker ${marker}`);
 }
-
-function sameSet(actual, expected) {
-  return [...(actual ?? [])].sort().join('|') === [...expected].sort().join('|');
-}
-
 function between(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);
   if (start < 0) return '';
@@ -73,79 +53,51 @@ function between(source, startMarker, endMarker) {
 const evidence = json(files.evidence);
 const current = read(files.current);
 const historical = read(files.historical);
-const slice97 = read(files.slice97);
-const slice98 = read(files.slice98);
-const slice99 = read(files.slice99);
-const slice100 = read(files.slice100);
-const slice101 = read(files.slice101);
-const slice102 = read(files.slice102);
+const slices = Object.fromEntries([97,98,99,100,101,102,103].map((n) => [n, read(files[`slice${n}`])]));
 const docsIndex = read(files.docsIndex);
 const tcpTransport = json(files.tcpTransport);
-const tcpServer = json(files.tcpServer);
-const tcpListener = json(files.tcpListener);
 const translationPostgres = json(files.translationPostgres);
 const fallback = json(files.fallback);
 const writeSurface = json(files.writeSurface);
 const tagPagination = json(files.tagPagination);
+const tagProjection = json(files.tagProjection);
 
 if (evidence) {
   if (
-    evidence.schema_version !== 2 ||
-    evidence.module !== 'blog' ||
+    evidence.schema_version !== 2 || evidence.module !== 'blog' ||
     evidence.surface !== 'canonical_implementation_cursor' ||
     evidence.status !== 'source_verified_no_compile' ||
-    evidence.compile_policy !== 'not_run_by_request' ||
-    evidence.runtime_status !== 'not_run'
+    evidence.compile_policy !== 'not_run_by_request' || evidence.runtime_status !== 'not_run'
   ) failures.push(`${files.evidence}: identity/status drift`);
-
   if (
     evidence.historical_baseline !== files.historical ||
     evidence.canonical_current_cursor !== files.current ||
     evidence.actualization_slice !== files.slice101 ||
     evidence.historical_baseline_last_embedded_slice !== 67 ||
-    evidence.latest_behavior_slice !== 102 ||
-    evidence.current_recorded_slice !== 102
+    evidence.latest_behavior_slice !== 103 || evidence.current_recorded_slice !== 103
   ) failures.push(`${files.evidence}: cursor path/version drift`);
 
   const tracks = evidence.source_tracks ?? {};
   if (
-    tracks.remote_comments_transport?.status !==
-      'source_implemented_maintainer_execution_pending' ||
-    tracks.remote_comments_transport?.transport_evidence !== files.tcpTransport ||
-    tracks.remote_comments_transport?.latest_audit_relay_slice !== files.slice97 ||
+    tracks.remote_comments_transport?.status !== 'source_implemented_maintainer_execution_pending' ||
     tracks.remote_comments_transport?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: remote Comments track drift`);
-
   if (
     tracks.comments_source_retention?.status !== 'blocked_until_slices_95_97_execution' ||
-    tracks.comments_source_retention?.blocking_slice !== files.slice97 ||
     tracks.comments_source_retention?.must_not_advance_before_execution !== true
   ) failures.push(`${files.evidence}: Comments source-retention gate drift`);
-
   if (
-    tracks.category_translation_postgres?.status !==
-      'source_ready_maintainer_execution_pending' ||
-    tracks.category_translation_postgres?.slice !== files.slice98 ||
-    tracks.category_translation_postgres?.evidence !== files.translationPostgres ||
+    tracks.category_translation_postgres?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.category_translation_postgres?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: category Translation track drift`);
-
   if (
-    tracks.cached_public_comments_snapshot?.status !==
-      'source_ready_maintainer_execution_pending' ||
-    tracks.cached_public_comments_snapshot?.slice !== files.slice99 ||
-    tracks.cached_public_comments_snapshot?.evidence !== files.fallback ||
+    tracks.cached_public_comments_snapshot?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.cached_public_comments_snapshot?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: cached Comments track drift`);
-
   if (
-    tracks.storefront_comment_form_fallback?.status !==
-      'not_applicable_no_storefront_write_surface' ||
-    tracks.storefront_comment_form_fallback?.slice !== files.slice100 ||
-    tracks.storefront_comment_form_fallback?.evidence !== files.writeSurface ||
+    tracks.storefront_comment_form_fallback?.status !== 'not_applicable_no_storefront_write_surface' ||
     tracks.storefront_comment_form_fallback?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: storefront write-surface track drift`);
-
   if (
     tracks.tag_list_pagination?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.tag_list_pagination?.slice !== files.slice102 ||
@@ -155,135 +107,99 @@ if (evidence) {
     tracks.tag_list_pagination?.database_side_pagination_claimed !== false ||
     tracks.tag_list_pagination?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: tag pagination track drift`);
-
   if (
-    tracks.tag_mutation_projection_consistency?.status !== 're_audit_required' ||
-    tracks.tag_mutation_projection_consistency?.must_define_canonical_search_visible_tag_source !== true ||
-    tracks.tag_mutation_projection_consistency?.must_define_atomic_reindex_ownership_before_mutation_change !== true
-  ) failures.push(`${files.evidence}: tag mutation/projection cursor drift`);
-
+    tracks.tag_canonical_projection?.status !== 'source_ready_maintainer_execution_pending' ||
+    tracks.tag_canonical_projection?.slice !== files.slice103 ||
+    tracks.tag_canonical_projection?.evidence !== files.tagProjection ||
+    tracks.tag_canonical_projection?.attachment_source !== 'blog_post_tags' ||
+    tracks.tag_canonical_projection?.dictionary_source !== 'rustok-taxonomy' ||
+    tracks.tag_canonical_projection?.metadata_tags_are_canonical !== false ||
+    tracks.tag_canonical_projection?.legacy_data_audit_pending !== true ||
+    tracks.tag_canonical_projection?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: canonical tag projection track drift`);
   if (
-    evidence.planning_result?.independent_production_source_gap_identified !== false ||
-    evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== true ||
+    tracks.tag_mutation_atomic_reindex?.status !== 'next_source_gap' ||
+    tracks.tag_mutation_atomic_reindex?.canonical_source_defined !== true ||
+    tracks.tag_mutation_atomic_reindex?.taxonomy_supplied_transaction_api_required !== true ||
+    tracks.tag_mutation_atomic_reindex?.blog_scope_reindex_same_transaction_required !== true ||
+    tracks.tag_mutation_atomic_reindex?.manual_predelete_relation_cleanup_must_be_removed !== true
+  ) failures.push(`${files.evidence}: tag mutation atomic-reindex cursor drift`);
+  if (
+    evidence.planning_result?.independent_production_source_gap_identified !== true ||
+    evidence.planning_result?.next_source_gap !== 'tag_mutation_atomic_reindex' ||
+    evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== false ||
     evidence.planning_result?.historical_stale_phrases_are_live_instructions !== false ||
-    evidence.planning_result?.production_behavior_changed_since_slice_101 !== true ||
     evidence.planning_result?.ffa_or_fba_promoted !== false ||
-    !Array.isArray(evidence.execution) ||
-    evidence.execution.length !== 0
+    !Array.isArray(evidence.execution) || evidence.execution.length !== 0
   ) failures.push(`${files.evidence}: planning/execution claim drift`);
 }
 
-for (const [label, artifact, expectedSurface] of [
-  [files.tcpTransport, tcpTransport, 'comments_tcp_json_transport'],
-  [files.tcpServer, tcpServer, 'comments_tcp_server_adapter'],
-  [files.tcpListener, tcpListener, 'comments_tcp_listener_lifecycle'],
-]) {
-  if (
-    artifact?.module !== 'blog' ||
-    artifact?.provider !== 'comments' ||
-    artifact?.surface !== expectedSurface ||
-    artifact?.status !== 'source_verified_no_compile' ||
-    artifact?.runtime_status !== 'not_run'
-  ) failures.push(`${label}: remote transport source evidence drift`);
-}
-
 if (
-  !sameSet(tcpServer?.operations, [
-    'create_comment',
-    'get_comment',
-    'list_comments_for_target',
-    'list_public_comments_for_target',
-    'update_comment',
-    'set_comment_status',
-    'delete_comment',
-  ])
-) failures.push(`${files.tcpServer}: seven-operation transport parity drift`);
-
+  tcpTransport?.status !== 'source_verified_no_compile' || tcpTransport?.runtime_status !== 'not_run'
+) failures.push(`${files.tcpTransport}: remote transport source evidence drift`);
 if (
-  translationPostgres?.status !== 'blog_category_translation_postgres_source_unvalidated' ||
-  translationPostgres?.source_contract?.translation_target_migration_up_down_up_covered !== true ||
-  translationPostgres?.source_contract?.concurrent_apply_requires_exactly_one_success !== true ||
-  translationPostgres?.source_contract?.cursor_recovery_drains_after_latest_cursor !== true ||
   translationPostgres?.source_contract?.postgres_execution_observed !== false ||
-  !Array.isArray(translationPostgres?.execution) ||
-  translationPostgres.execution.length !== 0
+  !Array.isArray(translationPostgres?.execution) || translationPostgres.execution.length !== 0
 ) failures.push(`${files.translationPostgres}: Translation PostgreSQL source status drift`);
-
 if (
   fallback?.storefront_read_degradation?.cached_thread_snapshot !== 'source_verified_no_compile' ||
-  fallback?.storefront_read_degradation?.runtime_evidence !== 'pending' ||
-  !sameSet(fallback?.storefront_read_degradation?.transports, ['graphql', 'native_ssr']) ||
-  fallback?.storefront_write_surface?.comment_form_fallback !==
-    'not_applicable_no_storefront_write_surface'
+  fallback?.storefront_write_surface?.comment_form_fallback !== 'not_applicable_no_storefront_write_surface'
 ) failures.push(`${files.fallback}: storefront fallback current-state drift`);
-
 if (
   writeSurface?.status !== 'source_verified_absent' ||
-  writeSurface?.actualization !== 'comment_form_fallback_not_applicable_no_storefront_write_surface' ||
-  writeSurface?.source_contract?.create_comment_surface_present !== false ||
   writeSurface?.source_contract?.comment_form_present !== false ||
-  writeSurface?.planning_effect?.new_storefront_write_surface_authorized !== false ||
-  !Array.isArray(writeSurface?.execution) ||
-  writeSurface.execution.length !== 0
+  !Array.isArray(writeSurface?.execution) || writeSurface.execution.length !== 0
 ) failures.push(`${files.writeSurface}: storefront write-surface evidence drift`);
-
 if (
-  tagPagination?.status !== 'source_verified_no_compile' ||
-  tagPagination?.runtime_status !== 'not_run' ||
   tagPagination?.source_contract?.maximum_page_size !== 100 ||
-  tagPagination?.source_contract?.owner_service_clamps_page_size !== true ||
-  tagPagination?.source_contract?.extreme_page_cannot_overflow_offset_arithmetic !== true ||
   tagPagination?.source_contract?.database_side_pagination_claimed !== false ||
-  !Array.isArray(tagPagination?.execution) ||
-  tagPagination.execution.length !== 0
+  !Array.isArray(tagPagination?.execution) || tagPagination.execution.length !== 0
 ) failures.push(`${files.tagPagination}: tag pagination source evidence drift`);
+if (
+  tagProjection?.status !== 'source_verified_no_compile' ||
+  tagProjection?.ownership?.attachment_table !== 'blog_post_tags' ||
+  tagProjection?.ownership?.metadata_tags_is_canonical_read_source !== false ||
+  tagProjection?.ownership?.metadata_tags_is_search_projection_source !== false ||
+  tagProjection?.source_contract?.tag_mutation_atomic_reindex_implemented !== false ||
+  !Array.isArray(tagProjection?.execution) || tagProjection.execution.length !== 0
+) failures.push(`${files.tagProjection}: canonical tag projection source evidence drift`);
 
-for (const [source, marker, label] of [
-  [slice97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice97],
-  [slice98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice98],
-  [slice99, 'Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.', files.slice99],
-  [slice100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.', files.slice100],
-  [slice102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.', files.slice102],
-]) need(source, marker, label);
-
-need(slice97, 'After retained maintainer execution of slices 95–97, define bounded lifecycle and', files.slice97);
-need(slice98, 'The Comments audit track remains independently blocked on maintainer execution', files.slice98);
-need(slice99, 'comment-form fallback is still a separate unfinished result', files.slice99);
-need(slice100, 'comment_form_fallback = not_applicable_no_storefront_write_surface', files.slice100);
-need(slice102, 'Re-audit Blog tag mutation/projection consistency as a separate ownership slice.', files.slice102);
+for (const [n, marker] of [
+  [97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.'],
+  [98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.'],
+  [99, 'Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.'],
+  [100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.'],
+  [102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.'],
+  [103, 'Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.'],
+]) need(slices[n], marker, files[`slice${n}`]);
+need(slices[103], 'Implement `tag_mutation_atomic_reindex` as slice 104', files.slice103);
+need(slices[103], 'metadata-only rows', files.slice103);
 
 for (const marker of [
-  'Status: `canonical_source_cursor_actualized_through_slice_102`.',
+  'Status: `canonical_source_cursor_actualized_through_slice_103`.',
   '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
   '`category_translation_postgres = source_ready_maintainer_execution_pending`',
   '`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`',
   '`comment_form_fallback = not_applicable_no_storefront_write_surface`',
   '`tag_list_pagination = source_ready_maintainer_execution_pending`',
-  '`tag_mutation_projection_consistency = re_audit_required`',
-  'do not advance that source work before retained maintainer execution of slices 95–97',
-  'This does **not** claim database-side pagination.',
-  '## Superseded historical cursor phrases',
+  '`tag_canonical_projection = source_ready_maintainer_execution_pending`',
+  '`tag_mutation_atomic_reindex = next_source_gap`',
+  'metadata-only legacy rows',
+  'Implement slice 104: `tag_mutation_atomic_reindex`.',
   'No tests, Cargo commands, Node verifiers',
 ]) need(current, marker, files.current);
 
-const supersededSection = between(
-  current,
-  '## Superseded historical cursor phrases',
-  '## Validation boundary',
-);
+const supersededSection = between(current, '## Superseded historical cursor phrases', '## Validation boundary');
 const liveCurrent = current.replace(supersededSection, '');
 for (const marker of [
   'remote transport remains pending',
   'cached snapshot and comment-form fallback remain planned',
-  'PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement',
   'then implement the remote network transport',
 ]) forbid(liveCurrent, marker, files.current);
 
 const completed = between(historical, '## Completed implementation slices', '## Next results');
 need(completed, '67. Executed all four Blog Comments projection PostgreSQL targets locally', files.historical);
-if (/\n68\.\s/.test(completed)) {
-  failures.push(`${files.historical}: historical embedded completed-slice list unexpectedly advanced without current-cursor evidence update`);
-}
+if (/\n68\.\s/.test(completed)) failures.push(`${files.historical}: historical embedded completed-slice list unexpectedly advanced without current-cursor evidence update`);
 
 for (const marker of [
   '## Planning cursor',
@@ -291,27 +207,13 @@ for (const marker of [
   '[Historical Implementation Plan](./implementation-plan.md)',
   'must not be treated as the live cursor',
 ]) need(docsIndex, marker, files.docsIndex);
-const currentLink = docsIndex.indexOf('[Current Implementation Cursor](./implementation-plan-current.md)');
-const historicalLink = docsIndex.indexOf('[Historical Implementation Plan](./implementation-plan.md)');
-if (currentLink < 0 || historicalLink < 0 || currentLink > historicalLink) {
+if (docsIndex.indexOf('[Current Implementation Cursor](./implementation-plan-current.md)') > docsIndex.indexOf('[Historical Implementation Plan](./implementation-plan.md)')) {
   failures.push(`${files.docsIndex}: canonical current cursor must be listed before the historical plan`);
 }
 
-for (const marker of [
-  'Status: `canonical_plan_current_cursor_source_ready_no_runtime_promotion`.',
-  'crates/rustok-blog/docs/implementation-plan-current.md',
-  'historical root implementation plan fell behind the continuation series',
-  'remote_comments_transport = source_implemented_maintainer_execution_pending',
-  'source_row_and_recovery_audit_retention = blocked_until_slices_95_97_execution',
-  'The next autonomous source slice must be justified by a fresh repository audit',
-]) need(slice101, marker, files.slice101);
-
-if (failures.length > 0) {
+if (failures.length) {
   console.error('[verify-blog-canonical-plan-current] FAIL');
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
-
-console.log(
-  '[verify-blog-canonical-plan-current] PASS cursor=slice-102 behavior-through=slice-102 execution=not-run',
-);
+console.log('[verify-blog-canonical-plan-current] PASS cursor=slice-103 behavior-through=slice-103 execution=not-run');

--- a/scripts/verify/verify-blog-canonical-plan-current.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.mjs
@@ -8,6 +8,7 @@ const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
   ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const failures = [];
+
 const files = {
   evidence: 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
   current: 'crates/rustok-blog/docs/implementation-plan-current.md',
@@ -21,27 +22,39 @@ const files = {
   slice103: 'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   docsIndex: 'crates/rustok-blog/docs/README.md',
   tcpTransport: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
+  tcpServer: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
+  tcpListener: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json',
   translationPostgres: 'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
   fallback: 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
   writeSurface: 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
   tagPagination: 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
   tagProjection: 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
 };
+
 function absolute(relativePath) { return path.join(repoRoot, relativePath); }
 function read(relativePath) {
   const target = absolute(relativePath);
-  if (!fs.existsSync(target)) { failures.push(`${relativePath}: missing file`); return ''; }
+  if (!fs.existsSync(target)) {
+    failures.push(`${relativePath}: missing file`);
+    return '';
+  }
   return fs.readFileSync(target, 'utf8');
 }
 function json(relativePath) {
   try { return JSON.parse(read(relativePath)); }
-  catch (error) { failures.push(`${relativePath}: invalid JSON: ${error.message}`); return null; }
+  catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
 }
 function need(source, marker, label) {
   if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
 }
 function forbid(source, marker, label) {
   if (source.includes(marker)) failures.push(`${label}: forbidden live cursor marker ${marker}`);
+}
+function sameSet(actual, expected) {
+  return [...(actual ?? [])].sort().join('|') === [...expected].sort().join('|');
 }
 function between(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);
@@ -53,9 +66,17 @@ function between(source, startMarker, endMarker) {
 const evidence = json(files.evidence);
 const current = read(files.current);
 const historical = read(files.historical);
-const slices = Object.fromEntries([97,98,99,100,101,102,103].map((n) => [n, read(files[`slice${n}`])]));
+const slice97 = read(files.slice97);
+const slice98 = read(files.slice98);
+const slice99 = read(files.slice99);
+const slice100 = read(files.slice100);
+const slice101 = read(files.slice101);
+const slice102 = read(files.slice102);
+const slice103 = read(files.slice103);
 const docsIndex = read(files.docsIndex);
 const tcpTransport = json(files.tcpTransport);
+const tcpServer = json(files.tcpServer);
+const tcpListener = json(files.tcpListener);
 const translationPostgres = json(files.translationPostgres);
 const fallback = json(files.fallback);
 const writeSurface = json(files.writeSurface);
@@ -64,40 +85,58 @@ const tagProjection = json(files.tagProjection);
 
 if (evidence) {
   if (
-    evidence.schema_version !== 2 || evidence.module !== 'blog' ||
+    evidence.schema_version !== 2 ||
+    evidence.module !== 'blog' ||
     evidence.surface !== 'canonical_implementation_cursor' ||
     evidence.status !== 'source_verified_no_compile' ||
-    evidence.compile_policy !== 'not_run_by_request' || evidence.runtime_status !== 'not_run'
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
   ) failures.push(`${files.evidence}: identity/status drift`);
+
   if (
     evidence.historical_baseline !== files.historical ||
     evidence.canonical_current_cursor !== files.current ||
     evidence.actualization_slice !== files.slice101 ||
     evidence.historical_baseline_last_embedded_slice !== 67 ||
-    evidence.latest_behavior_slice !== 103 || evidence.current_recorded_slice !== 103
+    evidence.latest_behavior_slice !== 103 ||
+    evidence.current_recorded_slice !== 103
   ) failures.push(`${files.evidence}: cursor path/version drift`);
 
   const tracks = evidence.source_tracks ?? {};
   if (
     tracks.remote_comments_transport?.status !== 'source_implemented_maintainer_execution_pending' ||
+    tracks.remote_comments_transport?.transport_evidence !== files.tcpTransport ||
+    tracks.remote_comments_transport?.latest_audit_relay_slice !== files.slice97 ||
     tracks.remote_comments_transport?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: remote Comments track drift`);
+
   if (
     tracks.comments_source_retention?.status !== 'blocked_until_slices_95_97_execution' ||
+    tracks.comments_source_retention?.blocking_slice !== files.slice97 ||
     tracks.comments_source_retention?.must_not_advance_before_execution !== true
   ) failures.push(`${files.evidence}: Comments source-retention gate drift`);
+
   if (
     tracks.category_translation_postgres?.status !== 'source_ready_maintainer_execution_pending' ||
+    tracks.category_translation_postgres?.slice !== files.slice98 ||
+    tracks.category_translation_postgres?.evidence !== files.translationPostgres ||
     tracks.category_translation_postgres?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: category Translation track drift`);
+
   if (
     tracks.cached_public_comments_snapshot?.status !== 'source_ready_maintainer_execution_pending' ||
+    tracks.cached_public_comments_snapshot?.slice !== files.slice99 ||
+    tracks.cached_public_comments_snapshot?.evidence !== files.fallback ||
     tracks.cached_public_comments_snapshot?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: cached Comments track drift`);
+
   if (
     tracks.storefront_comment_form_fallback?.status !== 'not_applicable_no_storefront_write_surface' ||
+    tracks.storefront_comment_form_fallback?.slice !== files.slice100 ||
+    tracks.storefront_comment_form_fallback?.evidence !== files.writeSurface ||
     tracks.storefront_comment_form_fallback?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: storefront write-surface track drift`);
+
   if (
     tracks.tag_list_pagination?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.tag_list_pagination?.slice !== files.slice102 ||
@@ -107,6 +146,7 @@ if (evidence) {
     tracks.tag_list_pagination?.database_side_pagination_claimed !== false ||
     tracks.tag_list_pagination?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: tag pagination track drift`);
+
   if (
     tracks.tag_canonical_projection?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.tag_canonical_projection?.slice !== files.slice103 ||
@@ -117,6 +157,7 @@ if (evidence) {
     tracks.tag_canonical_projection?.legacy_data_audit_pending !== true ||
     tracks.tag_canonical_projection?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: canonical tag projection track drift`);
+
   if (
     tracks.tag_mutation_atomic_reindex?.status !== 'next_source_gap' ||
     tracks.tag_mutation_atomic_reindex?.canonical_source_defined !== true ||
@@ -124,56 +165,109 @@ if (evidence) {
     tracks.tag_mutation_atomic_reindex?.blog_scope_reindex_same_transaction_required !== true ||
     tracks.tag_mutation_atomic_reindex?.manual_predelete_relation_cleanup_must_be_removed !== true
   ) failures.push(`${files.evidence}: tag mutation atomic-reindex cursor drift`);
+
   if (
     evidence.planning_result?.independent_production_source_gap_identified !== true ||
     evidence.planning_result?.next_source_gap !== 'tag_mutation_atomic_reindex' ||
     evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== false ||
     evidence.planning_result?.historical_stale_phrases_are_live_instructions !== false ||
+    evidence.planning_result?.production_behavior_changed_since_slice_101 !== true ||
     evidence.planning_result?.ffa_or_fba_promoted !== false ||
-    !Array.isArray(evidence.execution) || evidence.execution.length !== 0
+    !Array.isArray(evidence.execution) ||
+    evidence.execution.length !== 0
   ) failures.push(`${files.evidence}: planning/execution claim drift`);
 }
 
+for (const [label, artifact, expectedSurface] of [
+  [files.tcpTransport, tcpTransport, 'comments_tcp_json_transport'],
+  [files.tcpServer, tcpServer, 'comments_tcp_server_adapter'],
+  [files.tcpListener, tcpListener, 'comments_tcp_listener_lifecycle'],
+]) {
+  if (
+    artifact?.module !== 'blog' ||
+    artifact?.provider !== 'comments' ||
+    artifact?.surface !== expectedSurface ||
+    artifact?.status !== 'source_verified_no_compile' ||
+    artifact?.runtime_status !== 'not_run'
+  ) failures.push(`${label}: remote transport source evidence drift`);
+}
+
+if (!sameSet(tcpServer?.operations, [
+  'create_comment',
+  'get_comment',
+  'list_comments_for_target',
+  'list_public_comments_for_target',
+  'update_comment',
+  'set_comment_status',
+  'delete_comment',
+])) failures.push(`${files.tcpServer}: seven-operation transport parity drift`);
+
 if (
-  tcpTransport?.status !== 'source_verified_no_compile' || tcpTransport?.runtime_status !== 'not_run'
-) failures.push(`${files.tcpTransport}: remote transport source evidence drift`);
-if (
+  translationPostgres?.status !== 'blog_category_translation_postgres_source_unvalidated' ||
+  translationPostgres?.source_contract?.translation_target_migration_up_down_up_covered !== true ||
+  translationPostgres?.source_contract?.concurrent_apply_requires_exactly_one_success !== true ||
+  translationPostgres?.source_contract?.cursor_recovery_drains_after_latest_cursor !== true ||
   translationPostgres?.source_contract?.postgres_execution_observed !== false ||
   !Array.isArray(translationPostgres?.execution) || translationPostgres.execution.length !== 0
 ) failures.push(`${files.translationPostgres}: Translation PostgreSQL source status drift`);
+
 if (
   fallback?.storefront_read_degradation?.cached_thread_snapshot !== 'source_verified_no_compile' ||
+  fallback?.storefront_read_degradation?.runtime_evidence !== 'pending' ||
+  !sameSet(fallback?.storefront_read_degradation?.transports, ['graphql', 'native_ssr']) ||
   fallback?.storefront_write_surface?.comment_form_fallback !== 'not_applicable_no_storefront_write_surface'
 ) failures.push(`${files.fallback}: storefront fallback current-state drift`);
+
 if (
   writeSurface?.status !== 'source_verified_absent' ||
+  writeSurface?.actualization !== 'comment_form_fallback_not_applicable_no_storefront_write_surface' ||
+  writeSurface?.source_contract?.create_comment_surface_present !== false ||
   writeSurface?.source_contract?.comment_form_present !== false ||
+  writeSurface?.planning_effect?.new_storefront_write_surface_authorized !== false ||
   !Array.isArray(writeSurface?.execution) || writeSurface.execution.length !== 0
 ) failures.push(`${files.writeSurface}: storefront write-surface evidence drift`);
+
 if (
+  tagPagination?.status !== 'source_verified_no_compile' ||
+  tagPagination?.runtime_status !== 'not_run' ||
   tagPagination?.source_contract?.maximum_page_size !== 100 ||
+  tagPagination?.source_contract?.owner_service_clamps_page_size !== true ||
+  tagPagination?.source_contract?.extreme_page_cannot_overflow_offset_arithmetic !== true ||
   tagPagination?.source_contract?.database_side_pagination_claimed !== false ||
   !Array.isArray(tagPagination?.execution) || tagPagination.execution.length !== 0
 ) failures.push(`${files.tagPagination}: tag pagination source evidence drift`);
+
 if (
   tagProjection?.status !== 'source_verified_no_compile' ||
+  tagProjection?.runtime_status !== 'not_run' ||
+  tagProjection?.ownership?.dictionary_owner !== 'rustok-taxonomy' ||
   tagProjection?.ownership?.attachment_table !== 'blog_post_tags' ||
   tagProjection?.ownership?.metadata_tags_is_canonical_read_source !== false ||
   tagProjection?.ownership?.metadata_tags_is_search_projection_source !== false ||
+  tagProjection?.source_contract?.blog_read_harness_rejects_metadata_resurrection !== true ||
+  tagProjection?.source_contract?.stale_metadata_tags_are_ignored_by_search_harness !== true ||
+  tagProjection?.source_contract?.tag_mutation_semantics_changed !== false ||
   tagProjection?.source_contract?.tag_mutation_atomic_reindex_implemented !== false ||
+  tagProjection?.next_source_gap?.status !== 'tag_mutation_atomic_reindex_next' ||
   !Array.isArray(tagProjection?.execution) || tagProjection.execution.length !== 0
 ) failures.push(`${files.tagProjection}: canonical tag projection source evidence drift`);
 
-for (const [n, marker] of [
-  [97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.'],
-  [98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.'],
-  [99, 'Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.'],
-  [100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.'],
-  [102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.'],
-  [103, 'Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.'],
-]) need(slices[n], marker, files[`slice${n}`]);
-need(slices[103], 'Implement `tag_mutation_atomic_reindex` as slice 104', files.slice103);
-need(slices[103], 'metadata-only rows', files.slice103);
+for (const [source, marker, label] of [
+  [slice97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice97],
+  [slice98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice98],
+  [slice99, 'Status: `storefront_cached_public_comments_snapshot_source_ready_maintainer_execution_pending`.', files.slice99],
+  [slice100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.', files.slice100],
+  [slice102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.', files.slice102],
+  [slice103, 'Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.', files.slice103],
+]) need(source, marker, label);
+
+need(slice97, 'After retained maintainer execution of slices 95–97, define bounded lifecycle and', files.slice97);
+need(slice98, 'The Comments audit track remains independently blocked on maintainer execution', files.slice98);
+need(slice99, 'comment-form fallback is still a separate unfinished result', files.slice99);
+need(slice100, 'comment_form_fallback = not_applicable_no_storefront_write_surface', files.slice100);
+need(slice102, 'Re-audit Blog tag mutation/projection consistency as a separate ownership slice.', files.slice102);
+need(slice103, 'Implement `tag_mutation_atomic_reindex` as slice 104', files.slice103);
+need(slice103, 'metadata-only rows', files.slice103);
 
 for (const marker of [
   'Status: `canonical_source_cursor_actualized_through_slice_103`.',
@@ -184,8 +278,11 @@ for (const marker of [
   '`tag_list_pagination = source_ready_maintainer_execution_pending`',
   '`tag_canonical_projection = source_ready_maintainer_execution_pending`',
   '`tag_mutation_atomic_reindex = next_source_gap`',
+  'do not advance that source work before retained maintainer execution of slices 95–97',
+  'This does **not** claim database-side pagination.',
   'metadata-only legacy rows',
   'Implement slice 104: `tag_mutation_atomic_reindex`.',
+  '## Superseded historical cursor phrases',
   'No tests, Cargo commands, Node verifiers',
 ]) need(current, marker, files.current);
 
@@ -194,12 +291,15 @@ const liveCurrent = current.replace(supersededSection, '');
 for (const marker of [
   'remote transport remains pending',
   'cached snapshot and comment-form fallback remain planned',
+  'PostgreSQL migration, concurrent CAS, and change-cursor recovery evidence are still required before production inventory enablement',
   'then implement the remote network transport',
 ]) forbid(liveCurrent, marker, files.current);
 
 const completed = between(historical, '## Completed implementation slices', '## Next results');
 need(completed, '67. Executed all four Blog Comments projection PostgreSQL targets locally', files.historical);
-if (/\n68\.\s/.test(completed)) failures.push(`${files.historical}: historical embedded completed-slice list unexpectedly advanced without current-cursor evidence update`);
+if (/\n68\.\s/.test(completed)) {
+  failures.push(`${files.historical}: historical embedded completed-slice list unexpectedly advanced without current-cursor evidence update`);
+}
 
 for (const marker of [
   '## Planning cursor',
@@ -207,13 +307,25 @@ for (const marker of [
   '[Historical Implementation Plan](./implementation-plan.md)',
   'must not be treated as the live cursor',
 ]) need(docsIndex, marker, files.docsIndex);
-if (docsIndex.indexOf('[Current Implementation Cursor](./implementation-plan-current.md)') > docsIndex.indexOf('[Historical Implementation Plan](./implementation-plan.md)')) {
+const currentLink = docsIndex.indexOf('[Current Implementation Cursor](./implementation-plan-current.md)');
+const historicalLink = docsIndex.indexOf('[Historical Implementation Plan](./implementation-plan.md)');
+if (currentLink < 0 || historicalLink < 0 || currentLink > historicalLink) {
   failures.push(`${files.docsIndex}: canonical current cursor must be listed before the historical plan`);
 }
 
-if (failures.length) {
+for (const marker of [
+  'Status: `canonical_plan_current_cursor_source_ready_no_runtime_promotion`.',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+  'historical root implementation plan fell behind the continuation series',
+  'remote_comments_transport = source_implemented_maintainer_execution_pending',
+  'source_row_and_recovery_audit_retention = blocked_until_slices_95_97_execution',
+  'The next autonomous source slice must be justified by a fresh repository audit',
+]) need(slice101, marker, files.slice101);
+
+if (failures.length > 0) {
   console.error('[verify-blog-canonical-plan-current] FAIL');
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
+
 console.log('[verify-blog-canonical-plan-current] PASS cursor=slice-103 behavior-through=slice-103 execution=not-run');

--- a/scripts/verify/verify-blog-canonical-plan-current.test.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.test.mjs
@@ -2,14 +2,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  cpSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,38 +20,31 @@ const files = [
   'crates/rustok-blog/docs/implementation-plan-slice-100.md',
   'crates/rustok-blog/docs/implementation-plan-slice-101.md',
   'crates/rustok-blog/docs/implementation-plan-slice-102.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   'crates/rustok-blog/docs/README.md',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
-  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
-  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json',
   'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
   'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
+  'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
 ];
-
-function absolute(root, relativePath) {
-  return path.join(root, relativePath);
-}
-
+function absolute(root, relativePath) { return path.join(root, relativePath); }
 function write(root, relativePath, content) {
   const target = absolute(root, relativePath);
   mkdirSync(path.dirname(target), { recursive: true });
   writeFileSync(target, content);
 }
-
 function fixture(mutator = () => {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-current-plan-'));
   for (const relativePath of files) {
-    const source = path.join(repositoryRoot, relativePath);
     const target = absolute(root, relativePath);
     mkdirSync(path.dirname(target), { recursive: true });
-    cpSync(source, target);
+    cpSync(path.join(repositoryRoot, relativePath), target);
   }
   mutator(root);
   return root;
 }
-
 function run(root) {
   return spawnSync(process.execPath, [verifier], {
     cwd: repositoryRoot,
@@ -66,16 +52,11 @@ function run(root) {
     encoding: 'utf8',
   });
 }
-
 function rejects(mutator) {
   const root = fixture(mutator);
-  try {
-    return run(root);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  try { return run(root); }
+  finally { rmSync(root, { recursive: true, force: true }); }
 }
-
 function mutateJson(root, relativePath, mutator) {
   const target = absolute(root, relativePath);
   const value = JSON.parse(readFileSync(target, 'utf8'));
@@ -83,148 +64,93 @@ function mutateJson(root, relativePath, mutator) {
   write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-test('accepts the canonical Blog current implementation cursor', () => {
+test('accepts canonical Blog current implementation cursor through slice 103', () => {
   const root = fixture();
   try {
     const result = run(root);
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(result.stdout, /cursor=slice-102/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+    assert.match(result.stdout, /cursor=slice-103/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('rejects reopening remote transport as live current-cursor work', () => {
+test('rejects reopening remote transport', () => {
   const result = rejects((root) => {
-    const relativePath = 'crates/rustok-blog/docs/implementation-plan-current.md';
-    const source = readFileSync(absolute(root, relativePath), 'utf8');
-    write(
-      root,
-      relativePath,
-      source.replace(
-        '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
-        '`remote_comments_transport = remote transport remains pending`',
-      ),
-    );
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.source_tracks.remote_comments_transport.status = 'planned';
+    });
   });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /remote transport|current/);
+  assert.match(result.stderr, /remote Comments track drift/);
 });
 
-test('rejects promoting a new autonomous source gap without a fresh audit', () => {
+test('rejects Translation execution promotion', () => {
   const result = rejects((root) => {
-    mutateJson(
-      root,
-      'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
-      (value) => {
-        value.planning_result.independent_production_source_gap_identified = true;
-      },
-    );
-  });
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /planning\/execution claim drift/);
-});
-
-test('rejects Translation PostgreSQL execution promotion without retained execution', () => {
-  const result = rejects((root) => {
-    mutateJson(
-      root,
-      'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
-      (value) => {
-        value.source_contract.postgres_execution_observed = true;
-      },
-    );
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json', (value) => {
+      value.source_contract.postgres_execution_observed = true;
+    });
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Translation PostgreSQL source status drift/);
 });
 
-test('rejects reviving an active storefront comment form', () => {
+test('rejects reviving storefront comment form', () => {
   const result = rejects((root) => {
-    mutateJson(
-      root,
-      'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
-      (value) => {
-        value.source_contract.comment_form_present = true;
-        value.source_contract.create_comment_surface_present = true;
-      },
-    );
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json', (value) => {
+      value.source_contract.comment_form_present = true;
+    });
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /write-surface evidence drift/);
 });
 
-test('rejects a cached snapshot regression back to planned source work', () => {
+test('rejects reopening tag pagination', () => {
   const result = rejects((root) => {
-    mutateJson(
-      root,
-      'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
-      (value) => {
-        value.storefront_read_degradation.cached_thread_snapshot = 'planned';
-      },
-    );
-  });
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /storefront fallback current-state drift/);
-});
-
-test('rejects reopening the tag pagination source gap', () => {
-  const result = rejects((root) => {
-    mutateJson(
-      root,
-      'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json',
-      (value) => {
-        value.source_tracks.tag_list_pagination.status = 'planned';
-      },
-    );
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.source_tracks.tag_list_pagination.status = 'planned';
+    });
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /tag pagination track drift/);
 });
 
-test('rejects claiming database-side tag pagination', () => {
+test('rejects metadata tags becoming canonical again', () => {
   const result = rejects((root) => {
-    mutateJson(
-      root,
-      'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
-      (value) => {
-        value.source_contract.database_side_pagination_claimed = true;
-      },
-    );
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.source_tracks.tag_canonical_projection.metadata_tags_are_canonical = true;
+    });
   });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /tag pagination source evidence drift/);
+  assert.match(result.stderr, /canonical tag projection track drift/);
 });
 
-test('rejects listing the historical plan before the canonical current cursor', () => {
+test('rejects skipping atomic mutation reindex next cursor', () => {
   const result = rejects((root) => {
-    const relativePath = 'crates/rustok-blog/docs/README.md';
-    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.source_tracks.tag_mutation_atomic_reindex.status = 'done';
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag mutation atomic-reindex cursor drift/);
+});
+
+test('rejects premature atomic mutation implementation claim', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json', (value) => {
+      value.source_contract.tag_mutation_atomic_reindex_implemented = true;
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /canonical tag projection source evidence drift/);
+});
+
+test('rejects historical plan before canonical current cursor', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-blog/docs/README.md';
+    const source = readFileSync(absolute(root, file), 'utf8');
     const current = '[Current Implementation Cursor](./implementation-plan-current.md)';
     const historical = '[Historical Implementation Plan](./implementation-plan.md)';
-    write(
-      root,
-      relativePath,
-      source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical),
-    );
+    write(root, file, source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical));
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /canonical current cursor must be listed before/);
-});
-
-test('rejects an unrecorded advance of the historical embedded slice list', () => {
-  const result = rejects((root) => {
-    const relativePath = 'crates/rustok-blog/docs/implementation-plan.md';
-    const source = readFileSync(absolute(root, relativePath), 'utf8');
-    write(
-      root,
-      relativePath,
-      source.replace(
-        '\n## Next results',
-        '\n68. Unrecorded historical-list advance.\n\n## Next results',
-      ),
-    );
-  });
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /historical embedded completed-slice list unexpectedly advanced/);
 });

--- a/scripts/verify/verify-blog-canonical-plan-current.test.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.test.mjs
@@ -23,6 +23,8 @@ const files = [
   'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   'crates/rustok-blog/docs/README.md',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
+  'crates/rustok-blog/contracts/evidence/blog-comments-tcp-listener-lifecycle.json',
   'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
@@ -38,9 +40,10 @@ function write(root, relativePath, content) {
 function fixture(mutator = () => {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-current-plan-'));
   for (const relativePath of files) {
+    const source = path.join(repositoryRoot, relativePath);
     const target = absolute(root, relativePath);
     mkdirSync(path.dirname(target), { recursive: true });
-    cpSync(path.join(repositoryRoot, relativePath), target);
+    cpSync(source, target);
   }
   mutator(root);
   return root;
@@ -64,7 +67,7 @@ function mutateJson(root, relativePath, mutator) {
   write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-test('accepts canonical Blog current implementation cursor through slice 103', () => {
+test('accepts the canonical Blog current implementation cursor', () => {
   const root = fixture();
   try {
     const result = run(root);
@@ -73,17 +76,30 @@ test('accepts canonical Blog current implementation cursor through slice 103', (
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('rejects reopening remote transport', () => {
+test('rejects reopening remote transport as live current-cursor work', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/docs/implementation-plan-current.md';
+    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    write(root, relativePath, source.replace(
+      '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
+      '`remote_comments_transport = remote transport remains pending`',
+    ));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /remote transport|current/);
+});
+
+test('rejects advancing a different source gap than the retained next cursor', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
-      value.source_tracks.remote_comments_transport.status = 'planned';
+      value.planning_result.next_source_gap = 'another_gap';
     });
   });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /remote Comments track drift/);
+  assert.match(result.stderr, /planning\/execution claim drift/);
 });
 
-test('rejects Translation execution promotion', () => {
+test('rejects Translation PostgreSQL execution promotion without retained execution', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-category-translation-postgres-source.json', (value) => {
       value.source_contract.postgres_execution_observed = true;
@@ -93,17 +109,28 @@ test('rejects Translation execution promotion', () => {
   assert.match(result.stderr, /Translation PostgreSQL source status drift/);
 });
 
-test('rejects reviving storefront comment form', () => {
+test('rejects reviving an active storefront comment form', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json', (value) => {
       value.source_contract.comment_form_present = true;
+      value.source_contract.create_comment_surface_present = true;
     });
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /write-surface evidence drift/);
 });
 
-test('rejects reopening tag pagination', () => {
+test('rejects a cached snapshot regression back to planned source work', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-comments-runtime-fallback-smoke.json', (value) => {
+      value.storefront_read_degradation.cached_thread_snapshot = 'planned';
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /storefront fallback current-state drift/);
+});
+
+test('rejects reopening the tag pagination source gap', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
       value.source_tracks.tag_list_pagination.status = 'planned';
@@ -111,6 +138,16 @@ test('rejects reopening tag pagination', () => {
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /tag pagination track drift/);
+});
+
+test('rejects claiming database-side tag pagination', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json', (value) => {
+      value.source_contract.database_side_pagination_claimed = true;
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag pagination source evidence drift/);
 });
 
 test('rejects metadata tags becoming canonical again', () => {
@@ -123,17 +160,7 @@ test('rejects metadata tags becoming canonical again', () => {
   assert.match(result.stderr, /canonical tag projection track drift/);
 });
 
-test('rejects skipping atomic mutation reindex next cursor', () => {
-  const result = rejects((root) => {
-    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
-      value.source_tracks.tag_mutation_atomic_reindex.status = 'done';
-    });
-  });
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /tag mutation atomic-reindex cursor drift/);
-});
-
-test('rejects premature atomic mutation implementation claim', () => {
+test('rejects premature atomic tag mutation claim', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json', (value) => {
       value.source_contract.tag_mutation_atomic_reindex_implemented = true;
@@ -143,14 +170,47 @@ test('rejects premature atomic mutation implementation claim', () => {
   assert.match(result.stderr, /canonical tag projection source evidence drift/);
 });
 
-test('rejects historical plan before canonical current cursor', () => {
+test('rejects losing the tag mutation atomic-reindex next cursor', () => {
   const result = rejects((root) => {
-    const file = 'crates/rustok-blog/docs/README.md';
-    const source = readFileSync(absolute(root, file), 'utf8');
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.source_tracks.tag_mutation_atomic_reindex.status = 'done';
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag mutation atomic-reindex cursor drift/);
+});
+
+test('rejects listing the historical plan before the canonical current cursor', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/docs/README.md';
+    const source = readFileSync(absolute(root, relativePath), 'utf8');
     const current = '[Current Implementation Cursor](./implementation-plan-current.md)';
     const historical = '[Historical Implementation Plan](./implementation-plan.md)';
-    write(root, file, source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical));
+    write(root, relativePath, source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical));
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /canonical current cursor must be listed before/);
+});
+
+test('rejects an unrecorded advance of the historical embedded slice list', () => {
+  const result = rejects((root) => {
+    const relativePath = 'crates/rustok-blog/docs/implementation-plan.md';
+    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    write(root, relativePath, source.replace(
+      '\n## Next results',
+      '\n68. Unrecorded historical-list advance.\n\n## Next results',
+    ));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /historical embedded completed-slice list unexpectedly advanced/);
+});
+
+test('rejects remote transport operation parity regression', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json', (value) => {
+      value.operations = value.operations.filter((operation) => operation !== 'delete_comment');
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /seven-operation transport parity drift/);
 });

--- a/scripts/verify/verify-blog-tag-canonical-projection-source.mjs
+++ b/scripts/verify/verify-blog-tag-canonical-projection-source.mjs
@@ -11,37 +11,28 @@ const failures = [];
 const files = {
   evidence: 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
   tagService: 'crates/rustok-blog/src/services/tag.rs',
+  blogReadHarness: 'crates/rustok-blog/tests/taxonomy_tags.rs',
   projector: 'crates/rustok-search/src/blog_projector.rs',
   searchHarness: 'crates/rustok-search/tests/blog_projection_postgres_test.rs',
   searchEvidence: 'crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json',
   slice: 'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   current: 'crates/rustok-blog/docs/implementation-plan-current.md',
 };
-
 function read(relativePath) {
   const target = path.join(repoRoot, relativePath);
-  if (!fs.existsSync(target)) {
-    failures.push(`${relativePath}: missing file`);
-    return '';
-  }
+  if (!fs.existsSync(target)) { failures.push(`${relativePath}: missing file`); return ''; }
   return fs.readFileSync(target, 'utf8');
 }
 function json(relativePath) {
   try { return JSON.parse(read(relativePath)); }
-  catch (error) {
-    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
-    return null;
-  }
+  catch (error) { failures.push(`${relativePath}: invalid JSON: ${error.message}`); return null; }
 }
-function need(source, marker, label) {
-  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
-}
-function forbid(source, marker, label) {
-  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
-}
+function need(source, marker, label) { if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`); }
+function forbid(source, marker, label) { if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`); }
 
 const evidence = json(files.evidence);
 const tagService = read(files.tagService);
+const blogReadHarness = read(files.blogReadHarness);
 const projector = read(files.projector);
 const searchHarness = read(files.searchHarness);
 const searchEvidence = json(files.searchEvidence);
@@ -50,11 +41,9 @@ const current = read(files.current);
 
 if (evidence) {
   if (
-    evidence.schema_version !== 1 ||
-    evidence.module !== 'blog' ||
+    evidence.schema_version !== 1 || evidence.module !== 'blog' ||
     evidence.surface !== 'tag_canonical_read_search_projection' ||
-    evidence.status !== 'source_verified_no_compile' ||
-    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.status !== 'source_verified_no_compile' || evidence.compile_policy !== 'not_run_by_request' ||
     evidence.runtime_status !== 'not_run'
   ) failures.push(`${files.evidence}: identity/status drift`);
   if (
@@ -66,8 +55,10 @@ if (evidence) {
     evidence.ownership?.metadata_tags_is_search_projection_source !== false
   ) failures.push(`${files.evidence}: ownership drift`);
   if (
+    evidence.source_contract?.blog_read_harness !== files.blogReadHarness ||
     evidence.source_contract?.requested_post_ids_receive_explicit_empty_tag_entries !== true ||
     evidence.source_contract?.empty_relation_set_falls_back_to_metadata !== false ||
+    evidence.source_contract?.blog_read_harness_rejects_metadata_resurrection !== true ||
     evidence.source_contract?.search_requires_blog_post_tags !== true ||
     evidence.source_contract?.search_requires_taxonomy_terms !== true ||
     evidence.source_contract?.search_requires_taxonomy_term_translations !== true ||
@@ -77,44 +68,34 @@ if (evidence) {
     evidence.source_contract?.tag_mutation_atomic_reindex_implemented !== false ||
     !Array.isArray(evidence.execution) || evidence.execution.length !== 0
   ) failures.push(`${files.evidence}: source/execution drift`);
-  if (evidence.next_source_gap?.status !== 'tag_mutation_atomic_reindex_next') {
-    failures.push(`${files.evidence}: next source gap drift`);
-  }
+  if (evidence.next_source_gap?.status !== 'tag_mutation_atomic_reindex_next') failures.push(`${files.evidence}: next source gap drift`);
 }
 
 for (const marker of [
-  'let mut tags_by_post = post_ids',
-  '.map(|post_id| (post_id, Vec::new()))',
-  'if relations.is_empty() {',
-  'return Ok(tags_by_post);',
+  'let mut tags_by_post = post_ids', '.map(|post_id| (post_id, Vec::new()))',
+  'if relations.is_empty() {', 'return Ok(tags_by_post);',
   'resolve_term_names(tenant_id, &term_ids, locale, fallback_locale)',
 ]) need(tagService, marker, files.tagService);
+for (const marker of [
+  'post_read_does_not_resurrect_metadata_tags_after_relations_are_removed',
+  'stale-metadata-tag',
+  'blog_post_tag::Entity::delete_many()',
+  'assert!(post.tags.is_empty());',
+]) need(blogReadHarness, marker, files.blogReadHarness);
 
 for (const marker of [
-  "to_regclass('blog_post_tags')",
-  "to_regclass('taxonomy_terms')",
-  "to_regclass('taxonomy_term_translations')",
-  'FROM blog_post_tags relation',
-  'JOIN taxonomy_terms term',
-  'LEFT JOIN taxonomy_term_translations localized',
-  'LEFT JOIN taxonomy_term_translations fallback',
-  'term.tenant_id = p.tenant_id',
-  'localized.tenant_id = p.tenant_id',
-  'fallback.tenant_id = p.tenant_id',
+  "to_regclass('blog_post_tags')", "to_regclass('taxonomy_terms')", "to_regclass('taxonomy_term_translations')",
+  'FROM blog_post_tags relation', 'JOIN taxonomy_terms term',
+  'LEFT JOIN taxonomy_term_translations localized', 'LEFT JOIN taxonomy_term_translations fallback',
+  'term.tenant_id = p.tenant_id', 'localized.tenant_id = p.tenant_id', 'fallback.tenant_id = p.tenant_id',
   'COALESCE(localized.name, fallback.name, term.canonical_key)',
 ]) need(projector, marker, files.projector);
-for (const marker of ["jsonb_array_elements_text", "p.metadata -> 'tags'"]) {
-  forbid(projector, marker, files.projector);
-}
+for (const marker of ["jsonb_array_elements_text", "p.metadata -> 'tags'"]) forbid(projector, marker, files.projector);
 
 for (const marker of [
-  'blog_reindex_projects_attached_taxonomy_tags_not_metadata_snapshot',
-  'stale-metadata-only',
-  'CREATE TABLE taxonomy_terms',
-  'CREATE TABLE taxonomy_term_translations',
-  'CREATE TABLE blog_post_tags',
+  'blog_reindex_projects_attached_taxonomy_tags_not_metadata_snapshot', 'stale-metadata-only',
+  'CREATE TABLE taxonomy_terms', 'CREATE TABLE taxonomy_term_translations', 'CREATE TABLE blog_post_tags',
 ]) need(searchHarness, marker, files.searchHarness);
-
 if (
   searchEvidence?.production_contract?.blog_tag_attachment_source !== 'blog_post_tags' ||
   searchEvidence?.production_contract?.legacy_metadata_tags_are_projection_source !== false ||
@@ -126,11 +107,9 @@ for (const marker of [
   '`blog_tag_read_source = blog_post_tags_plus_taxonomy`',
   '`blog_search_tag_projection = relation_taxonomy_source_ready_maintainer_execution_pending`',
   'This slice does **not** change `TagService::update_tag` or `TagService::delete_tag` transaction semantics.',
-  'metadata-only rows',
-  'Implement `tag_mutation_atomic_reindex` as slice 104',
+  'metadata-only rows', 'Implement `tag_mutation_atomic_reindex` as slice 104',
   'No tests, Cargo commands, Node verifiers',
 ]) need(slice, marker, files.slice);
-
 for (const marker of [
   '`tag_canonical_projection = source_ready_maintainer_execution_pending`',
   '`tag_mutation_atomic_reindex = next_source_gap`',

--- a/scripts/verify/verify-blog-tag-canonical-projection-source.mjs
+++ b/scripts/verify/verify-blog-tag-canonical-projection-source.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const failures = [];
+const files = {
+  evidence: 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
+  tagService: 'crates/rustok-blog/src/services/tag.rs',
+  projector: 'crates/rustok-search/src/blog_projector.rs',
+  searchHarness: 'crates/rustok-search/tests/blog_projection_postgres_test.rs',
+  searchEvidence: 'crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json',
+  slice: 'crates/rustok-blog/docs/implementation-plan-slice-103.md',
+  current: 'crates/rustok-blog/docs/implementation-plan-current.md',
+};
+
+function read(relativePath) {
+  const target = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(target)) {
+    failures.push(`${relativePath}: missing file`);
+    return '';
+  }
+  return fs.readFileSync(target, 'utf8');
+}
+function json(relativePath) {
+  try { return JSON.parse(read(relativePath)); }
+  catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+function need(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+function forbid(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const evidence = json(files.evidence);
+const tagService = read(files.tagService);
+const projector = read(files.projector);
+const searchHarness = read(files.searchHarness);
+const searchEvidence = json(files.searchEvidence);
+const slice = read(files.slice);
+const current = read(files.current);
+
+if (evidence) {
+  if (
+    evidence.schema_version !== 1 ||
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'tag_canonical_read_search_projection' ||
+    evidence.status !== 'source_verified_no_compile' ||
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run'
+  ) failures.push(`${files.evidence}: identity/status drift`);
+  if (
+    evidence.ownership?.dictionary_owner !== 'rustok-taxonomy' ||
+    evidence.ownership?.attachment_owner !== 'rustok-blog' ||
+    evidence.ownership?.attachment_table !== 'blog_post_tags' ||
+    evidence.ownership?.compatibility_mirror !== 'blog_posts.metadata.tags' ||
+    evidence.ownership?.metadata_tags_is_canonical_read_source !== false ||
+    evidence.ownership?.metadata_tags_is_search_projection_source !== false
+  ) failures.push(`${files.evidence}: ownership drift`);
+  if (
+    evidence.source_contract?.requested_post_ids_receive_explicit_empty_tag_entries !== true ||
+    evidence.source_contract?.empty_relation_set_falls_back_to_metadata !== false ||
+    evidence.source_contract?.search_requires_blog_post_tags !== true ||
+    evidence.source_contract?.search_requires_taxonomy_terms !== true ||
+    evidence.source_contract?.search_requires_taxonomy_term_translations !== true ||
+    evidence.source_contract?.taxonomy_joins_are_tenant_constrained !== true ||
+    evidence.source_contract?.stale_metadata_tags_are_ignored_by_search_harness !== true ||
+    evidence.source_contract?.tag_mutation_semantics_changed !== false ||
+    evidence.source_contract?.tag_mutation_atomic_reindex_implemented !== false ||
+    !Array.isArray(evidence.execution) || evidence.execution.length !== 0
+  ) failures.push(`${files.evidence}: source/execution drift`);
+  if (evidence.next_source_gap?.status !== 'tag_mutation_atomic_reindex_next') {
+    failures.push(`${files.evidence}: next source gap drift`);
+  }
+}
+
+for (const marker of [
+  'let mut tags_by_post = post_ids',
+  '.map(|post_id| (post_id, Vec::new()))',
+  'if relations.is_empty() {',
+  'return Ok(tags_by_post);',
+  'resolve_term_names(tenant_id, &term_ids, locale, fallback_locale)',
+]) need(tagService, marker, files.tagService);
+
+for (const marker of [
+  "to_regclass('blog_post_tags')",
+  "to_regclass('taxonomy_terms')",
+  "to_regclass('taxonomy_term_translations')",
+  'FROM blog_post_tags relation',
+  'JOIN taxonomy_terms term',
+  'LEFT JOIN taxonomy_term_translations localized',
+  'LEFT JOIN taxonomy_term_translations fallback',
+  'term.tenant_id = p.tenant_id',
+  'localized.tenant_id = p.tenant_id',
+  'fallback.tenant_id = p.tenant_id',
+  'COALESCE(localized.name, fallback.name, term.canonical_key)',
+]) need(projector, marker, files.projector);
+for (const marker of ["jsonb_array_elements_text", "p.metadata -> 'tags'"]) {
+  forbid(projector, marker, files.projector);
+}
+
+for (const marker of [
+  'blog_reindex_projects_attached_taxonomy_tags_not_metadata_snapshot',
+  'stale-metadata-only',
+  'CREATE TABLE taxonomy_terms',
+  'CREATE TABLE taxonomy_term_translations',
+  'CREATE TABLE blog_post_tags',
+]) need(searchHarness, marker, files.searchHarness);
+
+if (
+  searchEvidence?.production_contract?.blog_tag_attachment_source !== 'blog_post_tags' ||
+  searchEvidence?.production_contract?.legacy_metadata_tags_are_projection_source !== false ||
+  !(searchEvidence?.cases ?? []).some((item) => item.name === 'canonical_taxonomy_tag_projection')
+) failures.push(`${files.searchEvidence}: canonical projection evidence drift`);
+
+for (const marker of [
+  'Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.',
+  '`blog_tag_read_source = blog_post_tags_plus_taxonomy`',
+  '`blog_search_tag_projection = relation_taxonomy_source_ready_maintainer_execution_pending`',
+  'This slice does **not** change `TagService::update_tag` or `TagService::delete_tag` transaction semantics.',
+  'metadata-only rows',
+  'Implement `tag_mutation_atomic_reindex` as slice 104',
+  'No tests, Cargo commands, Node verifiers',
+]) need(slice, marker, files.slice);
+
+for (const marker of [
+  '`tag_canonical_projection = source_ready_maintainer_execution_pending`',
+  '`tag_mutation_atomic_reindex = next_source_gap`',
+]) need(current, marker, files.current);
+
+if (failures.length) {
+  console.error('[verify-blog-tag-canonical-projection-source] FAIL');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+console.log('[verify-blog-tag-canonical-projection-source] PASS source=blog_post_tags+taxonomy execution=not-run');

--- a/scripts/verify/verify-blog-tag-canonical-projection-source.test.mjs
+++ b/scripts/verify/verify-blog-tag-canonical-projection-source.test.mjs
@@ -13,6 +13,7 @@ const verifier = path.join(repositoryRoot, 'scripts/verify/verify-blog-tag-canon
 const files = [
   'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
   'crates/rustok-blog/src/services/tag.rs',
+  'crates/rustok-blog/tests/taxonomy_tags.rs',
   'crates/rustok-search/src/blog_projector.rs',
   'crates/rustok-search/tests/blog_projection_postgres_test.rs',
   'crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json',
@@ -65,6 +66,16 @@ test('rejects metadata resurrection on empty relation set', () => {
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /tags_by_post/);
+});
+
+test('rejects removal of the Blog read regression harness', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-blog/tests/taxonomy_tags.rs';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace('post_read_does_not_resurrect_metadata_tags_after_relations_are_removed', 'removed_read_case'));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /post_read_does_not_resurrect/);
 });
 
 test('rejects metadata-backed Search projection', () => {

--- a/scripts/verify/verify-blog-tag-canonical-projection-source.test.mjs
+++ b/scripts/verify/verify-blog-tag-canonical-projection-source.test.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const verifier = path.join(repositoryRoot, 'scripts/verify/verify-blog-tag-canonical-projection-source.mjs');
+const files = [
+  'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
+  'crates/rustok-blog/src/services/tag.rs',
+  'crates/rustok-search/src/blog_projector.rs',
+  'crates/rustok-search/tests/blog_projection_postgres_test.rs',
+  'crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json',
+  'crates/rustok-blog/docs/implementation-plan-slice-103.md',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+];
+function absolute(root, relativePath) { return path.join(root, relativePath); }
+function write(root, relativePath, content) {
+  const target = absolute(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+function fixture(mutator = () => {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-tag-source-'));
+  for (const relativePath of files) {
+    const target = absolute(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(path.join(repositoryRoot, relativePath), target);
+  }
+  mutator(root);
+  return root;
+}
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: repositoryRoot,
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+function rejects(mutator) {
+  const root = fixture(mutator);
+  try { return run(root); }
+  finally { rmSync(root, { recursive: true, force: true }); }
+}
+
+test('accepts canonical Blog tag read/Search source', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /source=blog_post_tags\+taxonomy/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('rejects metadata resurrection on empty relation set', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-blog/src/services/tag.rs';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace('return Ok(tags_by_post);', 'return Ok(HashMap::new());'));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tags_by_post/);
+});
+
+test('rejects metadata-backed Search projection', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-search/src/blog_projector.rs';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace('FROM blog_post_tags relation', "FROM jsonb_array_elements_text(p.metadata -> 'tags') relation"));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /forbidden|blog_post_tags/);
+});
+
+test('rejects premature atomic mutation claim', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json';
+    const value = JSON.parse(readFileSync(absolute(root, file), 'utf8'));
+    value.source_contract.tag_mutation_atomic_reindex_implemented = true;
+    write(root, file, `${JSON.stringify(value, null, 2)}\n`);
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /source\/execution drift/);
+});

--- a/scripts/verify/verify-search-blog-projection.mjs
+++ b/scripts/verify/verify-search-blog-projection.mjs
@@ -53,6 +53,9 @@ for (const table of [
   "blog_post_translations",
   "blog_post_channel_visibility",
   "blog_category_translations",
+  "blog_post_tags",
+  "taxonomy_terms",
+  "taxonomy_term_translations",
 ]) {
   requireMarker(projector, `to_regclass('${table}')`, projectorPath);
 }
@@ -63,9 +66,20 @@ for (const marker of [
   "DELETE FROM search_documents",
   "pub(crate) async fn delete_tenant",
   '"delete_blog_scope"',
+  "FROM blog_post_tags relation",
+  "JOIN taxonomy_terms term",
+  "LEFT JOIN taxonomy_term_translations localized",
+  "LEFT JOIN taxonomy_term_translations fallback",
+  "localized.tenant_id = p.tenant_id",
+  "fallback.tenant_id = p.tenant_id",
+  "COALESCE(localized.name, fallback.name, term.canonical_key)",
 ]) {
   requireMarker(projector, marker, projectorPath);
 }
+for (const marker of [
+  "jsonb_array_elements_text",
+  "p.metadata -> 'tags'",
+]) rejectMarker(projector, marker, projectorPath);
 
 for (const marker of [
   "DomainEvent::TenantModuleToggled",
@@ -99,6 +113,11 @@ for (const marker of [
   'SET search_path TO "{schema_name}", public',
   "full_blog_reindex_replaces_only_current_tenant_blog_documents",
   "blog_events_upsert_publish_archive_and_delete_search_document",
+  "blog_reindex_projects_attached_taxonomy_tags_not_metadata_snapshot",
+  "stale-metadata-only",
+  "CREATE TABLE taxonomy_terms",
+  "CREATE TABLE taxonomy_term_translations",
+  "CREATE TABLE blog_post_tags",
   "blog_module_disable_cleans_scope_and_enable_rebuilds_it",
   "targeted_reindex_removes_stale_document_when_source_post_is_missing",
 ]) {
@@ -117,8 +136,17 @@ if (evidence) {
   for (const target of [routingTestPath, postgresTestPath]) {
     if (!targets.includes(target)) failures.push(`${evidencePath}: missing test target ${target}`);
   }
+  if (
+    evidence.production_contract?.blog_tag_attachment_source !== "blog_post_tags" ||
+    evidence.production_contract?.tag_dictionary_source !== "taxonomy_terms + taxonomy_term_translations" ||
+    evidence.production_contract?.legacy_metadata_tags_are_projection_source !== false
+  ) failures.push(`${evidencePath}: canonical Blog tag projection source drift`);
   const caseNames = new Set((evidence.cases ?? []).map((item) => item.name));
-  for (const caseName of ["module_toggle_cleanup_rebuild", "targeted_missing_post_cleanup"]) {
+  for (const caseName of [
+    "module_toggle_cleanup_rebuild",
+    "targeted_missing_post_cleanup",
+    "canonical_taxonomy_tag_projection",
+  ]) {
     if (!caseNames.has(caseName)) failures.push(`${evidencePath}: missing case ${caseName}`);
   }
 }

--- a/scripts/verify/verify-search-blog-projection.test.mjs
+++ b/scripts/verify/verify-search-blog-projection.test.mjs
@@ -2,116 +2,61 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+const repositoryRoot = path.resolve(".");
 const verifier = path.resolve("scripts/verify/verify-search-blog-projection.mjs");
+const files = [
+  "crates/rustok-search/src/blog_projector.rs",
+  "crates/rustok-search/src/ingestion.rs",
+  "crates/rustok-search/tests/blog_ingestion_contract_test.rs",
+  "crates/rustok-search/tests/blog_projection_postgres_test.rs",
+  "crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json",
+  "crates/rustok-search/docs/implementation-plan.md",
+];
+
+function absolute(root, relativePath) {
+  return path.join(root, relativePath);
+}
 
 function write(root, relativePath, content) {
-  const target = path.join(root, relativePath);
+  const target = absolute(root, relativePath);
   mkdirSync(path.dirname(target), { recursive: true });
   writeFileSync(target, content);
 }
 
-function fixture({ hardcodedPublic = false, missingPostgresHarness = false } = {}) {
+function fixture(mutator = () => {}) {
   const root = mkdtempSync(path.join(tmpdir(), "rustok-search-blog-projection-"));
-  const tablePrefix = hardcodedPublic ? "public." : "";
-  write(
-    root,
-    "crates/rustok-search/src/blog_projector.rs",
-    `
-      to_regclass('${tablePrefix}blog_posts')
-      to_regclass('${tablePrefix}blog_post_translations')
-      to_regclass('${tablePrefix}blog_post_channel_visibility')
-      to_regclass('${tablePrefix}blog_category_translations')
-      FROM blog_posts p
-      INSERT INTO search_documents
-      DELETE FROM search_documents
-      pub(crate) async fn delete_tenant
-      "delete_blog_scope"
-    `,
-  );
-  write(
-    root,
-    "crates/rustok-search/src/ingestion.rs",
-    `
-      DomainEvent::TenantModuleToggled
-      module_slug == "blog"
-      handle_blog_module_toggle
-      blog_projector.delete_tenant
-      "delete_blog_scope"
-      "rebuild_blog_scope"
-    `,
-  );
-  write(
-    root,
-    "crates/rustok-search/tests/blog_ingestion_contract_test.rs",
-    `
-      DomainEvent::BlogPostCreated
-      DomainEvent::BlogPostPublished
-      DomainEvent::BlogPostUnpublished
-      DomainEvent::BlogPostUpdated
-      DomainEvent::BlogPostArchived
-      DomainEvent::BlogPostDeleted
-      DomainEvent::TenantModuleToggled
-      target_type: "blog".to_string()
-    `,
-  );
-  if (!missingPostgresHarness) {
-    write(
-      root,
-      "crates/rustok-search/tests/blog_projection_postgres_test.rs",
-      `
-        RUSTOK_SEARCH_TEST_DATABASE_URL
-        SearchModule.migrations()
-        SearchIngestionHandler::new
-        ContractEventEnvelope::new
-        SET search_path TO "{schema_name}", public
-        full_blog_reindex_replaces_only_current_tenant_blog_documents
-        blog_events_upsert_publish_archive_and_delete_search_document
-        blog_module_disable_cleans_scope_and_enable_rebuilds_it
-        targeted_reindex_removes_stale_document_when_source_post_is_missing
-      `,
-    );
+  for (const relativePath of files) {
+    const target = absolute(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(path.join(repositoryRoot, relativePath), target);
   }
-  write(
-    root,
-    "crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json",
-    JSON.stringify({
-      schema_version: 1,
-      module: "search",
-      surface: "blog_post_projection",
-      status: "executable_no_run",
-      compile_policy: "not_run_by_request",
-      test_targets: [
-        "crates/rustok-search/tests/blog_ingestion_contract_test.rs",
-        "crates/rustok-search/tests/blog_projection_postgres_test.rs",
-      ],
-      cases: [
-        { name: "module_toggle_cleanup_rebuild" },
-        { name: "targeted_missing_post_cleanup" },
-      ],
-    }),
-  );
-  write(
-    root,
-    "crates/rustok-search/docs/implementation-plan.md",
-    "search-blog-projection-postgres-harness.json RUSTOK_SEARCH_TEST_DATABASE_URL search_path module-disabled cleanup targeted missing-post",
-  );
+  mutator(root);
   return root;
 }
 
 function run(root) {
   return spawnSync(process.execPath, [verifier], {
-    cwd: path.resolve("."),
+    cwd: repositoryRoot,
     env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
     encoding: "utf8",
   });
 }
 
-test("search Blog projection verifier passes canonical fixture", () => {
+function rejects(mutator) {
+  const root = fixture(mutator);
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("search Blog projection verifier accepts canonical owner-tag source", () => {
   const root = fixture();
   try {
     const result = run(root);
@@ -122,24 +67,33 @@ test("search Blog projection verifier passes canonical fixture", () => {
   }
 });
 
-test("search Blog projection verifier rejects hardcoded public source tables", () => {
-  const root = fixture({ hardcodedPublic: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /forbidden to_regclass\('public\.blog_/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+test("rejects metadata tags as Search projection source", () => {
+  const result = rejects((root) => {
+    const relativePath = "crates/rustok-search/src/blog_projector.rs";
+    const source = readFileSync(absolute(root, relativePath), "utf8");
+    write(root, relativePath, source.replace("FROM blog_post_tags relation", "FROM jsonb_array_elements_text(p.metadata -> 'tags') relation"));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /jsonb_array_elements_text|blog_post_tags/);
 });
 
-test("search Blog projection verifier rejects missing PostgreSQL harness", () => {
-  const root = fixture({ missingPostgresHarness: true });
-  try {
-    const result = run(root);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /expected file is missing|missing RUSTOK_SEARCH_TEST_DATABASE_URL/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+test("rejects missing Taxonomy table availability gate", () => {
+  const result = rejects((root) => {
+    const relativePath = "crates/rustok-search/src/blog_projector.rs";
+    const source = readFileSync(absolute(root, relativePath), "utf8");
+    write(root, relativePath, source.replace("AND to_regclass('taxonomy_term_translations') IS NOT NULL", ""));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /taxonomy_term_translations/);
+});
+
+test("rejects stale evidence claiming metadata is canonical", () => {
+  const result = rejects((root) => {
+    const relativePath = "crates/rustok-search/contracts/evidence/search-blog-projection-postgres-harness.json";
+    const value = JSON.parse(readFileSync(absolute(root, relativePath), "utf8"));
+    value.production_contract.legacy_metadata_tags_are_projection_source = true;
+    write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /canonical Blog tag projection source drift/);
 });


### PR DESCRIPTION
## Summary

Continue the canonical Blog cursor with slice 103 after the slice-102 ownership audit.

This slice resolves the source-of-truth mismatch before changing tag mutation semantics: Taxonomy owns the shared dictionary, Blog owns `blog_post_tags`, and `blog_posts.metadata.tags` is retained only as compatibility metadata rather than read/Search authority.

## Production source

- Blog tag reads seed an explicit empty tag vector for every requested post ID, so removing the final `blog_post_tags` relation cannot resurrect stale `metadata.tags` through the existing PostService fallback path.
- Search Blog projection now requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves attached tag names using document locale -> platform fallback locale -> canonical key.
- Search no longer projects Blog tags from `jsonb_array_elements_text(p.metadata -> 'tags')`.
- Taxonomy joins are tenant-constrained and tag aggregation remains distinct/deterministic.

## Retained evidence

- adds a Blog read harness proving relation removal leaves `post.tags` empty even while compatibility metadata remains stale;
- updates the Search PostgreSQL harness with canonical relation/Taxonomy source tables and a targeted stale-metadata rejection case;
- updates Search projection evidence/guard/self-test;
- adds `blog-tag-canonical-projection-source.json` and a dedicated fail-closed guard/self-test;
- advances the canonical Blog cursor/evidence through slice 103.

## Rollout caveat

This source is intentionally fail-closed for legacy metadata-only rows. Runtime promotion requires an audit for deployed rows that have metadata tags without equivalent `blog_post_tags`; if such rows exist, they require an owner-authorized backfill before rollout. No legacy-data audit or backfill result is claimed here.

## Deliberate non-scope / next cursor

`TagService::update_tag/delete_tag` transaction semantics are unchanged in slice 103. Slice 104 is the explicit next source gap: Taxonomy-owned supplied-transaction update/delete, Blog-scope reindex in the same transaction, and removal of the redundant manual pre-delete relation cleanup in favor of the declared FK cascade.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, PostgreSQL scenarios, formatting, builds, Clippy, workflows, CI, HTTP execution, runtime validation, or production validation were executed. Source/diff review only.