### PR TITLE
fix(blog): make tag mutations atomic with reindex

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
@@ -9,8 +9,8 @@
   "canonical_current_cursor": "crates/rustok-blog/docs/implementation-plan-current.md",
   "actualization_slice": "crates/rustok-blog/docs/implementation-plan-slice-101.md",
   "historical_baseline_last_embedded_slice": 67,
-  "latest_behavior_slice": 103,
-  "current_recorded_slice": 103,
+  "latest_behavior_slice": 104,
+  "current_recorded_slice": 104,
   "source_tracks": {
     "remote_comments_transport": {
       "status": "source_implemented_maintainer_execution_pending",
@@ -61,17 +61,21 @@
       "must_not_reopen_as_source_gap": true
     },
     "tag_mutation_atomic_reindex": {
-      "status": "next_source_gap",
+      "status": "source_ready_maintainer_execution_pending",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-104.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json",
       "canonical_source_defined": true,
-      "taxonomy_supplied_transaction_api_required": true,
-      "blog_scope_reindex_same_transaction_required": true,
-      "manual_predelete_relation_cleanup_must_be_removed": true
+      "taxonomy_owner_transaction_api_present": true,
+      "blog_scope_reindex_same_transaction": true,
+      "manual_predelete_relation_cleanup_removed": true,
+      "declared_fk_cascade_used": true,
+      "must_not_reopen_as_source_gap": true
     }
   },
   "planning_result": {
-    "independent_production_source_gap_identified": true,
-    "next_source_gap": "tag_mutation_atomic_reindex",
-    "future_autonomous_source_work_requires_fresh_audit": false,
+    "independent_production_source_gap_identified": false,
+    "next_source_gap": null,
+    "future_autonomous_source_work_requires_fresh_audit": true,
     "historical_stale_phrases_are_live_instructions": false,
     "production_behavior_changed_since_slice_101": true,
     "ffa_or_fba_promoted": false
@@ -83,9 +87,10 @@
     "no_compile_result",
     "no_database_side_tag_pagination_result",
     "no_postgresql_result",
+    "no_sqlite_tag_mutation_result",
     "no_legacy_data_audit_result",
     "no_legacy_backfill_result",
-    "no_tag_mutation_atomic_reindex_result",
+    "no_tag_mutation_atomic_reindex_runtime_result",
     "no_redis_result",
     "no_tcp_runtime_result",
     "no_browser_result",

--- a/crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "tag_mutation_atomic_reindex",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "ownership": {
+    "dictionary_owner": "rustok-taxonomy",
+    "attachment_owner": "rustok-blog",
+    "search_projection_owner": "rustok-search",
+    "module_scope": "blog",
+    "term_kind": "tag"
+  },
+  "production_contract": {
+    "taxonomy_module_mutation_api": "crates/rustok-taxonomy/src/module_term_mutation.rs",
+    "taxonomy_export": "crates/rustok-taxonomy/src/lib.rs",
+    "blog_tag_service": "crates/rustok-blog/src/services/tag.rs",
+    "blog_tag_relation_migration": "crates/rustok-blog/src/migrations/m20260328_000002_create_blog_taxonomy_tables.rs",
+    "canonical_outbox_api": "rustok_outbox::TransactionalEventBus::publish_root_in_tx",
+    "update_uses_supplied_transaction": true,
+    "delete_uses_supplied_transaction": true,
+    "taxonomy_update_permission_preserved": true,
+    "taxonomy_read_permission_preserved_for_update_response": true,
+    "taxonomy_delete_permission_preserved": true,
+    "module_scope_rechecked_by_taxonomy_owner": true,
+    "term_kind_rechecked_by_taxonomy_owner": true,
+    "translation_revision_cas_preserved": true,
+    "term_revision_cas_preserved": true,
+    "translation_change_evidence_same_transaction": true,
+    "blog_reindex_same_transaction": true,
+    "blog_reindex_target_type": "blog",
+    "blog_reindex_target_id": null,
+    "manual_predelete_relation_cleanup_removed": true,
+    "relation_cleanup_uses_declared_fk_cascade": true,
+    "tag_service_constructor_changed": false,
+    "database_schema_changed": false,
+    "search_projection_source_changed": false,
+    "production_behavior_changed": true,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "source_harness": {
+    "path": "crates/rustok-blog/tests/taxonomy_tags.rs",
+    "status": "executable_no_run",
+    "runtime_status": "not_run",
+    "cases": [
+      "tag_update_commits_dictionary_change_and_blog_reindex_together",
+      "tag_update_rolls_back_when_blog_reindex_outbox_write_fails",
+      "tag_delete_relies_on_taxonomy_fk_cascade_and_retains_reindex"
+    ]
+  },
+  "execution_requirements": [
+    "execute the Blog taxonomy tag harness with the canonical sys_events migration",
+    "confirm one durable Blog-scope ReindexRequested commits with a successful tag update",
+    "confirm forced canonical outbox failure rolls back the Taxonomy translation and term revisions",
+    "confirm tag delete removes blog_post_tags only through the declared taxonomy_terms FK cascade",
+    "execute Search Blog projection evidence after update/delete and confirm renamed/deleted tags are reflected"
+  ],
+  "planning_result": {
+    "tag_mutation_source_complete": true,
+    "additional_tag_mutation_scaffolding_required": false,
+    "next_autonomous_source_work_requires_fresh_audit": true
+  },
+  "execution": [],
+  "explicit_non_claims": [
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_compile_result",
+    "no_sqlite_result",
+    "no_postgresql_result",
+    "no_search_runtime_result",
+    "no_outbox_runtime_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -1,22 +1,23 @@
 # rustok-blog canonical implementation cursor
 
-Status: `canonical_source_cursor_actualized_through_slice_103`.
+Status: `canonical_source_cursor_actualized_through_slice_104`.
 
 This document is the canonical **current** source cursor for `rustok-blog`.
 `crates/rustok-blog/docs/implementation-plan.md` remains the long historical baseline and embedded implementation log, but its inline `Current state`, completed-slice list, and `Next results` stop before the later continuation series and must not be used as the live cursor without this file.
 
-The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 103 is the latest production/source behavior slice.
+The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 104 is the latest production/source behavior slice.
 
 ## Re-audit basis
 
-The source continuation through slice 103 retains the following planning corrections and independent Blog source results:
+The source continuation through slice 104 retains the following planning corrections and independent Blog source results:
 
 - the remote Comments transport is no longer an unimplemented source item;
 - the cached public Comments snapshot is no longer merely planned;
 - the storefront comment-form fallback is not an implementation target because the active storefront has no public Comments write surface;
 - Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution;
 - Blog tag list pagination is owner-bounded and overflow-safe;
-- Blog tag reads and Search projection now use `blog_post_tags + rustok-taxonomy` as the canonical source rather than `blog_posts.metadata.tags`.
+- Blog tag reads and Search projection use `blog_post_tags + rustok-taxonomy` rather than `blog_posts.metadata.tags` as the canonical source;
+- Blog tag update/delete now retain Taxonomy mutation and Blog-scope Search reindex in one owner transaction.
 
 None of these source states promote runtime evidence.
 
@@ -70,8 +71,6 @@ The legacy `hide_comment_form` token remains compatibility vocabulary in the exi
 
 ### Blog tag list pagination
 
-A fresh source audit after slice 101 found that `TagService::list_tags` accepted an arbitrarily large `per_page` and used unchecked page-offset multiplication, unlike the already bounded Blog category list contract.
-
 Slice 102 makes the owner service authoritative for the response bound and arithmetic safety:
 
 `tag_list_pagination = source_ready_maintainer_execution_pending`
@@ -91,23 +90,39 @@ Slice 103 resolves the cross-owner source question identified by slice 102:
 
 `tag_canonical_projection = source_ready_maintainer_execution_pending`
 
-The accepted ownership boundary is now source-locked:
+The accepted ownership boundary is source-locked:
 
 - `rustok-taxonomy` owns the shared tag dictionary;
 - `rustok-blog` owns post attachments in `blog_post_tags`;
 - `blog_posts.metadata.tags` remains compatibility metadata, but is not a canonical Blog read or Search projection source.
 
-Blog reads seed an explicit empty tag vector for each requested post ID. Therefore an empty relation set no longer becomes a missing map entry that can resurrect stale `metadata.tags` through the existing response fallback path.
+Blog reads seed an explicit empty tag vector for each requested post ID, so an empty relation set cannot resurrect stale metadata tags. Blog Search requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves attached names through document locale -> `PLATFORM_FALLBACK_LOCALE` -> canonical key.
 
-Blog Search now requires `blog_post_tags`, `taxonomy_terms`, and `taxonomy_term_translations` and resolves attached names through document locale -> `PLATFORM_FALLBACK_LOCALE` -> canonical key. Taxonomy joins are tenant-constrained and tag aggregation remains distinct/deterministic. The retained PostgreSQL harness deliberately keeps stale metadata while expecting projection from relation/Taxonomy rows.
+Runtime promotion still must audit deployed data for metadata-only legacy rows. If such rows exist, backfill owner relations before rollout. No audit/backfill result is claimed.
 
-Runtime promotion must audit deployed data for metadata-only legacy rows. If such rows exist, backfill owner relations before rollout. Slice 103 does not claim that the audit or a backfill was executed.
+### Blog tag mutation atomic reindex
 
-Mutation semantics intentionally remain separate:
+Slice 104 closes the mutation consistency gap exposed by slice 103:
 
-`tag_mutation_atomic_reindex = next_source_gap`
+`tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`
 
-Slice 103 does **not** change `TagService::update_tag/delete_tag`. The next source slice must define a Taxonomy-owned supplied-transaction mutation API, commit the dictionary mutation and Blog-scope reindex together, and remove Blog's redundant manual pre-delete relation cleanup in favor of the declared FK cascade.
+`rustok-taxonomy` now exposes narrow module-term update/delete functions that accept a supplied `DatabaseTransaction`, tenant/term identity, term kind, module slug, and caller security context. The Taxonomy owner rechecks module scope and term kind and preserves Taxonomy update/read/delete permissions, localized slug uniqueness, translation revision CAS, term revision CAS, and translation-change evidence.
+
+`TagService::update_tag` and `TagService::delete_tag` keep their existing Blog `tags:*` checks, then execute the Taxonomy mutation and:
+
+`ReindexRequested { target_type: "blog", target_id: None }`
+
+through `TransactionalEventBus::publish_root_in_tx` before committing the same transaction.
+
+Canonical delete relation cleanup is:
+
+`tag_delete_relation_cleanup = declared_fk_cascade`
+
+The old manual `blog_post_tags` pre-delete is removed. The existing `blog_post_tags.tag_id -> taxonomy_terms.id ON DELETE CASCADE` relation owns cleanup atomically with the Taxonomy term delete.
+
+The retained source harness covers successful rename + durable reindex, forced outbox failure rollback, and delete cascade + durable reindex. None of those cases were executed by the implementation agent.
+
+The Blog tag source line is source-complete through slice 104. Do not add another tag mutation scaffolding slice without new evidence.
 
 ## Remaining execution-owned results
 
@@ -118,10 +133,11 @@ The concrete retained execution results remain maintainer-owned:
 3. Execute slice 98 PostgreSQL evidence before advancing the Blog category Translation readiness result.
 4. Execute slice 102 tag pagination source/unit evidence before promoting runtime validation.
 5. Execute slice 103 Blog read/Search canonical tag projection evidence and audit deployed data for metadata-only legacy rows before runtime promotion.
-6. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
-7. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
+6. Execute slice 104 tag mutation/outbox rollback/delete-cascade harness and then Search projection evidence for rename/delete behavior.
+7. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
+8. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
 
-A future source implementation must follow the explicit current cursor. It must not manufacture work by reopening a source-complete or not-applicable track.
+A future autonomous source slice must start from a fresh broad repository audit and identify a genuinely new independent source gap outside the execution-gated tracks above. It must not manufacture work by reopening a source-complete or not-applicable cursor.
 
 ## Superseded historical cursor phrases
 
@@ -136,10 +152,10 @@ The continuation slice files and machine evidence remain the source of detailed 
 
 ## Validation boundary
 
-No tests, Cargo commands, Node verifiers, PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–103.
+No tests, Cargo commands, Node verifiers, SQLite/PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, Search execution, outbox relay execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–104.
 
 ## Next cursor
 
-Implement slice 104: `tag_mutation_atomic_reindex`.
+No independent production source gap is claimed after slice 104.
 
-Use a Taxonomy-owned supplied-transaction update/delete path, then commit Blog tag mutation and `ReindexRequested { target_type: "blog", target_id: None }` in the same transaction. Remove the manual pre-delete `blog_post_tags` cleanup and rely on the declared FK cascade. Preserve existing Blog `tags:*` authorization semantics and do not promote runtime evidence.
+Continue only after a fresh broad Blog source audit finds another gap outside the execution-gated tracks above, or after maintainers provide execution results that unlock one of their explicit follow-ups.

--- a/crates/rustok-blog/docs/implementation-plan-slice-104.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-104.md
@@ -1,0 +1,105 @@
+# Blog implementation plan — slice 104
+
+Status: `tag_mutation_atomic_reindex_source_ready_maintainer_execution_pending`.
+
+## Cursor
+
+Slice 103 made `blog_post_tags + rustok-taxonomy` authoritative for Blog tag reads and Search projection. It intentionally left one source gap: `TagService::update_tag/delete_tag` could mutate the Taxonomy dictionary without committing a Blog Search invalidation in the same transaction, and delete manually removed Blog relations before deleting the Taxonomy term even though the declared FK already cascades.
+
+Slice 104 closes that source gap without changing the public `TagService::new(DatabaseConnection)` constructor or bypassing Taxonomy ownership.
+
+## Taxonomy owner transaction boundary
+
+`rustok-taxonomy` now exposes a narrow module-term mutation boundary:
+
+- `update_module_term_in_tx`;
+- `delete_module_term_in_tx`.
+
+The caller must supply:
+
+- a `DatabaseTransaction`;
+- tenant ID and term ID;
+- `TaxonomyTermKind`;
+- the module slug;
+- the caller `SecurityContext`.
+
+The Taxonomy owner rechecks that the term is a module-scoped term for that exact module and kind. It retains Taxonomy permissions rather than relying only on Blog permissions:
+
+- update requires Taxonomy `Update` and `Read`, matching the successful permission set of the previous standalone update/response path;
+- delete requires Taxonomy `Delete`.
+
+The owner boundary preserves localized slug uniqueness, translation revision CAS, term revision CAS, and `translation_changes` evidence inside the supplied transaction.
+
+Canonical interpretation:
+
+`taxonomy_module_term_mutation = owner_supplied_transaction_source_ready`
+
+## Blog atomic update/delete
+
+`TagService::update_tag` and `TagService::delete_tag` still perform their existing Blog `tags:*` ownership checks before the mutation.
+
+They now open one Blog transaction and call the Taxonomy owner boundary inside it. Before commit they write one canonical root event using:
+
+`TransactionalEventBus::publish_root_in_tx`
+
+with:
+
+`ReindexRequested { target_type: "blog", target_id: None }`.
+
+Therefore the dictionary mutation, Taxonomy translation-change evidence, and Blog Search invalidation are committed or rolled back together.
+
+Canonical interpretation:
+
+`tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`
+
+No optional event bus field or alternate `TagService` constructor was added.
+
+## Delete cascade
+
+The Blog migration already declares:
+
+`blog_post_tags.tag_id -> taxonomy_terms.id ON DELETE CASCADE`.
+
+The old `TagService::delete_tag` manually deleted `blog_post_tags` before calling Taxonomy delete. That pre-delete is removed. The Taxonomy term deletion now owns the transaction and the database FK removes Blog attachment rows atomically with it.
+
+Canonical interpretation:
+
+`tag_delete_relation_cleanup = declared_fk_cascade`
+
+## Retained source harness
+
+`crates/rustok-blog/tests/taxonomy_tags.rs` now includes executable-no-run cases for:
+
+- successful tag rename + durable Blog-scope reindex in one committed path;
+- forced `sys_events` unavailability causing tag rename/revision rollback;
+- tag delete removing Taxonomy term and Blog relation through the declared FK cascade while retaining a durable reindex event.
+
+The harness installs `SysEventsMigration` because slice 104 writes canonical outbox rows rather than relying on the test-only memory transport for the reindex signal.
+
+These cases are source evidence only. They were not executed by the implementation agent.
+
+## Non-scope
+
+Slice 104 does not:
+
+- change Search projection SQL introduced by slice 103;
+- change Blog tag list pagination introduced by slice 102;
+- change Taxonomy global-term mutation behavior;
+- add a new event type;
+- add a database migration;
+- promote FFA/FBA or runtime readiness;
+- claim that the legacy metadata-only data audit from slice 103 was executed.
+
+## Validation boundary
+
+No tests, Cargo commands, Node verifiers, SQLite/PostgreSQL scenarios, formatting, builds, Clippy, workflows, CI, HTTP execution, Search execution, outbox relay execution, runtime validation, or production validation were executed by the implementation agent.
+
+## Next cursor
+
+The tag source line is source-complete through slice 104:
+
+- bounded list pagination: slice 102;
+- canonical relation/Taxonomy read and Search source: slice 103;
+- atomic dictionary mutation + Blog reindex: slice 104.
+
+Do not add another tag mutation scaffolding slice without new evidence. Continue only from a fresh broad Blog source audit outside execution-gated tracks, or from maintainer execution results that unlock an explicit follow-up.

--- a/crates/rustok-blog/src/services/tag.rs
+++ b/crates/rustok-blog/src/services/tag.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection,
     DatabaseTransaction, EntityTrait, JoinType, QueryFilter, QueryOrder, QuerySelect,
-    RelationTrait,
+    RelationTrait, TransactionTrait,
 };
 use tracing::instrument;
 use uuid::Uuid;
@@ -12,9 +12,11 @@ use uuid::Uuid;
 use rustok_api::{Action, PLATFORM_FALLBACK_LOCALE, Resource};
 use rustok_content::{normalize_locale_code, resolve_by_locale_with_fallback};
 use rustok_core::SecurityContext;
+use rustok_events::DomainEvent;
+use rustok_outbox::TransactionalEventBus;
 use rustok_taxonomy::{
-    CreateTaxonomyTermInput, TaxonomyScopeType, TaxonomyService, TaxonomyTermKind,
-    UpdateTaxonomyTermInput,
+    CreateTaxonomyTermInput, ModuleTermMutationResult, ModuleTermUpdateInput, TaxonomyScopeType,
+    TaxonomyService, TaxonomyTermKind, delete_module_term_in_tx, update_module_term_in_tx,
     entities::{taxonomy_term, taxonomy_term_alias, taxonomy_term_translation},
 };
 
@@ -107,28 +109,31 @@ impl TagService {
         ensure_module_owned_term(&term)?;
 
         let locale = normalize_locale(&input.locale)?;
-        let term = TaxonomyService::new(self.db.clone())
-            .update_term(
-                tenant_id,
-                tag_id,
-                security,
-                UpdateTaxonomyTermInput {
-                    locale: locale.clone(),
-                    name: input.name,
-                    slug: input.slug,
-                    description: None,
-                    status: None,
-                    aliases: None,
-                },
-            )
-            .await?;
+        let txn = self.db.begin().await.map_err(BlogError::from)?;
+        let term = update_module_term_in_tx(
+            &txn,
+            tenant_id,
+            tag_id,
+            &security,
+            TaxonomyTermKind::Tag,
+            BLOG_SCOPE_VALUE,
+            ModuleTermUpdateInput {
+                locale: locale.clone(),
+                name: input.name,
+                slug: input.slug,
+            },
+        )
+        .await?;
+        publish_blog_reindex_in_tx(&txn, tenant_id, security.user_id).await?;
+        txn.commit().await.map_err(BlogError::from)?;
+
         let use_count = self
             .count_tag_usage_map(tenant_id, &[tag_id])
             .await?
             .remove(&tag_id)
             .unwrap_or_default();
 
-        Ok(to_tag_response(term, use_count))
+        Ok(to_tag_mutation_response(term, use_count))
     }
 
     #[instrument(skip(self, security))]
@@ -142,14 +147,18 @@ impl TagService {
         enforce_owned_scope(&security, Resource::Tags, Action::Delete, term.id)?;
         ensure_module_owned_term(&term)?;
 
-        blog_post_tag::Entity::delete_many()
-            .filter(blog_post_tag::Column::TagId.eq(tag_id))
-            .exec(&self.db)
-            .await?;
-
-        TaxonomyService::new(self.db.clone())
-            .delete_term(tenant_id, tag_id, security)
-            .await?;
+        let txn = self.db.begin().await.map_err(BlogError::from)?;
+        delete_module_term_in_tx(
+            &txn,
+            tenant_id,
+            tag_id,
+            &security,
+            TaxonomyTermKind::Tag,
+            BLOG_SCOPE_VALUE,
+        )
+        .await?;
+        publish_blog_reindex_in_tx(&txn, tenant_id, security.user_id).await?;
+        txn.commit().await.map_err(BlogError::from)?;
         Ok(())
     }
 
@@ -293,6 +302,24 @@ impl TagService {
         }
         Ok(counts)
     }
+}
+
+async fn publish_blog_reindex_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    actor_id: Option<Uuid>,
+) -> BlogResult<()> {
+    TransactionalEventBus::publish_root_in_tx(
+        txn,
+        tenant_id,
+        actor_id,
+        DomainEvent::ReindexRequested {
+            target_type: "blog".to_string(),
+            target_id: None,
+        },
+    )
+    .await
+    .map_err(BlogError::from)
 }
 
 pub(crate) async fn sync_post_tags_in_tx(
@@ -572,6 +599,19 @@ fn to_tag_response(term: rustok_taxonomy::TaxonomyTermResponse, use_count: i32) 
         id: term.id,
         tenant_id: term.tenant_id,
         locale: term.requested_locale,
+        effective_locale: term.effective_locale,
+        name: term.name,
+        slug: term.slug,
+        use_count,
+        created_at: term.created_at,
+    }
+}
+
+fn to_tag_mutation_response(term: ModuleTermMutationResult, use_count: i32) -> TagResponse {
+    TagResponse {
+        id: term.id,
+        tenant_id: term.tenant_id,
+        locale: term.locale,
         effective_locale: term.effective_locale,
         name: term.name,
         slug: term.slug,

--- a/crates/rustok-blog/tests/taxonomy_tags.rs
+++ b/crates/rustok-blog/tests/taxonomy_tags.rs
@@ -1,18 +1,21 @@
 use std::sync::Arc;
 
 use rustok_blog::{
-    BlogModule, CreatePostInput, ListTagsFilter, PostService, TagService, entities::blog_post_tag,
+    BlogModule, CreatePostInput, ListTagsFilter, PostService, TagService, UpdateTagInput,
+    entities::blog_post_tag,
 };
 use rustok_core::{MemoryTransport, MigrationSource, SecurityContext, UserRole};
-use rustok_outbox::TransactionalEventBus;
+use rustok_events::{DomainEvent, EventEnvelope};
+use rustok_outbox::{SysEvents, SysEventsMigration, TransactionalEventBus};
 use rustok_taxonomy::{
     CreateTaxonomyTermInput, TaxonomyModule, TaxonomyScopeType, TaxonomyService, TaxonomyTermKind,
-    entities::taxonomy_term,
+    entities::{taxonomy_term, taxonomy_term_translation},
 };
 use sea_orm::{
-    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter,
+    ColumnTrait, ConnectOptions, ConnectionTrait, Database, DatabaseConnection, EntityTrait,
+    QueryFilter, QueryOrder,
 };
-use sea_orm_migration::SchemaManager;
+use sea_orm_migration::{MigrationTrait, SchemaManager};
 use uuid::Uuid;
 
 async fn setup_blog_test_db() -> DatabaseConnection {
@@ -38,6 +41,10 @@ async fn setup() -> (
 ) {
     let db = setup_blog_test_db().await;
     let schema = SchemaManager::new(&db);
+    SysEventsMigration
+        .up(&schema)
+        .await
+        .expect("outbox migration should apply");
     for migration in TaxonomyModule.migrations() {
         migration
             .up(&schema)
@@ -255,4 +262,222 @@ async fn post_read_does_not_resurrect_metadata_tags_after_relations_are_removed(
         .await
         .expect("post should load after relation removal");
     assert!(post.tags.is_empty());
+}
+
+#[tokio::test]
+async fn tag_update_commits_dictionary_change_and_blog_reindex_together() {
+    let (db, event_bus, _events, tenant_id) = setup().await;
+    let post_service = PostService::new(db.clone(), event_bus);
+    let tag_service = TagService::new(db.clone());
+    let security = admin();
+
+    let post_id = post_service
+        .create_post(
+            tenant_id,
+            security.clone(),
+            CreatePostInput {
+                locale: "en".to_string(),
+                title: "Atomic tag update".to_string(),
+                content: rustok_blog::richtext::article_document_from_plain_text(&"Body".to_string()),
+                excerpt: None,
+                slug: Some("atomic-tag-update".to_string()),
+                publish: true,
+                tags: vec!["rust".to_string()],
+                category_id: None,
+                featured_image_url: None,
+                seo_title: None,
+                seo_description: None,
+                channel_slugs: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("post should be created");
+    let tag_id = blog_post_tag::Entity::find()
+        .filter(blog_post_tag::Column::PostId.eq(post_id))
+        .one(&db)
+        .await
+        .expect("relation lookup should work")
+        .expect("post should have one tag")
+        .tag_id;
+
+    let updated = tag_service
+        .update_tag(
+            tenant_id,
+            tag_id,
+            security.clone(),
+            UpdateTagInput {
+                locale: "en".to_string(),
+                name: Some("backend".to_string()),
+                slug: None,
+            },
+        )
+        .await
+        .expect("tag update should commit");
+    assert_eq!(updated.name, "backend");
+    assert_eq!(updated.slug, "backend");
+
+    let post = post_service
+        .get_post(tenant_id, security, post_id, "en")
+        .await
+        .expect("post should resolve renamed taxonomy tag");
+    assert_eq!(post.tags, vec!["backend".to_string()]);
+
+    let event = SysEvents::find()
+        .order_by_desc(rustok_outbox::entity::Column::CreatedAt)
+        .one(&db)
+        .await
+        .expect("outbox lookup should work")
+        .expect("tag update should retain one durable reindex event");
+    let envelope: EventEnvelope = serde_json::from_value(event.payload)
+        .expect("outbox payload should decode as canonical event envelope");
+    assert_eq!(envelope.tenant_id, tenant_id);
+    assert!(matches!(
+        envelope.event,
+        DomainEvent::ReindexRequested { ref target_type, target_id: None }
+            if target_type == "blog"
+    ));
+}
+
+#[tokio::test]
+async fn tag_update_rolls_back_when_blog_reindex_outbox_write_fails() {
+    let (db, event_bus, _events, tenant_id) = setup().await;
+    let post_service = PostService::new(db.clone(), event_bus);
+    let tag_service = TagService::new(db.clone());
+    let security = admin();
+
+    let post_id = post_service
+        .create_post(
+            tenant_id,
+            security.clone(),
+            CreatePostInput {
+                locale: "en".to_string(),
+                title: "Rollback tag update".to_string(),
+                content: rustok_blog::richtext::article_document_from_plain_text(&"Body".to_string()),
+                excerpt: None,
+                slug: Some("rollback-tag-update".to_string()),
+                publish: true,
+                tags: vec!["rust".to_string()],
+                category_id: None,
+                featured_image_url: None,
+                seo_title: None,
+                seo_description: None,
+                channel_slugs: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("post should be created");
+    let tag_id = blog_post_tag::Entity::find()
+        .filter(blog_post_tag::Column::PostId.eq(post_id))
+        .one(&db)
+        .await
+        .expect("relation lookup should work")
+        .expect("post should have one tag")
+        .tag_id;
+
+    db.execute_unprepared("DROP TABLE sys_events")
+        .await
+        .expect("test should make canonical outbox persistence unavailable");
+
+    tag_service
+        .update_tag(
+            tenant_id,
+            tag_id,
+            security,
+            UpdateTagInput {
+                locale: "en".to_string(),
+                name: Some("backend".to_string()),
+                slug: None,
+            },
+        )
+        .await
+        .expect_err("outbox failure must abort the owner transaction");
+
+    let translation = taxonomy_term_translation::Entity::find()
+        .filter(taxonomy_term_translation::Column::TermId.eq(tag_id))
+        .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term_translation::Column::Locale.eq("en"))
+        .one(&db)
+        .await
+        .expect("translation lookup should work")
+        .expect("rolled-back translation should remain");
+    assert_eq!(translation.name, "rust");
+    assert_eq!(translation.slug, "rust");
+    assert_eq!(translation.revision, 1);
+
+    let term = taxonomy_term::Entity::find_by_id(tag_id)
+        .filter(taxonomy_term::Column::TenantId.eq(tenant_id))
+        .one(&db)
+        .await
+        .expect("term lookup should work")
+        .expect("rolled-back term should remain");
+    assert_eq!(term.revision, 1);
+}
+
+#[tokio::test]
+async fn tag_delete_relies_on_taxonomy_fk_cascade_and_retains_reindex() {
+    let (db, event_bus, _events, tenant_id) = setup().await;
+    let post_service = PostService::new(db.clone(), event_bus);
+    let tag_service = TagService::new(db.clone());
+    let security = admin();
+
+    let post_id = post_service
+        .create_post(
+            tenant_id,
+            security.clone(),
+            CreatePostInput {
+                locale: "en".to_string(),
+                title: "Atomic tag delete".to_string(),
+                content: rustok_blog::richtext::article_document_from_plain_text(&"Body".to_string()),
+                excerpt: None,
+                slug: Some("atomic-tag-delete".to_string()),
+                publish: true,
+                tags: vec!["rust".to_string()],
+                category_id: None,
+                featured_image_url: None,
+                seo_title: None,
+                seo_description: None,
+                channel_slugs: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("post should be created");
+    let tag_id = blog_post_tag::Entity::find()
+        .filter(blog_post_tag::Column::PostId.eq(post_id))
+        .one(&db)
+        .await
+        .expect("relation lookup should work")
+        .expect("post should have one tag")
+        .tag_id;
+
+    tag_service
+        .delete_tag(tenant_id, tag_id, security)
+        .await
+        .expect("tag delete should commit");
+
+    assert!(
+        taxonomy_term::Entity::find_by_id(tag_id)
+            .one(&db)
+            .await
+            .expect("term lookup should work")
+            .is_none()
+    );
+    assert!(
+        blog_post_tag::Entity::find()
+            .filter(blog_post_tag::Column::TagId.eq(tag_id))
+            .one(&db)
+            .await
+            .expect("relation lookup should work")
+            .is_none()
+    );
+    assert_eq!(
+        SysEvents::find()
+            .all(&db)
+            .await
+            .expect("outbox lookup should work")
+            .len(),
+        1
+    );
 }

--- a/crates/rustok-taxonomy/src/lib.rs
+++ b/crates/rustok-taxonomy/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dto;
 pub mod entities;
 pub mod error;
 pub mod migrations;
+pub mod module_term_mutation;
 pub mod services;
 mod translation_evidence;
 pub mod translation_target;
@@ -18,6 +19,10 @@ pub use dto::{
     UpdateTaxonomyTermInput,
 };
 pub use error::{TaxonomyError, TaxonomyResult};
+pub use module_term_mutation::{
+    ModuleTermMutationResult, ModuleTermUpdateInput, delete_module_term_in_tx,
+    update_module_term_in_tx,
+};
 pub use services::TaxonomyService;
 pub use translation_target::TaxonomyTranslationTargetProvider;
 

--- a/crates/rustok-taxonomy/src/module_term_mutation.rs
+++ b/crates/rustok-taxonomy/src/module_term_mutation.rs
@@ -40,7 +40,7 @@ pub async fn update_module_term_in_tx(
     module_slug: &str,
     input: ModuleTermUpdateInput,
 ) -> TaxonomyResult<ModuleTermMutationResult> {
-    // The pre-existing public update path requires Update and then Read when it
+    // The existing public update path requires Update and then Read when it
     // materializes the response. Preserve that successful-call permission set.
     enforce_scope(security, Resource::Taxonomy, Action::Update)?;
     enforce_scope(security, Resource::Taxonomy, Action::Read)?;
@@ -57,99 +57,105 @@ pub async fn update_module_term_in_tx(
         .one(txn)
         .await?;
 
-    let (translation_id, name, slug, target_revision, created_at) =
-        match existing_translation {
-            Some(existing) => {
-                let name = input.name.clone().unwrap_or_else(|| existing.name.clone());
-                validate_term_name(&name)?;
-                let slug = match input.slug.as_deref() {
-                    Some(slug) => normalize_non_empty_slug(slug)?,
-                    None if input.name.is_some() => normalize_non_empty_slug(&name)?,
-                    None => existing.slug.clone(),
-                };
-                ensure_translation_slug_available_in_tx(
-                    txn,
-                    tenant_id,
-                    kind,
-                    &module_scope,
-                    &locale,
-                    &slug,
-                    Some(term_id),
+    let (name, slug, target_revision, created_at) = match existing_translation {
+        Some(existing) => {
+            let name = input.name.clone().unwrap_or_else(|| existing.name.clone());
+            validate_term_name(&name)?;
+            let slug = match input.slug.as_deref() {
+                Some(slug) => normalize_non_empty_slug(slug)?,
+                None if input.name.is_some() => normalize_non_empty_slug(&name)?,
+                None => existing.slug.clone(),
+            };
+            ensure_translation_slug_available_in_tx(
+                txn,
+                tenant_id,
+                kind,
+                &module_scope,
+                &locale,
+                &slug,
+                Some(term_id),
+            )
+            .await?;
+
+            let revision = next_translation_revision(term_id, &locale, existing.revision)?;
+            let updated = taxonomy_term_translation::Entity::update_many()
+                .col_expr(
+                    taxonomy_term_translation::Column::Name,
+                    Expr::value(name.clone()),
                 )
+                .col_expr(
+                    taxonomy_term_translation::Column::Slug,
+                    Expr::value(slug.clone()),
+                )
+                .col_expr(
+                    taxonomy_term_translation::Column::Revision,
+                    Expr::value(revision),
+                )
+                .col_expr(
+                    taxonomy_term_translation::Column::UpdatedAt,
+                    Expr::value(now.fixed_offset()),
+                )
+                .filter(taxonomy_term_translation::Column::Id.eq(existing.id))
+                .filter(taxonomy_term_translation::Column::TermId.eq(term_id))
+                .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
+                .filter(taxonomy_term_translation::Column::Revision.eq(existing.revision))
+                .exec(txn)
                 .await?;
-
-                let revision = next_translation_revision(term_id, &locale, existing.revision)?;
-                let updated = taxonomy_term_translation::Entity::update_many()
-                    .col_expr(taxonomy_term_translation::Column::Name, Expr::value(name.clone()))
-                    .col_expr(taxonomy_term_translation::Column::Slug, Expr::value(slug.clone()))
-                    .col_expr(
-                        taxonomy_term_translation::Column::Revision,
-                        Expr::value(revision),
-                    )
-                    .col_expr(
-                        taxonomy_term_translation::Column::UpdatedAt,
-                        Expr::value(now.fixed_offset()),
-                    )
-                    .filter(taxonomy_term_translation::Column::Id.eq(existing.id))
-                    .filter(taxonomy_term_translation::Column::TermId.eq(term_id))
-                    .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
-                    .filter(taxonomy_term_translation::Column::Revision.eq(existing.revision))
-                    .exec(txn)
-                    .await?;
-                if updated.rows_affected != 1 {
-                    return Err(TaxonomyError::conflict(
-                        "taxonomy term translation changed before the module update could commit",
-                    ));
-                }
-
-                (
-                    existing.id,
-                    name,
-                    slug,
-                    revision,
-                    DateTime::<Utc>::from(existing.created_at),
-                )
+            if updated.rows_affected != 1 {
+                return Err(TaxonomyError::conflict(
+                    "taxonomy term translation changed before the module update could commit",
+                ));
             }
-            None => {
-                let name = input.name.clone().ok_or_else(|| {
-                    TaxonomyError::validation("Name is required when adding a new locale")
-                })?;
-                validate_term_name(&name)?;
-                let slug = normalize_non_empty_slug(input.slug.as_deref().unwrap_or(&name))?;
-                ensure_translation_slug_available_in_tx(
-                    txn,
-                    tenant_id,
-                    kind,
-                    &module_scope,
-                    &locale,
-                    &slug,
-                    Some(term_id),
-                )
-                .await?;
 
-                let translation_id = Uuid::new_v4();
-                taxonomy_term_translation::ActiveModel {
-                    id: Set(translation_id),
-                    term_id: Set(term_id),
-                    tenant_id: Set(tenant_id),
-                    locale: Set(locale.clone()),
-                    name: Set(name.clone()),
-                    slug: Set(slug.clone()),
-                    description: Set(None),
-                    revision: Set(1),
-                    created_at: Set(now.fixed_offset()),
-                    updated_at: Set(now.fixed_offset()),
-                }
-                .insert(txn)
-                .await?;
+            (
+                name,
+                slug,
+                revision,
+                existing.created_at.with_timezone(&Utc),
+            )
+        }
+        None => {
+            let name = input.name.clone().ok_or_else(|| {
+                TaxonomyError::validation("Name is required when adding a new locale")
+            })?;
+            validate_term_name(&name)?;
+            let slug = normalize_non_empty_slug(input.slug.as_deref().unwrap_or(&name))?;
+            ensure_translation_slug_available_in_tx(
+                txn,
+                tenant_id,
+                kind,
+                &module_scope,
+                &locale,
+                &slug,
+                Some(term_id),
+            )
+            .await?;
 
-                (translation_id, name, slug, 1, now)
+            taxonomy_term_translation::ActiveModel {
+                id: Set(Uuid::new_v4()),
+                term_id: Set(term_id),
+                tenant_id: Set(tenant_id),
+                locale: Set(locale.clone()),
+                name: Set(name.clone()),
+                slug: Set(slug.clone()),
+                description: Set(None),
+                revision: Set(1),
+                created_at: Set(now.fixed_offset()),
+                updated_at: Set(now.fixed_offset()),
             }
-        };
+            .insert(txn)
+            .await?;
+
+            (name, slug, 1, now)
+        }
+    };
 
     let resource_revision = next_term_revision(&term)?;
     let updated = taxonomy_term::Entity::update_many()
-        .col_expr(taxonomy_term::Column::Revision, Expr::value(resource_revision))
+        .col_expr(
+            taxonomy_term::Column::Revision,
+            Expr::value(resource_revision),
+        )
         .col_expr(
             taxonomy_term::Column::UpdatedAt,
             Expr::value(now.fixed_offset()),
@@ -182,7 +188,6 @@ pub async fn update_module_term_in_tx(
     )
     .await?;
 
-    let _ = translation_id;
     Ok(ModuleTermMutationResult {
         id: term_id,
         tenant_id,

--- a/crates/rustok-taxonomy/src/module_term_mutation.rs
+++ b/crates/rustok-taxonomy/src/module_term_mutation.rs
@@ -57,7 +57,7 @@ pub async fn update_module_term_in_tx(
         .one(txn)
         .await?;
 
-    let (name, slug, target_revision, created_at) = match existing_translation {
+    let (name, slug, target_revision) = match existing_translation {
         Some(existing) => {
             let name = input.name.clone().unwrap_or_else(|| existing.name.clone());
             validate_term_name(&name)?;
@@ -107,12 +107,7 @@ pub async fn update_module_term_in_tx(
                 ));
             }
 
-            (
-                name,
-                slug,
-                revision,
-                existing.created_at.with_timezone(&Utc),
-            )
+            (name, slug, revision)
         }
         None => {
             let name = input.name.clone().ok_or_else(|| {
@@ -146,7 +141,7 @@ pub async fn update_module_term_in_tx(
             .insert(txn)
             .await?;
 
-            (name, slug, 1, now)
+            (name, slug, 1)
         }
     };
 
@@ -195,7 +190,7 @@ pub async fn update_module_term_in_tx(
         effective_locale: locale,
         name,
         slug,
-        created_at,
+        created_at: term.created_at.with_timezone(&Utc),
     })
 }
 

--- a/crates/rustok-taxonomy/src/module_term_mutation.rs
+++ b/crates/rustok-taxonomy/src/module_term_mutation.rs
@@ -1,0 +1,385 @@
+use chrono::{DateTime, Utc};
+use rustok_api::{Action, Resource};
+use rustok_content::normalize_locale_code;
+use rustok_core::{PermissionScope, SecurityContext};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseTransaction, EntityTrait, JoinType,
+    QueryFilter, RelationTrait, sea_query::Expr,
+};
+use uuid::Uuid;
+
+use crate::dto::{TaxonomyScopeType, TaxonomyTermKind, TaxonomyTermStatus};
+use crate::entities::{taxonomy_term, taxonomy_term_translation};
+use crate::error::{TaxonomyError, TaxonomyResult};
+use crate::translation_evidence::{TranslationChangeEvidence, record_translation_change_in_tx};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleTermUpdateInput {
+    pub locale: String,
+    pub name: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleTermMutationResult {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub locale: String,
+    pub effective_locale: String,
+    pub name: String,
+    pub slug: String,
+    pub created_at: DateTime<Utc>,
+}
+
+pub async fn update_module_term_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    term_id: Uuid,
+    security: &SecurityContext,
+    kind: TaxonomyTermKind,
+    module_slug: &str,
+    input: ModuleTermUpdateInput,
+) -> TaxonomyResult<ModuleTermMutationResult> {
+    // The pre-existing public update path requires Update and then Read when it
+    // materializes the response. Preserve that successful-call permission set.
+    enforce_scope(security, Resource::Taxonomy, Action::Update)?;
+    enforce_scope(security, Resource::Taxonomy, Action::Read)?;
+
+    let module_scope = normalize_module_scope(module_slug)?;
+    let locale = normalize_locale(&input.locale)?;
+    let term = find_module_term_in_tx(txn, tenant_id, term_id, kind, &module_scope).await?;
+    let now = Utc::now();
+
+    let existing_translation = taxonomy_term_translation::Entity::find()
+        .filter(taxonomy_term_translation::Column::TermId.eq(term_id))
+        .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term_translation::Column::Locale.eq(&locale))
+        .one(txn)
+        .await?;
+
+    let (translation_id, name, slug, target_revision, created_at) =
+        match existing_translation {
+            Some(existing) => {
+                let name = input.name.clone().unwrap_or_else(|| existing.name.clone());
+                validate_term_name(&name)?;
+                let slug = match input.slug.as_deref() {
+                    Some(slug) => normalize_non_empty_slug(slug)?,
+                    None if input.name.is_some() => normalize_non_empty_slug(&name)?,
+                    None => existing.slug.clone(),
+                };
+                ensure_translation_slug_available_in_tx(
+                    txn,
+                    tenant_id,
+                    kind,
+                    &module_scope,
+                    &locale,
+                    &slug,
+                    Some(term_id),
+                )
+                .await?;
+
+                let revision = next_translation_revision(term_id, &locale, existing.revision)?;
+                let updated = taxonomy_term_translation::Entity::update_many()
+                    .col_expr(taxonomy_term_translation::Column::Name, Expr::value(name.clone()))
+                    .col_expr(taxonomy_term_translation::Column::Slug, Expr::value(slug.clone()))
+                    .col_expr(
+                        taxonomy_term_translation::Column::Revision,
+                        Expr::value(revision),
+                    )
+                    .col_expr(
+                        taxonomy_term_translation::Column::UpdatedAt,
+                        Expr::value(now.fixed_offset()),
+                    )
+                    .filter(taxonomy_term_translation::Column::Id.eq(existing.id))
+                    .filter(taxonomy_term_translation::Column::TermId.eq(term_id))
+                    .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
+                    .filter(taxonomy_term_translation::Column::Revision.eq(existing.revision))
+                    .exec(txn)
+                    .await?;
+                if updated.rows_affected != 1 {
+                    return Err(TaxonomyError::conflict(
+                        "taxonomy term translation changed before the module update could commit",
+                    ));
+                }
+
+                (
+                    existing.id,
+                    name,
+                    slug,
+                    revision,
+                    DateTime::<Utc>::from(existing.created_at),
+                )
+            }
+            None => {
+                let name = input.name.clone().ok_or_else(|| {
+                    TaxonomyError::validation("Name is required when adding a new locale")
+                })?;
+                validate_term_name(&name)?;
+                let slug = normalize_non_empty_slug(input.slug.as_deref().unwrap_or(&name))?;
+                ensure_translation_slug_available_in_tx(
+                    txn,
+                    tenant_id,
+                    kind,
+                    &module_scope,
+                    &locale,
+                    &slug,
+                    Some(term_id),
+                )
+                .await?;
+
+                let translation_id = Uuid::new_v4();
+                taxonomy_term_translation::ActiveModel {
+                    id: Set(translation_id),
+                    term_id: Set(term_id),
+                    tenant_id: Set(tenant_id),
+                    locale: Set(locale.clone()),
+                    name: Set(name.clone()),
+                    slug: Set(slug.clone()),
+                    description: Set(None),
+                    revision: Set(1),
+                    created_at: Set(now.fixed_offset()),
+                    updated_at: Set(now.fixed_offset()),
+                }
+                .insert(txn)
+                .await?;
+
+                (translation_id, name, slug, 1, now)
+            }
+        };
+
+    let resource_revision = next_term_revision(&term)?;
+    let updated = taxonomy_term::Entity::update_many()
+        .col_expr(taxonomy_term::Column::Revision, Expr::value(resource_revision))
+        .col_expr(
+            taxonomy_term::Column::UpdatedAt,
+            Expr::value(now.fixed_offset()),
+        )
+        .filter(taxonomy_term::Column::Id.eq(term_id))
+        .filter(taxonomy_term::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term::Column::Kind.eq(kind))
+        .filter(taxonomy_term::Column::ScopeType.eq(TaxonomyScopeType::Module))
+        .filter(taxonomy_term::Column::ScopeValue.eq(&module_scope))
+        .filter(taxonomy_term::Column::Revision.eq(term.revision))
+        .exec(txn)
+        .await?;
+    if updated.rows_affected != 1 {
+        return Err(TaxonomyError::conflict(
+            "taxonomy term changed before the module update could commit",
+        ));
+    }
+
+    record_translation_change_in_tx(
+        txn,
+        TranslationChangeEvidence {
+            tenant_id,
+            term_id,
+            locale: &locale,
+            resource_revision,
+            target_revision,
+            operation: "upsert",
+            lifecycle: lifecycle_for_status(term.status),
+        },
+    )
+    .await?;
+
+    let _ = translation_id;
+    Ok(ModuleTermMutationResult {
+        id: term_id,
+        tenant_id,
+        locale: locale.clone(),
+        effective_locale: locale,
+        name,
+        slug,
+        created_at,
+    })
+}
+
+pub async fn delete_module_term_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    term_id: Uuid,
+    security: &SecurityContext,
+    kind: TaxonomyTermKind,
+    module_slug: &str,
+) -> TaxonomyResult<()> {
+    enforce_scope(security, Resource::Taxonomy, Action::Delete)?;
+
+    let module_scope = normalize_module_scope(module_slug)?;
+    let term = find_module_term_in_tx(txn, tenant_id, term_id, kind, &module_scope).await?;
+    let translations = taxonomy_term_translation::Entity::find()
+        .filter(taxonomy_term_translation::Column::TermId.eq(term_id))
+        .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
+        .all(txn)
+        .await?;
+    let deletion_translation = translations.iter().min_by(|left, right| {
+        left.locale
+            .cmp(&right.locale)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let locale = deletion_translation
+        .map(|translation| translation.locale.as_str())
+        .unwrap_or(rustok_api::PLATFORM_FALLBACK_LOCALE);
+    let target_revision = deletion_translation
+        .map(|translation| translation.revision)
+        .unwrap_or_default();
+    let resource_revision = next_term_revision(&term)?;
+
+    record_translation_change_in_tx(
+        txn,
+        TranslationChangeEvidence {
+            tenant_id,
+            term_id,
+            locale,
+            resource_revision,
+            target_revision,
+            operation: "delete",
+            lifecycle: "deleted",
+        },
+    )
+    .await?;
+
+    let deleted = taxonomy_term::Entity::delete_many()
+        .filter(taxonomy_term::Column::Id.eq(term_id))
+        .filter(taxonomy_term::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term::Column::Kind.eq(kind))
+        .filter(taxonomy_term::Column::ScopeType.eq(TaxonomyScopeType::Module))
+        .filter(taxonomy_term::Column::ScopeValue.eq(&module_scope))
+        .filter(taxonomy_term::Column::Revision.eq(term.revision))
+        .exec(txn)
+        .await?;
+    if deleted.rows_affected != 1 {
+        return Err(TaxonomyError::conflict(
+            "taxonomy term changed before the module deletion could commit",
+        ));
+    }
+
+    Ok(())
+}
+
+async fn find_module_term_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    term_id: Uuid,
+    kind: TaxonomyTermKind,
+    module_scope: &str,
+) -> TaxonomyResult<taxonomy_term::Model> {
+    taxonomy_term::Entity::find_by_id(term_id)
+        .filter(taxonomy_term::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term::Column::Kind.eq(kind))
+        .filter(taxonomy_term::Column::ScopeType.eq(TaxonomyScopeType::Module))
+        .filter(taxonomy_term::Column::ScopeValue.eq(module_scope))
+        .one(txn)
+        .await?
+        .ok_or(TaxonomyError::TermNotFound(term_id))
+}
+
+async fn ensure_translation_slug_available_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    kind: TaxonomyTermKind,
+    module_scope: &str,
+    locale: &str,
+    slug: &str,
+    exclude_term_id: Option<Uuid>,
+) -> TaxonomyResult<()> {
+    let mut select = taxonomy_term_translation::Entity::find()
+        .join(
+            JoinType::InnerJoin,
+            taxonomy_term_translation::Relation::Term.def(),
+        )
+        .filter(taxonomy_term_translation::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term_translation::Column::Locale.eq(locale))
+        .filter(taxonomy_term_translation::Column::Slug.eq(slug))
+        .filter(taxonomy_term::Column::TenantId.eq(tenant_id))
+        .filter(taxonomy_term::Column::Kind.eq(kind))
+        .filter(taxonomy_term::Column::ScopeType.eq(TaxonomyScopeType::Module))
+        .filter(taxonomy_term::Column::ScopeValue.eq(module_scope));
+    if let Some(exclude_term_id) = exclude_term_id {
+        select = select.filter(taxonomy_term_translation::Column::TermId.ne(exclude_term_id));
+    }
+    if select.one(txn).await?.is_some() {
+        return Err(TaxonomyError::DuplicateSlug(slug.to_string()));
+    }
+    Ok(())
+}
+
+fn enforce_scope(
+    security: &SecurityContext,
+    resource: Resource,
+    action: Action,
+) -> TaxonomyResult<()> {
+    if matches!(security.get_scope(resource, action), PermissionScope::None) {
+        return Err(TaxonomyError::forbidden("Permission denied"));
+    }
+    Ok(())
+}
+
+fn normalize_locale(locale: &str) -> TaxonomyResult<String> {
+    normalize_locale_code(locale).ok_or_else(|| TaxonomyError::validation("Invalid locale"))
+}
+
+fn normalize_module_scope(module_slug: &str) -> TaxonomyResult<String> {
+    let value = module_slug
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '_' || *ch == '-')
+        .collect::<String>();
+    if value.is_empty() {
+        return Err(TaxonomyError::validation(
+            "Module scope requires a non-empty scope_value",
+        ));
+    }
+    Ok(value)
+}
+
+fn normalize_non_empty_slug(value: &str) -> TaxonomyResult<String> {
+    let slug = slug::slugify(value);
+    if slug.is_empty() {
+        return Err(TaxonomyError::validation(
+            "Localized slug cannot be empty after normalization",
+        ));
+    }
+    Ok(slug)
+}
+
+fn validate_term_name(name: &str) -> TaxonomyResult<()> {
+    if name.trim().is_empty() {
+        return Err(TaxonomyError::validation("Term name cannot be empty"));
+    }
+    if name.chars().count() > 120 {
+        return Err(TaxonomyError::validation(
+            "Term name cannot exceed 120 characters",
+        ));
+    }
+    Ok(())
+}
+
+fn next_term_revision(term: &taxonomy_term::Model) -> TaxonomyResult<i64> {
+    term.revision
+        .checked_add(1)
+        .filter(|revision| term.revision > 0 && *revision > 0)
+        .ok_or_else(|| {
+            TaxonomyError::conflict(format!(
+                "taxonomy term {} has an invalid or exhausted resource revision",
+                term.id
+            ))
+        })
+}
+
+fn next_translation_revision(term_id: Uuid, locale: &str, revision: i64) -> TaxonomyResult<i64> {
+    revision
+        .checked_add(1)
+        .filter(|next_revision| revision > 0 && *next_revision > 0)
+        .ok_or_else(|| TaxonomyError::TranslationRevisionExhausted {
+            term_id,
+            locale: locale.to_string(),
+        })
+}
+
+fn lifecycle_for_status(status: TaxonomyTermStatus) -> &'static str {
+    match status {
+        TaxonomyTermStatus::Active => "active",
+        TaxonomyTermStatus::Deprecated => "archived",
+    }
+}

--- a/scripts/verify/verify-blog-canonical-plan-current.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.mjs
@@ -20,6 +20,7 @@ const files = {
   slice101: 'crates/rustok-blog/docs/implementation-plan-slice-101.md',
   slice102: 'crates/rustok-blog/docs/implementation-plan-slice-102.md',
   slice103: 'crates/rustok-blog/docs/implementation-plan-slice-103.md',
+  slice104: 'crates/rustok-blog/docs/implementation-plan-slice-104.md',
   docsIndex: 'crates/rustok-blog/docs/README.md',
   tcpTransport: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
   tcpServer: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
@@ -29,6 +30,7 @@ const files = {
   writeSurface: 'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
   tagPagination: 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
   tagProjection: 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
+  tagMutation: 'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json',
 };
 
 function absolute(relativePath) { return path.join(repoRoot, relativePath); }
@@ -73,6 +75,7 @@ const slice100 = read(files.slice100);
 const slice101 = read(files.slice101);
 const slice102 = read(files.slice102);
 const slice103 = read(files.slice103);
+const slice104 = read(files.slice104);
 const docsIndex = read(files.docsIndex);
 const tcpTransport = json(files.tcpTransport);
 const tcpServer = json(files.tcpServer);
@@ -82,6 +85,7 @@ const fallback = json(files.fallback);
 const writeSurface = json(files.writeSurface);
 const tagPagination = json(files.tagPagination);
 const tagProjection = json(files.tagProjection);
+const tagMutation = json(files.tagMutation);
 
 if (evidence) {
   if (
@@ -98,8 +102,8 @@ if (evidence) {
     evidence.canonical_current_cursor !== files.current ||
     evidence.actualization_slice !== files.slice101 ||
     evidence.historical_baseline_last_embedded_slice !== 67 ||
-    evidence.latest_behavior_slice !== 103 ||
-    evidence.current_recorded_slice !== 103
+    evidence.latest_behavior_slice !== 104 ||
+    evidence.current_recorded_slice !== 104
   ) failures.push(`${files.evidence}: cursor path/version drift`);
 
   const tracks = evidence.source_tracks ?? {};
@@ -109,34 +113,29 @@ if (evidence) {
     tracks.remote_comments_transport?.latest_audit_relay_slice !== files.slice97 ||
     tracks.remote_comments_transport?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: remote Comments track drift`);
-
   if (
     tracks.comments_source_retention?.status !== 'blocked_until_slices_95_97_execution' ||
     tracks.comments_source_retention?.blocking_slice !== files.slice97 ||
     tracks.comments_source_retention?.must_not_advance_before_execution !== true
   ) failures.push(`${files.evidence}: Comments source-retention gate drift`);
-
   if (
     tracks.category_translation_postgres?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.category_translation_postgres?.slice !== files.slice98 ||
     tracks.category_translation_postgres?.evidence !== files.translationPostgres ||
     tracks.category_translation_postgres?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: category Translation track drift`);
-
   if (
     tracks.cached_public_comments_snapshot?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.cached_public_comments_snapshot?.slice !== files.slice99 ||
     tracks.cached_public_comments_snapshot?.evidence !== files.fallback ||
     tracks.cached_public_comments_snapshot?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: cached Comments track drift`);
-
   if (
     tracks.storefront_comment_form_fallback?.status !== 'not_applicable_no_storefront_write_surface' ||
     tracks.storefront_comment_form_fallback?.slice !== files.slice100 ||
     tracks.storefront_comment_form_fallback?.evidence !== files.writeSurface ||
     tracks.storefront_comment_form_fallback?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: storefront write-surface track drift`);
-
   if (
     tracks.tag_list_pagination?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.tag_list_pagination?.slice !== files.slice102 ||
@@ -146,7 +145,6 @@ if (evidence) {
     tracks.tag_list_pagination?.database_side_pagination_claimed !== false ||
     tracks.tag_list_pagination?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: tag pagination track drift`);
-
   if (
     tracks.tag_canonical_projection?.status !== 'source_ready_maintainer_execution_pending' ||
     tracks.tag_canonical_projection?.slice !== files.slice103 ||
@@ -157,24 +155,26 @@ if (evidence) {
     tracks.tag_canonical_projection?.legacy_data_audit_pending !== true ||
     tracks.tag_canonical_projection?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: canonical tag projection track drift`);
-
   if (
-    tracks.tag_mutation_atomic_reindex?.status !== 'next_source_gap' ||
+    tracks.tag_mutation_atomic_reindex?.status !== 'source_ready_maintainer_execution_pending' ||
+    tracks.tag_mutation_atomic_reindex?.slice !== files.slice104 ||
+    tracks.tag_mutation_atomic_reindex?.evidence !== files.tagMutation ||
     tracks.tag_mutation_atomic_reindex?.canonical_source_defined !== true ||
-    tracks.tag_mutation_atomic_reindex?.taxonomy_supplied_transaction_api_required !== true ||
-    tracks.tag_mutation_atomic_reindex?.blog_scope_reindex_same_transaction_required !== true ||
-    tracks.tag_mutation_atomic_reindex?.manual_predelete_relation_cleanup_must_be_removed !== true
-  ) failures.push(`${files.evidence}: tag mutation atomic-reindex cursor drift`);
+    tracks.tag_mutation_atomic_reindex?.taxonomy_owner_transaction_api_present !== true ||
+    tracks.tag_mutation_atomic_reindex?.blog_scope_reindex_same_transaction !== true ||
+    tracks.tag_mutation_atomic_reindex?.manual_predelete_relation_cleanup_removed !== true ||
+    tracks.tag_mutation_atomic_reindex?.declared_fk_cascade_used !== true ||
+    tracks.tag_mutation_atomic_reindex?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: tag mutation atomic-reindex track drift`);
 
   if (
-    evidence.planning_result?.independent_production_source_gap_identified !== true ||
-    evidence.planning_result?.next_source_gap !== 'tag_mutation_atomic_reindex' ||
-    evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== false ||
+    evidence.planning_result?.independent_production_source_gap_identified !== false ||
+    evidence.planning_result?.next_source_gap !== null ||
+    evidence.planning_result?.future_autonomous_source_work_requires_fresh_audit !== true ||
     evidence.planning_result?.historical_stale_phrases_are_live_instructions !== false ||
     evidence.planning_result?.production_behavior_changed_since_slice_101 !== true ||
     evidence.planning_result?.ffa_or_fba_promoted !== false ||
-    !Array.isArray(evidence.execution) ||
-    evidence.execution.length !== 0
+    !Array.isArray(evidence.execution) || evidence.execution.length !== 0
   ) failures.push(`${files.evidence}: planning/execution claim drift`);
 }
 
@@ -184,22 +184,15 @@ for (const [label, artifact, expectedSurface] of [
   [files.tcpListener, tcpListener, 'comments_tcp_listener_lifecycle'],
 ]) {
   if (
-    artifact?.module !== 'blog' ||
-    artifact?.provider !== 'comments' ||
-    artifact?.surface !== expectedSurface ||
-    artifact?.status !== 'source_verified_no_compile' ||
+    artifact?.module !== 'blog' || artifact?.provider !== 'comments' ||
+    artifact?.surface !== expectedSurface || artifact?.status !== 'source_verified_no_compile' ||
     artifact?.runtime_status !== 'not_run'
   ) failures.push(`${label}: remote transport source evidence drift`);
 }
 
 if (!sameSet(tcpServer?.operations, [
-  'create_comment',
-  'get_comment',
-  'list_comments_for_target',
-  'list_public_comments_for_target',
-  'update_comment',
-  'set_comment_status',
-  'delete_comment',
+  'create_comment', 'get_comment', 'list_comments_for_target',
+  'list_public_comments_for_target', 'update_comment', 'set_comment_status', 'delete_comment',
 ])) failures.push(`${files.tcpServer}: seven-operation transport parity drift`);
 
 if (
@@ -228,8 +221,7 @@ if (
 ) failures.push(`${files.writeSurface}: storefront write-surface evidence drift`);
 
 if (
-  tagPagination?.status !== 'source_verified_no_compile' ||
-  tagPagination?.runtime_status !== 'not_run' ||
+  tagPagination?.status !== 'source_verified_no_compile' || tagPagination?.runtime_status !== 'not_run' ||
   tagPagination?.source_contract?.maximum_page_size !== 100 ||
   tagPagination?.source_contract?.owner_service_clamps_page_size !== true ||
   tagPagination?.source_contract?.extreme_page_cannot_overflow_offset_arithmetic !== true ||
@@ -238,19 +230,27 @@ if (
 ) failures.push(`${files.tagPagination}: tag pagination source evidence drift`);
 
 if (
-  tagProjection?.status !== 'source_verified_no_compile' ||
-  tagProjection?.runtime_status !== 'not_run' ||
+  tagProjection?.status !== 'source_verified_no_compile' || tagProjection?.runtime_status !== 'not_run' ||
   tagProjection?.ownership?.dictionary_owner !== 'rustok-taxonomy' ||
   tagProjection?.ownership?.attachment_table !== 'blog_post_tags' ||
   tagProjection?.ownership?.metadata_tags_is_canonical_read_source !== false ||
   tagProjection?.ownership?.metadata_tags_is_search_projection_source !== false ||
   tagProjection?.source_contract?.blog_read_harness_rejects_metadata_resurrection !== true ||
   tagProjection?.source_contract?.stale_metadata_tags_are_ignored_by_search_harness !== true ||
-  tagProjection?.source_contract?.tag_mutation_semantics_changed !== false ||
-  tagProjection?.source_contract?.tag_mutation_atomic_reindex_implemented !== false ||
-  tagProjection?.next_source_gap?.status !== 'tag_mutation_atomic_reindex_next' ||
   !Array.isArray(tagProjection?.execution) || tagProjection.execution.length !== 0
 ) failures.push(`${files.tagProjection}: canonical tag projection source evidence drift`);
+
+if (
+  tagMutation?.status !== 'source_verified_no_compile' || tagMutation?.runtime_status !== 'not_run' ||
+  tagMutation?.production_contract?.update_uses_supplied_transaction !== true ||
+  tagMutation?.production_contract?.delete_uses_supplied_transaction !== true ||
+  tagMutation?.production_contract?.blog_reindex_same_transaction !== true ||
+  tagMutation?.production_contract?.manual_predelete_relation_cleanup_removed !== true ||
+  tagMutation?.production_contract?.relation_cleanup_uses_declared_fk_cascade !== true ||
+  tagMutation?.planning_result?.tag_mutation_source_complete !== true ||
+  tagMutation?.planning_result?.additional_tag_mutation_scaffolding_required !== false ||
+  !Array.isArray(tagMutation?.execution) || tagMutation.execution.length !== 0
+) failures.push(`${files.tagMutation}: tag mutation atomic-reindex source evidence drift`);
 
 for (const [source, marker, label] of [
   [slice97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice97],
@@ -259,6 +259,7 @@ for (const [source, marker, label] of [
   [slice100, 'Status: `storefront_comment_form_fallback_not_applicable_source_verified`.', files.slice100],
   [slice102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.', files.slice102],
   [slice103, 'Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.', files.slice103],
+  [slice104, 'Status: `tag_mutation_atomic_reindex_source_ready_maintainer_execution_pending`.', files.slice104],
 ]) need(source, marker, label);
 
 need(slice97, 'After retained maintainer execution of slices 95–97, define bounded lifecycle and', files.slice97);
@@ -268,20 +269,23 @@ need(slice100, 'comment_form_fallback = not_applicable_no_storefront_write_surfa
 need(slice102, 'Re-audit Blog tag mutation/projection consistency as a separate ownership slice.', files.slice102);
 need(slice103, 'Implement `tag_mutation_atomic_reindex` as slice 104', files.slice103);
 need(slice103, 'metadata-only rows', files.slice103);
+need(slice104, 'Do not add another tag mutation scaffolding slice without new evidence.', files.slice104);
 
 for (const marker of [
-  'Status: `canonical_source_cursor_actualized_through_slice_103`.',
+  'Status: `canonical_source_cursor_actualized_through_slice_104`.',
   '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
   '`category_translation_postgres = source_ready_maintainer_execution_pending`',
   '`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`',
   '`comment_form_fallback = not_applicable_no_storefront_write_surface`',
   '`tag_list_pagination = source_ready_maintainer_execution_pending`',
   '`tag_canonical_projection = source_ready_maintainer_execution_pending`',
-  '`tag_mutation_atomic_reindex = next_source_gap`',
+  '`tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`',
+  '`tag_delete_relation_cleanup = declared_fk_cascade`',
   'do not advance that source work before retained maintainer execution of slices 95–97',
   'This does **not** claim database-side pagination.',
   'metadata-only legacy rows',
-  'Implement slice 104: `tag_mutation_atomic_reindex`.',
+  'source-complete through slice 104',
+  'No independent production source gap is claimed after slice 104.',
   '## Superseded historical cursor phrases',
   'No tests, Cargo commands, Node verifiers',
 ]) need(current, marker, files.current);
@@ -328,4 +332,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('[verify-blog-canonical-plan-current] PASS cursor=slice-103 behavior-through=slice-103 execution=not-run');
+console.log('[verify-blog-canonical-plan-current] PASS cursor=slice-104 behavior-through=slice-104 execution=not-run');

--- a/scripts/verify/verify-blog-canonical-plan-current.test.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.test.mjs
@@ -21,6 +21,7 @@ const files = [
   'crates/rustok-blog/docs/implementation-plan-slice-101.md',
   'crates/rustok-blog/docs/implementation-plan-slice-102.md',
   'crates/rustok-blog/docs/implementation-plan-slice-103.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-104.md',
   'crates/rustok-blog/docs/README.md',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
@@ -30,6 +31,7 @@ const files = [
   'crates/rustok-blog/contracts/evidence/blog-comments-storefront-write-surface.json',
   'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
   'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
+  'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json',
 ];
 function absolute(root, relativePath) { return path.join(root, relativePath); }
 function write(root, relativePath, content) {
@@ -72,15 +74,15 @@ test('accepts the canonical Blog current implementation cursor', () => {
   try {
     const result = run(root);
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(result.stdout, /cursor=slice-103/);
+    assert.match(result.stdout, /cursor=slice-104/);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
 test('rejects reopening remote transport as live current-cursor work', () => {
   const result = rejects((root) => {
-    const relativePath = 'crates/rustok-blog/docs/implementation-plan-current.md';
-    const source = readFileSync(absolute(root, relativePath), 'utf8');
-    write(root, relativePath, source.replace(
+    const file = 'crates/rustok-blog/docs/implementation-plan-current.md';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace(
       '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
       '`remote_comments_transport = remote transport remains pending`',
     ));
@@ -89,10 +91,12 @@ test('rejects reopening remote transport as live current-cursor work', () => {
   assert.match(result.stderr, /remote transport|current/);
 });
 
-test('rejects advancing a different source gap than the retained next cursor', () => {
+test('rejects claiming another source gap without a fresh audit', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.planning_result.independent_production_source_gap_identified = true;
       value.planning_result.next_source_gap = 'another_gap';
+      value.planning_result.future_autonomous_source_work_requires_fresh_audit = false;
     });
   });
   assert.notEqual(result.status, 0);
@@ -160,33 +164,34 @@ test('rejects metadata tags becoming canonical again', () => {
   assert.match(result.stderr, /canonical tag projection track drift/);
 });
 
-test('rejects premature atomic tag mutation claim', () => {
-  const result = rejects((root) => {
-    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json', (value) => {
-      value.source_contract.tag_mutation_atomic_reindex_implemented = true;
-    });
-  });
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /canonical tag projection source evidence drift/);
-});
-
-test('rejects losing the tag mutation atomic-reindex next cursor', () => {
+test('rejects reopening atomic tag mutation after slice 104', () => {
   const result = rejects((root) => {
     mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
-      value.source_tracks.tag_mutation_atomic_reindex.status = 'done';
+      value.source_tracks.tag_mutation_atomic_reindex.status = 'next_source_gap';
     });
   });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /tag mutation atomic-reindex cursor drift/);
+  assert.match(result.stderr, /tag mutation atomic-reindex track drift/);
+});
+
+test('rejects premature tag mutation runtime promotion', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json', (value) => {
+      value.runtime_status = 'validated';
+      value.execution.push({ command: 'not-run' });
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /tag mutation atomic-reindex source evidence drift/);
 });
 
 test('rejects listing the historical plan before the canonical current cursor', () => {
   const result = rejects((root) => {
-    const relativePath = 'crates/rustok-blog/docs/README.md';
-    const source = readFileSync(absolute(root, relativePath), 'utf8');
+    const file = 'crates/rustok-blog/docs/README.md';
+    const source = readFileSync(absolute(root, file), 'utf8');
     const current = '[Current Implementation Cursor](./implementation-plan-current.md)';
     const historical = '[Historical Implementation Plan](./implementation-plan.md)';
-    write(root, relativePath, source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical));
+    write(root, file, source.replace(current, '__CURRENT__').replace(historical, current).replace('__CURRENT__', historical));
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /canonical current cursor must be listed before/);
@@ -194,9 +199,9 @@ test('rejects listing the historical plan before the canonical current cursor', 
 
 test('rejects an unrecorded advance of the historical embedded slice list', () => {
   const result = rejects((root) => {
-    const relativePath = 'crates/rustok-blog/docs/implementation-plan.md';
-    const source = readFileSync(absolute(root, relativePath), 'utf8');
-    write(root, relativePath, source.replace(
+    const file = 'crates/rustok-blog/docs/implementation-plan.md';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace(
       '\n## Next results',
       '\n68. Unrecorded historical-list advance.\n\n## Next results',
     ));

--- a/scripts/verify/verify-blog-tag-mutation-reindex-source.mjs
+++ b/scripts/verify/verify-blog-tag-mutation-reindex-source.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const failures = [];
+const files = {
+  evidence: 'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json',
+  taxonomyMutation: 'crates/rustok-taxonomy/src/module_term_mutation.rs',
+  taxonomyLib: 'crates/rustok-taxonomy/src/lib.rs',
+  tagService: 'crates/rustok-blog/src/services/tag.rs',
+  relationMigration: 'crates/rustok-blog/src/migrations/m20260328_000002_create_blog_taxonomy_tables.rs',
+  harness: 'crates/rustok-blog/tests/taxonomy_tags.rs',
+  slice: 'crates/rustok-blog/docs/implementation-plan-slice-104.md',
+  current: 'crates/rustok-blog/docs/implementation-plan-current.md',
+};
+function read(relativePath) {
+  const target = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(target)) { failures.push(`${relativePath}: missing file`); return ''; }
+  return fs.readFileSync(target, 'utf8');
+}
+function json(relativePath) {
+  try { return JSON.parse(read(relativePath)); }
+  catch (error) { failures.push(`${relativePath}: invalid JSON: ${error.message}`); return null; }
+}
+function need(source, marker, label) { if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`); }
+function forbid(source, marker, label) { if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`); }
+function between(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) return '';
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  return source.slice(start, end < 0 ? source.length : end);
+}
+
+const evidence = json(files.evidence);
+const taxonomyMutation = read(files.taxonomyMutation);
+const taxonomyLib = read(files.taxonomyLib);
+const tagService = read(files.tagService);
+const relationMigration = read(files.relationMigration);
+const harness = read(files.harness);
+const slice = read(files.slice);
+const current = read(files.current);
+
+if (evidence) {
+  if (
+    evidence.schema_version !== 1 || evidence.module !== 'blog' ||
+    evidence.surface !== 'tag_mutation_atomic_reindex' ||
+    evidence.status !== 'source_verified_no_compile' ||
+    evidence.compile_policy !== 'not_run_by_request' || evidence.runtime_status !== 'not_run'
+  ) failures.push(`${files.evidence}: identity/status drift`);
+  const contract = evidence.production_contract ?? {};
+  for (const [key, expected] of Object.entries({
+    update_uses_supplied_transaction: true,
+    delete_uses_supplied_transaction: true,
+    taxonomy_update_permission_preserved: true,
+    taxonomy_read_permission_preserved_for_update_response: true,
+    taxonomy_delete_permission_preserved: true,
+    module_scope_rechecked_by_taxonomy_owner: true,
+    term_kind_rechecked_by_taxonomy_owner: true,
+    translation_revision_cas_preserved: true,
+    term_revision_cas_preserved: true,
+    translation_change_evidence_same_transaction: true,
+    blog_reindex_same_transaction: true,
+    manual_predelete_relation_cleanup_removed: true,
+    relation_cleanup_uses_declared_fk_cascade: true,
+    tag_service_constructor_changed: false,
+    database_schema_changed: false,
+    search_projection_source_changed: false,
+    ffa_promoted: false,
+    fba_promoted: false,
+  })) {
+    if (contract[key] !== expected) failures.push(`${files.evidence}: ${key} drift`);
+  }
+  if (contract.blog_reindex_target_type !== 'blog' || contract.blog_reindex_target_id !== null) {
+    failures.push(`${files.evidence}: Blog reindex target drift`);
+  }
+  if (
+    evidence.source_harness?.path !== files.harness ||
+    evidence.source_harness?.status !== 'executable_no_run' ||
+    evidence.source_harness?.runtime_status !== 'not_run' ||
+    !Array.isArray(evidence.execution) || evidence.execution.length !== 0 ||
+    evidence.planning_result?.tag_mutation_source_complete !== true ||
+    evidence.planning_result?.additional_tag_mutation_scaffolding_required !== false ||
+    evidence.planning_result?.next_autonomous_source_work_requires_fresh_audit !== true
+  ) failures.push(`${files.evidence}: harness/planning/execution drift`);
+}
+
+for (const marker of [
+  'pub async fn update_module_term_in_tx(',
+  'pub async fn delete_module_term_in_tx(',
+  'enforce_scope(security, Resource::Taxonomy, Action::Update)?;',
+  'enforce_scope(security, Resource::Taxonomy, Action::Read)?;',
+  'enforce_scope(security, Resource::Taxonomy, Action::Delete)?;',
+  'TaxonomyScopeType::Module',
+  'taxonomy_term::Column::ScopeValue.eq(&module_scope)',
+  'taxonomy_term::Column::Kind.eq(kind)',
+  'taxonomy_term_translation::Column::Revision.eq(existing.revision)',
+  'taxonomy_term::Column::Revision.eq(term.revision)',
+  'record_translation_change_in_tx(',
+]) need(taxonomyMutation, marker, files.taxonomyMutation);
+for (const marker of [
+  'pub mod module_term_mutation;',
+  'delete_module_term_in_tx',
+  'update_module_term_in_tx',
+]) need(taxonomyLib, marker, files.taxonomyLib);
+
+const updateSection = between(tagService, 'pub async fn update_tag(', 'pub async fn delete_tag(');
+const deleteSection = between(tagService, 'pub async fn delete_tag(', 'pub async fn list_tags(');
+for (const marker of [
+  'self.db.begin()',
+  'update_module_term_in_tx(',
+  'publish_blog_reindex_in_tx(&txn, tenant_id, security.user_id)',
+  'txn.commit()',
+]) need(updateSection, marker, `${files.tagService} update_tag`);
+for (const marker of [
+  'self.db.begin()',
+  'delete_module_term_in_tx(',
+  'publish_blog_reindex_in_tx(&txn, tenant_id, security.user_id)',
+  'txn.commit()',
+]) need(deleteSection, marker, `${files.tagService} delete_tag`);
+forbid(deleteSection, 'blog_post_tag::Entity::delete_many()', `${files.tagService} delete_tag`);
+for (const marker of [
+  'TransactionalEventBus::publish_root_in_tx(',
+  'DomainEvent::ReindexRequested {',
+  'target_type: "blog".to_string()',
+  'target_id: None',
+]) need(tagService, marker, files.tagService);
+need(tagService, 'pub fn new(db: DatabaseConnection) -> Self', files.tagService);
+
+for (const marker of [
+  '.name("fk_blog_post_tags_tag")',
+  '.from(BlogPostTags::Table, BlogPostTags::TagId)',
+  '.to(TaxonomyTerms::Table, TaxonomyTerms::Id)',
+  '.on_delete(ForeignKeyAction::Cascade)',
+]) need(relationMigration, marker, files.relationMigration);
+
+for (const marker of [
+  'SysEventsMigration',
+  'tag_update_commits_dictionary_change_and_blog_reindex_together',
+  'tag_update_rolls_back_when_blog_reindex_outbox_write_fails',
+  'DROP TABLE sys_events',
+  'assert_eq!(translation.name, "rust")',
+  'assert_eq!(term.revision, 1)',
+  'tag_delete_relies_on_taxonomy_fk_cascade_and_retains_reindex',
+  'DomainEvent::ReindexRequested',
+]) need(harness, marker, files.harness);
+
+for (const marker of [
+  'Status: `tag_mutation_atomic_reindex_source_ready_maintainer_execution_pending`.',
+  '`taxonomy_module_term_mutation = owner_supplied_transaction_source_ready`',
+  '`tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`',
+  '`tag_delete_relation_cleanup = declared_fk_cascade`',
+  'These cases are source evidence only. They were not executed',
+  'Do not add another tag mutation scaffolding slice without new evidence.',
+]) need(slice, marker, files.slice);
+for (const marker of [
+  '`tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`',
+  'source-complete through slice 104',
+]) need(current, marker, files.current);
+
+if (failures.length) {
+  console.error('[verify-blog-tag-mutation-reindex-source] FAIL');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+console.log('[verify-blog-tag-mutation-reindex-source] PASS atomic=taxonomy+reindex delete=fk-cascade execution=not-run');

--- a/scripts/verify/verify-blog-tag-mutation-reindex-source.test.mjs
+++ b/scripts/verify/verify-blog-tag-mutation-reindex-source.test.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const verifier = path.join(repositoryRoot, 'scripts/verify/verify-blog-tag-mutation-reindex-source.mjs');
+const files = [
+  'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json',
+  'crates/rustok-taxonomy/src/module_term_mutation.rs',
+  'crates/rustok-taxonomy/src/lib.rs',
+  'crates/rustok-blog/src/services/tag.rs',
+  'crates/rustok-blog/src/migrations/m20260328_000002_create_blog_taxonomy_tables.rs',
+  'crates/rustok-blog/tests/taxonomy_tags.rs',
+  'crates/rustok-blog/docs/implementation-plan-slice-104.md',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+];
+function absolute(root, relativePath) { return path.join(root, relativePath); }
+function write(root, relativePath, content) {
+  const target = absolute(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+function fixture(mutator = () => {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-tag-mutation-'));
+  for (const relativePath of files) {
+    const target = absolute(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(path.join(repositoryRoot, relativePath), target);
+  }
+  mutator(root);
+  return root;
+}
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    cwd: repositoryRoot,
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+function rejects(mutator) {
+  const root = fixture(mutator);
+  try { return run(root); }
+  finally { rmSync(root, { recursive: true, force: true }); }
+}
+function mutateJson(root, relativePath, mutator) {
+  const target = absolute(root, relativePath);
+  const value = JSON.parse(readFileSync(target, 'utf8'));
+  mutator(value);
+  write(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test('accepts atomic Blog tag mutation/reindex source', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /atomic=taxonomy\+reindex/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('rejects restoring manual relation pre-delete', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-blog/src/services/tag.rs';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace(
+      'let txn = self.db.begin().await.map_err(BlogError::from)?;\n        delete_module_term_in_tx(',
+      'blog_post_tag::Entity::delete_many();\n        let txn = self.db.begin().await.map_err(BlogError::from)?;\n        delete_module_term_in_tx(',
+    ));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /delete_tag.*forbidden|pre-delete|delete_many/s);
+});
+
+test('rejects moving reindex outside update transaction', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-blog/src/services/tag.rs';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replace(
+      'publish_blog_reindex_in_tx(&txn, tenant_id, security.user_id).await?;',
+      '/* reindex omitted */',
+    ));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /update_tag.*publish_blog_reindex/s);
+});
+
+test('rejects weakening Taxonomy module-scope recheck', () => {
+  const result = rejects((root) => {
+    const file = 'crates/rustok-taxonomy/src/module_term_mutation.rs';
+    const source = readFileSync(absolute(root, file), 'utf8');
+    write(root, file, source.replaceAll('taxonomy_term::Column::ScopeValue.eq(&module_scope)', 'taxonomy_term::Column::ScopeValue.is_not_null()'));
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /ScopeValue/);
+});
+
+test('rejects premature runtime promotion', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json', (value) => {
+      value.runtime_status = 'validated';
+      value.execution.push({ command: 'not-actually-run' });
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /identity\/status drift|harness\/planning\/execution drift/);
+});


### PR DESCRIPTION
## Summary

Continue the canonical Blog cursor with slice 104 and close the tag mutation consistency gap left deliberately open by slice 103.

Blog tag reads/Search already use `blog_post_tags + rustok-taxonomy` as the canonical source. This PR makes Blog-owned tag update/delete commit the Taxonomy dictionary mutation, Taxonomy translation-change evidence, and Blog Search invalidation in one transaction.

## Taxonomy owner boundary

- adds narrow `update_module_term_in_tx` / `delete_module_term_in_tx` APIs owned by `rustok-taxonomy`;
- caller supplies a `DatabaseTransaction`, tenant/term identity, term kind, module slug, and `SecurityContext`;
- Taxonomy rechecks exact module scope and term kind;
- preserves Taxonomy Update+Read requirements for update response and Delete for delete;
- preserves localized slug uniqueness, translation revision CAS, term revision CAS, and translation-change evidence.

This is not a generic cross-module SQL bypass and does not change standalone Taxonomy CRUD.

## Blog mutation atomicity

- keeps the public `TagService::new(DatabaseConnection)` constructor unchanged;
- keeps existing Blog `tags:*` ownership checks;
- `update_tag` and `delete_tag` open one transaction, call the Taxonomy owner boundary, then write canonical `ReindexRequested { target_type: "blog", target_id: None }` through `TransactionalEventBus::publish_root_in_tx` before commit;
- removes the old manual `blog_post_tags` pre-delete from `delete_tag` and relies on the existing `blog_post_tags.tag_id -> taxonomy_terms.id ON DELETE CASCADE` FK.

## Retained evidence

- successful rename + durable Blog reindex source harness;
- forced `sys_events` failure source harness proving Taxonomy rename/revision rollback;
- delete source harness proving FK cascade + durable reindex;
- adds `blog-tag-mutation-reindex-source.json`, slice 104, a dedicated fail-closed verifier/self-test;
- advances the canonical Blog cursor/evidence through slice 104 while preserving earlier guard coverage.

## Scope

No Search projection SQL change, no new event type, no database migration, no `TagService` constructor change, no global Taxonomy mutation change, and no FFA/FBA promotion.

After slice 104 the Blog tag source line is source-complete through pagination (102), canonical read/Search projection (103), and atomic mutation/reindex (104). The next autonomous source cursor returns to a fresh broad Blog audit rather than more tag scaffolding.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, SQLite/PostgreSQL scenarios, formatting, builds, Clippy, workflows, CI, HTTP/Search execution, outbox relay execution, runtime validation, or production validation were executed. Source/diff review only.