### PR TITLE
feat(commerce): route GraphQL order lifecycle through owner port

### DIFF
--- a/crates/rustok-commerce/docs/graphql-order-lifecycle-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-order-lifecycle-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,50 @@
+# Commerce GraphQL order lifecycle owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+This slice continues the canonical ecommerce topology P0 by removing mounted Commerce GraphQL construction of the Order concrete service from the four order lifecycle mutations that already have a published Order owner command capability.
+
+Mounted fields covered by this slice:
+
+- `markOrderPaid`
+- `shipOrder`
+- `deliverOrder`
+- `cancelOrder`
+
+The fields keep their current tenant and `ORDERS_UPDATE` admission, explicit authenticated-actor anti-spoof check, inputs, and response projection.
+
+## Owner boundary
+
+Mounted schema data now requires the host-composed `rustok_order::OrderAdminCommandRuntime`. The server already composes that runtime into `HostRuntimeContext`, preferring an externally supplied runtime and otherwise creating the Order-owned in-process adapter.
+
+The four mounted GraphQL mutations call `OrderAdminCommandPort` with a request-owned `PortContext` carrying:
+
+- tenant identity;
+- authenticated user actor identity;
+- resolved request locale;
+- resolved request channel when present;
+- a bounded two-second deadline;
+- a deterministic mutation-scoped idempotency identity;
+- a correlation identity scoped to the order and lifecycle operation.
+
+Owner `PortError` values are mapped to stable GraphQL Order error families with bounded diagnostics. Raw owner messages and technical database/core details are not projected through the new mapper.
+
+Directly embedded compatibility schemas that do not carry `CommerceGraphqlRuntimeData` retain the explicit Order-owned in-process runtime fallback. Mounted schemas use the host-selected runtime.
+
+## Deliberately still open
+
+The broad canonical topology item remains open. `CommerceFulfillmentMutation` still has concrete Order service construction for post-order return/change commands such as storefront/admin return creation, order-change creation/cancellation, and return cancellation. Those operations do not yet have the same published owner command contract and should be addressed as a separate Order-owner capability slice rather than folded into this lifecycle cutover.
+
+The checkout compatibility source, Product schema-write replay work, Product dependency contract, mapper cleanup, remote/mounted evidence, and other canonical open items are unchanged.
+
+## Validation state
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL scenarios, workflows, CI reruns, runtime calls, database scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice.
+
+A source-only verifier is added for later maintainer execution:
+
+```bash
+node scripts/verify/verify-commerce-graphql-order-lifecycle-owner-port-cutover.mjs
+```

--- a/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
@@ -1,16 +1,21 @@
 use async_graphql::{Context, ErrorExtensions, FieldError, Object, Result};
 use rustok_api::Permission;
 use rustok_api::{
-    AuthContext,
+    AuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
     graphql::{GraphQLError, require_module_enabled},
 };
-use rustok_order::{OrderError, OrderService};
+use rustok_order::{
+    CancelOrderRequest as OwnerCancelOrderRequest,
+    DeliverOrderRequest as OwnerDeliverOrderRequest,
+    MarkOrderPaidRequest as OwnerMarkOrderPaidRequest, OrderError, OrderService,
+    ShipOrderRequest as OwnerShipOrderRequest,
+};
 use rustok_payment::error::PaymentError;
 use uuid::Uuid;
 
 use crate::graphql_runtime::{
-    order_change_orchestration_from_context, post_order_orchestration_from_context,
-    return_completion_orchestration_from_context,
+    order_admin_command_runtime_from_context, order_change_orchestration_from_context,
+    post_order_orchestration_from_context, return_completion_orchestration_from_context,
 };
 use crate::{PaymentOrchestrationError, PostOrderOrchestrationError};
 
