### PR TITLE
feat(page-builder): export deployment-aggregatable provider health metrics

### DIFF
--- a/crates/rustok-page-builder/Cargo.toml
+++ b/crates/rustok-page-builder/Cargo.toml
@@ -11,6 +11,7 @@ server = [
   "dep:async-trait",
   "dep:rustok-api",
   "dep:rustok-core",
+  "dep:rustok-telemetry",
   "dep:sea-orm-migration",
 ]
 
@@ -19,6 +20,7 @@ fly = { path = "../fly" }
 rustok-api = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 rustok-core = { workspace = true, optional = true }
+rustok-telemetry = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-metrics-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-metrics-source.json
@@ -1,0 +1,83 @@
+{
+  "format": "page_builder_provider_health_deployment_metrics_source_v1",
+  "status": "source_ready_unvalidated",
+  "module": "page_builder",
+  "scope": "deployment_aggregatable_prometheus_metrics",
+  "predecessor": "page_builder_provider_health_runtime_observation_source_v1",
+  "source_contract": {
+    "platform_registry_owner": "rustok-telemetry",
+    "default_fly_runtime_exports_metrics": true,
+    "duration_metric": "rustok_page_builder_provider_operation_duration_seconds",
+    "completion_metric": "rustok_page_builder_provider_operation_completed_total",
+    "freshness_metric": "rustok_page_builder_provider_last_observation_unix_seconds",
+    "operations": ["preview", "publish"],
+    "terminal_outcomes": [
+      "succeeded",
+      "sanitize_failed",
+      "runtime_failed",
+      "other_failed"
+    ],
+    "duration_histogram_contains_preview_threshold_seconds": 1.5,
+    "duration_histogram_contains_publish_threshold_seconds": 3.0,
+    "tenant_label_present": false,
+    "page_label_present": false,
+    "revision_label_present": false,
+    "correlation_label_present": false,
+    "deployment_label_present_in_application_metric": false,
+    "scrape_target_identity_owned_by_metrics_backend": true,
+    "counter_reset_aware_range_aggregation_required": true,
+    "freshness_requires_both_operations": true,
+    "missing_or_stale_expected_target_fails_closed": true,
+    "expected_target_inventory_present": false,
+    "exact_source_deployment_identity_present": false,
+    "pages_admin_health_binding_present": false,
+    "provider_health_observed_promoted": false,
+    "pages_reference_consumer_gate_promoted": false,
+    "ffa_or_fba_promoted": false,
+    "tests_run": false,
+    "static_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "runtime_execution_run": false,
+    "workflows_or_ci_run": false
+  },
+  "production_sources": [
+    "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
+    "crates/rustok-telemetry/src/lib.rs",
+    "crates/rustok-page-builder/src/runtime_telemetry.rs",
+    "crates/rustok-page-builder/Cargo.toml"
+  ],
+  "retained_unobserved_consumers": [
+    "crates/rustok-pages/src/graphql/builder_rollout.rs",
+    "crates/rustok-pages/admin/src/builder.rs"
+  ],
+  "verifier": "crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs",
+  "execution": [],
+  "next_cursor": {
+    "deployment_metrics_export": "source_ready_maintainer_execution_pending",
+    "freshness_signal_export": "source_ready_maintainer_execution_pending",
+    "exact_source_deployment_identity": "open",
+    "expected_target_inventory": "open",
+    "pages_provider_status_binding": "blocked_on_exact_deployment_observation_authority",
+    "observed_provider_health_gate": "open"
+  },
+  "explicit_non_claims": [
+    "no_prometheus_scrape_result",
+    "no_deployment_aggregation_result",
+    "no_expected_replica_inventory_result",
+    "no_exact_source_deployment_identity_result",
+    "no_live_slo_acceptance_result",
+    "no_pages_admin_observed_health_result",
+    "no_graphql_provider_health_promotion",
+    "no_reference_consumer_gate_acceptance",
+    "no_ffa_promotion",
+    "no_fba_promotion",
+    "no_test_result",
+    "no_verifier_result",
+    "no_cargo_result",
+    "no_formatting_result",
+    "no_runtime_result",
+    "no_workflow_result",
+    "no_ci_result"
+  ]
+}

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  telemetryMetrics: "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
+  telemetryLib: "crates/rustok-telemetry/src/lib.rs",
+  pageBuilderCargo: "crates/rustok-page-builder/Cargo.toml",
+  runtimeTelemetry: "crates/rustok-page-builder/src/runtime_telemetry.rs",
+  pagesGraphql: "crates/rustok-pages/src/graphql/builder_rollout.rs",
+  pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
+  evidence: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-metrics-source.json",
+  overlay: "docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-deployment-metrics] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const evidence = JSON.parse(sources.evidence);
+
+if (evidence.format !== "page_builder_provider_health_deployment_metrics_source_v1") {
+  failures.push("evidence format drifted");
+}
+if (evidence.status !== "source_ready_unvalidated") failures.push("evidence status drifted");
+if (evidence.scope !== "deployment_aggregatable_prometheus_metrics") failures.push("evidence scope drifted");
+if (!Array.isArray(evidence.execution) || evidence.execution.length !== 0) {
+  failures.push("execution evidence must remain empty");
+}
+
+const contract = evidence.source_contract ?? {};
+for (const [key, expected] of Object.entries({
+  platform_registry_owner: "rustok-telemetry",
+  default_fly_runtime_exports_metrics: true,
+  duration_metric: "rustok_page_builder_provider_operation_duration_seconds",
+  completion_metric: "rustok_page_builder_provider_operation_completed_total",
+  freshness_metric: "rustok_page_builder_provider_last_observation_unix_seconds",
+  duration_histogram_contains_preview_threshold_seconds: 1.5,
+  duration_histogram_contains_publish_threshold_seconds: 3.0,
+  tenant_label_present: false,
+  page_label_present: false,
+  revision_label_present: false,
+  correlation_label_present: false,
+  deployment_label_present_in_application_metric: false,
+  scrape_target_identity_owned_by_metrics_backend: true,
+  counter_reset_aware_range_aggregation_required: true,
+  freshness_requires_both_operations: true,
+  missing_or_stale_expected_target_fails_closed: true,
+  expected_target_inventory_present: false,
+  exact_source_deployment_identity_present: false,
+  pages_admin_health_binding_present: false,
+  provider_health_observed_promoted: false,
+  pages_reference_consumer_gate_promoted: false,
+  ffa_or_fba_promoted: false,
+  tests_run: false,
+  static_verifier_run: false,
+  cargo_run: false,
+  formatting_run: false,
+  runtime_execution_run: false,
+  workflows_or_ci_run: false,
+})) {
+  if (contract[key] !== expected) failures.push(`source_contract.${key} must equal ${JSON.stringify(expected)}`);
+}
+
+for (const marker of [
+  'pub const PAGE_BUILDER_PROVIDER_OPERATIONS: [&str; 2] = ["preview", "publish"]',
+  '"succeeded"',
+  '"sanitize_failed"',
+  '"runtime_failed"',
+  '"other_failed"',
+  'rustok_page_builder_provider_operation_duration_seconds',
+  'rustok_page_builder_provider_operation_completed_total',
+  'rustok_page_builder_provider_last_observation_unix_seconds',
+  '1.5',
+  '3.0',
+  '&["operation"]',
+  '&["operation", "outcome"]',
+  'pub fn record_page_builder_provider_operation',
+]) need(sources.telemetryMetrics, marker, "platform Page Builder metrics");
+for (const forbidden of [
+  '"tenant_id"',
+  '"page_id"',
+  '"revision_id"',
+  '"correlation_id"',
+  '&["deployment"]',
+  '&["instance"]',
+]) forbid(sources.telemetryMetrics, forbidden, "platform Page Builder metrics cardinality");
+
+need(sources.telemetryLib, "pub mod page_builder_provider_metrics;", "telemetry module registration");
+need(sources.telemetryLib, "page_builder_provider_metrics::register(registry)?;", "telemetry registry registration");
+need(sources.pageBuilderCargo, '"dep:rustok-telemetry"', "Page Builder server feature");
+need(sources.pageBuilderCargo, "rustok-telemetry = { workspace = true, optional = true }", "Page Builder telemetry dependency");
+
+for (const marker of [
+  "record_page_builder_provider_operation",
+  'ProviderHealthOperation::Preview => "preview"',
+  'ProviderHealthOperation::Publish => "publish"',
+  'ProviderHealthOutcome::Succeeded => "succeeded"',
+  'ProviderHealthOutcome::SanitizeFailed => "sanitize_failed"',
+  'ProviderHealthOutcome::RuntimeFailed => "runtime_failed"',
+  'ProviderHealthOutcome::OtherFailed => "other_failed"',
+  "let elapsed = pending_call.started_at.elapsed();",
+  "record_provider_health_observation(operation, elapsed, outcome);",
+]) need(sources.runtimeTelemetry, marker, "Page Builder runtime export");
+
+need(sources.pagesGraphql, "provider_health_observed: false", "Pages GraphQL remains unobserved");
+need(sources.pagesFacade, "PageBuilderAdminProviderStatus::unobserved", "Pages admin remains unobserved");
+forbid(sources.pagesGraphql, "page_builder_provider_metrics", "Pages GraphQL must not consume raw metrics");
+forbid(sources.pagesFacade, "page_builder_provider_metrics", "Pages admin must not consume raw metrics");
+
+for (const marker of [
+  "deployment-aggregatable-metrics-source-ready",
+  "freshness-signal-source-ready",
+  "exact-deployment-identity-open",
+  "rate(rustok_page_builder_provider_operation_duration_seconds_bucket",
+  "increase(rustok_page_builder_provider_operation_completed_total",
+  "missing or stale",
+  "Pages remains `unobserved`",
+  "tests were not run",
+]) need(sources.overlay, marker, "deployment metrics overlay");
+
+for (const marker of [
+  "deployment-metrics-source-ready",
+  "freshness-signal-source-ready",
+  "page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md",
+  "exact source/deployment identity",
+  "Pages remains `unobserved`",
+]) need(sources.parity, marker, "plan parity actualization");
+
+if (evidence.next_cursor?.exact_source_deployment_identity !== "open") {
+  failures.push("next cursor must keep exact source/deployment identity open");
+}
+if (evidence.next_cursor?.expected_target_inventory !== "open") {
+  failures.push("next cursor must keep expected target inventory open");
+}
+if (
+  evidence.next_cursor?.pages_provider_status_binding !==
+  "blocked_on_exact_deployment_observation_authority"
+) failures.push("Pages provider status binding must remain blocked");
+
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-deployment-metrics] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("[verify-page-builder-provider-health-deployment-metrics] PASS source_ready=true exact_deployment_identity=open execution=pending");

