### PR TITLE
feat(commerce): route GraphQL payment reads through owner ports

### DIFF
--- a/crates/rustok-commerce/contracts/evidence/graphql-query-payment-error-safety-source-review.json
+++ b/crates/rustok-commerce/contracts/evidence/graphql-query-payment-error-safety-source-review.json
@@ -1,12 +1,15 @@
 {
-  "schema_version": 1,
-  "status": "commerce_graphql_query_payment_error_safety_source_reviewed_unvalidated",
+  "schema_version": 2,
+  "status": "commerce_graphql_payment_read_owner_ports_source_reviewed_unvalidated",
   "reviewed_scope": [
     "crates/rustok-commerce/src/graphql/query.rs",
     "crates/rustok-commerce/src/graphql/safe_query/source.rs",
     "crates/rustok-commerce/src/graphql/safe_query/source/rustok_payment_shim.rs",
-    "crates/rustok-payment/src/services/payment.rs",
-    "crates/rustok-payment/src/error.rs",
+    "crates/rustok-commerce/src/graphql_runtime.rs",
+    "crates/rustok-commerce/src/graphql_runtime/payment_reads.rs",
+    "crates/rustok-payment/src/admin_read.rs",
+    "crates/rustok-payment/src/order_read.rs",
+    "crates/rustok-payment/src/cart_read.rs",
     "scripts/verify/verify-commerce-graphql-query-payment-error-safety.mjs",
     "crates/rustok-commerce/docs/graphql-query-payment-error-safety.md"
   ],
@@ -15,7 +18,15 @@
     "payment_owner_service_preserved": true,
     "payment_owner_read_methods_preserved": true,
     "payment_success_dtos_preserved": true,
-    "typed_payment_error_retained_to_transport": true,
+    "graphql_concrete_payment_service_removed": true,
+    "payment_admin_read_port_reused": true,
+    "payment_order_read_port_reused": true,
+    "payment_cart_read_port_added": true,
+    "graphql_payment_runtime_scoped": true,
+    "host_shared_owner_runtimes_preferred": true,
+    "embedded_in_process_owner_fallback_retained": true,
+    "trusted_actor_channel_locale_propagated": true,
+    "typed_port_error_retained_to_transport": true,
     "payment_collection_not_found_branch_preserved": true,
     "refund_not_found_branch_preserved": true,
     "owner_error_display_used_for_public_response": false,
@@ -37,8 +48,9 @@
     "diagnostic_debug_redacted": true,
     "technical_error_severity_preserved": true,
     "ordinary_rejection_warning_severity_preserved": true,
+    "admin_read_raw_owner_debug_removed": true,
     "graphql_fields_or_dtos_changed": false,
-    "payment_owner_contract_changed": false,
+    "payment_owner_contract_changed": true,
     "commerce_ffa_status_changed": false,
     "commerce_fba_status_changed": false,
     "payment_ffa_status_changed": false,
@@ -55,8 +67,9 @@
     "workflow_checks_run": false,
     "ci_run": false,
     "compile_proven": false,
-    "runtime_proven": false
+    "runtime_proven": false,
+    "remote_adapter_proven": false
   },
   "execution": [],
-  "validation_disclosure": "No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed."
+  "validation_disclosure": "Source/GitHub inspection only. No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, or remote-adapter execution were performed."
 }

--- a/crates/rustok-commerce/docs/graphql-query-payment-error-safety.md
+++ b/crates/rustok-commerce/docs/graphql-query-payment-error-safety.md
@@ -1,64 +1,65 @@
-# Commerce GraphQL payment query error safety
+# Commerce GraphQL payment query owner-port and error safety
 
 Status: `source_closed_unvalidated`
 
 ## Scope
 
-This source wave closes the identified typed-error loss in mounted Commerce GraphQL payment collection and refund reads.
+This source wave keeps the mounted Commerce GraphQL payment query contract unchanged while removing concrete `rustok_payment::PaymentService` construction from its private compatibility facade.
 
-The compatibility resolver source in `crates/rustok-commerce/src/graphql/query.rs` remains unchanged. Its existing `PaymentService` calls still perform the same reads and return the same successful payment collection and refund DTOs. Existing `PaymentCollectionNotFound` and `RefundNotFound` branches continue to return `None` where the GraphQL contract already requires that behavior.
+The resolver source in `crates/rustok-commerce/src/graphql/query.rs` remains unchanged. Its seven `PaymentService::new(db.clone())` expressions still call the same six logical reads and return the same successful payment collection/refund DTOs. Existing `PaymentCollectionNotFound` and `RefundNotFound` branches continue to return `None` where the GraphQL contract already requires that behavior.
 
-## Typed facade
+## Owner capabilities
 
-The mounted safe-query source aliases only the Payment dependency used by the unchanged compatibility query. The facade wraps the canonical `rustok_payment::PaymentService` and delegates these owner methods without changing arguments or successful projections:
+The private Payment compatibility facade now delegates to typed Payment owner capabilities instead of constructing `rustok_payment::PaymentService`:
 
-- `find_reusable_collection_by_cart`;
-- `find_latest_collection_by_order`;
-- `get_collection`;
-- `list_collections`;
-- `get_refund`;
-- `list_refunds`.
+- `PaymentCartReadPort::find_reusable_collection_by_cart` for the storefront cart-associated reusable collection lookup;
+- `PaymentOrderReadPort::find_latest_collection_by_order` for the order-associated lookup;
+- `PaymentAdminReadPort::{read,list}_payment_collection_projection` for collection detail/list reads;
+- `PaymentAdminReadPort::{read,list}_refund_projection` for refund detail/list reads.
 
-The original resolver converts several failures through `err.to_string()`. The facade preserves those expressions through an inherent typed conversion that returns the safe GraphQL boundary value. It does not format the Payment owner error into a public string.
+`PaymentCartReadPort` / `PaymentCartReadRuntime` are the only new Payment owner API in this slice. The in-process adapter owns the concrete `PaymentService`; Commerce never imports Payment ORM entities or raw SQL for these reads.
+
+## GraphQL runtime composition
+
+`CommercePaymentReadRuntime` composes the three narrow Payment owner runtimes. The mounted GraphQL extension carries that composite through a task-local resolver scope together with request-owned actor, channel, and locale facts.
+
+Schema composition prefers a host-shared `CommercePaymentReadRuntime`. If one is not supplied, it composes the runtime from any individually shared `PaymentAdminReadRuntime`, `PaymentOrderReadRuntime`, and `PaymentCartReadRuntime`, falling back to in-process owner adapters only for capabilities the host did not provide. Directly embedded compatibility schemas therefore retain an explicit owner-runtime fallback without returning to concrete Payment construction in the resolver facade.
+
+Each shim read builds a bounded two-second `PortContext` with the current tenant, validated user actor or stable service actor, resolved locale, resolved channel when present, and a stable correlation token. These are read calls; no write idempotency or durable receipt is claimed.
 
 ## Public envelopes
 
-Transport responses are classified structurally by `rustok_payment::error::PaymentError` variant.
+The facade retains the existing GraphQL compatibility variants while classifying owner `PortError` structurally:
 
-| Owner variant | Public code | Public message | Retryable |
+| Owner result | Public code | Public message | Retryable |
 | --- | --- | --- | --- |
 | Validation | `PAYMENT_REQUEST_INVALID` | `Payment query is invalid` | false |
-| Collection/payment/refund not found | `PAYMENT_RESOURCE_NOT_FOUND` | `Payment resource was not found` | false |
-| Invalid transition/provider rejection | `PAYMENT_STATE_CONFLICT` | `Payment state conflicts with this query` | false |
-| Provider unavailable/database | `PAYMENT_TEMPORARILY_UNAVAILABLE` | `Payment data is temporarily unavailable` | true |
-| Invalid/unknown provider outcome | `PAYMENT_RECONCILIATION_REQUIRED` | `Payment state requires reconciliation` | false |
-| Provider configuration | `PAYMENT_CONFIGURATION_ERROR` | `Payment provider configuration is invalid` | false |
+| Not found | `PAYMENT_RESOURCE_NOT_FOUND` | `Payment resource was not found` | false |
+| Conflict | `PAYMENT_STATE_CONFLICT` | `Payment state conflicts with this query` | false |
+| Unavailable/timeout | `PAYMENT_TEMPORARILY_UNAVAILABLE` | `Payment data is temporarily unavailable` | true |
+| Invariant/reconciliation | `PAYMENT_RECONCILIATION_REQUIRED` | `Payment state requires reconciliation` | false |
+| Configuration-coded owner failure | `PAYMENT_CONFIGURATION_ERROR` | `Payment provider configuration is invalid` | false |
 