@@ -52,6 +57,49 @@ fn order_error_envelope(error: &OrderError) -> (&'static str, &'static str, bool
             "Order operation could not be completed safely",
             "ORDER_OPERATION_FAILED",
             false,
+        ),
+    }
+}
+
+fn order_port_error_envelope(
+    error: &PortError,
+) -> (&'static str, &'static str, bool, &'static str) {
+    match &error.kind {
+        PortErrorKind::Validation => (
+            "Order request is invalid",
+            "ORDER_REQUEST_INVALID",
+            false,
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            "Order resource was not found",
+            "ORDER_RESOURCE_NOT_FOUND",
+            false,
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            "Order operation conflicts with the current state",
+            "ORDER_STATE_CONFLICT",
+            false,
+            "state_conflict",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            "Order service is temporarily unavailable",
+            "ORDER_TEMPORARILY_UNAVAILABLE",
+            true,
+            "temporarily_unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            "Order operation could not be completed safely",
+            "ORDER_OPERATION_FAILED",
+            false,
+            "invariant_violation",
+        ),
+        PortErrorKind::Forbidden => (
+            "Order request is invalid",
+            "ORDER_REQUEST_INVALID",
+            false,
+            "forbidden",
         ),
     }
 }
@@ -125,6 +173,31 @@ fn order_mutation_graphql_error(
     public_fulfillment_graphql_error(message, code, retryable)
 }
 
+fn order_owner_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) = order_port_error_envelope(&error);
+    tracing::error!(
+        owner = "rustok_order.admin_command",
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
+        operation,
+        correlation_id = %context.correlation_id,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_order_command",
+        "commerce GraphQL order owner command failed"
+    );
+    public_fulfillment_graphql_error(message, code, retryable)
+}
+
 fn post_order_graphql_error(
     tenant_id: Uuid,
     resource_id: Uuid,
@@ -152,6 +225,32 @@ fn post_order_graphql_error(
         ),
     };
     public_fulfillment_graphql_error(message, code, retryable)
+}
+
+fn order_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    order_id: Uuid,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-order-command:{operation}:{order_id}"),
+    )
+    .with_idempotency_key(format!("graphql-order:{order_id}:{operation}"))
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
 }
 
 #[derive(Default)]
@@ -209,15 +308,28 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let order = OrderService::new(db.clone(), event_bus.clone())
+        let runtime = order_admin_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_command_context(ctx, tenant_id, id, "mark_paid")?;
+        let order = runtime
+            .command_port()
             .mark_paid(
-                tenant_id,
-                auth.user_id,
-                id,
-                input.payment_id,
-                input.payment_method,
+                context.clone(),
+                OwnerMarkOrderPaidRequest {
+                    order_id: id,
+                    payment_id: input.payment_id,
+                    payment_method: input.payment_method,
+                },
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                order_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "mark_order_paid",
+                    &context,
+                    error,
+                )
+            })?;
 
         Ok(order.into())
     }
@@ -241,15 +353,22 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let order = OrderService::new(db.clone(), event_bus.clone())
-            .ship_order(
-                tenant_id,
-                auth.user_id,
-                id,
-                input.tracking_number,
-                input.carrier,
+        let runtime = order_admin_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_command_context(ctx, tenant_id, id, "ship")?;
+        let order = runtime
+            .command_port()
+            .ship(
+                context.clone(),
+                OwnerShipOrderRequest {
+                    order_id: id,
+                    tracking_number: input.tracking_number,
+                    carrier: input.carrier,
+                },
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                order_owner_graphql_error(tenant_id, id, "ship_order", &context, error)
+            })?;
 
         Ok(order.into())
     }
@@ -273,9 +392,21 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let order = OrderService::new(db.clone(), event_bus.clone())
-            .deliver_order(tenant_id, auth.user_id, id, input.delivered_signature)
-            .await?;
+        let runtime = order_admin_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_command_context(ctx, tenant_id, id, "deliver")?;
+        let order = runtime
+            .command_port()
+            .deliver(
+                context.clone(),
+                OwnerDeliverOrderRequest {
+                    order_id: id,
+                    delivered_signature: input.delivered_signature,
+                },
+            )
+            .await
+            .map_err(|error| {
+                order_owner_graphql_error(tenant_id, id, "deliver_order", &context, error)
+            })?;
 
         Ok(order.into())
     }
