### PR TITLE
feat(commerce): route GraphQL fulfillment commands through owner ports

### DIFF
--- a/crates/rustok-commerce/docs/graphql-fulfillment-command-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-fulfillment-command-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,47 @@
+# Commerce GraphQL Fulfillment command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+This slice continues the canonical ecommerce topology P0 by moving the mounted Commerce GraphQL Fulfillment provider-operation mutations behind host-composed owner ports while preserving the existing public GraphQL fields, permissions, DTO shapes, and public error families.
+
+Mounted fields covered by this slice:
+
+- `createFulfillment`
+- `shipFulfillment`
+- `deliverFulfillment`
+- `reopenFulfillment`
+- `reshipFulfillment`
+- `cancelFulfillment`
+
+## Owner boundaries
+
+Mounted lifecycle mutations now resolve `CommerceFulfillmentCommandRuntime` from `CommerceGraphqlRuntimeData` and call `FulfillmentAdminCommandPort`. The runtime prefers host-supplied `FulfillmentAdminCommandRuntime` and falls back to the Fulfillment-owned in-process adapter with the deployment-selected provider registry.
+
+`createFulfillment` keeps cross-owner order/shipping policy in Commerce, but the policy service is composed exclusively from the existing `OrderReadPort`, `FulfillmentReadPort`, `ShippingOptionReadPort`, and `FulfillmentAdminCreateCommandPort` capabilities. Mounted schemas therefore no longer construct a concrete Fulfillment service for manual creation. Directly embedded compatibility schemas that omit manifest runtime data retain the pre-existing concrete orchestration fallback only for that compatibility case.
+
+Provider journal ownership remains in `rustok-fulfillment`. This slice does not reimplement provider execution or persistence in GraphQL. The existing owner code continues to own create-label journaling/reconciliation and lifecycle provider-operation journaling/reconciliation.
+
+## Request context and public errors
+
+GraphQL builds typed `PortContext` values from validated `AuthContext` and `RequestContext` data. Lifecycle commands receive deterministic transport idempotency identities and two-second deadlines. Manual creation uses separate read/write contexts and an input-sensitive deterministic write idempotency identity, matching the established admin HTTP cross-owner create pattern.
+
+Owner `PortError` values are mapped back to the existing GraphQL Fulfillment public families:
+
+- `ORDER_RESOURCE_NOT_FOUND`
+- `FULFILLMENT_REQUEST_INVALID`
+- `FULFILLMENT_RESOURCE_NOT_FOUND`
+- `FULFILLMENT_STATE_CONFLICT`
+- `FULFILLMENT_TEMPORARILY_UNAVAILABLE`
+- `FULFILLMENT_RECONCILIATION_REQUIRED`
+
+Diagnostics record only bounded owner/error metadata, correlation identity, non-nil resource facts, and public classification; owner messages and opaque payloads are not exposed.
+
+## Canonical plan state
+
+The broad canonical topology item remains open. Other mounted Commerce concrete-owner paths, post-order/change/return orchestration, checkout/reconciliation work, and runtime verification gates are outside this slice.
+
+## Validation
+
+No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, provider execution, lost-response scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice. The maintainer explicitly requested to run tests independently.

--- a/crates/rustok-commerce/src/graphql/mutations/provider_operations.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/provider_operations.rs
@@ -4,6 +4,10 @@ use rustok_api::{
     graphql::require_module_enabled,
 };
 use rustok_fulfillment::error::FulfillmentError;
