### PR TITLE
feat(forum): enumerate stored reply locales for export

### DIFF
--- a/crates/rustok-forum/src/services/reply_facade.rs
+++ b/crates/rustok-forum/src/services/reply_facade.rs
@@ -30,6 +30,9 @@ pub struct ReplyService {
 }
 
 impl ReplyService {
+    pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize =
+        reply_owner::ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS;
+
     pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
         Self::with_optional_audience_facts(db, event_bus, None)
     }
@@ -55,6 +58,23 @@ impl ReplyService {
             ),
             db,
         }
+    }
+
+    pub async fn available_locales_for_replies(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        reply_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+        if security.is_public_read() {
+            return Err(ForumError::forbidden(
+                "Forum reply locale enumeration requires an authenticated operator context",
+            ));
+        }
+        self.inner
+            .available_locales_for_replies(tenant_id, security, reply_ids)
+            .await
     }
 
     pub async fn create(

--- a/crates/rustok-forum/src/services/reply_facade.rs
+++ b/crates/rustok-forum/src/services/reply_facade.rs
@@ -66,12 +66,12 @@ impl ReplyService {
         security: SecurityContext,
         reply_ids: &[Uuid],
     ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
-        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
         if security.is_public_read() {
             return Err(ForumError::forbidden(
                 "Forum reply locale enumeration requires an authenticated operator context",
             ));
         }
+        enforce_scope(&security, Resource::ForumReplies, Action::Manage)?;
         self.inner
             .available_locales_for_replies(tenant_id, security, reply_ids)
             .await

--- a/crates/rustok-forum/src/services/reply_inline.rs
+++ b/crates/rustok-forum/src/services/reply_inline.rs
@@ -1,6 +1,81 @@
+use std::collections::BTreeSet;
+
+use rustok_content::available_locales_from;
+
 use crate::dto::UpdateReplyCommandInput;
 
 impl ReplyService {
+    pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;
+
+    pub async fn available_locales_for_replies(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        reply_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+
+        if tenant_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum reply locale enumeration requires a non-nil tenant id".to_string(),
+            ));
+        }
+        if reply_ids.len() > Self::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS {
+            return Err(ForumError::Validation(format!(
+                "Forum reply locale enumeration exceeds {} reply ids: {}",
+                Self::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS,
+                reply_ids.len()
+            )));
+        }
+        if reply_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen = BTreeSet::new();
+        for reply_id in reply_ids {
+            if reply_id.is_nil() {
+                return Err(ForumError::Validation(
+                    "Forum reply locale enumeration requires non-nil reply ids".to_string(),
+                ));
+            }
+            if !seen.insert(*reply_id) {
+                return Err(ForumError::Validation(format!(
+                    "Forum reply locale enumeration contains duplicate reply id {reply_id}"
+                )));
+            }
+        }
+
+        let existing = forum_reply::Entity::find()
+            .filter(forum_reply::Column::TenantId.eq(tenant_id))
+            .filter(forum_reply::Column::Id.is_in(reply_ids.to_vec()))
+            .all(&self.db)
+            .await?;
+        let existing_ids = existing
+            .into_iter()
+            .map(|reply| reply.id)
+            .collect::<BTreeSet<_>>();
+        for reply_id in reply_ids {
+            if !existing_ids.contains(reply_id) {
+                return Err(ForumError::ReplyNotFound(*reply_id));
+            }
+        }
+
+        let mut bodies_by_reply = self.load_bodies_map(tenant_id, reply_ids).await?;
+        let mut result = Vec::with_capacity(reply_ids.len());
+        for reply_id in reply_ids {
+            let bodies = bodies_by_reply.remove(reply_id).unwrap_or_default();
+            let locales = available_locales_from(&bodies, |body| body.locale.as_str());
+            if locales.is_empty() {
+                return Err(ForumError::Validation(format!(
+                    "Forum reply {reply_id} has no stored locale body"
+                )));
+            }
+            result.push((*reply_id, locales));
+        }
+
+        Ok(result)
+    }
+
     pub(crate) async fn update_with_inline_relations(
         &self,
         tenant_id: Uuid,

--- a/crates/rustok-forum/src/services/reply_inline.rs
+++ b/crates/rustok-forum/src/services/reply_inline.rs
@@ -5,9 +5,9 @@ use rustok_content::available_locales_from;
 use crate::dto::UpdateReplyCommandInput;
 
 impl ReplyService {
-    pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;
+    pub(crate) const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;
 
-    pub async fn available_locales_for_replies(
+    pub(crate) async fn available_locales_for_replies(
         &self,
         tenant_id: Uuid,
         security: SecurityContext,

--- a/crates/rustok-forum/src/services/reply_inline.rs
+++ b/crates/rustok-forum/src/services/reply_inline.rs
@@ -13,7 +13,7 @@ impl ReplyService {
         security: SecurityContext,
         reply_ids: &[Uuid],
     ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
-        enforce_scope(&security, Resource::ForumReplies, Action::List)?;
+        enforce_scope(&security, Resource::ForumReplies, Action::Manage)?;
 
         if tenant_id.is_nil() {
             return Err(ForumError::Validation(

--- a/crates/rustok-forum/src/services/reply_owner_inline.rs
+++ b/crates/rustok-forum/src/services/reply_owner_inline.rs
@@ -1,6 +1,20 @@
 use crate::dto::{CreateReplyCommandInput, UpdateReplyCommandInput};
 
 impl ReplyService {
+    pub(crate) const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize =
+        reply::ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS;
+
+    pub(crate) async fn available_locales_for_replies(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        reply_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        self.inner
+            .available_locales_for_replies(tenant_id, security, reply_ids)
+            .await
+    }
+
     #[instrument(skip(self, security, input))]
     pub async fn create_command(
         &self,

--- a/crates/rustok-forum/src/services/reply_owner_inline.rs
+++ b/crates/rustok-forum/src/services/reply_owner_inline.rs
@@ -10,6 +10,7 @@ impl ReplyService {
         security: SecurityContext,
         reply_ids: &[Uuid],
     ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        enforce_scope(&security, Resource::ForumReplies, Action::Manage)?;
         self.inner
             .available_locales_for_replies(tenant_id, security, reply_ids)
             .await

--- a/docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md
@@ -21,7 +21,7 @@ Fresh `main` for this slice is `777002dac974df22d1b3374c7313812f86149a55`. The c
 
 FORUM-34D deliberately did not claim multilingual export completeness because `ReplyResponse` exposes one resolved locale view and does not expose the complete set of stored reply locales. Repeated fallback reads cannot prove completeness: multiple requested locales can resolve to the same stored effective locale.
 
-The next Forum-owned slice therefore exposes exact stored locale enumeration at the existing `ReplyService` owner boundary. It does not add an import/export runner, transport or second reply read model.
+The next Forum-owned slice therefore exposes exact stored locale enumeration at the existing public `ReplyService` owner facade. It does not add an import/export runner, transport or second reply read model.
 
 ## Public owner contract
 
@@ -31,9 +31,14 @@ The next Forum-owned slice therefore exposes exact stored locale enumeration at 
 - the existing trusted `SecurityContext`;
 - a caller-ordered slice of reply UUIDs.
 
-The method:
+The public facade:
 
 - requires `forum_replies:list` through the existing Forum RBAC boundary;
+- rejects `SecurityContext::is_public_read()` before delegating, so this export-oriented metadata cannot become an anonymous reply-existence or locale oracle;
+- delegates through the existing reply owner service rather than exposing raw persistence helpers.
+
+The bounded owner/storage implementation:
+
 - rejects a nil tenant id;
 - accepts at most `ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS = 512` reply IDs;
 - rejects nil reply IDs and duplicate reply IDs;
@@ -43,13 +48,13 @@ The method:
 - returns one `(reply_id, locales)` pair for every requested reply in caller order;
 - fails closed when an existing reply has no stored body locale.
 
-The contract exposes stored locale identities only. It does not return reply content, rendered HTML, author identity, status, votes, solution state or counters.
+The raw batched storage method and its bound remain crate-private. The contract exposes stored locale identities only; it does not return reply content, rendered HTML, author identity, status, votes, solution state or counters.
 
 ## No fallback and no N+1 semantics
 
-Locale enumeration is intentionally not a localized read. It does not call `resolve_by_locale_with_fallback`, does not accept a requested locale and does not synthesize fallback locales.
+Locale enumeration is intentionally not a localized read. The storage implementation does not call `resolve_by_locale_with_fallback`, does not accept a requested locale and does not synthesize fallback locales.
 
-The bounded method performs one tenant-scoped reply existence query and reuses the existing batched body loader for the complete bounded ID set. It does not call `ReplyService::get` or `find_reply` once per ID and therefore does not introduce an N+1 enumeration path.
+The bounded storage method performs one tenant-scoped reply existence query and reuses the existing batched `load_bodies_map` loader for the complete bounded ID set. It does not call `ReplyService::get` or `find_reply` once per ID and therefore does not introduce an N+1 enumeration path. The public facade does not perform per-reply visibility probes because anonymous/public-read contexts are rejected before the owner delegation.
 
 ## Ownership and limits
 

--- a/docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md
@@ -33,11 +33,11 @@ The next Forum-owned slice therefore exposes exact stored locale enumeration at 
 
 The public facade:
 
-- requires `forum_replies:list` through the existing Forum RBAC boundary;
-- rejects `SecurityContext::is_public_read()` before delegating, so this export-oriented metadata cannot become an anonymous reply-existence or locale oracle;
+- explicitly rejects `SecurityContext::is_public_read()`, so this export-oriented metadata cannot become an anonymous reply-existence or locale oracle;
+- requires `forum_replies:manage`, not ordinary list/read authority;
 - delegates through the existing reply owner service rather than exposing raw persistence helpers.
 
-The bounded owner/storage implementation:
+The internal owner and storage layers repeat the `forum_replies:manage` check before storage access. The bounded storage implementation then:
 
 - rejects a nil tenant id;
 - accepts at most `ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS = 512` reply IDs;
@@ -54,7 +54,7 @@ The raw batched storage method and its bound remain crate-private. The contract 
 
 Locale enumeration is intentionally not a localized read. The storage implementation does not call `resolve_by_locale_with_fallback`, does not accept a requested locale and does not synthesize fallback locales.
 
-The bounded storage method performs one tenant-scoped reply existence query and reuses the existing batched `load_bodies_map` loader for the complete bounded ID set. It does not call `ReplyService::get` or `find_reply` once per ID and therefore does not introduce an N+1 enumeration path. The public facade does not perform per-reply visibility probes because anonymous/public-read contexts are rejected before the owner delegation.
+The bounded storage method performs one tenant-scoped reply existence query and reuses the existing batched `load_bodies_map` loader for the complete bounded ID set. It does not call `ReplyService::get` or `find_reply` once per ID and therefore does not introduce an N+1 enumeration path. The public facade does not perform per-reply visibility probes because anonymous/public-read contexts are rejected before the owner delegation and the operation requires manage authority.
 
 ## Ownership and limits
 

--- a/docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md
@@ -1,0 +1,99 @@
+# FORUM-34E bounded reply locale enumeration actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34D are merged on `main`:
+
+- FORUM-34A maps bounded NodeBB category/topic/post source batches into runner-neutral external references without inventing RusTok target identities;
+- FORUM-34B inspects unresolved in-batch and external-owner dependencies without treating an observation as persistence admission;
+- FORUM-34C rejects source-local category cycles while leaving missing cross-batch parents unresolved;
+- FORUM-34D maps already-authorized full Forum owner responses into tenant-scoped export fragments using canonical rich-text documents and effective locales.
+
+The merged 34A-34D source was re-read before this slice. No ownership inversion or duplicate runner path was found. In particular, source IDs remain external references, cross-batch dependencies remain unresolved, only actual cycle members receive `cyclic_batch_relation`, and the export mapper remains side-effect free and cannot deserialize arbitrary external input as an authorized owner-view batch.
+
+The canonical Forum ledger still says `FORUM-34` is `planned`, which is stale relative to merged 34A-34D. This dated packet records the truthful execution cursor without replacing the large concurrent canonical plan through a whole-file contents write.
+
+Fresh `main` for this slice is `777002dac974df22d1b3374c7313812f86149a55`. The commits after FORUM-34D are Commerce and Blog only and do not modify `crates/rustok-forum/*`.
+
+## Gap selected
+
+FORUM-34D deliberately did not claim multilingual export completeness because `ReplyResponse` exposes one resolved locale view and does not expose the complete set of stored reply locales. Repeated fallback reads cannot prove completeness: multiple requested locales can resolve to the same stored effective locale.
+
+The next Forum-owned slice therefore exposes exact stored locale enumeration at the existing `ReplyService` owner boundary. It does not add an import/export runner, transport or second reply read model.
+
+## Public owner contract
+
+`ReplyService::available_locales_for_replies` accepts:
+
+- one explicit tenant id;
+- the existing trusted `SecurityContext`;
+- a caller-ordered slice of reply UUIDs.
+
+The method:
+
+- requires `forum_replies:list` through the existing Forum RBAC boundary;
+- rejects a nil tenant id;
+- accepts at most `ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS = 512` reply IDs;
+- rejects nil reply IDs and duplicate reply IDs;
+- verifies every requested reply exists in the same tenant before returning locale metadata;
+- loads all stored reply bodies for the bounded ID set through the existing batched `load_bodies_map` path;
+- derives locales directly from stored `forum_reply_body.locale` rows through `rustok_content::available_locales_from`;
+- returns one `(reply_id, locales)` pair for every requested reply in caller order;
+- fails closed when an existing reply has no stored body locale.
+
+The contract exposes stored locale identities only. It does not return reply content, rendered HTML, author identity, status, votes, solution state or counters.
+
+## No fallback and no N+1 semantics
+
+Locale enumeration is intentionally not a localized read. It does not call `resolve_by_locale_with_fallback`, does not accept a requested locale and does not synthesize fallback locales.
+
+The bounded method performs one tenant-scoped reply existence query and reuses the existing batched body loader for the complete bounded ID set. It does not call `ReplyService::get` or `find_reply` once per ID and therefore does not introduce an N+1 enumeration path.
+
+## Ownership and limits
+
+This slice adds no:
+
+- shared or Forum-only import/export runner;
+- checkpoint, receipt, replay or audit persistence;
+- import-side identity resolution;
+- candidate-to-owner write adapter;
+- attachment/media mapping;
+- votes/reputation transfer;
+- revision/history transfer policy;
+- Search rebuild orchestration;
+- GraphQL, REST, CLI or admin transport;
+- migration or schema change.
+
+`ReplyService` remains the Forum owner boundary. A future operator-authorized export composer can first enumerate exact locales for a bounded reply set and then perform the corresponding full owner reads under the same trusted tenant/RBAC context before constructing `ForumExportOwnerViewBatch`.
+
+This still does not make a complete tenant export by itself. Topic/category enumeration, cursor/checkpoint semantics and the neutral shared runner remain separate open work.
+
+## Remaining FORUM-34 scope
+
+After FORUM-34E, still open:
+
+- neutral shared import/export runner contract and host composition;
+- durable cursor/checkpoint/receipt/replay/audit semantics;
+- operator-authorized bounded export reader/composer over category/topic/reply owner services;
+- cross-batch import dependency resolution;
+- external-user resolution through auth/Profile owner contracts;
+- candidate-to-existing Forum owner command adapter;
+- revisions/history export/import policy;
+- votes/reputation export/import through their owners;
+- attachment/media mapping after FORUM-14 establishes Forum-owned relations;
+- URL alias transfer where route-owner contracts permit it;
+- runner-level dry-run/reconciliation/Search rebuild orchestration;
+- CLI/admin transport only after RBAC/idempotency/audit admission;
+- retained SQLite/PostgreSQL/restart/lost-response evidence.
+
+## Maintainer validation
+
+Per maintainer instruction, no test, Cargo command, Node verifier, formatter, migration, database scenario, workflow, CI, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
+```

--- a/scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
+++ b/scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
@@ -27,7 +27,7 @@ const packet = read(packetPath);
 for (const marker of [
   "pub(crate) const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;",
   "pub(crate) async fn available_locales_for_replies(",
-  "enforce_scope(&security, Resource::ForumReplies, Action::List)?;",
+  "enforce_scope(&security, Resource::ForumReplies, Action::Manage)?;",
   "tenant_id.is_nil()",
   "reply_ids.len() > Self::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS",
   "let mut seen = BTreeSet::new();",
@@ -83,6 +83,7 @@ for (const marker of [
   "pub(crate) const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize =",
   "reply::ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS;",
   "pub(crate) async fn available_locales_for_replies(",
+  "enforce_scope(&security, Resource::ForumReplies, Action::Manage)?;",
   ".available_locales_for_replies(tenant_id, security, reply_ids)",
 ]) {
   requireText(owner, marker, `${ownerPath}: missing owner delegation marker ${marker}`);
@@ -92,9 +93,9 @@ for (const marker of [
   "pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize =",
   "reply_owner::ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS;",
   "pub async fn available_locales_for_replies(",
-  "enforce_scope(&security, Resource::ForumReplies, Action::List)?;",
   "if security.is_public_read()",
   "Forum reply locale enumeration requires an authenticated operator context",
+  "enforce_scope(&security, Resource::ForumReplies, Action::Manage)?;",
   ".available_locales_for_replies(tenant_id, security, reply_ids)",
 ]) {
   requireText(facade, marker, `${facadePath}: missing public owner marker ${marker}`);
@@ -126,7 +127,7 @@ for (const marker of [
   "canonical Forum ledger still says `FORUM-34` is `planned`",
   "exact stored locale enumeration",
   "MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS = 512",
-  "requires `forum_replies:list`",
+  "requires `forum_replies:manage`",
   "rejects `SecurityContext::is_public_read()`",
   "anonymous reply-existence or locale oracle",
   "raw batched storage method and its bound remain crate-private",

--- a/scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
+++ b/scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const sourcePath = "crates/rustok-forum/src/services/reply_inline.rs";
+const packetPath = "docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md";
+
+const source = read(sourcePath);
+const packet = read(packetPath);
+
+for (const marker of [
+  "pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;",
+  "pub async fn available_locales_for_replies(",
+  "enforce_scope(&security, Resource::ForumReplies, Action::List)?;",
+  "tenant_id.is_nil()",
+  "reply_ids.len() > Self::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS",
+  "let mut seen = BTreeSet::new();",
+  "!seen.insert(*reply_id)",
+  "forum_reply::Entity::find()",
+  ".filter(forum_reply::Column::TenantId.eq(tenant_id))",
+  ".filter(forum_reply::Column::Id.is_in(reply_ids.to_vec()))",
+  "ForumError::ReplyNotFound(*reply_id)",
+  "self.load_bodies_map(tenant_id, reply_ids).await?",
+  "available_locales_from(&bodies, |body| body.locale.as_str())",
+  "result.push((*reply_id, locales));",
+]) {
+  requireText(source, marker, `${sourcePath}: missing ${marker}`);
+}
+
+const methodStart = source.indexOf("    pub async fn available_locales_for_replies(");
+const methodEnd = source.indexOf("    pub(crate) async fn update_with_inline_relations(", methodStart);
+if (methodStart < 0 || methodEnd <= methodStart) {
+  throw new Error(`${sourcePath}: locale enumeration method boundary is invalid`);
+}
+const method = source.slice(methodStart, methodEnd);
+
+for (const forbidden of [
+  "resolve_by_locale_with_fallback",
+  "fallback_locale",
+  "requested_locale",
+  ".get(tenant_id",
+  "find_reply(tenant_id",
+  "VoteService",
+  "SubscriptionService",
+  "TransactionalEventBus",
+]) {
+  requireAbsent(
+    method,
+    forbidden,
+    `${sourcePath}: locale enumeration must remain exact/batched and side-effect free: ${forbidden}`,
+  );
+}
+
+const awaitCount = method.split(".await?").length - 1;
+if (awaitCount !== 2) {
+  throw new Error(
+    `${sourcePath}: locale enumeration should keep the bounded two-query shape, found ${awaitCount} awaited owner queries`,
+  );
+}
+
+for (const marker of [
+  "FORUM-34E",
+  "34A-34D",
+  "canonical Forum ledger still says `FORUM-34` is `planned`",
+  "exact stored locale enumeration",
+  "MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS = 512",
+  "requires `forum_replies:list`",
+  "rejects nil reply IDs and duplicate reply IDs",
+  "one tenant-scoped reply existence query",
+  "existing batched `load_bodies_map` path",
+  "does not call `resolve_by_locale_with_fallback`",
+  "does not introduce an N+1 enumeration path",
+  "shared or Forum-only import/export runner",
+  "no test, Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-34E reply locale enumeration source: ok");

--- a/scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
+++ b/scripts/verify/verify-forum-reply-locale-enumeration-source.mjs
@@ -14,15 +14,19 @@ function requireAbsent(text, marker, message) {
   if (text.includes(marker)) throw new Error(message);
 }
 
-const sourcePath = "crates/rustok-forum/src/services/reply_inline.rs";
+const storagePath = "crates/rustok-forum/src/services/reply_inline.rs";
+const ownerPath = "crates/rustok-forum/src/services/reply_owner_inline.rs";
+const facadePath = "crates/rustok-forum/src/services/reply_facade.rs";
 const packetPath = "docs/modules/forum-34-reply-locale-enumeration-actualization-2026-08-09.md";
 
-const source = read(sourcePath);
+const storage = read(storagePath);
+const owner = read(ownerPath);
+const facade = read(facadePath);
 const packet = read(packetPath);
 
 for (const marker of [
-  "pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;",
-  "pub async fn available_locales_for_replies(",
+  "pub(crate) const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize = 512;",
+  "pub(crate) async fn available_locales_for_replies(",
   "enforce_scope(&security, Resource::ForumReplies, Action::List)?;",
   "tenant_id.is_nil()",
   "reply_ids.len() > Self::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS",
@@ -36,15 +40,20 @@ for (const marker of [
   "available_locales_from(&bodies, |body| body.locale.as_str())",
   "result.push((*reply_id, locales));",
 ]) {
-  requireText(source, marker, `${sourcePath}: missing ${marker}`);
+  requireText(storage, marker, `${storagePath}: missing ${marker}`);
 }
 
-const methodStart = source.indexOf("    pub async fn available_locales_for_replies(");
-const methodEnd = source.indexOf("    pub(crate) async fn update_with_inline_relations(", methodStart);
-if (methodStart < 0 || methodEnd <= methodStart) {
-  throw new Error(`${sourcePath}: locale enumeration method boundary is invalid`);
+const storageMethodStart = storage.indexOf(
+  "    pub(crate) async fn available_locales_for_replies(",
+);
+const storageMethodEnd = storage.indexOf(
+  "    pub(crate) async fn update_with_inline_relations(",
+  storageMethodStart,
+);
+if (storageMethodStart < 0 || storageMethodEnd <= storageMethodStart) {
+  throw new Error(`${storagePath}: locale enumeration method boundary is invalid`);
 }
-const method = source.slice(methodStart, methodEnd);
+const storageMethod = storage.slice(storageMethodStart, storageMethodEnd);
 
 for (const forbidden of [
   "resolve_by_locale_with_fallback",
@@ -57,16 +66,57 @@ for (const forbidden of [
   "TransactionalEventBus",
 ]) {
   requireAbsent(
-    method,
+    storageMethod,
     forbidden,
-    `${sourcePath}: locale enumeration must remain exact/batched and side-effect free: ${forbidden}`,
+    `${storagePath}: locale enumeration must remain exact/batched and side-effect free: ${forbidden}`,
   );
 }
 
-const awaitCount = method.split(".await?").length - 1;
+const awaitCount = storageMethod.split(".await?").length - 1;
 if (awaitCount !== 2) {
   throw new Error(
-    `${sourcePath}: locale enumeration should keep the bounded two-query shape, found ${awaitCount} awaited owner queries`,
+    `${storagePath}: locale enumeration should keep the bounded two-query shape, found ${awaitCount} awaited owner queries`,
+  );
+}
+
+for (const marker of [
+  "pub(crate) const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize =",
+  "reply::ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS;",
+  "pub(crate) async fn available_locales_for_replies(",
+  ".available_locales_for_replies(tenant_id, security, reply_ids)",
+]) {
+  requireText(owner, marker, `${ownerPath}: missing owner delegation marker ${marker}`);
+}
+
+for (const marker of [
+  "pub const MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS: usize =",
+  "reply_owner::ReplyService::MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS;",
+  "pub async fn available_locales_for_replies(",
+  "enforce_scope(&security, Resource::ForumReplies, Action::List)?;",
+  "if security.is_public_read()",
+  "Forum reply locale enumeration requires an authenticated operator context",
+  ".available_locales_for_replies(tenant_id, security, reply_ids)",
+]) {
+  requireText(facade, marker, `${facadePath}: missing public owner marker ${marker}`);
+}
+
+const facadeMethodStart = facade.indexOf("    pub async fn available_locales_for_replies(");
+const facadeMethodEnd = facade.indexOf("    pub async fn create(", facadeMethodStart);
+if (facadeMethodStart < 0 || facadeMethodEnd <= facadeMethodStart) {
+  throw new Error(`${facadePath}: public locale enumeration method boundary is invalid`);
+}
+const facadeMethod = facade.slice(facadeMethodStart, facadeMethodEnd);
+for (const forbidden of [
+  "topic_category_is_visible",
+  "for reply_id in reply_ids",
+  "find_reply(",
+  "forum_reply::Entity",
+  "forum_reply_body::Entity",
+]) {
+  requireAbsent(
+    facadeMethod,
+    forbidden,
+    `${facadePath}: public facade must reject public-read and delegate without per-reply probes: ${forbidden}`,
   );
 }
 
@@ -77,9 +127,11 @@ for (const marker of [
   "exact stored locale enumeration",
   "MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS = 512",
   "requires `forum_replies:list`",
-  "rejects nil reply IDs and duplicate reply IDs",
+  "rejects `SecurityContext::is_public_read()`",
+  "anonymous reply-existence or locale oracle",
+  "raw batched storage method and its bound remain crate-private",
   "one tenant-scoped reply existence query",
-  "existing batched `load_bodies_map` path",
+  "existing batched `load_bodies_map` loader",
   "does not call `resolve_by_locale_with_fallback`",
   "does not introduce an N+1 enumeration path",
   "shared or Forum-only import/export runner",


### PR DESCRIPTION
## Summary

Continue FORUM-34 with bounded exact stored-locale enumeration for reply export composition.

- expose `ReplyService::available_locales_for_replies` through the existing public owner facade;
- reserve the operation for non-public contexts with `forum_replies:manage` authority;
- keep the raw storage query crate-private and repeat the manage check through owner/storage layers;
- preserve caller order, reject nil/duplicate IDs, require same-tenant reply existence, and cap batches at 512 IDs;
- derive exact locales from stored `forum_reply_body.locale` rows with one existence query plus the existing batched body loader;
- add a dated FORUM-34E actualization packet and source guard.

## Recheck of merged FORUM-34 work

Re-read the merged 34A-34D implementation before selecting this slice:

- 34A keeps NodeBB IDs as external references and does not invent RusTok identities;
- 34B keeps cross-batch and external-owner dependencies unresolved rather than treating inspection as admission;
- 34C marks only actual source-local category cycle members and leaves missing external parents unresolved;
- 34D remains a side-effect-free mapping from already-authorized full owner responses, with non-wire owner-view input and effective-locale canonical rich-text export.

The canonical ledger still labels FORUM-34 `planned`; the dated 34E packet records the truthful incremental cursor without replacing the large concurrently edited plan file.

## Security / ownership

This is not a public localized read. Anonymous/public-read contexts fail closed before delegation, and ordinary list/read authority is insufficient: the operation requires `forum_replies:manage`. It returns locale identities only and adds no content, author, vote, solution, counter, runner, persistence, transport, or migration ownership.

## Validation

Per maintainer instruction, tests, Cargo commands, Node verifiers, formatters, migrations, workflows, CI commands, and `git diff --check` were intentionally not run.