--- a/crates/rustok-page-builder/src/runtime_telemetry.rs
+++ b/crates/rustok-page-builder/src/runtime_telemetry.rs
@@ -4,6 +4,7 @@ use crate::health::{
 };
 use crate::service::PageBuilderServiceError;
 use rustok_api::PortContext;
+use rustok_telemetry::page_builder_provider_metrics::record_page_builder_provider_operation;
 use serde::Serialize;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -164,12 +165,13 @@ impl PendingProviderHealthCall {
     }
 }
 
-/// Production-default runtime telemetry for the bounded process-local provider-health window.
+/// Production-default runtime telemetry for the bounded process-local provider-health window and
+/// deployment-aggregatable platform metrics.
 ///
 /// It observes only canonical Fly adapter terminal calls already emitted by the provider service.
 /// Load-project telemetry is intentionally excluded from the current Preview/Publish SLO contract.
-/// A process restart clears pending calls and the health window remains unobserved until the
-/// minimum sample floor is rebuilt.
+/// A process restart clears the local window; Prometheus counters/histograms also restart at the
+/// target and are expected to be aggregated with reset-aware range functions by the metrics backend.
 #[derive(Debug, Clone, Default)]
 pub struct ProviderHealthRuntimeTelemetry {
     pending: Arc<Mutex<VecDeque<PendingProviderHealthCall>>>,
@@ -183,6 +185,22 @@ impl ProviderHealthRuntimeTelemetry {
             PageBuilderRuntimeOperation::RenderPreview => Some(ProviderHealthOperation::Preview),
             PageBuilderRuntimeOperation::SaveProject => Some(ProviderHealthOperation::Publish),
             PageBuilderRuntimeOperation::LoadProject => None,
+        }
+    }
+
+    const fn operation_label(operation: ProviderHealthOperation) -> &'static str {
+        match operation {
+            ProviderHealthOperation::Preview => "preview",
+            ProviderHealthOperation::Publish => "publish",
+        }
+    }
+
+    const fn outcome_label(outcome: ProviderHealthOutcome) -> &'static str {
+        match outcome {
+            ProviderHealthOutcome::Succeeded => "succeeded",
+            ProviderHealthOutcome::SanitizeFailed => "sanitize_failed",
+            ProviderHealthOutcome::RuntimeFailed => "runtime_failed",
+            ProviderHealthOutcome::OtherFailed => "other_failed",
         }
     }
 
