### PR TITLE
feat(forum): inspect NodeBB import dependencies

### DIFF
--- a/crates/rustok-forum/src/import_inspection.rs
+++ b/crates/rustok-forum/src/import_inspection.rs
@@ -76,17 +76,17 @@ impl NodebbForumImportInspector {
         let mut unresolved_dependencies = Vec::new();
 
         for (record, candidate) in batch.categories.iter().zip(&candidates.categories) {
-            if let (Some(parent_id), Some(parent_source)) = (
-                record.parent_cid.filter(|value| *value > 0),
-                candidate.parent_source.as_ref(),
-            ) && !category_ids.contains(&parent_id)
-            {
-                unresolved_dependencies.push(ForumImportDependencyIssue {
-                    owner: candidate.source.clone(),
-                    relation: ForumImportDependencyRelation::CategoryParent,
-                    target: parent_source.clone(),
-                    disposition: ForumImportDependencyDisposition::MissingBatchRecord,
-                });
+            if let Some(parent_id) = record.parent_cid.filter(|value| *value > 0) {
+                if !category_ids.contains(&parent_id) {
+                    if let Some(parent_source) = candidate.parent_source.as_ref() {
+                        unresolved_dependencies.push(ForumImportDependencyIssue {
+                            owner: candidate.source.clone(),
+                            relation: ForumImportDependencyRelation::CategoryParent,
+                            target: parent_source.clone(),
+                            disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                        });
+                    }
+                }
             }
         }
 
@@ -100,26 +100,25 @@ impl NodebbForumImportInspector {
                 });
             }
 
