### PR TITLE
feat(commerce): route GraphQL payment commands through owner ports

### DIFF
--- a/crates/rustok-commerce/docs/graphql-payment-command-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-payment-command-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,103 @@
+# Commerce GraphQL Payment command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-09
+
+## Scope
+
+This source slice moves the mounted Commerce GraphQL Payment provider mutations behind existing Payment-owned typed command capabilities:
+
+- `authorizePaymentCollection`;
+- `capturePaymentCollection`;
+- `cancelPaymentCollection`;
+- `createRefund`;
+- `completeRefund`;
+- `cancelRefund`.
+
+The GraphQL field names, arguments, `PAYMENTS_UPDATE` permission checks, successful DTOs, and public error-code families remain unchanged. Fulfillment mutations in the same provider-operation object are intentionally out of scope for this slice.
+
+## Owner capabilities
+
+Commerce GraphQL now delegates collection transitions to `PaymentAdminCollectionCommandPort` and refund mutations to `PaymentAdminRefundCommandPort`. These are existing Payment owner capabilities already used by mounted admin HTTP routes.
+
+`CommercePaymentCommandRuntime` composes the two owner runtimes for GraphQL. Schema composition prefers a host-shared composite runtime. If one is not present, it independently prefers host-shared `PaymentAdminCollectionCommandRuntime` and `PaymentAdminRefundCommandRuntime` values. Missing capabilities use Payment-owned in-process adapters with the deployment-selected `PaymentProviderRegistry`.
+
+Mounted GraphQL therefore no longer constructs `PaymentOrchestrationService` for these six mutations. Payment persistence, provider journals, replay decisions, and provider execution remain inside `rustok-payment`.
+
+## Request-owned write context
+
+Each mutation passes a typed `PortContext` containing:
+
+- the requested tenant id;
+- the authenticated GraphQL user as `PortActor::user`;
+- request locale when available, otherwise `und`;
+- request channel when available;
+- a stable GraphQL correlation identity;
+- a two-second owner-call deadline;
+- mandatory write-admission idempotency identity.
+
+Collection transition admission identities are transport-local:
+
+```text
+graphql-payment-collection:{collection_id}:authorize_payment_collection
+graphql-payment-collection:{collection_id}:capture_payment_collection
+graphql-payment-collection:{collection_id}:cancel_payment_collection
+```
+
+Refund transition admission identities are likewise transport-local:
+
+```text
+graphql-refund:{refund_id}:complete_refund
+graphql-refund:{refund_id}:cancel_refund
+```
+
+These `PortContext` identities are generic owner write-admission identity only. They are not described as new durable receipts.
+
+## Durable Payment replay semantics
+
+The owner command implementations preserve the already-established durable identities:
+
+```text
+payment_collection:{collection_id}:authorize
+payment_collection:{collection_id}:capture
+payment_collection:{collection_id}:cancel
+payment_refund:{refund_id}
+```
+
+The GraphQL `createRefund` caller-provided `idempotencyKey` is passed without transformation both as the owner write-admission idempotency identity and as `CreateAdminRefundRequest.creation_key`. Payment continues to call `PaymentRefundCreationService::create_or_replay` with that exact creation identity.
+
+Provider metadata and journal recovery semantics remain owned by the same Payment command adapters used by admin HTTP. This slice does not add a second GraphQL-specific provider journal or receipt layer.
+
+## GraphQL error compatibility
+
+Payment owner `PortError` values are mapped back to the existing bounded GraphQL families:
+
+- validation -> `PAYMENT_REQUEST_INVALID`;
+- not found -> `PAYMENT_RESOURCE_NOT_FOUND`;
+- invalid transition/provider rejection -> `PAYMENT_STATE_CONFLICT`;
+- provider/database unavailable -> `PAYMENT_TEMPORARILY_UNAVAILABLE` with `retryable = true`;
+- invalid/unknown provider outcome and reserved-refund reconciliation -> `PAYMENT_RECONCILIATION_REQUIRED`;
+- provider configuration -> `PAYMENT_CONFIGURATION_ERROR`.
+
+The reserved-refund provider-unavailable owner code remains in the temporarily-unavailable GraphQL family, matching the previous GraphQL provider-error behavior after refund reservation.
+
+Commerce logs only bounded owner kind/code length, stable operation/correlation facts, and public classification. It does not log the complete `PortError.message`, provider identifiers, provider payloads, or arbitrary owner code text.
+
+## Still open
+
+The broad canonical topology item remains open. At minimum, Commerce GraphQL Fulfillment provider mutations in the same file still use `FulfillmentOrchestrationService`, and additional post-order/change/return, checkout/reconciliation, or other mounted orchestration paths may still require owner-boundary work.
+
+No FFA/FBA or broad topology status is promoted by this source slice.
+
+## Intended checks
+
+The focused source guard added with this slice is:
+
+```bash
+node scripts/verify/verify-commerce-graphql-payment-command-owner-port-cutover.mjs
+```
+
+Relevant compile/runtime checks remain for the maintainer to run separately.
+
+No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, provider execution, lost-response scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice.

