### PR TITLE
feat(page-builder): bind provider health targets to deployment identity

### DIFF
--- a/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json
@@ -1,0 +1,131 @@
+{
+  "format": "page_builder_provider_health_deployment_identity_source_v1",
+  "status": "source_ready_execution_pending",
+  "provider": "page_builder",
+  "source_identity": {
+    "runtime_environment": "RUSTOK_SOURCE_COMMIT",
+    "metric": "rustok_page_builder_provider_build_info",
+    "metric_label": "source_commit",
+    "canonical_git_sha_length": 40,
+    "missing_or_invalid_metric_identity": "fail_closed",
+    "release_source": "OCI_REVISION",
+    "canonical_release_value": "github.sha"
+  },
+  "deployment_identity": {
+    "deployment_id": {
+      "authority": "maintainer_supplied_inventory",
+      "max_bytes": 128,
+      "allowed_characters": "ASCII alphanumeric plus . _ : / -"
+    },
+    "deployment_image_digest": {
+      "authority": "maintainer_supplied_immutable_rep_digest",
+      "format": "REPOSITORY@sha256:<64 lowercase hex>",
+      "origin_to_repo_digest_binding": "maintainer_reviewed_external_fact",
+      "cryptographic_origin_to_repo_digest_binding_claimed": false
+    },
+    "source_commit": {
+      "authority": "checkout_head_and_live_target_build_info",
+      "all_expected_targets_must_equal_checkout_head": true
+    }
+  },
+  "expected_target_inventory": {
+    "authority": "maintainer_supplied_complete_inventory",
+    "inventory_complete_must_be_true": true,
+    "minimum_targets": 1,
+    "maximum_targets": 64,
+    "target_id_max_bytes": 128,
+    "target_id_allowed_characters": "ASCII alphanumeric plus . _ : / -",
+    "target_ids_unique": true,
+    "metrics_urls_unique": true,
+    "metrics_url_protocols": ["http", "https"],
+    "metrics_url_credentials_forbidden": true,
+    "metrics_url_query_forbidden": true,
+    "metrics_url_fragment_forbidden": true,
+    "redirects_followed": false,
+    "raw_metrics_urls_retained": false
+  },
+  "capture": {
+    "runner": "scripts/evidence/capture-page-builder-provider-health-deployment-identity.mjs",
+    "input": {
+      "required": [
+        "--inventory FILE",
+        "--deployment-image-digest REPOSITORY@sha256:DIGEST"
+      ],
+      "optional": [
+        "--source-commit SHA",
+        "--output FILE"
+      ],
+      "inventory_shape": {
+        "schema_version": 1,
+        "deployment_id": "bounded deployment identifier",
+        "inventory_complete": true,
+        "targets": [
+          {
+            "target_id": "bounded unique identifier",
+            "metrics_url": "absolute target metrics URL"
+          }
+        ]
+      }
+    },
+    "credential_environment": {
+      "common_headers_json": "RUSTOK_PAGE_BUILDER_PROVIDER_HEALTH_METRICS_HEADERS_JSON",
+      "authorization": "RUSTOK_PAGE_BUILDER_PROVIDER_HEALTH_METRICS_AUTHORIZATION",
+      "cookie": "RUSTOK_PAGE_BUILDER_PROVIDER_HEALTH_METRICS_COOKIE"
+    },
+    "request_timeout_ms": 30000,
+    "maximum_metrics_body_bytes": 8388608,
+    "required_live_series": "rustok_page_builder_provider_build_info{source_commit=\"<checkout-head>\"} 1",
+    "all_expected_targets_required": true,
+    "partial_success": "rejected",
+    "default_output": "target/page-builder-provider-health-deployment-identity.json",
+    "atomic_replace": true
+  },
+  "retained_output": [
+    "exact checkout source commit",
+    "maintainer-supplied deployment id",
+    "maintainer-supplied immutable deployment image RepoDigest",
+    "expected target count and target ids",
+    "per-target metrics URL SHA-256 and byte length",
+    "per-target metrics response SHA-256 and byte length",
+    "per-target exact source-commit verification",
+    "required-source SHA-256 hashes",
+    "credential environment names only"
+  ],
+  "forbidden_output": [
+    "raw metrics target URLs",
+    "authorization values",
+    "cookie values",
+    "common header values",
+    "raw metrics response bodies",
+    "tenant ids",
+    "page ids",
+    "revision ids",
+    "correlation ids"
+  ],
+  "non_claims": {
+    "runtime_capture_executed": false,
+    "deployment_image_digest_cryptographically_proved_by_target": false,
+    "prometheus_backend_query_executed": false,
+    "provider_health_snapshot_evaluated": false,
+    "pages_provider_health_observed": false,
+    "pages_reference_consumer_gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "required_source_files": [
+    "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
+    "apps/server/Dockerfile.release",
+    ".github/workflows/release.yml",
+    "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+    "scripts/evidence/capture-page-builder-provider-health-deployment-identity.mjs",
+    "crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs",
+    "docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md"
+  ],
+  "next_cursor": {
+    "deployment_identity_capture": "maintainer_execution_pending",
+    "deployment_health_backend_evaluator": "open",
+    "pages_provider_status_binding": "blocked_on_deployment_evaluator_and_runtime_evidence",
+    "observed_health_acceptance": "pending"
+  }
+}

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  telemetryMetrics: "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
+  releaseDockerfile: "apps/server/Dockerfile.release",
+  releaseWorkflow: ".github/workflows/release.yml",
+  capture: "scripts/evidence/capture-page-builder-provider-health-deployment-identity.mjs",
+  evidence: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+  overlay: "docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+  pagesGraphql: "crates/rustok-pages/src/graphql/builder_rollout.rs",
+  pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-deployment-identity] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const evidence = JSON.parse(sources.evidence);
+
+if (evidence.format !== "page_builder_provider_health_deployment_identity_source_v1") {
+  failures.push("evidence format drifted");
+}
+if (evidence.status !== "source_ready_execution_pending") failures.push("evidence status drifted");
+
+for (const [key, expected] of Object.entries({
+  runtime_environment: "RUSTOK_SOURCE_COMMIT",
+  metric: "rustok_page_builder_provider_build_info",
+  metric_label: "source_commit",
+  canonical_git_sha_length: 40,
+  missing_or_invalid_metric_identity: "fail_closed",
+  release_source: "OCI_REVISION",
+  canonical_release_value: "github.sha",
+})) {
+  if (evidence.source_identity?.[key] !== expected) {
+    failures.push(`source_identity.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+const inventory = evidence.expected_target_inventory ?? {};
+for (const [key, expected] of Object.entries({
+  authority: "maintainer_supplied_complete_inventory",
+  inventory_complete_must_be_true: true,
+  minimum_targets: 1,
+  maximum_targets: 64,
+  target_ids_unique: true,
+  metrics_urls_unique: true,
+  metrics_url_credentials_forbidden: true,
+  metrics_url_query_forbidden: true,
+  metrics_url_fragment_forbidden: true,
+  redirects_followed: false,
+  raw_metrics_urls_retained: false,
+})) {
+  if (inventory[key] !== expected) {
+    failures.push(`expected_target_inventory.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  runtime_capture_executed: false,
+  deployment_image_digest_cryptographically_proved_by_target: false,
+  prometheus_backend_query_executed: false,
+  provider_health_snapshot_evaluated: false,
+  pages_provider_health_observed: false,
+  pages_reference_consumer_gate_accepted: false,
+  forum_wave_accepted: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+})) {
+  if (evidence.non_claims?.[key] !== expected) {
+    failures.push(`non_claims.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const marker of [
+  'PAGE_BUILDER_PROVIDER_SOURCE_COMMIT_ENV: &str = "RUSTOK_SOURCE_COMMIT"',
+  '"rustok_page_builder_provider_build_info"',
+  '&["source_commit"]',
+  "fn canonical_source_commit",
+  "fn deployed_source_commit",
+  "PAGE_BUILDER_PROVIDER_BUILD_INFO",
+  ".with_label_values(&[source_commit.as_str()])",
+  ".set(1);",
+]) need(sources.telemetryMetrics, marker, "provider build-info metric");
+for (const forbidden of [
+  '&["deployment_id"]',
+  '&["target_id"]',
+  '&["tenant_id"]',
+  '&["page_id"]',
+  '&["correlation_id"]',
+]) forbid(sources.telemetryMetrics, forbidden, "provider build-info metric cardinality");
+
+for (const marker of [
+  "ARG OCI_REVISION=unknown",
+  'org.opencontainers.image.revision="${OCI_REVISION}"',
+  "RUSTOK_SOURCE_COMMIT=${OCI_REVISION}",
+]) need(sources.releaseDockerfile, marker, "release source identity");
+need(
+  sources.releaseWorkflow,
+  '--build-arg "OCI_REVISION=$GITHUB_SHA"',
+  "release workflow exact source commit",
+);
+
+for (const marker of [
+  "--inventory",
+  "--deployment-image-digest",
+  "--source-commit",
+  "inventory_complete must be true",
+  "inventory targets must contain between 1 and 64 expected targets",
+  "duplicate target_id",
+  "duplicate metrics_url",
+  "redirect: \"manual\"",
+  "function requireBuildInfo",
+  "must expose exactly one Page Builder provider build-info series",
+  "does not match git HEAD",
+  "partial expected-target capture is forbidden",
+  "raw_metrics_url_persisted: false",
+  "raw_response_persisted: false",
+  "deployment_identity_verified_health_evaluation_pending",
+  "provider_health_snapshot_evaluated: false",
+  "pages_provider_health_observed: false",
+]) need(sources.capture, marker, "deployment identity capture harness");
+
+for (const marker of [
+  "deployment-identity-contract-source-ready",
+  "expected-target-inventory-contract-source-ready",
+  "maintainer_reviewed_external_fact",
+  "rustok_page_builder_provider_build_info",
+  "Partial success is forbidden",
+  "Pages remains `unobserved`",
+  "deployment health backend evaluator [open]",
+  "tests were not run",
+]) need(sources.overlay, marker, "deployment identity overlay");
+
+for (const marker of [
+  "deployment-metrics-source-ready",
+  "freshness-signal-source-ready",
+  "deployment-identity-contract-source-ready",
+  "expected-target-inventory-contract-source-ready",
+  "page-builder-provider-health-deployment-identity-actualization-2026-08-09.md",
+  "exact source/deployment identity",
+  "Pages remains `unobserved`",
+]) need(sources.parity, marker, "plan parity actualization");
+
+need(sources.pagesGraphql, "provider_health_observed: false", "Pages GraphQL remains unobserved");
+forbid(sources.pagesGraphql, "provider_health_observed: true", "Pages GraphQL health promotion");
+need(sources.pagesFacade, "PageBuilderAdminProviderStatus::unobserved", "Pages admin remains unobserved");
+forbid(sources.pagesGraphql, "page_builder_provider_build_info", "Pages GraphQL must not bind raw identity metric");
+forbid(sources.pagesFacade, "page_builder_provider_build_info", "Pages admin must not bind raw identity metric");
+
+if (evidence.next_cursor?.deployment_identity_capture !== "maintainer_execution_pending") {
+  failures.push("deployment identity capture must remain maintainer execution pending");
+}
+if (evidence.next_cursor?.deployment_health_backend_evaluator !== "open") {
+  failures.push("deployment health backend evaluator must remain open");
+}
+if (
+  evidence.next_cursor?.pages_provider_status_binding !==
+  "blocked_on_deployment_evaluator_and_runtime_evidence"
+) {
+  failures.push("Pages provider status binding must remain blocked on evaluator and runtime evidence");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-deployment-identity] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "[verify-page-builder-provider-health-deployment-identity] PASS source_ready=true execution=pending evaluator=open pages_health=unobserved",
+);

--- a/crates/rustok-telemetry/src/page_builder_provider_metrics.rs
+++ b/crates/rustok-telemetry/src/page_builder_provider_metrics.rs
@@ -2,6 +2,7 @@ use lazy_static::lazy_static;
 use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+pub const PAGE_BUILDER_PROVIDER_SOURCE_COMMIT_ENV: &str = "RUSTOK_SOURCE_COMMIT";
 pub const PAGE_BUILDER_PROVIDER_OPERATIONS: [&str; 2] = ["preview", "publish"];
 pub const PAGE_BUILDER_PROVIDER_OUTCOMES: [&str; 4] = [
     "succeeded",
@@ -11,6 +12,19 @@ pub const PAGE_BUILDER_PROVIDER_OUTCOMES: [&str; 4] = [
 ];
 
 lazy_static! {
+    /// Runtime source identity for deployment-health target admission.
+    ///
+    /// The label is emitted only when `RUSTOK_SOURCE_COMMIT` is a canonical 40-character Git SHA.
+    /// Missing or malformed source identity therefore leaves the series absent so deployment-health
+    /// capture/evaluation can fail closed instead of treating an unknown image as authoritative.
+    pub static ref PAGE_BUILDER_PROVIDER_BUILD_INFO: IntGaugeVec = IntGaugeVec::new(
+        Opts::new(
+            "rustok_page_builder_provider_build_info",
+            "Canonical source commit reported by this Page Builder provider target"
+        ),
+        &["source_commit"],
+    )
+    .expect("Failed to create Page Builder provider build info gauge");
     pub static ref PAGE_BUILDER_PROVIDER_OPERATION_DURATION_SECONDS: HistogramVec =
         HistogramVec::new(
             HistogramOpts::new(
@@ -43,7 +57,20 @@ lazy_static! {
         .expect("Failed to create Page Builder provider freshness gauge");
 }
 
+fn canonical_source_commit(value: &str) -> Option<String> {
+    let value = value.trim();
+    (value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| value.to_ascii_lowercase())
+}
+
+fn deployed_source_commit() -> Option<String> {
+    std::env::var(PAGE_BUILDER_PROVIDER_SOURCE_COMMIT_ENV)
+        .ok()
+        .and_then(|value| canonical_source_commit(&value))
+}
+
 pub fn register(registry: &Registry) -> Result<(), prometheus::Error> {
+    registry.register(Box::new(PAGE_BUILDER_PROVIDER_BUILD_INFO.clone()))?;
     registry.register(Box::new(
         PAGE_BUILDER_PROVIDER_OPERATION_DURATION_SECONDS.clone(),
     ))?;
@@ -53,6 +80,13 @@ pub fn register(registry: &Registry) -> Result<(), prometheus::Error> {
     registry.register(Box::new(
         PAGE_BUILDER_PROVIDER_LAST_OBSERVATION_UNIX_SECONDS.clone(),
     ))?;
+
+    if let Some(source_commit) = deployed_source_commit() {
+        PAGE_BUILDER_PROVIDER_BUILD_INFO
+            .with_label_values(&[source_commit.as_str()])
+            .set(1);
+    }
+
     Ok(())
 }
 
@@ -61,7 +95,9 @@ pub fn register(registry: &Registry) -> Result<(), prometheus::Error> {
 /// Labels are intentionally bounded to the two provider operations and four terminal outcomes.
 /// Tenant, page, revision, correlation, host and deployment identifiers are not metric labels.
 /// Scrape infrastructure owns target/deployment labels so aggregation can remain operationally
-/// bounded and exact deployment identity can be admitted separately.
+/// bounded. The process itself emits only the canonical source commit build-info series; immutable
+/// deployment image digest and expected-target inventory remain execution inputs admitted by the
+/// deployment-identity capture contract.
 pub fn record_page_builder_provider_operation(
     operation: &'static str,
     outcome: &'static str,
@@ -105,5 +141,15 @@ mod tests {
                 "other_failed"
             ]
         );
+    }
+
+    #[test]
+    fn source_commit_identity_is_canonical_and_bounded() {
+        let lower = "0123456789abcdef0123456789abcdef01234567";
+        let upper = "0123456789ABCDEF0123456789ABCDEF01234567";
+        assert_eq!(canonical_source_commit(lower).as_deref(), Some(lower));
+        assert_eq!(canonical_source_commit(upper).as_deref(), Some(lower));
+        assert!(canonical_source_commit("unknown").is_none());
+        assert!(canonical_source_commit("0123456789abcdef").is_none());
     }
 }

--- a/docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md
+++ b/docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md
@@ -1,0 +1,175 @@
+# Page Builder provider-health deployment identity actualization — 2026-08-09
+
+Status: `deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / live-identity-capture-execution-pending / deployment-health-evaluator-open / pages-binding-blocked`.
+
+## Why this slice exists
+
+The previous provider-health slices made two pieces source-ready:
+
+1. bounded process-local Preview/Publish observations;
+2. deployment-aggregatable Prometheus duration, outcome and freshness series.
+
+Those metrics still could not be authoritative for Pages because a backend series without an exact deployment boundary can silently mix old/new targets, omit a replica, or aggregate an unexpected target. The missing source contract was therefore identity and completeness, not another SLO formula.
+
+This slice defines that boundary without claiming runtime execution.
+
+## Reused release identity
+
+RusToK already has a canonical release source-identity path:
+
+```text
+GitHub release commit (`github.sha`)
+-> Docker build arg `OCI_REVISION`
+-> OCI label `org.opencontainers.image.revision`
+-> runtime env `RUSTOK_SOURCE_COMMIT`
+```
+
+The same runtime environment is already consumed by the Forum Page Builder deployment-attestation flow. Provider health now exposes it through one fixed-cardinality build-info series:
+
+```text
+rustok_page_builder_provider_build_info{source_commit="<40-char-git-sha>"} 1
+```
+
+The series is emitted only when `RUSTOK_SOURCE_COMMIT` is a canonical Git SHA. Missing or malformed identity leaves the build-info series absent; the deployment capture harness therefore fails closed.
+
+No tenant, page, revision, correlation, target, host or deployment id is added as an application metric label.
+
+## Immutable deployment digest boundary
+
+The pushed image RepoDigest does not exist until after the image is published, so the running process cannot derive or cryptographically prove its own RepoDigest from `RUSTOK_SOURCE_COMMIT` alone.
+
+The deployment identity packet therefore follows the repository's existing Forum attestation boundary:
+
+- every expected live target must report the exact checkout source commit;
+- the immutable deployment image digest is supplied explicitly as `REPOSITORY@sha256:<digest>`;
+- the origin/target-to-RepoDigest association is recorded as a `maintainer_reviewed_external_fact`;
+- a cryptographic origin-to-RepoDigest binding is **not** claimed.
+
+This keeps the source/deployment statement exact without inventing provenance the runtime does not possess.
+
+## Expected-target inventory contract
+
+`capture-page-builder-provider-health-deployment-identity.mjs` requires a deployment-specific inventory file with this shape:
+
+```json
+{
+  "schema_version": 1,
+  "deployment_id": "prod-eu-wave-1",
+  "inventory_complete": true,
+  "targets": [
+    {
+      "target_id": "server-a",
+      "metrics_url": "https://example.invalid/metrics/"
+    }
+  ]
+}
+```
+
+The example is structural only; no production inventory is committed by this slice.
+
+The harness rejects:
+
+- `inventory_complete != true`;
+- zero targets or more than 64 targets;
+- duplicate target ids;
+- duplicate metrics URLs;
+- unbounded/unsupported target or deployment identifiers;
+- metrics URLs with embedded credentials, query strings or fragments;
+- redirects;
+- any expected target that does not answer `200`;
+- any expected target missing the build-info series;
+- more than one build-info series on a target;
+- any source commit that differs from the exact checkout `HEAD`.
+
+Partial success is forbidden: every expected target must verify before an identity packet is written.
+
+## Retained identity packet
+
+The default output is:
+
+```text
+target/page-builder-provider-health-deployment-identity.json
+```
+
+It retains:
+
+- exact checkout source commit;
+- maintainer-supplied deployment id;
+- maintainer-supplied immutable deployment image RepoDigest;
+- expected and verified target counts;
+- target ids;
+- SHA-256/byte length of each metrics URL, but not the raw URL;
+- SHA-256/byte length of each metrics response, but not the raw body;
+- exact per-target source-commit verification;
+- hashes of the source files that define the identity contract;
+- credential environment variable names only.
+
+Authorization, cookies, common-header values, raw metrics URLs and raw metrics bodies are not retained.
+
+## Deliberately unpromoted provider health
+
+This slice does **not** evaluate SLO health.
+
+The deployment identity packet is an admission input for the next evaluator slice. It does not by itself calculate Preview/Publish p95, failure rates, freshness acceptance or deployment health.
+
+Therefore:
+
+- Pages remains `unobserved`;
+- `provider_health_observed = false` remains authoritative;
+- Pages admin remains `PageBuilderAdminProviderStatus::unobserved(...)`;
+- the Pages reference-consumer gate remains unaccepted;
+- Forum Wave remains blocked on the Pages gate;
+- FFA/FBA promotion remains unclaimed.
+
+## Source evidence
+
+Runtime identity metric:
+
+- `crates/rustok-telemetry/src/page_builder_provider_metrics.rs`.
+
+Canonical release identity chain:
+
+- `apps/server/Dockerfile.release`;
+- `.github/workflows/release.yml`.
+
+Machine contract:
+
+- `crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json`.
+
+Capture harness:
+
+- `scripts/evidence/capture-page-builder-provider-health-deployment-identity.mjs`.
+
+Fail-closed source guard:
+
+- `crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs`.
+
+## Next cursor
+
+Provider-health source sequence is now:
+
+```text
+bounded process-local Preview/Publish observation [source-ready]
+-> deployment metrics + freshness signal [source-ready]
+-> source/deployment identity + expected-target inventory contract [source-ready]
+-> live exact-target identity capture [maintainer execution pending]
+-> deployment health backend evaluator [open]
+-> Pages provider-status transport/binding [blocked]
+-> retained deployment/runtime evidence [maintainer execution]
+-> observed-health acceptance decision [pending]
+```
+
+The next autonomous source slice is the deployment health evaluator: it must consume only identity-admitted expected targets, apply an explicit freshness window, use reset-aware backend aggregation, reject missing/stale/mismatched targets, and emit a deployment-bound `ProviderHealthSnapshot` without binding Pages until runtime evidence exists.
+
+## Validation boundary
+
+Per maintainer instruction, tests were not run. No Cargo commands, Node verifiers, formatting, builds, metrics scrapes, Prometheus backend queries, GraphQL/HTTP requests, browser runs, workflows, CI, deployment capture or production observations were executed.
+
+Suggested maintainer commands, intentionally not run:
+
+```bash
+cargo test -p rustok-telemetry page_builder_provider
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+```

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,17 +1,18 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / exact-deployment-observation-open / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-open / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has four source actualizations:
+This parity packet now has five source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
 - `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353;
 - `docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`, which introduced bounded process-local runtime observation source;
-- `docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`, which exports the same terminal observations through platform-owned deployment-aggregatable Prometheus metrics and a per-operation freshness signal while leaving exact deployment observation authority open.
+- `docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`, which exports the same terminal observations through platform-owned deployment-aggregatable Prometheus metrics and a per-operation freshness signal;
+- `docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md`, which defines the exact source/deployment identity and expected-target inventory capture contract while leaving live capture and the deployment health evaluator pending.
 
-The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation and deployment-aggregatable metric source now exist, but Pages remains `unobserved` because exact source/deployment identity, expected-target inventory and an admitted deployment evaluator do not yet exist.
+The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation, deployment-aggregatable metrics/freshness, and the exact source/deployment identity + expected-target inventory capture contract are source-ready. Pages remains `unobserved` because live target identity capture, the deployment health backend evaluator and retained runtime evidence do not yet exist.
 
 ## Current source truth
 
@@ -28,11 +29,15 @@ The synchronized source boundary is now:
 - the canonical provider degraded error catalog is separately proved through a non-mutating server-owned `feature-disabled / FEATURE_DISABLED` capability preflight;
 - the reference candidate requires artifact/HTTP, browser, runtime-matrix and canonical feature-preflight packets bound to one exact source/deployment chain;
 - default Fly composition retains bounded process-local Preview/Publish terminal observations through the existing runtime-telemetry seam, with a 256-sample cap per operation and no health snapshot below 20 Preview plus 20 Publish samples;
-- the same matched terminal calls now export platform-owned Prometheus duration histograms, terminal outcome counters and per-operation last-observation timestamps with fixed `preview|publish` / terminal-outcome labels only;
+- the same matched terminal calls export platform-owned Prometheus duration histograms, terminal outcome counters and per-operation last-observation timestamps with fixed `preview|publish` / terminal-outcome labels only;
 - deployment metrics deliberately carry no tenant/page/revision/correlation/deployment application labels; scrape/discovery infrastructure owns target identity and reset-aware aggregation;
-- freshness is now observable per scrape target and operation, but an exact expected-target inventory and source/deployment identity binding remain open, so missing/stale target admission cannot yet be evaluated authoritatively inside Pages;
+- provider metrics now expose `rustok_page_builder_provider_build_info{source_commit="<sha>"} 1` only when `RUSTOK_SOURCE_COMMIT` is canonical, reusing the release `github.sha -> OCI_REVISION -> RUSTOK_SOURCE_COMMIT` identity chain;
+- the deployment identity capture contract requires a maintainer-supplied immutable image RepoDigest plus a complete 1..64 expected-target inventory, rejects partial target verification, and requires every target to report the exact checkout source commit;
+- raw metrics target URLs, metric bodies and credential values are not retained by identity capture; target URL/body digests and credential environment names are retained instead;
+- the image RepoDigest association is intentionally recorded as a maintainer-reviewed external fact because the running process cannot cryptographically derive its post-push RepoDigest from source SHA alone;
+- source inspection does not supply a production target inventory, execute target capture, choose the backend health window, or evaluate deployment SLO health;
 - the process-local window remains restartable and is not deployment-wide health authority; pre-telemetry validation/inspection is outside its current measurement boundary;
-- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until exact deployment observation authority exists;
+- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until exact live deployment identity is captured and an admitted deployment evaluator produces retained evidence;
 - `pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`;
 - Forum browser/runtime/deployment evidence and observed Wave remain blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
@@ -59,13 +64,15 @@ In parallel, the provider-health source cursor is now:
 ```text
 bounded process-local Preview/Publish observation [source-ready]
 -> deployment-aggregatable metrics + freshness signal [source-ready]
--> exact source/deployment identity + expected-target inventory [open]
--> deployment health evaluator / Pages provider-status transport [blocked]
+-> exact source/deployment identity + expected-target inventory contract [source-ready]
+-> live exact-target identity capture [maintainer execution pending]
+-> deployment health backend evaluator [open]
+-> Pages provider-status transport/binding [blocked]
 -> retained deployment/runtime evidence [maintainer execution]
 -> observed-health acceptance decision [pending]
 ```
 
-Source inspection alone must not mark any execution or acceptance step complete, and raw/process-local or unbound Prometheus observations must not be substituted for exact deployment provider-health evidence.
+Source inspection alone must not mark any execution or acceptance step complete. Raw/process-local, unbound Prometheus observations, or a source-ready inventory contract without a live complete target capture must not be substituted for exact deployment provider-health evidence.
 
 ## Anti-drift guard
 
@@ -87,15 +94,16 @@ Provider-health source is independently fail-closed by:
 ```text
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
 ```
 
-The first guard locks the bounded process-local window. The second locks the platform metric names, bounded label vocabulary, registry wiring, reset-aware aggregation/freshness contract and the continued absence of Pages observed-health binding.
+The first guard locks the bounded process-local window. The second locks the platform metric names, bounded label vocabulary, registry wiring, reset-aware aggregation/freshness contract and the continued absence of Pages observed-health binding. The third locks the release source identity, build-info metric, complete expected-target inventory contract, fail-closed capture harness and continued non-promotion of Pages health.
 
 The Pages reference-consumer gate continues to list the plan-parity verifier as a required source guard.
 
 ## Execution boundary
 
-No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
+No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, deployment identity captures, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
 
 Suggested maintainer commands, intentionally not run:
 
@@ -103,6 +111,7 @@ Suggested maintainer commands, intentionally not run:
 node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
 ```
 
 All execution and acceptance evidence remains maintainer-owned.

--- a/scripts/evidence/capture-page-builder-provider-health-deployment-identity.mjs
+++ b/scripts/evidence/capture-page-builder-provider-health-deployment-identity.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+);
+const MAX_INVENTORY_BYTES = 1024 * 1024;
+const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+
+function fail(message) {
+  throw new Error(`Page Builder provider-health deployment identity capture failed: ${message}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      console.log(
+        "usage: capture-page-builder-provider-health-deployment-identity.mjs " +
+          "--inventory FILE --deployment-image-digest REPOSITORY@sha256:DIGEST " +
+          "[--source-commit SHA] [--output FILE]",
+      );
+      process.exit(0);
+    }
+    if (
+      ["--inventory", "--deployment-image-digest", "--source-commit", "--output"].includes(
+        argument,
+      )
+    ) {
+      const value = argv[index + 1];
+      if (!value) fail(`${argument} requires a value`);
+      const key = argument
+        .slice(2)
+        .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      options[key] = value;
+      index += 1;
+      continue;
+    }
+    fail(`unknown argument ${argument}`);
+  }
+  return options;
+}
+
+function requireCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
+    fail(`${label} must be a lowercase 40-character git commit`);
+  }
+  return value;
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell: false,
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) fail(`git HEAD lookup failed: ${result.error.message}`);
+  if (result.status !== 0) fail("git HEAD lookup returned a non-zero status");
+  return requireCommit(result.stdout.trim(), "git HEAD");
+}
+
+function requireDeploymentImageDigest(value) {
+  if (
+    typeof value !== "string" ||
+    value.length > 512 ||
+    /[\s\u0000-\u001f\u007f]/u.test(value) ||
+    value.includes("://")
+  ) {
+    fail("--deployment-image-digest must be a bounded Docker RepoDigest");
+  }
+  const parts = value.split("@");
+  if (
+    parts.length !== 2 ||
+    parts[0].length === 0 ||
+    !/^sha256:[0-9a-f]{64}$/u.test(parts[1])
+  ) {
+    fail("--deployment-image-digest must be REPOSITORY@sha256:DIGEST");
+  }
+  return value;
+}
+
+function requireBoundedIdentifier(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value) > 128 ||
+    !/^[A-Za-z0-9._:/-]+$/u.test(value)
+  ) {
+    fail(`${label} must be a bounded deployment identifier`);
+  }
+  return value;
+}
+
+function requireMetricsUrl(value, label) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail(`${label} must be an absolute HTTP(S) URL`);
+  }
+  if (
+    !["http:", "https:"].includes(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    fail(`${label} must be an HTTP(S) URL without credentials, query, or fragment`);
+  }
+  return parsed.href;
+}
+
+function regularJsonFile(inputPath, label, maximumBytes) {
+  const absolute = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(process.cwd(), inputPath);
+  if (!existsSync(absolute)) fail(`${label} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) {
+    fail(`${label} must be a regular non-symlink file`);
+  }
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > maximumBytes) {
+    fail(`${label} is outside the bounded size`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(absolute, "utf8"));
+  } catch (error) {
+    fail(`${label} must contain JSON: ${error.message}`);
+  }
+  return parsed;
+}
+
+function requireInventory(inputPath) {
+  const inventory = regularJsonFile(inputPath, "inventory", MAX_INVENTORY_BYTES);
+  if (inventory === null || typeof inventory !== "object" || Array.isArray(inventory)) {
+    fail("inventory must be a JSON object");
+  }
+  if (inventory.schema_version !== 1) fail("inventory schema_version must be 1");
+  const deploymentId = requireBoundedIdentifier(inventory.deployment_id, "deployment_id");
+  if (inventory.inventory_complete !== true) {
+    fail("inventory_complete must be true before deployment identity can be captured");
+  }
+  if (
+    !Array.isArray(inventory.targets) ||
+    inventory.targets.length === 0 ||
+    inventory.targets.length > 64
+  ) {
+    fail("inventory targets must contain between 1 and 64 expected targets");
+  }
+
+  const targetIds = new Set();
+  const metricsUrls = new Set();
+  const targets = inventory.targets.map((target, index) => {
+    if (target === null || typeof target !== "object" || Array.isArray(target)) {
+      fail(`targets[${index}] must be an object`);
+    }
+    const targetId = requireBoundedIdentifier(target.target_id, `targets[${index}].target_id`);
+    const metricsUrl = requireMetricsUrl(target.metrics_url, `targets[${index}].metrics_url`);
+    if (targetIds.has(targetId)) fail(`duplicate target_id ${targetId}`);
+    if (metricsUrls.has(metricsUrl)) fail(`duplicate metrics_url for target ${targetId}`);
+    targetIds.add(targetId);
+    metricsUrls.add(metricsUrl);
+    return { target_id: targetId, metrics_url: metricsUrl };
+  });
+
+  return { deployment_id: deploymentId, targets };
+}
+
+function boundedSecretEnvironment(name, maximumLength) {
+  const value = process.env[name];
+  if (value === undefined || value === "") return null;
+  if (value.length > maximumLength || /[\r\n\u0000]/u.test(value)) {
+    fail(`${name} is outside the bounded credential input`);
+  }
+  return value;
+}
+
+function requestHeaders(contract) {
+  const environmentNames = [];
+  const headers = {
+    accept: "text/plain",
+    "cache-control": "no-cache",
+    pragma: "no-cache",
+  };
+
+  const commonName = contract.capture.credential_environment.common_headers_json;
+  const common = process.env[commonName];
+  if (common) {
+    if (common.length > 16_384 || /[\u0000]/u.test(common)) {
+      fail(`${commonName} is outside the bounded common-header input`);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(common);
+    } catch (error) {
+      fail(`${commonName} must contain a JSON object: ${error.message}`);
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      fail(`${commonName} must contain a JSON object`);
+    }
+    for (const [headerName, headerValue] of Object.entries(parsed)) {
+      const normalized = headerName.toLowerCase();
+      if (!/^[a-z0-9!#$%&'*+.^_`|~-]+$/u.test(normalized)) {
+        fail(`${commonName} contains invalid header ${headerName}`);
+      }
+      if (["authorization", "cookie", "host", "content-length"].includes(normalized)) {
+        fail(`${commonName} must not contain credential or framing headers`);
+      }
+      if (
+        typeof headerValue !== "string" ||
+        headerValue.length > 4096 ||
+        /[\r\n\u0000]/u.test(headerValue)
+      ) {
+        fail(`${commonName}.${headerName} is outside the bounded header input`);
+      }
+      headers[normalized] = headerValue;
+    }
+    environmentNames.push(commonName);
+  }
+
+  const authorizationName = contract.capture.credential_environment.authorization;
+  const authorization = boundedSecretEnvironment(authorizationName, 8192);
+  if (authorization) {
+    headers.authorization = authorization;
+    environmentNames.push(authorizationName);
+  }
+
+  const cookieName = contract.capture.credential_environment.cookie;
+  const cookie = boundedSecretEnvironment(cookieName, 16_384);
+  if (cookie) {
+    headers.cookie = cookie;
+    environmentNames.push(cookieName);
+  }
+
+  return { headers, environment_names: [...new Set(environmentNames)].sort() };
+}
+
+function regularSourceHash(relativePath) {
+  const absolute = path.resolve(repoRoot, relativePath);
+  const relative = path.relative(repoRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail(`source file ${relativePath} escapes repository root`);
+  }
+  if (!existsSync(absolute)) fail(`source file ${relativePath} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) {
+    fail(`source file ${relativePath} must be a regular non-symlink file`);
+  }
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > MAX_SOURCE_BYTES) {
+    fail(`source file ${relativePath} is outside the bounded source size`);
+  }
+  return sha256(readFileSync(absolute));
+}
+
+function sourceHashes(contract) {
+  if (
+    !Array.isArray(contract.required_source_files) ||
+    contract.required_source_files.length === 0 ||
+    contract.required_source_files.length > 64
+  ) {
+    fail("required source-file set is outside the bounded contract");
+  }
+  return Object.fromEntries(
+    contract.required_source_files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]),
+  );
+}
+
+function requireBuildInfo(metricsBody, sourceCommit, targetId) {
+  const lines = metricsBody.toString("utf8").split(/\r?\n/u);
+  const matches = [];
+  const pattern =
+    /^rustok_page_builder_provider_build_info\{source_commit="([0-9A-Fa-f]{40})"\}\s+([^\s]+)(?:\s+\d+)?$/u;
+  for (const line of lines) {
+    const match = pattern.exec(line.trim());
+    if (!match) continue;
+    const value = Number(match[2]);
+    if (!Number.isFinite(value)) fail(`${targetId} build-info value is not finite`);
+    matches.push({ source_commit: match[1].toLowerCase(), value });
+  }
+  if (matches.length !== 1) {
+    fail(`${targetId} must expose exactly one Page Builder provider build-info series`);
+  }
+  if (matches[0].value !== 1) fail(`${targetId} build-info series must equal 1`);
+  if (matches[0].source_commit !== sourceCommit) {
+    fail(
+      `${targetId} reports source commit ${matches[0].source_commit}, expected ${sourceCommit}`,
+    );
+  }
+  return matches[0].source_commit;
+}
+
+async function captureTarget(target, contract, sourceCommit, credentials) {
+  let response;
+  try {
+    response = await fetch(target.metrics_url, {
+      method: "GET",
+      headers: credentials.headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(contract.capture.request_timeout_ms),
+    });
+  } catch (error) {
+    fail(`${target.target_id} metrics request failed: ${error.message}`);
+  }
+  if (response.status !== 200) {
+    fail(`${target.target_id} metrics request expected 200, got ${response.status}`);
+  }
+  const body = Buffer.from(await response.arrayBuffer());
+  if (body.byteLength <= 0 || body.byteLength > contract.capture.maximum_metrics_body_bytes) {
+    fail(`${target.target_id} metrics response is outside the bounded body size`);
+  }
+  const reportedSourceCommit = requireBuildInfo(body, sourceCommit, target.target_id);
+  return {
+    target_id: target.target_id,
+    metrics_url_bytes: Buffer.byteLength(target.metrics_url),
+    metrics_url_sha256: sha256(target.metrics_url),
+    raw_metrics_url_persisted: false,
+    status: response.status,
+    response_bytes: body.byteLength,
+    response_sha256: sha256(body),
+    raw_response_persisted: false,
+    reported_source_commit: reportedSourceCommit,
+    source_commit_verified_equal_checkout: true,
+  };
+}
+
+function outputPath(contract, requested) {
+  const candidate = requested ?? contract.capture.default_output;
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
+    fail("output path is invalid");
+  }
+  const absolute = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail("deployment identity output must remain inside repository target/");
+  }
+  return absolute;
+}
+
+function writeAtomic(location, document) {
+  mkdirSync(path.dirname(location), { recursive: true });
+  const temporary = `${location}.tmp-${process.pid}`;
+  rmSync(temporary, { force: true });
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+  renameSync(temporary, location);
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (!options.inventory) fail("--inventory is required");
+  if (!options.deploymentImageDigest) fail("--deployment-image-digest is required");
+
+  const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+  if (contract.status !== "source_ready_execution_pending") {
+    fail("deployment identity source contract must not claim execution before capture starts");
+  }
+
+  const head = currentCommit();
+  const sourceCommit = options.sourceCommit
+    ? requireCommit(options.sourceCommit, "--source-commit")
+    : head;
+  if (sourceCommit !== head) {
+    fail(`source commit ${sourceCommit} does not match git HEAD ${head}`);
+  }
+  const deploymentImageDigest = requireDeploymentImageDigest(options.deploymentImageDigest);
+  const inventory = requireInventory(options.inventory);
+  const credentials = requestHeaders(contract);
+  const output = outputPath(contract, options.output);
+  rmSync(output, { force: true });
+
+  const targetRecords = [];
+  for (const target of inventory.targets) {
+    targetRecords.push(await captureTarget(target, contract, sourceCommit, credentials));
+  }
+  if (targetRecords.length !== inventory.targets.length) {
+    fail("partial expected-target capture is forbidden");
+  }
+
+  writeAtomic(output, {
+    format: "page_builder_provider_health_deployment_identity_v1",
+    status: "deployment_identity_verified_health_evaluation_pending",
+    captured_at: new Date().toISOString(),
+    deployment: {
+      deployment_id: inventory.deployment_id,
+      deployment_image_digest: deploymentImageDigest,
+      source_commit: sourceCommit,
+      inventory_complete: true,
+      expected_target_count: inventory.targets.length,
+      verified_target_count: targetRecords.length,
+      origin_to_repo_digest_binding: "maintainer_reviewed_external_fact",
+      cryptographic_origin_to_repo_digest_binding: false,
+    },
+    expected_targets: targetRecords,
+    source_files: sourceHashes(contract),
+    credentials: {
+      environment_names: credentials.environment_names,
+      values_persisted: false,
+    },
+    privacy: {
+      raw_metrics_urls_persisted: false,
+      raw_metrics_responses_persisted: false,
+      credential_values_persisted: false,
+      tenant_page_revision_or_correlation_ids_persisted: false,
+    },
+    prometheus_backend_query_executed: false,
+    provider_health_snapshot_evaluated: false,
+    pages_provider_health_observed: false,
+    pages_reference_consumer_gate_accepted: false,
+    forum_wave_accepted: false,
+    ffa_promoted: false,
+    fba_promoted: false,
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder provider-health parity cursor after #3391.

#3391 made canonical Preview/Publish observations deployment-aggregatable and freshness-aware. This PR closes the next source-only identity gap by defining a fail-closed exact source/deployment identity + complete expected-target inventory contract without promoting provider health.

### Changes

- expose `rustok_page_builder_provider_build_info{source_commit="<sha>"} 1` from the platform telemetry registry when `RUSTOK_SOURCE_COMMIT` is canonical;
- reuse the existing release identity chain `github.sha -> OCI_REVISION -> RUSTOK_SOURCE_COMMIT` rather than introducing a second build identity;
- add a deployment identity source contract requiring:
  - exact checkout source SHA;
  - immutable `REPOSITORY@sha256:<digest>` supplied as deployment fact;
  - explicit `inventory_complete: true`;
  - 1..64 unique expected target ids and metrics URLs;
- add a capture harness that rejects missing/malformed build identity, redirects, partial target success, duplicate targets, and any target whose live build-info SHA differs from checkout `HEAD`;
- retain target URL/body hashes instead of raw metrics URLs/bodies and retain credential environment names only;
- add a fail-closed source verifier and a dated actualization packet;
- advance Pages/Page Builder plan parity.

## Provenance boundary

The target can prove its exact source SHA through `RUSTOK_SOURCE_COMMIT`. The final OCI RepoDigest only exists after image push, so this PR does **not** pretend that the process can derive or cryptographically prove its own RepoDigest. As in the existing Forum deployment-attestation flow, target/origin -> RepoDigest remains an explicit maintainer-reviewed external fact.

## Deliberate non-promotion

This PR does not execute deployment capture and does not evaluate SLO health. It does not bind raw metrics or identity packets into Pages.

Therefore:

- `provider_health_observed` remains `false`;
- Pages admin remains unobserved;
- the Pages reference-consumer gate remains unaccepted;
- Forum Wave remains blocked;
- FFA/FBA promotion remains unclaimed.

## Validation

Per maintainer instruction, tests/verifiers are intentionally not run by this implementation agent. No Cargo, Node verifier, formatting, build, metrics scrape, Prometheus query, GraphQL/HTTP, browser, workflow, CI or deployment capture was executed.

Suggested maintainer commands:

```bash
cargo test -p rustok-telemetry page_builder_provider
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
```

## Next source cursor

`process-local observation [source-ready] -> deployment metrics/freshness [source-ready] -> deployment identity + expected-target inventory contract [source-ready] -> live exact-target identity capture [maintainer execution pending] -> deployment health backend evaluator [open] -> Pages binding [blocked] -> runtime evidence -> observed-health acceptance`