### PR TITLE
feat(forum): batch category and topic export locales

### DIFF
--- a/crates/rustok-forum/src/services/category_locale_enumeration.rs
+++ b/crates/rustok-forum/src/services/category_locale_enumeration.rs
@@ -1,0 +1,77 @@
+impl CategoryService {
+    pub const MAX_FORUM_CATEGORY_LOCALE_ENUMERATION_IDS: usize = 512;
+
+    pub(crate) async fn available_locales_for_categories(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        category_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+
+        if tenant_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum category locale enumeration requires a non-nil tenant id".to_string(),
+            ));
+        }
+        if category_ids.len() > Self::MAX_FORUM_CATEGORY_LOCALE_ENUMERATION_IDS {
+            return Err(ForumError::Validation(format!(
+                "Forum category locale enumeration is limited to {} category IDs",
+                Self::MAX_FORUM_CATEGORY_LOCALE_ENUMERATION_IDS
+            )));
+        }
+        if category_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen = std::collections::BTreeSet::new();
+        for category_id in category_ids {
+            if category_id.is_nil() {
+                return Err(ForumError::Validation(
+                    "Forum category locale enumeration requires non-nil category IDs".to_string(),
+                ));
+            }
+            if !seen.insert(*category_id) {
+                return Err(ForumError::Validation(format!(
+                    "Forum category locale enumeration repeats category {category_id}"
+                )));
+            }
+        }
+
+        let existing = forum_category::Entity::find()
+            .filter(forum_category::Column::TenantId.eq(tenant_id))
+            .filter(forum_category::Column::Id.is_in(category_ids.to_vec()))
+            .all(&self.db)
+            .await?;
+        let existing_ids = existing
+            .into_iter()
+            .map(|category| category.id)
+            .collect::<std::collections::BTreeSet<_>>();
+        for category_id in category_ids {
+            if !existing_ids.contains(category_id) {
+                return Err(ForumError::CategoryNotFound(*category_id));
+            }
+        }
+
+        let mut translations_by_category = self
+            .load_translations_map_for_categories(tenant_id, category_ids)
+            .await?;
+        let mut result = Vec::with_capacity(category_ids.len());
+        for category_id in category_ids {
+            let translations = translations_by_category
+                .remove(category_id)
+                .unwrap_or_default();
+            let locales = available_locales_from(&translations, |translation| {
+                translation.locale.as_str()
+            });
+            if locales.is_empty() {
+                return Err(ForumError::Validation(format!(
+                    "Forum category {category_id} has no stored locale translation"
+                )));
+            }
+            result.push((*category_id, locales));
+        }
+
+        Ok(result)
+    }
+}