@@ -227,7 +245,13 @@ impl ProviderHealthRuntimeTelemetry {
             },
             PageBuilderRuntimeCallStatus::Started => return,
         };
-        record_provider_health_observation(operation, pending_call.started_at.elapsed(), outcome);
+        let elapsed = pending_call.started_at.elapsed();
+        record_provider_health_observation(operation, elapsed, outcome);
+        record_page_builder_provider_operation(
+            Self::operation_label(operation),
+            Self::outcome_label(outcome),
+            elapsed,
+        );
     }
 }
 
@@ -306,6 +330,26 @@ mod tests {
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .len(),
             0
+        );
+    }
+
+    #[test]
+    fn provider_health_metric_labels_match_bounded_platform_contract() {
+        assert_eq!(
+            ProviderHealthRuntimeTelemetry::operation_label(ProviderHealthOperation::Preview),
+            "preview"
+        );
+        assert_eq!(
+            ProviderHealthRuntimeTelemetry::operation_label(ProviderHealthOperation::Publish),
+            "publish"
+        );
+        assert_eq!(
+            ProviderHealthRuntimeTelemetry::outcome_label(ProviderHealthOutcome::SanitizeFailed),
+            "sanitize_failed"
+        );
+        assert_eq!(
+            ProviderHealthRuntimeTelemetry::outcome_label(ProviderHealthOutcome::RuntimeFailed),
+            "runtime_failed"
         );
     }
 }

