### PR TITLE
feat(forum): add runner-neutral NodeBB import mapping

### DIFF
--- a/crates/rustok-forum/src/import_mapping.rs
+++ b/crates/rustok-forum/src/import_mapping.rs
@@ -241,7 +241,10 @@ fn required_text(
 }
 
 fn optional_text(value: Option<&str>) -> Option<String> {
-    value.map(str::trim).filter(|value| !value.is_empty()).map(str::to_owned)
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
 }
 
 fn positive_optional(value: Option<i64>) -> Option<i64> {
@@ -307,8 +310,8 @@ fn map_post(
     ensure_positive("topic", record.tid)?;
     let role = match topic_main_posts.get(&record.tid) {
         Some(Some(main_pid)) if *main_pid == record.pid => ForumImportPostRole::TopicBody,
-        Some(_) => ForumImportPostRole::Reply,
-        None => ForumImportPostRole::Unresolved,
+        Some(Some(_)) => ForumImportPostRole::Reply,
+        Some(None) | None => ForumImportPostRole::Unresolved,
     };
     Ok(ForumImportPostCandidate {
         source: source_ref(ForumImportEntityKind::Post, record.pid),
@@ -371,7 +374,10 @@ mod tests {
         assert_eq!(mapped.categories[0].parent_source, None);
         assert_eq!(mapped.topics[0].source.key, "topic:9");
         assert_eq!(
-            mapped.topics[0].author_source.as_ref().map(|value| value.key.as_str()),
+            mapped.topics[0]
+                .author_source
+                .as_ref()
+                .map(|value| value.key.as_str()),
             Some("user:7")
         );
         assert_eq!(mapped.posts[0].role, ForumImportPostRole::TopicBody);
@@ -395,6 +401,35 @@ mod tests {
         let mapped = NodebbForumImportMapper.map_batch(&batch).unwrap();
         assert_eq!(mapped.posts[0].role, ForumImportPostRole::Unresolved);
         assert_eq!(mapped.posts[0].author_source, None);
+    }
+
+    #[test]
+    fn post_role_stays_unresolved_when_topic_has_no_main_post() {
+        let batch = NodebbExportBatch {
+            topics: vec![NodebbTopicRecord {
+                tid: 9,
+                cid: 4,
+                uid: None,
+                title: "No main post yet".to_owned(),
+                slug: None,
+                main_pid: None,
+                timestamp: None,
+                pinned: false,
+                locked: false,
+            }],
+            posts: vec![NodebbPostRecord {
+                pid: 12,
+                tid: 9,
+                uid: None,
+                content: "Ambiguous post".to_owned(),
+                timestamp: None,
+                deleted: false,
+            }],
+            ..Default::default()
+        };
+
+        let mapped = NodebbForumImportMapper.map_batch(&batch).unwrap();
+        assert_eq!(mapped.posts[0].role, ForumImportPostRole::Unresolved);
     }
 
     #[test]

--- a/crates/rustok-forum/src/import_mapping.rs
+++ b/crates/rustok-forum/src/import_mapping.rs
@@ -1,0 +1,451 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub const FORUM_IMPORT_SOURCE_NODEBB: &str = "nodebb";
+pub const MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH: usize = 512;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumImportEntityKind {
+    Category,
+    Topic,
+    Post,
+    User,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ForumImportExternalRef {
+    pub source: String,
+    pub kind: ForumImportEntityKind,
+    pub key: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumImportPostRole {
+    TopicBody,
+    Reply,
+    Unresolved,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ForumImportCategoryCandidate {
+    pub source: ForumImportExternalRef,
+    pub parent_source: Option<ForumImportExternalRef>,
+    pub name: String,
+    pub description: Option<String>,
+    pub position: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ForumImportTopicCandidate {
+    pub source: ForumImportExternalRef,
+    pub category_source: ForumImportExternalRef,
+    pub author_source: Option<ForumImportExternalRef>,
+    pub title: String,
+    pub slug: Option<String>,
+    pub body_post_source: Option<ForumImportExternalRef>,
+    pub created_at_ms: Option<i64>,
+    pub is_pinned: bool,
+    pub is_locked: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ForumImportPostCandidate {
+    pub source: ForumImportExternalRef,
+    pub topic_source: ForumImportExternalRef,
+    pub author_source: Option<ForumImportExternalRef>,
+    pub role: ForumImportPostRole,
+    pub body: String,
+    pub created_at_ms: Option<i64>,
+    pub deleted: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ForumImportCandidateBatch {
+    pub categories: Vec<ForumImportCategoryCandidate>,
+    pub topics: Vec<ForumImportTopicCandidate>,
+    pub posts: Vec<ForumImportPostCandidate>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodebbExportBatch {
+    #[serde(default)]
+    pub categories: Vec<NodebbCategoryRecord>,
+    #[serde(default)]
+    pub topics: Vec<NodebbTopicRecord>,
+    #[serde(default)]
+    pub posts: Vec<NodebbPostRecord>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodebbCategoryRecord {
+    pub cid: i64,
+    #[serde(rename = "parentCid", alias = "parent_cid", default)]
+    pub parent_cid: Option<i64>,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub order: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodebbTopicRecord {
+    pub tid: i64,
+    pub cid: i64,
+    #[serde(default)]
+    pub uid: Option<i64>,
+    pub title: String,
+    #[serde(default)]
+    pub slug: Option<String>,
+    #[serde(rename = "mainPid", alias = "main_pid", default)]
+    pub main_pid: Option<i64>,
+    #[serde(default)]
+    pub timestamp: Option<i64>,
+    #[serde(default)]
+    pub pinned: bool,
+    #[serde(default)]
+    pub locked: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodebbPostRecord {
+    pub pid: i64,
+    pub tid: i64,
+    #[serde(default)]
+    pub uid: Option<i64>,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub timestamp: Option<i64>,
+    #[serde(default)]
+    pub deleted: bool,
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum ForumImportMappingError {
+    #[error("Forum import batch exceeds {max} source records: {actual}")]
+    BatchTooLarge { max: usize, actual: usize },
+    #[error("NodeBB {kind} source id must be positive: {id}")]
+    InvalidSourceId { kind: &'static str, id: i64 },
+    #[error("NodeBB {kind} source id is duplicated in the batch: {id}")]
+    DuplicateSourceId { kind: &'static str, id: i64 },
+    #[error("NodeBB {kind} required text field is empty: {field}")]
+    EmptyRequiredText {
+        kind: &'static str,
+        field: &'static str,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NodebbForumImportMapper;
+
+impl NodebbForumImportMapper {
+    pub fn map_batch(
+        &self,
+        batch: &NodebbExportBatch,
+    ) -> Result<ForumImportCandidateBatch, ForumImportMappingError> {
+        ensure_batch_bound(batch)?;
+        ensure_unique_positive_ids(
+            "category",
+            batch.categories.iter().map(|record| record.cid),
+        )?;
+        ensure_unique_positive_ids("topic", batch.topics.iter().map(|record| record.tid))?;
+        ensure_unique_positive_ids("post", batch.posts.iter().map(|record| record.pid))?;
+
+        let topic_main_posts = batch
+            .topics
+            .iter()
+            .map(|topic| {
+                ensure_positive("category", topic.cid)?;
+                let main_pid = positive_optional(topic.main_pid);
+                Ok((topic.tid, main_pid))
+            })
+            .collect::<Result<BTreeMap<_, _>, ForumImportMappingError>>()?;
+
+        let categories = batch
+            .categories
+            .iter()
+            .map(map_category)
+            .collect::<Result<Vec<_>, _>>()?;
+        let topics = batch
+            .topics
+            .iter()
+            .map(map_topic)
+            .collect::<Result<Vec<_>, _>>()?;
+        let posts = batch
+            .posts
+            .iter()
+            .map(|post| map_post(post, &topic_main_posts))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ForumImportCandidateBatch {
+            categories,
+            topics,
+            posts,
+        })
+    }
+}
+
+fn ensure_batch_bound(batch: &NodebbExportBatch) -> Result<(), ForumImportMappingError> {
+    let actual = batch
+        .categories
+        .len()
+        .saturating_add(batch.topics.len())
+        .saturating_add(batch.posts.len());
+    if actual > MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH {
+        return Err(ForumImportMappingError::BatchTooLarge {
+            max: MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn ensure_unique_positive_ids(
+    kind: &'static str,
+    ids: impl IntoIterator<Item = i64>,
+) -> Result<(), ForumImportMappingError> {
+    let mut seen = BTreeSet::new();
+    for id in ids {
+        ensure_positive(kind, id)?;
+        if !seen.insert(id) {
+            return Err(ForumImportMappingError::DuplicateSourceId { kind, id });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_positive(kind: &'static str, id: i64) -> Result<i64, ForumImportMappingError> {
+    if id <= 0 {
+        Err(ForumImportMappingError::InvalidSourceId { kind, id })
+    } else {
+        Ok(id)
+    }
+}
+
+fn required_text(
+    kind: &'static str,
+    field: &'static str,
+    value: &str,
+) -> Result<String, ForumImportMappingError> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(ForumImportMappingError::EmptyRequiredText { kind, field })
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn optional_text(value: Option<&str>) -> Option<String> {
+    value.map(str::trim).filter(|value| !value.is_empty()).map(str::to_owned)
+}
+
+fn positive_optional(value: Option<i64>) -> Option<i64> {
+    value.filter(|value| *value > 0)
+}
+
+fn source_ref(kind: ForumImportEntityKind, id: i64) -> ForumImportExternalRef {
+    let kind_name = match kind {
+        ForumImportEntityKind::Category => "category",
+        ForumImportEntityKind::Topic => "topic",
+        ForumImportEntityKind::Post => "post",
+        ForumImportEntityKind::User => "user",
+    };
+    ForumImportExternalRef {
+        source: FORUM_IMPORT_SOURCE_NODEBB.to_owned(),
+        kind,
+        key: format!("{kind_name}:{id}"),
+    }
+}
+
+fn author_ref(uid: Option<i64>) -> Option<ForumImportExternalRef> {
+    positive_optional(uid).map(|uid| source_ref(ForumImportEntityKind::User, uid))
+}
+
+fn map_category(
+    record: &NodebbCategoryRecord,
+) -> Result<ForumImportCategoryCandidate, ForumImportMappingError> {
+    ensure_positive("category", record.cid)?;
+    Ok(ForumImportCategoryCandidate {
+        source: source_ref(ForumImportEntityKind::Category, record.cid),
+        parent_source: positive_optional(record.parent_cid)
+            .map(|cid| source_ref(ForumImportEntityKind::Category, cid)),
+        name: required_text("category", "name", &record.name)?,
+        description: optional_text(record.description.as_deref()),
+        position: record.order,
+    })
+}
+
+fn map_topic(
+    record: &NodebbTopicRecord,
+) -> Result<ForumImportTopicCandidate, ForumImportMappingError> {
+    ensure_positive("topic", record.tid)?;
+    ensure_positive("category", record.cid)?;
+    Ok(ForumImportTopicCandidate {
+        source: source_ref(ForumImportEntityKind::Topic, record.tid),
+        category_source: source_ref(ForumImportEntityKind::Category, record.cid),
+        author_source: author_ref(record.uid),
+        title: required_text("topic", "title", &record.title)?,
+        slug: optional_text(record.slug.as_deref()),
+        body_post_source: positive_optional(record.main_pid)
+            .map(|pid| source_ref(ForumImportEntityKind::Post, pid)),
+        created_at_ms: record.timestamp.filter(|value| *value >= 0),
+        is_pinned: record.pinned,
+        is_locked: record.locked,
+    })
+}
+
+fn map_post(
+    record: &NodebbPostRecord,
+    topic_main_posts: &BTreeMap<i64, Option<i64>>,
+) -> Result<ForumImportPostCandidate, ForumImportMappingError> {
+    ensure_positive("post", record.pid)?;
+    ensure_positive("topic", record.tid)?;
+    let role = match topic_main_posts.get(&record.tid) {
+        Some(Some(main_pid)) if *main_pid == record.pid => ForumImportPostRole::TopicBody,
+        Some(_) => ForumImportPostRole::Reply,
+        None => ForumImportPostRole::Unresolved,
+    };
+    Ok(ForumImportPostCandidate {
+        source: source_ref(ForumImportEntityKind::Post, record.pid),
+        topic_source: source_ref(ForumImportEntityKind::Topic, record.tid),
+        author_source: author_ref(record.uid),
+        role,
+        body: record.content.clone(),
+        created_at_ms: record.timestamp.filter(|value| *value >= 0),
+        deleted: record.deleted,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_nodebb_ids_as_external_keys_without_rustok_identity() {
+        let batch = NodebbExportBatch {
+            categories: vec![NodebbCategoryRecord {
+                cid: 4,
+                parent_cid: Some(0),
+                name: "General".to_owned(),
+                description: None,
+                order: Some(2),
+            }],
+            topics: vec![NodebbTopicRecord {
+                tid: 9,
+                cid: 4,
+                uid: Some(7),
+                title: "Welcome".to_owned(),
+                slug: Some("welcome".to_owned()),
+                main_pid: Some(11),
+                timestamp: Some(1234),
+                pinned: true,
+                locked: false,
+            }],
+            posts: vec![
+                NodebbPostRecord {
+                    pid: 11,
+                    tid: 9,
+                    uid: Some(7),
+                    content: "Topic body".to_owned(),
+                    timestamp: Some(1234),
+                    deleted: false,
+                },
+                NodebbPostRecord {
+                    pid: 12,
+                    tid: 9,
+                    uid: Some(8),
+                    content: "Reply".to_owned(),
+                    timestamp: Some(1235),
+                    deleted: false,
+                },
+            ],
+        };
+
+        let mapped = NodebbForumImportMapper.map_batch(&batch).unwrap();
+        assert_eq!(mapped.categories[0].source.key, "category:4");
+        assert_eq!(mapped.categories[0].parent_source, None);
+        assert_eq!(mapped.topics[0].source.key, "topic:9");
+        assert_eq!(
+            mapped.topics[0].author_source.as_ref().map(|value| value.key.as_str()),
+            Some("user:7")
+        );
+        assert_eq!(mapped.posts[0].role, ForumImportPostRole::TopicBody);
+        assert_eq!(mapped.posts[1].role, ForumImportPostRole::Reply);
+    }
+
+    #[test]
+    fn post_role_stays_unresolved_when_topic_is_outside_batch() {
+        let batch = NodebbExportBatch {
+            posts: vec![NodebbPostRecord {
+                pid: 12,
+                tid: 9,
+                uid: Some(0),
+                content: "Cross-page post".to_owned(),
+                timestamp: None,
+                deleted: false,
+            }],
+            ..Default::default()
+        };
+
+        let mapped = NodebbForumImportMapper.map_batch(&batch).unwrap();
+        assert_eq!(mapped.posts[0].role, ForumImportPostRole::Unresolved);
+        assert_eq!(mapped.posts[0].author_source, None);
+    }
+
+    #[test]
+    fn rejects_duplicate_or_non_positive_owner_source_ids() {
+        let duplicate = NodebbExportBatch {
+            categories: vec![
+                NodebbCategoryRecord {
+                    cid: 4,
+                    parent_cid: None,
+                    name: "A".to_owned(),
+                    description: None,
+                    order: None,
+                },
+                NodebbCategoryRecord {
+                    cid: 4,
+                    parent_cid: None,
+                    name: "B".to_owned(),
+                    description: None,
+                    order: None,
+                },
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            NodebbForumImportMapper.map_batch(&duplicate),
+            Err(ForumImportMappingError::DuplicateSourceId {
+                kind: "category",
+                id: 4,
+            })
+        );
+
+        let invalid = NodebbExportBatch {
+            topics: vec![NodebbTopicRecord {
+                tid: 0,
+                cid: 4,
+                uid: None,
+                title: "Invalid".to_owned(),
+                slug: None,
+                main_pid: None,
+                timestamp: None,
+                pinned: false,
+                locked: false,
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            NodebbForumImportMapper.map_batch(&invalid),
+            Err(ForumImportMappingError::InvalidSourceId {
+                kind: "topic",
+                id: 0,
+            })
+        );
+    }
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -17,6 +17,7 @@ pub mod dto;
 pub mod entities;
 pub mod error;
 pub mod graphql;
+pub mod import_mapping;
 pub mod locale;
 pub mod mentions;
 pub mod migrations;
@@ -56,6 +57,7 @@ pub use dto::*;
 pub use entities::*;
 pub use error::{ForumError, ForumResult};
 pub use graphql::{ForumMutation, ForumQuery};
+pub use import_mapping::*;
 pub use mentions::*;
 pub use moderation_subject::{
     FORUM_MODERATION_MODULE, ForumModerationSubjectAdapterFactory,

--- a/docs/modules/forum-34-nodebb-mapping-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-nodebb-mapping-actualization-2026-08-09.md
@@ -69,14 +69,14 @@ This is import-candidate validation only. It does not replace the final Forum ow
 
 ## Topic-body versus reply classification
 
-NodeBB topic body identity can depend on `mainPid`. FORUM-34A deliberately avoids cross-page guessing.
+NodeBB topic body identity can depend on `mainPid`. FORUM-34A deliberately avoids cross-page or missing-source guessing.
 
-For a post whose topic is present in the same bounded batch:
+For a post whose topic is present in the same bounded batch **and carries a positive `mainPid`**:
 
 - matching `mainPid` -> `TopicBody`;
-- other post -> `Reply`.
+- another post for that topic -> `Reply`.
 
-If the topic is outside the current batch, the role is `Unresolved`. The mapper does not silently treat that post as a reply. A future shared runner can resolve the topic/main-post relationship using its own bounded source/checkpoint state.
+If the topic is outside the current batch, or the topic has no positive `mainPid`, the role is `Unresolved`. The mapper does not silently treat an ambiguous post as a reply. A future shared runner can resolve the topic/main-post relationship using its own bounded source/checkpoint state.
 
 ## Ownership and safety
 

--- a/docs/modules/forum-34-nodebb-mapping-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-nodebb-mapping-actualization-2026-08-09.md
@@ -1,0 +1,117 @@
+# FORUM-34A NodeBB mapping boundary actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor transition
+
+Fresh `main` before this slice was `bd70dda0ab61aadf41a2f15c59d454962f12b1ac`.
+
+FORUM-33 has no additional truthful source slice on that baseline:
+
+- no persisted Forum-owned attachment relation/source-revision authority exists, so attachment reconciliation remains blocked on FORUM-14;
+- posting-policy evaluation still has no mounted production enforcement call site, so spam-outcome telemetry remains blocked;
+- Moderation still exposes no public application-operation read/status contract suitable for Forum lag/status diagnostics.
+
+The canonical Forum ledger places `FORUM-34` next and describes it as the Forum import/export adapter plus NodeBB mapping over a shared runner.
+
+## Shared-runner recheck
+
+Fresh repository search found no neutral shared import runner/framework contract, no `rustok-import` owner crate, and no generic `ImportRunner` / `ImportAdapter` / `ImportJob` API suitable for Forum composition.
+
+FORUM-34A therefore does **not** create a Forum-only runner, job table, receipt table, scheduler, CLI, transport, migration, database writer or orchestration loop. Those responsibilities stay blocked until the shared runner exists.
+
+Forum can still truthfully own the source-specific mapping/validation boundary required by the canonical ownership rules. This slice starts that boundary only.
+
+## Public mapping contract
+
+`rustok-forum::import_mapping` now exposes a runner-neutral, side-effect-free NodeBB mapping surface:
+
+- `NodebbExportBatch`;
+- `NodebbCategoryRecord`;
+- `NodebbTopicRecord`;
+- `NodebbPostRecord`;
+- `NodebbForumImportMapper`;
+- bounded Forum import candidate DTOs and external references;
+- fixed structural mapping errors.
+
+The mapper accepts at most `MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH = 512` source records across categories, topics and posts.
+
+It performs no database access and does not call Forum owner write services. A future shared runner must decide transaction, receipt, replay, checkpoint and recovery semantics before any candidate reaches owner commands.
+
+## Identity boundary
+
+NodeBB numeric identities are preserved only as external source references:
+
+```text
+nodebb/category:{cid}
+nodebb/topic:{tid}
+nodebb/post:{pid}
+nodebb/user:{uid}
+```
+
+The DTO representation stores `source = "nodebb"`, a fixed entity kind and the external key separately.
+
+The mapper never manufactures RusTok UUIDs. In particular, NodeBB `uid` is not treated as a RusTok user/profile identity. Positive user IDs become external author references; non-positive/guest-style values remain unresolved (`None`). A future shared runner plus the proper identity/Profile owner composition must resolve those references explicitly.
+
+## Structural normalization
+
+The source-specific mapper currently retains the minimum NodeBB facts needed for later Forum owner commands:
+
+- category: `cid`, optional parent, name, description and order;
+- topic: `tid`, category, external author, title, optional slug, optional `mainPid`, timestamp, pinned and locked state;
+- post: `pid`, topic, external author, content, timestamp and deleted state.
+
+Root/non-positive `parentCid` is normalized to no parent. Non-positive optional `uid` / `mainPid` values are treated as absent rather than converted into domain identities. Negative timestamps are not promoted as candidate timestamps.
+
+Required category names and topic titles are trimmed and must remain non-empty. Category/topic/post owner source IDs must be positive and unique within their entity kind for the current batch.
+
+This is import-candidate validation only. It does not replace the final Forum owner validation that must run before persistence.
+
+## Topic-body versus reply classification
+
+NodeBB topic body identity can depend on `mainPid`. FORUM-34A deliberately avoids cross-page guessing.
+
+For a post whose topic is present in the same bounded batch:
+
+- matching `mainPid` -> `TopicBody`;
+- other post -> `Reply`.
+
+If the topic is outside the current batch, the role is `Unresolved`. The mapper does not silently treat that post as a reply. A future shared runner can resolve the topic/main-post relationship using its own bounded source/checkpoint state.
+
+## Ownership and safety
+
+The mapping module imports no SeaORM/database types, `Uuid`, Media storage API, Profiles persistence, Notifications, Search or Moderation storage. It has no create/update/delete operation and no runtime-extension registration.
+
+That keeps FORUM-34A below the orchestration boundary:
+
+1. source-specific mapping and structural validation belong to Forum;
+2. external identity resolution belongs to the relevant shared owner/composition;
+3. generic run/checkpoint/retry/receipt/audit orchestration belongs to the future shared import runner;
+4. final category/topic/reply persistence must enter existing Forum owner commands rather than writing tables directly.
+
+## Remaining FORUM-34 scope
+
+Still open:
+
+- neutral shared import runner contract and host composition;
+- durable runner checkpoint/receipt/replay/audit semantics;
+- explicit external-user resolution policy;
+- candidate-to-existing-Forum-owner command adapter;
+- cross-batch category/topic/post dependency resolution;
+- attachment/media mapping after FORUM-14 provides Forum-owned attachment relations;
+- import reconciliation and dry-run reporting;
+- Forum export adapter;
+- admin/CLI transport only after runner/RBAC/idempotency boundaries exist;
+- runtime, PostgreSQL/SQLite and restart/lost-response evidence.
+
+The canonical implementation plan is intentionally not replaced wholesale through the GitHub contents API because it is large, concurrent and currently carries unrelated roadmap edits. This dated actualization records the FORUM-34A execution cursor without pretending the canonical ledger's `planned` status is already fully reconciled.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo command, Node verifier, formatter, migration, database scenario, CLI, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-nodebb-import-mapping-source.mjs
+```

--- a/scripts/verify/verify-forum-nodebb-import-mapping-source.mjs
+++ b/scripts/verify/verify-forum-nodebb-import-mapping-source.mjs
@@ -43,7 +43,9 @@ for (const marker of [
   "author_ref(record.uid)",
   "positive_optional(record.main_pid)",
   "topic_main_posts.get(&record.tid)",
-  "ForumImportPostRole::Unresolved",
+  "Some(Some(_)) => ForumImportPostRole::Reply",
+  "Some(None) | None => ForumImportPostRole::Unresolved",
+  "post_role_stays_unresolved_when_topic_has_no_main_post",
 ]) {
   requireText(mapping, marker, `${mappingPath}: missing ${marker}`);
 }
@@ -125,6 +127,7 @@ for (const marker of [
   "does **not** create a Forum-only runner",
   "NodeBB numeric identities are preserved only as external source references",
   "never manufactures RusTok UUIDs",
+  "or the topic has no positive `mainPid`",
   "role is `Unresolved`",
   "final Forum owner validation",
   "Forum export adapter",

--- a/scripts/verify/verify-forum-nodebb-import-mapping-source.mjs
+++ b/scripts/verify/verify-forum-nodebb-import-mapping-source.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const mappingPath = "crates/rustok-forum/src/import_mapping.rs";
+const libPath = "crates/rustok-forum/src/lib.rs";
+const packetPath = "docs/modules/forum-34-nodebb-mapping-actualization-2026-08-09.md";
+
+const mapping = read(mappingPath);
+const lib = read(libPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  'pub const FORUM_IMPORT_SOURCE_NODEBB: &str = "nodebb";',
+  "pub const MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH: usize = 512;",
+  "pub struct NodebbExportBatch",
+  "pub struct NodebbCategoryRecord",
+  "pub struct NodebbTopicRecord",
+  "pub struct NodebbPostRecord",
+  "pub struct ForumImportExternalRef",
+  "pub enum ForumImportPostRole",
+  "TopicBody",
+  "Reply",
+  "Unresolved",
+  "pub struct NodebbForumImportMapper;",
+  "pub fn map_batch(",
+  "ensure_batch_bound(batch)?;",
+  "ensure_unique_positive_ids(",
+  'key: format!("{kind_name}:{id}"),',
+  "positive_optional(record.parent_cid)",
+  "author_ref(record.uid)",
+  "positive_optional(record.main_pid)",
+  "topic_main_posts.get(&record.tid)",
+  "ForumImportPostRole::Unresolved",
+]) {
+  requireText(mapping, marker, `${mappingPath}: missing ${marker}`);
+}
+
+for (const marker of [
+  "pub mod import_mapping;",
+  "pub use import_mapping::*;",
+]) {
+  requireText(lib, marker, `${libPath}: missing public mapping export ${marker}`);
+}
+
+for (const forbidden of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "Entity::",
+  "ActiveModel",
+  "Uuid",
+  "rustok_media",
+  "rustok_profiles",
+  "rustok_notifications",
+  "rustok_search",
+  "rustok_moderation",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE ",
+  ".insert(",
+  ".update(",
+  ".delete(",
+  "register_runtime_extensions",
+]) {
+  requireAbsent(
+    mapping,
+    forbidden,
+    `${mappingPath}: runner-neutral mapping must not contain ${forbidden}`,
+  );
+}
+
+for (const forbiddenIdentity of [
+  "Uuid::new",
+  "Uuid::parse",
+  "user_id: Uuid",
+  "tenant_id: Uuid",
+  "category_id: Uuid",
+  "topic_id: Uuid",
+  "reply_id: Uuid",
+]) {
+  requireAbsent(
+    mapping,
+    forbiddenIdentity,
+    `${mappingPath}: external NodeBB ids must not become RusTok identities: ${forbiddenIdentity}`,
+  );
+}
+
+const mapperStart = mapping.indexOf("impl NodebbForumImportMapper");
+const testsStart = mapping.indexOf("#[cfg(test)]", mapperStart);
+if (mapperStart < 0 || testsStart <= mapperStart) {
+  throw new Error(`${mappingPath}: mapper source boundary is invalid`);
+}
+const mapper = mapping.slice(mapperStart, testsStart);
+for (const forbidden of [
+  "async fn",
+  ".await",
+  "Transaction",
+  "Service::new",
+  "PortContext",
+  "receipt",
+  "checkpoint",
+  "scheduler",
+]) {
+  requireAbsent(mapper, forbidden, `${mappingPath}: mapper must stay side-effect free: ${forbidden}`);
+}
+
+for (const marker of [
+  "FORUM-34A",
+  "shared-runner-blocked",
+  "FORUM-33 has no additional truthful source slice",
+  "no neutral shared import runner/framework contract",
+  "does **not** create a Forum-only runner",
+  "NodeBB numeric identities are preserved only as external source references",
+  "never manufactures RusTok UUIDs",
+  "role is `Unresolved`",
+  "final Forum owner validation",
+  "Forum export adapter",
+  "no tests, Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-34A NodeBB import mapping source: ok");


### PR DESCRIPTION
## Summary

Start FORUM-34 with the source-specific mapping/validation boundary that Forum can own before a neutral shared import runner exists.

- add bounded `NodebbExportBatch` category/topic/post source records;
- map NodeBB numeric identities only to external source references, never RusTok UUIDs;
- keep external author identity unresolved for future shared-runner/Profile-owner composition;
- preserve a positive topic `mainPid` as the body-post source reference;
- classify a post as topic body/reply only when its topic and a positive `mainPid` are present in the same bounded batch; otherwise leave the role unresolved;
- reject non-positive owner source IDs, duplicate same-kind IDs, empty category names/topic titles, and batches above 512 records;
- expose the runner-neutral mapping API from `rustok-forum`;
- add FORUM-34A actualization and a focused source guard.

## Ownership / limits

Fresh source search found no neutral shared import runner/framework contract. This PR deliberately adds no Forum-only runner, job/checkpoint/receipt/audit storage, migration, scheduler, CLI, admin transport, direct DB writer, Media lifecycle or user/profile identity ownership. Future persistence must enter existing Forum owner commands through a shared runner.

FORUM-33 remains blocked on FORUM-14 attachment authority, mounted posting-policy enforcement and a public Moderation application-operation read/status contract, so no synthetic FORUM-33 metric is added.

## Validation

Per maintainer instruction, no tests, Cargo command, Node verifier, formatter, migration, DB scenario, CLI, workflow, CI, lock generation or `git diff --check` was run. Maintainer will run tests.