--- a/crates/rustok-commerce/src/graphql/mutations/provider_operations.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/provider_operations.rs
@@ -1,13 +1,20 @@
 use async_graphql::{Context, ErrorExtensions, Object, Result};
-use rustok_api::{Permission, graphql::require_module_enabled};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    graphql::require_module_enabled,
+};
 use rustok_fulfillment::error::FulfillmentError;
-use rustok_payment::error::PaymentError;
+use rustok_payment::{
+    AuthorizeAdminPaymentCollectionRequest, CancelAdminPaymentCollectionRequest,
+    CancelAdminRefundRequest, CaptureAdminPaymentCollectionRequest, CompleteAdminRefundRequest,
+    CreateAdminRefundRequest,
+};
 use uuid::Uuid;
 
 use crate::graphql_runtime::{
-    fulfillment_orchestration_from_context, payment_orchestration_from_context,
+    fulfillment_orchestration_from_context, payment_command_runtime_from_context,
 };
-use crate::{FulfillmentOrchestrationError, PaymentOrchestrationError};
+use crate::FulfillmentOrchestrationError;
 
 use super::super::{MODULE_SLUG, require_commerce_permission, types::*};
 use super::helpers::*;
@@ -23,55 +30,76 @@ fn public_provider_graphql_error(
     })
 }
 