--- a/crates/rustok-forum/src/services/category_owner_locale_enumeration.rs
+++ b/crates/rustok-forum/src/services/category_owner_locale_enumeration.rs
@@ -1,0 +1,21 @@
+impl CategoryService {
+    pub const MAX_FORUM_CATEGORY_LOCALE_ENUMERATION_IDS: usize =
+        category::CategoryService::MAX_FORUM_CATEGORY_LOCALE_ENUMERATION_IDS;
+
+    pub async fn available_locales_for_categories(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        category_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        if security.is_public_read() {
+            return Err(ForumError::forbidden(
+                "Forum category locale enumeration requires an authenticated operator context",
+            ));
+        }
+        enforce_scope(&security, Resource::ForumCategories, Action::Manage)?;
+        self.inner
+            .available_locales_for_categories(tenant_id, security, category_ids)
+            .await
+    }
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -3,6 +3,7 @@
 mod bounded_compat;
 mod category {
     include!("category.rs");
+    include!("category_locale_enumeration.rs");
     include!("category_projection_owner.rs");
     include!("category_visibility_list.rs");
 }
@@ -26,7 +27,10 @@ mod category_lifecycle {
     include!("category_lifecycle_owner.rs");
 }
 mod category_moderation_audience;
-mod category_owner;
+mod category_owner {
+    include!("category_owner.rs");
+    include!("category_owner_locale_enumeration.rs");
+}
 mod category_policy;
 mod category_reply_create_audience;
 mod category_route;
@@ -99,6 +103,7 @@ pub mod subscription;
 #[allow(clippy::collapsible_if)]
 mod topic {
     include!("topic.rs");
+    include!("topic_locale_enumeration.rs");
     include!("topic_inline.rs");
     include!("topic_visibility_list.rs");
     include!("topic_widget_preview.rs");
@@ -115,7 +120,10 @@ mod topic_canonical_resolution;
 mod topic_route;
 mod topic_route_backfill;
 mod topic_create_audience_authorization;
-mod topic_facade;
+mod topic_facade {
+    include!("topic_facade.rs");
+    include!("topic_facade_locale_enumeration.rs");
+}
 mod topic_fork;
 mod topic_merge;
 mod topic_merge_audience_reconciliation;

--- a/crates/rustok-forum/src/services/topic_facade_locale_enumeration.rs
+++ b/crates/rustok-forum/src/services/topic_facade_locale_enumeration.rs
@@ -1,0 +1,21 @@
+impl TopicService {
+    pub const MAX_FORUM_TOPIC_LOCALE_ENUMERATION_IDS: usize =
+        super::topic::TopicService::MAX_FORUM_TOPIC_LOCALE_ENUMERATION_IDS;
+
+    pub async fn available_locales_for_topics(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        topic_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        if security.is_public_read() {
+            return Err(ForumError::forbidden(
+                "Forum topic locale enumeration requires an authenticated operator context",
+            ));
+        }
+        enforce_scope(&security, Resource::ForumTopics, Action::Manage)?;
+        self.inner
+            .available_locales_for_topics(tenant_id, security, topic_ids)
+            .await
+    }
+}

--- a/crates/rustok-forum/src/services/topic_locale_enumeration.rs
+++ b/crates/rustok-forum/src/services/topic_locale_enumeration.rs
@@ -1,0 +1,75 @@
+impl TopicService {
+    pub const MAX_FORUM_TOPIC_LOCALE_ENUMERATION_IDS: usize = 512;
+
+    pub(crate) async fn available_locales_for_topics(
+        &self,
+        tenant_id: Uuid,
+        security: SecurityContext,
+        topic_ids: &[Uuid],
+    ) -> ForumResult<Vec<(Uuid, Vec<String>)>> {
+        enforce_scope(&security, Resource::ForumTopics, Action::Manage)?;
+
+        if tenant_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum topic locale enumeration requires a non-nil tenant id".to_string(),
+            ));
+        }
+        if topic_ids.len() > Self::MAX_FORUM_TOPIC_LOCALE_ENUMERATION_IDS {
+            return Err(ForumError::Validation(format!(
+                "Forum topic locale enumeration is limited to {} topic IDs",
+                Self::MAX_FORUM_TOPIC_LOCALE_ENUMERATION_IDS
+            )));
+        }
+        if topic_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen = std::collections::BTreeSet::new();
+        for topic_id in topic_ids {
+            if topic_id.is_nil() {
+                return Err(ForumError::Validation(
+                    "Forum topic locale enumeration requires non-nil topic IDs".to_string(),
+                ));
+            }
+            if !seen.insert(*topic_id) {
+                return Err(ForumError::Validation(format!(
+                    "Forum topic locale enumeration repeats topic {topic_id}"
+                )));
+            }
+        }
+
+        let existing = forum_topic::Entity::find()
+            .filter(forum_topic::Column::TenantId.eq(tenant_id))
+            .filter(forum_topic::Column::Id.is_in(topic_ids.to_vec()))
+            .all(&self.db)
+            .await?;
+        let existing_ids = existing
+            .into_iter()
+            .map(|topic| topic.id)
+            .collect::<std::collections::BTreeSet<_>>();
+        for topic_id in topic_ids {
+            if !existing_ids.contains(topic_id) {
+                return Err(ForumError::TopicNotFound(*topic_id));
+            }
+        }
+
+        let mut translations_by_topic = self
+            .load_translations_map_for_topics(tenant_id, topic_ids)
+            .await?;
+        let mut result = Vec::with_capacity(topic_ids.len());
+        for topic_id in topic_ids {
+            let translations = translations_by_topic.remove(topic_id).unwrap_or_default();
+            let locales = available_locales_from(&translations, |translation| {
+                translation.locale.as_str()
+            });
+            if locales.is_empty() {
+                return Err(ForumError::Validation(format!(
+                    "Forum topic {topic_id} has no stored locale translation"
+                )));
+            }
+            result.push((*topic_id, locales));
+        }
+
+        Ok(result)
+    }
+}

