### PR TITLE
feat(page-builder): retain bounded provider health runtime observations

### DIFF
--- a/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-runtime-observation-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-runtime-observation-source.json
@@ -1,0 +1,69 @@
+{
+  "format": "page_builder_provider_health_runtime_observation_source_v1",
+  "status": "source_ready_unvalidated",
+  "module": "page_builder",
+  "scope": "process_local_runtime_observation",
+  "source_contract": {
+    "default_fly_composition_records_runtime_health": true,
+    "preview_source_operation": "render_preview",
+    "publish_source_operation": "save_project",
+    "load_project_excluded": true,
+    "window_capacity_per_operation": 256,
+    "minimum_preview_samples": 20,
+    "minimum_publish_samples": 20,
+    "snapshot_absent_below_sample_floor": true,
+    "process_restart_resets_window": true,
+    "provider_health_snapshot_uses_existing_pilot_thresholds": true,
+    "terminal_success_and_failure_are_recorded": true,
+    "sanitize_failure_rate_uses_telemetry_visible_publish_failures_only": true,
+    "runtime_error_rate_uses_telemetry_visible_preview_and_publish_failures_only": true,
+    "pre_telemetry_validation_and_inspection_are_not_included": true,
+    "bounded_pending_call_correlation": true,
+    "deployment_wide_aggregation_present": false,
+    "deployment_freshness_contract_present": false,
+    "pages_admin_health_binding_present": false,
+    "provider_health_observed_promoted": false,
+    "pages_reference_consumer_gate_promoted": false,
+    "ffa_or_fba_promoted": false,
+    "tests_run": false,
+    "static_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "runtime_execution_run": false,
+    "workflows_or_ci_run": false
+  },
+  "production_sources": [
+    "crates/rustok-page-builder/src/health.rs",
+    "crates/rustok-page-builder/src/runtime_telemetry.rs",
+    "crates/rustok-page-builder/src/composition.rs",
+    "crates/rustok-page-builder/src/adapters/fly_service.rs"
+  ],
+  "retained_unobserved_consumers": [
+    "crates/rustok-pages/src/graphql/builder_rollout.rs",
+    "crates/rustok-pages/admin/src/builder.rs"
+  ],
+  "verifier": "crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs",
+  "execution": [],
+  "next_cursor": {
+    "deployment_aggregation_and_freshness_contract": "open",
+    "exact_source_deployment_identity": "open",
+    "pages_provider_status_binding": "blocked_on_deployment_observation_authority",
+    "observed_provider_health_gate": "open"
+  },
+  "explicit_non_claims": [
+    "no_deployment_wide_provider_health_result",
+    "no_live_slo_acceptance_result",
+    "no_pages_admin_observed_health_result",
+    "no_graphql_provider_health_promotion",
+    "no_reference_consumer_gate_acceptance",
+    "no_ffa_promotion",
+    "no_fba_promotion",
+    "no_test_result",
+    "no_verifier_result",
+    "no_cargo_result",
+    "no_formatting_result",
+    "no_runtime_result",
+    "no_workflow_result",
+    "no_ci_result"
+  ]
+}

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  health: "crates/rustok-page-builder/src/health.rs",
+  telemetry: "crates/rustok-page-builder/src/runtime_telemetry.rs",
+  composition: "crates/rustok-page-builder/src/composition.rs",
+  flyService: "crates/rustok-page-builder/src/adapters/fly_service.rs",
+  pagesGraphql: "crates/rustok-pages/src/graphql/builder_rollout.rs",
+  pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
+  evidence: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-runtime-observation-source.json",
+  overlay: "docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-runtime-observation] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const evidence = JSON.parse(sources.evidence);
+
+if (evidence.format !== "page_builder_provider_health_runtime_observation_source_v1") {
+  failures.push("evidence format drifted");
+}
+if (evidence.status !== "source_ready_unvalidated") failures.push("evidence status drifted");
+if (evidence.scope !== "process_local_runtime_observation") failures.push("evidence scope drifted");
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("execution evidence must remain empty");
+}
+
+const contract = evidence.source_contract ?? {};
+for (const [key, expected] of Object.entries({
+  default_fly_composition_records_runtime_health: true,
+  preview_source_operation: "render_preview",
+  publish_source_operation: "save_project",
+  load_project_excluded: true,
+  window_capacity_per_operation: 256,
+  minimum_preview_samples: 20,
+  minimum_publish_samples: 20,
+  snapshot_absent_below_sample_floor: true,
+  process_restart_resets_window: true,
+  provider_health_snapshot_uses_existing_pilot_thresholds: true,
+  terminal_success_and_failure_are_recorded: true,
+  sanitize_failure_rate_uses_telemetry_visible_publish_failures_only: true,
+  runtime_error_rate_uses_telemetry_visible_preview_and_publish_failures_only: true,
+  pre_telemetry_validation_and_inspection_are_not_included: true,
+  bounded_pending_call_correlation: true,
+  deployment_wide_aggregation_present: false,
+  deployment_freshness_contract_present: false,
+  pages_admin_health_binding_present: false,
+  provider_health_observed_promoted: false,
+  pages_reference_consumer_gate_promoted: false,
+  ffa_or_fba_promoted: false,
+  tests_run: false,
+  static_verifier_run: false,
+  cargo_run: false,
+  formatting_run: false,
+  runtime_execution_run: false,
+  workflows_or_ci_run: false,
+})) {
+  if (contract[key] !== expected) failures.push(`source_contract.${key} must equal ${JSON.stringify(expected)}`);
+}
+
+for (const marker of [
+  "pub const PROVIDER_HEALTH_WINDOW_CAPACITY: usize = 256;",
+  "pub const PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION: usize = 20;",
+  "pub enum ProviderHealthOperation",
+  "Preview,",
+  "Publish,",
+  "pub enum ProviderHealthOutcome",
+  "pub fn record_provider_health_observation",
+  "pub fn provider_health_runtime_snapshot() -> Option<ProviderHealthSnapshot>",
+  "window.preview.len() < PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION",
+  "window.publish.len() < PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION",
+  "ProviderHealthSnapshot::evaluate(ProviderSloObservations",
+  "process-local provider-health snapshot",
+]) need(sources.health, marker, "health runtime window");
+
+for (const marker of [
+  "const PROVIDER_HEALTH_PENDING_CALL_CAPACITY: usize = 1024;",
+  "pub struct ProviderHealthRuntimeTelemetry",
+  "PageBuilderRuntimeOperation::RenderPreview => Some(ProviderHealthOperation::Preview)",
+  "PageBuilderRuntimeOperation::SaveProject => Some(ProviderHealthOperation::Publish)",
+  "PageBuilderRuntimeOperation::LoadProject => None",
+  "Some(PageBuilderErrorKind::Sanitize) => ProviderHealthOutcome::SanitizeFailed",
+  "Some(PageBuilderErrorKind::Runtime) => ProviderHealthOutcome::RuntimeFailed",
+  "record_provider_health_observation(operation, pending_call.started_at.elapsed(), outcome)",
+]) need(sources.telemetry, marker, "runtime telemetry observer");
+
+for (const marker of [
+  "T = ProviderHealthRuntimeTelemetry",
+  "FlyAdapterBackedPageBuilderService::with_telemetry",
+  "ProviderHealthRuntimeTelemetry::default()",
+  "process-local Preview/Publish runtime observations",
+]) need(sources.composition, marker, "default composition");
+
+for (const marker of [
+  "PageBuilderRuntimeCallEvidence::render_preview",
+  "self.telemetry.record_runtime_call(&evidence);",
+  "self.telemetry.record_runtime_call(&evidence.succeeded());",
+  "PageBuilderRuntimeCallEvidence::save_project",
+  "self.telemetry.record_runtime_call(&evidence.failed(&error));",
+]) need(sources.flyService, marker, "Fly terminal telemetry seam");
+
+// This first slice must not promote process-local observations into authoritative Pages health.
+need(sources.pagesGraphql, "provider_health_observed: false", "Pages GraphQL remains unobserved");
+need(sources.pagesFacade, "PageBuilderAdminProviderStatus::unobserved", "Pages admin remains unobserved");
+forbid(sources.pagesGraphql, "provider_health_runtime_snapshot()", "Pages GraphQL must not consume process-local health yet");
+forbid(sources.pagesFacade, "provider_health_runtime_snapshot()", "Pages admin must not consume process-local health yet");
+
+for (const marker of [
+  "process-local-runtime-observation-source-ready",
+  "deployment-observed-health-open",
+  "20 Preview",
+  "20 Publish",
+  "256",
+  "provider_health_observed = false",
+  "deployment-wide",
+  "tests were not run",
+]) need(sources.overlay, marker, "runtime observation overlay");
+
+for (const marker of [
+  "provider-runtime-observation-source-ready",
+  "deployment-observed-health-open",
+  "page-builder-provider-health-runtime-observation-actualization-2026-08-09.md",
+  "Pages remains `unobserved`",
+]) need(sources.parity, marker, "plan parity actualization");
+
+if (evidence.next_cursor?.deployment_aggregation_and_freshness_contract !== "open") {
+  failures.push("next cursor must keep deployment aggregation/freshness open");
+}
+if (evidence.next_cursor?.pages_provider_status_binding !== "blocked_on_deployment_observation_authority") {
+  failures.push("Pages provider status binding must remain blocked");
+}
+if (evidence.next_cursor?.observed_provider_health_gate !== "open") {
+  failures.push("observed provider health gate must remain open");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-runtime-observation] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("[verify-page-builder-provider-health-runtime-observation] PASS source_ready=true deployment_health=open execution=pending");