-            if let (Some(main_pid), Some(main_post_source)) = (
-                record.main_pid.filter(|value| *value > 0),
-                candidate.body_post_source.as_ref(),
-            ) {
-                match post_topics.get(&main_pid) {
-                    None => unresolved_dependencies.push(ForumImportDependencyIssue {
-                        owner: candidate.source.clone(),
-                        relation: ForumImportDependencyRelation::TopicMainPost,
-                        target: main_post_source.clone(),
-                        disposition: ForumImportDependencyDisposition::MissingBatchRecord,
-                    }),
-                    Some(post_topic_id) if *post_topic_id != record.tid => {
-                        unresolved_dependencies.push(ForumImportDependencyIssue {
+            if let Some(main_pid) = record.main_pid.filter(|value| *value > 0) {
+                if let Some(main_post_source) = candidate.body_post_source.as_ref() {
+                    match post_topics.get(&main_pid) {
+                        None => unresolved_dependencies.push(ForumImportDependencyIssue {
                             owner: candidate.source.clone(),
                             relation: ForumImportDependencyRelation::TopicMainPost,
                             target: main_post_source.clone(),
-                            disposition: ForumImportDependencyDisposition::MismatchedBatchRecord,
-                        });
+                            disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                        }),
+                        Some(post_topic_id) if *post_topic_id != record.tid => {
+                            unresolved_dependencies.push(ForumImportDependencyIssue {
+                                owner: candidate.source.clone(),
+                                relation: ForumImportDependencyRelation::TopicMainPost,
+                                target: main_post_source.clone(),
+                                disposition: ForumImportDependencyDisposition::MismatchedBatchRecord,
+                            });
+                        }
+                        Some(_) => {}
                     }
-                    Some(_) => {}
                 }
             }
 
@@ -225,7 +224,7 @@ mod tests {
 
         let inspected = NodebbForumImportInspector.inspect_batch(&batch).unwrap();
         let issues = &inspected.unresolved_dependencies;
-        assert_eq!(issues.len(), 6);
+        assert_eq!(issues.len(), 7);
         assert_eq!(issues[0].relation, ForumImportDependencyRelation::CategoryParent);
         assert_eq!(issues[0].disposition, ForumImportDependencyDisposition::MissingBatchRecord);
         assert_eq!(issues[1].relation, ForumImportDependencyRelation::TopicCategory);
@@ -236,6 +235,8 @@ mod tests {
         assert_eq!(issues[4].relation, ForumImportDependencyRelation::TopicMainPost);
         assert_eq!(issues[4].disposition, ForumImportDependencyDisposition::MismatchedBatchRecord);
         assert_eq!(issues[5].relation, ForumImportDependencyRelation::PostTopic);
+        assert_eq!(issues[6].relation, ForumImportDependencyRelation::AuthorUser);
+        assert_eq!(issues[6].target.key, "user:8");
     }
 
     #[test]

--- a/crates/rustok-forum/src/import_inspection.rs
+++ b/crates/rustok-forum/src/import_inspection.rs
@@ -1,0 +1,276 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::import_mapping::{
+    ForumImportCandidateBatch, ForumImportExternalRef, ForumImportMappingError, NodebbExportBatch,
+    NodebbForumImportMapper, MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH,
+};
+
+pub const MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH: usize =
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH * 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumImportDependencyRelation {
+    CategoryParent,
+    TopicCategory,
+    TopicMainPost,
+    PostTopic,
+    AuthorUser,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumImportDependencyDisposition {
+    MissingBatchRecord,
+    MismatchedBatchRecord,
+    ExternalOwnerResolution,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ForumImportDependencyIssue {
+    pub owner: ForumImportExternalRef,
+    pub relation: ForumImportDependencyRelation,
+    pub target: ForumImportExternalRef,
+    pub disposition: ForumImportDependencyDisposition,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodebbForumImportInspection {
+    pub candidates: ForumImportCandidateBatch,
+    pub unresolved_dependencies: Vec<ForumImportDependencyIssue>,
+}
+
+impl NodebbForumImportInspection {
+    pub fn is_dependency_complete(&self) -> bool {
+        self.unresolved_dependencies.is_empty()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NodebbForumImportInspector;
+
+impl NodebbForumImportInspector {
+    pub fn inspect_batch(
+        &self,
+        batch: &NodebbExportBatch,
+    ) -> Result<NodebbForumImportInspection, ForumImportMappingError> {
+        let candidates = NodebbForumImportMapper.map_batch(batch)?;
+        let category_ids = batch
+            .categories
+            .iter()
+            .map(|record| record.cid)
+            .collect::<BTreeSet<_>>();
+        let topic_ids = batch
+            .topics
+            .iter()
+            .map(|record| record.tid)
+            .collect::<BTreeSet<_>>();
+        let post_topics = batch
+            .posts
+            .iter()
+            .map(|record| (record.pid, record.tid))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut unresolved_dependencies = Vec::new();
+
+        for (record, candidate) in batch.categories.iter().zip(&candidates.categories) {
+            if let (Some(parent_id), Some(parent_source)) = (
+                record.parent_cid.filter(|value| *value > 0),
+                candidate.parent_source.as_ref(),
+            ) && !category_ids.contains(&parent_id)
+            {
+                unresolved_dependencies.push(ForumImportDependencyIssue {
+                    owner: candidate.source.clone(),
+                    relation: ForumImportDependencyRelation::CategoryParent,
+                    target: parent_source.clone(),
+                    disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                });
+            }
+        }
+
+        for (record, candidate) in batch.topics.iter().zip(&candidates.topics) {
+            if !category_ids.contains(&record.cid) {
+                unresolved_dependencies.push(ForumImportDependencyIssue {
+                    owner: candidate.source.clone(),
+                    relation: ForumImportDependencyRelation::TopicCategory,
+                    target: candidate.category_source.clone(),
+                    disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                });
+            }
+
+            if let (Some(main_pid), Some(main_post_source)) = (
+                record.main_pid.filter(|value| *value > 0),
+                candidate.body_post_source.as_ref(),
+            ) {
+                match post_topics.get(&main_pid) {
+                    None => unresolved_dependencies.push(ForumImportDependencyIssue {
+                        owner: candidate.source.clone(),
+                        relation: ForumImportDependencyRelation::TopicMainPost,
+                        target: main_post_source.clone(),
+                        disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                    }),
+                    Some(post_topic_id) if *post_topic_id != record.tid => {
+                        unresolved_dependencies.push(ForumImportDependencyIssue {
+                            owner: candidate.source.clone(),
+                            relation: ForumImportDependencyRelation::TopicMainPost,
+                            target: main_post_source.clone(),
+                            disposition: ForumImportDependencyDisposition::MismatchedBatchRecord,
+                        });
+                    }
+                    Some(_) => {}
+                }
+            }
+
+            if let Some(author_source) = candidate.author_source.as_ref() {
+                unresolved_dependencies.push(ForumImportDependencyIssue {
+                    owner: candidate.source.clone(),
+                    relation: ForumImportDependencyRelation::AuthorUser,
+                    target: author_source.clone(),
+                    disposition: ForumImportDependencyDisposition::ExternalOwnerResolution,
+                });
+            }
+        }
+
+        for (record, candidate) in batch.posts.iter().zip(&candidates.posts) {
+            if !topic_ids.contains(&record.tid) {
+                unresolved_dependencies.push(ForumImportDependencyIssue {
+                    owner: candidate.source.clone(),
+                    relation: ForumImportDependencyRelation::PostTopic,
+                    target: candidate.topic_source.clone(),
+                    disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                });
+            }
+
+            if let Some(author_source) = candidate.author_source.as_ref() {
+                unresolved_dependencies.push(ForumImportDependencyIssue {
+                    owner: candidate.source.clone(),
+                    relation: ForumImportDependencyRelation::AuthorUser,
+                    target: author_source.clone(),
+                    disposition: ForumImportDependencyDisposition::ExternalOwnerResolution,
+                });
+            }
+        }
+
+        debug_assert!(
+            unresolved_dependencies.len() <= MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH
+        );
+
+        Ok(NodebbForumImportInspection {
+            candidates,
+            unresolved_dependencies,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import_mapping::{NodebbCategoryRecord, NodebbPostRecord, NodebbTopicRecord};
+
+    #[test]
+    fn reports_missing_mismatched_and_external_dependencies_in_source_order() {
+        let batch = NodebbExportBatch {
+            categories: vec![NodebbCategoryRecord {
+                cid: 2,
+                parent_cid: Some(99),
+                name: "Child".to_owned(),
+                description: None,
+                order: None,
+            }],
+            topics: vec![
+                NodebbTopicRecord {
+                    tid: 10,
+                    cid: 77,
+                    uid: Some(7),
+                    title: "Missing category".to_owned(),
+                    slug: None,
+                    main_pid: Some(101),
+                    timestamp: None,
+                    pinned: false,
+                    locked: false,
+                },
+                NodebbTopicRecord {
+                    tid: 11,
+                    cid: 2,
+                    uid: None,
+                    title: "Mismatched body".to_owned(),
+                    slug: None,
+                    main_pid: Some(102),
+                    timestamp: None,
+                    pinned: false,
+                    locked: false,
+                },
+            ],
+            posts: vec![
+                NodebbPostRecord {
+                    pid: 102,
+                    tid: 10,
+                    uid: None,
+                    content: "Belongs to another topic".to_owned(),
+                    timestamp: None,
+                    deleted: false,
+                },
+                NodebbPostRecord {
+                    pid: 103,
+                    tid: 88,
+                    uid: Some(8),
+                    content: "Missing topic".to_owned(),
+                    timestamp: None,
+                    deleted: false,
+                },
+            ],
+        };
+
+        let inspected = NodebbForumImportInspector.inspect_batch(&batch).unwrap();
+        let issues = &inspected.unresolved_dependencies;
+        assert_eq!(issues.len(), 6);
+        assert_eq!(issues[0].relation, ForumImportDependencyRelation::CategoryParent);
+        assert_eq!(issues[0].disposition, ForumImportDependencyDisposition::MissingBatchRecord);
+        assert_eq!(issues[1].relation, ForumImportDependencyRelation::TopicCategory);
+        assert_eq!(issues[2].relation, ForumImportDependencyRelation::TopicMainPost);
+        assert_eq!(issues[2].target.key, "post:101");
+        assert_eq!(issues[3].relation, ForumImportDependencyRelation::AuthorUser);
+        assert_eq!(issues[3].disposition, ForumImportDependencyDisposition::ExternalOwnerResolution);
+        assert_eq!(issues[4].relation, ForumImportDependencyRelation::TopicMainPost);
+        assert_eq!(issues[4].disposition, ForumImportDependencyDisposition::MismatchedBatchRecord);
+        assert_eq!(issues[5].relation, ForumImportDependencyRelation::PostTopic);
+    }
+
+    #[test]
+    fn complete_in_batch_relations_need_no_dependency_guessing() {
+        let batch = NodebbExportBatch {
+            categories: vec![NodebbCategoryRecord {
+                cid: 2,
+                parent_cid: None,
+                name: "General".to_owned(),
+                description: None,
+                order: None,
+            }],
+            topics: vec![NodebbTopicRecord {
+                tid: 10,
+                cid: 2,
+                uid: None,
+                title: "Topic".to_owned(),
+                slug: None,
+                main_pid: Some(101),
+                timestamp: None,
+                pinned: false,
+                locked: false,
+            }],
+            posts: vec![NodebbPostRecord {
+                pid: 101,
+                tid: 10,
+                uid: None,
+                content: "Body".to_owned(),
+                timestamp: None,
+                deleted: false,
+            }],
+        };
+
+        let inspected = NodebbForumImportInspector.inspect_batch(&batch).unwrap();
+        assert!(inspected.is_dependency_complete());
+        assert_eq!(inspected.candidates.posts.len(), 1);
+    }
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -17,6 +17,7 @@ pub mod dto;
 pub mod entities;
 pub mod error;
 pub mod graphql;
+pub mod import_inspection;
 pub mod import_mapping;
 pub mod locale;
 pub mod mentions;
@@ -57,6 +58,7 @@ pub use dto::*;
 pub use entities::*;
 pub use error::{ForumError, ForumResult};
 pub use graphql::{ForumMutation, ForumQuery};
+pub use import_inspection::*;
 pub use import_mapping::*;
 pub use mentions::*;
 pub use moderation_subject::{

--- a/docs/modules/forum-34-nodebb-dependency-inspection-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-nodebb-dependency-inspection-actualization-2026-08-09.md
@@ -1,0 +1,110 @@
+# FORUM-34B NodeBB dependency inspection actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor
+
+FORUM-34A introduced the bounded runner-neutral NodeBB category/topic/post mapper and external source-reference contract.
+
+Fresh `main` before this slice was `84911afda2c54321a6e30da616b4bb3eea6edb74`. A fresh repository search still finds no neutral shared import runner/framework, `rustok-import` owner crate, generic `ImportRunner`, `ImportAdapter`, `ImportJob`, checkpoint or receipt API suitable for Forum composition.
+
+The historical FORUM-34 scope requires imports to be dry-runnable, resumable, cursor-based, idempotent and bounded. FORUM-34B advances only the dry-run mapping boundary that Forum can truthfully own before shared orchestration exists.
+
+## Public inspection contract
+
+`rustok-forum::import_inspection` adds a side-effect-free `NodebbForumImportInspector` over the existing `NodebbForumImportMapper`.
+
+`inspect_batch` first runs the FORUM-34A structural mapper. Invalid or oversized source batches therefore retain the same mapping errors and never receive dependency diagnostics that could mask a structural failure.
+
+For a structurally valid batch it returns:
+
+- the exact mapped `ForumImportCandidateBatch`;
+- a deterministic `unresolved_dependencies` list in category, topic and post source order.
+
+The inspector does not change candidate data and does not resolve anything by querying the database or another owner.
+
+## Dependency relations
+
+The fixed relation vocabulary is:
+
+- `category_parent` — a positive category parent reference;
+- `topic_category` — the category required by a topic;
+- `topic_main_post` — the positive NodeBB `mainPid` selected as the topic body;
+- `post_topic` — the topic required by a post;
+- `author_user` — an external NodeBB author identity requiring shared identity/Profile-owner composition.
+
+The fixed dispositions are:
+
+- `missing_batch_record` — the referenced category/topic/post is not present in this bounded source batch;
+- `mismatched_batch_record` — currently used when a referenced `mainPid` exists in the batch but belongs to another topic;
+- `external_owner_resolution` — a positive NodeBB user reference that Forum must not convert into a RusTok user/profile identity itself.
+
+No arbitrary error string, DB result or provider state is encoded into the relation/disposition vocabulary.
+
+## Fail-closed semantics
+
+FORUM-34B deliberately does not treat a missing reference as proof that the source object does not exist globally. The shared runner may later satisfy a `missing_batch_record` from an earlier/later cursor page or durable source-reference map.
+
+Likewise, positive NodeBB `uid` values remain unresolved external references. Forum neither invents UUIDs nor reads Profiles/auth persistence to match them.
+
+A `topic_main_post` mismatch is explicit rather than silently accepting a post from another topic as the body source.
+
+`NodebbForumImportInspection::is_dependency_complete()` is true only when this inspection found no batch dependency or external-owner dependency. It is not a persistence-admission decision: final Forum owner validation, identity resolution, idempotency, RBAC and runner receipts remain separate gates.
+
+## Bounds
+
+The FORUM-34A source batch remains capped at `MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH = 512` records.
+
+Each source record can emit at most three dependency issues, so FORUM-34B exposes the deterministic upper bound:
+
+```text
+MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH = 1536
+```
+
+The inspector uses only bounded `BTreeSet` / `BTreeMap` indexes over the current batch. It never loads another page or complete export into memory.
+
+## Ownership boundary
+
+The inspection module imports no SeaORM/database type, `Uuid`, Media lifecycle API, Profiles persistence, Notifications, Search or Moderation storage. It has no async call, transaction, create/update/delete operation, runtime extension, scheduler or transport.
+
+FORUM-34B does not add:
+
+- a Forum-only import runner;
+- checkpoint, receipt, replay or audit persistence;
+- a migration;
+- CLI/admin transport;
+- cross-batch lookup;
+- identity/profile matching;
+- candidate persistence;
+- search rebuild execution;
+- attachment/media import mapping.
+
+Those remain blocked on their proper shared runner or owner contracts.
+
+## Remaining FORUM-34 scope
+
+Still open after FORUM-34B:
+
+- neutral shared runner contract and host composition;
+- durable cursor/checkpoint/receipt/replay/audit semantics;
+- explicit external-user resolution through the proper shared owner boundary;
+- cross-batch dependency resolution using runner-owned state;
+- candidate-to-existing Forum owner command adapter;
+- attachment/media mapping after FORUM-14 provides Forum-owned relations;
+- Forum export adapter over stable bounded owner reads;
+- dry-run report composition at runner/job level;
+- reconciliation/search rebuild orchestration;
+- CLI/admin transport only after RBAC/idempotency/audit admission exists;
+- retained SQLite/PostgreSQL/restart/lost-response evidence.
+
+The large canonical implementation plan is not replaced wholesale through the GitHub contents API; this dated packet records the execution cursor without overwriting unrelated concurrent roadmap edits.
+
+## Maintainer validation
+
+Per maintainer instruction, no test, Cargo command, Node verifier, formatter, migration, DB scenario, CLI, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-nodebb-import-dependency-inspection-source.mjs
+```

--- a/scripts/verify/verify-forum-nodebb-import-dependency-inspection-source.mjs
+++ b/scripts/verify/verify-forum-nodebb-import-dependency-inspection-source.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const inspectionPath = "crates/rustok-forum/src/import_inspection.rs";
+const libPath = "crates/rustok-forum/src/lib.rs";
+const packetPath =
+  "docs/modules/forum-34-nodebb-dependency-inspection-actualization-2026-08-09.md";
+
+const inspection = read(inspectionPath);
+const lib = read(libPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "pub const MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH: usize =",
+  "MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH * 3;",
+  "pub enum ForumImportDependencyRelation",
+  "CategoryParent",
+  "TopicCategory",
+  "TopicMainPost",
+  "PostTopic",
+  "AuthorUser",
+  "pub enum ForumImportDependencyDisposition",
+  "MissingBatchRecord",
+  "MismatchedBatchRecord",
+  "ExternalOwnerResolution",
+  "pub struct ForumImportDependencyIssue",
+  "pub struct NodebbForumImportInspection",
+  "pub struct NodebbForumImportInspector;",
+  "pub fn inspect_batch(",
+  "let candidates = NodebbForumImportMapper.map_batch(batch)?;",
+  ".collect::<BTreeSet<_>>();",
+  ".collect::<BTreeMap<_, _>>();",
+  "record.parent_cid.filter(|value| *value > 0)",
+  "!category_ids.contains(&record.cid)",
+  "post_topics.get(&main_pid)",
+  "*post_topic_id != record.tid",
+  "!topic_ids.contains(&record.tid)",
+  "candidate.author_source.as_ref()",
+  "unresolved_dependencies.len() <= MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH",
+]) {
+  requireText(inspection, marker, `${inspectionPath}: missing ${marker}`);
+}
+
+for (const marker of [
+  "pub mod import_inspection;",
+  "pub use import_inspection::*;",
+  "pub mod import_mapping;",
+  "pub use import_mapping::*;",
+]) {
+  requireText(lib, marker, `${libPath}: missing public import contract ${marker}`);
+}
+
+for (const forbidden of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "Entity::",
+  "ActiveModel",
+  "Uuid",
+  "rustok_media",
+  "rustok_profiles",
+  "rustok_notifications",
+  "rustok_search",
+  "rustok_moderation",
+  "async fn",
+  ".await",
+  "PortContext",
+  "Service::new",
+  "register_runtime_extensions",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE ",
+  ".insert(",
+  ".update(",
+  ".delete(",
+]) {
+  requireAbsent(
+    inspection,
+    forbidden,
+    `${inspectionPath}: dependency inspection must remain side-effect free: ${forbidden}`,
+  );
+}
+
+for (const forbiddenIdentity of [
+  "Uuid::new",
+  "Uuid::parse",
+  "user_id: Uuid",
+  "tenant_id: Uuid",
+  "category_id: Uuid",
+  "topic_id: Uuid",
+  "reply_id: Uuid",
+]) {
+  requireAbsent(
+    inspection,
+    forbiddenIdentity,
+    `${inspectionPath}: dependency inspection must not manufacture owner identity: ${forbiddenIdentity}`,
+  );
+}
+
+for (const marker of [
+  "FORUM-34B",
+  "shared-runner-blocked",
+  "no neutral shared import runner/framework",
+  "dry-runnable, resumable, cursor-based, idempotent and bounded",
+  "missing_batch_record",
+  "mismatched_batch_record",
+  "external_owner_resolution",
+  "does not treat a missing reference as proof",
+  "is not a persistence-admission decision",
+  "MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH = 1536",
+  "Forum export adapter over stable bounded owner reads",
+  "no test, Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-34B NodeBB import dependency inspection source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 after #3379 with a bounded, runner-neutral dependency inspection layer over the existing NodeBB mapper.

- run the existing structural mapper first and preserve its exact errors/candidates;
- report deterministic unresolved category-parent, topic-category, topic-main-post and post-topic dependencies for the current bounded batch;
- report positive NodeBB author IDs as explicit external-owner resolution dependencies instead of inventing RusTok user/profile identities;
- distinguish `missing_batch_record`, `mismatched_batch_record` and `external_owner_resolution`;
- flag a `mainPid` that exists in the batch but belongs to another topic;
- cap possible dependency issues at 1536 for the existing 512-record source batch;
- expose the inspection API from `rustok-forum`;
- add FORUM-34B actualization and a focused source guard.

## Ownership / limits

Fresh source search still finds no neutral shared import runner/framework. This PR adds no Forum-only runner, checkpoint/receipt/audit persistence, DB lookup/write, migration, scheduler, CLI/admin transport, identity/profile matching, cross-batch lookup, Media lifecycle or Search rebuild execution. Missing batch references remain unresolved because a future shared runner may satisfy them from another cursor page or durable source-reference map.

`is_dependency_complete()` is only a mapping/dependency observation and is not persistence admission; final owner validation, RBAC, idempotency and runner receipts remain separate gates.

## Validation

Per maintainer instruction, no tests, Cargo command, Node verifier, formatter, migration, DB scenario, CLI, workflow, CI, lock generation or `git diff --check` was run. Maintainer will run tests.