### PR TITLE
feat(order): publish post-order command owner port

### DIFF
--- a/crates/rustok-commerce/docs/order-post-order-command-owner-capability-2026-08-09.md
+++ b/crates/rustok-commerce/docs/order-post-order-command-owner-capability-2026-08-09.md
@@ -1,0 +1,54 @@
+# Order post-order command owner capability
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+This slice continues the canonical ecommerce topology P0 after GraphQL order lifecycle cutover PR #3392.
+
+The mounted Commerce GraphQL fulfillment/post-order mutation object still has five direct `OrderService` construction paths for owner-local post-order writes:
+
+- storefront order-return creation;
+- admin order-change creation;
+- admin order-change cancellation;
+- admin order-return creation;
+- admin order-return cancellation.
+
+Before cutting those consumers over, this slice publishes the missing Order-owned command boundary rather than moving foreign persistence or lifecycle policy into Commerce.
+
+## Owner capability
+
+`rustok-order` now publishes `OrderPostOrderCommandPort` and `OrderPostOrderCommandRuntime` with four owner-local operations:
+
+- `create_change`;
+- `cancel_change`;
+- `create_return`;
+- `cancel_return`.
+
+The in-process adapter delegates to the existing `OrderService` methods and keeps Order persistence, validation, lifecycle policy, and event behavior inside `rustok-order`.
+
+The request contracts wrap the existing Order DTOs and stable resource identities rather than duplicating transport-specific GraphQL shapes.
+
+## Boundary and error policy
+
+The port requires write admission through `PortContext`, validates tenant and actor identities, and maps `OrderError` into bounded `PortError` families.
+
+Database/core details are never copied into public `PortError.message`. Diagnostics log stable operation/error variants plus correlation/resource shape without raw backend errors.
+
+This source slice does not claim durable replay receipts for post-order create operations. The mounted consumer cutover must preserve explicit caller context and the broader ecommerce production gate remains open until replay/runtime evidence is retained.
+
+## Explicitly not changed
+
+This slice does not change:
+
+- mounted GraphQL resolvers;
+- Commerce post-order payment/refund orchestration;
+- return completion or order-change apply flows;
+- database schema or migrations;
+- FBA/FFA promotion state.
+
+The next slice can host-compose this runtime and replace the five remaining direct GraphQL `OrderService` owner-local write calls.
+
+## Validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, workflows, CI reruns, database scenarios, mounted GraphQL scenarios, restart scenarios, or remote-adapter scenarios were executed for this slice.

--- a/crates/rustok-order/src/lib.rs
+++ b/crates/rustok-order/src/lib.rs
@@ -26,6 +26,7 @@ pub mod entities;
 pub mod error;
 pub mod migrations;
 mod order_read;
+mod post_order_command;
 pub mod ports;
 pub mod services;
 pub mod status;
@@ -68,6 +69,11 @@ pub use order_read::{
     ListOrderReturnProjectionsRequest, OrderChangeProjectionPage, OrderProjectionPage,
     OrderReadPort, OrderReturnProjectionPage, ReadOrderChangeProjectionRequest,
     ReadOrderProjectionRequest, ReadOrderReturnProjectionRequest, in_process_order_read_port,
+};
+pub use post_order_command::{
+    CancelOrderChangeRequest, CancelOrderReturnRequest, CreateOrderChangeRequest,
+    CreateOrderReturnRequest, InProcessOrderPostOrderCommandPort, OrderPostOrderCommandPort,
+    OrderPostOrderCommandRuntime, in_process_order_post_order_command_port,
 };
 pub use ports::*;
 pub use status::*;