--- a/crates/rustok-page-builder/src/composition.rs
+++ b/crates/rustok-page-builder/src/composition.rs
@@ -4,7 +4,7 @@ use crate::rollout::{BuilderCapabilityFlags, BuilderRolloutError};
 use crate::runtime_scenario_release::{
     NoopPageBuilderScenarioBaselineStore, PageBuilderScenarioBaselineStore,
 };
-use crate::runtime_telemetry::{NoopPageBuilderRuntimeTelemetry, PageBuilderRuntimeTelemetry};
+use crate::runtime_telemetry::{PageBuilderRuntimeTelemetry, ProviderHealthRuntimeTelemetry};
 use crate::service::{
     AuthorizedPageBuilderHandlers, CapabilityGuardedService, PageBuilderCapabilityAuthorizer,
     PageBuilderCapabilityPortPolicies, PageBuilderProjectStore,
@@ -13,21 +13,23 @@ use crate::service::{
 pub type FlyPageBuilderGuardedService<
     S,
     R,
-    T = NoopPageBuilderRuntimeTelemetry,
+    T = ProviderHealthRuntimeTelemetry,
     B = NoopPageBuilderScenarioBaselineStore,
 > = CapabilityGuardedService<FlyAdapterBackedPageBuilderService<S, R, T, B>>;
 
 pub type FlyPageBuilderHandlers<
     S,
     R,
-    T = NoopPageBuilderRuntimeTelemetry,
+    T = ProviderHealthRuntimeTelemetry,
     B = NoopPageBuilderScenarioBaselineStore,
 > = AuthorizedPageBuilderHandlers<FlyPageBuilderGuardedService<S, R, T, B>>;
 
 /// Compose the default current-only Page Builder server pipeline.
 ///
 /// Consumers provide tenant-scoped persistence and contextual preview rendering ports. The module
-/// owns the service, rollout/port guards and authorization order.
+/// owns the service, rollout/port guards and authorization order. The default pipeline also records
+/// bounded process-local Preview/Publish runtime observations; the health window remains
+/// `unobserved` until its minimum sample floor is satisfied and is not deployment-wide evidence.
 pub fn compose_fly_page_builder_handlers<S, R>(
     store: S,
     renderer: R,
@@ -37,7 +39,11 @@ where
     S: PageBuilderProjectStore,
     R: PageBuilderPreviewRenderingPort,
 {
-    let service = FlyAdapterBackedPageBuilderService::new(store, renderer);
+    let service = FlyAdapterBackedPageBuilderService::with_telemetry(
+        store,
+        renderer,
+        ProviderHealthRuntimeTelemetry::default(),
+    );
     compose_configured_fly_page_builder_handlers(
         service,
         flags,
@@ -49,7 +55,9 @@ where
 /// Compose the current-only Page Builder server pipeline with explicit policies and authorizer.
 ///
 /// Telemetry, scenario baselines and Fly validation policy are configured on `service` before it is
-/// passed here. Invalid rollout flags are rejected before handlers can be exposed.
+/// passed here. Invalid rollout flags are rejected before handlers can be exposed. Explicitly
+/// configured services may still supply another telemetry implementation when a host owns a
+/// different observation sink.
 pub fn compose_configured_fly_page_builder_handlers<S, R, T, B>(
     service: FlyAdapterBackedPageBuilderService<S, R, T, B>,
     flags: BuilderCapabilityFlags,

--- a/crates/rustok-page-builder/src/health.rs
+++ b/crates/rustok-page-builder/src/health.rs
@@ -1,4 +1,10 @@
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+pub const PROVIDER_HEALTH_WINDOW_CAPACITY: usize = 256;
+pub const PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION: usize = 20;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -192,10 +198,190 @@ impl ProviderSloEvaluation {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderHealthOperation {
+    Preview,
+    Publish,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderHealthOutcome {
+    Succeeded,
+    SanitizeFailed,
+    RuntimeFailed,
+    OtherFailed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProviderHealthRuntimeSampleCounts {
+    pub preview: usize,
+    pub publish: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProviderHealthRuntimeSample {
+    elapsed_ms: u64,
+    outcome: ProviderHealthOutcome,
+}
+
+#[derive(Debug, Default)]
+struct ProviderHealthRuntimeWindow {
+    preview: VecDeque<ProviderHealthRuntimeSample>,
+    publish: VecDeque<ProviderHealthRuntimeSample>,
+}
+
+static PROVIDER_HEALTH_RUNTIME_WINDOW: OnceLock<Mutex<ProviderHealthRuntimeWindow>> = OnceLock::new();
+
+/// Record one completed provider operation in the bounded process-local SLO window.
+///
+/// This is deliberately not deployment-wide evidence. The runtime window is reset on process
+/// restart and remains unobserved until both preview and publish have the minimum sample count.
+/// Callers must not promote rollout/Wave gates from this snapshot without separately retained
+/// exact-source deployment evidence.
+pub fn record_provider_health_observation(
+    operation: ProviderHealthOperation,
+    elapsed: Duration,
+    outcome: ProviderHealthOutcome,
+) {
+    let sample = ProviderHealthRuntimeSample {
+        elapsed_ms: elapsed.as_millis().min(u64::MAX as u128) as u64,
+        outcome,
+    };
+    let window = PROVIDER_HEALTH_RUNTIME_WINDOW
+        .get_or_init(|| Mutex::new(ProviderHealthRuntimeWindow::default()));
+    let mut window = window
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let samples = match operation {
+        ProviderHealthOperation::Preview => &mut window.preview,
+        ProviderHealthOperation::Publish => &mut window.publish,
+    };
+    if samples.len() >= PROVIDER_HEALTH_WINDOW_CAPACITY {
+        samples.pop_front();
+    }
+    samples.push_back(sample);
+}
+
+pub fn provider_health_runtime_sample_counts() -> ProviderHealthRuntimeSampleCounts {
+    let Some(window) = PROVIDER_HEALTH_RUNTIME_WINDOW.get() else {
+        return ProviderHealthRuntimeSampleCounts::default();
+    };
+    let window = window
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ProviderHealthRuntimeSampleCounts {
+        preview: window.preview.len(),
+        publish: window.publish.len(),
+    }
+}
+
+/// Return a process-local provider-health snapshot only after a bounded minimum sample exists for
+/// both preview and publish. `None` means unobserved and must never be interpreted as healthy.
+pub fn provider_health_runtime_snapshot() -> Option<ProviderHealthSnapshot> {
+    let window = PROVIDER_HEALTH_RUNTIME_WINDOW.get()?;
+    let window = window
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    snapshot_from_runtime_window(&window)
+}
+
+fn snapshot_from_runtime_window(
+    window: &ProviderHealthRuntimeWindow,
+) -> Option<ProviderHealthSnapshot> {
+    if window.preview.len() < PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION
+        || window.publish.len() < PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION
+    {
+        return None;
+    }
+
+    let preview_p95_ms = p95_ms(&window.preview);
+    let publish_p95_ms = p95_ms(&window.publish);
+    let sanitize_failures = window
+        .publish
+        .iter()
+        .filter(|sample| sample.outcome == ProviderHealthOutcome::SanitizeFailed)
+        .count();
+    let runtime_failures = window
+        .preview
+        .iter()
+        .chain(window.publish.iter())
+        .filter(|sample| sample.outcome == ProviderHealthOutcome::RuntimeFailed)
+        .count();
+    let total_runtime_samples = window.preview.len() + window.publish.len();
+
+    Some(ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+        preview_p95_ms,
+        publish_p95_ms,
+        sanitize_failure_rate: sanitize_failures as f64 / window.publish.len() as f64,
+        runtime_error_rate: runtime_failures as f64 / total_runtime_samples as f64,
+    }))
+}
+
+fn p95_ms(samples: &VecDeque<ProviderHealthRuntimeSample>) -> u64 {
+    let mut values: Vec<_> = samples.iter().map(|sample| sample.elapsed_ms).collect();
+    values.sort_unstable();
+    let rank = ((values.len() * 95 + 99) / 100).saturating_sub(1);
+    values[rank]
+}
+
 const fn status(value: bool) -> ProviderSloStatus {
     if value {
         ProviderSloStatus::Pass
     } else {
         ProviderSloStatus::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_window_requires_both_operation_sample_floors() {
+        let mut window = ProviderHealthRuntimeWindow::default();
+        for _ in 0..PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION {
+            window.preview.push_back(ProviderHealthRuntimeSample {
+                elapsed_ms: 100,
+                outcome: ProviderHealthOutcome::Succeeded,
+            });
+        }
+        assert!(snapshot_from_runtime_window(&window).is_none());
+        for _ in 0..PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION {
+            window.publish.push_back(ProviderHealthRuntimeSample {
+                elapsed_ms: 200,
+                outcome: ProviderHealthOutcome::Succeeded,
+            });
+        }
+        let snapshot = snapshot_from_runtime_window(&window).expect("observed snapshot");
+        assert_eq!(snapshot.state, ProviderHealthState::Ready);
+        assert_eq!(snapshot.observed.preview_p95_ms, 100);
+        assert_eq!(snapshot.observed.publish_p95_ms, 200);
+    }
+
+    #[test]
+    fn runtime_window_evaluates_terminal_failure_rates() {
+        let mut window = ProviderHealthRuntimeWindow::default();
+        for index in 0..PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION {
+            window.preview.push_back(ProviderHealthRuntimeSample {
+                elapsed_ms: 100 + index as u64,
+                outcome: if index == 0 {
+                    ProviderHealthOutcome::RuntimeFailed
+                } else {
+                    ProviderHealthOutcome::Succeeded
+                },
+            });
+            window.publish.push_back(ProviderHealthRuntimeSample {
+                elapsed_ms: 200 + index as u64,
+                outcome: if index == 0 {
+                    ProviderHealthOutcome::SanitizeFailed
+                } else {
+                    ProviderHealthOutcome::Succeeded
+                },
+            });
+        }
+        let snapshot = snapshot_from_runtime_window(&window).expect("observed snapshot");
+        assert_eq!(snapshot.observed.sanitize_failure_rate, 0.05);
+        assert_eq!(snapshot.observed.runtime_error_rate, 0.025);
+        assert_eq!(snapshot.state, ProviderHealthState::Unavailable);
     }
 }

--- a/crates/rustok-page-builder/src/runtime_telemetry.rs
+++ b/crates/rustok-page-builder/src/runtime_telemetry.rs
@@ -1,7 +1,15 @@
 use crate::dto::{PageBuilderErrorKind, PageBuilderModuleMetadata};
+use crate::health::{
+    ProviderHealthOperation, ProviderHealthOutcome, record_provider_health_observation,
+};
 use crate::service::PageBuilderServiceError;
 use rustok_api::PortContext;
 use serde::Serialize;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+const PROVIDER_HEALTH_PENDING_CALL_CAPACITY: usize = 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -125,19 +133,136 @@ impl PageBuilderRuntimeTelemetry for NoopPageBuilderRuntimeTelemetry {
     fn record_runtime_call(&self, _evidence: &PageBuilderRuntimeCallEvidence) {}
 }
 
+#[derive(Debug)]
+struct PendingProviderHealthCall {
+    operation: PageBuilderRuntimeOperation,
+    tenant_id: String,
+    page_id: String,
+    revision_id: Option<String>,
+    correlation_id: String,
+    started_at: Instant,
+}
+
+impl PendingProviderHealthCall {
+    fn from_evidence(evidence: &PageBuilderRuntimeCallEvidence) -> Self {
+        Self {
+            operation: evidence.operation,
+            tenant_id: evidence.tenant_id.clone(),
+            page_id: evidence.page_id.clone(),
+            revision_id: evidence.revision_id.clone(),
+            correlation_id: evidence.correlation_id.clone(),
+            started_at: Instant::now(),
+        }
+    }
+
+    fn matches(&self, evidence: &PageBuilderRuntimeCallEvidence) -> bool {
+        self.operation == evidence.operation
+            && self.tenant_id == evidence.tenant_id
+            && self.page_id == evidence.page_id
+            && self.revision_id == evidence.revision_id
+            && self.correlation_id == evidence.correlation_id
+    }
+}
+
+/// Production-default runtime telemetry for the bounded process-local provider-health window.
+///
+/// It observes only canonical Fly adapter terminal calls already emitted by the provider service.
+/// Load-project telemetry is intentionally excluded from the current Preview/Publish SLO contract.
+/// A process restart clears pending calls and the health window remains unobserved until the
+/// minimum sample floor is rebuilt.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderHealthRuntimeTelemetry {
+    pending: Arc<Mutex<VecDeque<PendingProviderHealthCall>>>,
+}
+
+impl ProviderHealthRuntimeTelemetry {
+    fn provider_operation(
+        operation: PageBuilderRuntimeOperation,
+    ) -> Option<ProviderHealthOperation> {
+        match operation {
+            PageBuilderRuntimeOperation::RenderPreview => Some(ProviderHealthOperation::Preview),
+            PageBuilderRuntimeOperation::SaveProject => Some(ProviderHealthOperation::Publish),
+            PageBuilderRuntimeOperation::LoadProject => None,
+        }
+    }
+
+    fn remember_started(&self, evidence: &PageBuilderRuntimeCallEvidence) {
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(index) = pending.iter().rposition(|call| call.matches(evidence)) {
+            pending.remove(index);
+        }
+        if pending.len() >= PROVIDER_HEALTH_PENDING_CALL_CAPACITY {
+            pending.pop_front();
+        }
+        pending.push_back(PendingProviderHealthCall::from_evidence(evidence));
+    }
+
+    fn finish(
+        &self,
+        evidence: &PageBuilderRuntimeCallEvidence,
+        operation: ProviderHealthOperation,
+    ) {
+        let pending_call = {
+            let mut pending = self
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let Some(index) = pending.iter().rposition(|call| call.matches(evidence)) else {
+                return;
+            };
+            pending.remove(index)
+        };
+        let Some(pending_call) = pending_call else {
+            return;
+        };
+        let outcome = match evidence.status {
+            PageBuilderRuntimeCallStatus::Succeeded => ProviderHealthOutcome::Succeeded,
+            PageBuilderRuntimeCallStatus::Failed => match evidence.error_kind {
+                Some(PageBuilderErrorKind::Sanitize) => ProviderHealthOutcome::SanitizeFailed,
+                Some(PageBuilderErrorKind::Runtime) => ProviderHealthOutcome::RuntimeFailed,
+                _ => ProviderHealthOutcome::OtherFailed,
+            },
+            PageBuilderRuntimeCallStatus::Started => return,
+        };
+        record_provider_health_observation(operation, pending_call.started_at.elapsed(), outcome);
+    }
+}
+
+impl PageBuilderRuntimeTelemetry for ProviderHealthRuntimeTelemetry {
+    fn record_runtime_call(&self, evidence: &PageBuilderRuntimeCallEvidence) {
+        let Some(operation) = Self::provider_operation(evidence.operation) else {
+            return;
+        };
+        match evidence.status {
+            PageBuilderRuntimeCallStatus::Started => self.remember_started(evidence),
+            PageBuilderRuntimeCallStatus::Succeeded | PageBuilderRuntimeCallStatus::Failed => {
+                self.finish(evidence, operation)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::health::provider_health_runtime_sample_counts;
     use rustok_api::PortActor;
 
-    #[test]
-    fn runtime_evidence_contains_only_current_fields() {
-        let context = PortContext::new(
+    fn context(correlation_id: &str) -> PortContext {
+        PortContext::new(
             "tenant-a",
             PortActor::user("editor-a"),
             "en",
-            "correlation-a",
-        );
+            correlation_id,
+        )
+    }
+
+    #[test]
+    fn runtime_evidence_contains_only_current_fields() {
+        let context = context("correlation-a");
         let value = serde_json::to_value(PageBuilderRuntimeCallEvidence::load_project(
             &context, "home",
         ))
@@ -146,5 +271,23 @@ mod tests {
         assert_eq!(value["module_slug"], "page_builder");
         assert!(value.get("contract").is_none());
         assert!(value.get("version").is_none());
+    }
+
+    #[test]
+    fn provider_health_telemetry_ignores_load_project_and_records_terminal_preview() {
+        let telemetry = ProviderHealthRuntimeTelemetry::default();
+        let before = provider_health_runtime_sample_counts();
+        let context = context("provider-health-preview");
+        let load = PageBuilderRuntimeCallEvidence::load_project(&context, "home");
+        telemetry.record_runtime_call(&load);
+        telemetry.record_runtime_call(&load.succeeded());
+        assert_eq!(provider_health_runtime_sample_counts(), before);
+
+        let preview = PageBuilderRuntimeCallEvidence::render_preview(&context, "home");
+        telemetry.record_runtime_call(&preview);
+        telemetry.record_runtime_call(&preview.succeeded());
+        let after = provider_health_runtime_sample_counts();
+        assert_eq!(after.preview, before.preview + 1);
+        assert_eq!(after.publish, before.publish);
     }
 }

--- a/crates/rustok-page-builder/src/runtime_telemetry.rs
+++ b/crates/rustok-page-builder/src/runtime_telemetry.rs
@@ -248,7 +248,6 @@ impl PageBuilderRuntimeTelemetry for ProviderHealthRuntimeTelemetry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::health::provider_health_runtime_sample_counts;
     use rustok_api::PortActor;
 
     fn context(correlation_id: &str) -> PortContext {
@@ -274,20 +273,39 @@ mod tests {
     }
 
     #[test]
-    fn provider_health_telemetry_ignores_load_project_and_records_terminal_preview() {
+    fn provider_health_telemetry_ignores_load_project_and_closes_matching_preview() {
         let telemetry = ProviderHealthRuntimeTelemetry::default();
-        let before = provider_health_runtime_sample_counts();
         let context = context("provider-health-preview");
         let load = PageBuilderRuntimeCallEvidence::load_project(&context, "home");
         telemetry.record_runtime_call(&load);
         telemetry.record_runtime_call(&load.succeeded());
-        assert_eq!(provider_health_runtime_sample_counts(), before);
+        assert_eq!(
+            telemetry
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            0
+        );
 
         let preview = PageBuilderRuntimeCallEvidence::render_preview(&context, "home");
         telemetry.record_runtime_call(&preview);
+        assert_eq!(
+            telemetry
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            1
+        );
         telemetry.record_runtime_call(&preview.succeeded());
-        let after = provider_health_runtime_sample_counts();
-        assert_eq!(after.preview, before.preview + 1);
-        assert_eq!(after.publish, before.publish);
+        assert_eq!(
+            telemetry
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            0
+        );
     }
 }

--- a/docs/modules/page-builder-provider-degraded-controls-actualization-2026-08-07.md
+++ b/docs/modules/page-builder-provider-degraded-controls-actualization-2026-08-07.md
@@ -1,7 +1,7 @@
 # Page Builder Provider Degraded Controls Actualization
 
 Date: 2026-08-07  
-Status: `current-source-overlay / admin-provider-status-source-ready / degraded-control-source-ready / observed-health-execution-open`
+Status: `current-source-overlay / admin-provider-status-source-ready / degraded-control-source-ready / process-local-runtime-observation-source-ready / deployment-observed-health-open`.
 
 ## Why this slice exists
 
@@ -44,22 +44,16 @@ No provider status can grant a capability denied by tenant or permission policy.
 
 ## Pages reference consumer
 
-`PagesBuilderFacade` now has one source function for the provider rollout flags used by both sides of the seam:
+The Pages reference consumer exposes the same server-owned rollout flags through its provider status and authoritative Page Builder composition.
 
-```text
-pages_builder_capability_flags()
-```
-
-The facade exposes those flags through `provider_status()`, and the SSR capability composition passes the same flags to `compose_fly_page_builder_handlers`.
-
-Pages does not currently have a live SLO snapshot source, so its health remains explicitly `unobserved`. The existing Pages host capability policy derived from verified role and contribution-assembly diagnostics remains separate and continues to be intersected before provider-status narrowing.
+Pages admin health remains explicitly `unobserved`. The existing Pages host capability policy derived from verified role and contribution-assembly diagnostics remains separate and continues to be intersected before provider-status narrowing.
 
 ## Admin UX and control path
 
 The capability panel now distinguishes:
 
 1. provider control state — `ready`, `degraded`, `unavailable`, or `unobserved`;
-2. observed provider health — or `unobserved` when no live snapshot exists;
+2. observed provider health — or `unobserved` when no authoritative live snapshot exists;
 3. host provider policy — the existing tenant/RBAC/contribution evaluation;
 4. concrete rollout flags;
 5. declared observed degradation reasons when present.
@@ -70,27 +64,48 @@ Server preview is not only visually disabled. The click path rechecks the same p
 
 No fallback editor is mounted for unavailable state.
 
+## 2026-08-09 runtime observation continuation
+
+`docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md` now closes the first source-only part of the former live-observation gap.
+
+Default Fly composition records bounded process-local terminal observations for canonical Preview rendering and Publish project-save calls through the existing Page Builder runtime-telemetry seam. The local window is capped, requires a minimum Preview/Publish sample floor, and evaluates only through the existing pilot `ProviderHealthSnapshot` thresholds.
+
+This does **not** make Pages health observed. The local window is restartable, lacks deployment-wide aggregation/freshness and exact source/deployment identity, and does not cover validation/inspection that occurs before the existing telemetry seam. Pages therefore continues to expose `provider_health_observed = false` and to construct `PageBuilderAdminProviderStatus::unobserved(...)`.
+
+The next provider-health source cursor is deployment aggregation/freshness plus exact deployment identity. Pages provider-status binding remains blocked on that authority.
+
 ## Deliberately unchanged boundaries
 
-This slice does not add or change:
+These slices do not add or change:
 
 - database schema or migrations;
 - GraphQL, HTTP or OpenAPI APIs;
 - Pages persistence, reviewed publish, rollback or repair contracts;
 - public storefront rendering or cache policy;
-- a live metrics/SLO collection pipeline;
 - tenant rollout persistence;
-- a second editor or degraded fallback editor.
+- a second editor or degraded fallback editor;
+- Pages reference-consumer gate acceptance;
+- Forum Wave acceptance;
+- FFA/FBA promotion.
 
-Observed health remains a future composition/runtime evidence source. The new admin seam prevents that missing observation from being mislabeled as healthy in the meantime.
+Observed deployment health remains open. The admin seam and new process-local observer prevent missing deployment evidence from being mislabeled as healthy in the meantime.
 
 ## Machine evidence
+
+Admin degraded-control source:
 
 ```text
 crates/rustok-page-builder/contracts/evidence/page-builder-admin-provider-status-source.json
 crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
 ```
 
+Process-local runtime observation source:
+
+```text
+crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-runtime-observation-source.json
+crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
+```
+
 ## Validation boundary
 
-Execution remains pending. No Rust tests, Node verifiers, Cargo checks, formatting, browser scenarios, workflows or CI were run by this implementation slice. FFA/FBA promotion remains blocked on accepted execution and observed-provider evidence.
+Execution remains pending. No Rust tests, Node verifiers, Cargo checks, formatting, browser scenarios, workflows, CI or runtime evidence were run by this implementation slice. FFA/FBA promotion remains blocked on accepted execution and authoritative observed-provider evidence.

--- a/docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md
+++ b/docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md
@@ -1,0 +1,107 @@
+# Page Builder provider-health runtime observation actualization — 2026-08-09
+
+Status: `process-local-runtime-observation-source-ready / deployment-observed-health-open / pages-health-binding-blocked / execution-pending`.
+
+## Recheck result
+
+The Pages / Page Builder parity recheck confirmed that rollout ownership, degraded controls, the four-profile runtime-matrix harness, canonical `FEATURE_DISABLED` preflight and reference-consumer candidate are already source-ready. The remaining provider-health source gap was real rather than stale plan text:
+
+- `ProviderHealthSnapshot` and the pilot SLO evaluator already existed;
+- the canonical Fly service already emitted started/succeeded/failed runtime telemetry for preview rendering and project save;
+- default composition still selected `NoopPageBuilderRuntimeTelemetry`;
+- Pages GraphQL explicitly reported `provider_health_observed = false` and Pages admin constructed `PageBuilderAdminProviderStatus::unobserved(...)`.
+
+This slice activates the existing provider runtime seam without promoting local process observations into deployment-wide health.
+
+## Source-ready runtime observation boundary
+
+Default `compose_fly_page_builder_handlers(...)` now installs `ProviderHealthRuntimeTelemetry` on the canonical Fly-backed service.
+
+The retained SLO window is deliberately bounded and process-local:
+
+- at most `256` completed Preview samples;
+- at most `256` completed Publish samples;
+- no snapshot before at least `20 Preview` and `20 Publish` samples are present;
+- process restart clears the observation window and returns the provider to `unobserved` until the sample floor is rebuilt;
+- unmatched or over-capacity pending calls are bounded separately and cannot create an unbounded correlation map.
+
+The current operation mapping is exact:
+
+```text
+RenderPreview -> Preview
+SaveProject   -> Publish
+LoadProject   -> excluded from the Preview/Publish SLO window
+```
+
+The window feeds the existing `ProviderHealthSnapshot::evaluate(...)` and therefore reuses the declared pilot thresholds instead of introducing a second health policy.
+
+## Measurement limits
+
+This is a runtime observation source, not a completed observability product.
+
+The existing Fly telemetry seam starts after structural inspection and request validation for these operations. Consequently:
+
+- Preview p95 covers the telemetry-visible renderer call;
+- Publish p95 covers the telemetry-visible project save call;
+- runtime error rate covers terminal runtime failures visible on those two calls;
+- sanitize failure rate can only include sanitize failures that reach the telemetry-visible Publish terminal path;
+- pre-telemetry validation, inspection and release-gate failures are not folded into these rates.
+
+Those boundaries are retained explicitly in machine evidence so a later aggregation slice cannot silently reinterpret this process-local sample as end-to-end deployment health.
+
+## Deliberately unpromoted Pages health
+
+Pages remains `unobserved` by design.
+
+This slice does **not** connect `provider_health_runtime_snapshot()` to Pages GraphQL or admin status. `provider_health_observed = false` remains the authoritative Pages rollout response, and `PageBuilderAdminProviderStatus::unobserved(...)` remains the admin facade state.
+
+A process-local, restartable window is insufficient authority for a tenant/deployment health decision. Before Pages can expose observed provider health, the next source slice must define a deployment-wide aggregation/freshness boundary with exact source/deployment identity and fail-closed stale/missing observation behavior.
+
+The existing Pages reference-consumer gate therefore remains unaccepted, Forum Wave remains blocked by that gate, and FFA/FBA promotion remains unclaimed.
+
+## Source evidence
+
+Production source:
+
+- `crates/rustok-page-builder/src/health.rs`;
+- `crates/rustok-page-builder/src/runtime_telemetry.rs`;
+- `crates/rustok-page-builder/src/composition.rs`;
+- `crates/rustok-page-builder/src/adapters/fly_service.rs`.
+
+Machine evidence:
+
+- `crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-runtime-observation-source.json`.
+
+Fail-closed source guard:
+
+- `crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs`.
+
+The guard also source-locks the non-promotion boundary: Pages GraphQL must still contain `provider_health_observed: false`, and Pages admin must still use `PageBuilderAdminProviderStatus::unobserved` until deployment observation authority exists.
+
+## Next cursor
+
+The provider-health source sequence is now:
+
+```text
+bounded process-local Preview/Publish observation
+-> deployment aggregation + freshness contract
+-> exact source/deployment identity binding
+-> Pages provider-status transport/binding
+-> retained deployment/runtime evidence
+-> observed-health acceptance decision
+```
+
+The first item is source-ready in this slice. The remaining items stay open.
+
+## Validation boundary
+
+Per maintainer instruction, tests were not run. No Cargo commands, Node verifiers, formatting, builds, GraphQL/HTTP requests, browser runs, workflows, CI, runtime scenarios or production observations were executed.
+
+Suggested maintainer commands, intentionally not run:
+
+```bash
+cargo test -p rustok-page-builder health
+cargo test -p rustok-page-builder runtime_telemetry
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
+cargo check -p rustok-page-builder --all-targets
+```

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,15 +1,16 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-observed-health-open / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has two source actualizations:
+This parity packet now has three source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
-- `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353.
+- `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353;
+- `docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`, which refines the still-open provider-health cursor with bounded process-local runtime observation source while deliberately leaving deployment-observed health open.
 
-The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor.
+The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 runtime-observation overlay is the current refinement: local Preview/Publish observation source exists, but Pages remains `unobserved` because deployment aggregation, freshness and exact deployment identity do not yet exist.
 
 ## Current source truth
 
@@ -25,8 +26,10 @@ The synchronized source boundary is now:
 - standalone browser-intent denial remains the distinct `FLY_CAPABILITY_DENIED` security contract;
 - the canonical provider degraded error catalog is separately proved through a non-mutating server-owned `feature-disabled / FEATURE_DISABLED` capability preflight;
 - the reference candidate requires artifact/HTTP, browser, runtime-matrix and canonical feature-preflight packets bound to one exact source/deployment chain;
+- default Fly composition now retains bounded process-local Preview/Publish terminal observations through the existing runtime-telemetry seam, with a 256-sample cap per operation and no health snapshot below 20 Preview plus 20 Publish samples;
+- this process-local window is restartable and is not deployment-wide health authority; pre-telemetry validation/inspection is outside its current measurement boundary;
+- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until deployment aggregation/freshness/source-identity exists;
 - `pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`;
-- provider health remains `unobserved` until a real SLO source exists;
 - Forum browser/runtime/deployment evidence and observed Wave remain blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
 
@@ -34,7 +37,7 @@ The synchronized source boundary is now:
 
 No additional Pages/Page Builder rollout architecture slice is identified by the source reconciliation.
 
-The next cursor is maintainer execution in this order:
+The rollout acceptance cursor remains maintainer execution in this order:
 
 ```text
 artifact/HTTP
@@ -47,11 +50,22 @@ artifact/HTTP
 -> Forum browser/runtime/deployment evidence and observed Wave
 ```
 
-Source inspection alone must not mark any of those execution or acceptance steps complete.
+In parallel, the still-open provider-health source cursor is now narrower and explicit:
+
+```text
+bounded process-local Preview/Publish observation [source-ready]
+-> deployment aggregation + freshness contract [open]
+-> exact source/deployment identity binding [open]
+-> Pages provider-status transport/binding [blocked]
+-> retained deployment/runtime evidence [maintainer execution]
+-> observed-health acceptance decision [pending]
+```
+
+Source inspection alone must not mark any execution or acceptance step complete, and process-local observations must not be substituted for deployment-wide provider-health evidence.
 
 ## Anti-drift guard
 
-`crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs` source-locks the synchronized cursor across:
+`crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs` continues to source-lock the synchronized rollout cursor across:
 
 - the shared Pages/Page Builder parity plan;
 - the local Page Builder implementation plan;
@@ -64,16 +78,23 @@ Source inspection alone must not mark any of those execution or acceptance steps
 
 The guard rejects the former `forum-fly-adapter-open`/discovery-only cursor, an accepted Pages gate without execution evidence, fabricated provider health, Forum Wave promotion while the Pages gate remains pending, and any plan wording that treats `FLY_CAPABILITY_DENIED` as equivalent to the canonical provider `FEATURE_DISABLED` contract.
 
-The Pages reference-consumer gate continues to list this plan-parity verifier as a required source guard.
+The new provider-health source slice is independently fail-closed by:
+
+`crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs`
+
+That guard locks the bounded runtime window and default Fly telemetry composition while also requiring Pages GraphQL/admin to remain unobserved until deployment observation authority exists.
+
+The Pages reference-consumer gate continues to list the plan-parity verifier as a required source guard.
 
 ## Execution boundary
 
 No tests, Node verifiers, Cargo commands, formatting, builds, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
 
-Suggested maintainer command, intentionally not run:
+Suggested maintainer commands, intentionally not run:
 
 ```bash
 node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
 ```
 
 All execution and acceptance evidence remains maintainer-owned.


### PR DESCRIPTION
## Summary

Re-audits the current Pages / Page Builder parity cursor against `main` and continues the one genuine open source gap: observed Page Builder provider health.

The rollout/reference-consumer architecture itself is already source-ready; execution/acceptance remains maintainer-owned. This PR therefore does not reopen rollout work. Instead it adds the first bounded runtime-observation source slice on the existing Page Builder telemetry seam.

### Changes

- add a bounded process-local provider-health window in `rustok-page-builder`;
  - max 256 completed Preview samples;
  - max 256 completed Publish samples;
  - no snapshot before 20 Preview + 20 Publish samples;
  - reuse the existing pilot `ProviderHealthSnapshot` evaluator/thresholds;
- add `ProviderHealthRuntimeTelemetry` over the existing Fly runtime call evidence;
  - `RenderPreview -> Preview`;
  - `SaveProject -> Publish`;
  - `LoadProject` excluded from the Preview/Publish SLO window;
  - pending call correlation is bounded;
- wire the observer into the default Fly Page Builder composition while keeping explicitly configured telemetry supported;
- retain machine-readable source evidence and a fail-closed static guard;
- actualize provider-health and Pages/Page Builder parity packets.

## Deliberate boundaries

This is **not** deployment-wide observed health.

- the window is process-local and resets on restart;
- deployment aggregation/freshness and exact source/deployment identity remain open;
- the current telemetry window begins after existing structural inspection/request validation, so pre-telemetry validation/inspection is not included;
- sanitize failure rate can only include sanitize failures visible on the telemetry-covered Publish terminal path;
- Pages GraphQL intentionally remains `provider_health_observed = false`;
- Pages admin intentionally remains `PageBuilderAdminProviderStatus::unobserved(...)`;
- no Pages reference-consumer gate acceptance;
- no Forum Wave acceptance;
- no FFA/FBA promotion;
- no GraphQL/HTTP/database schema changes.

## Validation

Per maintainer instruction, tests are intentionally not run by this implementation agent. No Cargo, Node verifier, formatting, build, browser, workflow, CI, GraphQL/HTTP or runtime execution was performed.

Suggested maintainer commands:

```bash
cargo test -p rustok-page-builder health
cargo test -p rustok-page-builder runtime_telemetry
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
cargo check -p rustok-page-builder --all-targets
```

## Next source cursor

`process-local observation [source-ready] -> deployment aggregation/freshness [open] -> exact deployment identity [open] -> Pages provider-status binding [blocked] -> maintainer runtime evidence -> observed-health acceptance`