-Validation text, provider identifiers and operation text, lifecycle values, database causes, and complete owner errors are not copied into GraphQL responses.
+Configuration compatibility is recognized only from the three closed built-in owner codes `payment.admin_read_configuration`, `payment.order_read_configuration`, and `payment.cart_read_configuration`; arbitrary external adapter codes are not logged or pattern-matched as configuration.
+
+The compatibility `PaymentCollectionNotFound` and `RefundNotFound` enum variants are reconstructed only from owner `NotFound` plus the requested resource kind, preserving the unchanged branches in `query.rs`.
+
+Validation text, provider identifiers and operation text, lifecycle values, database causes, complete owner errors, and arbitrary owner codes are not copied into GraphQL responses.
 
 ## Bounded diagnostics
 
-The facade records only:
+The Commerce facade records only a redacted diagnostic token, owner operation, stable correlation token, tenant/resource shape facts, structural `PortError` kind, owner-code character length, selected public code, and retryability. The owner code itself is not logged.
 
-- a diagnostic token whose `Debug` output is always `redacted`;
-- canonical owner and owner operation;
-- a stable Commerce GraphQL correlation token derived from the operation and owner resource identity;
-- tenant identity, resource kind, and closed UUID shape;
-- structural error kind;
-- closed owner-detail shape and aggregate character length;
-- selected public code and retryability;
-- error severity for technical, configuration, and reconciliation failures;
-- warning severity for validation, not-found, and conflict rejections.
-
-The complete `PaymentError`, provider identifiers, provider operation text, validation text, lifecycle values, and database error are not logged.
+The Payment admin read owner adapter was also tightened in this slice: its technical failure log no longer emits `error = ?error`. Order and cart read owner adapters already log only bounded error variants/codes and shape facts.
 
 ## Preserved contracts
 
-- `rustok-payment` remains the owner of payment collection and refund persistence and read behavior.
-- The canonical owner service and six read methods are preserved.
-- The query source, GraphQL fields, authorization checks, filters, pagination, result ordering, and DTO conversions are unchanged.
+- `rustok-payment` remains the owner of payment collection/refund persistence and read behavior.
+- The underlying Payment service and six canonical read methods remain intact inside owner adapters.
+- `query.rs`, GraphQL fields, authorization checks, filters, pagination, result ordering, and DTO conversions are unchanged.
+- No Payment provider call is introduced by these read ports.
 - Commerce and Payment FFA/FBA status is unchanged.
-- The broad ecommerce mapper and public-envelope cleanup remains open.
+- The broad Commerce topology P0 remains open for remaining GraphQL mutations/provider operations, post-order/change/return, checkout/reconciliation, and other concrete-owner paths.
 - No compile, runtime, mounted GraphQL, remote-adapter, or parity evidence is claimed.
 
 ## Evidence
@@ -68,9 +69,10 @@ The complete `PaymentError`, provider identifiers, provider operation text, vali
 
 ## Still open
 
-- Execute the focused source verifier and Cargo checks.
-- Retain mounted payment collection/refund success, not-found, validation, database, and reconciliation GraphQL evidence.
-- Continue order execution/compensation, inventory, tax, promotion, remaining adapter, write-side, and non-`PortError` ecommerce envelope cleanup.
+- Execute the focused source verifier and Cargo checks under maintainer control.
+- Retain mounted success/not-found/validation/database/reconciliation GraphQL evidence.
+- Retain remote-adapter selection evidence proving host-selected Payment read runtimes are used by mounted GraphQL.
+- Continue the remaining broad Commerce topology cutover.
 
 ## Intended checks
 