--- a/crates/rustok-order/src/post_order_command.rs
+++ b/crates/rustok-order/src/post_order_command.rs
@@ -1,0 +1,286 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, PortErrorKind};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    CancelOrderChangeInput, CancelOrderReturnInput, CreateOrderChangeInput,
+    CreateOrderReturnInput, OrderChangeResponse, OrderError, OrderReturnResponse, OrderService,
+};
+
+const ORDER_POST_ORDER_COMMAND_OWNER: &str = "rustok_order";
+const ORDER_POST_ORDER_COMMAND_BOUNDARY: &str = "order_post_order_command_port";
+
+#[async_trait]
+pub trait OrderPostOrderCommandPort: Send + Sync {
+    async fn create_change(
+        &self,
+        context: PortContext,
+        request: CreateOrderChangeRequest,
+    ) -> Result<OrderChangeResponse, PortError>;
+
+    async fn cancel_change(
+        &self,
+        context: PortContext,
+        request: CancelOrderChangeRequest,
+    ) -> Result<OrderChangeResponse, PortError>;
+
+    async fn create_return(
+        &self,
+        context: PortContext,
+        request: CreateOrderReturnRequest,
+    ) -> Result<OrderReturnResponse, PortError>;
+
+    async fn cancel_return(
+        &self,
+        context: PortContext,
+        request: CancelOrderReturnRequest,
+    ) -> Result<OrderReturnResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateOrderChangeRequest {
+    pub order_id: Uuid,
+    pub input: CreateOrderChangeInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelOrderChangeRequest {
+    pub change_id: Uuid,
+    pub input: CancelOrderChangeInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateOrderReturnRequest {
+    pub order_id: Uuid,
+    pub input: CreateOrderReturnInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelOrderReturnRequest {
+    pub return_id: Uuid,
+    pub input: CancelOrderReturnInput,
+}
+
+pub struct InProcessOrderPostOrderCommandPort {
+    inner: OrderService,
+}
+
+impl InProcessOrderPostOrderCommandPort {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self {
+            inner: OrderService::new(db, event_bus),
+        }
+    }
+}
+
+pub fn in_process_order_post_order_command_port(
+    db: DatabaseConnection,
+    event_bus: TransactionalEventBus,
+) -> Arc<dyn OrderPostOrderCommandPort> {
+    Arc::new(InProcessOrderPostOrderCommandPort::new(db, event_bus))
+}
+
+#[derive(Clone)]
+pub struct OrderPostOrderCommandRuntime {
+    command_port: Arc<dyn OrderPostOrderCommandPort>,
+}
+
+impl OrderPostOrderCommandRuntime {
+    pub fn new(command_port: Arc<dyn OrderPostOrderCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self::new(in_process_order_post_order_command_port(db, event_bus))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn OrderPostOrderCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl OrderPostOrderCommandPort for InProcessOrderPostOrderCommandPort {
+    async fn create_change(
+        &self,
+        context: PortContext,
+        request: CreateOrderChangeRequest,
+    ) -> Result<OrderChangeResponse, PortError> {
+        const OPERATION: &str = "create_change";
+        let (tenant_id, actor_id) = require_post_order_command_context(&context, OPERATION)?;
+        self.inner
+            .create_order_change(tenant_id, actor_id, request.order_id, request.input)
+            .await
+            .map_err(|error| map_order_error(&context, OPERATION, request.order_id, error))
+    }
+
+    async fn cancel_change(
+        &self,
+        context: PortContext,
+        request: CancelOrderChangeRequest,
+    ) -> Result<OrderChangeResponse, PortError> {
+        const OPERATION: &str = "cancel_change";
+        let (tenant_id, _) = require_post_order_command_context(&context, OPERATION)?;
+        self.inner
+            .cancel_order_change(tenant_id, request.change_id, request.input)
+            .await
+            .map_err(|error| map_order_error(&context, OPERATION, request.change_id, error))
+    }
+
+    async fn create_return(
+        &self,
+        context: PortContext,
+        request: CreateOrderReturnRequest,
+    ) -> Result<OrderReturnResponse, PortError> {
+        const OPERATION: &str = "create_return";
+        let (tenant_id, _) = require_post_order_command_context(&context, OPERATION)?;
+        self.inner
+            .create_return(tenant_id, request.order_id, request.input)
+            .await
+            .map_err(|error| map_order_error(&context, OPERATION, request.order_id, error))
+    }
+
+    async fn cancel_return(
+        &self,
+        context: PortContext,
+        request: CancelOrderReturnRequest,
+    ) -> Result<OrderReturnResponse, PortError> {
+        const OPERATION: &str = "cancel_return";
+        let (tenant_id, _) = require_post_order_command_context(&context, OPERATION)?;
+        self.inner
+            .cancel_return(tenant_id, request.return_id, request.input)
+            .await
+            .map_err(|error| map_order_error(&context, OPERATION, request.return_id, error))
+    }
+}
+
+fn require_post_order_command_context(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(Uuid, Uuid), PortError> {
+    context.require_policy(PortCallPolicy::write()).inspect_err(|error| {
+        log_context_error(context, operation, "policy", error);
+    })?;
+    let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let error = PortError::validation(
+            "order.post_order_command_context_invalid",
+            "order command context is invalid",
+        );
+        log_context_error(context, operation, "tenant_id", &error);
+        error
+    })?;
+    let actor_id = Uuid::parse_str(&context.actor.id).map_err(|_| {
+        let error = PortError::validation(
+            "order.post_order_command_context_invalid",
+            "order command context is invalid",
+        );
+        log_context_error(context, operation, "actor_id", &error);
+        error
+    })?;
+    Ok((tenant_id, actor_id))
+}
+
+fn map_order_error(
+    context: &PortContext,
+    operation: &'static str,
+    resource_id: Uuid,
+    error: OrderError,
+) -> PortError {
+    let (kind, code, message, retryable, error_variant, technical) = match &error {
+        OrderError::Validation(_) => (
+            PortErrorKind::Validation,
+            "order.post_order_command_validation",
+            "order request is invalid",
+            false,
+            "validation",
+            false,
+        ),
+        OrderError::OrderNotFound(_)
+        | OrderError::OrderReturnNotFound(_)
+        | OrderError::OrderChangeNotFound(_) => (
+            PortErrorKind::NotFound,
+            "order.post_order_resource_not_found",
+            "order resource was not found",
+            false,
+            "not_found",
+            false,
+        ),
+        OrderError::InvalidTransition { .. } => (
+            PortErrorKind::Conflict,
+            "order.post_order_command_state_conflict",
+            "order lifecycle transition conflicts with the requested operation",
+            false,
+            "invalid_transition",
+            false,
+        ),
+        OrderError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "order.post_order_storage_unavailable",
+            "order storage is temporarily unavailable",
+            true,
+            "database",
+            true,
+        ),
+        OrderError::Core(_) => (
+            PortErrorKind::InvariantViolation,
+            "order.post_order_command_invariant",
+            "order operation could not be completed safely",
+            false,
+            "core",
+            true,
+        ),
+    };
+
+    if technical {
+        tracing::error!(
+            owner = ORDER_POST_ORDER_COMMAND_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            resource_id_non_nil = !resource_id.is_nil(),
+            error_variant,
+            public_code = code,
+            retryable,
+            boundary = ORDER_POST_ORDER_COMMAND_BOUNDARY,
+            "order post-order command failed"
+        );
+    } else {
+        tracing::warn!(
+            owner = ORDER_POST_ORDER_COMMAND_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            resource_id_non_nil = !resource_id.is_nil(),
+            error_variant,
+            public_code = code,
+            retryable,
+            boundary = ORDER_POST_ORDER_COMMAND_BOUNDARY,
+            "order post-order command was rejected"
+        );
+    }
+
+    PortError::new(kind, code, message, retryable)
+}
+
+fn log_context_error(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = ORDER_POST_ORDER_COMMAND_OWNER,
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = ORDER_POST_ORDER_COMMAND_BOUNDARY,
+        "order post-order command context was rejected"
+    );
+}

--- a/scripts/verify/verify-order-post-order-command-port.mjs
+++ b/scripts/verify/verify-order-post-order-command-port.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+const portPath = 'crates/rustok-order/src/post_order_command.rs';
+const libPath = 'crates/rustok-order/src/lib.rs';
+const recordPath = 'crates/rustok-commerce/docs/order-post-order-command-owner-capability-2026-08-09.md';
+
+const port = read(portPath);
+const lib = read(libPath);
+const record = read(recordPath);
+
+const requireText = (text, marker, message) => {
+  if (!text.includes(marker)) throw new Error(message);
+};
+
+for (const marker of [
+  'pub trait OrderPostOrderCommandPort',
+  'async fn create_change(',
+  'async fn cancel_change(',
+  'async fn create_return(',
+  'async fn cancel_return(',
+  'pub struct OrderPostOrderCommandRuntime',
+  'context.require_policy(PortCallPolicy::write())',
+  '.create_order_change(tenant_id, actor_id, request.order_id, request.input)',
+  '.cancel_order_change(tenant_id, request.change_id, request.input)',
+  '.create_return(tenant_id, request.order_id, request.input)',
+  '.cancel_return(tenant_id, request.return_id, request.input)',
+  'PortErrorKind::Unavailable',
+  'PortErrorKind::InvariantViolation',
+]) {
+  requireText(port, marker, `${portPath}: missing ${marker}`);
+}
+
+for (const marker of [
+  'mod post_order_command;',
+  'OrderPostOrderCommandPort',
+  'OrderPostOrderCommandRuntime',
+  'in_process_order_post_order_command_port',
+]) {
+  requireText(lib, marker, `${libPath}: missing ${marker}`);
+}
+
+for (const forbidden of [
+  'error.to_string()',
+  'format!("{error}',
+  'PortError::new(kind, code, error',
+]) {
+  if (port.includes(forbidden)) {
+    throw new Error(`${portPath}: technical error text must stay out of public PortError: ${forbidden}`);
+  }
+}
+
+requireText(
+  record,
+  'source_complete_unvalidated',
+  `${recordPath}: source validation state must remain explicit`,
+);
+requireText(
+  record,
+  'does not claim durable replay receipts',
+  `${recordPath}: replay limitation must remain explicit`,
+);
+
+console.log('order post-order command port source guard passed');


### PR DESCRIPTION
## Summary

Continue the ecommerce topology P0 by publishing the missing Order-owned post-order write capability before cutting mounted Commerce GraphQL consumers over.

- add `OrderPostOrderCommandPort` / `OrderPostOrderCommandRuntime`;
- cover create/cancel order-change and create/cancel order-return owner-local operations;
- reuse existing Order DTOs and `OrderService` policy/persistence instead of duplicating transport-specific shapes;
- require write `PortContext` admission and validated tenant/actor identities;
- map `OrderError` to bounded `PortError` families without exposing database/core details;
- export an in-process adapter behind the same owner contract expected by later host composition;
- add a source-only verifier and dated capability record;
- keep mounted GraphQL cutover, durable create replay receipts, and the broad ecommerce topology P0 open.

## Source recheck

After #3392, the mounted GraphQL order lifecycle commands use `OrderAdminCommandPort`, but five owner-local return/change writes still construct `OrderService` directly. The Order service already owns the required create/cancel methods, so this PR publishes a typed owner boundary first rather than moving persistence or lifecycle policy into Commerce.

The branch was refreshed onto current `main` (`286b7af7ec942005f434c41fe9a6c48a674d766f`) after unrelated Forum #3393 landed. It is one commit ahead and zero behind.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, workflows, CI reruns, database scenarios, mounted GraphQL scenarios, restart scenarios, or remote-adapter scenarios were executed. The added verifier is source-only evidence for maintainer execution.