-fn payment_error_envelope(error: &PaymentError) -> (&'static str, &'static str, bool) {
-    match error {
-        PaymentError::Validation(_) => (
-            "Payment request is invalid",
-            "PAYMENT_REQUEST_INVALID",
+fn payment_command_error_envelope(
+    error: &PortError,
+) -> (&'static str, &'static str, bool, &'static str) {
+    match error.code.as_str() {
+        "payment.refund_reserved_reconciliation_required"
+        | "payment.provider_invalid_response"
+        | "payment.provider_outcome_unknown" => (
+            "Payment operation requires reconciliation",
+            "PAYMENT_RECONCILIATION_REQUIRED",
             false,
+            "reconciliation_required",
         ),
-        PaymentError::PaymentCollectionNotFound(_)
-        | PaymentError::PaymentNotFound(_)
-        | PaymentError::RefundNotFound(_) => (
-            "Payment resource was not found",
-            "PAYMENT_RESOURCE_NOT_FOUND",
-            false,
-        ),
-        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
-            "Payment operation conflicts with the current state",
-            "PAYMENT_STATE_CONFLICT",
-            false,
-        ),
-        PaymentError::ProviderUnavailable { .. } | PaymentError::Database(_) => (
+        "payment.refund_reserved_provider_unavailable"
+        | "payment.provider_unavailable"
+        | "payment.database_unavailable" => (
             "Payment service is temporarily unavailable",
             "PAYMENT_TEMPORARILY_UNAVAILABLE",
             true,
+            "temporarily_unavailable",
         ),
-        PaymentError::ProviderInvalidResponse { .. }
-        | PaymentError::ProviderOutcomeUnknown { .. } => (
-            "Payment operation requires reconciliation",
-            "PAYMENT_RECONCILIATION_REQUIRED",
-            false,
-        ),
-        PaymentError::ProviderConfiguration { .. } => (
+        "payment.provider_not_configured" => (
             "Payment operation is not configured",
             "PAYMENT_CONFIGURATION_ERROR",
             false,
+            "configuration",
         ),
-    }
-}
-
-fn payment_orchestration_error_envelope(
-    error: &PaymentOrchestrationError,
-) -> (&'static str, &'static str, bool) {
-    match error {
-        PaymentOrchestrationError::Provider(source)
-        | PaymentOrchestrationError::Payment(source) => payment_error_envelope(source),
-        PaymentOrchestrationError::ProviderAfterRefundReservation { .. } => (
-            "Payment operation requires reconciliation",
-            "PAYMENT_RECONCILIATION_REQUIRED",
+        "payment.provider_rejected" | "payment.invalid_transition" => (
+            "Payment operation conflicts with the current state",
+            "PAYMENT_STATE_CONFLICT",
             false,
+            "state_conflict",
         ),
+        _ => match &error.kind {
+            PortErrorKind::Validation => (
+                "Payment request is invalid",
+                "PAYMENT_REQUEST_INVALID",
+                false,
+                "validation",
+            ),
+            PortErrorKind::NotFound => (
+                "Payment resource was not found",
+                "PAYMENT_RESOURCE_NOT_FOUND",
+                false,
+                "not_found",
+            ),
+            PortErrorKind::Conflict => (
+                "Payment operation conflicts with the current state",
+                "PAYMENT_STATE_CONFLICT",
+                false,
+                "state_conflict",
+            ),
+            PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+                "Payment service is temporarily unavailable",
+                "PAYMENT_TEMPORARILY_UNAVAILABLE",
+                true,
+                "temporarily_unavailable",
+            ),
+            PortErrorKind::InvariantViolation => (
+                "Payment operation requires reconciliation",
+                "PAYMENT_RECONCILIATION_REQUIRED",
+                false,
+                "reconciliation_required",
+            ),
+            PortErrorKind::Forbidden => (
+                "Payment request is invalid",
+                "PAYMENT_REQUEST_INVALID",
+                false,
+                "forbidden",
+            ),
+        },
     }
 }
 
@@ -133,16 +161,24 @@ fn payment_provider_graphql_error(
     tenant_id: Uuid,
     resource_id: Uuid,
     operation: &'static str,
-    error: PaymentOrchestrationError,
+    context: &PortContext,
+    error: PortError,
 ) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) = payment_command_error_envelope(&error);
     tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        resource_id = %resource_id,
+        owner = "rustok_payment",
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
         operation,
-        "commerce GraphQL payment provider operation failed"
+        correlation_id = %context.correlation_id,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_payment_command",
+        "commerce GraphQL payment owner command failed"
     );
-    let (message, code, retryable) = payment_orchestration_error_envelope(&error);
     public_provider_graphql_error(message, code, retryable)
 }
 
@@ -161,6 +197,86 @@ fn fulfillment_provider_graphql_error(
     );
     let (message, code, retryable) = fulfillment_orchestration_error_envelope(&error);
     public_provider_graphql_error(message, code, retryable)
+}
+
+fn payment_collection_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    collection_id: Uuid,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-payment-command:{operation}:{collection_id}"),
+    )
+    .with_idempotency_key(format!(
+        "graphql-payment-collection:{collection_id}:{operation}"
+    ))
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
+fn payment_refund_create_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    collection_id: Uuid,
+    creation_key: &str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-payment-command:create_refund:{collection_id}"),
+    )
+    .with_idempotency_key(creation_key.to_string())
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
+fn payment_refund_transition_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    refund_id: Uuid,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-payment-command:{operation}:{refund_id}"),
+    )
+    .with_idempotency_key(format!("graphql-refund:{refund_id}:{operation}"))
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
 }
 
 #[derive(Default)]