+use rustok_fulfillment::{
+    CancelAdminFulfillmentRequest, DeliverAdminFulfillmentRequest, ReopenAdminFulfillmentRequest,
+    ReshipAdminFulfillmentRequest, ShipAdminFulfillmentRequest,
+};
 use rustok_payment::{
     AuthorizeAdminPaymentCollectionRequest, CancelAdminPaymentCollectionRequest,
     CancelAdminRefundRequest, CaptureAdminPaymentCollectionRequest, CompleteAdminRefundRequest,
@@ -12,7 +16,8 @@ use rustok_payment::{
 use uuid::Uuid;
 
 use crate::graphql_runtime::{
-    fulfillment_orchestration_from_context, payment_command_runtime_from_context,
+    fulfillment_command_runtime_from_context, fulfillment_orchestration_from_context,
+    manual_fulfillment_owner_orchestration_from_context, payment_command_runtime_from_context,
 };
 use crate::FulfillmentOrchestrationError;
 
@@ -157,6 +162,75 @@ fn fulfillment_orchestration_error_envelope(
     }
 }
 
+fn fulfillment_command_error_envelope(
+    error: &PortError,
+) -> (&'static str, &'static str, bool, &'static str) {
+    match error.code.as_str() {
+        "order.order_not_found" => (
+            "Order resource was not found",
+            "ORDER_RESOURCE_NOT_FOUND",
+            false,
+            "order_not_found",
+        ),
+        "fulfillment.reconciliation_required" => (
+            "Fulfillment operation requires reconciliation",
+            "FULFILLMENT_RECONCILIATION_REQUIRED",
+            false,
+            "reconciliation_required",
+        ),
+        "fulfillment.database_unavailable" | "order.database_unavailable" => (
+            "Fulfillment service is temporarily unavailable",
+            "FULFILLMENT_TEMPORARILY_UNAVAILABLE",
+            true,
+            "temporarily_unavailable",
+        ),
+        "fulfillment.invalid_transition" => (
+            "Fulfillment operation conflicts with the current state",
+            "FULFILLMENT_STATE_CONFLICT",
+            false,
+            "state_conflict",
+        ),
+        _ => match &error.kind {
+            PortErrorKind::Validation => (
+                "Fulfillment request is invalid",
+                "FULFILLMENT_REQUEST_INVALID",
+                false,
+                "validation",
+            ),
+            PortErrorKind::NotFound => (
+                "Fulfillment resource was not found",
+                "FULFILLMENT_RESOURCE_NOT_FOUND",
+                false,
+                "not_found",
+            ),
+            PortErrorKind::Conflict => (
+                "Fulfillment operation conflicts with the current state",
+                "FULFILLMENT_STATE_CONFLICT",
+                false,
+                "state_conflict",
+            ),
+            PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+                "Fulfillment service is temporarily unavailable",
+                "FULFILLMENT_TEMPORARILY_UNAVAILABLE",
+                true,
+                "temporarily_unavailable",
+            ),
+            PortErrorKind::InvariantViolation => (
+                "Fulfillment operation requires reconciliation",
+                "FULFILLMENT_RECONCILIATION_REQUIRED",
+                false,
+                "reconciliation_required",
+            ),
+            PortErrorKind::Forbidden => (
+                "Fulfillment request is invalid",
+                "FULFILLMENT_REQUEST_INVALID",
+                false,
+                "forbidden",
+            ),
+        },
+    }
+}
+
 fn payment_provider_graphql_error(
     tenant_id: Uuid,
     resource_id: Uuid,
@@ -182,20 +256,48 @@ fn payment_provider_graphql_error(
     public_provider_graphql_error(message, code, retryable)
 }
 
-fn fulfillment_provider_graphql_error(
+fn fulfillment_owner_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) = fulfillment_command_error_envelope(&error);
+    tracing::error!(
+        owner = "rustok_fulfillment",
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
+        operation,
+        correlation_id = %context.correlation_id,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_fulfillment_command",
+        "commerce GraphQL fulfillment owner command failed"
+    );
+    public_provider_graphql_error(message, code, retryable)
+}
+
+fn legacy_fulfillment_provider_graphql_error(
     tenant_id: Uuid,
     resource_id: Uuid,
     operation: &'static str,
     error: FulfillmentOrchestrationError,
 ) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        resource_id = %resource_id,
-        operation,
-        "commerce GraphQL fulfillment provider operation failed"
-    );
     let (message, code, retryable) = fulfillment_orchestration_error_envelope(&error);
+    tracing::error!(
+        owner = "rustok_commerce.fulfillment_orchestration_compat",
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
+        operation,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_fulfillment_compat",
+        "commerce GraphQL embedded compatibility fulfillment operation failed"
+    );
     public_provider_graphql_error(message, code, retryable)
 }
 
@@ -276,6 +378,104 @@ fn payment_refund_transition_context(
     Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
         Some(channel) => context.with_channel(channel),
         None => context,
+    })
+}
+
+fn fulfillment_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    fulfillment_id: Uuid,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-fulfillment-command:{operation}:{fulfillment_id}"),
+    )
+    .with_idempotency_key(format!(
+        "graphql-fulfillment:{fulfillment_id}:{operation}"
+    ))
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
+fn fulfillment_create_read_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    order_id: Uuid,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-fulfillment-create-read:{order_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
+fn fulfillment_create_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    input: &crate::dto::CreateFulfillmentInput,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let payload = serde_json::to_vec(input).map_err(|_| {
+        public_provider_graphql_error(
+            "Fulfillment request is invalid",
+            "FULFILLMENT_REQUEST_INVALID",
+            false,
+        )
+    })?;
+    let first = fnv1a64(&payload, 0xcbf29ce484222325);
+    let second = fnv1a64(&payload, 0x84222325cbf29ce4);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!(
+            "commerce-graphql-fulfillment-create-command:{}",
+            input.order_id
+        ),
+    )
+    .with_idempotency_key(format!(
+        "graphql-fulfillment:create:{}:{first:016x}{second:016x}",
+        input.order_id
+    ))
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
+fn fnv1a64(bytes: &[u8], offset_basis: u64) -> u64 {
+    bytes.iter().fold(offset_basis, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
     })
 }
 