--- a/crates/rustok-telemetry/src/lib.rs
+++ b/crates/rustok-telemetry/src/lib.rs
@@ -2,6 +2,7 @@ pub mod consumer_poison_metrics;
 pub mod dlq_duplicate_alert_metrics;
 pub mod metrics;
 pub mod otel;
+pub mod page_builder_provider_metrics;
 pub mod rbac_invalidation_metrics;
 pub mod runtime_consumer_metrics;
 pub mod social_graph_index_privacy_shadow_metrics;
@@ -231,6 +232,7 @@ fn init_metrics_handle(metrics: bool) -> Result<Option<Arc<MetricsHandle>>, Tele
 
     dlq_duplicate_alert_metrics::register(registry)?;
     metrics::register_all(registry)?;
+    page_builder_provider_metrics::register(registry)?;
     rbac_invalidation_metrics::register(registry)?;
 
     let _ = REGISTRY.set(registry.clone());

--- a/crates/rustok-telemetry/src/page_builder_provider_metrics.rs
+++ b/crates/rustok-telemetry/src/page_builder_provider_metrics.rs
@@ -1,0 +1,109 @@
+use lazy_static::lazy_static;
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub const PAGE_BUILDER_PROVIDER_OPERATIONS: [&str; 2] = ["preview", "publish"];
+pub const PAGE_BUILDER_PROVIDER_OUTCOMES: [&str; 4] = [
+    "succeeded",
+    "sanitize_failed",
+    "runtime_failed",
+    "other_failed",
+];
+
+lazy_static! {
+    pub static ref PAGE_BUILDER_PROVIDER_OPERATION_DURATION_SECONDS: HistogramVec =
+        HistogramVec::new(
+            HistogramOpts::new(
+                "rustok_page_builder_provider_operation_duration_seconds",
+                "Canonical Page Builder provider operation duration in seconds"
+            )
+            .buckets(vec![
+                0.05, 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0,
+            ]),
+            &["operation"],
+        )
+        .expect("Failed to create Page Builder provider duration histogram");
+    pub static ref PAGE_BUILDER_PROVIDER_OPERATION_COMPLETED_TOTAL: IntCounterVec =
+        IntCounterVec::new(
+            Opts::new(
+                "rustok_page_builder_provider_operation_completed_total",
+                "Completed canonical Page Builder provider operations by terminal outcome"
+            ),
+            &["operation", "outcome"],
+        )
+        .expect("Failed to create Page Builder provider completion counter");
+    pub static ref PAGE_BUILDER_PROVIDER_LAST_OBSERVATION_UNIX_SECONDS: IntGaugeVec =
+        IntGaugeVec::new(
+            Opts::new(
+                "rustok_page_builder_provider_last_observation_unix_seconds",
+                "Unix timestamp of the latest canonical Page Builder provider observation"
+            ),
+            &["operation"],
+        )
+        .expect("Failed to create Page Builder provider freshness gauge");
+}
+
+pub fn register(registry: &Registry) -> Result<(), prometheus::Error> {
+    registry.register(Box::new(
+        PAGE_BUILDER_PROVIDER_OPERATION_DURATION_SECONDS.clone(),
+    ))?;
+    registry.register(Box::new(
+        PAGE_BUILDER_PROVIDER_OPERATION_COMPLETED_TOTAL.clone(),
+    ))?;
+    registry.register(Box::new(
+        PAGE_BUILDER_PROVIDER_LAST_OBSERVATION_UNIX_SECONDS.clone(),
+    ))?;
+    Ok(())
+}
+
+/// Record one terminal canonical Page Builder provider operation in the platform registry.
+///
+/// Labels are intentionally bounded to the two provider operations and four terminal outcomes.
+/// Tenant, page, revision, correlation, host and deployment identifiers are not metric labels.
+/// Scrape infrastructure owns target/deployment labels so aggregation can remain operationally
+/// bounded and exact deployment identity can be admitted separately.
+pub fn record_page_builder_provider_operation(
+    operation: &'static str,
+    outcome: &'static str,
+    elapsed: Duration,
+) {
+    if !PAGE_BUILDER_PROVIDER_OPERATIONS.contains(&operation)
+        || !PAGE_BUILDER_PROVIDER_OUTCOMES.contains(&outcome)
+    {
+        return;
+    }
+
+    PAGE_BUILDER_PROVIDER_OPERATION_DURATION_SECONDS
+        .with_label_values(&[operation])
+        .observe(elapsed.as_secs_f64());
+    PAGE_BUILDER_PROVIDER_OPERATION_COMPLETED_TOTAL
+        .with_label_values(&[operation, outcome])
+        .inc();
+
+    let observed_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or(0);
+    PAGE_BUILDER_PROVIDER_LAST_OBSERVATION_UNIX_SECONDS
+        .with_label_values(&[operation])
+        .set(observed_at);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_builder_provider_metric_labels_are_bounded() {
+        assert_eq!(PAGE_BUILDER_PROVIDER_OPERATIONS, ["preview", "publish"]);
+        assert_eq!(
+            PAGE_BUILDER_PROVIDER_OUTCOMES,
+            [
+                "succeeded",
+                "sanitize_failed",
+                "runtime_failed",
+                "other_failed"
+            ]
+        );
+    }
+}