@@ -299,9 +430,21 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let order = OrderService::new(db.clone(), event_bus.clone())
-            .cancel_order(tenant_id, auth.user_id, id, input.reason)
-            .await?;
+        let runtime = order_admin_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_command_context(ctx, tenant_id, id, "cancel")?;
+        let order = runtime
+            .command_port()
+            .cancel(
+                context.clone(),
+                OwnerCancelOrderRequest {
+                    order_id: id,
+                    reason: input.reason,
+                },
+            )
+            .await
+            .map_err(|error| {
+                order_owner_graphql_error(tenant_id, id, "cancel_order", &context, error)
+            })?;
 
         Ok(order.into())
     }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -11,7 +11,7 @@ use rustok_fulfillment::{
     in_process_fulfillment_read_port, in_process_shipping_option_admin_read_port,
     in_process_shipping_option_read_port,
 };
-use rustok_order::{OrderReadPort, in_process_order_read_port};
+use rustok_order::{OrderAdminCommandRuntime, OrderReadPort, in_process_order_read_port};
 use rustok_payment::providers::PaymentProviderRegistry;
 use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogReadRuntime};
 use sea_orm::DatabaseConnection;
@@ -333,8 +333,8 @@ pub(crate) fn product_catalog_command_runtime_for_current_graphql_scope(
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual provider
 /// registries remain deterministic fallbacks. Mounted Payment/Fulfillment reads and commands,
-/// shipping-option, Product catalog, and order reads consume host-selected runtime data. Directly
-/// embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
+/// shipping-option, Product catalog, and order reads/commands consume host-selected runtime data.
+/// Directly embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
@@ -347,6 +347,7 @@ pub struct CommerceGraphqlRuntimeData {
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
+    order_admin_command_runtime: OrderAdminCommandRuntime,
     product_catalog_read_runtime: ProductCatalogReadRuntime,
     product_catalog_command_runtime: ProductCatalogCommandRuntime,
 }
@@ -387,6 +388,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn order_read_runtime(&self) -> CommerceOrderReadRuntime {
         self.order_read_runtime.clone()
+    }
+
+    pub fn order_admin_command_runtime(&self) -> OrderAdminCommandRuntime {
+        self.order_admin_command_runtime.clone()
     }
 
     pub fn product_catalog_read_runtime(&self) -> ProductCatalogReadRuntime {
@@ -459,6 +464,11 @@ pub fn attach_schema_data(
             .ok_or_else(|| {
                 "commerce GraphQL requires CommerceOrderReadRuntime in host composition".to_string()
             })?,
+        order_admin_command_runtime: inputs
+            .shared_get::<OrderAdminCommandRuntime>()
+            .ok_or_else(|| {
+                "commerce GraphQL requires OrderAdminCommandRuntime in host composition".to_string()
+            })?,
         product_catalog_read_runtime: inputs
             .shared_get::<ProductCatalogReadRuntime>()
             .ok_or_else(|| {
@@ -507,6 +517,16 @@ pub(crate) fn fulfillment_command_runtime_from_context(
                 .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider);
             CommerceFulfillmentCommandRuntime::in_process(db, provider_registry)
         })
+}
+
+pub(crate) fn order_admin_command_runtime_from_context(
+    ctx: &Context<'_>,
+    db: DatabaseConnection,
+    event_bus: rustok_outbox::TransactionalEventBus,
+) -> OrderAdminCommandRuntime {
+    ctx.data_opt::<CommerceGraphqlRuntimeData>()
+        .map(CommerceGraphqlRuntimeData::order_admin_command_runtime)
+        .unwrap_or_else(|| OrderAdminCommandRuntime::in_process(db, event_bus))
 }
 
 pub(crate) fn manual_fulfillment_owner_orchestration_from_context(

--- a/scripts/verify/verify-commerce-graphql-order-lifecycle-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-lifecycle-owner-port-cutover.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const paths = {
+  mutations: 'crates/rustok-commerce/src/graphql/mutations/fulfillment.rs',
+  graphqlRuntime: 'crates/rustok-commerce/src/graphql_runtime.rs',
+  orderOwner: 'crates/rustok-order/src/admin_command.rs',
+  hostRuntime: 'apps/server/src/services/commerce_provider_runtime.rs',
+  plan: 'crates/rustok-commerce/docs/implementation-plan.md',
+  document: 'crates/rustok-commerce/docs/graphql-order-lifecycle-owner-port-cutover-2026-08-09.md',
+};
+
+const mutations = read(paths.mutations);
+const graphqlRuntime = read(paths.graphqlRuntime);
+const orderOwner = read(paths.orderOwner);
+const hostRuntime = read(paths.hostRuntime);
+const plan = read(paths.plan);
+const document = read(paths.document);
+
+const requireText = (source, value, label) => {
+  if (!source.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (source, value, label) => {
+  if (source.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const sliceFunction = (name, nextName) => {
+  const start = mutations.indexOf(`    async fn ${name}(`);
+  const end = mutations.indexOf(`    async fn ${nextName}(`, start + 1);
+  if (start < 0 || end <= start) {
+    failures.push(`${paths.mutations}: invalid function boundary ${name} -> ${nextName}`);
+    return '';
+  }
+  return mutations.slice(start, end);
+};
+
+for (const marker of [
+  'order_admin_command_runtime_from_context',
+  'OwnerMarkOrderPaidRequest',
+  'OwnerShipOrderRequest',
+  'OwnerDeliverOrderRequest',
+  'OwnerCancelOrderRequest',
+  'PortActor::user(auth.user_id.to_string())',
+  '.with_idempotency_key(format!("graphql-order:{order_id}:{operation}"))',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'request.channel_slug.as_deref()',
+  'boundary = "commerce_graphql_order_command"',
+  'owner_code_length = error.code.chars().count()',
+  '"ORDER_REQUEST_INVALID"',
+  '"ORDER_RESOURCE_NOT_FOUND"',
+  '"ORDER_STATE_CONFLICT"',
+  '"ORDER_TEMPORARILY_UNAVAILABLE"',
+  '"ORDER_OPERATION_FAILED"',
+]) requireText(mutations, marker, `${paths.mutations}: mounted Order owner command contract`);
+
+const lifecycleSlices = [
+  ['mark_order_paid', 'ship_order', '.mark_paid(', 'OwnerMarkOrderPaidRequest'],
+  ['ship_order', 'deliver_order', '.ship(', 'OwnerShipOrderRequest'],
+  ['deliver_order', 'cancel_order', '.deliver(', 'OwnerDeliverOrderRequest'],
+  ['cancel_order', 'create_order_change', '.cancel(', 'OwnerCancelOrderRequest'],
+];
+for (const [name, nextName, ownerCall, requestType] of lifecycleSlices) {
+  const source = sliceFunction(name, nextName);
+  for (const marker of [
+    'order_admin_command_runtime_from_context',
+    '.command_port()',
+    ownerCall,
+    requestType,
+    'order_command_context(',
+    'order_owner_graphql_error(',
+  ]) requireText(source, marker, `${paths.mutations}: ${name} owner cutover`);
+  forbidText(source, 'OrderService::new', `${paths.mutations}: ${name} concrete OrderService`);
+}
+
+for (const forbidden of [
+  'owner_message = %error.message',
+  'message = %error.message',
+  'error = ?error',
+]) {
+  const start = mutations.indexOf('fn order_owner_graphql_error(');
+  const end = mutations.indexOf('fn post_order_graphql_error(', start);
+  if (start >= 0 && end > start) {
+    forbidText(
+      mutations.slice(start, end),
+      forbidden,
+      `${paths.mutations}: bounded Order diagnostics`,
+    );
+  }
+}
+
+for (const marker of [
+  'use rustok_order::{OrderAdminCommandRuntime, OrderReadPort, in_process_order_read_port};',
+  'order_admin_command_runtime: OrderAdminCommandRuntime',
+  'pub fn order_admin_command_runtime(&self) -> OrderAdminCommandRuntime',
+  '.shared_get::<OrderAdminCommandRuntime>()',
+  'commerce GraphQL requires OrderAdminCommandRuntime in host composition',
+  'pub(crate) fn order_admin_command_runtime_from_context(',
+  '.map(CommerceGraphqlRuntimeData::order_admin_command_runtime)',
+  'OrderAdminCommandRuntime::in_process(db, event_bus)',
+]) requireText(graphqlRuntime, marker, `${paths.graphqlRuntime}: Order command runtime composition`);
+
+for (const marker of [
+  'pub trait OrderAdminCommandPort: Send + Sync',
+  'async fn mark_paid(',
+  'async fn ship(',
+  'async fn deliver(',
+  'async fn cancel(',
+  'pub struct OrderAdminCommandRuntime',
+  'pub fn command_port(&self) -> Arc<dyn OrderAdminCommandPort>',
+]) requireText(orderOwner, marker, `${paths.orderOwner}: Order owner command capability`);
+
+for (const marker of [
+  '.shared_get::<rustok_order::OrderAdminCommandRuntime>()',
+  'rustok_order::OrderAdminCommandRuntime::in_process(',
+  'host.with_shared_value(runtime)',
+]) requireText(hostRuntime, marker, `${paths.hostRuntime}: host-composed Order command runtime`);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  `${paths.plan}: broad topology item remains open`,
+);
+
+for (const marker of [
+  '# Commerce GraphQL order lifecycle owner-port cutover',
+  'Status: `source_complete_unvalidated`',
+  '`markOrderPaid`',
+  '`shipOrder`',
+  '`deliverOrder`',
+  '`cancelOrder`',
+  '`OrderAdminCommandPort`',
+  'The broad canonical topology item remains open.',
+  'no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL scenarios, workflows, CI reruns, runtime calls, database scenarios, restart scenarios, or remote-adapter scenarios were executed',
+]) requireText(document, marker, `${paths.document}: truthful source record`);
+
+for (const marker of [
+  'create_storefront_order_return',
+  'create_order_change',
+  'cancel_order_change',
+  'create_order_return',
+  'cancel_order_return',
+  'OrderService::new',
+]) requireText(mutations, marker, `${paths.mutations}: explicitly open post-order owner work`);
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL order lifecycle owner-port cutover verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('commerce GraphQL order lifecycle commands route through the host-selected Order owner port');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by removing mounted Commerce GraphQL construction of `OrderService` from the four order lifecycle mutations that already have an Order-owned command capability.

- require host-composed `OrderAdminCommandRuntime` in mounted Commerce GraphQL runtime data;
- route `markOrderPaid`, `shipOrder`, `deliverOrder`, and `cancelOrder` through `OrderAdminCommandPort`;
- preserve current tenant scope, `ORDERS_UPDATE` admission, authenticated actor anti-spoofing, inputs, and response projection;
- carry tenant/actor/locale/channel/correlation/deadline plus deterministic mutation-scoped idempotency context to the owner call;
- map owner `PortError` values to stable bounded GraphQL Order error families without exposing technical messages;
- retain an explicit Order-owned in-process fallback only for embedded compatibility schemas without `CommerceGraphqlRuntimeData`;
- leave return/change concrete `OrderService` paths open for a separate Order post-order command capability slice;
- add a source-only verifier and dated source record. The broad topology P0 remains open.

## Source recheck

The ecommerce implementation plan still has the broad mounted concrete-owner topology item open. `CommerceFulfillmentMutation` was re-read after the GraphQL Fulfillment provider-command cutover (#3388) and still constructed `OrderService` directly for order lifecycle and post-order commands. The existing `OrderAdminCommandRuntime` already covers mark-paid/ship/deliver/cancel, and `apps/server` already host-composes it, so this slice reuses that owner boundary rather than inventing another adapter.

Post-order return/change calls are deliberately excluded because they do not yet have the same published owner command contract.

The branch is one commit ahead and zero behind current `main` (`96c8886738c3df22e176c808fd04d27d8eedb552`).

## Validation

Per maintainer instruction, no tests, Node verifiers, Cargo commands, formatting, mounted GraphQL scenarios, workflows, CI reruns, runtime calls, database scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice. The added verifier is source-only evidence for maintainer execution.