@@ -556,35 +756,59 @@ impl CommerceProviderMutation {
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let order_id = input.order_id;
-        let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
-            .create_manual_fulfillment(
-                tenant_id,
-                crate::dto::CreateFulfillmentInput {
-                    order_id,
-                    shipping_option_id: input.shipping_option_id,
-                    customer_id: input.customer_id,
-                    carrier: input.carrier,
-                    tracking_number: input.tracking_number,
-                    items: Some(
-                        input
-                            .items
-                            .into_iter()
-                            .map(|item| {
-                                Ok(crate::dto::CreateFulfillmentItemInput {
-                                    order_line_item_id: item.order_line_item_id,
-                                    quantity: item.quantity,
-                                    metadata: parse_optional_metadata(item.metadata.as_deref())?,
-                                })
-                            })
-                            .collect::<Result<Vec<_>>>()?,
-                    ),
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
-                },
-            )
-            .await
-            .map_err(|error| {
-                fulfillment_provider_graphql_error(tenant_id, order_id, "create_fulfillment", error)
-            })?;
+        let create_input = crate::dto::CreateFulfillmentInput {
+            order_id,
+            shipping_option_id: input.shipping_option_id,
+            customer_id: input.customer_id,
+            carrier: input.carrier,
+            tracking_number: input.tracking_number,
+            items: Some(
+                input
+                    .items
+                    .into_iter()
+                    .map(|item| {
+                        Ok(crate::dto::CreateFulfillmentItemInput {
+                            order_line_item_id: item.order_line_item_id,
+                            quantity: item.quantity,
+                            metadata: parse_optional_metadata(item.metadata.as_deref())?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            ),
+            metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        };
+
+        let fulfillment = if let Some(service) =
+            manual_fulfillment_owner_orchestration_from_context(ctx)
+        {
+            let read_context = fulfillment_create_read_context(ctx, tenant_id, order_id)?;
+            let write_context =
+                fulfillment_create_command_context(ctx, tenant_id, &create_input)?;
+            service
+                .create_manual_fulfillment(read_context, write_context.clone(), create_input)
+                .await
+                .map_err(|error| {
+                    fulfillment_owner_graphql_error(
+                        tenant_id,
+                        order_id,
+                        "create_fulfillment",
+                        &write_context,
+                        error,
+                    )
+                })?
+        } else {
+            fulfillment_orchestration_from_context(ctx, db.clone())
+                .create_manual_fulfillment(tenant_id, create_input)
+                .await
+                .map_err(|error| {
+                    legacy_fulfillment_provider_graphql_error(
+                        tenant_id,
+                        order_id,
+                        "create_fulfillment",
+                        error,
+                    )
+                })?
+        };
         Ok(fulfillment.into())
     }
 
@@ -602,28 +826,39 @@ impl CommerceProviderMutation {
             "Permission denied: fulfillments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
+        let runtime = fulfillment_command_runtime_from_context(ctx, db.clone());
+        let context = fulfillment_command_context(ctx, tenant_id, id, "ship")?;
+        let fulfillment = runtime
+            .lifecycle_command_port()
             .ship_fulfillment(
-                tenant_id,
-                id,
-                crate::dto::ShipFulfillmentInput {
-                    carrier: input.carrier,
-                    tracking_number: input.tracking_number,
-                    items: input.items.map(|items| {
-                        items
-                            .into_iter()
-                            .map(|item| crate::dto::FulfillmentItemQuantityInput {
-                                fulfillment_item_id: item.fulfillment_item_id,
-                                quantity: item.quantity,
-                            })
-                            .collect()
-                    }),
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                ShipAdminFulfillmentRequest {
+                    fulfillment_id: id,
+                    input: crate::dto::ShipFulfillmentInput {
+                        carrier: input.carrier,
+                        tracking_number: input.tracking_number,
+                        items: input.items.map(|items| {
+                            items
+                                .into_iter()
+                                .map(|item| crate::dto::FulfillmentItemQuantityInput {
+                                    fulfillment_item_id: item.fulfillment_item_id,
+                                    quantity: item.quantity,
+                                })
+                                .collect()
+                        }),
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                fulfillment_provider_graphql_error(tenant_id, id, "ship_fulfillment", error)
+                fulfillment_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "ship_fulfillment",
+                    &context,
+                    error,
+                )
             })?;
         Ok(fulfillment.into())
     }
@@ -642,27 +877,38 @@ impl CommerceProviderMutation {
             "Permission denied: fulfillments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
+        let runtime = fulfillment_command_runtime_from_context(ctx, db.clone());
+        let context = fulfillment_command_context(ctx, tenant_id, id, "deliver")?;
+        let fulfillment = runtime
+            .lifecycle_command_port()
             .deliver_fulfillment(
-                tenant_id,
-                id,
-                crate::dto::DeliverFulfillmentInput {
-                    delivered_note: input.delivered_note,
-                    items: input.items.map(|items| {
-                        items
-                            .into_iter()
-                            .map(|item| crate::dto::FulfillmentItemQuantityInput {
-                                fulfillment_item_id: item.fulfillment_item_id,
-                                quantity: item.quantity,
-                            })
-                            .collect()
-                    }),
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                DeliverAdminFulfillmentRequest {
+                    fulfillment_id: id,
+                    input: crate::dto::DeliverFulfillmentInput {
+                        delivered_note: input.delivered_note,
+                        items: input.items.map(|items| {
+                            items
+                                .into_iter()
+                                .map(|item| crate::dto::FulfillmentItemQuantityInput {
+                                    fulfillment_item_id: item.fulfillment_item_id,
+                                    quantity: item.quantity,
+                                })
+                                .collect()
+                        }),
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                fulfillment_provider_graphql_error(tenant_id, id, "deliver_fulfillment", error)
+                fulfillment_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "deliver_fulfillment",
+                    &context,
+                    error,
+                )
             })?;
         Ok(fulfillment.into())
     }
@@ -681,26 +927,37 @@ impl CommerceProviderMutation {
             "Permission denied: fulfillments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
+        let runtime = fulfillment_command_runtime_from_context(ctx, db.clone());
+        let context = fulfillment_command_context(ctx, tenant_id, id, "reopen")?;
+        let fulfillment = runtime
+            .lifecycle_command_port()
             .reopen_fulfillment(
-                tenant_id,
-                id,
-                crate::dto::ReopenFulfillmentInput {
-                    items: input.items.map(|items| {
-                        items
-                            .into_iter()
-                            .map(|item| crate::dto::FulfillmentItemQuantityInput {
-                                fulfillment_item_id: item.fulfillment_item_id,
-                                quantity: item.quantity,
-                            })
-                            .collect()
-                    }),
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                ReopenAdminFulfillmentRequest {
+                    fulfillment_id: id,
+                    input: crate::dto::ReopenFulfillmentInput {
+                        items: input.items.map(|items| {
+                            items
+                                .into_iter()
+                                .map(|item| crate::dto::FulfillmentItemQuantityInput {
+                                    fulfillment_item_id: item.fulfillment_item_id,
+                                    quantity: item.quantity,
+                                })
+                                .collect()
+                        }),
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                fulfillment_provider_graphql_error(tenant_id, id, "reopen_fulfillment", error)
+                fulfillment_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "reopen_fulfillment",
+                    &context,
+                    error,
+                )
             })?;
         Ok(fulfillment.into())
     }
@@ -719,28 +976,39 @@ impl CommerceProviderMutation {
             "Permission denied: fulfillments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
+        let runtime = fulfillment_command_runtime_from_context(ctx, db.clone());
+        let context = fulfillment_command_context(ctx, tenant_id, id, "reship")?;
+        let fulfillment = runtime
+            .lifecycle_command_port()
             .reship_fulfillment(
-                tenant_id,
-                id,
-                crate::dto::ReshipFulfillmentInput {
-                    carrier: input.carrier,
-                    tracking_number: input.tracking_number,
-                    items: input.items.map(|items| {
-                        items
-                            .into_iter()
-                            .map(|item| crate::dto::FulfillmentItemQuantityInput {
-                                fulfillment_item_id: item.fulfillment_item_id,
-                                quantity: item.quantity,
-                            })
-                            .collect()
-                    }),
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                ReshipAdminFulfillmentRequest {
+                    fulfillment_id: id,
+                    input: crate::dto::ReshipFulfillmentInput {
+                        carrier: input.carrier,
+                        tracking_number: input.tracking_number,
+                        items: input.items.map(|items| {
+                            items
+                                .into_iter()
+                                .map(|item| crate::dto::FulfillmentItemQuantityInput {
+                                    fulfillment_item_id: item.fulfillment_item_id,
+                                    quantity: item.quantity,
+                                })
+                                .collect()
+                        }),
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                fulfillment_provider_graphql_error(tenant_id, id, "reship_fulfillment", error)
+                fulfillment_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "reship_fulfillment",
+                    &context,
+                    error,
+                )
             })?;
         Ok(fulfillment.into())
     }
@@ -759,18 +1027,29 @@ impl CommerceProviderMutation {
             "Permission denied: fulfillments:update required",
         )?;
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let fulfillment = fulfillment_orchestration_from_context(ctx, db.clone())
+        let runtime = fulfillment_command_runtime_from_context(ctx, db.clone());
+        let context = fulfillment_command_context(ctx, tenant_id, id, "cancel")?;
+        let fulfillment = runtime
+            .lifecycle_command_port()
             .cancel_fulfillment(
-                tenant_id,
-                id,
-                crate::dto::CancelFulfillmentInput {
-                    reason: input.reason,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                CancelAdminFulfillmentRequest {
+                    fulfillment_id: id,
+                    input: crate::dto::CancelFulfillmentInput {
+                        reason: input.reason,
+                        metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                    },
                 },
             )
             .await
             .map_err(|error| {
-                fulfillment_provider_graphql_error(tenant_id, id, "cancel_fulfillment", error)
+                fulfillment_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "cancel_fulfillment",
+                    &context,
+                    error,
+                )
             })?;
         Ok(fulfillment.into())
     }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -16,8 +16,10 @@ use rustok_payment::providers::PaymentProviderRegistry;
 use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogReadRuntime};
 use sea_orm::DatabaseConnection;
 
+mod fulfillment_commands;
 mod payment_commands;
 mod payment_reads;
+pub use fulfillment_commands::CommerceFulfillmentCommandRuntime;
 pub use payment_commands::CommercePaymentCommandRuntime;
 pub use payment_reads::CommercePaymentReadRuntime;
 
@@ -330,9 +332,9 @@ pub(crate) fn product_catalog_command_runtime_for_current_graphql_scope(
 /// Provider registries and host-selectable ports available to every commerce GraphQL resolver.
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual provider
-/// registries remain deterministic fallbacks. Mounted Payment reads/commands, shipping-option,
-/// fulfillment-lifecycle, Product catalog, and order reads consume host-selected runtime data.
-/// Directly embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
+/// registries remain deterministic fallbacks. Mounted Payment/Fulfillment reads and commands,
+/// shipping-option, Product catalog, and order reads consume host-selected runtime data. Directly
+/// embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
@@ -341,6 +343,7 @@ pub struct CommerceGraphqlRuntimeData {
     marketplace_financial_runtime: crate::MarketplaceFinancialRuntime,
     payment_read_runtime: CommercePaymentReadRuntime,
     payment_command_runtime: CommercePaymentCommandRuntime,
+    fulfillment_command_runtime: CommerceFulfillmentCommandRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
@@ -368,6 +371,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn payment_command_runtime(&self) -> CommercePaymentCommandRuntime {
         self.payment_command_runtime.clone()
+    }
+
+    pub fn fulfillment_command_runtime(&self) -> CommerceFulfillmentCommandRuntime {
+        self.fulfillment_command_runtime.clone()
     }
 
     pub fn shipping_option_read_runtime(&self) -> CommerceShippingOptionReadRuntime {
@@ -433,6 +440,9 @@ pub fn attach_schema_data(
         payment_command_runtime: inputs
             .shared_get::<CommercePaymentCommandRuntime>()
             .unwrap_or_else(|| CommercePaymentCommandRuntime::from_graphql_inputs(inputs)),
+        fulfillment_command_runtime: inputs
+            .shared_get::<CommerceFulfillmentCommandRuntime>()
+            .unwrap_or_else(|| CommerceFulfillmentCommandRuntime::from_graphql_inputs(inputs)),
         shipping_option_read_runtime: inputs
             .shared_get::<CommerceShippingOptionReadRuntime>()
             .ok_or_else(|| {
@@ -482,6 +492,38 @@ pub(crate) fn payment_command_runtime_from_context(
                 payment_provider_registry_from_context(ctx),
             )
         })
+}
+
+pub(crate) fn fulfillment_command_runtime_from_context(
+    ctx: &Context<'_>,
+    db: DatabaseConnection,
+) -> CommerceFulfillmentCommandRuntime {
+    ctx.data_opt::<CommerceGraphqlRuntimeData>()
+        .map(CommerceGraphqlRuntimeData::fulfillment_command_runtime)
+        .unwrap_or_else(|| {
+            let provider_registry = ctx
+                .data_opt::<CommerceGraphqlRuntimeData>()
+                .map(CommerceGraphqlRuntimeData::fulfillment_provider_registry)
+                .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider);
+            CommerceFulfillmentCommandRuntime::in_process(db, provider_registry)
+        })
+}
+
+pub(crate) fn manual_fulfillment_owner_orchestration_from_context(
+    ctx: &Context<'_>,
+) -> Option<crate::services::AdminManualFulfillmentOrchestrationService> {
+    ctx.data_opt::<CommerceGraphqlRuntimeData>().map(|runtime| {
+        crate::services::AdminManualFulfillmentOrchestrationService::new(
+            runtime.order_read_runtime().order_read_port(),
+            runtime
+                .fulfillment_lifecycle_read_runtime()
+                .fulfillment_read_port(),
+            runtime
+                .shipping_option_read_runtime()
+                .shipping_option_read_port(),
+            runtime.fulfillment_command_runtime().create_command_port(),
+        )
+    })
 }
 
 pub(crate) fn refund_reconciliation_from_context(

--- a/crates/rustok-commerce/src/graphql_runtime/fulfillment_commands.rs
+++ b/crates/rustok-commerce/src/graphql_runtime/fulfillment_commands.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use rustok_fulfillment::{
+    FulfillmentAdminCommandPort, FulfillmentAdminCommandRuntime,
+    FulfillmentAdminCreateCommandPort, FulfillmentAdminCreateCommandRuntime,
+    providers::FulfillmentProviderRegistry,
+};
+use sea_orm::DatabaseConnection;
+
+/// Host-selected Fulfillment owner commands consumed by mounted Commerce GraphQL mutations.
+///
+/// Commerce composes the existing lifecycle and manual-create command capabilities but does not
+/// own Fulfillment persistence, provider journals, or provider execution. Hosts may inject either
+/// owner runtime independently; missing capabilities use the Fulfillment-owned in-process adapters
+/// with the deployment-selected provider registry.
+#[derive(Clone)]
+pub struct CommerceFulfillmentCommandRuntime {
+    lifecycle_commands: FulfillmentAdminCommandRuntime,
+    create_commands: FulfillmentAdminCreateCommandRuntime,
+}
+
+impl CommerceFulfillmentCommandRuntime {
+    pub fn new(
+        lifecycle_commands: FulfillmentAdminCommandRuntime,
+        create_commands: FulfillmentAdminCreateCommandRuntime,
+    ) -> Self {
+        Self {
+            lifecycle_commands,
+            create_commands,
+        }
+    }
+
+    pub fn in_process(
+        db: DatabaseConnection,
+        provider_registry: FulfillmentProviderRegistry,
+    ) -> Self {
+        Self::new(
+            FulfillmentAdminCommandRuntime::in_process(
+                db.clone(),
+                provider_registry.clone(),
+            ),
+            FulfillmentAdminCreateCommandRuntime::in_process(db, provider_registry),
+        )
+    }
+
+    pub(crate) fn from_graphql_inputs(
+        inputs: &rustok_api::graphql::GraphqlRuntimeInputs,
+    ) -> Self {
+        let provider_registry = inputs
+            .shared_get::<FulfillmentProviderRegistry>()
+            .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider);
+        let lifecycle_commands = inputs
+            .shared_get::<FulfillmentAdminCommandRuntime>()
+            .unwrap_or_else(|| {
+                FulfillmentAdminCommandRuntime::in_process(
+                    inputs.db_clone(),
+                    provider_registry.clone(),
+                )
+            });
+        let create_commands = inputs
+            .shared_get::<FulfillmentAdminCreateCommandRuntime>()
+            .unwrap_or_else(|| {
+                FulfillmentAdminCreateCommandRuntime::in_process(
+                    inputs.db_clone(),
+                    provider_registry.clone(),
+                )
+            });
+        Self::new(lifecycle_commands, create_commands)
+    }
+
+    pub fn lifecycle_command_port(&self) -> Arc<dyn FulfillmentAdminCommandPort> {
+        self.lifecycle_commands.command_port()
+    }
+
+    pub fn create_command_port(&self) -> Arc<dyn FulfillmentAdminCreateCommandPort> {
+        self.create_commands.command_port()
+    }
+}

--- a/scripts/verify/verify-commerce-graphql-fulfillment-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-fulfillment-command-owner-port-cutover.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  providerOperations: 'crates/rustok-commerce/src/graphql/mutations/provider_operations.rs',
+  graphqlRuntime: 'crates/rustok-commerce/src/graphql_runtime.rs',
+  fulfillmentCommands: 'crates/rustok-commerce/src/graphql_runtime/fulfillment_commands.rs',
+  lifecycleOwner: 'crates/rustok-fulfillment/src/admin_command.rs',
+  createOwner: 'crates/rustok-fulfillment/src/admin_create_command.rs',
+  manualCreate: 'crates/rustok-commerce/src/services/admin_manual_fulfillment_orchestration.rs',
+  plan: 'crates/rustok-commerce/docs/implementation-plan.md',
+  document: 'crates/rustok-commerce/docs/graphql-fulfillment-command-owner-port-cutover-2026-08-09.md',
+};
+
+const providerOperations = read(paths.providerOperations);
+const graphqlRuntime = read(paths.graphqlRuntime);
+const fulfillmentCommands = read(paths.fulfillmentCommands);
+const lifecycleOwner = read(paths.lifecycleOwner);
+const createOwner = read(paths.createOwner);
+const manualCreate = read(paths.manualCreate);
+const plan = read(paths.plan);
+const document = read(paths.document);
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const sliceBetween = (source, start, end) => {
+  const from = source.indexOf(start);
+  const to = end ? source.indexOf(end, from + start.length) : source.length;
+  if (from < 0 || to < 0) return '';
+  return source.slice(from, to);
+};
+
+for (const marker of [
+  'CancelAdminFulfillmentRequest',
+  'DeliverAdminFulfillmentRequest',
+  'ReopenAdminFulfillmentRequest',
+  'ReshipAdminFulfillmentRequest',
+  'ShipAdminFulfillmentRequest',
+  'fulfillment_command_runtime_from_context',
+  'manual_fulfillment_owner_orchestration_from_context',
+  '.lifecycle_command_port()',
+  '.ship_fulfillment(',
+  '.deliver_fulfillment(',
+  '.reopen_fulfillment(',
+  '.reship_fulfillment(',
+  '.cancel_fulfillment(',
+  'Permission::FULFILLMENTS_CREATE',
+  'Permission::FULFILLMENTS_UPDATE',
+  'PortActor::user(auth.user_id.to_string())',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'request.channel_slug.as_deref()',
+  'graphql-fulfillment:{fulfillment_id}:{operation}',
+  'graphql-fulfillment:create:{}:{first:016x}{second:016x}',
+]) requireText(providerOperations, marker, `${paths.providerOperations}: mounted Fulfillment owner command contract`);
+
+for (const [start, end, label] of [
+  ['async fn ship_fulfillment(', 'async fn deliver_fulfillment(', 'ship'],
+  ['async fn deliver_fulfillment(', 'async fn reopen_fulfillment(', 'deliver'],
+  ['async fn reopen_fulfillment(', 'async fn reship_fulfillment(', 'reopen'],
+  ['async fn reship_fulfillment(', 'async fn cancel_fulfillment(', 'reship'],
+  ['async fn cancel_fulfillment(', null, 'cancel'],
+]) {
+  const method = sliceBetween(providerOperations, start, end);
+  requireText(method, 'fulfillment_command_runtime_from_context', `${paths.providerOperations}: ${label} owner runtime`);
+  requireText(method, '.lifecycle_command_port()', `${paths.providerOperations}: ${label} owner command port`);
+  forbidText(method, 'fulfillment_orchestration_from_context', `${paths.providerOperations}: ${label} concrete orchestration`);
+}
+
+const createMethod = sliceBetween(
+  providerOperations,
+  'async fn create_fulfillment(',
+  'async fn ship_fulfillment(',
+);
+for (const marker of [
+  'manual_fulfillment_owner_orchestration_from_context(ctx)',
+  'fulfillment_create_read_context(ctx, tenant_id, order_id)',
+  'fulfillment_create_command_context(ctx, tenant_id, &create_input)',
+  '.create_manual_fulfillment(read_context, write_context.clone(), create_input)',
+]) requireText(createMethod, marker, `${paths.providerOperations}: mounted create owner-port composition`);
+requireText(
+  createMethod,
+  'fulfillment_orchestration_from_context(ctx, db.clone())',
+  `${paths.providerOperations}: embedded compatibility fallback remains explicit`,
+);
+
+for (const marker of [
+  '"order.order_not_found"',
+  '"fulfillment.reconciliation_required"',
+  '"fulfillment.database_unavailable" | "order.database_unavailable"',
+  '"fulfillment.invalid_transition"',
+  '"ORDER_RESOURCE_NOT_FOUND"',
+  '"FULFILLMENT_REQUEST_INVALID"',
+  '"FULFILLMENT_RESOURCE_NOT_FOUND"',
+  '"FULFILLMENT_STATE_CONFLICT"',
+  '"FULFILLMENT_TEMPORARILY_UNAVAILABLE"',
+  '"FULFILLMENT_RECONCILIATION_REQUIRED"',
+  'owner_code_length = error.code.chars().count()',
+  'owner_error_kind = ?error.kind',
+  'boundary = "commerce_graphql_fulfillment_command"',
+]) requireText(providerOperations, marker, `${paths.providerOperations}: GraphQL Fulfillment envelope parity`);
+
+const ownerErrorMapper = sliceBetween(
+  providerOperations,
+  'fn fulfillment_owner_graphql_error(',
+  'fn legacy_fulfillment_provider_graphql_error(',
+);
+for (const forbidden of [
+  'error = ?error',
+  'owner_code = %error.code',
+  'owner_message = %error.message',
+  'message = %error.message',
+]) forbidText(ownerErrorMapper, forbidden, `${paths.providerOperations}: bounded Fulfillment diagnostics`);
+
+for (const marker of [
+  'mod fulfillment_commands;',
+  'pub use fulfillment_commands::CommerceFulfillmentCommandRuntime;',
+  'fulfillment_command_runtime: CommerceFulfillmentCommandRuntime',
+  'pub fn fulfillment_command_runtime(&self) -> CommerceFulfillmentCommandRuntime',
+  '.shared_get::<CommerceFulfillmentCommandRuntime>()',
+  'CommerceFulfillmentCommandRuntime::from_graphql_inputs(inputs)',
+  'pub(crate) fn fulfillment_command_runtime_from_context(',
+  '.map(CommerceGraphqlRuntimeData::fulfillment_command_runtime)',
+  'pub(crate) fn manual_fulfillment_owner_orchestration_from_context(',
+  'runtime.order_read_runtime().order_read_port()',
+  '.fulfillment_lifecycle_read_runtime()',
+  '.shipping_option_read_runtime()',
+  'runtime.fulfillment_command_runtime().create_command_port()',
+]) requireText(graphqlRuntime, marker, `${paths.graphqlRuntime}: GraphQL Fulfillment runtime composition`);
+
+for (const marker of [
+  'pub struct CommerceFulfillmentCommandRuntime',
+  'FulfillmentAdminCommandRuntime',
+  'FulfillmentAdminCreateCommandRuntime',
+  'pub(crate) fn from_graphql_inputs(',
+  '.shared_get::<FulfillmentAdminCommandRuntime>()',
+  '.shared_get::<FulfillmentAdminCreateCommandRuntime>()',
+  'FulfillmentAdminCommandRuntime::in_process(',
+  'FulfillmentAdminCreateCommandRuntime::in_process(',
+  '.shared_get::<FulfillmentProviderRegistry>()',
+  'pub fn lifecycle_command_port(&self) -> Arc<dyn FulfillmentAdminCommandPort>',
+  'pub fn create_command_port(&self) -> Arc<dyn FulfillmentAdminCreateCommandPort>',
+]) requireText(fulfillmentCommands, marker, `${paths.fulfillmentCommands}: host-selected Fulfillment owner commands`);
+
+for (const marker of [
+  'FulfillmentProviderOperationJournal',
+  'stable_operation_key(fulfillment_id, operation, &immutable_payload)',
+  '"fulfillment:{fulfillment_id}:{operation}:{first:016x}{second:016x}"',
+  'mark_reconciliation_required(',
+  'FulfillmentProviderRegistry',
+]) requireText(lifecycleOwner, marker, `${paths.lifecycleOwner}: durable lifecycle provider identity`);
+
+for (const marker of [
+  'FulfillmentProviderOperationJournal',
+  'format!("fulfillment:{}:create_label", fulfillment.id)',
+  'operation: "create_label".to_string()',
+  'mark_reconciliation_required(',
+  'FulfillmentProviderRegistry',
+]) requireText(createOwner, marker, `${paths.createOwner}: durable create-label provider identity`);
+
+for (const marker of [
+  'OrderReadPort',
+  'FulfillmentReadPort',
+  'ShippingOptionReadPort',
+  'FulfillmentAdminCreateCommandPort',
+  '.create_fulfillment(',
+]) requireText(manualCreate, marker, `${paths.manualCreate}: cross-owner create policy stays on typed ports`);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  `${paths.plan}: broad topology item remains open`,
+);
+
+for (const marker of [
+  '# Commerce GraphQL Fulfillment command owner-port cutover',
+  'Status: `source_complete_unvalidated`',
+  '`createFulfillment`',
+  '`shipFulfillment`',
+  '`deliverFulfillment`',
+  '`reopenFulfillment`',
+  '`reshipFulfillment`',
+  '`cancelFulfillment`',
+  '`FulfillmentAdminCommandPort`',
+  '`FulfillmentAdminCreateCommandPort`',
+  'The broad canonical topology item remains open.',
+  'No tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI, runtime calls, provider execution, lost-response scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice.',
+]) requireText(document, marker, `${paths.document}: truthful source record`);
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL Fulfillment command owner-port cutover verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('commerce GraphQL Fulfillment commands route through typed owner ports with preserved durable identities');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by routing the six mounted Commerce GraphQL Fulfillment provider mutations through existing Fulfillment-owned command capabilities.

- compose a host-selectable `CommerceFulfillmentCommandRuntime` from `FulfillmentAdminCommandRuntime` and `FulfillmentAdminCreateCommandRuntime`;
- route `shipFulfillment`, `deliverFulfillment`, `reopenFulfillment`, `reshipFulfillment`, and `cancelFulfillment` through `FulfillmentAdminCommandPort`;
- keep `createFulfillment` cross-owner policy in Commerce while composing it from `OrderReadPort`, `FulfillmentReadPort`, `ShippingOptionReadPort`, and `FulfillmentAdminCreateCommandPort` on mounted schemas;
- retain the existing concrete create orchestration only as an explicit embedded-schema compatibility fallback when manifest runtime data is absent;
- preserve public GraphQL permissions/DTOs/error families and use bounded owner-error diagnostics;
- keep provider journal, durable provider identities, reconciliation, persistence, and provider execution inside `rustok-fulfillment`;
- add a source guard and dated source record. The broad topology P0 remains open.

## Source recheck

Before this slice, the merged ecommerce chain was re-read through GraphQL Payment commands (#3385). That PR explicitly left GraphQL Fulfillment provider mutations as the next mounted concrete-owner path. Existing Fulfillment owner command/create runtimes and the Commerce manual cross-owner creation service were rechecked and reused rather than duplicated.

The branch was refreshed onto current `main` (`b8bc448c76578be97e24f1ee1c57068561dcce86`) after unrelated Forum and Page Builder changes landed. It is one commit ahead and zero behind.

A final parity recheck confirmed that journal reconciliation-pending / journal-commit failure states were already surfaced by the legacy Commerce orchestration as validation errors, so this PR intentionally preserves that existing GraphQL envelope instead of changing public API semantics.

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI reruns, runtime calls, provider execution, lost-response scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice. The new verifier is source-only evidence for the maintainer to run independently.