--- a/docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md
+++ b/docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md
@@ -1,0 +1,146 @@
+# Page Builder provider-health deployment metrics actualization — 2026-08-09
+
+Status: `deployment-aggregatable-metrics-source-ready / freshness-signal-source-ready / exact-deployment-identity-open / pages-health-binding-blocked / execution-pending`.
+
+## Cursor
+
+This packet continues `page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`.
+
+The predecessor slice made the canonical Fly service retain a bounded process-local Preview/Publish observation window, but intentionally kept Pages health `unobserved` because a restartable in-process window is not deployment authority.
+
+This slice closes the next bounded source gap: the same terminal Preview/Publish observations are now exported through the platform Prometheus registry in a shape that can be aggregated across scrape targets and checked for freshness without adding a second observability stack.
+
+## Platform-owned metric source
+
+`rustok-telemetry` now owns three fixed-cardinality Page Builder provider series:
+
+```text
+rustok_page_builder_provider_operation_duration_seconds{operation="preview|publish"}
+rustok_page_builder_provider_operation_completed_total{operation="preview|publish",outcome="..."}
+rustok_page_builder_provider_last_observation_unix_seconds{operation="preview|publish"}
+```
+
+Allowed terminal outcomes are exactly:
+
+```text
+succeeded
+sanitize_failed
+runtime_failed
+other_failed
+```
+
+The duration histogram explicitly contains the current pilot latency thresholds (`1.5s` Preview and `3.0s` Publish), so deployment aggregation does not need a second histogram policy.
+
+The default Page Builder runtime telemetry records the platform metric and the predecessor process-local window from the same matched terminal call. `LoadProject` remains excluded from the provider Preview/Publish SLO contract.
+
+## Cardinality and ownership
+
+Application metrics deliberately do not include tenant, page, revision, correlation, instance or deployment labels.
+
+Target/instance/deployment identity belongs to scrape/discovery infrastructure. This avoids turning user/content identifiers into Prometheus cardinality while still allowing a metrics backend to aggregate or preserve per-target series through its own labels.
+
+`rustok-page-builder` depends on `rustok-telemetry` only under its existing `server` feature. Non-server consumers keep the provider crate free of the telemetry dependency.
+
+## Deployment aggregation contract
+
+The exported series support reset-aware deployment calculations such as:
+
+```text
+Preview p95:
+histogram_quantile(0.95,
+  sum by (le) (
+    rate(rustok_page_builder_provider_operation_duration_seconds_bucket{operation="preview"}[<window>])
+  )
+)
+
+Publish p95:
+histogram_quantile(0.95,
+  sum by (le) (
+    rate(rustok_page_builder_provider_operation_duration_seconds_bucket{operation="publish"}[<window>])
+  )
+)
+
+Sanitize failure rate:
+sum(increase(rustok_page_builder_provider_operation_completed_total{operation="publish",outcome="sanitize_failed"}[<window>]))
+/
+sum(increase(rustok_page_builder_provider_operation_completed_total{operation="publish"}[<window>]))
+
+Runtime error rate:
+sum(increase(rustok_page_builder_provider_operation_completed_total{outcome="runtime_failed"}[<window>]))
+/
+sum(increase(rustok_page_builder_provider_operation_completed_total[<window>]))
+```
+
+Counter/histogram resets must be handled with range functions (`rate`/`increase`) rather than raw cumulative subtraction.
+
+This packet does not choose a production query window or claim a live backend query result. Those values become authoritative only when the exact deployment/source observation packet is bound.
+
+## Freshness contract
+
+`rustok_page_builder_provider_last_observation_unix_seconds` exposes the latest terminal observation independently for Preview and Publish on each scrape target.
+
+A future deployment evaluator must:
+
+1. preserve scrape target identity instead of collapsing freshness first;
+2. require both Preview and Publish freshness for every expected active target admitted into the deployment observation set;
+3. fail closed when an expected target is missing or stale for the evaluator's admitted freshness bound;
+4. only then aggregate latency/error series for provider-health evaluation.
+
+The repository does not yet own an exact expected-target inventory, deployment digest binding or freshness-age admission value for Pages provider health. Therefore this slice provides the aggregation/freshness **signal contract**, not the final observed-health authority.
+
+## Deliberately unpromoted Pages health
+
+Pages remains `unobserved`.
+
+This slice does not connect Prometheus metrics to:
+
+- `provider_health_observed` in Pages GraphQL;
+- `PageBuilderAdminProviderStatus::observed(...)` in Pages admin;
+- `pages_reference_consumer_gate` acceptance;
+- Forum Wave acceptance;
+- FFA/FBA promotion.
+
+The next source cursor is exact source/deployment observation identity plus expected-target inventory. Only that authority may define the admitted query/freshness window and produce a deployment-bound `ProviderHealthSnapshot` for Pages.
+
+## Source evidence
+
+Production source:
+
+- `crates/rustok-telemetry/src/page_builder_provider_metrics.rs`;
+- `crates/rustok-telemetry/src/lib.rs`;
+- `crates/rustok-page-builder/src/runtime_telemetry.rs`;
+- `crates/rustok-page-builder/Cargo.toml`.
+
+Machine evidence:
+
+- `crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-metrics-source.json`.
+
+Fail-closed source guard:
+
+- `crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs`.
+
+The guard also retains the anti-promotion boundary: Pages GraphQL/admin must still be unobserved until exact deployment observation authority exists.
+
+## Next cursor
+
+```text
+bounded process-local observation [source-ready]
+-> deployment-aggregatable metrics + freshness signal [source-ready]
+-> exact source/deployment identity + expected-target inventory [open]
+-> deployment health evaluator / Pages provider-status transport [blocked]
+-> retained runtime evidence [maintainer execution]
+-> observed-health acceptance [pending]
+```
+
+## Validation boundary
+
+Per maintainer instruction, tests were not run. No Cargo commands, Node verifiers, formatting, Prometheus scrapes, backend queries, GraphQL/HTTP requests, browser runs, workflows, CI or production observations were executed.
+
+Suggested maintainer commands, intentionally not run:
+
+```bash
+cargo test -p rustok-telemetry page_builder_provider
+cargo test -p rustok-page-builder runtime_telemetry
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+cargo check -p rustok-page-builder --all-targets
+```

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,16 +1,17 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-observed-health-open / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / exact-deployment-observation-open / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has three source actualizations:
+This parity packet now has four source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
 - `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353;
-- `docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`, which refines the still-open provider-health cursor with bounded process-local runtime observation source while deliberately leaving deployment-observed health open.
+- `docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`, which introduced bounded process-local runtime observation source;
+- `docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`, which exports the same terminal observations through platform-owned deployment-aggregatable Prometheus metrics and a per-operation freshness signal while leaving exact deployment observation authority open.
 
-The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 runtime-observation overlay is the current refinement: local Preview/Publish observation source exists, but Pages remains `unobserved` because deployment aggregation, freshness and exact deployment identity do not yet exist.
+The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation and deployment-aggregatable metric source now exist, but Pages remains `unobserved` because exact source/deployment identity, expected-target inventory and an admitted deployment evaluator do not yet exist.
 
 ## Current source truth
 
@@ -26,9 +27,12 @@ The synchronized source boundary is now:
 - standalone browser-intent denial remains the distinct `FLY_CAPABILITY_DENIED` security contract;
 - the canonical provider degraded error catalog is separately proved through a non-mutating server-owned `feature-disabled / FEATURE_DISABLED` capability preflight;
 - the reference candidate requires artifact/HTTP, browser, runtime-matrix and canonical feature-preflight packets bound to one exact source/deployment chain;
-- default Fly composition now retains bounded process-local Preview/Publish terminal observations through the existing runtime-telemetry seam, with a 256-sample cap per operation and no health snapshot below 20 Preview plus 20 Publish samples;
-- this process-local window is restartable and is not deployment-wide health authority; pre-telemetry validation/inspection is outside its current measurement boundary;
-- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until deployment aggregation/freshness/source-identity exists;
+- default Fly composition retains bounded process-local Preview/Publish terminal observations through the existing runtime-telemetry seam, with a 256-sample cap per operation and no health snapshot below 20 Preview plus 20 Publish samples;
+- the same matched terminal calls now export platform-owned Prometheus duration histograms, terminal outcome counters and per-operation last-observation timestamps with fixed `preview|publish` / terminal-outcome labels only;
+- deployment metrics deliberately carry no tenant/page/revision/correlation/deployment application labels; scrape/discovery infrastructure owns target identity and reset-aware aggregation;
+- freshness is now observable per scrape target and operation, but an exact expected-target inventory and source/deployment identity binding remain open, so missing/stale target admission cannot yet be evaluated authoritatively inside Pages;
+- the process-local window remains restartable and is not deployment-wide health authority; pre-telemetry validation/inspection is outside its current measurement boundary;
+- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until exact deployment observation authority exists;
 - `pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`;
 - Forum browser/runtime/deployment evidence and observed Wave remain blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
@@ -50,18 +54,18 @@ artifact/HTTP
 -> Forum browser/runtime/deployment evidence and observed Wave
 ```
 
