### PR TITLE
feat(forum): compose bounded owner export reads

### DIFF
--- a/crates/rustok-forum/src/export_mapping.rs
+++ b/crates/rustok-forum/src/export_mapping.rs
@@ -409,3 +409,7 @@ mod tests {
         );
     }
 }
+
+#[path = "export_reader.rs"]
+mod reader;
+pub use reader::*;

--- a/crates/rustok-forum/src/export_reader.rs
+++ b/crates/rustok-forum/src/export_reader.rs
@@ -1,0 +1,350 @@
+use std::collections::BTreeSet;
+
+use rustok_api::{Action, Resource};
+use rustok_content::normalize_locale_code;
+use rustok_core::{PermissionScope, SecurityContext};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::error::ForumError;
+use crate::services::{CategoryService, ReplyService, TopicService};
+
+use super::{
+    ForumExportFragment, ForumExportMappingError, ForumExportOwnerViewBatch,
+    ForumOwnerExportMapper, MAX_FORUM_EXPORT_OWNER_VIEWS_PER_FRAGMENT,
+};
+
+pub const MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT: usize =
+    MAX_FORUM_EXPORT_OWNER_VIEWS_PER_FRAGMENT;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ForumExportReadTargetKind {
+    Category,
+    Topic,
+    Reply,
+}
+
+impl ForumExportReadTargetKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Category => "category",
+            Self::Topic => "topic",
+            Self::Reply => "reply",
+        }
+    }
+
+    const fn permission_label(self) -> &'static str {
+        match self {
+            Self::Category => "forum_categories",
+            Self::Topic => "forum_topics",
+            Self::Reply => "forum_replies",
+        }
+    }
+
+    const fn resource(self) -> Resource {
+        match self {
+            Self::Category => Resource::ForumCategories,
+            Self::Topic => Resource::ForumTopics,
+            Self::Reply => Resource::ForumReplies,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumExportReadTarget {
+    pub kind: ForumExportReadTargetKind,
+    pub id: Uuid,
+    pub locale: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumExportReadBatch {
+    pub tenant_id: Uuid,
+    pub targets: Vec<ForumExportReadTarget>,
+}
+
+#[derive(Debug, Error)]
+pub enum ForumExportReadError {
+    #[error("Forum export owner read requires an authenticated operator context")]
+    OperatorContextRequired,
+    #[error("Forum export owner read requires at least one localized target")]
+    EmptyTargets,
+    #[error("Forum export owner read requires {resource}:manage")]
+    ManagePermissionRequired { resource: &'static str },
+    #[error("Forum export owner read requires a non-nil tenant id")]
+    NilTenantId,
+    #[error("Forum export owner read exceeds {max} localized targets: {actual}")]
+    TooManyTargets { max: usize, actual: usize },
+    #[error("Forum export {kind} target requires a non-nil id")]
+    NilTargetId { kind: &'static str },
+    #[error("Forum export {kind} {id} has invalid locale {locale}")]
+    InvalidLocale {
+        kind: &'static str,
+        id: Uuid,
+        locale: String,
+    },
+    #[error("Forum export {kind} {id} repeats locale {locale}")]
+    DuplicateTarget {
+        kind: &'static str,
+        id: Uuid,
+        locale: String,
+    },
+    #[error(
+        "Forum export {kind} target {requested_id} resolved to different owner id {actual_id}"
+    )]
+    OwnerIdentityChanged {
+        kind: &'static str,
+        requested_id: Uuid,
+        actual_id: Uuid,
+    },
+    #[error(
+        "Forum export {kind} {id} requested exact locale {requested_locale} but owner resolved {effective_locale}"
+    )]
+    LocaleNotStored {
+        kind: &'static str,
+        id: Uuid,
+        requested_locale: String,
+        effective_locale: String,
+    },
+    #[error(transparent)]
+    Owner(#[from] ForumError),
+    #[error(transparent)]
+    Mapping(#[from] ForumExportMappingError),
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForumOwnerExportReader;
+
+impl ForumOwnerExportReader {
+    pub async fn read_fragment(
+        &self,
+        categories: &CategoryService,
+        topics: &TopicService,
+        replies: &ReplyService,
+        security: &SecurityContext,
+        batch: &ForumExportReadBatch,
+    ) -> Result<ForumExportFragment, ForumExportReadError> {
+        let targets = validate_read_batch(security, batch)?;
+        require_requested_manage_scopes(security, &targets)?;
+
+        let mut owner_views = ForumExportOwnerViewBatch {
+            tenant_id: batch.tenant_id,
+            categories: Vec::new(),
+            topics: Vec::new(),
+            replies: Vec::new(),
+        };
+
+        for target in targets {
+            match target.kind {
+                ForumExportReadTargetKind::Category => {
+                    let response = categories
+                        .get_with_locale_fallback(
+                            batch.tenant_id,
+                            security.clone(),
+                            target.id,
+                            &target.locale,
+                            None,
+                        )
+                        .await?;
+                    ensure_exact_owner_view(
+                        target.kind,
+                        target.id,
+                        &target.locale,
+                        response.id,
+                        &response.effective_locale,
+                    )?;
+                    owner_views.categories.push(response);
+                }
+                ForumExportReadTargetKind::Topic => {
+                    let response = topics
+                        .get_with_locale_fallback(
+                            batch.tenant_id,
+                            security.clone(),
+                            target.id,
+                            &target.locale,
+                            None,
+                        )
+                        .await?;
+                    ensure_exact_owner_view(
+                        target.kind,
+                        target.id,
+                        &target.locale,
+                        response.id,
+                        &response.effective_locale,
+                    )?;
+                    owner_views.topics.push(response);
+                }
+                ForumExportReadTargetKind::Reply => {
+                    let response = replies
+                        .get_with_locale_fallback(
+                            batch.tenant_id,
+                            security.clone(),
+                            target.id,
+                            &target.locale,
+                            None,
+                        )
+                        .await?;
+                    ensure_exact_owner_view(
+                        target.kind,
+                        target.id,
+                        &target.locale,
+                        response.id,
+                        &response.effective_locale,
+                    )?;
+                    owner_views.replies.push(response);
+                }
+            }
+        }
+
+        Ok(ForumOwnerExportMapper.map_fragment(&owner_views)?)
+    }
+}
+
+fn validate_read_batch(
+    security: &SecurityContext,
+    batch: &ForumExportReadBatch,
+) -> Result<Vec<ForumExportReadTarget>, ForumExportReadError> {
+    if security.is_public_read() {
+        return Err(ForumExportReadError::OperatorContextRequired);
+    }
+    if batch.tenant_id.is_nil() {
+        return Err(ForumExportReadError::NilTenantId);
+    }
+    if batch.targets.is_empty() {
+        return Err(ForumExportReadError::EmptyTargets);
+    }
+    if batch.targets.len() > MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT {
+        return Err(ForumExportReadError::TooManyTargets {
+            max: MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT,
+            actual: batch.targets.len(),
+        });
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(batch.targets.len());
+    for target in &batch.targets {
+        let kind = target.kind.label();
+        if target.id.is_nil() {
+            return Err(ForumExportReadError::NilTargetId { kind });
+        }
+        let locale = normalize_locale_code(&target.locale).ok_or_else(|| {
+            ForumExportReadError::InvalidLocale {
+                kind,
+                id: target.id,
+                locale: target.locale.clone(),
+            }
+        })?;
+        if !seen.insert((target.kind, target.id, locale.clone())) {
+            return Err(ForumExportReadError::DuplicateTarget {
+                kind,
+                id: target.id,
+                locale,
+            });
+        }
+        normalized.push(ForumExportReadTarget {
+            kind: target.kind,
+            id: target.id,
+            locale,
+        });
+    }
+    Ok(normalized)
+}
+
+fn require_requested_manage_scopes(
+    security: &SecurityContext,
+    targets: &[ForumExportReadTarget],
+) -> Result<(), ForumExportReadError> {
+    let kinds = targets
+        .iter()
+        .map(|target| target.kind)
+        .collect::<BTreeSet<_>>();
+    for kind in kinds {
+        if matches!(
+            security.get_scope(kind.resource(), Action::Manage),
+            PermissionScope::None
+        ) {
+            return Err(ForumExportReadError::ManagePermissionRequired {
+                resource: kind.permission_label(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_exact_owner_view(
+    kind: ForumExportReadTargetKind,
+    requested_id: Uuid,
+    requested_locale: &str,
+    actual_id: Uuid,
+    effective_locale: &str,
+) -> Result<(), ForumExportReadError> {
+    if actual_id != requested_id {
+        return Err(ForumExportReadError::OwnerIdentityChanged {
+            kind: kind.label(),
+            requested_id,
+            actual_id,
+        });
+    }
+    let effective_locale = normalize_locale_code(effective_locale)
+        .unwrap_or_else(|| effective_locale.to_owned());
+    if effective_locale != requested_locale {
+        return Err(ForumExportReadError::LocaleNotStored {
+            kind: kind.label(),
+            id: requested_id,
+            requested_locale: requested_locale.to_owned(),
+            effective_locale,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_owner_view_rejects_fallback_and_identity_redirects() {
+        let id = Uuid::new_v4();
+        assert!(matches!(
+            ensure_exact_owner_view(
+                ForumExportReadTargetKind::Reply,
+                id,
+                "de",
+                id,
+                "en",
+            ),
+            Err(ForumExportReadError::LocaleNotStored { .. })
+        ));
+
+        assert!(matches!(
+            ensure_exact_owner_view(
+                ForumExportReadTargetKind::Topic,
+                id,
+                "en",
+                Uuid::new_v4(),
+                "en",
+            ),
+            Err(ForumExportReadError::OwnerIdentityChanged { .. })
+        ));
+    }
+
+    #[test]
+    fn target_kind_maps_to_exact_manage_resource() {
+        assert_eq!(
+            ForumExportReadTargetKind::Category.resource(),
+            Resource::ForumCategories
+        );
+        assert_eq!(
+            ForumExportReadTargetKind::Topic.resource(),
+            Resource::ForumTopics
+        );
+        assert_eq!(
+            ForumExportReadTargetKind::Reply.resource(),
+            Resource::ForumReplies
+        );
+        assert_eq!(
+            ForumExportReadTargetKind::Reply.permission_label(),
+            "forum_replies"
+        );
+    }
+}

--- a/docs/modules/forum-34-owner-export-reader-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-owner-export-reader-actualization-2026-08-09.md
@@ -1,0 +1,119 @@
+# FORUM-34F bounded owner export reader actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34E are merged on `main` before this slice:
+
+- 34A maps bounded NodeBB category/topic/post source records into runner-neutral external references;
+- 34B inspects missing, mismatched and external-owner dependencies without treating inspection as persistence admission;
+- 34C rejects source-local category cycles while leaving cross-batch parents unresolved;
+- 34D maps already-authorized full Forum owner responses into tenant-scoped `rustok.forum.export.v1` fragments;
+- 34E exposes manage-only bounded exact stored-locale enumeration for reply export planning.
+
+Fresh `main` for this rebased slice is `c1243da5ecf0b00589daf67d6304b8d210f8dc73`. The commits after 34E are Commerce, Page Builder, Translation and event-contract maintenance; repository search still finds no generic `ImportRunner`, `ExportRunner`, `ImportAdapter`, `ExportAdapter` or `rustok-import` owner suitable for Forum migration orchestration.
+
+The newer `TranslationExchangeService` remains Translation-owned lifecycle/orchestration for translation exchange artifacts. It does not become the shared Forum category/topic/reply migration runner and does not move Forum import/export ownership into `rustok-translation`.
+
+The canonical Forum ledger still labels `FORUM-34` as `planned`, although 34A-34E are merged and this slice adds another source-ready boundary. That status is stale. The GitHub connector available for this maintenance path only supports whole-file contents replacement for existing files; rewriting the large concurrently edited canonical plan without a complete safe source image would risk deleting unrelated roadmap content. This dated packet records the truthful execution cursor and keeps canonical-plan synchronization explicitly open rather than performing a destructive partial replacement.
+
+## Gap selected
+
+34D deliberately accepts only already-authorized full owner responses. 34E closes reply locale discovery, but a caller still had no bounded Forum-owned composition boundary that could request exact localized owner views and feed them into the 34D mapper.
+
+34F adds that composition boundary without adding a second storage read path.
+
+## Public contract
+
+`rustok-forum::export_mapping` now also publishes:
+
+- `MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT`;
+- `ForumExportReadTargetKind` (`Category`, `Topic`, `Reply`);
+- `ForumExportReadTarget`;
+- `ForumExportReadBatch`;
+- `ForumExportReadError`;
+- `ForumOwnerExportReader`.
+
+`ForumExportReadBatch` and `ForumExportReadTarget` are in-process composition types only. They deliberately do not derive `Serialize` or `Deserialize`; no new GraphQL, REST, CLI or file-format admission path is created by this slice.
+
+A read batch carries one explicit tenant and at most 512 localized targets. Targets are normalized through the shared locale normalizer and duplicate `(kind, id, normalized locale)` requests are rejected before any owner call. Nil tenant IDs, nil target IDs, invalid locales and empty batches fail closed.
+
+## Operator admission
+
+`ForumOwnerExportReader::read_fragment` rejects `SecurityContext::public_read()` before owner reads.
+
+For every resource kind present in the request it requires the exact corresponding manage authority:
+
+- category targets require `forum_categories:manage`;
+- topic targets require `forum_topics:manage`;
+- reply targets require `forum_replies:manage`.
+
+Ordinary list/read authority is intentionally insufficient for this export-oriented composition API.
+
+## Owner-only read composition
+
+The reader has no SeaORM/database/entity dependency. It receives existing `CategoryService`, `TopicService` and `ReplyService` owner facades from the caller and uses only their localized owner read methods.
+
+For each bounded target it calls the corresponding owner with the same trusted tenant/security context and with no caller-supplied fallback locale. The shared owner locale resolver can still select platform/first-available fallback content when an exact translation is absent, so 34F does not trust the returned response blindly. After every owner call it verifies:
+
+1. returned owner identity equals the requested UUID;
+2. normalized `effective_locale` equals the normalized requested locale.
+
+A mismatch fails closed before mapping. This prevents a fallback read from silently fabricating multilingual export completeness and prevents Topic canonical resolution from silently exporting a different topic identity. URL aliases/merged-topic transfer remain separate future FORUM-34 scope.
+
+After all owner views pass those checks, 34F constructs the existing non-wire `ForumExportOwnerViewBatch` and delegates serialization semantics to `ForumOwnerExportMapper`. The reader therefore does not duplicate field selection, canonical rich-text handling, viewer-state exclusion or export schema ownership from 34D.
+
+## Bounded execution semantics
+
+This is the first executable owner-reader composition boundary, not the final high-throughput tenant exporter.
+
+The reader executes at most 512 localized owner calls per fragment and preserves target order within each exported resource-kind vector. It intentionally does not add direct batched SQL to bypass owner services. A future shared runner may add chunking/checkpoints and Forum may add owner-native bulk response methods if required by retained performance evidence, but those optimizations must preserve the same exact-locale and owner-authorization semantics.
+
+## Ownership and non-goals
+
+34F adds no:
+
+- generic or Forum-only durable migration runner;
+- checkpoint/receipt/replay/audit persistence;
+- source-to-target identity receipt storage;
+- external-user resolution;
+- candidate-to-owner import writes;
+- revisions/history transfer;
+- vote/reputation transfer;
+- attachment/media transfer;
+- URL alias transfer;
+- Search rebuild orchestration;
+- GraphQL/REST/CLI/admin transport;
+- migration or schema change;
+- direct read of another module's persistence.
+
+## Remaining FORUM-34 scope
+
+After 34F, still open:
+
+- synchronize the canonical implementation-plan ledger from stale `planned` to truthful `in_progress` without overwriting concurrent roadmap edits;
+- neutral shared import/export runner contract and host composition;
+- durable cursor/checkpoint/receipt/replay/audit semantics;
+- bounded tenant/category/topic/reply enumeration and runner chunk orchestration around the owner reader;
+- retained performance evidence and any owner-native bulk response optimization justified by it;
+- cross-batch import dependency resolution;
+- external-user resolution through auth/Profile owner contracts;
+- candidate-to-existing Forum owner command adapter;
+- revisions/history export/import policy;
+- votes/reputation export/import through their owners;
+- attachment/media mapping after FORUM-14 establishes Forum-owned relations;
+- URL alias transfer where route-owner contracts permit it;
+- runner-level dry-run/reconciliation/Search rebuild orchestration;
+- CLI/admin transport only after RBAC/idempotency/audit admission;
+- retained SQLite/PostgreSQL/restart/lost-response evidence.
+
+## Maintainer validation
+
+Per maintainer instruction, no test, Cargo command, Node verifier, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-owner-export-reader-source.mjs
+```

--- a/scripts/verify/verify-forum-owner-export-reader-source.mjs
+++ b/scripts/verify/verify-forum-owner-export-reader-source.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function requireText(text, marker, message) {
+  if (!text.includes(marker)) throw new Error(message);
+}
+
+function requireAbsent(text, marker, message) {
+  if (text.includes(marker)) throw new Error(message);
+}
+
+const mappingPath = "crates/rustok-forum/src/export_mapping.rs";
+const readerPath = "crates/rustok-forum/src/export_reader.rs";
+const packetPath = "docs/modules/forum-34-owner-export-reader-actualization-2026-08-09.md";
+
+const mapping = read(mappingPath);
+const reader = read(readerPath);
+const packet = read(packetPath);
+
+for (const marker of [
+  '#[path = "export_reader.rs"]',
+  "mod reader;",
+  "pub use reader::*;",
+]) {
+  requireText(mapping, marker, `${mappingPath}: missing reader composition marker ${marker}`);
+}
+
+for (const marker of [
+  "pub const MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT: usize =",
+  "MAX_FORUM_EXPORT_OWNER_VIEWS_PER_FRAGMENT;",
+  "pub enum ForumExportReadTargetKind",
+  "pub struct ForumExportReadTarget",
+  "pub struct ForumExportReadBatch",
+  "pub enum ForumExportReadError",
+  "pub struct ForumOwnerExportReader;",
+  "pub async fn read_fragment(",
+  "if security.is_public_read()",
+  "ForumExportReadError::OperatorContextRequired",
+  "ForumExportReadError::EmptyTargets",
+  "security.get_scope(kind.resource(), Action::Manage)",
+  'Self::Category => "forum_categories"',
+  'Self::Topic => "forum_topics"',
+  'Self::Reply => "forum_replies"',
+  "MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT",
+  "normalize_locale_code(&target.locale)",
+  "!seen.insert((target.kind, target.id, locale.clone()))",
+  ".get_with_locale_fallback(",
+  "response.id",
+  "response.effective_locale",
+  "OwnerIdentityChanged",
+  "LocaleNotStored",
+  "ForumExportOwnerViewBatch",
+  "ForumOwnerExportMapper.map_fragment(&owner_views)",
+]) {
+  requireText(reader, marker, `${readerPath}: missing ${marker}`);
+}
+
+const targetStart = reader.indexOf(
+  "#[derive(Clone, Debug, Eq, PartialEq)]\npub struct ForumExportReadTarget",
+);
+const errorStart = reader.indexOf("#[derive(Debug, Error)]", targetStart);
+if (targetStart < 0 || errorStart <= targetStart) {
+  throw new Error(`${readerPath}: read-batch non-wire boundary is invalid`);
+}
+const batchContract = reader.slice(targetStart, errorStart);
+for (const forbidden of ["Serialize", "Deserialize", "#[serde("]) {
+  requireAbsent(
+    batchContract,
+    forbidden,
+    `${readerPath}: export read targets must remain non-wire in-process types: ${forbidden}`,
+  );
+}
+
+for (const forbidden of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "crate::entities",
+  "Entity::",
+  "QueryFilter",
+  ".all(&",
+  ".one(&",
+  ".insert(",
+  ".update(",
+  ".delete(",
+  "ForumExportCategoryRecord {",
+  "ForumExportTopicRecord {",
+  "ForumExportReplyRecord {",
+]) {
+  requireAbsent(
+    reader,
+    forbidden,
+    `${readerPath}: export reader must compose owner services and mapper without direct storage/schema duplication: ${forbidden}`,
+  );
+}
+
+const ownerReadCalls = reader.split(".get_with_locale_fallback(").length - 1;
+if (ownerReadCalls !== 3) {
+  throw new Error(
+    `${readerPath}: expected exactly three typed owner read branches, found ${ownerReadCalls}`,
+  );
+}
+
+const mapperCalls = reader.split("ForumOwnerExportMapper.map_fragment(&owner_views)").length - 1;
+if (mapperCalls !== 1) {
+  throw new Error(`${readerPath}: reader must delegate export field mapping exactly once`);
+}
+
+for (const marker of [
+  "FORUM-34F",
+  "FORUM-34A through FORUM-34E",
+  "still finds no generic `ImportRunner`, `ExportRunner`, `ImportAdapter`, `ExportAdapter` or `rustok-import`",
+  "canonical Forum ledger still labels `FORUM-34` as `planned`",
+  "do not derive `Serialize` or `Deserialize`",
+  "at most 512 localized targets",
+  "category targets require `forum_categories:manage`",
+  "topic targets require `forum_topics:manage`",
+  "reply targets require `forum_replies:manage`",
+  "has no SeaORM/database/entity dependency",
+  "normalized `effective_locale` equals the normalized requested locale",
+  "prevents a fallback read from silently fabricating multilingual export completeness",
+  "prevents Topic canonical resolution from silently exporting a different topic identity",
+  "ForumOwnerExportMapper",
+  "at most 512 localized owner calls per fragment",
+  "no test, Cargo command",
+]) {
+  requireText(packet, marker, `${packetPath}: missing ${marker}`);
+}
+
+console.log("Forum FORUM-34F bounded owner export reader source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with a bounded, operator-only owner export reader that composes existing Forum owner facades into the existing 34D export mapper.

- add non-wire `ForumExportReadTarget` / `ForumExportReadBatch` composition inputs capped at 512 localized targets;
- reject public-read contexts, nil/empty/duplicate targets and invalid locales before owner calls;
- require `forum_categories:manage`, `forum_topics:manage`, or `forum_replies:manage` for every requested resource kind;
- read only through existing `CategoryService`, `TopicService`, and `ReplyService` facades with the same tenant/security context;
- fail closed when an owner read falls back to another locale or when Topic canonical resolution returns a different owner id;
- delegate field selection, canonical rich text, viewer-state exclusion, schema and fragment bounds to the existing `ForumOwnerExportMapper`;
- add a dated FORUM-34F actualization packet and a source guard that forbids direct SeaORM/entity access or export-record duplication in the reader.

## Recheck / current main

The slice was rebased onto current `main` at `c1243da5ecf0b00589daf67d6304b8d210f8dc73`. The intervening changes are Page Builder and Commerce only and do not overlap Forum source.

Repository recheck still finds no generic `ImportRunner`, `ExportRunner`, `ImportAdapter`, `ExportAdapter`, or `rustok-import` owner suitable for Forum migration orchestration. The newer `TranslationExchangeService` remains Translation-specific and is not treated as the missing neutral Forum migration runner.

The canonical implementation plan still incorrectly labels `FORUM-34` as `planned` despite merged 34A-34E. The connector available for this maintenance path can only replace the complete large plan file, and the retrieved representation is truncated; the dated 34F packet records the truthful cursor and leaves safe canonical-plan synchronization explicitly open rather than risking destructive replacement of concurrent roadmap content.

## Ownership / non-goals

This PR adds no direct database/export storage path, durable runner, checkpoint/receipt/replay/audit persistence, import write adapter, identity resolution, attachment/vote/history transfer, Search rebuild, transport, migration or schema change. The current sequential owner reads are deliberately bounded; owner-native bulk optimization remains evidence-driven future work.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, DB scenario, workflow, CI command, lock generation, or `git diff --check` was run. Maintainer will run tests.