--- a/docs/modules/forum-34-category-topic-locale-enumeration-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-category-topic-locale-enumeration-actualization-2026-08-09.md
@@ -1,0 +1,102 @@
+# FORUM-34G bounded category/topic locale enumeration actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34F are merged before this slice. 34E established manage-only exact stored-locale enumeration for replies; 34F added the bounded operator owner-reader that consumes explicit localized targets and delegates field mapping to the 34D export mapper.
+
+Fresh `main` for this slice is `22600b287fe01c2e30e5c5ce82137010032897c7`. The commits after 34F are Order and Page Builder only and do not overlap Forum import/export source.
+
+A recheck of `rustok-core` RBAC confirms that an effective `Manage` permission satisfies narrower actions for the same resource. Therefore the 34F owner reader's `*:manage` admission remains compatible with the downstream owner `Read` checks; no hidden `manage + read` contract correction is required.
+
+The canonical Forum implementation-plan ledger still labels `FORUM-34` as `planned` even though 34A-34F are merged. Safe synchronization of that large concurrently edited source remains open; this packet records the truthful FORUM-34G cursor without replacing a partial/truncated roadmap image.
+
+## Gap selected
+
+The next export planner needs exact locale identities for categories, topics and replies before constructing 34F localized targets. Replies already have a bounded batch API from 34E. Categories and topics exposed `available_locales` only as a side effect of full localized owner reads, which would force the planner to hydrate one full owner response per source ID and create avoidable N+1 work.
+
+34G closes that parity gap with dedicated bounded owner locale-enumeration APIs for categories and topics.
+
+## Public owner contracts
+
+`CategoryService` now exposes:
+
+- `MAX_FORUM_CATEGORY_LOCALE_ENUMERATION_IDS = 512`;
+- `available_locales_for_categories(tenant_id, security, category_ids)`.
+
+`TopicService` now exposes:
+
+- `MAX_FORUM_TOPIC_LOCALE_ENUMERATION_IDS = 512`;
+- `available_locales_for_topics(tenant_id, security, topic_ids)`.
+
+Both methods return `Vec<(Uuid, Vec<String>)>` in caller-supplied ID order. They are in-process owner APIs; this slice adds no GraphQL, REST, CLI, file-format or serde admission surface.
+
+## Admission and validation
+
+Both public facades:
+
+- reject `SecurityContext::public_read()`;
+- require the exact resource `Action::Manage` scope;
+- delegate with the same trusted tenant/security context.
+
+The raw owner storage methods repeat the `Manage` check and then fail closed on:
+
+- nil tenant IDs;
+- more than 512 IDs;
+- nil IDs;
+- duplicate IDs;
+- IDs not present in the requested tenant;
+- owner rows that have no stored localized rows.
+
+An empty ID batch returns an empty result without a storage query.
+
+## Exact stored-locale semantics
+
+Locale enumeration does not call `resolve_by_locale_with_fallback`, full `get`, list hydration, vote/subscription reads, taxonomy, custom-field resolution, visibility composition or canonical topic resolution.
+
+For each resource kind the storage path performs:
+
+1. one tenant-scoped bounded existence query for the complete requested ID set;
+2. one existing batched translation loader over the same tenant and IDs;
+3. `available_locales_from` over only the stored category/topic translation rows.
+
+The result therefore describes stored locale identities, not requested/effective fallback locales and not presentation eligibility.
+
+The locale API intentionally does not claim that an archived/deleted/otherwise non-presentable owner row is export-readable. A later 34F exact owner read still applies the public owner visibility/lifecycle boundary before producing an export fragment. 34G supplies planning facts only; it does not bypass owner eligibility.
+
+## N+1 boundary
+
+34G adds no per-ID owner `get`, `find_topic`, `find_category`, translation query or viewer-state hydration loop. Category and topic locale identities are each resolved with a bounded existence query plus the existing batched translation query.
+
+Together with 34E, all three current Forum export shapes now have bounded exact stored-locale discovery suitable for a later planner without introducing one full owner read per source ID merely to discover languages.
+
+## Ownership and non-goals
+
+34G adds no:
+
+- generic or Forum-only durable migration runner;
+- tenant-wide enumeration or checkpoint cursor;
+- export eligibility decision;
+- full owner response hydration;
+- persistence write;
+- import adapter;
+- durable receipt/replay/audit state;
+- external-user resolution;
+- revision/history, vote/reputation or attachment transfer;
+- Search rebuild orchestration;
+- transport or schema migration.
+
+## Next FORUM-34 cursor
+
+The next safe Forum-owned slice can compose the category/topic/reply locale-enumeration APIs into a bounded non-wire target planner that emits 34F `ForumExportReadBatch` values and rejects expansion beyond the 512 localized-target fragment bound. Tenant-wide enumeration, durable chunk cursors and replay/checkpoint ownership remain blocked on an admitted shared runner contract and explicit lifecycle/history scope.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-category-topic-locale-enumeration-source.mjs
+```

--- a/scripts/verify/verify-forum-category-topic-locale-enumeration-source.mjs
+++ b/scripts/verify/verify-forum-category-topic-locale-enumeration-source.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  services: "crates/rustok-forum/src/services/mod.rs",
+  categoryRaw: "crates/rustok-forum/src/services/category_locale_enumeration.rs",
+  categoryFacade: "crates/rustok-forum/src/services/category_owner_locale_enumeration.rs",
+  topicRaw: "crates/rustok-forum/src/services/topic_locale_enumeration.rs",
+  topicFacade: "crates/rustok-forum/src/services/topic_facade_locale_enumeration.rs",
+  replyFacade: "crates/rustok-forum/src/services/reply_facade.rs",
+  packet: "docs/modules/forum-34-category-topic-locale-enumeration-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(Object.entries(files).map(([key, path]) => [key, read(path)]));
+
+for (const marker of [
+  'include!("category_locale_enumeration.rs");',
+  'include!("category_owner_locale_enumeration.rs");',
+  'include!("topic_locale_enumeration.rs");',
+  'include!("topic_facade_locale_enumeration.rs");',
+]) need(source.services, marker, "services module graph");
+
+for (const [label, text, kind, entity, translationLoader] of [
+  ["category raw", source.categoryRaw, "CATEGORY", "forum_category", "load_translations_map_for_categories"],
+  ["topic raw", source.topicRaw, "TOPIC", "forum_topic", "load_translations_map_for_topics"],
+]) {
+  for (const marker of [
+    `MAX_FORUM_${kind}_LOCALE_ENUMERATION_IDS: usize = 512`,
+    "pub(crate) async fn available_locales_for_",
+    "Action::Manage",
+    "tenant_id.is_nil()",
+    ".is_nil()",
+    "!seen.insert(*",
+    `${entity}::Entity::find()`,
+    `${entity}::Column::TenantId.eq(tenant_id)`,
+    `${entity}::Column::Id.is_in(",
+    translationLoader,
+    "available_locales_from(",
+    "has no stored locale translation",
+    "result.push((*",
+  ]) need(text, marker, label);
+
+  for (const marker of [
+    "resolve_by_locale_with_fallback",
+    ".get_with_locale_fallback(",
+    ".get(",
+    "VoteService",
+    "SubscriptionService",
+    "TaxonomyService",
+    "Serialize",
+    "Deserialize",
+  ]) forbid(text, marker, label);
+
+  const existenceQueries = text.split("::Entity::find()").length - 1;
+  if (existenceQueries !== 1) {
+    throw new Error(`${label}: expected one direct existence query, found ${existenceQueries}`);
+  }
+}
+
+for (const [label, text, kind, method] of [
+  ["category facade", source.categoryFacade, "CATEGORY", "available_locales_for_categories"],
+  ["topic facade", source.topicFacade, "TOPIC", "available_locales_for_topics"],
+]) {
+  for (const marker of [
+    `MAX_FORUM_${kind}_LOCALE_ENUMERATION_IDS`,
+    `pub async fn ${method}(`,
+    "security.is_public_read()",
+    "authenticated operator context",
+    "Action::Manage",
+    `.${method}(`,
+  ]) need(text, marker, label);
+  for (const marker of ["sea_orm", "crate::entities", "::Entity::find()", "Serialize", "Deserialize"]) {
+    forbid(text, marker, label);
+  }
+}
+
+for (const marker of [
+  "pub async fn available_locales_for_replies(",
+  "MAX_FORUM_REPLY_LOCALE_ENUMERATION_IDS",
+  "Action::Manage",
+]) need(source.replyFacade, marker, "reply parity baseline");
+
+for (const marker of [
+  "FORUM-34G",
+  "FORUM-34A through FORUM-34F",
+  "effective `Manage` permission satisfies narrower actions",
+  "still labels `FORUM-34` as `planned`",
+  "more than 512 IDs",
+  "one tenant-scoped bounded existence query",
+  "one existing batched translation loader",
+  "does not claim that an archived/deleted/otherwise non-presentable owner row is export-readable",
+  "no per-ID owner `get`",
+  "all three current Forum export shapes",
+  "next safe Forum-owned slice can compose",
+  "no tests, Cargo commands",
+]) need(source.packet, marker, "FORUM-34G packet");
+
+console.log("Forum FORUM-34G category/topic locale enumeration source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with bounded exact stored-locale enumeration parity for categories and topics, matching the reply API added in 34E and preparing the next export target-planner slice.

- add `CategoryService::available_locales_for_categories` with a 512-ID cap;
- add `TopicService::available_locales_for_topics` with a 512-ID cap;
- reject public-read contexts and require the corresponding `*:manage` scope at the public owner boundary;
- repeat manage admission in raw owner storage before queries;
- reject nil tenant IDs, nil/duplicate IDs, missing tenant-owned rows, and owner rows without stored localized records;
- preserve caller-supplied ID order;
- use one bounded tenant-scoped existence query plus the existing batched translation loader per resource kind;
- derive only exact stored locale identities with `available_locales_from`, without fallback resolution, full owner hydration, votes/subscriptions, taxonomy/custom-field resolution, or canonical topic redirect;
- keep locale discovery separate from export eligibility: archived/deleted/non-presentable rows are not claimed export-readable until the later 34F exact owner read succeeds;
- add a dated FORUM-34G actualization packet and source-only verifier.

## Recheck

The branch is based on current `main` at `22600b287fe01c2e30e5c5ce82137010032897c7`; intervening work after #3393 is Order/Page Builder only and does not overlap Forum import/export source.

A recheck of `rustok-core` RBAC confirms that `Manage` is treated as an effective permission for narrower actions on the same resource, so 34F's manage-only contract is compatible with downstream owner `Read` checks and does not need correction.

The canonical Forum implementation plan still incorrectly labels `FORUM-34` as `planned`. The dated 34G packet records the truthful cursor; safe synchronization of the large concurrently edited canonical plan remains open rather than replacing a partial/truncated roadmap image.

## Non-goals

No tenant-wide enumeration, durable runner, checkpoint/receipt/replay/audit state, import write adapter, identity resolution, history/vote/reputation/attachment transfer, Search rebuild orchestration, GraphQL/REST/CLI transport, migration or schema change is added here. The next safe slice can compose category/topic/reply locale facts into bounded 34F localized targets.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, DB scenario, workflow, CI command, lock generation, or `git diff --check` was run. Maintainer will run tests.