-In parallel, the still-open provider-health source cursor is now narrower and explicit:
+In parallel, the provider-health source cursor is now:
 
 ```text
 bounded process-local Preview/Publish observation [source-ready]
--> deployment aggregation + freshness contract [open]
--> exact source/deployment identity binding [open]
--> Pages provider-status transport/binding [blocked]
+-> deployment-aggregatable metrics + freshness signal [source-ready]
+-> exact source/deployment identity + expected-target inventory [open]
+-> deployment health evaluator / Pages provider-status transport [blocked]
 -> retained deployment/runtime evidence [maintainer execution]
 -> observed-health acceptance decision [pending]
 ```
 
-Source inspection alone must not mark any execution or acceptance step complete, and process-local observations must not be substituted for deployment-wide provider-health evidence.
+Source inspection alone must not mark any execution or acceptance step complete, and raw/process-local or unbound Prometheus observations must not be substituted for exact deployment provider-health evidence.
 
 ## Anti-drift guard
 
@@ -78,23 +82,27 @@ Source inspection alone must not mark any execution or acceptance step complete,
 
 The guard rejects the former `forum-fly-adapter-open`/discovery-only cursor, an accepted Pages gate without execution evidence, fabricated provider health, Forum Wave promotion while the Pages gate remains pending, and any plan wording that treats `FLY_CAPABILITY_DENIED` as equivalent to the canonical provider `FEATURE_DISABLED` contract.
 
