### PR TITLE
fix(blog): project localized category names in post reads

### DIFF
--- a/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json
@@ -9,8 +9,8 @@
   "canonical_current_cursor": "crates/rustok-blog/docs/implementation-plan-current.md",
   "actualization_slice": "crates/rustok-blog/docs/implementation-plan-slice-101.md",
   "historical_baseline_last_embedded_slice": 67,
-  "latest_behavior_slice": 104,
-  "current_recorded_slice": 104,
+  "latest_behavior_slice": 105,
+  "current_recorded_slice": 105,
   "source_tracks": {
     "remote_comments_transport": {
       "status": "source_implemented_maintainer_execution_pending",
@@ -70,6 +70,19 @@
       "manual_predelete_relation_cleanup_removed": true,
       "declared_fk_cascade_used": true,
       "must_not_reopen_as_source_gap": true
+    },
+    "post_category_name_projection": {
+      "status": "source_ready_maintainer_execution_pending",
+      "slice": "crates/rustok-blog/docs/implementation-plan-slice-105.md",
+      "evidence": "crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json",
+      "category_identity_source": "blog_posts.category_id",
+      "category_name_source": "blog_category_translations.name",
+      "detail_projection_present": true,
+      "authenticated_list_projection_present": true,
+      "public_list_projection_present": true,
+      "list_batch_projection": true,
+      "category_translation_readiness_promoted": false,
+      "must_not_reopen_as_source_gap": true
     }
   },
   "planning_result": {
@@ -88,9 +101,11 @@
     "no_database_side_tag_pagination_result",
     "no_postgresql_result",
     "no_sqlite_tag_mutation_result",
+    "no_sqlite_post_category_name_result",
     "no_legacy_data_audit_result",
     "no_legacy_backfill_result",
     "no_tag_mutation_atomic_reindex_runtime_result",
+    "no_category_translation_readiness_result",
     "no_redis_result",
     "no_tcp_runtime_result",
     "no_browser_result",

--- a/crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json
+++ b/crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "module": "blog",
+  "surface": "post_category_name_projection",
+  "status": "source_verified_no_compile",
+  "compile_policy": "not_run_by_request",
+  "runtime_status": "not_run",
+  "owner": "rustok-blog",
+  "source_contract": {
+    "category_identity_source": "blog_posts.category_id",
+    "category_name_source": "blog_category_translations.name",
+    "tenant_bound_translation_query": true,
+    "detail_projection_present": true,
+    "authenticated_list_projection_present": true,
+    "public_list_projection_present": true,
+    "list_projection_uses_batch_category_query": true,
+    "list_projection_avoids_per_post_category_query": true,
+    "category_ids_deduplicated_before_query": true,
+    "requested_locale_precedence": true,
+    "tenant_fallback_precedence": true,
+    "platform_fallback_precedence": true,
+    "first_available_fallback_retained": true,
+    "missing_category_or_translation_returns_none": true,
+    "category_translation_write_semantics_changed": false,
+    "category_translation_readiness_promoted": false,
+    "search_projection_source_changed": false,
+    "database_schema_changed": false,
+    "graphql_schema_changed": false,
+    "http_schema_changed": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "production_source": "crates/rustok-blog/src/services/post.rs",
+  "dto_source": "crates/rustok-blog/src/dto/post.rs",
+  "source_harness": {
+    "path": "crates/rustok-blog/tests/post_category_name_projection.rs",
+    "status": "executable_no_run",
+    "suggested_command": "cargo test -p rustok-blog --test post_category_name_projection -- --exact",
+    "runtime_status": "not_run"
+  },
+  "verifier": "scripts/verify/verify-blog-post-category-name-projection-source.mjs",
+  "self_test": "scripts/verify/verify-blog-post-category-name-projection-source.test.mjs",
+  "planning_result": {
+    "post_category_name_source_complete": true,
+    "additional_category_name_projection_scaffolding_required": false,
+    "next_autonomous_source_work_requires_fresh_audit": true
+  },
+  "execution": [],
+  "explicit_non_claims": [
+    "no_rust_test_result",
+    "no_javascript_verifier_result",
+    "no_compile_result",
+    "no_sqlite_result",
+    "no_postgresql_result",
+    "no_category_translation_readiness_result",
+    "no_search_runtime_result",
+    "no_graphql_runtime_result",
+    "no_http_runtime_result",
+    "no_workflow_result",
+    "no_ci_result",
+    "no_production_result"
+  ]
+}

--- a/crates/rustok-blog/docs/implementation-plan-current.md
+++ b/crates/rustok-blog/docs/implementation-plan-current.md
@@ -1,15 +1,15 @@
 # rustok-blog canonical implementation cursor
 
-Status: `canonical_source_cursor_actualized_through_slice_104`.
+Status: `canonical_source_cursor_actualized_through_slice_105`.
 
 This document is the canonical **current** source cursor for `rustok-blog`.
 `crates/rustok-blog/docs/implementation-plan.md` remains the long historical baseline and embedded implementation log, but its inline `Current state`, completed-slice list, and `Next results` stop before the later continuation series and must not be used as the live cursor without this file.
 
-The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 104 is the latest production/source behavior slice.
+The continuation series is authoritative for source work after the historical baseline. Slice 101 establishes this current-cursor boundary. Slice 105 is the latest production/source behavior slice.
 
 ## Re-audit basis
 
-The source continuation through slice 104 retains the following planning corrections and independent Blog source results:
+The source continuation through slice 105 retains the following planning corrections and independent Blog source results:
 
 - the remote Comments transport is no longer an unimplemented source item;
 - the cached public Comments snapshot is no longer merely planned;
@@ -17,7 +17,8 @@ The source continuation through slice 104 retains the following planning correct
 - Blog category Translation PostgreSQL migration/concurrent-CAS/change-cursor evidence source is already retained and waits for maintainer execution;
 - Blog tag list pagination is owner-bounded and overflow-safe;
 - Blog tag reads and Search projection use `blog_post_tags + rustok-taxonomy` rather than `blog_posts.metadata.tags` as the canonical source;
-- Blog tag update/delete now retain Taxonomy mutation and Blog-scope Search reindex in one owner transaction.
+- Blog tag update/delete retain Taxonomy mutation and Blog-scope Search reindex in one owner transaction;
+- Blog post detail/authenticated-list/public-list reads now populate the existing localized `category_name` DTO field from Blog-owned category translations instead of returning a permanent `None` placeholder.
 
 None of these source states promote runtime evidence.
 
@@ -106,7 +107,7 @@ Slice 104 closes the mutation consistency gap exposed by slice 103:
 
 `tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`
 
-`rustok-taxonomy` now exposes narrow module-term update/delete functions that accept a supplied `DatabaseTransaction`, tenant/term identity, term kind, module slug, and caller security context. The Taxonomy owner rechecks module scope and term kind and preserves Taxonomy update/read/delete permissions, localized slug uniqueness, translation revision CAS, term revision CAS, and translation-change evidence.
+`rustok-taxonomy` exposes narrow module-term update/delete functions that accept a supplied `DatabaseTransaction`, tenant/term identity, term kind, module slug, and caller security context. The Taxonomy owner rechecks module scope and term kind and preserves Taxonomy update/read/delete permissions, localized slug uniqueness, translation revision CAS, term revision CAS, and translation-change evidence.
 
 `TagService::update_tag` and `TagService::delete_tag` keep their existing Blog `tags:*` checks, then execute the Taxonomy mutation and:
 
@@ -124,6 +125,27 @@ The retained source harness covers successful rename + durable reindex, forced o
 
 The Blog tag source line is source-complete through slice 104. Do not add another tag mutation scaffolding slice without new evidence.
 
+### Blog post category-name projection
+
+The fresh broad audit after slice 104 found that the existing `PostResponse.category_name` and `PostSummary.category_name` fields were permanent `None` placeholders in Blog owner reads even when `blog_posts.category_id` referenced an existing localized Blog category.
+
+Slice 105 closes that read parity gap:
+
+`post_category_name_projection = source_ready_maintainer_execution_pending`
+
+Canonical identity and localized label sources are:
+
+- `blog_posts.category_id` for the category identity;
+- `blog_category_translations.name` for the localized name.
+
+Detail, authenticated list, and public visible list now project the existing field. List paths collect and deduplicate the current page's category IDs and use one tenant-scoped translation query for the page rather than calling category reads per post.
+
+The shared locale resolver preserves requested locale -> caller-supplied tenant fallback -> platform fallback -> first available semantics. A post without a category, or a category with no translations, retains `category_name = None`.
+
+This is a read projection only. It does not change Category create/update/delete or Translation write semantics, does not promote the slice 98 Category Translation PostgreSQL readiness result, does not alter Search SQL, and does not change GraphQL/HTTP/native DTO schemas.
+
+The Blog post category-name projection line is source-complete through slice 105. Do not add another category-name scaffolding slice without new evidence.
+
 ## Remaining execution-owned results
 
 The concrete retained execution results remain maintainer-owned:
@@ -134,8 +156,9 @@ The concrete retained execution results remain maintainer-owned:
 4. Execute slice 102 tag pagination source/unit evidence before promoting runtime validation.
 5. Execute slice 103 Blog read/Search canonical tag projection evidence and audit deployed data for metadata-only legacy rows before runtime promotion.
 6. Execute slice 104 tag mutation/outbox rollback/delete-cascade harness and then Search projection evidence for rename/delete behavior.
-7. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
-8. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
+7. Execute slice 105 post category-name detail/authenticated-list/public-list source harness before promoting runtime validation.
+8. Execute category CRUD/Search refresh/canonical navigation/mounted rate-limit evidence already retained by the historical plan.
+9. Execute the Blog article richtext cutover/backfill/browser evidence already retained by the historical plan.
 
 A future autonomous source slice must start from a fresh broad repository audit and identify a genuinely new independent source gap outside the execution-gated tracks above. It must not manufacture work by reopening a source-complete or not-applicable cursor.
 
@@ -152,10 +175,10 @@ The continuation slice files and machine evidence remain the source of detailed 
 
 ## Validation boundary
 
-No tests, Cargo commands, Node verifiers, SQLite/PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, Search execution, outbox relay execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–104.
+No tests, Cargo commands, Node verifiers, SQLite/PostgreSQL/Redis/TCP scenarios, browser targets, formatting, Clippy, builds, workflows, CI, HTTP execution, Search execution, outbox relay execution, runtime validation, or production validation were executed by the implementation agent while producing slices 101–105.
 
 ## Next cursor
 
-No independent production source gap is claimed after slice 104.
+No independent production source gap is claimed after slice 105.
 
 Continue only after a fresh broad Blog source audit finds another gap outside the execution-gated tracks above, or after maintainers provide execution results that unlock one of their explicit follow-ups.

--- a/crates/rustok-blog/docs/implementation-plan-slice-105.md
+++ b/crates/rustok-blog/docs/implementation-plan-slice-105.md
@@ -1,0 +1,99 @@
+# rustok-blog implementation plan — slice 105
+
+Status: `post_category_name_projection_source_ready_maintainer_execution_pending`.
+
+## Why this slice exists
+
+The broad source audit after slice 104 found a DTO/read parity gap outside the execution-gated Comments, Category Translation readiness, and tag tracks.
+
+`PostResponse` and `PostSummary` both expose `category_name`, but all three owner read paths assigned `None` even when `blog_posts.category_id` referenced an existing localized Blog category:
+
+- detail via `build_post_response`;
+- authenticated/admin list via `list_posts_with_locale_fallback`;
+- public/storefront list via `list_public_visible_with_locale_fallback`.
+
+The Category translation tables and locale policy are already production source. This slice only projects that already-owned data into the existing post DTO field.
+
+## Accepted source contract
+
+`post_category_name_projection = source_ready_maintainer_execution_pending`
+
+Canonical identity remains:
+
+`category_identity_source = blog_posts.category_id`
+
+Canonical localized label source is:
+
+`category_name_source = blog_category_translations.name`
+
+The owner projection is tenant-bound and uses the shared locale resolver:
+
+1. requested locale;
+2. caller-supplied tenant fallback locale when present;
+3. `PLATFORM_FALLBACK_LOCALE`;
+4. first available translation.
+
+A post with no category or a category without any translation keeps `category_name = None`.
+
+## Batch/read behavior
+
+List paths collect the page's category IDs, deduplicate them, and issue one tenant-scoped category-translation query for the page. They do not call `CategoryService::get` once per post and do not introduce an N+1 category read.
+
+Detail uses the same helper for its single optional category ID.
+
+No post pagination, visibility, tag projection, author projection, Search SQL, or DTO schema changes are part of this slice.
+
+## Source evidence
+
+Production source:
+
+- `crates/rustok-blog/src/services/post.rs`
+
+DTO contract:
+
+- `crates/rustok-blog/src/dto/post.rs`
+
+Executable source harness:
+
+- `crates/rustok-blog/tests/post_category_name_projection.rs`
+
+The harness retains one localized category attached to a published post and requires the same translated `category_name` across:
+
+- detail with requested/fallback locale resolution;
+- authenticated list;
+- public visible list.
+
+Suggested maintainer command:
+
+`cargo test -p rustok-blog --test post_category_name_projection`
+
+Machine evidence:
+
+- `crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json`
+
+Fail-closed source guard:
+
+- `scripts/verify/verify-blog-post-category-name-projection-source.mjs`
+
+Focused guard self-test:
+
+- `scripts/verify/verify-blog-post-category-name-projection-source.test.mjs`
+
+## Explicit non-changes
+
+This slice does **not**:
+
+- change Category create/update/delete/Translation write semantics;
+- promote slice 98 PostgreSQL Category Translation readiness;
+- change Search Blog projector SQL;
+- change GraphQL, HTTP, native, or storefront schemas;
+- add a database migration;
+- change post/category permissions;
+- promote FFA or FBA evidence;
+- claim runtime, database, browser, HTTP, Search, workflow, CI, or production execution.
+
+## Result
+
+The existing `category_name` field is now a real Blog owner projection rather than a permanent `None` placeholder on post reads.
+
+No additional category-name projection scaffolding is required after this slice. The next autonomous source slice must return to a fresh broad Blog audit rather than reopening this read projection or the execution-gated Category Translation readiness track.

--- a/crates/rustok-blog/src/services/post.rs
+++ b/crates/rustok-blog/src/services/post.rs
@@ -28,7 +28,9 @@ use serde_json::Value;
 use crate::dto::{
     CreatePostInput, PostListQuery, PostListResponse, PostResponse, PostSummary, UpdatePostInput,
 };
-use crate::entities::{blog_post, blog_post_channel_visibility, blog_post_translation};
+use crate::entities::{
+    blog_category_translation, blog_post, blog_post_channel_visibility, blog_post_translation,
+};
 use crate::error::{BlogError, BlogResult};
 use crate::richtext::{canonical_article_body, normalize_article, project_stored_article};
 use crate::services::category::CategoryService;
@@ -636,6 +638,18 @@ impl PostService {
             fallback_locale.as_deref(),
         )
         .await?;
+        let category_ids = posts
+            .iter()
+            .filter_map(|post| post.category_id)
+            .collect::<Vec<_>>();
+        let category_names_map = self
+            .load_category_names_map(
+                tenant_id,
+                &category_ids,
+                &locale,
+                fallback_locale.as_deref(),
+            )
+            .await?;
 
         let mut items = Vec::with_capacity(posts.len());
         for post in posts {
@@ -661,7 +675,9 @@ impl PostService {
                 author_id: post.author_id,
                 author_name: None,
                 category_id: post.category_id,
-                category_name: None,
+                category_name: post
+                    .category_id
+                    .and_then(|category_id| category_names_map.get(&category_id).cloned()),
                 tags,
                 featured_image_url: post.featured_image_url.clone(),
                 channel_slugs: channel_slugs_map
@@ -734,6 +750,18 @@ impl PostService {
             fallback_locale.as_deref(),
         )
         .await?;
+        let category_ids = posts
+            .iter()
+            .filter_map(|post| post.category_id)
+            .collect::<Vec<_>>();
+        let category_names_map = self
+            .load_category_names_map(
+                tenant_id,
+                &category_ids,
+                &locale,
+                fallback_locale.as_deref(),
+            )
+            .await?;
 
         let mut items = Vec::with_capacity(posts.len());
         for post in posts {
@@ -759,7 +787,9 @@ impl PostService {
                 author_id: post.author_id,
                 author_name: None,
                 category_id: post.category_id,
-                category_name: None,
+                category_name: post
+                    .category_id
+                    .and_then(|category_id| category_names_map.get(&category_id).cloned()),
                 tags,
                 featured_image_url: post.featured_image_url.clone(),
                 channel_slugs: channel_slugs_map
@@ -867,6 +897,58 @@ impl PostService {
                 .push(translation);
         }
         Ok(map)
+    }
+
+    async fn load_category_names_map(
+        &self,
+        tenant_id: Uuid,
+        category_ids: &[Uuid],
+        locale: &str,
+        fallback_locale: Option<&str>,
+    ) -> BlogResult<HashMap<Uuid, String>> {
+        if category_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut category_ids = category_ids.to_vec();
+        category_ids.sort_unstable();
+        category_ids.dedup();
+
+        let translations = blog_category_translation::Entity::find()
+            .filter(blog_category_translation::Column::TenantId.eq(tenant_id))
+            .filter(blog_category_translation::Column::CategoryId.is_in(category_ids.clone()))
+            .all(&self.db)
+            .await
+            .map_err(BlogError::from)?;
+
+        let mut translations_by_category: HashMap<
+            Uuid,
+            Vec<blog_category_translation::Model>,
+        > = HashMap::new();
+        for translation in translations {
+            translations_by_category
+                .entry(translation.category_id)
+                .or_default()
+                .push(translation);
+        }
+
+        let mut names = HashMap::new();
+        for category_id in category_ids {
+            let Some(translations) = translations_by_category.get(&category_id) else {
+                continue;
+            };
+            let resolved = resolve_by_locale_with_fallback(
+                translations,
+                locale,
+                fallback_locale,
+                |translation| translation.locale.as_str(),
+            );
+            if let Some(translation) = resolved.item {
+                names.insert(category_id, translation.name.clone());
+            }
+        }
+
+        Ok(names)
     }
 
     async fn load_channel_slugs(&self, post_id: Uuid) -> BlogResult<Vec<String>> {
@@ -1072,6 +1154,19 @@ impl PostService {
             fallback_locale,
         )
         .await?;
+        let category_name = if let Some(category_id) = post.category_id {
+            self.load_category_names_map(
+                post.tenant_id,
+                &[category_id],
+                locale,
+                fallback_locale,
+            )
+            .await?
+            .get(&category_id)
+            .cloned()
+        } else {
+            None
+        };
         let resolved = resolve_translation_record(&translations, locale, fallback_locale);
         let translation = resolved.translation;
         let body = match translation {
@@ -1097,7 +1192,7 @@ impl PostService {
             excerpt: translation.and_then(|item| item.excerpt.clone()),
             status: storage_to_status(&post.status)?,
             category_id: post.category_id,
-            category_name: None,
+            category_name,
             tags: tags_map
                 .get(&post.id)
                 .cloned()

--- a/crates/rustok-blog/tests/post_category_name_projection.rs
+++ b/crates/rustok-blog/tests/post_category_name_projection.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+
+use rustok_blog::{
+    BlogModule, BlogPostStatus, CategoryService, CreateCategoryInput, CreatePostInput, PostListQuery,
+    PostService,
+};
+use rustok_core::{MigrationSource, SecurityContext, UserRole};
+use rustok_outbox::{OutboxTransport, SysEventsMigration, TransactionalEventBus};
+use rustok_taxonomy::TaxonomyModule;
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm_migration::{MigrationTrait, SchemaManager};
+use uuid::Uuid;
+
+async fn setup_blog_test_db() -> DatabaseConnection {
+    let db_url = format!(
+        "sqlite:file:blog_post_category_name_{}?mode=memory&cache=shared",
+        Uuid::new_v4()
+    );
+    let mut options = ConnectOptions::new(db_url);
+    options
+        .max_connections(5)
+        .min_connections(1)
+        .sqlx_logging(false);
+    Database::connect(options)
+        .await
+        .expect("blog category-name sqlite database should connect")
+}
+
+async fn ensure_schema(db: &DatabaseConnection) {
+    let manager = SchemaManager::new(db);
+    SysEventsMigration
+        .up(&manager)
+        .await
+        .expect("outbox migration should apply");
+    for migration in TaxonomyModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("taxonomy migration should apply");
+    }
+    for migration in BlogModule.migrations() {
+        migration
+            .up(&manager)
+            .await
+            .expect("blog migration should apply");
+    }
+}
+
+fn event_bus(db: &DatabaseConnection) -> TransactionalEventBus {
+    TransactionalEventBus::new(Arc::new(OutboxTransport::new(db.clone())))
+}
+
+#[tokio::test]
+async fn post_category_name_projects_across_detail_and_list_paths() {
+    let db = setup_blog_test_db().await;
+    ensure_schema(&db).await;
+
+    let bus = event_bus(&db);
+    let category_service = CategoryService::new(db.clone(), bus.clone());
+    let post_service = PostService::new(db.clone(), bus);
+    let tenant_id = Uuid::new_v4();
+    let admin = SecurityContext::new(UserRole::Admin, Some(Uuid::new_v4()));
+
+    let category_id = category_service
+        .create(
+            tenant_id,
+            admin.clone(),
+            CreateCategoryInput {
+                locale: "de".to_string(),
+                name: "Nachrichten".to_string(),
+                slug: Some("nachrichten".to_string()),
+                description: None,
+                parent_id: None,
+                position: Some(0),
+                settings: serde_json::json!({}),
+            },
+        )
+        .await
+        .expect("category should be created");
+
+    let post_id = post_service
+        .create_post(
+            tenant_id,
+            admin.clone(),
+            CreatePostInput {
+                locale: "de".to_string(),
+                title: "Kategorie im Post".to_string(),
+                content: rustok_blog::richtext::article_document_from_plain_text("Body"),
+                excerpt: None,
+                slug: Some("kategorie-im-post".to_string()),
+                publish: true,
+                tags: Vec::new(),
+                category_id: Some(category_id),
+                featured_image_url: None,
+                seo_title: None,
+                seo_description: None,
+                channel_slugs: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("post should be created");
+
+    let detail = post_service
+        .get_post_with_locale_fallback(
+            tenant_id,
+            admin.clone(),
+            post_id,
+            "fr",
+            Some("de"),
+        )
+        .await
+        .expect("detail should resolve category name through fallback");
+    assert_eq!(detail.category_id, Some(category_id));
+    assert_eq!(detail.category_name.as_deref(), Some("Nachrichten"));
+
+    let listed = post_service
+        .list_posts_with_locale_fallback(
+            tenant_id,
+            admin,
+            PostListQuery {
+                locale: Some("fr".to_string()),
+                page: Some(1),
+                per_page: Some(10),
+                ..Default::default()
+            },
+            Some("de"),
+        )
+        .await
+        .expect("authenticated list should resolve category name");
+    assert_eq!(listed.items.len(), 1);
+    assert_eq!(listed.items[0].category_id, Some(category_id));
+    assert_eq!(
+        listed.items[0].category_name.as_deref(),
+        Some("Nachrichten")
+    );
+
+    let public = post_service
+        .list_public_visible_with_locale_fallback(
+            tenant_id,
+            PostListQuery {
+                status: Some(BlogPostStatus::Published),
+                locale: Some("fr".to_string()),
+                page: Some(1),
+                per_page: Some(10),
+                ..Default::default()
+            },
+            Some("de"),
+            None,
+        )
+        .await
+        .expect("public list should resolve category name");
+    assert_eq!(public.items.len(), 1);
+    assert_eq!(public.items[0].category_id, Some(category_id));
+    assert_eq!(
+        public.items[0].category_name.as_deref(),
+        Some("Nachrichten")
+    );
+}

--- a/scripts/verify/verify-blog-canonical-plan-current.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.mjs
@@ -21,6 +21,7 @@ const files = {
   slice102: 'crates/rustok-blog/docs/implementation-plan-slice-102.md',
   slice103: 'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   slice104: 'crates/rustok-blog/docs/implementation-plan-slice-104.md',
+  slice105: 'crates/rustok-blog/docs/implementation-plan-slice-105.md',
   docsIndex: 'crates/rustok-blog/docs/README.md',
   tcpTransport: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
   tcpServer: 'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
@@ -31,6 +32,7 @@ const files = {
   tagPagination: 'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
   tagProjection: 'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
   tagMutation: 'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json',
+  postCategoryName: 'crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json',
 };
 
 function absolute(relativePath) { return path.join(repoRoot, relativePath); }
@@ -76,6 +78,7 @@ const slice101 = read(files.slice101);
 const slice102 = read(files.slice102);
 const slice103 = read(files.slice103);
 const slice104 = read(files.slice104);
+const slice105 = read(files.slice105);
 const docsIndex = read(files.docsIndex);
 const tcpTransport = json(files.tcpTransport);
 const tcpServer = json(files.tcpServer);
@@ -86,6 +89,7 @@ const writeSurface = json(files.writeSurface);
 const tagPagination = json(files.tagPagination);
 const tagProjection = json(files.tagProjection);
 const tagMutation = json(files.tagMutation);
+const postCategoryName = json(files.postCategoryName);
 
 if (evidence) {
   if (
@@ -102,8 +106,8 @@ if (evidence) {
     evidence.canonical_current_cursor !== files.current ||
     evidence.actualization_slice !== files.slice101 ||
     evidence.historical_baseline_last_embedded_slice !== 67 ||
-    evidence.latest_behavior_slice !== 104 ||
-    evidence.current_recorded_slice !== 104
+    evidence.latest_behavior_slice !== 105 ||
+    evidence.current_recorded_slice !== 105
   ) failures.push(`${files.evidence}: cursor path/version drift`);
 
   const tracks = evidence.source_tracks ?? {};
@@ -166,6 +170,19 @@ if (evidence) {
     tracks.tag_mutation_atomic_reindex?.declared_fk_cascade_used !== true ||
     tracks.tag_mutation_atomic_reindex?.must_not_reopen_as_source_gap !== true
   ) failures.push(`${files.evidence}: tag mutation atomic-reindex track drift`);
+  if (
+    tracks.post_category_name_projection?.status !== 'source_ready_maintainer_execution_pending' ||
+    tracks.post_category_name_projection?.slice !== files.slice105 ||
+    tracks.post_category_name_projection?.evidence !== files.postCategoryName ||
+    tracks.post_category_name_projection?.category_identity_source !== 'blog_posts.category_id' ||
+    tracks.post_category_name_projection?.category_name_source !== 'blog_category_translations.name' ||
+    tracks.post_category_name_projection?.detail_projection_present !== true ||
+    tracks.post_category_name_projection?.authenticated_list_projection_present !== true ||
+    tracks.post_category_name_projection?.public_list_projection_present !== true ||
+    tracks.post_category_name_projection?.list_batch_projection !== true ||
+    tracks.post_category_name_projection?.category_translation_readiness_promoted !== false ||
+    tracks.post_category_name_projection?.must_not_reopen_as_source_gap !== true
+  ) failures.push(`${files.evidence}: post category-name projection track drift`);
 
   if (
     evidence.planning_result?.independent_production_source_gap_identified !== false ||
@@ -252,6 +269,22 @@ if (
   !Array.isArray(tagMutation?.execution) || tagMutation.execution.length !== 0
 ) failures.push(`${files.tagMutation}: tag mutation atomic-reindex source evidence drift`);
 
+if (
+  postCategoryName?.status !== 'source_verified_no_compile' ||
+  postCategoryName?.runtime_status !== 'not_run' ||
+  postCategoryName?.source_contract?.category_identity_source !== 'blog_posts.category_id' ||
+  postCategoryName?.source_contract?.category_name_source !== 'blog_category_translations.name' ||
+  postCategoryName?.source_contract?.tenant_bound_translation_query !== true ||
+  postCategoryName?.source_contract?.detail_projection_present !== true ||
+  postCategoryName?.source_contract?.authenticated_list_projection_present !== true ||
+  postCategoryName?.source_contract?.public_list_projection_present !== true ||
+  postCategoryName?.source_contract?.list_projection_uses_batch_category_query !== true ||
+  postCategoryName?.source_contract?.category_translation_readiness_promoted !== false ||
+  postCategoryName?.planning_result?.post_category_name_source_complete !== true ||
+  postCategoryName?.planning_result?.additional_category_name_projection_scaffolding_required !== false ||
+  !Array.isArray(postCategoryName?.execution) || postCategoryName.execution.length !== 0
+) failures.push(`${files.postCategoryName}: post category-name projection source evidence drift`);
+
 for (const [source, marker, label] of [
   [slice97, 'Status: `canonical_outbox_relay_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice97],
   [slice98, 'Status: `category_translation_postgres_evidence_source_ready_maintainer_execution_pending`.', files.slice98],
@@ -260,6 +293,7 @@ for (const [source, marker, label] of [
   [slice102, 'Status: `tag_list_pagination_owner_bound_source_ready_maintainer_execution_pending`.', files.slice102],
   [slice103, 'Status: `tag_canonical_read_search_projection_source_ready_maintainer_execution_pending`.', files.slice103],
   [slice104, 'Status: `tag_mutation_atomic_reindex_source_ready_maintainer_execution_pending`.', files.slice104],
+  [slice105, 'Status: `post_category_name_projection_source_ready_maintainer_execution_pending`.', files.slice105],
 ]) need(source, marker, label);
 
 need(slice97, 'After retained maintainer execution of slices 95–97, define bounded lifecycle and', files.slice97);
@@ -270,9 +304,10 @@ need(slice102, 'Re-audit Blog tag mutation/projection consistency as a separate 
 need(slice103, 'Implement `tag_mutation_atomic_reindex` as slice 104', files.slice103);
 need(slice103, 'metadata-only rows', files.slice103);
 need(slice104, 'Do not add another tag mutation scaffolding slice without new evidence.', files.slice104);
+need(slice105, 'No additional category-name projection scaffolding is required after this slice.', files.slice105);
 
 for (const marker of [
-  'Status: `canonical_source_cursor_actualized_through_slice_104`.',
+  'Status: `canonical_source_cursor_actualized_through_slice_105`.',
   '`remote_comments_transport = source_implemented_maintainer_execution_pending`',
   '`category_translation_postgres = source_ready_maintainer_execution_pending`',
   '`cached_public_comments_snapshot = source_ready_maintainer_execution_pending`',
@@ -281,11 +316,13 @@ for (const marker of [
   '`tag_canonical_projection = source_ready_maintainer_execution_pending`',
   '`tag_mutation_atomic_reindex = source_ready_maintainer_execution_pending`',
   '`tag_delete_relation_cleanup = declared_fk_cascade`',
+  '`post_category_name_projection = source_ready_maintainer_execution_pending`',
   'do not advance that source work before retained maintainer execution of slices 95–97',
   'This does **not** claim database-side pagination.',
   'metadata-only legacy rows',
   'source-complete through slice 104',
-  'No independent production source gap is claimed after slice 104.',
+  'source-complete through slice 105',
+  'No independent production source gap is claimed after slice 105.',
   '## Superseded historical cursor phrases',
   'No tests, Cargo commands, Node verifiers',
 ]) need(current, marker, files.current);
@@ -332,4 +369,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('[verify-blog-canonical-plan-current] PASS cursor=slice-104 behavior-through=slice-104 execution=not-run');
+console.log('[verify-blog-canonical-plan-current] PASS cursor=slice-105 behavior-through=slice-105 execution=not-run');

--- a/scripts/verify/verify-blog-canonical-plan-current.test.mjs
+++ b/scripts/verify/verify-blog-canonical-plan-current.test.mjs
@@ -22,6 +22,7 @@ const files = [
   'crates/rustok-blog/docs/implementation-plan-slice-102.md',
   'crates/rustok-blog/docs/implementation-plan-slice-103.md',
   'crates/rustok-blog/docs/implementation-plan-slice-104.md',
+  'crates/rustok-blog/docs/implementation-plan-slice-105.md',
   'crates/rustok-blog/docs/README.md',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-transport.json',
   'crates/rustok-blog/contracts/evidence/blog-comments-tcp-server-adapter.json',
@@ -32,6 +33,7 @@ const files = [
   'crates/rustok-blog/contracts/evidence/blog-tag-pagination-source.json',
   'crates/rustok-blog/contracts/evidence/blog-tag-canonical-projection-source.json',
   'crates/rustok-blog/contracts/evidence/blog-tag-mutation-reindex-source.json',
+  'crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json',
 ];
 function absolute(root, relativePath) { return path.join(root, relativePath); }
 function write(root, relativePath, content) {
@@ -74,7 +76,7 @@ test('accepts the canonical Blog current implementation cursor', () => {
   try {
     const result = run(root);
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(result.stdout, /cursor=slice-104/);
+    assert.match(result.stdout, /cursor=slice-105/);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -183,6 +185,27 @@ test('rejects premature tag mutation runtime promotion', () => {
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /tag mutation atomic-reindex source evidence drift/);
+});
+
+test('rejects reopening post category-name projection after slice 105', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-canonical-plan-current-source.json', (value) => {
+      value.source_tracks.post_category_name_projection.status = 'planned';
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /post category-name projection track drift/);
+});
+
+test('rejects premature post category-name runtime promotion', () => {
+  const result = rejects((root) => {
+    mutateJson(root, 'crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json', (value) => {
+      value.runtime_status = 'validated';
+      value.execution.push({ command: 'not-run' });
+    });
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /post category-name projection source evidence drift/);
 });
 
 test('rejects listing the historical plan before the canonical current cursor', () => {

--- a/scripts/verify/verify-blog-post-category-name-projection-source.mjs
+++ b/scripts/verify/verify-blog-post-category-name-projection-source.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const failures = [];
+
+const files = {
+  evidence: 'crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json',
+  postService: 'crates/rustok-blog/src/services/post.rs',
+  dto: 'crates/rustok-blog/src/dto/post.rs',
+  harness: 'crates/rustok-blog/tests/post_category_name_projection.rs',
+  slice: 'crates/rustok-blog/docs/implementation-plan-slice-105.md',
+  current: 'crates/rustok-blog/docs/implementation-plan-current.md',
+};
+
+function read(relativePath) {
+  const target = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(target)) {
+    failures.push(`${relativePath}: missing file`);
+    return '';
+  }
+  return fs.readFileSync(target, 'utf8');
+}
+function json(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    failures.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return null;
+  }
+}
+function need(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+}
+function forbid(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+function count(source, marker) {
+  return source.split(marker).length - 1;
+}
+
+const evidence = json(files.evidence);
+const postService = read(files.postService);
+const dto = read(files.dto);
+const harness = read(files.harness);
+const slice = read(files.slice);
+const current = read(files.current);
+
+if (evidence) {
+  if (
+    evidence.schema_version !== 1 ||
+    evidence.module !== 'blog' ||
+    evidence.surface !== 'post_category_name_projection' ||
+    evidence.status !== 'source_verified_no_compile' ||
+    evidence.compile_policy !== 'not_run_by_request' ||
+    evidence.runtime_status !== 'not_run' ||
+    evidence.owner !== 'rustok-blog'
+  ) failures.push(`${files.evidence}: identity/status drift`);
+
+  const contract = evidence.source_contract ?? {};
+  for (const [key, expected] of Object.entries({
+    category_identity_source: 'blog_posts.category_id',
+    category_name_source: 'blog_category_translations.name',
+    tenant_bound_translation_query: true,
+    detail_projection_present: true,
+    authenticated_list_projection_present: true,
+    public_list_projection_present: true,
+    list_projection_uses_batch_category_query: true,
+    list_projection_avoids_per_post_category_query: true,
+    category_ids_deduplicated_before_query: true,
+    requested_locale_precedence: true,
+    tenant_fallback_precedence: true,
+    platform_fallback_precedence: true,
+    first_available_fallback_retained: true,
+    missing_category_or_translation_returns_none: true,
+    category_translation_write_semantics_changed: false,
+    category_translation_readiness_promoted: false,
+    search_projection_source_changed: false,
+    database_schema_changed: false,
+    graphql_schema_changed: false,
+    http_schema_changed: false,
+    ffa_promoted: false,
+    fba_promoted: false,
+  })) {
+    if (contract[key] !== expected) failures.push(`${files.evidence}: ${key} drift`);
+  }
+
+  if (
+    evidence.production_source !== files.postService ||
+    evidence.dto_source !== files.dto ||
+    evidence.source_harness?.path !== files.harness ||
+    evidence.source_harness?.status !== 'executable_no_run' ||
+    evidence.source_harness?.runtime_status !== 'not_run' ||
+    evidence.verifier !== 'scripts/verify/verify-blog-post-category-name-projection-source.mjs' ||
+    evidence.self_test !== 'scripts/verify/verify-blog-post-category-name-projection-source.test.mjs' ||
+    evidence.planning_result?.post_category_name_source_complete !== true ||
+    evidence.planning_result?.additional_category_name_projection_scaffolding_required !== false ||
+    evidence.planning_result?.next_autonomous_source_work_requires_fresh_audit !== true ||
+    !Array.isArray(evidence.execution) ||
+    evidence.execution.length !== 0
+  ) failures.push(`${files.evidence}: source/harness/planning drift`);
+}
+
+if (count(dto, 'pub category_name: Option<String>') < 2) {
+  failures.push(`${files.dto}: detail/list category_name DTO contract missing`);
+}
+
+for (const marker of [
+  'blog_category_translation, blog_post, blog_post_channel_visibility, blog_post_translation',
+  'async fn load_category_names_map(',
+  'category_ids.sort_unstable();',
+  'category_ids.dedup();',
+  'blog_category_translation::Column::TenantId.eq(tenant_id)',
+  'blog_category_translation::Column::CategoryId.is_in(category_ids.clone())',
+  'resolve_by_locale_with_fallback(',
+  'fallback_locale,',
+  'translation.name.clone()',
+  'let category_names_map = self',
+  '.and_then(|category_id| category_names_map.get(&category_id).cloned())',
+  'let category_name = if let Some(category_id) = post.category_id',
+  'category_name,',
+]) need(postService, marker, files.postService);
+
+if (count(postService, '.load_category_names_map(') !== 3) {
+  failures.push(`${files.postService}: expected exactly three category-name projection calls`);
+}
+forbid(postService, 'category_name: None', files.postService);
+forbid(postService, 'CategoryService::new(self.db.clone()', files.postService);
+forbid(postService, '.get(\n                tenant_id,\n                SecurityContext::system()', files.postService);
+
+for (const marker of [
+  'post_category_name_projects_across_detail_and_list_paths',
+  'CreateCategoryInput',
+  'name: "Nachrichten".to_string()',
+  'get_post_with_locale_fallback(',
+  'Some("de")',
+  'list_posts_with_locale_fallback(',
+  'list_public_visible_with_locale_fallback(',
+  'detail.category_name.as_deref()',
+  'listed.items[0].category_name.as_deref()',
+  'public.items[0].category_name.as_deref()',
+]) need(harness, marker, files.harness);
+
+for (const marker of [
+  'Status: `post_category_name_projection_source_ready_maintainer_execution_pending`.',
+  '`post_category_name_projection = source_ready_maintainer_execution_pending`',
+  '`category_identity_source = blog_posts.category_id`',
+  '`category_name_source = blog_category_translations.name`',
+  'They do not call `CategoryService::get` once per post',
+  'No additional category-name projection scaffolding is required after this slice.',
+]) need(slice, marker, files.slice);
+
+for (const marker of [
+  'Status: `canonical_source_cursor_actualized_through_slice_105`.',
+  '`post_category_name_projection = source_ready_maintainer_execution_pending`',
+  'source-complete through slice 105',
+]) need(current, marker, files.current);
+
+if (failures.length) {
+  console.error('[verify-blog-post-category-name-projection-source] FAIL');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('[verify-blog-post-category-name-projection-source] PASS detail=list=public batch=true execution=not-run');

--- a/scripts/verify/verify-blog-post-category-name-projection-source.test.mjs
+++ b/scripts/verify/verify-blog-post-category-name-projection-source.test.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const verifier = path.join(
+  repositoryRoot,
+  'scripts/verify/verify-blog-post-category-name-projection-source.mjs',
+);
+const files = [
+  'crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json',
+  'crates/rustok-blog/src/services/post.rs',
+  'crates/rustok-blog/src/dto/post.rs',
+  'crates/rustok-blog/tests/post_category_name_projection.rs',
+  'crates/rustok-blog/docs/implementation-plan-slice-105.md',
+  'crates/rustok-blog/docs/implementation-plan-current.md',
+];
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), 'rustok-blog-category-name-'));
+  for (const relativePath of files) {
+    const source = path.join(repositoryRoot, relativePath);
+    const target = path.join(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(source, target);
+  }
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [verifier], {
+    env: { ...process.env, RUSTOK_VERIFY_REPO_ROOT: root },
+    encoding: 'utf8',
+  });
+}
+
+function mutate(root, relativePath, transform) {
+  const target = path.join(root, relativePath);
+  const source = readFileSync(target, 'utf8');
+  writeFileSync(target, transform(source));
+}
+
+function expectFailure(root, message) {
+  const result = run(root);
+  assert.notEqual(result.status, 0, `${message}\nstdout=${result.stdout}\nstderr=${result.stderr}`);
+}
+
+test('canonical category-name projection source passes', () => {
+  const root = fixture();
+  try {
+    const result = run(root);
+    assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects restoring permanent None category projection', () => {
+  const root = fixture();
+  try {
+    mutate(root, 'crates/rustok-blog/src/services/post.rs', (source) =>
+      source.replace('category_name,', 'category_name: None,'),
+    );
+    expectFailure(root, 'permanent None detail projection must fail');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects dropping tenant binding from category translation query', () => {
+  const root = fixture();
+  try {
+    mutate(root, 'crates/rustok-blog/src/services/post.rs', (source) =>
+      source.replace(
+        '.filter(blog_category_translation::Column::TenantId.eq(tenant_id))',
+        '',
+      ),
+    );
+    expectFailure(root, 'cross-tenant category projection must fail');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects replacing batch category lookup with non-batch lookup', () => {
+  const root = fixture();
+  try {
+    mutate(root, 'crates/rustok-blog/src/services/post.rs', (source) =>
+      source.replace(
+        'blog_category_translation::Column::CategoryId.is_in(category_ids.clone())',
+        'blog_category_translation::Column::CategoryId.eq(category_ids[0])',
+      ),
+    );
+    expectFailure(root, 'non-batch category lookup must fail');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects dropping caller fallback locale', () => {
+  const root = fixture();
+  try {
+    mutate(root, 'crates/rustok-blog/src/services/post.rs', (source) =>
+      source.replace(
+        'translations,\n                locale,\n                fallback_locale,',
+        'translations,\n                locale,\n                None,',
+      ),
+    );
+    expectFailure(root, 'fallback removal must fail');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects fake execution promotion', () => {
+  const root = fixture();
+  try {
+    mutate(
+      root,
+      'crates/rustok-blog/contracts/evidence/blog-post-category-name-projection-source.json',
+      (source) => source.replace('"execution": []', '"execution": ["fake"]'),
+    );
+    expectFailure(root, 'fake execution claim must fail');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects current cursor rollback before slice 105', () => {
+  const root = fixture();
+  try {
+    mutate(root, 'crates/rustok-blog/docs/implementation-plan-current.md', (source) =>
+      source.replace(
+        'canonical_source_cursor_actualized_through_slice_105',
+        'canonical_source_cursor_actualized_through_slice_104',
+      ),
+    );
+    expectFailure(root, 'cursor rollback must fail');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Continue the canonical Blog cursor with slice 105 and close a fresh read/DTO parity gap found after slice 104.

`PostResponse` and `PostSummary` already expose `category_name`, but Blog owner detail, authenticated list, and public visible list hardcoded that field to `None`. This PR projects the existing Blog-owned localized category name into those read DTOs.

## Owner projection

- keeps category identity authoritative in `blog_posts.category_id`;
- reads localized names from `blog_category_translations.name`;
- tenant-binds every category translation query;
- uses the shared locale resolver: requested -> caller tenant fallback -> platform fallback -> first available;
- keeps `None` when a post has no category or the category has no translations.

## Batch behavior

- authenticated and public list paths collect/deduplicate the current page's category IDs;
- each list path performs one category-translation query for the page;
- no per-post `CategoryService::get` calls and no category N+1;
- detail reuses the same projection helper for its single optional category.

## Retained evidence

- adds an executable-no-run Rust harness covering detail, authenticated list, public list, and tenant fallback;
- adds machine evidence plus a focused fail-closed verifier/self-test;
- advances the canonical Blog cursor/evidence through slice 105 while preserving all prior cursor checks.

## Explicit non-changes

No Category create/update/delete or Translation write changes, no slice-98 readiness promotion, no Search SQL change, no GraphQL/HTTP/native schema change, no database migration, no permission change, and no FFA/FBA promotion.

## Validation boundary

Per maintainer instruction, no tests, Cargo commands, Node verifiers, SQLite/PostgreSQL scenarios, formatting, builds, Clippy, workflows, CI, HTTP/Search execution, runtime validation, or production validation were executed. Source/diff review only.