@@ -182,20 +298,32 @@ impl CommerceProviderMutation {
             "Permission denied: payments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let collection = payment_orchestration_from_context(ctx, db.clone())
-            .authorize_collection(
-                tenant_id,
-                id,
-                crate::dto::AuthorizePaymentInput {
-                    provider_id: input.provider_id,
-                    provider_payment_id: input.provider_payment_id,
-                    amount: parse_optional_decimal(input.amount.as_deref())?,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        let runtime = payment_command_runtime_from_context(ctx, db.clone());
+        let context =
+            payment_collection_command_context(ctx, tenant_id, id, "authorize_payment_collection")?;
+        let collection = runtime
+            .collection_command_port()
+            .authorize_payment_collection(
+                context.clone(),
+                AuthorizeAdminPaymentCollectionRequest {
+                    collection_id: id,
+                    input: crate::dto::AuthorizePaymentInput {
+                        provider_id: input.provider_id,
+                        provider_payment_id: input.provider_payment_id,
+                        amount: parse_optional_decimal(input.amount.as_deref())?,
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                payment_provider_graphql_error(tenant_id, id, "authorize_payment_collection", error)
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "authorize_payment_collection",
+                    &context,
+                    error,
+                )
             })?;
         Ok(collection.into())
     }
@@ -214,18 +342,30 @@ impl CommerceProviderMutation {
             "Permission denied: payments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let collection = payment_orchestration_from_context(ctx, db.clone())
-            .capture_collection(
-                tenant_id,
-                id,
-                crate::dto::CapturePaymentInput {
-                    amount: parse_optional_decimal(input.amount.as_deref())?,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        let runtime = payment_command_runtime_from_context(ctx, db.clone());
+        let context =
+            payment_collection_command_context(ctx, tenant_id, id, "capture_payment_collection")?;
+        let collection = runtime
+            .collection_command_port()
+            .capture_payment_collection(
+                context.clone(),
+                CaptureAdminPaymentCollectionRequest {
+                    collection_id: id,
+                    input: crate::dto::CapturePaymentInput {
+                        amount: parse_optional_decimal(input.amount.as_deref())?,
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                payment_provider_graphql_error(tenant_id, id, "capture_payment_collection", error)
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "capture_payment_collection",
+                    &context,
+                    error,
+                )
             })?;
         Ok(collection.into())
     }
@@ -244,18 +384,30 @@ impl CommerceProviderMutation {
             "Permission denied: payments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let collection = payment_orchestration_from_context(ctx, db.clone())
-            .cancel_collection(
-                tenant_id,
-                id,
-                crate::dto::CancelPaymentInput {
-                    reason: input.reason,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        let runtime = payment_command_runtime_from_context(ctx, db.clone());
+        let context =
+            payment_collection_command_context(ctx, tenant_id, id, "cancel_payment_collection")?;
+        let collection = runtime
+            .collection_command_port()
+            .cancel_payment_collection(
+                context.clone(),
+                CancelAdminPaymentCollectionRequest {
+                    collection_id: id,
+                    input: crate::dto::CancelPaymentInput {
+                        reason: input.reason,
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                payment_provider_graphql_error(tenant_id, id, "cancel_payment_collection", error)
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "cancel_payment_collection",
+                    &context,
+                    error,
+                )
             })?;
         Ok(collection.into())
     }
@@ -275,15 +427,25 @@ impl CommerceProviderMutation {
             "Permission denied: payments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let refund = payment_orchestration_from_context(ctx, db.clone())
-            .create_refund_idempotent(
-                tenant_id,
-                payment_collection_id,
-                idempotency_key,
-                crate::dto::CreateRefundInput {
-                    amount: parse_decimal(&input.amount)?,
-                    reason: input.reason,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        let runtime = payment_command_runtime_from_context(ctx, db.clone());
+        let context = payment_refund_create_context(
+            ctx,
+            tenant_id,
+            payment_collection_id,
+            idempotency_key.as_str(),
+        )?;
+        let refund = runtime
+            .refund_command_port()
+            .create_refund(
+                context.clone(),
+                CreateAdminRefundRequest {
+                    collection_id: payment_collection_id,
+                    creation_key: idempotency_key,
+                    input: crate::dto::CreateRefundInput {
+                        amount: parse_decimal(&input.amount)?,
+                        reason: input.reason,
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
@@ -292,6 +454,7 @@ impl CommerceProviderMutation {
                     tenant_id,
                     payment_collection_id,
                     "create_refund",
+                    &context,
                     error,
                 )
             })?;
@@ -312,17 +475,28 @@ impl CommerceProviderMutation {
             "Permission denied: payments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let refund = payment_orchestration_from_context(ctx, db.clone())
+        let runtime = payment_command_runtime_from_context(ctx, db.clone());
+        let context = payment_refund_transition_context(ctx, tenant_id, id, "complete_refund")?;
+        let refund = runtime
+            .refund_command_port()
             .complete_refund(
-                tenant_id,
-                id,
-                crate::dto::CompleteRefundInput {
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                CompleteAdminRefundRequest {
+                    refund_id: id,
+                    input: crate::dto::CompleteRefundInput {
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                payment_provider_graphql_error(tenant_id, id, "complete_refund", error)
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "complete_refund",
+                    &context,
+                    error,
+                )
             })?;
         Ok(refund.into())
     }
@@ -341,18 +515,29 @@ impl CommerceProviderMutation {
             "Permission denied: payments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let refund = payment_orchestration_from_context(ctx, db.clone())
+        let runtime = payment_command_runtime_from_context(ctx, db.clone());
+        let context = payment_refund_transition_context(ctx, tenant_id, id, "cancel_refund")?;
+        let refund = runtime
+            .refund_command_port()
             .cancel_refund(
-                tenant_id,
-                id,
-                crate::dto::CancelRefundInput {
-                    reason: input.reason,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                CancelAdminRefundRequest {
+                    refund_id: id,
+                    input: crate::dto::CancelRefundInput {
+                        reason: input.reason,
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                payment_provider_graphql_error(tenant_id, id, "cancel_refund", error)
+                payment_provider_graphql_error(
+                    tenant_id,
+                    id,
+                    "cancel_refund",
+                    &context,
+                    error,
+                )
             })?;
         Ok(refund.into())
     }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -16,7 +16,9 @@ use rustok_payment::providers::PaymentProviderRegistry;
 use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogReadRuntime};
 use sea_orm::DatabaseConnection;
 
+mod payment_commands;
 mod payment_reads;
+pub use payment_commands::CommercePaymentCommandRuntime;
 pub use payment_reads::CommercePaymentReadRuntime;
 
 /// Host-selected shipping-option read ports used by mounted commerce GraphQL resolvers.
@@ -328,7 +330,7 @@ pub(crate) fn product_catalog_command_runtime_for_current_graphql_scope(
 /// Provider registries and host-selectable ports available to every commerce GraphQL resolver.
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual provider
-/// registries remain deterministic fallbacks. Mounted Payment, shipping-option,
+/// registries remain deterministic fallbacks. Mounted Payment reads/commands, shipping-option,
 /// fulfillment-lifecycle, Product catalog, and order reads consume host-selected runtime data.
 /// Directly embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
 #[derive(Clone)]
@@ -338,6 +340,7 @@ pub struct CommerceGraphqlRuntimeData {
     #[cfg(feature = "marketplace-financial")]
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
     payment_read_runtime: CommercePaymentReadRuntime,
+    payment_command_runtime: CommercePaymentCommandRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
@@ -361,6 +364,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn payment_read_runtime(&self) -> CommercePaymentReadRuntime {
         self.payment_read_runtime.clone()
+    }
+
+    pub fn payment_command_runtime(&self) -> CommercePaymentCommandRuntime {
+        self.payment_command_runtime.clone()
     }
 
     pub fn shipping_option_read_runtime(&self) -> CommerceShippingOptionReadRuntime {
@@ -423,6 +430,9 @@ pub fn attach_schema_data(
                         }),
                 )
             }),
+        payment_command_runtime: inputs
+            .shared_get::<CommercePaymentCommandRuntime>()
+            .unwrap_or_else(|| CommercePaymentCommandRuntime::from_graphql_inputs(inputs)),
         shipping_option_read_runtime: inputs
             .shared_get::<CommerceShippingOptionReadRuntime>()
             .ok_or_else(|| {
@@ -460,12 +470,18 @@ pub(crate) fn payment_provider_registry_from_context(ctx: &Context<'_>) -> Payme
         .unwrap_or_else(PaymentProviderRegistry::with_manual_provider)
 }
 
-pub(crate) fn payment_orchestration_from_context(
+pub(crate) fn payment_command_runtime_from_context(
     ctx: &Context<'_>,
     db: DatabaseConnection,
-) -> crate::PaymentOrchestrationService {
-    crate::PaymentOrchestrationService::new(db)
-        .with_provider_registry(payment_provider_registry_from_context(ctx))
+) -> CommercePaymentCommandRuntime {
+    ctx.data_opt::<CommerceGraphqlRuntimeData>()
+        .map(CommerceGraphqlRuntimeData::payment_command_runtime)
+        .unwrap_or_else(|| {
+            CommercePaymentCommandRuntime::in_process(
+                db,
+                payment_provider_registry_from_context(ctx),
+            )
+        })
 }
 
 pub(crate) fn refund_reconciliation_from_context(

--- a/crates/rustok-commerce/src/graphql_runtime/payment_commands.rs
+++ b/crates/rustok-commerce/src/graphql_runtime/payment_commands.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use rustok_payment::{
+    PaymentAdminCollectionCommandPort, PaymentAdminCollectionCommandRuntime,
+    PaymentAdminRefundCommandPort, PaymentAdminRefundCommandRuntime,
+    providers::PaymentProviderRegistry,
+};
+use sea_orm::DatabaseConnection;
+
+/// Host-selected Payment owner commands consumed by mounted Commerce GraphQL mutations.
+///
+/// Commerce composes the existing collection and refund command capabilities but does not own
+/// Payment persistence, provider journals, or provider execution. Hosts may inject either owner
+/// runtime independently; missing capabilities use the Payment-owned in-process adapters with the
+/// deployment-selected provider registry.
+#[derive(Clone)]
+pub struct CommercePaymentCommandRuntime {
+    collection_commands: PaymentAdminCollectionCommandRuntime,
+    refund_commands: PaymentAdminRefundCommandRuntime,
+}
+
+impl CommercePaymentCommandRuntime {
+    pub fn new(
+        collection_commands: PaymentAdminCollectionCommandRuntime,
+        refund_commands: PaymentAdminRefundCommandRuntime,
+    ) -> Self {
+        Self {
+            collection_commands,
+            refund_commands,
+        }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        provider_registry: PaymentProviderRegistry,
+    ) -> Self {
+        Self::new(
+            PaymentAdminCollectionCommandRuntime::in_process(
+                db.clone(),
+                provider_registry.clone(),
+            ),
+            PaymentAdminRefundCommandRuntime::in_process(db, provider_registry),
+        )
+    }
+
+    pub(crate) fn from_graphql_inputs(
+        inputs: &rustok_api::graphql::GraphqlRuntimeInputs,
+    ) -> Self {
+        let provider_registry = inputs
+            .shared_get::<PaymentProviderRegistry>()
+            .unwrap_or_else(PaymentProviderRegistry::with_manual_provider);
+        let collection_commands = inputs
+            .shared_get::<PaymentAdminCollectionCommandRuntime>()
+            .unwrap_or_else(|| {
+                PaymentAdminCollectionCommandRuntime::in_process(
+                    inputs.db_clone(),
+                    provider_registry.clone(),
+                )
+            });
+        let refund_commands = inputs
+            .shared_get::<PaymentAdminRefundCommandRuntime>()
+            .unwrap_or_else(|| {
+                PaymentAdminRefundCommandRuntime::in_process(
+                    inputs.db_clone(),
+                    provider_registry.clone(),
+                )
+            });
+        Self::new(collection_commands, refund_commands)
+    }
+
+    pub fn collection_command_port(&self) -> Arc<dyn PaymentAdminCollectionCommandPort> {
+        self.collection_commands.command_port()
+    }
+
+    pub fn refund_command_port(&self) -> Arc<dyn PaymentAdminRefundCommandPort> {
+        self.refund_commands.command_port()
+    }
+}

--- a/scripts/verify/verify-commerce-graphql-payment-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-payment-command-owner-port-cutover.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  providerOperations: 'crates/rustok-commerce/src/graphql/mutations/provider_operations.rs',
+  graphqlRuntime: 'crates/rustok-commerce/src/graphql_runtime.rs',
+  paymentCommands: 'crates/rustok-commerce/src/graphql_runtime/payment_commands.rs',
+  collectionOwner: 'crates/rustok-payment/src/admin_collection_command.rs',
+  refundOwner: 'crates/rustok-payment/src/admin_refund_command.rs',
+  plan: 'crates/rustok-commerce/docs/implementation-plan.md',
+  document: 'crates/rustok-commerce/docs/graphql-payment-command-owner-port-cutover-2026-08-09.md',
+};
+
+const providerOperations = read(paths.providerOperations);
+const graphqlRuntime = read(paths.graphqlRuntime);
+const paymentCommands = read(paths.paymentCommands);
+const collectionOwner = read(paths.collectionOwner);
+const refundOwner = read(paths.refundOwner);
+const plan = read(paths.plan);
+const document = read(paths.document);
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const marker of [
+  'AuthorizeAdminPaymentCollectionRequest',
+  'CaptureAdminPaymentCollectionRequest',
+  'CancelAdminPaymentCollectionRequest',
+  'CreateAdminRefundRequest',
+  'CompleteAdminRefundRequest',
+  'CancelAdminRefundRequest',
+  'payment_command_runtime_from_context',
+  '.collection_command_port()',
+  '.authorize_payment_collection(',
+  '.capture_payment_collection(',
+  '.cancel_payment_collection(',
+  '.refund_command_port()',
+  '.create_refund(',
+  '.complete_refund(',
+  '.cancel_refund(',
+  'Permission::PAYMENTS_UPDATE',
+  'PortActor::user(auth.user_id.to_string())',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'request.channel_slug.as_deref()',
+  'graphql-payment-collection:{collection_id}:{operation}',
+  'graphql-refund:{refund_id}:{operation}',
+  '.with_idempotency_key(creation_key.to_string())',
+  'creation_key: idempotency_key',
+]) requireText(providerOperations, marker, `${paths.providerOperations}: mounted Payment owner command contract`);
+
+for (const forbidden of [
+  'payment_orchestration_from_context',
+  'PaymentOrchestrationError',
+  'rustok_payment::error::PaymentError',
+  'PaymentOrchestrationService',
+  'PaymentProviderOperationJournal',
+  'PaymentService::new',
+]) forbidText(providerOperations, forbidden, `${paths.providerOperations}: concrete Payment orchestration`);
+
+for (const marker of [
+  '"payment.refund_reserved_reconciliation_required"',
+  '"payment.refund_reserved_provider_unavailable"',
+  '"payment.provider_invalid_response"',
+  '"payment.provider_outcome_unknown"',
+  '"payment.provider_unavailable"',
+  '"payment.database_unavailable"',
+  '"payment.provider_not_configured"',
+  '"payment.provider_rejected" | "payment.invalid_transition"',
+  '"PAYMENT_REQUEST_INVALID"',
+  '"PAYMENT_RESOURCE_NOT_FOUND"',
+  '"PAYMENT_STATE_CONFLICT"',
+  '"PAYMENT_TEMPORARILY_UNAVAILABLE"',
+  '"PAYMENT_RECONCILIATION_REQUIRED"',
+  '"PAYMENT_CONFIGURATION_ERROR"',
+  'owner_code_length = error.code.chars().count()',
+  'owner_error_kind = ?error.kind',
+  'boundary = "commerce_graphql_payment_command"',
+]) requireText(providerOperations, marker, `${paths.providerOperations}: GraphQL Payment envelope parity`);
+
+for (const forbidden of [
+  'error = ?error',
+  'owner_code = %error.code',
+  'owner_message = %error.message',
+  'message = %error.message',
+]) forbidText(
+  providerOperations.slice(
+    providerOperations.indexOf('fn payment_provider_graphql_error('),
+    providerOperations.indexOf('fn fulfillment_provider_graphql_error('),
+  ),
+  forbidden,
+  `${paths.providerOperations}: bounded Payment diagnostics`,
+);
+
+for (const marker of [
+  'mod payment_commands;',
+  'pub use payment_commands::CommercePaymentCommandRuntime;',
+  'payment_command_runtime: CommercePaymentCommandRuntime',
+  'pub fn payment_command_runtime(&self) -> CommercePaymentCommandRuntime',
+  '.shared_get::<CommercePaymentCommandRuntime>()',
+  'CommercePaymentCommandRuntime::from_graphql_inputs(inputs)',
+  'pub(crate) fn payment_command_runtime_from_context(',
+  '.map(CommerceGraphqlRuntimeData::payment_command_runtime)',
+  'CommercePaymentCommandRuntime::in_process(',
+  'payment_provider_registry_from_context(ctx)',
+]) requireText(graphqlRuntime, marker, `${paths.graphqlRuntime}: GraphQL command runtime composition`);
+
+forbidText(
+  graphqlRuntime,
+  'pub(crate) fn payment_orchestration_from_context(',
+  `${paths.graphqlRuntime}: mounted Payment orchestration helper`,
+);
+
+for (const marker of [
+  'pub struct CommercePaymentCommandRuntime',
+  'PaymentAdminCollectionCommandRuntime',
+  'PaymentAdminRefundCommandRuntime',
+  'pub(crate) fn from_graphql_inputs(',
+  '.shared_get::<PaymentAdminCollectionCommandRuntime>()',
+  '.shared_get::<PaymentAdminRefundCommandRuntime>()',
+  'PaymentAdminCollectionCommandRuntime::in_process(',
+  'PaymentAdminRefundCommandRuntime::in_process(',
+  '.shared_get::<PaymentProviderRegistry>()',
+  'pub fn collection_command_port(&self) -> Arc<dyn PaymentAdminCollectionCommandPort>',
+  'pub fn refund_command_port(&self) -> Arc<dyn PaymentAdminRefundCommandPort>',
+]) requireText(paymentCommands, marker, `${paths.paymentCommands}: host-selected Payment owner commands`);
+
+for (const marker of [
+  'format!("payment_collection:{}:authorize", collection.id)',
+  'format!("payment_collection:{}:capture", collection.id)',
+  'format!("payment_collection:{}:cancel", collection.id)',
+  'PaymentProviderOperationJournal',
+  'PaymentProviderRegistry',
+  'PaymentService',
+]) requireText(collectionOwner, marker, `${paths.collectionOwner}: durable collection provider identity`);
+
+for (const marker of [
+  '.create_or_replay(',
+  'request.creation_key',
+  'idempotency_key: Some(format!("payment_refund:{}", refund.id))',
+  'PaymentRefundCreationService',
+  'PaymentProviderOperationJournal',
+  'PaymentProviderRegistry',
+]) requireText(refundOwner, marker, `${paths.refundOwner}: durable refund replay identity`);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  `${paths.plan}: broad topology item remains open`,
+);
+
+for (const marker of [
+  '# Commerce GraphQL Payment command owner-port cutover',
+  'Status: `source_complete_unvalidated`',
+  '`authorizePaymentCollection`',
+  '`capturePaymentCollection`',
+  '`cancelPaymentCollection`',
+  '`createRefund`',
+  '`completeRefund`',
+  '`cancelRefund`',
+  '`PaymentAdminCollectionCommandPort`',
+  '`PaymentAdminRefundCommandPort`',
+  '`PaymentRefundCreationService::create_or_replay`',
+  'The broad canonical topology item remains open.',
+  'No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, provider execution, lost-response scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice.',
+]) requireText(document, marker, `${paths.document}: truthful source record`);
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL Payment command owner-port cutover verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('commerce GraphQL Payment commands route through typed owner ports with preserved durable identities');


### PR DESCRIPTION
## Summary
- route the six mounted Commerce GraphQL Payment provider mutations through existing Payment-owned command capabilities
- use `PaymentAdminCollectionCommandPort` for authorize/capture/cancel collection transitions
- use `PaymentAdminRefundCommandPort` for create/complete/cancel refund mutations
- add `CommercePaymentCommandRuntime` with host-shared composite/individual owner-runtime preference and Payment-owned in-process fallback
- preserve the existing GraphQL fields, `PAYMENTS_UPDATE` permission checks, DTOs, and public error-code families
- preserve durable Payment provider identities: `payment_collection:{id}:authorize|capture|cancel` and `payment_refund:{refund_id}`
- pass the GraphQL `createRefund` caller `idempotencyKey` unchanged as `CreateAdminRefundRequest.creation_key`, retaining `PaymentRefundCreationService::create_or_replay` semantics
- propagate authenticated actor, request locale/channel, correlation identity, bounded deadline, and generic owner write-admission identity through `PortContext`
- keep Payment diagnostics bounded without logging raw owner messages, provider payloads, or arbitrary owner-code text
- add a focused source record and source guard without executing it

## Out of scope
GraphQL Fulfillment provider mutations in the same provider-operation object remain on `FulfillmentOrchestrationService`. The broad Commerce topology P0 therefore remains open, along with other remaining post-order/change/return, checkout/reconciliation, and concrete-owner paths.

## Validation status
Source/GitHub inspection only. Tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, provider execution, lost-response/restart scenarios, and remote-adapter execution were intentionally not run per maintainer instruction.