-The new provider-health source slice is independently fail-closed by:
+Provider-health source is independently fail-closed by:
 
-`crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs`
+```text
+crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
+crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+```
 
-That guard locks the bounded runtime window and default Fly telemetry composition while also requiring Pages GraphQL/admin to remain unobserved until deployment observation authority exists.
+The first guard locks the bounded process-local window. The second locks the platform metric names, bounded label vocabulary, registry wiring, reset-aware aggregation/freshness contract and the continued absence of Pages observed-health binding.
 
 The Pages reference-consumer gate continues to list the plan-parity verifier as a required source guard.
 
 ## Execution boundary
 
-No tests, Node verifiers, Cargo commands, formatting, builds, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
+No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
 
 Suggested maintainer commands, intentionally not run:
 
 ```bash
 node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
 ```
 
 All execution and acceptance evidence remains maintainer-owned.


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder provider-health parity cursor after #3389.

#3389 made canonical Fly Preview/Publish calls retain a bounded process-local provider-health window. This PR closes the next bounded source gap by exporting the same matched terminal observations through the platform Prometheus registry in a deployment-aggregatable, freshness-aware shape.

### Changes

- add platform-owned Page Builder provider metric series in `rustok-telemetry`:
  - `rustok_page_builder_provider_operation_duration_seconds{operation}`;
  - `rustok_page_builder_provider_operation_completed_total{operation,outcome}`;
  - `rustok_page_builder_provider_last_observation_unix_seconds{operation}`;
