### PR TITLE
feat(forum): reject cyclic NodeBB category dependencies

### DIFF
--- a/crates/rustok-forum/src/import_inspection.rs
+++ b/crates/rustok-forum/src/import_inspection.rs
@@ -25,6 +25,7 @@ pub enum ForumImportDependencyRelation {
 pub enum ForumImportDependencyDisposition {
     MissingBatchRecord,
     MismatchedBatchRecord,
+    CyclicBatchRelation,
     ExternalOwnerResolution,
 }
 
@@ -62,6 +63,7 @@ impl NodebbForumImportInspector {
             .iter()
             .map(|record| record.cid)
             .collect::<BTreeSet<_>>();
+        let cyclic_category_ids = category_cycle_members(batch, &category_ids);
         let topic_ids = batch
             .topics
             .iter()
@@ -77,13 +79,20 @@ impl NodebbForumImportInspector {
 
         for (record, candidate) in batch.categories.iter().zip(&candidates.categories) {
             if let Some(parent_id) = record.parent_cid.filter(|value| *value > 0) {
-                if !category_ids.contains(&parent_id) {
-                    if let Some(parent_source) = candidate.parent_source.as_ref() {
+                if let Some(parent_source) = candidate.parent_source.as_ref() {
+                    let disposition = if !category_ids.contains(&parent_id) {
+                        Some(ForumImportDependencyDisposition::MissingBatchRecord)
+                    } else if cyclic_category_ids.contains(&record.cid) {
+                        Some(ForumImportDependencyDisposition::CyclicBatchRelation)
+                    } else {
+                        None
+                    };
+                    if let Some(disposition) = disposition {
                         unresolved_dependencies.push(ForumImportDependencyIssue {
                             owner: candidate.source.clone(),
                             relation: ForumImportDependencyRelation::CategoryParent,
                             target: parent_source.clone(),
-                            disposition: ForumImportDependencyDisposition::MissingBatchRecord,
+                            disposition,
                         });
                     }
                 }
@@ -163,6 +172,60 @@ impl NodebbForumImportInspector {
     }
 }
 
+fn category_cycle_members(
+    batch: &NodebbExportBatch,
+    category_ids: &BTreeSet<i64>,
+) -> BTreeSet<i64> {
+    let parent_by_category = batch
+        .categories
+        .iter()
+        .filter_map(|record| {
+            record
+                .parent_cid
+                .filter(|parent_id| *parent_id > 0)
+                .map(|parent_id| (record.cid, parent_id))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut completed = BTreeSet::new();
+    let mut cyclic = BTreeSet::new();
+
+    for start in category_ids.iter().copied() {
+        if completed.contains(&start) {
+            continue;
+        }
+
+        let mut path = Vec::new();
+        let mut position_by_category = BTreeMap::new();
+        let mut current = start;
+
+        loop {
+            if let Some(position) = position_by_category.get(&current).copied() {
+                cyclic.extend(path[position..].iter().copied());
+                break;
+            }
+            if completed.contains(&current) {
+                break;
+            }
+
+            position_by_category.insert(current, path.len());
+            path.push(current);
+
+            let Some(parent_id) = parent_by_category.get(&current).copied() else {
+                break;
+            };
+            if !category_ids.contains(&parent_id) {
+                break;
+            }
+            current = parent_id;
+        }
+
+        completed.extend(path.into_iter());
+    }
+
+    cyclic
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,6 +300,92 @@ mod tests {
         assert_eq!(issues[5].relation, ForumImportDependencyRelation::PostTopic);
         assert_eq!(issues[6].relation, ForumImportDependencyRelation::AuthorUser);
         assert_eq!(issues[6].target.key, "user:8");
+    }
+
+    #[test]
+    fn reports_self_and_multi_node_category_cycles_in_source_order() {
+        let batch = NodebbExportBatch {
+            categories: vec![
+                NodebbCategoryRecord {
+                    cid: 1,
+                    parent_cid: Some(1),
+                    name: "Self".to_owned(),
+                    description: None,
+                    order: None,
+                },
+                NodebbCategoryRecord {
+                    cid: 2,
+                    parent_cid: Some(3),
+                    name: "Cycle A".to_owned(),
+                    description: None,
+                    order: None,
+                },
+                NodebbCategoryRecord {
+                    cid: 3,
+                    parent_cid: Some(2),
+                    name: "Cycle B".to_owned(),
+                    description: None,
+                    order: None,
+                },
+                NodebbCategoryRecord {
+                    cid: 4,
+                    parent_cid: Some(99),
+                    name: "External parent".to_owned(),
+                    description: None,
+                    order: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let inspected = NodebbForumImportInspector.inspect_batch(&batch).unwrap();
+        let issues = &inspected.unresolved_dependencies;
+        assert_eq!(issues.len(), 4);
+        assert_eq!(issues[0].owner.key, "category:1");
+        assert_eq!(issues[0].target.key, "category:1");
+        assert_eq!(issues[0].disposition, ForumImportDependencyDisposition::CyclicBatchRelation);
+        assert_eq!(issues[1].owner.key, "category:2");
+        assert_eq!(issues[1].target.key, "category:3");
+        assert_eq!(issues[1].disposition, ForumImportDependencyDisposition::CyclicBatchRelation);
+        assert_eq!(issues[2].owner.key, "category:3");
+        assert_eq!(issues[2].target.key, "category:2");
+        assert_eq!(issues[2].disposition, ForumImportDependencyDisposition::CyclicBatchRelation);
+        assert_eq!(issues[3].owner.key, "category:4");
+        assert_eq!(issues[3].disposition, ForumImportDependencyDisposition::MissingBatchRecord);
+        assert!(!inspected.is_dependency_complete());
+    }
+
+    #[test]
+    fn acyclic_in_batch_category_chain_is_dependency_complete() {
+        let batch = NodebbExportBatch {
+            categories: vec![
+                NodebbCategoryRecord {
+                    cid: 1,
+                    parent_cid: None,
+                    name: "Root".to_owned(),
+                    description: None,
+                    order: None,
+                },
+                NodebbCategoryRecord {
+                    cid: 2,
+                    parent_cid: Some(1),
+                    name: "Child".to_owned(),
+                    description: None,
+                    order: None,
+                },
+                NodebbCategoryRecord {
+                    cid: 3,
+                    parent_cid: Some(2),
+                    name: "Grandchild".to_owned(),
+                    description: None,
+                    order: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let inspected = NodebbForumImportInspector.inspect_batch(&batch).unwrap();
+        assert!(inspected.is_dependency_complete());
     }
 
     #[test]

--- a/docs/modules/forum-34-nodebb-category-cycle-validation-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-nodebb-category-cycle-validation-actualization-2026-08-09.md
@@ -1,0 +1,123 @@
+# FORUM-34C NodeBB category cycle validation actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor
+
+FORUM-34A introduced the bounded runner-neutral NodeBB source mapper. FORUM-34B added side-effect-free dependency inspection for missing batch records, mismatched `mainPid` ownership and external author identity resolution.
+
+Fresh `main` before this slice was `5070b9002287311d9bc7150b3b78123c55fa9548`. The only change after FORUM-34B was Blog/Taxonomy work; no Forum source overlapped. Fresh repository search still finds no neutral shared import runner/framework, `rustok-import` owner crate or generic import job/checkpoint/receipt contract suitable for Forum composition.
+
+## Gap closed
+
+FORUM-34B treated an in-batch category parent reference as resolved whenever the referenced category ID existed in the same bounded batch.
+
+That left one unsafe graph shape: self-parent and multi-node category cycles could make `NodebbForumImportInspection::is_dependency_complete()` return true even though a future importer could not construct a valid category tree from that batch.
+
+FORUM-34C closes only that source-local graph gap.
+
+## Public behavior
+
+`ForumImportDependencyDisposition` now includes the fixed additive value:
+
+```text
+cyclic_batch_relation
+```
+
+`NodebbForumImportInspector::inspect_batch` computes category-cycle membership using only positive parent references whose target category is present in the current bounded batch.
+
+For every category that is itself a member of such a cycle, the existing `category_parent` dependency is emitted with `cyclic_batch_relation` in the original category source order.
+
+This includes:
+
+- direct self-parent (`cid == parentCid`);
+- two-node cycles;
+- longer in-batch parent cycles.
+
+A category that merely points into a cyclic component is not itself labeled cyclic. The actual cycle members already make the inspection incomplete.
+
+## Cross-page fail-closed rule
+
+A positive `parentCid` whose category record is absent from the current batch remains:
+
+```text
+missing_batch_record
+```
+
+FORUM-34C does not infer that such a reference is cyclic or invalid globally. A future shared runner may resolve it from an earlier/later cursor page or from runner-owned durable source-reference state.
+
+Therefore cycle evidence is intentionally limited to relationships fully proven by the current bounded source batch.
+
+## Bounds and determinism
+
+The source batch remains capped at `MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH = 512`.
+
+Cycle detection builds bounded `BTreeMap` / `BTreeSet` indexes from the current category records only. It performs no recursive database lookup and never loads another export page.
+
+The existing dependency issue bound remains valid:
+
+```text
+MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH = 1536
+```
+
+Each source record still emits at most three dependency issues, and each category emits at most one parent dependency issue whether it is missing or cyclic.
+
+Diagnostics remain deterministic in original category/topic/post source order.
+
+## Ownership boundary
+
+This slice adds no:
+
+- database read or write;
+- migration;
+- UUID synthesis;
+- Profiles/auth lookup;
+- Media access;
+- Forum-only runner;
+- checkpoint, receipt, replay or audit persistence;
+- cross-batch lookup;
+- scheduler;
+- CLI/admin transport;
+- candidate persistence;
+- search rebuild execution.
+
+The category-cycle check is a pure source-batch validation concern owned by the Forum NodeBB adapter. Runner orchestration and cross-page state remain outside Forum until a neutral shared contract exists.
+
+## Evidence added in source
+
+Source tests cover:
+
+- direct self-parent;
+- a two-node category cycle;
+- a missing external parent remaining `missing_batch_record` rather than cyclic;
+- an acyclic in-batch category chain remaining dependency-complete.
+
+These tests are source additions only in this slice and were not executed.
+
+## Remaining FORUM-34 scope
+
+Still open after FORUM-34C:
+
+- neutral shared runner contract and host composition;
+- durable cursor/checkpoint/receipt/replay/audit semantics;
+- external-user resolution through the proper owner boundary;
+- cross-batch dependency resolution;
+- candidate-to-existing Forum owner command adapter;
+- attachment/media mapping after FORUM-14 provides Forum-owned relations;
+- Forum export adapter over stable bounded owner reads;
+- runner-level dry-run report composition;
+- reconciliation/search rebuild orchestration;
+- CLI/admin transport only after RBAC/idempotency/audit admission exists;
+- retained SQLite/PostgreSQL/restart/lost-response evidence.
+
+The large canonical implementation plan is not replaced wholesale through the GitHub contents API; this dated packet records the FORUM-34C cursor without overwriting unrelated concurrent roadmap edits.
+
+## Maintainer validation
+
+Per maintainer instruction, no test, Cargo command, Node verifier, formatter, migration, DB scenario, CLI, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-nodebb-category-cycle-validation-source.mjs
+```

--- a/scripts/verify/verify-forum-nodebb-category-cycle-validation-source.mjs
+++ b/scripts/verify/verify-forum-nodebb-category-cycle-validation-source.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const inspectionPath = "crates/rustok-forum/src/import_inspection.rs";
+const packetPath =
+  "docs/modules/forum-34-nodebb-category-cycle-validation-actualization-2026-08-09.md";
+
+const inspection = read(inspectionPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "CyclicBatchRelation",
+  "let cyclic_category_ids = category_cycle_members(batch, &category_ids);",
+  "cyclic_category_ids.contains(&record.cid)",
+  "ForumImportDependencyDisposition::CyclicBatchRelation",
+  "fn category_cycle_members(",
+  ".collect::<BTreeMap<_, _>>();",
+  "position_by_category.get(&current).copied()",
+  "cyclic.extend(path[position..].iter().copied());",
+  "if !category_ids.contains(&parent_id)",
+  "completed.extend(path.into_iter());",
+  "reports_self_and_multi_node_category_cycles_in_source_order",
+  "acyclic_in_batch_category_chain_is_dependency_complete",
+  'assert_eq!(issues[0].target.key, "category:1");',
+  "ForumImportDependencyDisposition::MissingBatchRecord",
+  "MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH",
+]) {
+  requireText(inspection, marker, `${inspectionPath}: missing ${marker}`);
+}
+
+for (const forbidden of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "Entity::",
+  "ActiveModel",
+  "Uuid",
+  "rustok_media",
+  "rustok_profiles",
+  "rustok_notifications",
+  "rustok_search",
+  "rustok_moderation",
+  "async fn",
+  ".await",
+  "PortContext",
+  "Service::new",
+  "register_runtime_extensions",
+  "INSERT ",
+  "UPDATE ",
+  "DELETE ",
+  ".insert(",
+  ".update(",
+  ".delete(",
+]) {
+  requireAbsent(
+    inspection,
+    forbidden,
+    `${inspectionPath}: category cycle validation must remain side-effect free: ${forbidden}`,
+  );
+}
+
+const cycleStart = inspection.indexOf("fn category_cycle_members(");
+const testsStart = inspection.indexOf("#[cfg(test)]", cycleStart);
+if (cycleStart < 0 || testsStart <= cycleStart) {
+  throw new Error(`${inspectionPath}: cycle helper source boundary is invalid`);
+}
+const cycleHelper = inspection.slice(cycleStart, testsStart);
+for (const forbidden of [
+  "NodebbForumImportMapper",
+  "ForumImportExternalRef",
+  "std::fs",
+  "serde_json",
+  "loop { loop",
+]) {
+  requireAbsent(
+    cycleHelper,
+    forbidden,
+    `${inspectionPath}: cycle helper must stay bounded to category ids/parents: ${forbidden}`,
+  );
+}
+
+for (const marker of [
+  "FORUM-34C",
+  "shared-runner-blocked",
+  "self-parent and multi-node category cycles",
+  "cyclic_batch_relation",
+  "missing external parent remaining `missing_batch_record` rather than cyclic",
+  "does not infer that such a reference is cyclic or invalid globally",
+  "MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH = 512",
+  "MAX_FORUM_IMPORT_DEPENDENCY_ISSUES_PER_BATCH = 1536",
+  "no test, Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-34C NodeBB category cycle validation source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 after #3380 by making bounded NodeBB category dependency inspection fail closed on source-local parent cycles.

- add fixed additive `cyclic_batch_relation` dependency disposition;
- detect direct self-parent and multi-node category cycles only when every traversed parent is present in the same bounded batch;
- emit one deterministic `category_parent` issue for each category that is itself a cycle member, in original category source order;
- preserve absent positive parents as `missing_batch_record` rather than inferring a global cycle;
- keep ordinary ancestors that merely point into a cyclic component out of the cycle-member set;
- retain the existing 512 source-record / 1536 dependency-issue bounds;
- add source tests for self-cycle, two-node cycle, missing external parent and acyclic chain;
- add FORUM-34C actualization and source guard.

## Ownership / limits

Fresh source search still finds no neutral shared import runner/framework. This PR adds no DB read/write, migration, UUID synthesis, identity/Profile lookup, Media access, Forum-only runner, checkpoint/receipt/audit state, cross-batch lookup, scheduler, CLI/admin transport, persistence or Search rebuild execution.

Cycle evidence is intentionally limited to the current source batch. Cross-page graph resolution remains future shared-runner state.

## Validation

Per maintainer instruction, no tests, Cargo command, Node verifier, formatter, migration, DB scenario, CLI, workflow, CI, lock generation or `git diff --check` was run. Maintainer will run tests.