@@ -80,4 +82,4 @@ cargo check -p rustok-commerce --lib
 cargo check -p rustok-payment --lib
 ```
 
-No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed.
+Source/GitHub inspection only. No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, or remote-adapter execution were performed.

--- a/crates/rustok-commerce/src/graphql/safe_query/source/rustok_payment_shim.rs
+++ b/crates/rustok-commerce/src/graphql/safe_query/source/rustok_payment_shim.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+
+use ::rustok_api::{PortContext, PortError as OwnerPortError, PortErrorKind};
 use ::rustok_payment::{
-    dto::{
-        ListPaymentCollectionsInput, ListRefundsInput, PaymentCollectionResponse, RefundResponse,
-    },
-    error::PaymentError as OwnerPaymentError,
+    LatestPaymentCollectionByOrderRequest, ListPaymentCollectionProjectionsRequest,
+    ListRefundProjectionsRequest, PaymentAdminReadPort, PaymentCartReadPort,
+    PaymentCollectionResponse, PaymentOrderReadPort, ReadPaymentCollectionProjectionRequest,
+    ReadRefundProjectionRequest, RefundResponse, ReusablePaymentCollectionByCartRequest,
+    dto::{ListPaymentCollectionsInput, ListRefundsInput},
 };
 use ::sea_orm::DatabaseConnection;
 use ::uuid::Uuid;
@@ -19,10 +23,6 @@ impl std::fmt::Debug for PaymentQueryDiagnosticError {
     }
 }
 
-fn text_shape(value: &str) -> &'static str {
-    if value.is_empty() { "empty" } else { "present" }
-}
-
 fn uuid_shape(value: &Uuid) -> &'static str {
     if value.is_nil() {
         "uuid_nil"
@@ -31,43 +31,25 @@ fn uuid_shape(value: &Uuid) -> &'static str {
     }
 }
 
-fn owner_detail(error: &OwnerPaymentError) -> (&'static str, usize) {
-    match error {
-        OwnerPaymentError::Validation(value) => (text_shape(value), value.chars().count()),
-        OwnerPaymentError::PaymentCollectionNotFound(value)
-        | OwnerPaymentError::PaymentNotFound(value)
-        | OwnerPaymentError::RefundNotFound(value) => (uuid_shape(value), 0),
-        OwnerPaymentError::InvalidTransition { from, to } => (
-            "two_status_values",
-            from.chars().count().saturating_add(to.chars().count()),
-        ),
-        OwnerPaymentError::ProviderUnavailable {
-            provider_id,
-            operation,
-        }
-        | OwnerPaymentError::ProviderRejected {
-            provider_id,
-            operation,
-        }
-        | OwnerPaymentError::ProviderInvalidResponse {
-            provider_id,
-            operation,
-        }
-        | OwnerPaymentError::ProviderOutcomeUnknown {
-            provider_id,
-            operation,
-        } => (
-            "provider_operation_values",
-            provider_id
-                .chars()
-                .count()
-                .saturating_add(operation.chars().count()),
-        ),
-        OwnerPaymentError::ProviderConfiguration { provider_id } => {
-            (text_shape(provider_id), provider_id.chars().count())
-        }
-        OwnerPaymentError::Database(_) => ("database_redacted", 0),
+fn port_error_kind(kind: &PortErrorKind) -> &'static str {
+    match kind {
+        PortErrorKind::Validation => "validation",
+        PortErrorKind::NotFound => "not_found",
+        PortErrorKind::Conflict => "conflict",
+        PortErrorKind::Forbidden => "forbidden",
+        PortErrorKind::Unavailable => "unavailable",
+        PortErrorKind::Timeout => "timeout",
+        PortErrorKind::InvariantViolation => "invariant_violation",
     }
+}
+
+fn is_configuration_error(error: &OwnerPortError) -> bool {
+    matches!(
+        error.code.as_str(),
+        "payment.admin_read_configuration"
+            | "payment.order_read_configuration"
+            | "payment.cart_read_configuration"
+    )
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,7 +85,7 @@ impl PaymentQueryResource {
 
 #[derive(Debug)]
 pub(crate) struct PaymentQueryError {
-    error: OwnerPaymentError,
+    error: OwnerPortError,
     tenant_id: Uuid,
     operation: &'static str,
     resource: PaymentQueryResource,
@@ -111,7 +93,7 @@ pub(crate) struct PaymentQueryError {
 
 impl PaymentQueryError {
     fn new(
-        error: OwnerPaymentError,
+        error: OwnerPortError,
         tenant_id: Uuid,
         operation: &'static str,
         resource: PaymentQueryResource,
@@ -125,56 +107,63 @@ impl PaymentQueryError {
     }
 
     fn into_boundary(self) -> BoundaryError {
-        let (message, code, retryable, error_kind, technical) = match &self.error {
-            OwnerPaymentError::Validation(_) => (
-                "Payment query is invalid",
-                "PAYMENT_REQUEST_INVALID",
-                false,
-                "validation",
-                false,
-            ),
-            OwnerPaymentError::PaymentCollectionNotFound(_)
-            | OwnerPaymentError::PaymentNotFound(_)
-            | OwnerPaymentError::RefundNotFound(_) => (
-                "Payment resource was not found",
-                "PAYMENT_RESOURCE_NOT_FOUND",
-                false,
-                "not_found",
-                false,
-            ),
-            OwnerPaymentError::InvalidTransition { .. }
-            | OwnerPaymentError::ProviderRejected { .. } => (
-                "Payment state conflicts with this query",
-                "PAYMENT_STATE_CONFLICT",
-                false,
-                "state_conflict",
-                false,
-            ),
-            OwnerPaymentError::ProviderUnavailable { .. }
-            | OwnerPaymentError::Database(_) => (
-                "Payment data is temporarily unavailable",
-                "PAYMENT_TEMPORARILY_UNAVAILABLE",
-                true,
-                "temporarily_unavailable",
-                true,
-            ),
-            OwnerPaymentError::ProviderInvalidResponse { .. }
-            | OwnerPaymentError::ProviderOutcomeUnknown { .. } => (
-                "Payment state requires reconciliation",
-                "PAYMENT_RECONCILIATION_REQUIRED",
-                false,
-                "reconciliation_required",
-                true,
-            ),
-            OwnerPaymentError::ProviderConfiguration { .. } => (
+        let configuration = is_configuration_error(&self.error);
+        let (message, code, retryable, error_kind, technical) = if configuration {
+            (
                 "Payment provider configuration is invalid",
                 "PAYMENT_CONFIGURATION_ERROR",
                 false,
                 "configuration",
                 true,
-            ),
+            )
+        } else {
+            match &self.error.kind {
+                PortErrorKind::Validation => (
+                    "Payment query is invalid",
+                    "PAYMENT_REQUEST_INVALID",
+                    false,
+                    "validation",
+                    false,
+                ),
+                PortErrorKind::NotFound => (
+                    "Payment resource was not found",
+                    "PAYMENT_RESOURCE_NOT_FOUND",
+                    false,
+                    "not_found",
+                    false,
+                ),
+                PortErrorKind::Conflict => (
+                    "Payment state conflicts with this query",
+                    "PAYMENT_STATE_CONFLICT",
+                    false,
+                    "state_conflict",
+                    false,
+                ),
+                PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+                    "Payment data is temporarily unavailable",
+                    "PAYMENT_TEMPORARILY_UNAVAILABLE",
+                    true,
+                    "temporarily_unavailable",
+                    true,
+                ),
+                PortErrorKind::InvariantViolation => (
+                    "Payment state requires reconciliation",
+                    "PAYMENT_RECONCILIATION_REQUIRED",
+                    false,
+                    "reconciliation_required",
+                    true,
+                ),
+                PortErrorKind::Forbidden => (
+                    "Payment query is invalid",
+                    "PAYMENT_REQUEST_INVALID",
+                    false,
+                    "forbidden",
+                    false,
+                ),
+            }
         };
-        let (owner_detail_shape, owner_detail_length) = owner_detail(&self.error);
+        let owner_detail_shape = port_error_kind(&self.error.kind);
+        let owner_detail_length = self.error.code.chars().count();
         let resource_kind = self.resource.kind();
         let resource_id = self.resource.id();
         let resource_id_shape = uuid_shape(&resource_id);
@@ -228,7 +217,7 @@ impl PaymentQueryError {
 
 pub(crate) mod error {
     use super::{
-        BoundaryError, OwnerPaymentError, PaymentQueryError, PaymentQueryResource, Uuid,
+        BoundaryError, OwnerPortError, PaymentQueryError, PaymentQueryResource, PortErrorKind, Uuid,
     };
 
     #[derive(Debug)]
@@ -239,19 +228,21 @@ pub(crate) mod error {
     }
 
     impl PaymentError {
-        pub(super) fn from_owner(
-            error: OwnerPaymentError,
+        pub(super) fn from_owner_port(
+            error: OwnerPortError,
             tenant_id: Uuid,
             operation: &'static str,
             resource: PaymentQueryResource,
         ) -> Self {
+            let not_found = error.kind == PortErrorKind::NotFound;
+            let collection_not_found =
+                not_found && matches!(resource, PaymentQueryResource::Collection(_));
+            let refund_not_found =
+                not_found && matches!(resource, PaymentQueryResource::Refund(_));
             let error = PaymentQueryError::new(error, tenant_id, operation, resource);
-            if matches!(
-                &error.error,
-                OwnerPaymentError::PaymentCollectionNotFound(_)
-            ) {
+            if collection_not_found {
                 Self::PaymentCollectionNotFound(error)
-            } else if matches!(&error.error, OwnerPaymentError::RefundNotFound(_)) {
+            } else if refund_not_found {
                 Self::RefundNotFound(error)
             } else {
                 Self::Other(error)
@@ -272,13 +263,39 @@ pub(crate) mod error {
 use error::PaymentError;
 
 pub(crate) struct PaymentService {
-    inner: ::rustok_payment::PaymentService,
+    admin_reads: Arc<dyn PaymentAdminReadPort>,
+    order_reads: Arc<dyn PaymentOrderReadPort>,
+    cart_reads: Arc<dyn PaymentCartReadPort>,
 }
 
 impl PaymentService {
     pub(crate) fn new(db: DatabaseConnection) -> Self {
+        let runtime = crate::graphql_runtime::payment_read_runtime_for_current_graphql_scope(db);
         Self {
-            inner: ::rustok_payment::PaymentService::new(db),
+            admin_reads: runtime.admin_read_port(),
+            order_reads: runtime.order_read_port(),
+            cart_reads: runtime.cart_read_port(),
+        }
+    }
+
+    fn context(
+        &self,
+        tenant_id: Uuid,
+        operation: &'static str,
+        resource: PaymentQueryResource,
+    ) -> PortContext {
+        let (actor, channel, locale) =
+            crate::graphql_runtime::payment_read_call_context_for_current_graphql_scope();
+        let context = PortContext::new(
+            tenant_id.to_string(),
+            actor,
+            locale.as_deref().unwrap_or("und"),
+            format!("commerce-graphql-payment:{operation}:{}", resource.id()),
+        )
+        .with_deadline(std::time::Duration::from_secs(2));
+        match channel.as_deref() {
+            Some(channel) => context.with_channel(channel),
+            None => context,
         }
     }
 
@@ -287,17 +304,15 @@ impl PaymentService {
         tenant_id: Uuid,
         cart_id: Uuid,
     ) -> Result<Option<PaymentCollectionResponse>, PaymentError> {
-        self.inner
-            .find_reusable_collection_by_cart(tenant_id, cart_id)
+        const OPERATION: &str = "find_reusable_collection_by_cart";
+        let resource = PaymentQueryResource::Cart(cart_id);
+        self.cart_reads
+            .find_reusable_collection_by_cart(
+                self.context(tenant_id, OPERATION, resource),
+                ReusablePaymentCollectionByCartRequest { cart_id },
+            )
             .await
-            .map_err(|error| {
-                PaymentError::from_owner(
-                    error,
-                    tenant_id,
-                    "find_reusable_collection_by_cart",
-                    PaymentQueryResource::Cart(cart_id),
-                )
-            })
+            .map_err(|error| PaymentError::from_owner_port(error, tenant_id, OPERATION, resource))
     }
 
     pub(crate) async fn find_latest_collection_by_order(
@@ -305,17 +320,15 @@ impl PaymentService {
         tenant_id: Uuid,
         order_id: Uuid,
     ) -> Result<Option<PaymentCollectionResponse>, PaymentError> {
-        self.inner
-            .find_latest_collection_by_order(tenant_id, order_id)
+        const OPERATION: &str = "find_latest_collection_by_order";
+        let resource = PaymentQueryResource::Order(order_id);
+        self.order_reads
+            .find_latest_collection_by_order(
+                self.context(tenant_id, OPERATION, resource),
+                LatestPaymentCollectionByOrderRequest { order_id },
+            )
             .await
-            .map_err(|error| {
-                PaymentError::from_owner(
-                    error,
-                    tenant_id,
-                    "find_latest_collection_by_order",
-                    PaymentQueryResource::Order(order_id),
-                )
-            })
+            .map_err(|error| PaymentError::from_owner_port(error, tenant_id, OPERATION, resource))
     }
 
     pub(crate) async fn get_collection(
@@ -323,17 +336,15 @@ impl PaymentService {
         tenant_id: Uuid,
         collection_id: Uuid,
     ) -> Result<PaymentCollectionResponse, PaymentError> {
-        self.inner
-            .get_collection(tenant_id, collection_id)
+        const OPERATION: &str = "get_collection";
+        let resource = PaymentQueryResource::Collection(collection_id);
+        self.admin_reads
+            .read_payment_collection_projection(
+                self.context(tenant_id, OPERATION, resource),
+                ReadPaymentCollectionProjectionRequest { collection_id },
+            )
             .await
-            .map_err(|error| {
-                PaymentError::from_owner(
-                    error,
-                    tenant_id,
-                    "get_collection",
-                    PaymentQueryResource::Collection(collection_id),
-                )
-            })
+            .map_err(|error| PaymentError::from_owner_port(error, tenant_id, OPERATION, resource))
     }
 
     pub(crate) async fn list_collections(
@@ -341,17 +352,24 @@ impl PaymentService {
         tenant_id: Uuid,
         input: ListPaymentCollectionsInput,
     ) -> Result<(Vec<PaymentCollectionResponse>, u64), PaymentError> {
-        self.inner
-            .list_collections(tenant_id, input)
+        const OPERATION: &str = "list_collections";
+        let resource = PaymentQueryResource::Tenant(tenant_id);
+        let page = self
+            .admin_reads
+            .list_payment_collection_projections(
+                self.context(tenant_id, OPERATION, resource),
+                ListPaymentCollectionProjectionsRequest {
+                    page: input.page,
+                    per_page: input.per_page,
+                    status: input.status,
+                    order_id: input.order_id,
+                    cart_id: input.cart_id,
+                    customer_id: input.customer_id,
+                },
+            )
             .await
-            .map_err(|error| {
-                PaymentError::from_owner(
-                    error,
-                    tenant_id,
-                    "list_collections",
-                    PaymentQueryResource::Tenant(tenant_id),
-                )
-            })
+            .map_err(|error| PaymentError::from_owner_port(error, tenant_id, OPERATION, resource))?;
+        Ok((page.items, page.total))
     }
 
     pub(crate) async fn get_refund(
@@ -359,17 +377,15 @@ impl PaymentService {
         tenant_id: Uuid,
         refund_id: Uuid,
     ) -> Result<RefundResponse, PaymentError> {
-        self.inner
-            .get_refund(tenant_id, refund_id)
+        const OPERATION: &str = "get_refund";
+        let resource = PaymentQueryResource::Refund(refund_id);
+        self.admin_reads
+            .read_refund_projection(
+                self.context(tenant_id, OPERATION, resource),
+                ReadRefundProjectionRequest { refund_id },
+            )
             .await
-            .map_err(|error| {
-                PaymentError::from_owner(
-                    error,
-                    tenant_id,
-                    "get_refund",
-                    PaymentQueryResource::Refund(refund_id),
-                )
-            })
+            .map_err(|error| PaymentError::from_owner_port(error, tenant_id, OPERATION, resource))
     }
 
     pub(crate) async fn list_refunds(
@@ -377,16 +393,22 @@ impl PaymentService {
         tenant_id: Uuid,
         input: ListRefundsInput,
     ) -> Result<(Vec<RefundResponse>, u64), PaymentError> {
-        self.inner
-            .list_refunds(tenant_id, input)
+        const OPERATION: &str = "list_refunds";
+        let resource = PaymentQueryResource::Tenant(tenant_id);
+        let page = self
+            .admin_reads
+            .list_refund_projections(
+                self.context(tenant_id, OPERATION, resource),
+                ListRefundProjectionsRequest {
+                    page: input.page,
+                    per_page: input.per_page,
+                    payment_collection_id: input.payment_collection_id,
+                    order_id: input.order_id,
+                    status: input.status,
+                },
+            )
             .await
-            .map_err(|error| {
-                PaymentError::from_owner(
-                    error,
-                    tenant_id,
-                    "list_refunds",
-                    PaymentQueryResource::Tenant(tenant_id),
-                )
-            })
+            .map_err(|error| PaymentError::from_owner_port(error, tenant_id, OPERATION, resource))?;
+        Ok((page.items, page.total))
     }
 }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -16,6 +16,9 @@ use rustok_payment::providers::PaymentProviderRegistry;
 use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogReadRuntime};
 use sea_orm::DatabaseConnection;
 
+mod payment_reads;
+pub use payment_reads::CommercePaymentReadRuntime;
+
 /// Host-selected shipping-option read ports used by mounted commerce GraphQL resolvers.
 ///
 /// The application host composes this runtime once and carries it through
@@ -190,10 +193,9 @@ tokio::task_local! {
 
 /// Resolver-scoped bridge from schema runtime data to private compatibility facades.
 ///
-/// The mounted extension carries shipping-option, fulfillment-lifecycle, order, and Product catalog
-/// owner read/command ports plus validated order actor/channel/locale and fulfillment public-channel
-/// facts so every included Commerce resolver uses host-selected adapters and request-owned context
-/// for the current async task.
+/// The mounted extension carries Payment, shipping-option, fulfillment-lifecycle, order, and
+/// Product owner capabilities plus validated request-owned identity/channel/locale facts so every
+/// included Commerce resolver uses host-selected adapters for the current async task.
 #[derive(Default)]
 pub struct CommerceShippingOptionReadScope;
 
@@ -219,8 +221,12 @@ impl Extension for CommerceShippingOptionReadScopeExtension {
         let order_call_context = CommerceOrderReadCallContext::from_extension_context(ctx);
         let fulfillment_call_context =
             CommerceFulfillmentReadCallContext::from_extension_context(ctx);
-        CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME
-            .scope(
+        let payment_call_context =
+            payment_reads::CommercePaymentReadCallContext::from_extension_context(ctx);
+        payment_reads::scope_current_payment_reads(
+            runtime_data.payment_read_runtime(),
+            payment_call_context,
+            CURRENT_COMMERCE_SHIPPING_OPTION_READ_RUNTIME.scope(
                 runtime_data.shipping_option_read_runtime(),
                 CURRENT_COMMERCE_FULFILLMENT_LIFECYCLE_READ_RUNTIME.scope(
                     runtime_data.fulfillment_lifecycle_read_runtime(),
@@ -241,8 +247,9 @@ impl Extension for CommerceShippingOptionReadScopeExtension {
                         ),
                     ),
                 ),
-            )
-            .await
+            ),
+        )
+        .await
     }
 }
 
@@ -284,6 +291,22 @@ pub(crate) fn order_read_call_context_for_current_graphql_scope() -> CommerceOrd
         .unwrap_or_default()
 }
 
+pub(crate) fn payment_read_runtime_for_current_graphql_scope(
+    db: DatabaseConnection,
+) -> CommercePaymentReadRuntime {
+    payment_reads::runtime_for_current_graphql_scope(db)
+}
+
+pub(crate) fn payment_read_call_context_for_current_graphql_scope(
+) -> (PortActor, Option<String>, Option<String>) {
+    let context = payment_reads::call_context_for_current_graphql_scope();
+    (
+        context.actor(),
+        context.channel().map(str::to_owned),
+        context.locale().map(str::to_owned),
+    )
+}
+
 pub(crate) fn product_catalog_read_runtime_for_current_graphql_scope(
     db: DatabaseConnection,
     event_bus: rustok_outbox::TransactionalEventBus,
@@ -305,15 +328,16 @@ pub(crate) fn product_catalog_command_runtime_for_current_graphql_scope(
 /// Provider registries and host-selectable ports available to every commerce GraphQL resolver.
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual provider
-/// registries remain deterministic fallbacks. Mounted shipping-option, fulfillment-lifecycle,
-/// Product catalog reads/commands, and order reads consume host-selected runtime data. Directly
-/// embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
+/// registries remain deterministic fallbacks. Mounted Payment, shipping-option,
+/// fulfillment-lifecycle, Product catalog, and order reads consume host-selected runtime data.
+/// Directly embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
     #[cfg(feature = "marketplace-financial")]
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
+    payment_read_runtime: CommercePaymentReadRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
@@ -333,6 +357,10 @@ impl CommerceGraphqlRuntimeData {
     #[cfg(feature = "marketplace-financial")]
     pub fn marketplace_financial_runtime(&self) -> crate::MarketplaceFinancialRuntime {
         self.marketplace_financial_runtime.clone()
+    }
+
+    pub fn payment_read_runtime(&self) -> CommercePaymentReadRuntime {
+        self.payment_read_runtime.clone()
     }
 
     pub fn shipping_option_read_runtime(&self) -> CommerceShippingOptionReadRuntime {
@@ -374,6 +402,27 @@ pub fn attach_schema_data(
                 "commerce marketplace-financial GraphQL requires MarketplaceFinancialRuntime in host composition"
                     .to_string()
             })?,
+        payment_read_runtime: inputs
+            .shared_get::<CommercePaymentReadRuntime>()
+            .unwrap_or_else(|| {
+                CommercePaymentReadRuntime::new(
+                    inputs
+                        .shared_get::<rustok_payment::PaymentAdminReadRuntime>()
+                        .unwrap_or_else(|| {
+                            rustok_payment::PaymentAdminReadRuntime::in_process(inputs.db_clone())
+                        }),
+                    inputs
+                        .shared_get::<rustok_payment::PaymentOrderReadRuntime>()
+                        .unwrap_or_else(|| {
+                            rustok_payment::PaymentOrderReadRuntime::in_process(inputs.db_clone())
+                        }),
+                    inputs
+                        .shared_get::<rustok_payment::PaymentCartReadRuntime>()
+                        .unwrap_or_else(|| {
+                            rustok_payment::PaymentCartReadRuntime::in_process(inputs.db_clone())
+                        }),
+                )
+            }),
         shipping_option_read_runtime: inputs
             .shared_get::<CommerceShippingOptionReadRuntime>()
             .ok_or_else(|| {

--- a/crates/rustok-commerce/src/graphql_runtime/payment_reads.rs
+++ b/crates/rustok-commerce/src/graphql_runtime/payment_reads.rs
@@ -1,0 +1,135 @@
+use std::{future::Future, sync::Arc};
+
+use async_graphql::extensions::ExtensionContext;
+use rustok_api::{AuthContext, PortActor, RequestContext};
+use rustok_payment::{
+    PaymentAdminReadPort, PaymentAdminReadRuntime, PaymentCartReadPort, PaymentCartReadRuntime,
+    PaymentOrderReadPort, PaymentOrderReadRuntime,
+};
+use sea_orm::DatabaseConnection;
+
+/// Host-selected Payment owner reads consumed by mounted Commerce GraphQL resolvers.
+///
+/// The three underlying owner capabilities intentionally retain their existing narrow ownership:
+/// admin collection/refund projections, order-associated lookup, and storefront cart-associated
+/// lookup. Commerce only composes them for the resolver compatibility facade.
+#[derive(Clone)]
+pub struct CommercePaymentReadRuntime {
+    admin_reads: PaymentAdminReadRuntime,
+    order_reads: PaymentOrderReadRuntime,
+    cart_reads: PaymentCartReadRuntime,
+}
+
+impl CommercePaymentReadRuntime {
+    pub fn new(
+        admin_reads: PaymentAdminReadRuntime,
+        order_reads: PaymentOrderReadRuntime,
+        cart_reads: PaymentCartReadRuntime,
+    ) -> Self {
+        Self {
+            admin_reads,
+            order_reads,
+            cart_reads,
+        }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(
+            PaymentAdminReadRuntime::in_process(db.clone()),
+            PaymentOrderReadRuntime::in_process(db.clone()),
+            PaymentCartReadRuntime::in_process(db),
+        )
+    }
+
+    pub fn admin_read_port(&self) -> Arc<dyn PaymentAdminReadPort> {
+        self.admin_reads.read_port()
+    }
+
+    pub fn order_read_port(&self) -> Arc<dyn PaymentOrderReadPort> {
+        self.order_reads.read_port()
+    }
+
+    pub fn cart_read_port(&self) -> Arc<dyn PaymentCartReadPort> {
+        self.cart_reads.read_port()
+    }
+}
+
+/// Trusted request-owned identity facts used for Payment owner read `PortContext` values.
+#[derive(Clone)]
+pub(crate) struct CommercePaymentReadCallContext {
+    actor: PortActor,
+    channel: Option<String>,
+    locale: Option<String>,
+}
+
+impl CommercePaymentReadCallContext {
+    pub(crate) fn from_extension_context(ctx: &ExtensionContext<'_>) -> Self {
+        let actor = ctx
+            .data_opt::<AuthContext>()
+            .map(|auth| PortActor::user(auth.user_id.to_string()))
+            .unwrap_or_else(|| PortActor::service("rustok-commerce.graphql-payment-query"));
+        let request = ctx.data_opt::<RequestContext>();
+        Self {
+            actor,
+            channel: request.and_then(|request| request.channel_slug.clone()),
+            locale: request.map(|request| request.locale.clone()),
+        }
+    }
+
+    pub(crate) fn actor(&self) -> PortActor {
+        self.actor.clone()
+    }
+
+    pub(crate) fn channel(&self) -> Option<&str> {
+        self.channel.as_deref()
+    }
+
+    pub(crate) fn locale(&self) -> Option<&str> {
+        self.locale.as_deref()
+    }
+}
+
+impl Default for CommercePaymentReadCallContext {
+    fn default() -> Self {
+        Self {
+            actor: PortActor::service("rustok-commerce.graphql-payment-query"),
+            channel: None,
+            locale: None,
+        }
+    }
+}
+
+tokio::task_local! {
+    static CURRENT_COMMERCE_PAYMENT_READ_RUNTIME: CommercePaymentReadRuntime;
+    static CURRENT_COMMERCE_PAYMENT_READ_CALL_CONTEXT: CommercePaymentReadCallContext;
+}
+
+pub(crate) async fn scope_current_payment_reads<F, T>(
+    runtime: CommercePaymentReadRuntime,
+    call_context: CommercePaymentReadCallContext,
+    future: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    CURRENT_COMMERCE_PAYMENT_READ_RUNTIME
+        .scope(
+            runtime,
+            CURRENT_COMMERCE_PAYMENT_READ_CALL_CONTEXT.scope(call_context, future),
+        )
+        .await
+}
+
+pub(crate) fn runtime_for_current_graphql_scope(
+    db: DatabaseConnection,
+) -> CommercePaymentReadRuntime {
+    CURRENT_COMMERCE_PAYMENT_READ_RUNTIME
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| CommercePaymentReadRuntime::in_process(db))
+}
+
+pub(crate) fn call_context_for_current_graphql_scope() -> CommercePaymentReadCallContext {
+    CURRENT_COMMERCE_PAYMENT_READ_CALL_CONTEXT
+        .try_with(Clone::clone)
+        .unwrap_or_default()
+}

--- a/crates/rustok-payment/src/admin_read.rs
+++ b/crates/rustok-payment/src/admin_read.rs
@@ -241,9 +241,14 @@ fn map_payment_error(
             false,
             "conflict",
         ),
-        PaymentError::ProviderUnavailable { .. }
-        | PaymentError::ProviderConfiguration { .. }
-        | PaymentError::Database(_) => (
+        PaymentError::ProviderConfiguration { .. } => (
+            PortErrorKind::Unavailable,
+            "payment.admin_read_configuration",
+            "payment read capability is temporarily unavailable",
+            true,
+            "provider_configuration",
+        ),
+        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
             PortErrorKind::Unavailable,
             "payment.admin_read_unavailable",
             "payment read capability is temporarily unavailable",
@@ -276,7 +281,6 @@ fn map_payment_error(
             deadline_ms = ?context.deadline_ms,
             error_variant,
             boundary = PAYMENT_ADMIN_READ_BOUNDARY,
-            error = ?error,
             "payment admin read owner operation failed"
         );
     } else {

--- a/crates/rustok-payment/src/cart_read.rs
+++ b/crates/rustok-payment/src/cart_read.rs
@@ -1,0 +1,200 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{PaymentCollectionResponse, PaymentError, PaymentService};
+
+const PAYMENT_CART_READ_OWNER: &str = "rustok_payment";
+const PAYMENT_CART_READ_BOUNDARY: &str = "payment_cart_read_port";
+
+#[async_trait]
+pub trait PaymentCartReadPort: Send + Sync {
+    async fn find_reusable_collection_by_cart(
+        &self,
+        context: PortContext,
+        request: ReusablePaymentCollectionByCartRequest,
+    ) -> Result<Option<PaymentCollectionResponse>, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReusablePaymentCollectionByCartRequest {
+    pub cart_id: Uuid,
+}
+
+pub struct InProcessPaymentCartReadPort {
+    inner: PaymentService,
+}
+
+impl InProcessPaymentCartReadPort {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            inner: PaymentService::new(db),
+        }
+    }
+}
+
+pub fn in_process_payment_cart_read_port(db: DatabaseConnection) -> Arc<dyn PaymentCartReadPort> {
+    Arc::new(InProcessPaymentCartReadPort::new(db))
+}
+
+#[derive(Clone)]
+pub struct PaymentCartReadRuntime {
+    read_port: Arc<dyn PaymentCartReadPort>,
+}
+
+impl PaymentCartReadRuntime {
+    pub fn new(read_port: Arc<dyn PaymentCartReadPort>) -> Self {
+        Self { read_port }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(in_process_payment_cart_read_port(db))
+    }
+
+    pub fn read_port(&self) -> Arc<dyn PaymentCartReadPort> {
+        self.read_port.clone()
+    }
+}
+
+#[async_trait]
+impl PaymentCartReadPort for InProcessPaymentCartReadPort {
+    async fn find_reusable_collection_by_cart(
+        &self,
+        context: PortContext,
+        request: ReusablePaymentCollectionByCartRequest,
+    ) -> Result<Option<PaymentCollectionResponse>, PortError> {
+        const OPERATION: &str = "find_reusable_collection_by_cart";
+        context.require_policy(PortCallPolicy::read()).inspect_err(|error| {
+            log_context_rejection(&context, OPERATION, "policy", error);
+        })?;
+        let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+            let error = PortError::validation(
+                "payment.cart_read_context_invalid",
+                "payment cart read context is invalid",
+            );
+            log_context_rejection(&context, OPERATION, "tenant_id", &error);
+            error
+        })?;
+
+        self.inner
+            .find_reusable_collection_by_cart(tenant_id, request.cart_id)
+            .await
+            .map_err(|error| map_payment_error(&context, OPERATION, request.cart_id, error))
+    }
+}
+
+fn map_payment_error(
+    context: &PortContext,
+    operation: &'static str,
+    cart_id: Uuid,
+    error: PaymentError,
+) -> PortError {
+    let (kind, code, message, retryable, error_variant, technical) = match &error {
+        PaymentError::Validation(_) => (
+            PortErrorKind::Validation,
+            "payment.cart_read_validation",
+            "payment cart read request is invalid",
+            false,
+            "validation",
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            PortErrorKind::NotFound,
+            "payment.cart_read_not_found",
+            "payment resource was not found",
+            false,
+            "not_found",
+            false,
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            PortErrorKind::Conflict,
+            "payment.cart_read_conflict",
+            "payment state conflicts with the read request",
+            false,
+            "conflict",
+            false,
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            PortErrorKind::Unavailable,
+            "payment.cart_read_configuration",
+            "payment data is temporarily unavailable",
+            true,
+            "provider_configuration",
+            true,
+        ),
+        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "payment.cart_read_unavailable",
+            "payment data is temporarily unavailable",
+            true,
+            "unavailable",
+            true,
+        ),
+        PaymentError::ProviderInvalidResponse { .. }
+        | PaymentError::ProviderOutcomeUnknown { .. } => (
+            PortErrorKind::InvariantViolation,
+            "payment.cart_read_invariant",
+            "payment state could not be read safely",
+            false,
+            "invariant",
+            true,
+        ),
+    };
+
+    if technical {
+        tracing::error!(
+            owner = PAYMENT_CART_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            cart_id_non_nil = !cart_id.is_nil(),
+            error_variant,
+            code,
+            retryable,
+            boundary = PAYMENT_CART_READ_BOUNDARY,
+            "payment cart read failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = PAYMENT_CART_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            cart_id_non_nil = !cart_id.is_nil(),
+            error_variant,
+            code,
+            retryable,
+            boundary = PAYMENT_CART_READ_BOUNDARY,
+            "payment cart read was rejected"
+        );
+    }
+
+    PortError::new(kind, code, message, retryable)
+}
+
+fn log_context_rejection(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = PAYMENT_CART_READ_OWNER,
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = PAYMENT_CART_READ_BOUNDARY,
+        "payment cart read context was rejected"
+    );
+}

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -6,6 +6,7 @@ use sea_orm_migration::MigrationTrait;
 mod admin_collection_command;
 mod admin_read;
 mod admin_refund_command;
+mod cart_read;
 #[path = "checkout_compensation.rs"]
 mod checkout_compensation_persistent;
 #[path = "checkout_compensation_api.rs"]
@@ -48,6 +49,10 @@ pub use admin_refund_command::{
     CancelAdminRefundRequest, CompleteAdminRefundRequest, CreateAdminRefundRequest,
     InProcessPaymentAdminRefundCommandPort, PaymentAdminRefundCommandPort,
     PaymentAdminRefundCommandRuntime, in_process_payment_admin_refund_command_port,
+};
+pub use cart_read::{
+    InProcessPaymentCartReadPort, PaymentCartReadPort, PaymentCartReadRuntime,
+    ReusablePaymentCollectionByCartRequest, in_process_payment_cart_read_port,
 };
 pub use checkout_compensation::{
     CheckoutPaymentCompensationPort, CheckoutPaymentCompensationRequest,

--- a/crates/rustok-payment/src/order_read.rs
+++ b/crates/rustok-payment/src/order_read.rs
@@ -124,9 +124,15 @@ fn map_payment_error(
             "conflict",
             false,
         ),
-        PaymentError::ProviderUnavailable { .. }
-        | PaymentError::ProviderConfiguration { .. }
-        | PaymentError::Database(_) => (
+        PaymentError::ProviderConfiguration { .. } => (
+            PortErrorKind::Unavailable,
+            "payment.order_read_configuration",
+            "payment storage is temporarily unavailable",
+            true,
+            "provider_configuration",
+            true,
+        ),
+        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
             PortErrorKind::Unavailable,
             "payment.order_read_unavailable",
             "payment storage is temporarily unavailable",

--- a/scripts/verify/verify-commerce-graphql-query-payment-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-query-payment-error-safety.mjs
@@ -16,20 +16,23 @@ const paths = {
   safeSource: 'crates/rustok-commerce/src/graphql/safe_query/source.rs',
   paymentShim:
     'crates/rustok-commerce/src/graphql/safe_query/source/rustok_payment_shim.rs',
+  graphqlRuntime: 'crates/rustok-commerce/src/graphql_runtime.rs',
+  paymentRuntime: 'crates/rustok-commerce/src/graphql_runtime/payment_reads.rs',
+  paymentLib: 'crates/rustok-payment/src/lib.rs',
+  adminRead: 'crates/rustok-payment/src/admin_read.rs',
+  orderRead: 'crates/rustok-payment/src/order_read.rs',
+  cartRead: 'crates/rustok-payment/src/cart_read.rs',
   ownerService: 'crates/rustok-payment/src/services/payment.rs',
-  ownerError: 'crates/rustok-payment/src/error.rs',
+  plan: 'crates/rustok-commerce/docs/implementation-plan.md',
   evidence:
     'crates/rustok-commerce/contracts/evidence/graphql-query-payment-error-safety-source-review.json',
   document: 'crates/rustok-commerce/docs/graphql-query-payment-error-safety.md',
 };
 
-const query = read(paths.query);
-const safeSource = read(paths.safeSource);
-const paymentShim = read(paths.paymentShim);
-const ownerService = read(paths.ownerService);
-const ownerError = read(paths.ownerError);
-const evidence = JSON.parse(read(paths.evidence));
-const document = read(paths.document);
+const sources = Object.fromEntries(
+  Object.entries(paths).map(([key, relativePath]) => [key, read(relativePath)]),
+);
+const evidence = JSON.parse(sources.evidence);
 
 const requireText = (source, value, label) => {
   if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
@@ -38,16 +41,6 @@ const forbidText = (source, value, label) => {
   if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
 const countText = (source, value) => source.split(value).length - 1;
-
-function blockBetween(source, start, end, label) {
-  const startIndex = source.indexOf(start);
-  const endIndex = source.indexOf(end, startIndex + start.length);
-  if (startIndex < 0 || endIndex < 0) {
-    failures.push(`${label}: unable to isolate source block`);
-    return '';
-  }
-  return source.slice(startIndex, endIndex);
-}
 
 for (const marker of [
   'use rustok_payment::PaymentService;',
@@ -59,7 +52,7 @@ for (const marker of [
   '.list_refunds(',
   'Err(rustok_payment::error::PaymentError::PaymentCollectionNotFound(_))',
   'Err(rustok_payment::error::PaymentError::RefundNotFound(_))',
-]) requireText(query, marker, `${paths.query}: unchanged payment query contract`);
+]) requireText(sources.query, marker, `${paths.query}: unchanged payment query contract`);
 
 for (const [marker, expected] of [
   ['PaymentService::new(db.clone())', 7],
@@ -70,7 +63,7 @@ for (const [marker, expected] of [
   ['.get_refund(', 1],
   ['.list_refunds(', 2],
 ]) {
-  const actual = countText(query, marker);
+  const actual = countText(sources.query, marker);
   if (actual !== expected) {
     failures.push(`${paths.query}: expected ${expected} occurrences of ${marker}, found ${actual}`);
   }
@@ -81,97 +74,128 @@ for (const marker of [
   'mod rustok_payment_shim;',
   'use self::rustok_payment_shim as rustok_payment;',
   'include!("../query.rs");',
-]) requireText(safeSource, marker, `${paths.safeSource}: mounted Payment facade`);
+]) requireText(sources.safeSource, marker, `${paths.safeSource}: mounted Payment facade`);
 
 for (const marker of [
-  'inner: ::rustok_payment::PaymentService',
-  'inner: ::rustok_payment::PaymentService::new(db)',
-  'pub(crate) async fn find_reusable_collection_by_cart(',
-  '.find_reusable_collection_by_cart(tenant_id, cart_id)',
-  'pub(crate) async fn find_latest_collection_by_order(',
-  '.find_latest_collection_by_order(tenant_id, order_id)',
-  'pub(crate) async fn get_collection(',
-  '.get_collection(tenant_id, collection_id)',
-  'pub(crate) async fn list_collections(',
-  '.list_collections(tenant_id, input)',
-  'pub(crate) async fn get_refund(',
-  '.get_refund(tenant_id, refund_id)',
-  'pub(crate) async fn list_refunds(',
-  '.list_refunds(tenant_id, input)',
-]) requireText(paymentShim, marker, `${paths.paymentShim}: canonical owner delegation`);
-
-for (const marker of [
+  'PaymentAdminReadPort',
+  'PaymentOrderReadPort',
+  'PaymentCartReadPort',
+  'payment_read_runtime_for_current_graphql_scope',
+  'payment_read_call_context_for_current_graphql_scope',
+  'PortContext::new(',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'context.with_channel(channel)',
+  'ReusablePaymentCollectionByCartRequest { cart_id }',
+  'LatestPaymentCollectionByOrderRequest { order_id }',
+  'ReadPaymentCollectionProjectionRequest { collection_id }',
+  'ListPaymentCollectionProjectionsRequest {',
+  'ReadRefundProjectionRequest { refund_id }',
+  'ListRefundProjectionsRequest {',
   'pub(crate) enum PaymentError {',
   'PaymentCollectionNotFound(PaymentQueryError)',
   'RefundNotFound(PaymentQueryError)',
   'Other(PaymentQueryError)',
-  'OwnerPaymentError::PaymentCollectionNotFound(_)',
-  'OwnerPaymentError::RefundNotFound(_)',
+  'PaymentError::from_owner_port',
   'pub(crate) fn to_string(self) -> BoundaryError',
-  'error.into_boundary()',
-]) requireText(paymentShim, marker, `${paths.paymentShim}: typed compatibility conversion`);
-
-const mapper = blockBetween(
-  paymentShim,
-  'fn into_boundary(self) -> BoundaryError {',
-  'pub(crate) mod error {',
-  'typed Payment GraphQL mapper',
-);
-
-for (const [variant, message, code] of [
-  ['OwnerPaymentError::Validation(_)', 'Payment query is invalid', 'PAYMENT_REQUEST_INVALID'],
-  ['OwnerPaymentError::PaymentCollectionNotFound(_)', 'Payment resource was not found', 'PAYMENT_RESOURCE_NOT_FOUND'],
-  ['OwnerPaymentError::InvalidTransition { .. }', 'Payment state conflicts with this query', 'PAYMENT_STATE_CONFLICT'],
-  ['OwnerPaymentError::ProviderUnavailable { .. }', 'Payment data is temporarily unavailable', 'PAYMENT_TEMPORARILY_UNAVAILABLE'],
-  ['OwnerPaymentError::ProviderInvalidResponse { .. }', 'Payment state requires reconciliation', 'PAYMENT_RECONCILIATION_REQUIRED'],
-  ['OwnerPaymentError::ProviderConfiguration { .. }', 'Payment provider configuration is invalid', 'PAYMENT_CONFIGURATION_ERROR'],
-]) {
-  for (const marker of [variant, `"${message}"`, `"${code}"`]) {
-    requireText(mapper, marker, `${paths.paymentShim}: ${code} transport policy`);
-  }
-}
-
-for (const marker of [
-  'owner_detail(&self.error)',
+  'fn is_configuration_error(error: &OwnerPortError)',
+  '"payment.admin_read_configuration"',
+  '"payment.order_read_configuration"',
+  '"payment.cart_read_configuration"',
+  'PAYMENT_REQUEST_INVALID',
+  'PAYMENT_RESOURCE_NOT_FOUND',
+  'PAYMENT_STATE_CONFLICT',
+  'PAYMENT_TEMPORARILY_UNAVAILABLE',
+  'PAYMENT_RECONCILIATION_REQUIRED',
+  'PAYMENT_CONFIGURATION_ERROR',
   'error = ?diagnostic_error',
-  'owner = "rustok_payment"',
-  'owner_operation = self.operation',
-  'correlation_id',
-  'tenant_id = %self.tenant_id',
-  'resource_kind',
-  'resource_id_shape',
-  'owner_detail_shape',
   'owner_detail_length',
-  'public_code = code',
-  'boundary = GRAPHQL_QUERY_PAYMENT_BOUNDARY',
-  'tracing::error!(',
-  'tracing::warn!(',
   'BoundaryError::Public {',
-]) requireText(mapper, marker, `${paths.paymentShim}: bounded Payment diagnostics`);
+]) requireText(sources.paymentShim, marker, `${paths.paymentShim}: owner-port facade`);
 
 for (const forbidden of [
+  '::rustok_payment::PaymentService',
+  'inner: ::rustok_payment::PaymentService',
   'error = ?self.error',
   'error = %self.error',
-  'owner_error = ?self.error',
-  'owner_error = %self.error',
   'message = %self.error',
+  'self.error.message',
   'self.error.to_string()',
-  'format!("{}", self.error)',
-  'format!("{:?}", self.error)',
+  'owner_code =',
   'provider_id =',
   'provider_operation =',
   'validation_message =',
-]) forbidText(mapper, forbidden, `${paths.paymentShim}: raw Payment owner payload`);
+]) forbidText(sources.paymentShim, forbidden, `${paths.paymentShim}: concrete/raw Payment payload`);
 
 for (const marker of [
-  'fn owner_detail(error: &OwnerPaymentError)',
-  'OwnerPaymentError::Database(_) => ("database_redacted", 0)',
-  '"provider_operation_values"',
-  'provider_id.chars()',
-  'operation.chars().count()',
-  'from.chars().count().saturating_add(to.chars().count())',
-  'fn uuid_shape(value: &Uuid)',
-]) requireText(paymentShim, marker, `${paths.paymentShim}: bounded owner detail projection`);
+  'pub struct CommercePaymentReadRuntime',
+  'admin_reads: PaymentAdminReadRuntime',
+  'order_reads: PaymentOrderReadRuntime',
+  'cart_reads: PaymentCartReadRuntime',
+  'pub fn admin_read_port(&self)',
+  'pub fn order_read_port(&self)',
+  'pub fn cart_read_port(&self)',
+  'CURRENT_COMMERCE_PAYMENT_READ_RUNTIME',
+  'CURRENT_COMMERCE_PAYMENT_READ_CALL_CONTEXT',
+  'scope_current_payment_reads',
+  'ctx.data_opt::<AuthContext>()',
+  'ctx.data_opt::<RequestContext>()',
+  'PortActor::service("rustok-commerce.graphql-payment-query")',
+]) requireText(sources.paymentRuntime, marker, `${paths.paymentRuntime}: scoped Payment runtime`);
+
+for (const marker of [
+  'mod payment_reads;',
+  'pub use payment_reads::CommercePaymentReadRuntime;',
+  'payment_reads::scope_current_payment_reads(',
+  'payment_read_runtime: CommercePaymentReadRuntime',
+  'pub fn payment_read_runtime(&self) -> CommercePaymentReadRuntime',
+  '.shared_get::<CommercePaymentReadRuntime>()',
+  '.shared_get::<rustok_payment::PaymentAdminReadRuntime>()',
+  '.shared_get::<rustok_payment::PaymentOrderReadRuntime>()',
+  '.shared_get::<rustok_payment::PaymentCartReadRuntime>()',
+  'PaymentAdminReadRuntime::in_process(inputs.db_clone())',
+  'PaymentOrderReadRuntime::in_process(inputs.db_clone())',
+  'PaymentCartReadRuntime::in_process(inputs.db_clone())',
+  'pub(crate) fn payment_read_call_context_for_current_graphql_scope(',
+  '-> (PortActor, Option<String>, Option<String>)',
+]) requireText(sources.graphqlRuntime, marker, `${paths.graphqlRuntime}: host/runtime bridge`);
+
+for (const marker of [
+  'mod cart_read;',
+  'PaymentCartReadPort',
+  'PaymentCartReadRuntime',
+  'ReusablePaymentCollectionByCartRequest',
+  'in_process_payment_cart_read_port',
+]) requireText(sources.paymentLib, marker, `${paths.paymentLib}: cart read exports`);
+
+for (const marker of [
+  'pub trait PaymentCartReadPort',
+  'pub struct PaymentCartReadRuntime',
+  'context.require_policy(PortCallPolicy::read())',
+  '.find_reusable_collection_by_cart(tenant_id, request.cart_id)',
+  '"payment.cart_read_configuration"',
+  '"payment.cart_read_unavailable"',
+  'error_variant',
+  'cart_id_non_nil',
+]) requireText(sources.cartRead, marker, `${paths.cartRead}: Payment cart owner read`);
+for (const forbidden of ['error = ?error', 'error = %error']) {
+  forbidText(sources.cartRead, forbidden, `${paths.cartRead}: raw owner error`);
+}
+
+for (const marker of [
+  'pub trait PaymentAdminReadPort',
+  'context.require_policy(PortCallPolicy::read())',
+  '"payment.admin_read_configuration"',
+  '"payment.admin_read_unavailable"',
+]) requireText(sources.adminRead, marker, `${paths.adminRead}: Payment admin owner read`);
+forbidText(sources.adminRead, 'error = ?error', `${paths.adminRead}: raw owner debug`);
+forbidText(sources.adminRead, 'error = %error', `${paths.adminRead}: raw owner display`);
+
+for (const marker of [
+  'pub trait PaymentOrderReadPort',
+  '.find_latest_collection_by_order(tenant_id, request.order_id)',
+  '"payment.order_read_configuration"',
+  '"payment.order_read_unavailable"',
+]) requireText(sources.orderRead, marker, `${paths.orderRead}: Payment order owner read`);
 
 for (const marker of [
   'pub struct PaymentService',
@@ -181,34 +205,22 @@ for (const marker of [
   'pub async fn list_collections(',
   'pub async fn get_refund(',
   'pub async fn list_refunds(',
-  'PaymentResult<Option<PaymentCollectionResponse>>',
-  'PaymentResult<PaymentCollectionResponse>',
-  'PaymentResult<(Vec<PaymentCollectionResponse>, u64)>',
-  'PaymentResult<RefundResponse>',
-  'PaymentResult<(Vec<RefundResponse>, u64)>',
-]) requireText(ownerService, marker, `${paths.ownerService}: preserved owner contract`);
+]) requireText(sources.ownerService, marker, `${paths.ownerService}: preserved owner service methods`);
 
-for (const marker of [
-  'pub enum PaymentError',
-  'Validation(String)',
-  'PaymentCollectionNotFound(Uuid)',
-  'PaymentNotFound(Uuid)',
-  'RefundNotFound(Uuid)',
-  'InvalidTransition { from: String, to: String }',
-  'ProviderUnavailable {',
-  'ProviderRejected {',
-  'ProviderInvalidResponse {',
-  'ProviderOutcomeUnknown {',
-  'ProviderConfiguration { provider_id: String }',
-  'Database(#[from] DbErr)',
-]) requireText(ownerError, marker, `${paths.ownerError}: exhaustive owner variants`);
-
-for (const [key, expected] of Object.entries({
+const expectedSourceContract = {
   query_resolver_source_changed: false,
   payment_owner_service_preserved: true,
   payment_owner_read_methods_preserved: true,
   payment_success_dtos_preserved: true,
-  typed_payment_error_retained_to_transport: true,
+  graphql_concrete_payment_service_removed: true,
+  payment_admin_read_port_reused: true,
+  payment_order_read_port_reused: true,
+  payment_cart_read_port_added: true,
+  graphql_payment_runtime_scoped: true,
+  host_shared_owner_runtimes_preferred: true,
+  embedded_in_process_owner_fallback_retained: true,
+  trusted_actor_channel_locale_propagated: true,
+  typed_port_error_retained_to_transport: true,
   payment_collection_not_found_branch_preserved: true,
   refund_not_found_branch_preserved: true,
   owner_error_display_used_for_public_response: false,
@@ -224,15 +236,17 @@ for (const [key, expected] of Object.entries({
   diagnostic_debug_redacted: true,
   technical_error_severity_preserved: true,
   ordinary_rejection_warning_severity_preserved: true,
+  admin_read_raw_owner_debug_removed: true,
   graphql_fields_or_dtos_changed: false,
-  payment_owner_contract_changed: false,
+  payment_owner_contract_changed: true,
   commerce_ffa_status_changed: false,
   commerce_fba_status_changed: false,
   payment_ffa_status_changed: false,
   payment_fba_status_changed: false,
   broad_ecommerce_cleanup_closed: false,
   runtime_evidence_claimed: false,
-})) {
+};
+for (const [key, expected] of Object.entries(expectedSourceContract)) {
   if (evidence.source_contract?.[key] !== expected) {
     failures.push(`${paths.evidence}: source_contract.${key} must be ${expected}`);
   }
@@ -261,6 +275,7 @@ for (const key of [
   'ci_run',
   'compile_proven',
   'runtime_proven',
+  'remote_adapter_proven',
 ]) {
   if (evidence.validation?.[key] !== false) {
     failures.push(`${paths.evidence}: validation.${key} must remain false`);
@@ -271,29 +286,33 @@ if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
 }
 
 for (const marker of [
-  '# Commerce GraphQL payment query error safety',
+  '# Commerce GraphQL payment query owner-port and error safety',
   'Status: `source_closed_unvalidated`',
-  'The compatibility resolver source in `crates/rustok-commerce/src/graphql/query.rs` remains unchanged.',
-  '`find_reusable_collection_by_cart`',
-  '`find_latest_collection_by_order`',
-  '`get_collection`',
-  '`list_collections`',
-  '`get_refund`',
-  '`list_refunds`',
-  'It does not format the Payment owner error into a public string.',
+  '`PaymentCartReadPort` / `PaymentCartReadRuntime` are the only new Payment owner API',
+  '`CommercePaymentReadRuntime`',
   '`PAYMENT_TEMPORARILY_UNAVAILABLE`',
   '`PAYMENT_RECONCILIATION_REQUIRED`',
-  'Commerce and Payment FFA/FBA status is unchanged.',
-  'The broad ecommerce mapper and public-envelope cleanup remains open.',
-  'No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, or CI were executed.',
-]) requireText(document, marker, `${paths.document}: truthful source contract`);
+  'The broad Commerce topology P0 remains open',
+  'No compile, runtime, mounted GraphQL, remote-adapter, or parity evidence is claimed.',
+]) requireText(sources.document, marker, `${paths.document}: truthful source contract`);
+
+requireText(
+  sources.plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,',
+  `${paths.plan}: broad topology remains open`,
+);
+requireText(
+  sources.plan,
+  'Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  `${paths.plan}: broad topology continuation`,
+);
 
 if (failures.length > 0) {
-  console.error('Commerce GraphQL payment error-safety verification failed:');
+  console.error('Commerce GraphQL payment owner-read verification failed:');
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  'Commerce GraphQL payment reads preserve canonical owner calls and route typed failures through bounded structural envelopes',
+  'Commerce GraphQL Payment reads are source-routed through typed owner ports with bounded envelopes',
 );


### PR DESCRIPTION
## Summary
- keep `crates/rustok-commerce/src/graphql/query.rs` unchanged while replacing its private Payment compatibility facade with typed owner reads
- reuse `PaymentAdminReadPort` for collection/refund list/detail reads and `PaymentOrderReadPort` for latest-by-order
- add the narrow `PaymentCartReadPort` / `PaymentCartReadRuntime` for reusable-by-cart lookup
- add `CommercePaymentReadRuntime` and carry it through the mounted GraphQL task-local resolver scope
- prefer a host-shared composite runtime, then individually shared Payment admin/order/cart runtimes, with explicit in-process owner fallbacks for missing/embedded capabilities
- propagate trusted request actor, channel, locale, tenant, correlation identity, and a bounded two-second read deadline through `PortContext`
- preserve the unchanged `PaymentCollectionNotFound` / `RefundNotFound` compatibility branches and existing GraphQL public error-code families
- retain provider-configuration compatibility through three closed owner codes rather than arbitrary string matching
- remove raw Payment owner debug from `PaymentAdminReadPort` technical diagnostics and keep GraphQL diagnostics bounded without logging arbitrary owner codes
- actualize the existing source evidence/document and source guard without executing the guard

## Out of scope
The broad Commerce topology P0 remains open for GraphQL mutations/provider operations, post-order/change/return, checkout/reconciliation, and other remaining concrete-owner paths.

## Validation status
Source/GitHub inspection only. Tests, Cargo commands, formatting, verifier execution, workflows, CI, mounted GraphQL scenarios, runtime calls, remote-adapter execution, and parity evidence were intentionally not run per maintainer instruction.