- keep labels fixed-cardinality:
  - operations: `preview`, `publish`;
  - outcomes: `succeeded`, `sanitize_failed`, `runtime_failed`, `other_failed`;
  - no tenant/page/revision/correlation/deployment application labels;
- include 1.5s and 3.0s latency buckets matching the existing pilot SLO thresholds;
- wire the existing Page Builder terminal telemetry observer to both the process-local window and platform metrics;
- make `rustok-telemetry` an optional dependency activated only by Page Builder's existing `server` feature;
- retain machine-readable source evidence, a fail-closed source guard and a new deployment-metrics actualization packet;
- advance the Pages/Page Builder parity cursor.

## Deployment/freshness boundary

These metrics are source-ready for reset-aware backend aggregation (`rate`/`increase`) and expose per-target last-observation timestamps for Preview and Publish.

This PR intentionally does **not** define or claim:

- a live Prometheus scrape/backend result;
- exact expected replica/target inventory;
- exact source/deployment digest binding;
- a production query/freshness window;
- a deployment-bound `ProviderHealthSnapshot`;
- Pages GraphQL/admin observed-health binding;
- Pages reference-consumer gate acceptance;
- Forum Wave acceptance;
- FFA/FBA promotion.

Pages therefore remains explicitly `unobserved`.

## Validation

Per maintainer instruction, tests are intentionally not run by this implementation agent. No Cargo, Node verifier, formatting, Prometheus scrape/query, GraphQL/HTTP, browser, workflow or CI execution was performed.

Suggested maintainer commands:

```bash
cargo test -p rustok-telemetry page_builder_provider
cargo test -p rustok-page-builder runtime_telemetry
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
cargo check -p rustok-page-builder --all-targets
```

## Next source cursor

`process-local observation [source-ready] -> deployment metrics + freshness signal [source-ready] -> exact source/deployment identity + expected-target inventory [open] -> deployment evaluator / Pages binding [blocked] -> maintainer runtime evidence -> observed-health acceptance`