### PR TITLE
feat(commerce): route GraphQL post-order writes through owner port

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -118,6 +118,30 @@ pub fn attach_commerce_provider_registries(
         }
     };
 
+    #[cfg(all(feature = "mod-commerce", feature = "mod-order"))]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_order::OrderPostOrderCommandRuntime>()
+            .or_else(|| server.shared_get::<rustok_order::OrderPostOrderCommandRuntime>())
+            .or_else(|| {
+                server
+                    .shared_get::<rustok_outbox::TransactionalEventBus>()
+                    .map(|event_bus| {
+                        rustok_order::OrderPostOrderCommandRuntime::in_process(
+                            server.db_clone(),
+                            event_bus,
+                        )
+                    })
+            });
+        match runtime {
+            Some(runtime) => {
+                server.shared_insert(runtime.clone());
+                host.with_shared_value(runtime)
+            }
+            None => host,
+        }
+    };
+
     #[cfg(all(feature = "mod-commerce", feature = "mod-payment"))]
     let host = {
         let runtime = host

--- a/crates/rustok-commerce/docs/graphql-post-order-command-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-post-order-command-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,70 @@
+# Commerce GraphQL post-order command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+This slice continues the canonical ecommerce standalone/topology P0 after Order published
+`OrderPostOrderCommandPort` / `OrderPostOrderCommandRuntime` in #3394.
+
+Mounted Commerce GraphQL now routes the five owner-local Order return/change writes through the
+Order-owned post-order command port:
+
+- `createStorefrontOrderReturn`;
+- `createOrderChange`;
+- `cancelOrderChange`;
+- `createOrderReturn`;
+- `cancelOrderReturn`.
+
+The storefront path preserves the existing channel gate and `ensure_storefront_order_access`
+ownership check before admitting the write. Admin paths preserve `ORDERS_UPDATE` admission and
+current tenant scope.
+
+## Runtime composition
+
+`apps/server` now composes `OrderPostOrderCommandRuntime` into the shared host runtime, preserving an
+externally supplied runtime when present and otherwise using the Order-owned in-process adapter.
+
+`CommerceGraphqlRuntimeData` requires the host-selected runtime for mounted schemas. Only directly
+embedded compatibility schemas without mounted runtime data may construct the explicit
+Order-owned in-process fallback.
+
+## Request and error boundary
+
+The GraphQL boundary derives tenant, authenticated actor, locale, and channel from trusted request
+context, applies a two-second owner-call deadline, and supplies a request-scoped idempotency key.
+This slice does **not** claim durable create replay receipts; that remains separate Order-owned work.
+
+Owner `PortError` values are mapped to the existing bounded GraphQL Order families:
+
+- `ORDER_REQUEST_INVALID`;
+- `ORDER_RESOURCE_NOT_FOUND`;
+- `ORDER_STATE_CONFLICT`;
+- `ORDER_TEMPORARILY_UNAVAILABLE`;
+- `ORDER_OPERATION_FAILED`.
+
+Diagnostics record bounded owner/error facts and do not expose raw owner messages or backend/core
+causes.
+
+## Deliberately unchanged
+
+Cross-domain post-order flows remain Commerce orchestration:
+
+- `applyOrderChange`;
+- `createOrderReturnDecision`;
+- `completeOrderReturn`.
+
+They coordinate payment/refund effects and are not owner-local Order writes.
+
+The broad implementation-plan item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and
+Fulfillment concrete services behind host-composed owner ports` remains open. This cutover does not
+claim all remaining concrete-service construction is gone; storefront access/read helpers and other
+separately scoped topology work still require follow-up.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL
+scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios
+were executed for this slice. The accompanying verifier is source-only evidence for maintainer
+execution.

--- a/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
@@ -5,9 +5,13 @@ use rustok_api::{
     graphql::{GraphQLError, require_module_enabled},
 };
 use rustok_order::{
+    CancelOrderChangeRequest as OwnerCancelOrderChangeRequest,
     CancelOrderRequest as OwnerCancelOrderRequest,
+    CancelOrderReturnRequest as OwnerCancelOrderReturnRequest,
+    CreateOrderChangeRequest as OwnerCreateOrderChangeRequest,
+    CreateOrderReturnRequest as OwnerCreateOrderReturnRequest,
     DeliverOrderRequest as OwnerDeliverOrderRequest,
-    MarkOrderPaidRequest as OwnerMarkOrderPaidRequest, OrderError, OrderService,
+    MarkOrderPaidRequest as OwnerMarkOrderPaidRequest, OrderError,
     ShipOrderRequest as OwnerShipOrderRequest,
 };
 use rustok_payment::error::PaymentError;
@@ -15,7 +19,8 @@ use uuid::Uuid;
 
 use crate::graphql_runtime::{
     order_admin_command_runtime_from_context, order_change_orchestration_from_context,
-    post_order_orchestration_from_context, return_completion_orchestration_from_context,
+    order_post_order_command_runtime_from_context, post_order_orchestration_from_context,
+    return_completion_orchestration_from_context,
 };
 use crate::{PaymentOrchestrationError, PostOrderOrchestrationError};
 
@@ -156,23 +161,6 @@ fn payment_orchestration_error_envelope(
     }
 }
 
-fn order_mutation_graphql_error(
-    tenant_id: Uuid,
-    resource_id: Uuid,
-    operation: &'static str,
-    error: OrderError,
-) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        resource_id = %resource_id,
-        operation,
-        "commerce GraphQL fulfillment order mutation failed"
-    );
-    let (message, code, retryable) = order_error_envelope(&error);
-    public_fulfillment_graphql_error(message, code, retryable)
-}
-
 fn order_owner_graphql_error(
     tenant_id: Uuid,
     resource_id: Uuid,
@@ -194,6 +182,31 @@ fn order_owner_graphql_error(
         retryable,
         boundary = "commerce_graphql_order_command",
         "commerce GraphQL order owner command failed"
+    );
+    public_fulfillment_graphql_error(message, code, retryable)
+}
+
+fn post_order_owner_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) = order_port_error_envelope(&error);
+    tracing::error!(
+        owner = "rustok_order.post_order_command",
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
+        operation,
+        correlation_id = %context.correlation_id,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_post_order_command",
+        "commerce GraphQL post-order owner command failed"
     );
     public_fulfillment_graphql_error(message, code, retryable)
 }
@@ -253,6 +266,32 @@ fn order_command_context(
     })
 }
 
+fn order_post_order_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-post-order-command:{operation}:{resource_id}"),
+    )
+    .with_idempotency_key(Uuid::new_v4().to_string())
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
+
 #[derive(Default)]
 pub struct CommerceFulfillmentMutation;
 
@@ -274,14 +313,31 @@ impl CommerceFulfillmentMutation {
 
         ensure_storefront_order_access(db, event_bus, tenant_id, ctx, order_id).await?;
 
-        let item = OrderService::new(db.clone(), event_bus.clone())
-            .create_return(tenant_id, order_id, build_create_order_return_input(input)?)
+        let owner_input = build_create_order_return_input(input)?;
+        let runtime =
+            order_post_order_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_post_order_command_context(
+            ctx,
+            tenant_id,
+            order_id,
+            "create_storefront_order_return",
+        )?;
+        let item = runtime
+            .command_port()
+            .create_return(
+                context.clone(),
+                OwnerCreateOrderReturnRequest {
+                    order_id,
+                    input: owner_input,
+                },
+            )
             .await
             .map_err(|error| {
-                order_mutation_graphql_error(
+                post_order_owner_graphql_error(
                     tenant_id,
                     order_id,
                     "create_storefront_order_return",
+                    &context,
                     error,
                 )
             })?;
@@ -457,7 +513,7 @@ impl CommerceFulfillmentMutation {
         input: CreateOrderChangeInputObject,
     ) -> Result<GqlOrderChange> {
         require_module_enabled(ctx, MODULE_SLUG).await?;
-        let auth = require_commerce_permission(
+        require_commerce_permission(
             ctx,
             &[Permission::ORDERS_UPDATE],
             "Permission denied: orders:update required",
@@ -466,14 +522,30 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let item = OrderService::new(db.clone(), event_bus.clone())
-            .create_order_change(
-                tenant_id,
-                auth.user_id,
-                order_id,
-                build_create_order_change_input(input)?,
+        let owner_input = build_create_order_change_input(input)?;
+        let runtime =
+            order_post_order_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context =
+            order_post_order_command_context(ctx, tenant_id, order_id, "create_order_change")?;
+        let item = runtime
+            .command_port()
+            .create_change(
+                context.clone(),
+                OwnerCreateOrderChangeRequest {
+                    order_id,
+                    input: owner_input,
+                },
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                post_order_owner_graphql_error(
+                    tenant_id,
+                    order_id,
+                    "create_order_change",
+                    &context,
+                    error,
+                )
+            })?;
 
         Ok(item.into())
     }
@@ -534,16 +606,32 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let item = OrderService::new(db.clone(), event_bus.clone())
-            .cancel_order_change(
-                tenant_id,
-                id,
-                crate::dto::CancelOrderChangeInput {
-                    reason: input.reason,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        let owner_input = rustok_order::CancelOrderChangeInput {
+            reason: input.reason,
+            metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        };
+        let runtime =
+            order_post_order_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_post_order_command_context(ctx, tenant_id, id, "cancel_order_change")?;
+        let item = runtime
+            .command_port()
+            .cancel_change(
+                context.clone(),
+                OwnerCancelOrderChangeRequest {
+                    change_id: id,
+                    input: owner_input,
                 },
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                post_order_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "cancel_order_change",
+                    &context,
+                    error,
+                )
+            })?;
 
         Ok(item.into())
     }
@@ -565,9 +653,30 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let item = OrderService::new(db.clone(), event_bus.clone())
-            .create_return(tenant_id, order_id, build_create_order_return_input(input)?)
-            .await?;
+        let owner_input = build_create_order_return_input(input)?;
+        let runtime =
+            order_post_order_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context =
+            order_post_order_command_context(ctx, tenant_id, order_id, "create_order_return")?;
+        let item = runtime
+            .command_port()
+            .create_return(
+                context.clone(),
+                OwnerCreateOrderReturnRequest {
+                    order_id,
+                    input: owner_input,
+                },
+            )
+            .await
+            .map_err(|error| {
+                post_order_owner_graphql_error(
+                    tenant_id,
+                    order_id,
+                    "create_order_return",
+                    &context,
+                    error,
+                )
+            })?;
 
         Ok(item.into())
     }
@@ -712,16 +821,32 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
-        let item = OrderService::new(db.clone(), event_bus.clone())
+        let owner_input = rustok_order::CancelOrderReturnInput {
+            reason: input.reason,
+            metadata: parse_optional_metadata(input.metadata.as_deref())?,
+        };
+        let runtime =
+            order_post_order_command_runtime_from_context(ctx, db.clone(), event_bus.clone());
+        let context = order_post_order_command_context(ctx, tenant_id, id, "cancel_order_return")?;
+        let item = runtime
+            .command_port()
             .cancel_return(
-                tenant_id,
-                id,
-                crate::dto::CancelOrderReturnInput {
-                    reason: input.reason,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
+                context.clone(),
+                OwnerCancelOrderReturnRequest {
+                    return_id: id,
+                    input: owner_input,
                 },
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                post_order_owner_graphql_error(
+                    tenant_id,
+                    id,
+                    "cancel_order_return",
+                    &context,
+                    error,
+                )
+            })?;
 
         Ok(item.into())
     }

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -11,7 +11,10 @@ use rustok_fulfillment::{
     in_process_fulfillment_read_port, in_process_shipping_option_admin_read_port,
     in_process_shipping_option_read_port,
 };
-use rustok_order::{OrderAdminCommandRuntime, OrderReadPort, in_process_order_read_port};
+use rustok_order::{
+    OrderAdminCommandRuntime, OrderPostOrderCommandRuntime, OrderReadPort,
+    in_process_order_read_port,
+};
 use rustok_payment::providers::PaymentProviderRegistry;
 use rustok_product::{ProductCatalogCommandRuntime, ProductCatalogReadRuntime};
 use sea_orm::DatabaseConnection;
@@ -348,6 +351,7 @@ pub struct CommerceGraphqlRuntimeData {
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
     order_admin_command_runtime: OrderAdminCommandRuntime,
+    order_post_order_command_runtime: OrderPostOrderCommandRuntime,
     product_catalog_read_runtime: ProductCatalogReadRuntime,
     product_catalog_command_runtime: ProductCatalogCommandRuntime,
 }
@@ -392,6 +396,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn order_admin_command_runtime(&self) -> OrderAdminCommandRuntime {
         self.order_admin_command_runtime.clone()
+    }
+
+    pub fn order_post_order_command_runtime(&self) -> OrderPostOrderCommandRuntime {
+        self.order_post_order_command_runtime.clone()
     }
 
     pub fn product_catalog_read_runtime(&self) -> ProductCatalogReadRuntime {
@@ -469,6 +477,12 @@ pub fn attach_schema_data(
             .ok_or_else(|| {
                 "commerce GraphQL requires OrderAdminCommandRuntime in host composition".to_string()
             })?,
+        order_post_order_command_runtime: inputs
+            .shared_get::<OrderPostOrderCommandRuntime>()
+            .ok_or_else(|| {
+                "commerce GraphQL requires OrderPostOrderCommandRuntime in host composition"
+                    .to_string()
+            })?,
         product_catalog_read_runtime: inputs
             .shared_get::<ProductCatalogReadRuntime>()
             .ok_or_else(|| {
@@ -527,6 +541,16 @@ pub(crate) fn order_admin_command_runtime_from_context(
     ctx.data_opt::<CommerceGraphqlRuntimeData>()
         .map(CommerceGraphqlRuntimeData::order_admin_command_runtime)
         .unwrap_or_else(|| OrderAdminCommandRuntime::in_process(db, event_bus))
+}
+
+pub(crate) fn order_post_order_command_runtime_from_context(
+    ctx: &Context<'_>,
+    db: DatabaseConnection,
+    event_bus: rustok_outbox::TransactionalEventBus,
+) -> OrderPostOrderCommandRuntime {
+    ctx.data_opt::<CommerceGraphqlRuntimeData>()
+        .map(CommerceGraphqlRuntimeData::order_post_order_command_runtime)
+        .unwrap_or_else(|| OrderPostOrderCommandRuntime::in_process(db, event_bus))
 }
 
 pub(crate) fn manual_fulfillment_owner_orchestration_from_context(

--- a/scripts/verify/verify-commerce-graphql-post-order-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-post-order-command-owner-port-cutover.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+const expect = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+const mutationPath = 'crates/rustok-commerce/src/graphql/mutations/fulfillment.rs';
+const runtimePath = 'crates/rustok-commerce/src/graphql_runtime.rs';
+const hostPath = 'apps/server/src/services/commerce_provider_runtime.rs';
+const ownerPath = 'crates/rustok-order/src/post_order_command.rs';
+const planPath = 'crates/rustok-commerce/docs/implementation-plan.md';
+const recordPath =
+  'crates/rustok-commerce/docs/graphql-post-order-command-owner-port-cutover-2026-08-09.md';
+
+const mutations = read(mutationPath);
+const runtime = read(runtimePath);
+const host = read(hostPath);
+const owner = read(ownerPath);
+const plan = read(planPath);
+const record = read(recordPath);
+
+const body = (name) => {
+  const start = mutations.indexOf(`async fn ${name}(`);
+  expect(start >= 0, `missing GraphQL mutation ${name}`);
+  const next = mutations.indexOf('\n    async fn ', start + 1);
+  return mutations.slice(start, next >= 0 ? next : mutations.length);
+};
+
+expect(owner.includes('pub trait OrderPostOrderCommandPort'), 'owner post-order port is missing');
+expect(owner.includes('pub struct OrderPostOrderCommandRuntime'), 'owner post-order runtime is missing');
+expect(
+  runtime.includes('order_post_order_command_runtime: OrderPostOrderCommandRuntime'),
+  'Commerce GraphQL runtime data does not carry the post-order runtime',
+);
+expect(
+  runtime.includes('shared_get::<OrderPostOrderCommandRuntime>()'),
+  'mounted schema does not require host-selected post-order runtime',
+);
+expect(
+  runtime.includes('order_post_order_command_runtime_from_context'),
+  'GraphQL compatibility runtime helper is missing',
+);
+expect(
+  host.includes('shared_get::<rustok_order::OrderPostOrderCommandRuntime>()'),
+  'server host does not preserve a supplied post-order runtime',
+);
+expect(
+  host.includes('rustok_order::OrderPostOrderCommandRuntime::in_process'),
+  'server host does not compose the Order-owned in-process fallback',
+);
+
+const storefrontCreate = body('create_storefront_order_return');
+const createChange = body('create_order_change');
+const cancelChange = body('cancel_order_change');
+const createReturn = body('create_order_return');
+const cancelReturn = body('cancel_order_return');
+
+for (const [name, source] of [
+  ['create_storefront_order_return', storefrontCreate],
+  ['create_order_change', createChange],
+  ['cancel_order_change', cancelChange],
+  ['create_order_return', createReturn],
+  ['cancel_order_return', cancelReturn],
+]) {
+  expect(
+    source.includes('order_post_order_command_runtime_from_context'),
+    `${name} does not resolve the owner runtime`,
+  );
+  expect(!source.includes('OrderService::new'), `${name} still constructs OrderService`);
+  expect(
+    source.includes('post_order_owner_graphql_error'),
+    `${name} does not use the bounded owner error envelope`,
+  );
+}
+
+expect(storefrontCreate.includes('ensure_storefront_order_access'), 'storefront ownership gate was removed');
+expect(storefrontCreate.includes('.create_return('), 'storefront return is not routed through owner create_return');
+expect(createChange.includes('.create_change('), 'order change create is not routed through owner port');
+expect(cancelChange.includes('.cancel_change('), 'order change cancel is not routed through owner port');
+expect(createReturn.includes('.create_return('), 'order return create is not routed through owner port');
+expect(cancelReturn.includes('.cancel_return('), 'order return cancel is not routed through owner port');
+
+expect(
+  body('apply_order_change').includes('order_change_orchestration_from_context'),
+  'cross-domain order-change orchestration was unexpectedly removed',
+);
+expect(
+  body('create_order_return_decision').includes('post_order_orchestration_from_context'),
+  'return-decision orchestration was unexpectedly removed',
+);
+expect(
+  body('complete_order_return').includes('return_completion_orchestration_from_context'),
+  'return-completion orchestration was unexpectedly removed',
+);
+
+expect(
+  mutations.includes('owner_code_length = error.code.chars().count()'),
+  'bounded owner diagnostic code-length marker is missing',
+);
+expect(
+  !mutations.includes('owner_message = %error.message'),
+  'raw owner message leaked into GraphQL diagnostics',
+);
+expect(
+  plan.includes('- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,'),
+  'broad ecommerce topology P0 was closed prematurely',
+);
+expect(record.includes('Status: `source_complete_unvalidated`'), 'source record status is not truthful');
+expect(record.includes('no tests, Cargo commands, Node verifiers'), 'source record does not state validation was skipped');
+
+console.log('commerce GraphQL post-order owner-port source guard passed');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce standalone/topology P0 after Order published `OrderPostOrderCommandPort` / `OrderPostOrderCommandRuntime` in #3394.

- host-compose `OrderPostOrderCommandRuntime` in `apps/server`, preserving an externally supplied runtime and otherwise using the Order-owned in-process adapter;
- require the host-selected runtime in mounted `CommerceGraphqlRuntimeData`, with an explicit in-process fallback only for embedded compatibility schemas without mounted runtime data;
- route `createStorefrontOrderReturn`, `createOrderChange`, `cancelOrderChange`, `createOrderReturn`, and `cancelOrderReturn` through `OrderPostOrderCommandPort`;
- preserve storefront channel/access admission, admin `ORDERS_UPDATE` admission, tenant scope, authenticated actor, locale/channel context, and a bounded owner-call deadline;
- map owner `PortError` values to bounded existing GraphQL Order error families without leaking raw owner/backend messages;
- leave cross-domain `applyOrderChange`, return decision, and return completion on Commerce orchestration because they coordinate payment/refund effects;
- add a source-only verifier and dated source record;
- keep durable create replay receipts and the broad mounted concrete-service topology P0 open.

## Source recheck

After #3394, the five owner-local return/change GraphQL writes still constructed `OrderService` directly. The new Order post-order runtime now provides the exact create/cancel boundary needed by those consumers. The canonical implementation-plan item `Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports` remains unchecked because other separately scoped concrete-service paths and verification work remain.

The branch was refreshed onto current `main` (`bd4ec22aeae1f85033d41aa97b52da7ddc630fad`) after unrelated Forum #3397 landed. It is one commit ahead and zero behind.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, mounted GraphQL scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios were executed. The added verifier is source-only evidence for maintainer execution.