### PR TITLE
feat(page-builder): evaluate deployment-bound provider health

### DIFF
--- a/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json
@@ -78,6 +78,8 @@
     "counter_reset_aware_function": "increase",
     "histogram_quantile": 0.95,
     "histogram_aggregation": "sum cumulative bucket increases across identity-admitted targets before quantile evaluation",
+    "histogram_completion_population_must_match": true,
+    "population_consistency_tolerance_fraction": 0.000001,
     "minimum_preview_samples": 20,
     "minimum_publish_samples": 20,
     "sample_floor_failure": "fail_closed",
@@ -111,6 +113,7 @@
     "target_selector_sha256_retained": true,
     "source_commit_retained": true,
     "deployment_image_digest_retained": true,
+    "completion_and_histogram_sample_counts_retained": true,
     "provider_health_snapshot_retained": true,
     "slo_evaluation_retained": true
   },

--- a/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json
@@ -1,0 +1,145 @@
+{
+  "format": "page_builder_provider_health_deployment_evaluator_source_v1",
+  "status": "source_ready_execution_pending",
+  "provider": "page_builder",
+  "predecessors": [
+    "page_builder_provider_health_deployment_metrics_source_v1",
+    "page_builder_provider_health_deployment_identity_source_v1"
+  ],
+  "identity_input": {
+    "format": "page_builder_provider_health_deployment_identity_v1",
+    "required_status": "deployment_identity_verified_health_evaluation_pending",
+    "source_commit_must_equal_checkout_head": true,
+    "inventory_complete_must_be_true": true,
+    "expected_target_count_must_equal_verified_target_count": true,
+    "deployment_image_digest_retained_as_maintainer_reviewed_external_fact": true
+  },
+  "backend_target_map": {
+    "schema_version": 1,
+    "authority": "maintainer_supplied_complete_prometheus_target_mapping",
+    "deployment_id_must_equal_identity_packet": true,
+    "inventory_complete_must_be_true": true,
+    "target_id_set_must_equal_identity_packet": true,
+    "target_label_name": "operator_selected_exact_match_label",
+    "target_label_values_unique": true,
+    "common_exact_matchers_allowed": true,
+    "common_exact_matchers_maximum": 8,
+    "reserved_matcher_labels": [
+      "__name__",
+      "source_commit",
+      "operation",
+      "outcome",
+      "le"
+    ],
+    "regex_matchers_allowed": false,
+    "raw_matcher_values_retained": false
+  },
+  "backend_query": {
+    "runner": "scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs",
+    "prometheus_api": "/api/v1/query",
+    "request_method": "POST",
+    "redirects_followed": false,
+    "request_timeout_ms": 30000,
+    "maximum_response_bytes": 2097152,
+    "maximum_parallel_queries": 8,
+    "query_window_seconds_minimum": 300,
+    "query_window_seconds_maximum": 86400,
+    "freshness_seconds_minimum": 60,
+    "freshness_must_not_exceed_query_window": true,
+    "identity_capture_must_predate_entire_query_window": true,
+    "identity_capture_maximum_age_seconds": 86400,
+    "backend_clock_source": "prometheus_time_function",
+    "credential_environment": {
+      "common_headers_json": "RUSTOK_PAGE_BUILDER_PROVIDER_HEALTH_PROMETHEUS_HEADERS_JSON",
+      "authorization": "RUSTOK_PAGE_BUILDER_PROVIDER_HEALTH_PROMETHEUS_AUTHORIZATION",
+      "cookie": "RUSTOK_PAGE_BUILDER_PROVIDER_HEALTH_PROMETHEUS_COOKIE"
+    }
+  },
+  "source_admission": {
+    "current_build_info_required_per_target": true,
+    "current_build_info_source_commit_must_equal_identity": true,
+    "current_backend_series_identity_must_be_unique_per_target": true,
+    "expected_source_build_info_must_exist_in_entire_query_window": true,
+    "unexpected_source_build_info_in_query_window": "fail_closed",
+    "partial_target_query_success": "fail_closed"
+  },
+  "freshness_admission": {
+    "preview_required_per_target": true,
+    "publish_required_per_target": true,
+    "missing_operation_freshness": "fail_closed",
+    "stale_operation_freshness": "fail_closed",
+    "future_operation_timestamp_tolerance_seconds": 5
+  },
+  "aggregation": {
+    "duration_series": "rustok_page_builder_provider_operation_duration_seconds_bucket",
+    "completion_series": "rustok_page_builder_provider_operation_completed_total",
+    "freshness_series": "rustok_page_builder_provider_last_observation_unix_seconds",
+    "build_info_series": "rustok_page_builder_provider_build_info",
+    "counter_reset_aware_function": "increase",
+    "histogram_quantile": 0.95,
+    "histogram_aggregation": "sum cumulative bucket increases across identity-admitted targets before quantile evaluation",
+    "minimum_preview_samples": 20,
+    "minimum_publish_samples": 20,
+    "sample_floor_failure": "fail_closed",
+    "sanitize_failure_rate_denominator": "all publish terminal completions",
+    "runtime_error_rate_denominator": "all preview plus publish terminal completions",
+    "unknown_operation_or_outcome": "fail_closed",
+    "non_finite_or_negative_backend_value": "fail_closed"
+  },
+  "provider_health_policy": {
+    "preview_p95_ms_max": 1500,
+    "publish_p95_ms_max": 3000,
+    "sanitize_failure_rate_max": 0.01,
+    "runtime_error_rate_max": 0.01,
+    "unavailable_runtime_error_multiplier": 2.0,
+    "degradation_reasons": [
+      "provider_unhealthy",
+      "sanitize_backpressure",
+      "publish_backlog"
+    ],
+    "must_match_rust_provider_health_snapshot_evaluate": true
+  },
+  "output": {
+    "format": "page_builder_provider_health_deployment_evaluation_v1",
+    "status": "deployment_health_evaluated_pages_binding_pending",
+    "default_path": "target/page-builder-provider-health-deployment-evaluation.json",
+    "atomic_replace": true,
+    "raw_prometheus_url_retained": false,
+    "raw_promql_retained": false,
+    "raw_backend_responses_retained": false,
+    "raw_target_matcher_values_retained": false,
+    "target_selector_sha256_retained": true,
+    "source_commit_retained": true,
+    "deployment_image_digest_retained": true,
+    "provider_health_snapshot_retained": true,
+    "slo_evaluation_retained": true
+  },
+  "non_claims": {
+    "runtime_evaluation_executed": false,
+    "deployment_identity_capture_executed_by_this_slice": false,
+    "pages_provider_health_observed": false,
+    "pages_reference_consumer_gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "tests_run": false,
+    "static_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "workflow_or_ci_run": false
+  },
+  "required_source_files": [
+    "crates/rustok-page-builder/src/health.rs",
+    "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
+    "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
+    "scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs",
+    "crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs",
+    "docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md"
+  ],
+  "next_cursor": {
+    "deployment_health_backend_evaluator": "source_ready_maintainer_execution_pending",
+    "deployment_health_runtime_evidence": "maintainer_execution_pending",
+    "pages_provider_status_binding": "blocked_on_retained_deployment_evaluation_and_owner_acceptance",
+    "observed_health_acceptance": "pending"
+  }
+}

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  health: "crates/rustok-page-builder/src/health.rs",
+  telemetry: "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
+  identityContract: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+  evaluatorContract: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
+  evaluator: "scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs",
+  overlay: "docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+  pagesGraphql: "crates/rustok-pages/src/graphql/builder_rollout.rs",
+  pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-deployment-evaluator] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const contract = JSON.parse(sources.evaluatorContract);
+
+if (contract.format !== "page_builder_provider_health_deployment_evaluator_source_v1") {
+  failures.push("evaluator contract format drifted");
+}
+if (contract.status !== "source_ready_execution_pending") {
+  failures.push("evaluator contract must remain source_ready_execution_pending");
+}
+if (!Array.isArray(contract.predecessors) || !contract.predecessors.includes("page_builder_provider_health_deployment_identity_source_v1")) {
+  failures.push("deployment identity source must remain an evaluator predecessor");
+}
+
+for (const [key, expected] of Object.entries({
+  format: "page_builder_provider_health_deployment_identity_v1",
+  required_status: "deployment_identity_verified_health_evaluation_pending",
+  source_commit_must_equal_checkout_head: true,
+  inventory_complete_must_be_true: true,
+  expected_target_count_must_equal_verified_target_count: true,
+})) {
+  if (contract.identity_input?.[key] !== expected) {
+    failures.push(`identity_input.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  authority: "maintainer_supplied_complete_prometheus_target_mapping",
+  deployment_id_must_equal_identity_packet: true,
+  inventory_complete_must_be_true: true,
+  target_id_set_must_equal_identity_packet: true,
+  target_label_values_unique: true,
+  regex_matchers_allowed: false,
+  raw_matcher_values_retained: false,
+})) {
+  if (contract.backend_target_map?.[key] !== expected) {
+    failures.push(`backend_target_map.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+for (const reserved of ["__name__", "source_commit", "operation", "outcome", "le"]) {
+  if (!(contract.backend_target_map?.reserved_matcher_labels ?? []).includes(reserved)) {
+    failures.push(`backend target map must reserve ${reserved}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  prometheus_api: "/api/v1/query",
+  request_method: "POST",
+  redirects_followed: false,
+  maximum_parallel_queries: 8,
+  query_window_seconds_minimum: 300,
+  query_window_seconds_maximum: 86400,
+  freshness_seconds_minimum: 60,
+  freshness_must_not_exceed_query_window: true,
+  identity_capture_must_predate_entire_query_window: true,
+  identity_capture_maximum_age_seconds: 86400,
+  backend_clock_source: "prometheus_time_function",
+})) {
+  if (contract.backend_query?.[key] !== expected) {
+    failures.push(`backend_query.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  current_build_info_required_per_target: true,
+  current_build_info_source_commit_must_equal_identity: true,
+  current_backend_series_identity_must_be_unique_per_target: true,
+  expected_source_build_info_must_exist_in_entire_query_window: true,
+  unexpected_source_build_info_in_query_window: "fail_closed",
+  partial_target_query_success: "fail_closed",
+})) {
+  if (contract.source_admission?.[key] !== expected) {
+    failures.push(`source_admission.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  preview_required_per_target: true,
+  publish_required_per_target: true,
+  missing_operation_freshness: "fail_closed",
+  stale_operation_freshness: "fail_closed",
+  future_operation_timestamp_tolerance_seconds: 5,
+})) {
+  if (contract.freshness_admission?.[key] !== expected) {
+    failures.push(`freshness_admission.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  duration_series: "rustok_page_builder_provider_operation_duration_seconds_bucket",
+  completion_series: "rustok_page_builder_provider_operation_completed_total",
+  freshness_series: "rustok_page_builder_provider_last_observation_unix_seconds",
+  build_info_series: "rustok_page_builder_provider_build_info",
+  counter_reset_aware_function: "increase",
+  histogram_quantile: 0.95,
+  minimum_preview_samples: 20,
+  minimum_publish_samples: 20,
+  sample_floor_failure: "fail_closed",
+  unknown_operation_or_outcome: "fail_closed",
+  non_finite_or_negative_backend_value: "fail_closed",
+})) {
+  if (contract.aggregation?.[key] !== expected) {
+    failures.push(`aggregation.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  preview_p95_ms_max: 1500,
+  publish_p95_ms_max: 3000,
+  sanitize_failure_rate_max: 0.01,
+  runtime_error_rate_max: 0.01,
+  unavailable_runtime_error_multiplier: 2.0,
+  must_match_rust_provider_health_snapshot_evaluate: true,
+})) {
+  if (contract.provider_health_policy?.[key] !== expected) {
+    failures.push(`provider_health_policy.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const [key, expected] of Object.entries({
+  runtime_evaluation_executed: false,
+  deployment_identity_capture_executed_by_this_slice: false,
+  pages_provider_health_observed: false,
+  pages_reference_consumer_gate_accepted: false,
+  forum_wave_accepted: false,
+  ffa_promoted: false,
+  fba_promoted: false,
+  tests_run: false,
+  static_verifier_run: false,
+  cargo_run: false,
+  formatting_run: false,
+  workflow_or_ci_run: false,
+})) {
+  if (contract.non_claims?.[key] !== expected) {
+    failures.push(`non_claims.${key} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+for (const marker of [
+  "pub const PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION: usize = 20;",
+  "preview_p95_ms: 1500",
+  "publish_p95_ms: 3000",
+  "sanitize_failure_rate_max: 0.01",
+  "runtime_error_rate_max: 0.01",
+  "ProviderHealthState::Unavailable",
+  "thresholds.runtime_error_rate_max * 2.0",
+]) need(sources.health, marker, "Rust provider health policy");
+
+for (const marker of [
+  "rustok_page_builder_provider_build_info",
+  "rustok_page_builder_provider_operation_duration_seconds",
+  "rustok_page_builder_provider_operation_completed_total",
+  "rustok_page_builder_provider_last_observation_unix_seconds",
+]) need(sources.telemetry, marker, "platform provider metrics");
+
+for (const marker of [
+  '"deployment_health_backend_evaluator": "open"',
+  '"deployment_identity_capture": "maintainer_execution_pending"',
+]) need(sources.identityContract, marker, "identity predecessor cursor");
+
+for (const marker of [
+  "--identity",
+  "--backend-map",
+  "--prometheus-url",
+  "--window-seconds",
+  "--freshness-seconds",
+  "RESERVED_MATCHER_LABELS",
+  "backend map targets must exactly cover the identity target count",
+  "backend map target set is incomplete",
+  'redirect: "manual"',
+  'queryPrometheus(prometheusUrl, "time()"',
+  "identity capture must predate the entire query window",
+  "identity capture is older than the admitted maximum age",
+  "must expose exactly one current admitted build-info series equal to 1",
+  "count_over_time(rustok_page_builder_provider_build_info",
+  'source_commit!="',
+  "observed an unexpected source commit inside the query window",
+  "multiple expected target ids resolve to the same current backend series",
+  "rustok_page_builder_provider_last_observation_unix_seconds",
+  "freshness is stale",
+  "increase(rustok_page_builder_provider_operation_completed_total",
+  "increase(rustok_page_builder_provider_operation_duration_seconds_bucket",
+  "MINIMUM_SAMPLES_PER_OPERATION = 20",
+  "histogramQuantile95",
+  "sanitizeFailures / publishSamples",
+  "runtimeFailures / (previewSamples + publishSamples)",
+  "THRESHOLDS.preview_p95_ms",
+  "THRESHOLDS.publish_p95_ms",
+  "THRESHOLDS.runtime_error_rate_max * 2.0",
+  "raw_prometheus_url_persisted: false",
+  "raw_matcher_values_persisted: false",
+  "pages_provider_health_observed: false",
+]) need(sources.evaluator, marker, "deployment evaluator runner");
+
+for (const marker of [
+  "deployment-health-backend-evaluator-source-ready",
+  "exact-target-source-admission-source-ready",
+  "freshness-and-sample-floor-source-ready",
+  "identity capture must predate the **entire** query window",
+  "Partial success is rejected",
+  "Prometheus `time()`",
+  "preview terminal completions >= 20",
+  "publish terminal completions >= 20",
+  "summed cumulative bucket increases",
+  "Pages remains `unobserved`",
+  "retained identity/evaluator runtime evidence [maintainer execution pending]",
+  "tests were not run",
+]) need(sources.overlay, marker, "deployment evaluator overlay");
+
+for (const marker of [
+  "deployment-health-evaluator-source-ready",
+  "page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md",
+  "retained deployment health evaluator packet",
+  "Pages remains `unobserved`",
+]) need(sources.parity, marker, "plan parity actualization");
+
+need(sources.pagesGraphql, "provider_health_observed: false", "Pages GraphQL remains unobserved");
+forbid(sources.pagesGraphql, "provider_health_observed: true", "Pages GraphQL promotion");
+need(sources.pagesFacade, "PageBuilderAdminProviderStatus::unobserved", "Pages admin remains unobserved");
+forbid(sources.pagesGraphql, "deployment_evaluation", "Pages GraphQL must not bind evaluator packet yet");
+forbid(sources.pagesFacade, "deployment_evaluation", "Pages admin must not bind evaluator packet yet");
+
+if (contract.next_cursor?.deployment_health_backend_evaluator !== "source_ready_maintainer_execution_pending") {
+  failures.push("deployment evaluator cursor must be source-ready and execution-pending");
+}
+if (contract.next_cursor?.deployment_health_runtime_evidence !== "maintainer_execution_pending") {
+  failures.push("deployment health runtime evidence must remain maintainer execution pending");
+}
+if (
+  contract.next_cursor?.pages_provider_status_binding !==
+  "blocked_on_retained_deployment_evaluation_and_owner_acceptance"
+) failures.push("Pages provider-status binding must remain blocked on retained evaluation and owner acceptance");
+
+if (failures.length > 0) {
+  console.error("[verify-page-builder-provider-health-deployment-evaluator] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  "[verify-page-builder-provider-health-deployment-evaluator] PASS source_ready=true execution=pending pages_health=unobserved",
+);

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
@@ -6,11 +6,11 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const failures = [];
-const files = {
+const paths = {
   health: "crates/rustok-page-builder/src/health.rs",
   telemetry: "crates/rustok-telemetry/src/page_builder_provider_metrics.rs",
-  identityContract: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
-  evaluatorContract: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
+  identity: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+  contract: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
   evaluator: "scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs",
   overlay: "docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md",
   parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
@@ -18,264 +18,182 @@ const files = {
   pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
 };
 
-const absolute = (relativePath) => path.join(repoRoot, relativePath);
-const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
-const need = (source, marker, label) => {
-  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
-};
-const forbid = (source, marker, label) => {
-  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
-};
-
-for (const [label, relativePath] of Object.entries(files)) {
-  if (!fs.existsSync(absolute(relativePath))) {
-    failures.push(`${label}: missing ${relativePath}`);
-    continue;
+function load(label) {
+  const relative = paths[label];
+  const absolute = path.join(repoRoot, relative);
+  if (!fs.existsSync(absolute)) {
+    failures.push(`${label}: missing ${relative}`);
+    return "";
   }
-  const stats = fs.lstatSync(absolute(relativePath));
+  const stats = fs.lstatSync(absolute);
   if (!stats.isFile() || stats.isSymbolicLink()) {
-    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+    failures.push(`${label}: ${relative} must be a regular non-symlink file`);
+    return "";
   }
-}
-if (failures.length > 0) {
-  console.error("[verify-page-builder-provider-health-deployment-evaluator] FAIL");
-  failures.forEach((failure) => console.error(`- ${failure}`));
-  process.exit(1);
+  return fs.readFileSync(absolute, "utf8");
 }
 
-const sources = Object.fromEntries(
-  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
-);
-const contract = JSON.parse(sources.evaluatorContract);
-
-if (contract.format !== "page_builder_provider_health_deployment_evaluator_source_v1") {
-  failures.push("evaluator contract format drifted");
-}
-if (contract.status !== "source_ready_execution_pending") {
-  failures.push("evaluator contract must remain source_ready_execution_pending");
-}
-if (!Array.isArray(contract.predecessors) || !contract.predecessors.includes("page_builder_provider_health_deployment_identity_source_v1")) {
-  failures.push("deployment identity source must remain an evaluator predecessor");
+function need(source, marker, label) {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
 }
 
-for (const [key, expected] of Object.entries({
-  format: "page_builder_provider_health_deployment_identity_v1",
-  required_status: "deployment_identity_verified_health_evaluation_pending",
-  source_commit_must_equal_checkout_head: true,
-  inventory_complete_must_be_true: true,
-  expected_target_count_must_equal_verified_target_count: true,
-})) {
-  if (contract.identity_input?.[key] !== expected) {
-    failures.push(`identity_input.${key} must equal ${JSON.stringify(expected)}`);
+function forbid(source, marker, label) {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+}
+
+const sources = Object.fromEntries(Object.keys(paths).map((label) => [label, load(label)]));
+if (failures.length === 0) {
+  let contract;
+  try {
+    contract = JSON.parse(sources.contract);
+  } catch (error) {
+    failures.push(`contract: invalid JSON: ${error.message}`);
+    contract = {};
   }
-}
 
-for (const [key, expected] of Object.entries({
-  authority: "maintainer_supplied_complete_prometheus_target_mapping",
-  deployment_id_must_equal_identity_packet: true,
-  inventory_complete_must_be_true: true,
-  target_id_set_must_equal_identity_packet: true,
-  target_label_values_unique: true,
-  regex_matchers_allowed: false,
-  raw_matcher_values_retained: false,
-})) {
-  if (contract.backend_target_map?.[key] !== expected) {
-    failures.push(`backend_target_map.${key} must equal ${JSON.stringify(expected)}`);
+  if (contract.format !== "page_builder_provider_health_deployment_evaluator_source_v1") {
+    failures.push("contract format drifted");
   }
-}
-for (const reserved of ["__name__", "source_commit", "operation", "outcome", "le"]) {
-  if (!(contract.backend_target_map?.reserved_matcher_labels ?? []).includes(reserved)) {
-    failures.push(`backend target map must reserve ${reserved}`);
+  if (contract.status !== "source_ready_execution_pending") {
+    failures.push("contract must remain source_ready_execution_pending");
   }
-}
 
-for (const [key, expected] of Object.entries({
-  prometheus_api: "/api/v1/query",
-  request_method: "POST",
-  redirects_followed: false,
-  maximum_parallel_queries: 8,
-  query_window_seconds_minimum: 300,
-  query_window_seconds_maximum: 86400,
-  freshness_seconds_minimum: 60,
-  freshness_must_not_exceed_query_window: true,
-  identity_capture_must_predate_entire_query_window: true,
-  identity_capture_maximum_age_seconds: 86400,
-  backend_clock_source: "prometheus_time_function",
-})) {
-  if (contract.backend_query?.[key] !== expected) {
-    failures.push(`backend_query.${key} must equal ${JSON.stringify(expected)}`);
+  const expectedContractValues = [
+    [contract.identity_input, "format", "page_builder_provider_health_deployment_identity_v1"],
+    [contract.identity_input, "required_status", "deployment_identity_verified_health_evaluation_pending"],
+    [contract.identity_input, "source_commit_must_equal_checkout_head", true],
+    [contract.identity_input, "inventory_complete_must_be_true", true],
+    [contract.backend_target_map, "authority", "maintainer_supplied_complete_prometheus_target_mapping"],
+    [contract.backend_target_map, "target_id_set_must_equal_identity_packet", true],
+    [contract.backend_target_map, "target_label_values_unique", true],
+    [contract.backend_target_map, "regex_matchers_allowed", false],
+    [contract.backend_query, "prometheus_api", "/api/v1/query"],
+    [contract.backend_query, "request_method", "POST"],
+    [contract.backend_query, "redirects_followed", false],
+    [contract.backend_query, "maximum_parallel_queries", 8],
+    [contract.backend_query, "query_window_seconds_minimum", 300],
+    [contract.backend_query, "query_window_seconds_maximum", 86400],
+    [contract.backend_query, "freshness_seconds_minimum", 60],
+    [contract.backend_query, "identity_capture_must_predate_entire_query_window", true],
+    [contract.backend_query, "identity_capture_maximum_age_seconds", 86400],
+    [contract.backend_query, "backend_clock_source", "prometheus_time_function"],
+    [contract.source_admission, "unexpected_source_build_info_in_query_window", "fail_closed"],
+    [contract.source_admission, "partial_target_query_success", "fail_closed"],
+    [contract.freshness_admission, "preview_required_per_target", true],
+    [contract.freshness_admission, "publish_required_per_target", true],
+    [contract.freshness_admission, "stale_operation_freshness", "fail_closed"],
+    [contract.aggregation, "counter_reset_aware_function", "increase"],
+    [contract.aggregation, "histogram_quantile", 0.95],
+    [contract.aggregation, "histogram_completion_population_must_match", true],
+    [contract.aggregation, "population_consistency_tolerance_fraction", 0.000001],
+    [contract.aggregation, "minimum_preview_samples", 20],
+    [contract.aggregation, "minimum_publish_samples", 20],
+    [contract.provider_health_policy, "preview_p95_ms_max", 1500],
+    [contract.provider_health_policy, "publish_p95_ms_max", 3000],
+    [contract.provider_health_policy, "sanitize_failure_rate_max", 0.01],
+    [contract.provider_health_policy, "runtime_error_rate_max", 0.01],
+    [contract.provider_health_policy, "unavailable_runtime_error_multiplier", 2.0],
+    [contract.non_claims, "runtime_evaluation_executed", false],
+    [contract.non_claims, "pages_provider_health_observed", false],
+    [contract.non_claims, "pages_reference_consumer_gate_accepted", false],
+    [contract.non_claims, "forum_wave_accepted", false],
+    [contract.non_claims, "tests_run", false],
+    [contract.next_cursor, "deployment_health_backend_evaluator", "source_ready_maintainer_execution_pending"],
+    [contract.next_cursor, "deployment_health_runtime_evidence", "maintainer_execution_pending"],
+  ];
+  for (const [object, key, expected] of expectedContractValues) {
+    if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
   }
-}
 
-for (const [key, expected] of Object.entries({
-  current_build_info_required_per_target: true,
-  current_build_info_source_commit_must_equal_identity: true,
-  current_backend_series_identity_must_be_unique_per_target: true,
-  expected_source_build_info_must_exist_in_entire_query_window: true,
-  unexpected_source_build_info_in_query_window: "fail_closed",
-  partial_target_query_success: "fail_closed",
-})) {
-  if (contract.source_admission?.[key] !== expected) {
-    failures.push(`source_admission.${key} must equal ${JSON.stringify(expected)}`);
+  for (const reserved of ["__name__", "source_commit", "operation", "outcome", "le"]) {
+    if (!(contract.backend_target_map?.reserved_matcher_labels ?? []).includes(reserved)) {
+      failures.push(`reserved matcher label missing: ${reserved}`);
+    }
   }
+
+  for (const marker of [
+    "pub const PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION: usize = 20;",
+    "preview_p95_ms: 1500",
+    "publish_p95_ms: 3000",
+    "sanitize_failure_rate_max: 0.01",
+    "runtime_error_rate_max: 0.01",
+    "thresholds.runtime_error_rate_max * 2.0",
+  ]) need(sources.health, marker, "Rust health policy");
+
+  for (const marker of [
+    "rustok_page_builder_provider_build_info",
+    "rustok_page_builder_provider_operation_duration_seconds",
+    "rustok_page_builder_provider_operation_completed_total",
+    "rustok_page_builder_provider_last_observation_unix_seconds",
+  ]) need(sources.telemetry, marker, "provider metrics");
+
+  for (const marker of [
+    '"deployment_health_backend_evaluator": "open"',
+    '"deployment_identity_capture": "maintainer_execution_pending"',
+  ]) need(sources.identity, marker, "identity predecessor");
+
+  for (const marker of [
+    "--identity",
+    "--backend-map",
+    "--prometheus-url",
+    "--window-seconds",
+    "--freshness-seconds",
+    "RESERVED_MATCHER_LABELS",
+    "backend map targets must exactly cover the identity target count",
+    "backend map target set is incomplete",
+    'redirect: "manual"',
+    'queryPrometheus(prometheusUrl, "time()"',
+    "identity capture must predate the entire query window",
+    "identity capture is older than the admitted maximum age",
+    "must expose exactly one current admitted build-info series equal to 1",
+    "count_over_time(rustok_page_builder_provider_build_info",
+    "selectorExcludingSource",
+    "observed an unexpected source commit inside the query window",
+    "multiple expected target ids resolve to the same current backend series",
+    "rustok_page_builder_provider_last_observation_unix_seconds",
+    "freshness is stale",
+    "increase(rustok_page_builder_provider_operation_completed_total",
+    "increase(rustok_page_builder_provider_operation_duration_seconds_bucket",
+    "requireHistogramPopulationConsistency",
+    "histogram +Inf population does not match terminal completion population",
+    "MINIMUM_SAMPLES_PER_OPERATION = 20",
+    "histogramQuantile95",
+    "sanitizeFailures / publishSamples",
+    "runtimeFailures / (previewSamples + publishSamples)",
+    "THRESHOLDS.runtime_error_rate_max * 2.0",
+    "raw_prometheus_url_persisted: false",
+    "raw_matcher_values_persisted: false",
+    "pages_provider_health_observed: false",
+  ]) need(sources.evaluator, marker, "evaluator runner");
+
+  for (const marker of [
+    "deployment-health-backend-evaluator-source-ready",
+    "exact-target-source-admission-source-ready",
+    "freshness-and-sample-floor-source-ready",
+    "identity capture must predate the **entire** query window",
+    "partial target success is rejected",
+    "Prometheus `time()`",
+    "preview terminal completions >= 20",
+    "publish terminal completions >= 20",
+    "summed cumulative bucket increases",
+    "Pages remains `unobserved`",
+    "retained identity/evaluator runtime evidence [maintainer execution pending]",
+    "tests were not run",
+  ]) need(sources.overlay, marker, "evaluator overlay");
+
+  for (const marker of [
+    "deployment-health-evaluator-source-ready",
+    "page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md",
+    "retained deployment health evaluator packet",
+    "Pages remains `unobserved`",
+  ]) need(sources.parity, marker, "parity actualization");
+
+  need(sources.pagesGraphql, "provider_health_observed: false", "Pages GraphQL remains unobserved");
+  forbid(sources.pagesGraphql, "provider_health_observed: true", "Pages GraphQL promotion");
+  need(sources.pagesFacade, "PageBuilderAdminProviderStatus::unobserved", "Pages admin remains unobserved");
+  forbid(sources.pagesGraphql, "deployment_evaluation", "Pages GraphQL evaluator binding");
+  forbid(sources.pagesFacade, "deployment_evaluation", "Pages admin evaluator binding");
 }
-
-for (const [key, expected] of Object.entries({
-  preview_required_per_target: true,
-  publish_required_per_target: true,
-  missing_operation_freshness: "fail_closed",
-  stale_operation_freshness: "fail_closed",
-  future_operation_timestamp_tolerance_seconds: 5,
-})) {
-  if (contract.freshness_admission?.[key] !== expected) {
-    failures.push(`freshness_admission.${key} must equal ${JSON.stringify(expected)}`);
-  }
-}
-
-for (const [key, expected] of Object.entries({
-  duration_series: "rustok_page_builder_provider_operation_duration_seconds_bucket",
-  completion_series: "rustok_page_builder_provider_operation_completed_total",
-  freshness_series: "rustok_page_builder_provider_last_observation_unix_seconds",
-  build_info_series: "rustok_page_builder_provider_build_info",
-  counter_reset_aware_function: "increase",
-  histogram_quantile: 0.95,
-  minimum_preview_samples: 20,
-  minimum_publish_samples: 20,
-  sample_floor_failure: "fail_closed",
-  unknown_operation_or_outcome: "fail_closed",
-  non_finite_or_negative_backend_value: "fail_closed",
-})) {
-  if (contract.aggregation?.[key] !== expected) {
-    failures.push(`aggregation.${key} must equal ${JSON.stringify(expected)}`);
-  }
-}
-
-for (const [key, expected] of Object.entries({
-  preview_p95_ms_max: 1500,
-  publish_p95_ms_max: 3000,
-  sanitize_failure_rate_max: 0.01,
-  runtime_error_rate_max: 0.01,
-  unavailable_runtime_error_multiplier: 2.0,
-  must_match_rust_provider_health_snapshot_evaluate: true,
-})) {
-  if (contract.provider_health_policy?.[key] !== expected) {
-    failures.push(`provider_health_policy.${key} must equal ${JSON.stringify(expected)}`);
-  }
-}
-
-for (const [key, expected] of Object.entries({
-  runtime_evaluation_executed: false,
-  deployment_identity_capture_executed_by_this_slice: false,
-  pages_provider_health_observed: false,
-  pages_reference_consumer_gate_accepted: false,
-  forum_wave_accepted: false,
-  ffa_promoted: false,
-  fba_promoted: false,
-  tests_run: false,
-  static_verifier_run: false,
-  cargo_run: false,
-  formatting_run: false,
-  workflow_or_ci_run: false,
-})) {
-  if (contract.non_claims?.[key] !== expected) {
-    failures.push(`non_claims.${key} must equal ${JSON.stringify(expected)}`);
-  }
-}
-
-for (const marker of [
-  "pub const PROVIDER_HEALTH_MINIMUM_SAMPLES_PER_OPERATION: usize = 20;",
-  "preview_p95_ms: 1500",
-  "publish_p95_ms: 3000",
-  "sanitize_failure_rate_max: 0.01",
-  "runtime_error_rate_max: 0.01",
-  "ProviderHealthState::Unavailable",
-  "thresholds.runtime_error_rate_max * 2.0",
-]) need(sources.health, marker, "Rust provider health policy");
-
-for (const marker of [
-  "rustok_page_builder_provider_build_info",
-  "rustok_page_builder_provider_operation_duration_seconds",
-  "rustok_page_builder_provider_operation_completed_total",
-  "rustok_page_builder_provider_last_observation_unix_seconds",
-]) need(sources.telemetry, marker, "platform provider metrics");
-
-for (const marker of [
-  '"deployment_health_backend_evaluator": "open"',
-  '"deployment_identity_capture": "maintainer_execution_pending"',
-]) need(sources.identityContract, marker, "identity predecessor cursor");
-
-for (const marker of [
-  "--identity",
-  "--backend-map",
-  "--prometheus-url",
-  "--window-seconds",
-  "--freshness-seconds",
-  "RESERVED_MATCHER_LABELS",
-  "backend map targets must exactly cover the identity target count",
-  "backend map target set is incomplete",
-  'redirect: "manual"',
-  'queryPrometheus(prometheusUrl, "time()"',
-  "identity capture must predate the entire query window",
-  "identity capture is older than the admitted maximum age",
-  "must expose exactly one current admitted build-info series equal to 1",
-  "count_over_time(rustok_page_builder_provider_build_info",
-  'source_commit!="',
-  "observed an unexpected source commit inside the query window",
-  "multiple expected target ids resolve to the same current backend series",
-  "rustok_page_builder_provider_last_observation_unix_seconds",
-  "freshness is stale",
-  "increase(rustok_page_builder_provider_operation_completed_total",
-  "increase(rustok_page_builder_provider_operation_duration_seconds_bucket",
-  "MINIMUM_SAMPLES_PER_OPERATION = 20",
-  "histogramQuantile95",
-  "sanitizeFailures / publishSamples",
-  "runtimeFailures / (previewSamples + publishSamples)",
-  "THRESHOLDS.preview_p95_ms",
-  "THRESHOLDS.publish_p95_ms",
-  "THRESHOLDS.runtime_error_rate_max * 2.0",
-  "raw_prometheus_url_persisted: false",
-  "raw_matcher_values_persisted: false",
-  "pages_provider_health_observed: false",
-]) need(sources.evaluator, marker, "deployment evaluator runner");
-
-for (const marker of [
-  "deployment-health-backend-evaluator-source-ready",
-  "exact-target-source-admission-source-ready",
-  "freshness-and-sample-floor-source-ready",
-  "identity capture must predate the **entire** query window",
-  "Partial success is rejected",
-  "Prometheus `time()`",
-  "preview terminal completions >= 20",
-  "publish terminal completions >= 20",
-  "summed cumulative bucket increases",
-  "Pages remains `unobserved`",
-  "retained identity/evaluator runtime evidence [maintainer execution pending]",
-  "tests were not run",
-]) need(sources.overlay, marker, "deployment evaluator overlay");
-
-for (const marker of [
-  "deployment-health-evaluator-source-ready",
-  "page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md",
-  "retained deployment health evaluator packet",
-  "Pages remains `unobserved`",
-]) need(sources.parity, marker, "plan parity actualization");
-
-need(sources.pagesGraphql, "provider_health_observed: false", "Pages GraphQL remains unobserved");
-forbid(sources.pagesGraphql, "provider_health_observed: true", "Pages GraphQL promotion");
-need(sources.pagesFacade, "PageBuilderAdminProviderStatus::unobserved", "Pages admin remains unobserved");
-forbid(sources.pagesGraphql, "deployment_evaluation", "Pages GraphQL must not bind evaluator packet yet");
-forbid(sources.pagesFacade, "deployment_evaluation", "Pages admin must not bind evaluator packet yet");
-
-if (contract.next_cursor?.deployment_health_backend_evaluator !== "source_ready_maintainer_execution_pending") {
-  failures.push("deployment evaluator cursor must be source-ready and execution-pending");
-}
-if (contract.next_cursor?.deployment_health_runtime_evidence !== "maintainer_execution_pending") {
-  failures.push("deployment health runtime evidence must remain maintainer execution pending");
-}
-if (
-  contract.next_cursor?.pages_provider_status_binding !==
-  "blocked_on_retained_deployment_evaluation_and_owner_acceptance"
-) failures.push("Pages provider-status binding must remain blocked on retained evaluation and owner acceptance");
 
 if (failures.length > 0) {
   console.error("[verify-page-builder-provider-health-deployment-evaluator] FAIL");

--- a/docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md
+++ b/docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md
@@ -1,0 +1,257 @@
+# Page Builder provider-health deployment evaluator actualization — 2026-08-09
+
+Status: `deployment-health-backend-evaluator-source-ready / exact-target-source-admission-source-ready / freshness-and-sample-floor-source-ready / pages-health-binding-blocked / maintainer-execution-pending`.
+
+## Cursor
+
+This packet continues:
+
+- `page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`;
+- `page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`;
+- `page-builder-provider-health-deployment-identity-actualization-2026-08-09.md`.
+
+The predecessor slices established bounded process-local observations, platform Prometheus metrics, exact runtime source identity and a complete expected-target inventory contract. The remaining source gap was the deployment evaluator that admits only those exact targets, rejects mixed/stale source windows, computes the deployment SLO observations and retains a deployment-bound provider-health snapshot.
+
+This slice closes that **source** gap. It does not execute the evaluator and does not promote Pages health.
+
+## Evaluator input boundary
+
+The runner is:
+
+```text
+scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs
+```
+
+It requires:
+
+```text
+--identity FILE
+--backend-map FILE
+--prometheus-url URL
+--window-seconds N
+--freshness-seconds N
+```
+
+The identity packet must be the retained output from the exact-target deployment-identity capture and must:
+
+- have format `page_builder_provider_health_deployment_identity_v1`;
+- have status `deployment_identity_verified_health_evaluation_pending`;
+- carry the exact current checkout source SHA;
+- retain `inventory_complete = true`;
+- have equal expected/verified target counts;
+- retain the immutable image RepoDigest as the previously admitted maintainer-reviewed external deployment fact.
+
+No source-only path can fabricate this input.
+
+## Exact backend target mapping
+
+The evaluator deliberately does not assume that Prometheus uses `instance`, `pod`, `host`, or any other specific target label.
+
+Maintainer input supplies one complete mapping packet:
+
+```json
+{
+  "schema_version": 1,
+  "deployment_id": "prod-eu",
+  "inventory_complete": true,
+  "target_label": "instance",
+  "common_matchers": {
+    "job": "rustok-server"
+  },
+  "targets": [
+    {
+      "target_id": "server-a",
+      "target_label_value": "10.0.0.10:5150"
+    }
+  ]
+}
+```
+
+The target id set must equal the identity packet exactly. Target label values must be unique. Matchers are exact equality only; regex matchers are not accepted. Reserved metric-contract labels (`__name__`, `source_commit`, `operation`, `outcome`, `le`) cannot be supplied as topology matchers.
+
+Raw matcher values are used for queries but are not retained in the output. The output retains target ids, matcher names and selector SHA-256 values.
+
+## Exact-source admission across the whole SLO window
+
+Current build identity alone is not sufficient because a rate window can otherwise straddle an older deployment that reused the same Prometheus target labels.
+
+The evaluator therefore requires all of the following for every expected target:
+
+1. current `rustok_page_builder_provider_build_info{source_commit="<identity-sha>"}` exists exactly once and equals `1`;
+2. the admitted source build-info has samples inside the full query window;
+3. `count_over_time(...source_commit!="<identity-sha>"[window])` returns no positive sample count;
+4. each expected target resolves to a unique current backend series fingerprint;
+5. partial target success is rejected.
+
+The identity capture itself must predate the **entire** query window. This prevents the evaluator from treating pre-attestation metric history as admitted deployment health.
+
+The evaluator also bounds identity age to 24 hours. A stale historical identity packet is not deployment authority indefinitely.
+
+## Backend clock, query window and freshness
+
+Prometheus `time()` is the evaluator clock source, avoiding local runner clock skew when deciding target freshness.
+
+The admitted query window is maintainer-selected but bounded to:
+
+```text
+300s <= window <= 86400s
+```
+
+Freshness is also explicit and bounded:
+
+```text
+60s <= freshness <= window
+```
+
+For **every expected target**, both of these series must exist and be fresh:
+
+```text
+rustok_page_builder_provider_last_observation_unix_seconds{operation="preview"}
+rustok_page_builder_provider_last_observation_unix_seconds{operation="publish"}
+```
+
+A missing target, missing operation, stale operation timestamp, or timestamp more than five seconds ahead of backend `time()` fails closed.
+
+## Reset-aware deployment aggregation
+
+The evaluator uses `increase(...)` over the admitted window for counters and histogram buckets. It never subtracts raw cumulative values.
+
+For every admitted target it reads:
+
+```text
+increase(rustok_page_builder_provider_operation_completed_total[window])
+increase(rustok_page_builder_provider_operation_duration_seconds_bucket[window])
+```
+
+The target-local results are then summed by operation/outcome and by cumulative histogram boundary.
+
+The deployment sample floor is the same source policy as the process-local observation contract:
+
+```text
+preview terminal completions >= 20
+publish terminal completions >= 20
+```
+
+Less than either floor fails closed; absence is not interpreted as healthy.
+
+The deployment p95 is calculated from the **summed cumulative bucket increases**, not by averaging per-target p95 values. This preserves histogram semantics across multiple provider instances.
+
+Failure-rate denominators remain aligned with the Rust provider-health policy:
+
+- sanitize failure rate = `publish/sanitize_failed` / all Publish terminal completions;
+- runtime error rate = Preview + Publish `runtime_failed` / all Preview + Publish terminal completions.
+
+Unknown operation/outcome labels and non-finite or negative backend values fail closed.
+
+## Provider-health policy parity
+
+The evaluator source-locks the same pilot thresholds as `crates/rustok-page-builder/src/health.rs`:
+
+```text
+preview_p95_ms <= 1500
+publish_p95_ms <= 3000
+sanitize_failure_rate <= 0.01
+runtime_error_rate <= 0.01
+```
+
+It emits the same degradation reasons:
+
+- `provider_unhealthy` for Preview latency or runtime error breach;
+- `sanitize_backpressure` for sanitize failure breach;
+- `publish_backlog` for Publish latency breach.
+
+Runtime error rate above two times the pilot maximum produces `unavailable`; other threshold failures produce `degraded`; no threshold failure produces `ready`.
+
+The retained output contains both the deployment-bound snapshot and explicit SLO pass/fail evaluation.
+
+## Retained evidence and privacy
+
+Default output:
+
+```text
+target/page-builder-provider-health-deployment-evaluation.json
+```
+
+Retained fields include:
+
+- deployment id, immutable image RepoDigest and exact source SHA;
+- identity capture time and age;
+- expected/verified backend target counts;
+- query/freshness windows;
+- target ids, selector hashes, source-window admission and freshness ages;
+- Preview/Publish sample counts;
+- computed SLO observations;
+- provider-health snapshot and SLO evaluation;
+- hashes of source files used by the evaluator;
+- credential environment names only.
+
+The output does **not** retain:
+
+- raw Prometheus URL;
+- raw PromQL;
+- raw Prometheus responses;
+- raw target matcher values;
+- authorization/cookie/common-header values;
+- tenant/page/revision/correlation identifiers.
+
+## Pages remains `unobserved`
+
+This slice deliberately does not connect evaluator output to:
+
+- `provider_health_observed` in Pages GraphQL;
+- `PageBuilderAdminProviderStatus::observed(...)` in Pages admin;
+- `pages_reference_consumer_gate` acceptance;
+- Forum Wave acceptance;
+- FFA/FBA promotion.
+
+A source-ready evaluator is not runtime evidence. Pages may consume observed health only after a retained evaluator packet is executed for the admitted deployment and the owner acceptance/binding step is made explicit.
+
+## Source guard
+
+Machine source contract:
+
+```text
+crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json
+```
+
+Fail-closed source guard:
+
+```text
+crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+```
+
+The guard locks:
+
+- exact identity packet requirements;
+- complete 1:1 backend target mapping;
+- source-window anti-mixing checks;
+- backend-clock freshness semantics;
+- reset-aware aggregation;
+- 20 + 20 sample floors;
+- Rust health threshold/state parity;
+- continued Pages anti-promotion.
+
+## Next cursor
+
+```text
+bounded process-local observation [source-ready]
+-> deployment metrics + freshness [source-ready]
+-> deployment identity + expected-target inventory contract [source-ready]
+-> deployment health backend evaluator [source-ready]
+-> retained identity/evaluator runtime evidence [maintainer execution pending]
+-> Pages provider-status binding + owner acceptance [blocked]
+-> observed-health acceptance [pending]
+```
+
+## Validation boundary
+
+Per maintainer instruction, tests were not run. No Cargo commands, Node verifiers, formatting, build, metrics scrape, Prometheus query, deployment identity capture, evaluator execution, GraphQL/HTTP request, browser run, workflow or CI was executed by this slice.
+
+Suggested maintainer source checks, intentionally not run:
+
+```bash
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
+node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+```

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,18 +1,19 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-open / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has five source actualizations:
+This parity packet now has six source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
 - `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353;
 - `docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`, which introduced bounded process-local runtime observation source;
 - `docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`, which exports the same terminal observations through platform-owned deployment-aggregatable Prometheus metrics and a per-operation freshness signal;
-- `docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md`, which defines the exact source/deployment identity and expected-target inventory capture contract while leaving live capture and the deployment health evaluator pending.
+- `docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md`, which defines the exact source/deployment identity and expected-target inventory capture contract;
+- `docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md`, which defines the fail-closed backend evaluator over identity-admitted targets while leaving execution, Pages binding and observed-health acceptance pending.
 
-The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation, deployment-aggregatable metrics/freshness, and the exact source/deployment identity + expected-target inventory capture contract are source-ready. Pages remains `unobserved` because live target identity capture, the deployment health backend evaluator and retained runtime evidence do not yet exist.
+The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation, deployment-aggregatable metrics/freshness, exact source/deployment identity + expected-target inventory, and the deployment-health evaluator are source-ready. Pages remains `unobserved` because the exact identity/evaluator packets have not been executed and retained for an admitted deployment, and no owner acceptance/binding step has occurred.
 
 ## Current source truth
 
@@ -31,13 +32,18 @@ The synchronized source boundary is now:
 - default Fly composition retains bounded process-local Preview/Publish terminal observations through the existing runtime-telemetry seam, with a 256-sample cap per operation and no health snapshot below 20 Preview plus 20 Publish samples;
 - the same matched terminal calls export platform-owned Prometheus duration histograms, terminal outcome counters and per-operation last-observation timestamps with fixed `preview|publish` / terminal-outcome labels only;
 - deployment metrics deliberately carry no tenant/page/revision/correlation/deployment application labels; scrape/discovery infrastructure owns target identity and reset-aware aggregation;
-- provider metrics now expose `rustok_page_builder_provider_build_info{source_commit="<sha>"} 1` only when `RUSTOK_SOURCE_COMMIT` is canonical, reusing the release `github.sha -> OCI_REVISION -> RUSTOK_SOURCE_COMMIT` identity chain;
+- provider metrics expose `rustok_page_builder_provider_build_info{source_commit="<sha>"} 1` only when `RUSTOK_SOURCE_COMMIT` is canonical, reusing the release `github.sha -> OCI_REVISION -> RUSTOK_SOURCE_COMMIT` identity chain;
 - the deployment identity capture contract requires a maintainer-supplied immutable image RepoDigest plus a complete 1..64 expected-target inventory, rejects partial target verification, and requires every target to report the exact checkout source commit;
+- the deployment-health evaluator requires a complete 1:1 mapping from those exact target ids to bounded Prometheus exact-match topology labels instead of assuming a particular `instance`/`job` convention;
+- evaluator source admission requires current exact build-info, admitted-source build-info samples across the full query window, no unexpected source build-info inside that window, unique current backend series per expected target and complete target success;
+- Prometheus `time()` is the evaluator clock; the query window is explicitly bounded to 300..86400 seconds and Preview/Publish freshness is required for every expected target with an explicit freshness bound no larger than that window;
+- evaluator aggregation is reset-aware through `increase(...)`, requires at least 20 Preview and 20 Publish terminal completions, sums cumulative histogram buckets across admitted targets before p95 evaluation, and applies the same 1500ms / 3000ms / 1% / 1% provider-health policy as Rust `ProviderHealthSnapshot::evaluate`;
+- a retained deployment health evaluator packet can therefore contain a deployment-bound provider snapshot and SLO evaluation without raw Prometheus URL, raw PromQL, raw backend responses, raw target matcher values or credential values;
 - raw metrics target URLs, metric bodies and credential values are not retained by identity capture; target URL/body digests and credential environment names are retained instead;
-- the image RepoDigest association is intentionally recorded as a maintainer-reviewed external fact because the running process cannot cryptographically derive its post-push RepoDigest from source SHA alone;
-- source inspection does not supply a production target inventory, execute target capture, choose the backend health window, or evaluate deployment SLO health;
+- the image RepoDigest association remains a maintainer-reviewed external fact because the running process cannot cryptographically derive its post-push RepoDigest from source SHA alone;
+- source inspection does not execute target identity capture, Prometheus queries or the deployment evaluator and does not produce runtime health evidence;
 - the process-local window remains restartable and is not deployment-wide health authority; pre-telemetry validation/inspection is outside its current measurement boundary;
-- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until exact live deployment identity is captured and an admitted deployment evaluator produces retained evidence;
+- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until a retained deployment health evaluator packet exists for the admitted deployment and owner acceptance/binding is explicit;
 - `pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`;
 - Forum browser/runtime/deployment evidence and observed Wave remain blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
@@ -65,14 +71,13 @@ In parallel, the provider-health source cursor is now:
 bounded process-local Preview/Publish observation [source-ready]
 -> deployment-aggregatable metrics + freshness signal [source-ready]
 -> exact source/deployment identity + expected-target inventory contract [source-ready]
--> live exact-target identity capture [maintainer execution pending]
--> deployment health backend evaluator [open]
--> Pages provider-status transport/binding [blocked]
--> retained deployment/runtime evidence [maintainer execution]
+-> deployment health backend evaluator [source-ready]
+-> live exact-target identity capture + retained deployment health evaluator packet [maintainer execution pending]
+-> Pages provider-status transport/binding + owner acceptance [blocked]
 -> observed-health acceptance decision [pending]
 ```
 
-Source inspection alone must not mark any execution or acceptance step complete. Raw/process-local, unbound Prometheus observations, or a source-ready inventory contract without a live complete target capture must not be substituted for exact deployment provider-health evidence.
+Source inspection alone must not mark any execution or acceptance step complete. Raw/process-local, unbound Prometheus observations, a source-ready inventory contract without a live complete target capture, or a source-ready evaluator without retained runtime output must not be substituted for exact deployment provider-health evidence.
 
 ## Anti-drift guard
 
@@ -95,15 +100,16 @@ Provider-health source is independently fail-closed by:
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
+crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
 ```
 
-The first guard locks the bounded process-local window. The second locks the platform metric names, bounded label vocabulary, registry wiring, reset-aware aggregation/freshness contract and the continued absence of Pages observed-health binding. The third locks the release source identity, build-info metric, complete expected-target inventory contract, fail-closed capture harness and continued non-promotion of Pages health.
+The first guard locks the bounded process-local window. The second locks platform metric names, bounded label vocabulary, registry wiring and reset-aware aggregation/freshness source. The third locks release source identity, build-info, complete expected-target inventory and fail-closed direct capture. The fourth locks complete backend target mapping, exact-source window admission, backend-clock freshness, sample floors, histogram aggregation, Rust health-policy parity and continued non-promotion of Pages health.
 
 The Pages reference-consumer gate continues to list the plan-parity verifier as a required source guard.
 
 ## Execution boundary
 
-No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, deployment identity captures, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
+No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, deployment identity captures, evaluator executions, GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
 
 Suggested maintainer commands, intentionally not run:
 
@@ -112,6 +118,7 @@ node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-pa
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-runtime-observation.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
 ```
 
 All execution and acceptance evidence remains maintainer-owned.

--- a/scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs
+++ b/scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs
@@ -32,6 +32,7 @@ const THRESHOLDS = {
   runtime_error_rate_max: 0.01,
 };
 const MINIMUM_SAMPLES_PER_OPERATION = 20;
+const COUNT_EPSILON = 1e-6;
 
 function fail(message) {
   throw new Error(`Page Builder provider-health deployment evaluation failed: ${message}`);
@@ -43,6 +44,14 @@ function sha256(value) {
 
 function parseArguments(argv) {
   const options = {};
+  const accepted = new Set([
+    "--identity",
+    "--backend-map",
+    "--prometheus-url",
+    "--window-seconds",
+    "--freshness-seconds",
+    "--output",
+  ]);
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--help" || argument === "-h") {
@@ -53,26 +62,15 @@ function parseArguments(argv) {
       );
       process.exit(0);
     }
-    if (
-      [
-        "--identity",
-        "--backend-map",
-        "--prometheus-url",
-        "--window-seconds",
-        "--freshness-seconds",
-        "--output",
-      ].includes(argument)
-    ) {
-      const value = argv[index + 1];
-      if (!value) fail(`${argument} requires a value`);
-      const key = argument
+    if (!accepted.has(argument)) fail(`unknown argument ${argument}`);
+    const value = argv[index + 1];
+    if (!value) fail(`${argument} requires a value`);
+    options[
+      argument
         .slice(2)
-        .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
-      options[key] = value;
-      index += 1;
-      continue;
-    }
-    fail(`unknown argument ${argument}`);
+        .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+    ] = value;
+    index += 1;
   }
   return options;
 }
@@ -96,10 +94,10 @@ function regularJsonFile(inputPath, label) {
     ? path.resolve(inputPath)
     : path.resolve(process.cwd(), inputPath);
   if (!existsSync(absolute)) fail(`${label} is missing`);
-  const link = lstatSync(absolute);
-  if (link.isSymbolicLink() || !link.isFile()) fail(`${label} must be a regular non-symlink file`);
-  const stats = statSync(absolute);
-  if (stats.size <= 0 || stats.size > MAX_INPUT_BYTES) fail(`${label} is outside the bounded size`);
+  const metadata = lstatSync(absolute);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) fail(`${label} must be a regular non-symlink file`);
+  const size = statSync(absolute).size;
+  if (size <= 0 || size > MAX_INPUT_BYTES) fail(`${label} is outside the bounded size`);
   try {
     return JSON.parse(readFileSync(absolute, "utf8"));
   } catch (error) {
@@ -147,7 +145,7 @@ function requireIdentity(document, head) {
   if (deployment.inventory_complete !== true) fail("identity inventory is not complete");
   if (
     !Number.isInteger(deployment.expected_target_count) ||
-    deployment.expected_target_count <= 0 ||
+    deployment.expected_target_count < 1 ||
     deployment.expected_target_count > 64 ||
     deployment.expected_target_count !== deployment.verified_target_count
   ) fail("identity expected/verified target counts are invalid");
@@ -195,18 +193,15 @@ function requireBackendMap(document, identity) {
     fail("backend map targets must exactly cover the identity target count");
   }
   const mappedIds = new Set();
-  const values = new Set();
+  const targetValues = new Set();
   const targets = document.targets.map((target, index) => {
     const targetId = boundedIdentifier(target?.target_id, `backend targets[${index}].target_id`);
     if (!identity.targetIds.has(targetId)) fail(`backend map contains unknown target ${targetId}`);
     if (mappedIds.has(targetId)) fail(`backend map duplicates target ${targetId}`);
-    const targetValue = exactLabelValue(
-      target?.target_label_value,
-      `backend targets[${index}].target_label_value`,
-    );
-    if (values.has(targetValue)) fail(`backend map duplicates target label value ${targetValue}`);
+    const targetValue = exactLabelValue(target?.target_label_value, `backend targets[${index}].target_label_value`);
+    if (targetValues.has(targetValue)) fail(`backend map duplicates target label value ${targetValue}`);
     mappedIds.add(targetId);
-    values.add(targetValue);
+    targetValues.add(targetValue);
     return { target_id: targetId, target_label_value: targetValue };
   });
   if (mappedIds.size !== identity.targetIds.size) fail("backend map target set is incomplete");
@@ -243,7 +238,7 @@ function credentialHeaders(contract) {
     "cache-control": "no-cache",
     pragma: "no-cache",
   };
-  const names = [];
+  const environmentNames = [];
   const env = contract.backend_query.credential_environment;
   const common = process.env[env.common_headers_json];
   if (common) {
@@ -262,26 +257,34 @@ function credentialHeaders(contract) {
       if (typeof value !== "string" || value.length > 4096 || /[\r\n\u0000]/u.test(value)) fail(`common header ${name} is outside the bounded input`);
       headers[normalized] = value;
     }
-    names.push(env.common_headers_json);
+    environmentNames.push(env.common_headers_json);
   }
   for (const [field, header, limit] of [
     ["authorization", "authorization", 8192],
-    ["cookie", "cookie", 16384],
+    ["cookie", "cookie", 16_384],
   ]) {
     const envName = env[field];
     const value = process.env[envName];
     if (!value) continue;
     if (value.length > limit || /[\r\n\u0000]/u.test(value)) fail(`${envName} is outside the bounded input`);
     headers[header] = value;
-    names.push(envName);
+    environmentNames.push(envName);
   }
-  return { headers, environment_names: [...new Set(names)].sort() };
+  return { headers, environment_names: [...new Set(environmentNames)].sort() };
 }
 
-function selector(commonMatchers, targetLabel, targetValue, extra = {}) {
-  const all = { ...commonMatchers, [targetLabel]: targetValue, ...extra };
+function quoted(value) {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+function selector(commonMatchers, targetLabel, targetValue, extraEquals = {}) {
+  const all = { ...commonMatchers, [targetLabel]: targetValue, ...extraEquals };
   const entries = Object.entries(all).sort(([left], [right]) => left.localeCompare(right));
-  return `{${entries.map(([name, value]) => `${name}="${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`).join(",")}}`;
+  return `{${entries.map(([name, value]) => `${name}="${quoted(value)}"`).join(",")}}`;
+}
+
+function selectorExcludingSource(baseSelector, sourceCommit) {
+  return `${baseSelector.slice(0, -1)},source_commit!="${sourceCommit}"}`;
 }
 
 async function queryPrometheus(baseUrl, query, credentials, contract) {
@@ -322,26 +325,32 @@ function numericSample(result, label) {
   return value;
 }
 
-function currentSeriesFingerprint(metric) {
+function fingerprint(metric) {
   return sha256(JSON.stringify(Object.entries(metric ?? {}).sort(([a], [b]) => a.localeCompare(b))));
 }
 
 function parseFreshness(results, targetId) {
-  const byOperation = new Map();
+  const values = new Map();
   for (const result of results) {
     const operation = result?.metric?.operation;
     if (!OPERATIONS.includes(operation)) fail(`${targetId} freshness returned unknown operation ${operation}`);
-    if (byOperation.has(operation)) fail(`${targetId} freshness returned duplicate ${operation} series`);
-    byOperation.set(operation, numericSample(result, `${targetId} ${operation} freshness`));
+    if (values.has(operation)) fail(`${targetId} freshness returned duplicate ${operation} series`);
+    values.set(operation, numericSample(result, `${targetId} ${operation} freshness`));
   }
   for (const operation of OPERATIONS) {
-    if (!byOperation.has(operation)) fail(`${targetId} is missing ${operation} freshness`);
+    if (!values.has(operation)) fail(`${targetId} is missing ${operation} freshness`);
   }
-  return byOperation;
+  return values;
+}
+
+function zeroCompletions() {
+  return Object.fromEntries(
+    OPERATIONS.map((operation) => [operation, Object.fromEntries(OUTCOMES.map((outcome) => [outcome, 0]))]),
+  );
 }
 
 function parseCompletions(results, targetId) {
-  const totals = Object.fromEntries(OPERATIONS.map((operation) => [operation, Object.fromEntries(OUTCOMES.map((outcome) => [outcome, 0]))]));
+  const totals = zeroCompletions();
   for (const result of results) {
     const operation = result?.metric?.operation;
     const outcome = result?.metric?.outcome;
@@ -367,16 +376,32 @@ function parseBuckets(results, targetId) {
   return buckets;
 }
 
-function addCompletionTotals(destination, source) {
+function operationTotal(completions, operation) {
+  return OUTCOMES.reduce((total, outcome) => total + completions[operation][outcome], 0);
+}
+
+function addCompletions(destination, source) {
   for (const operation of OPERATIONS) {
     for (const outcome of OUTCOMES) destination[operation][outcome] += source[operation][outcome];
   }
 }
 
-function addBucketTotals(destination, source) {
+function addBuckets(destination, source) {
   for (const operation of OPERATIONS) {
     for (const [le, value] of source[operation]) {
       destination[operation].set(le, (destination[operation].get(le) ?? 0) + value);
+    }
+  }
+}
+
+function requireHistogramPopulationConsistency(completions, buckets) {
+  for (const operation of OPERATIONS) {
+    if (!buckets[operation].has("+Inf")) fail(`${operation} histogram is missing +Inf bucket`);
+    const completionCount = operationTotal(completions, operation);
+    const histogramCount = buckets[operation].get("+Inf");
+    const tolerance = Math.max(COUNT_EPSILON, completionCount * COUNT_EPSILON);
+    if (Math.abs(completionCount - histogramCount) > tolerance) {
+      fail(`${operation} histogram +Inf population does not match terminal completion population`);
     }
   }
 }
@@ -389,15 +414,15 @@ function histogramQuantile95(bucketMap, operation) {
     .sort(([left], [right]) => left - right);
   if (finite.length === 0) fail(`${operation} histogram has no finite buckets`);
   const total = bucketMap.get("+Inf");
-  if (!(total >= MINIMUM_SAMPLES_PER_OPERATION)) {
+  if (total < MINIMUM_SAMPLES_PER_OPERATION) {
     fail(`${operation} histogram has fewer than ${MINIMUM_SAMPLES_PER_OPERATION} samples`);
   }
   let previousCumulative = 0;
   for (const [, cumulative] of finite) {
-    if (cumulative + 1e-9 < previousCumulative) fail(`${operation} histogram buckets are not cumulative`);
+    if (cumulative + COUNT_EPSILON < previousCumulative) fail(`${operation} histogram buckets are not cumulative`);
     previousCumulative = cumulative;
   }
-  if (total + 1e-9 < previousCumulative) fail(`${operation} +Inf bucket is below finite cumulative count`);
+  if (total + COUNT_EPSILON < previousCumulative) fail(`${operation} +Inf bucket is below finite cumulative count`);
 
   const rank = total * 0.95;
   let lowerBound = 0;
@@ -405,7 +430,7 @@ function histogramQuantile95(bucketMap, operation) {
   for (const [upperBound, cumulative] of finite) {
     if (cumulative >= rank) {
       const bucketCount = cumulative - lowerCumulative;
-      if (bucketCount <= 1e-12) return Math.ceil(upperBound * 1000);
+      if (bucketCount <= COUNT_EPSILON) return Math.ceil(upperBound * 1000);
       const fraction = Math.max(0, Math.min(1, (rank - lowerCumulative) / bucketCount));
       return Math.ceil((lowerBound + (upperBound - lowerBound) * fraction) * 1000);
     }
@@ -413,10 +438,6 @@ function histogramQuantile95(bucketMap, operation) {
     lowerCumulative = cumulative;
   }
   return Math.ceil(finite[finite.length - 1][0] * 1000);
-}
-
-function operationTotal(completions, operation) {
-  return OUTCOMES.reduce((total, outcome) => total + completions[operation][outcome], 0);
 }
 
 function status(pass) {
@@ -463,19 +484,24 @@ function regularSourceHash(relativePath) {
   const relative = path.relative(repoRoot, absolute);
   if (relative.startsWith("..") || path.isAbsolute(relative)) fail(`source file ${relativePath} escapes repository root`);
   if (!existsSync(absolute)) fail(`source file ${relativePath} is missing`);
-  const link = lstatSync(absolute);
-  if (link.isSymbolicLink() || !link.isFile()) fail(`source file ${relativePath} must be a regular non-symlink file`);
-  const stats = statSync(absolute);
-  if (stats.size <= 0 || stats.size > MAX_SOURCE_BYTES) fail(`source file ${relativePath} is outside the bounded size`);
+  const metadata = lstatSync(absolute);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) fail(`source file ${relativePath} must be a regular non-symlink file`);
+  const size = statSync(absolute).size;
+  if (size <= 0 || size > MAX_SOURCE_BYTES) fail(`source file ${relativePath} is outside the bounded source size`);
   return sha256(readFileSync(absolute));
 }
 
 function sourceHashes(contract) {
-  return Object.fromEntries(contract.required_source_files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]));
+  return Object.fromEntries(
+    contract.required_source_files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]),
+  );
 }
 
 function outputPath(contract, requested) {
   const candidate = requested ?? contract.output.default_path;
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
+    fail("evaluation output path is invalid");
+  }
   const absolute = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
   const targetRoot = path.resolve(repoRoot, "target");
   const relative = path.relative(targetRoot, absolute);
@@ -497,30 +523,26 @@ async function evaluateTarget(target, context) {
     context.backendMap.targetLabel,
     target.target_label_value,
   );
+  const sourceSelector = selector(
+    context.backendMap.commonMatchers,
+    context.backendMap.targetLabel,
+    target.target_label_value,
+    { source_commit: context.identity.deployment.source_commit },
+  );
+
   const currentBuild = await queryPrometheus(
     context.prometheusUrl,
-    `rustok_page_builder_provider_build_info${selector(
-      context.backendMap.commonMatchers,
-      context.backendMap.targetLabel,
-      target.target_label_value,
-      { source_commit: context.identity.deployment.source_commit },
-    )}`,
+    `rustok_page_builder_provider_build_info${sourceSelector}`,
     context.credentials,
     context.contract,
   );
   if (currentBuild.length !== 1 || numericSample(currentBuild[0], `${target.target_id} current build-info`) !== 1) {
     fail(`${target.target_id} must expose exactly one current admitted build-info series equal to 1`);
   }
-  const fingerprint = currentSeriesFingerprint(currentBuild[0].metric);
 
   const admittedWindow = await queryPrometheus(
     context.prometheusUrl,
-    `count_over_time(rustok_page_builder_provider_build_info${selector(
-      context.backendMap.commonMatchers,
-      context.backendMap.targetLabel,
-      target.target_label_value,
-      { source_commit: context.identity.deployment.source_commit },
-    )}[${context.windowSeconds}s])`,
+    `count_over_time(rustok_page_builder_provider_build_info${sourceSelector}[${context.windowSeconds}s])`,
     context.credentials,
     context.contract,
   );
@@ -530,7 +552,10 @@ async function evaluateTarget(target, context) {
 
   const unexpectedWindow = await queryPrometheus(
     context.prometheusUrl,
-    `count_over_time(rustok_page_builder_provider_build_info${baseSelector.replace(/}$/u, `,source_commit!="${context.identity.deployment.source_commit}"}`)}[${context.windowSeconds}s])`,
+    `count_over_time(rustok_page_builder_provider_build_info${selectorExcludingSource(
+      baseSelector,
+      context.identity.deployment.source_commit,
+    )}[${context.windowSeconds}s])`,
     context.credentials,
     context.contract,
   );
@@ -574,12 +599,13 @@ async function evaluateTarget(target, context) {
     ),
     target.target_id,
   );
+  requireHistogramPopulationConsistency(completions, buckets);
 
   return {
     target_id: target.target_id,
     selector_sha256: sha256(baseSelector),
     raw_selector_persisted: false,
-    backend_series_fingerprint_sha256: fingerprint,
+    backend_series_fingerprint_sha256: fingerprint(currentBuild[0].metric),
     current_source_commit_verified: true,
     unexpected_source_in_window: false,
     preview_freshness_age_seconds: freshnessAges.preview,
@@ -597,7 +623,7 @@ async function mapWithConcurrency(items, limit, mapper) {
       const index = next;
       next += 1;
       if (index >= items.length) return;
-      results[index] = await mapper(items[index], index);
+      results[index] = await mapper(items[index]);
     }
   }
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
@@ -607,11 +633,15 @@ async function mapWithConcurrency(items, limit, mapper) {
 async function main() {
   const options = parseArguments(process.argv.slice(2));
   for (const required of ["identity", "backendMap", "prometheusUrl", "windowSeconds", "freshnessSeconds"]) {
-    if (!options[required]) fail(`--${required.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)} is required`);
+    if (!options[required]) {
+      fail(`--${required.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)} is required`);
+    }
   }
 
   const contract = JSON.parse(readFileSync(contractPath, "utf8"));
-  if (contract.status !== "source_ready_execution_pending") fail("evaluator source contract must remain execution-pending before runtime evaluation");
+  if (contract.status !== "source_ready_execution_pending") {
+    fail("evaluator source contract must remain execution-pending before runtime evaluation");
+  }
   const head = currentCommit();
   const identity = requireIdentity(regularJsonFile(options.identity, "identity packet"), head);
   const backendMap = requireBackendMap(regularJsonFile(options.backendMap, "backend target map"), identity);
@@ -627,24 +657,26 @@ async function main() {
   const backendNow = numericSample(timeResult[0], "Prometheus time()");
   const identityAge = backendNow - identity.capturedAtSeconds;
   if (identityAge < windowSeconds) fail("identity capture must predate the entire query window");
-  if (identityAge > contract.backend_query.identity_capture_maximum_age_seconds) fail("identity capture is older than the admitted maximum age");
+  if (identityAge > contract.backend_query.identity_capture_maximum_age_seconds) {
+    fail("identity capture is older than the admitted maximum age");
+  }
 
-  const context = {
-    contract,
-    identity,
-    backendMap,
-    prometheusUrl,
-    credentials,
-    windowSeconds,
-    freshnessSeconds,
-    backendNow,
-  };
   const targetResults = await mapWithConcurrency(
     backendMap.targets,
     contract.backend_query.maximum_parallel_queries,
-    (target) => evaluateTarget(target, context),
+    (target) => evaluateTarget(target, {
+      contract,
+      identity,
+      backendMap,
+      prometheusUrl,
+      credentials,
+      windowSeconds,
+      freshnessSeconds,
+      backendNow,
+    }),
   );
   if (targetResults.length !== identity.targetIds.size) fail("partial target evaluation is forbidden");
+
   const fingerprints = new Set();
   for (const result of targetResults) {
     if (fingerprints.has(result.backend_series_fingerprint_sha256)) {
@@ -653,17 +685,20 @@ async function main() {
     fingerprints.add(result.backend_series_fingerprint_sha256);
   }
 
-  const completions = Object.fromEntries(OPERATIONS.map((operation) => [operation, Object.fromEntries(OUTCOMES.map((outcome) => [outcome, 0]))]));
+  const completions = zeroCompletions();
   const buckets = { preview: new Map(), publish: new Map() };
   for (const target of targetResults) {
-    addCompletionTotals(completions, target.completions);
-    addBucketTotals(buckets, target.buckets);
+    addCompletions(completions, target.completions);
+    addBuckets(buckets, target.buckets);
   }
+  requireHistogramPopulationConsistency(completions, buckets);
+
   const previewSamples = operationTotal(completions, "preview");
   const publishSamples = operationTotal(completions, "publish");
   if (previewSamples < MINIMUM_SAMPLES_PER_OPERATION || publishSamples < MINIMUM_SAMPLES_PER_OPERATION) {
     fail(`deployment sample floor requires at least ${MINIMUM_SAMPLES_PER_OPERATION} preview and publish completions`);
   }
+
   const sanitizeFailures = completions.publish.sanitize_failed;
   const runtimeFailures = completions.preview.runtime_failed + completions.publish.runtime_failed;
   const observed = {
@@ -707,6 +742,8 @@ async function main() {
     samples: {
       preview: previewSamples,
       publish: publishSamples,
+      preview_histogram: buckets.preview.get("+Inf"),
+      publish_histogram: buckets.publish.get("+Inf"),
       minimum_per_operation: MINIMUM_SAMPLES_PER_OPERATION,
     },
     ...evaluated,

--- a/scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs
+++ b/scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs
@@ -1,0 +1,729 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
+);
+const MAX_INPUT_BYTES = 2 * 1024 * 1024;
+const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+const RESERVED_MATCHER_LABELS = new Set(["__name__", "source_commit", "operation", "outcome", "le"]);
+const OPERATIONS = ["preview", "publish"];
+const OUTCOMES = ["succeeded", "sanitize_failed", "runtime_failed", "other_failed"];
+const THRESHOLDS = {
+  preview_p95_ms: 1500,
+  publish_p95_ms: 3000,
+  sanitize_failure_rate_max: 0.01,
+  runtime_error_rate_max: 0.01,
+};
+const MINIMUM_SAMPLES_PER_OPERATION = 20;
+
+function fail(message) {
+  throw new Error(`Page Builder provider-health deployment evaluation failed: ${message}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      console.log(
+        "usage: evaluate-page-builder-provider-health-deployment.mjs " +
+          "--identity FILE --backend-map FILE --prometheus-url URL " +
+          "--window-seconds N --freshness-seconds N [--output FILE]",
+      );
+      process.exit(0);
+    }
+    if (
+      [
+        "--identity",
+        "--backend-map",
+        "--prometheus-url",
+        "--window-seconds",
+        "--freshness-seconds",
+        "--output",
+      ].includes(argument)
+    ) {
+      const value = argv[index + 1];
+      if (!value) fail(`${argument} requires a value`);
+      const key = argument
+        .slice(2)
+        .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      options[key] = value;
+      index += 1;
+      continue;
+    }
+    fail(`unknown argument ${argument}`);
+  }
+  return options;
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell: false,
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) fail(`git HEAD lookup failed: ${result.error.message}`);
+  if (result.status !== 0) fail("git HEAD lookup returned a non-zero status");
+  const value = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(value)) fail("git HEAD is not a canonical lowercase commit");
+  return value;
+}
+
+function regularJsonFile(inputPath, label) {
+  const absolute = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(process.cwd(), inputPath);
+  if (!existsSync(absolute)) fail(`${label} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) fail(`${label} must be a regular non-symlink file`);
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > MAX_INPUT_BYTES) fail(`${label} is outside the bounded size`);
+  try {
+    return JSON.parse(readFileSync(absolute, "utf8"));
+  } catch (error) {
+    fail(`${label} must contain JSON: ${error.message}`);
+  }
+}
+
+function boundedIdentifier(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value) > 128 ||
+    !/^[A-Za-z0-9._:/-]+$/u.test(value)
+  ) fail(`${label} must be a bounded identifier`);
+  return value;
+}
+
+function exactLabelName(value, label) {
+  if (typeof value !== "string" || !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(value)) {
+    fail(`${label} must be a Prometheus label name`);
+  }
+  if (RESERVED_MATCHER_LABELS.has(value)) fail(`${label} uses reserved label ${value}`);
+  return value;
+}
+
+function exactLabelValue(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value) > 256 ||
+    !/^[A-Za-z0-9._:/@-]+$/u.test(value)
+  ) fail(`${label} must be a bounded exact-match label value`);
+  return value;
+}
+
+function requireIdentity(document, head) {
+  if (document?.format !== "page_builder_provider_health_deployment_identity_v1") {
+    fail("identity packet format is not page_builder_provider_health_deployment_identity_v1");
+  }
+  if (document.status !== "deployment_identity_verified_health_evaluation_pending") {
+    fail("identity packet is not admitted for health evaluation");
+  }
+  const deployment = document.deployment ?? {};
+  if (deployment.source_commit !== head) fail("identity source commit does not match git HEAD");
+  if (deployment.inventory_complete !== true) fail("identity inventory is not complete");
+  if (
+    !Number.isInteger(deployment.expected_target_count) ||
+    deployment.expected_target_count <= 0 ||
+    deployment.expected_target_count > 64 ||
+    deployment.expected_target_count !== deployment.verified_target_count
+  ) fail("identity expected/verified target counts are invalid");
+  if (
+    typeof deployment.deployment_image_digest !== "string" ||
+    !/^[^\s@]+@sha256:[0-9a-f]{64}$/u.test(deployment.deployment_image_digest)
+  ) fail("identity deployment image digest is invalid");
+  if (!Array.isArray(document.expected_targets) || document.expected_targets.length !== deployment.expected_target_count) {
+    fail("identity expected target list does not match admitted target count");
+  }
+  const targetIds = new Set();
+  for (const [index, target] of document.expected_targets.entries()) {
+    const targetId = boundedIdentifier(target?.target_id, `identity.expected_targets[${index}].target_id`);
+    if (targetIds.has(targetId)) fail(`identity contains duplicate target ${targetId}`);
+    if (target?.source_commit_verified_equal_checkout !== true || target?.reported_source_commit !== head) {
+      fail(`identity target ${targetId} is not bound to checkout source commit`);
+    }
+    targetIds.add(targetId);
+  }
+  const capturedAtMs = Date.parse(document.captured_at);
+  if (!Number.isFinite(capturedAtMs)) fail("identity captured_at is invalid");
+  return { deployment, targetIds, capturedAtSeconds: capturedAtMs / 1000 };
+}
+
+function requireBackendMap(document, identity) {
+  if (document?.schema_version !== 1) fail("backend map schema_version must be 1");
+  if (document.deployment_id !== identity.deployment.deployment_id) {
+    fail("backend map deployment_id does not match identity packet");
+  }
+  if (document.inventory_complete !== true) fail("backend map inventory_complete must be true");
+  const targetLabel = exactLabelName(document.target_label, "backend map target_label");
+  const commonMatchers = document.common_matchers ?? {};
+  if (commonMatchers === null || typeof commonMatchers !== "object" || Array.isArray(commonMatchers)) {
+    fail("backend map common_matchers must be an object");
+  }
+  const commonEntries = Object.entries(commonMatchers);
+  if (commonEntries.length > 8) fail("backend map common_matchers exceeds 8 entries");
+  const normalizedCommon = {};
+  for (const [name, value] of commonEntries) {
+    const matcherName = exactLabelName(name, `common matcher ${name}`);
+    if (matcherName === targetLabel) fail("target label must not be duplicated in common_matchers");
+    normalizedCommon[matcherName] = exactLabelValue(value, `common matcher ${name}`);
+  }
+  if (!Array.isArray(document.targets) || document.targets.length !== identity.targetIds.size) {
+    fail("backend map targets must exactly cover the identity target count");
+  }
+  const mappedIds = new Set();
+  const values = new Set();
+  const targets = document.targets.map((target, index) => {
+    const targetId = boundedIdentifier(target?.target_id, `backend targets[${index}].target_id`);
+    if (!identity.targetIds.has(targetId)) fail(`backend map contains unknown target ${targetId}`);
+    if (mappedIds.has(targetId)) fail(`backend map duplicates target ${targetId}`);
+    const targetValue = exactLabelValue(
+      target?.target_label_value,
+      `backend targets[${index}].target_label_value`,
+    );
+    if (values.has(targetValue)) fail(`backend map duplicates target label value ${targetValue}`);
+    mappedIds.add(targetId);
+    values.add(targetValue);
+    return { target_id: targetId, target_label_value: targetValue };
+  });
+  if (mappedIds.size !== identity.targetIds.size) fail("backend map target set is incomplete");
+  return { targetLabel, commonMatchers: normalizedCommon, targets };
+}
+
+function requirePrometheusUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    fail("--prometheus-url must be an absolute HTTP(S) URL");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password || parsed.search || parsed.hash) {
+    fail("--prometheus-url must not contain credentials, query, or fragment");
+  }
+  if (!parsed.pathname.endsWith("/")) parsed.pathname += "/";
+  return parsed;
+}
+
+function boundedInteger(value, label, minimum, maximum) {
+  if (!/^[0-9]+$/u.test(value ?? "")) fail(`${label} must be an integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    fail(`${label} must be between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function credentialHeaders(contract) {
+  const headers = {
+    accept: "application/json",
+    "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-cache",
+    pragma: "no-cache",
+  };
+  const names = [];
+  const env = contract.backend_query.credential_environment;
+  const common = process.env[env.common_headers_json];
+  if (common) {
+    if (common.length > 16_384 || /[\u0000]/u.test(common)) fail(`${env.common_headers_json} is outside the bounded input`);
+    let parsed;
+    try {
+      parsed = JSON.parse(common);
+    } catch (error) {
+      fail(`${env.common_headers_json} must contain a JSON object: ${error.message}`);
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) fail(`${env.common_headers_json} must contain an object`);
+    for (const [name, value] of Object.entries(parsed)) {
+      const normalized = name.toLowerCase();
+      if (!/^[a-z0-9!#$%&'*+.^_`|~-]+$/u.test(normalized)) fail(`invalid common header ${name}`);
+      if (["authorization", "cookie", "host", "content-length"].includes(normalized)) fail(`common headers must not contain ${normalized}`);
+      if (typeof value !== "string" || value.length > 4096 || /[\r\n\u0000]/u.test(value)) fail(`common header ${name} is outside the bounded input`);
+      headers[normalized] = value;
+    }
+    names.push(env.common_headers_json);
+  }
+  for (const [field, header, limit] of [
+    ["authorization", "authorization", 8192],
+    ["cookie", "cookie", 16384],
+  ]) {
+    const envName = env[field];
+    const value = process.env[envName];
+    if (!value) continue;
+    if (value.length > limit || /[\r\n\u0000]/u.test(value)) fail(`${envName} is outside the bounded input`);
+    headers[header] = value;
+    names.push(envName);
+  }
+  return { headers, environment_names: [...new Set(names)].sort() };
+}
+
+function selector(commonMatchers, targetLabel, targetValue, extra = {}) {
+  const all = { ...commonMatchers, [targetLabel]: targetValue, ...extra };
+  const entries = Object.entries(all).sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([name, value]) => `${name}="${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`).join(",")}}`;
+}
+
+async function queryPrometheus(baseUrl, query, credentials, contract) {
+  const endpoint = new URL("api/v1/query", baseUrl);
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: credentials.headers,
+      body: new URLSearchParams({ query }).toString(),
+      redirect: "manual",
+      signal: AbortSignal.timeout(contract.backend_query.request_timeout_ms),
+    });
+  } catch (error) {
+    fail(`Prometheus query request failed: ${error.message}`);
+  }
+  if (response.status !== 200) fail(`Prometheus query expected 200, got ${response.status}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.byteLength <= 0 || bytes.byteLength > contract.backend_query.maximum_response_bytes) {
+    fail("Prometheus response is outside the bounded body size");
+  }
+  let payload;
+  try {
+    payload = JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    fail(`Prometheus response is not JSON: ${error.message}`);
+  }
+  if (payload?.status !== "success" || payload?.data?.resultType !== "vector" || !Array.isArray(payload.data.result)) {
+    fail("Prometheus query did not return a successful vector result");
+  }
+  return payload.data.result;
+}
+
+function numericSample(result, label) {
+  if (!Array.isArray(result?.value) || result.value.length < 2) fail(`${label} has no instant value`);
+  const value = Number(result.value[1]);
+  if (!Number.isFinite(value) || value < 0) fail(`${label} is non-finite or negative`);
+  return value;
+}
+
+function currentSeriesFingerprint(metric) {
+  return sha256(JSON.stringify(Object.entries(metric ?? {}).sort(([a], [b]) => a.localeCompare(b))));
+}
+
+function parseFreshness(results, targetId) {
+  const byOperation = new Map();
+  for (const result of results) {
+    const operation = result?.metric?.operation;
+    if (!OPERATIONS.includes(operation)) fail(`${targetId} freshness returned unknown operation ${operation}`);
+    if (byOperation.has(operation)) fail(`${targetId} freshness returned duplicate ${operation} series`);
+    byOperation.set(operation, numericSample(result, `${targetId} ${operation} freshness`));
+  }
+  for (const operation of OPERATIONS) {
+    if (!byOperation.has(operation)) fail(`${targetId} is missing ${operation} freshness`);
+  }
+  return byOperation;
+}
+
+function parseCompletions(results, targetId) {
+  const totals = Object.fromEntries(OPERATIONS.map((operation) => [operation, Object.fromEntries(OUTCOMES.map((outcome) => [outcome, 0]))]));
+  for (const result of results) {
+    const operation = result?.metric?.operation;
+    const outcome = result?.metric?.outcome;
+    if (!OPERATIONS.includes(operation)) fail(`${targetId} completion returned unknown operation ${operation}`);
+    if (!OUTCOMES.includes(outcome)) fail(`${targetId} completion returned unknown outcome ${outcome}`);
+    totals[operation][outcome] += numericSample(result, `${targetId} ${operation}/${outcome} completion`);
+  }
+  return totals;
+}
+
+function parseBuckets(results, targetId) {
+  const buckets = { preview: new Map(), publish: new Map() };
+  for (const result of results) {
+    const operation = result?.metric?.operation;
+    const le = result?.metric?.le;
+    if (!OPERATIONS.includes(operation)) fail(`${targetId} histogram returned unknown operation ${operation}`);
+    if (typeof le !== "string" || (le !== "+Inf" && !Number.isFinite(Number(le)))) {
+      fail(`${targetId} histogram returned invalid le=${le}`);
+    }
+    const value = numericSample(result, `${targetId} ${operation} histogram bucket ${le}`);
+    buckets[operation].set(le, (buckets[operation].get(le) ?? 0) + value);
+  }
+  return buckets;
+}
+
+function addCompletionTotals(destination, source) {
+  for (const operation of OPERATIONS) {
+    for (const outcome of OUTCOMES) destination[operation][outcome] += source[operation][outcome];
+  }
+}
+
+function addBucketTotals(destination, source) {
+  for (const operation of OPERATIONS) {
+    for (const [le, value] of source[operation]) {
+      destination[operation].set(le, (destination[operation].get(le) ?? 0) + value);
+    }
+  }
+}
+
+function histogramQuantile95(bucketMap, operation) {
+  if (!bucketMap.has("+Inf")) fail(`${operation} histogram is missing +Inf bucket`);
+  const finite = [...bucketMap.entries()]
+    .filter(([le]) => le !== "+Inf")
+    .map(([le, value]) => [Number(le), value])
+    .sort(([left], [right]) => left - right);
+  if (finite.length === 0) fail(`${operation} histogram has no finite buckets`);
+  const total = bucketMap.get("+Inf");
+  if (!(total >= MINIMUM_SAMPLES_PER_OPERATION)) {
+    fail(`${operation} histogram has fewer than ${MINIMUM_SAMPLES_PER_OPERATION} samples`);
+  }
+  let previousCumulative = 0;
+  for (const [, cumulative] of finite) {
+    if (cumulative + 1e-9 < previousCumulative) fail(`${operation} histogram buckets are not cumulative`);
+    previousCumulative = cumulative;
+  }
+  if (total + 1e-9 < previousCumulative) fail(`${operation} +Inf bucket is below finite cumulative count`);
+
+  const rank = total * 0.95;
+  let lowerBound = 0;
+  let lowerCumulative = 0;
+  for (const [upperBound, cumulative] of finite) {
+    if (cumulative >= rank) {
+      const bucketCount = cumulative - lowerCumulative;
+      if (bucketCount <= 1e-12) return Math.ceil(upperBound * 1000);
+      const fraction = Math.max(0, Math.min(1, (rank - lowerCumulative) / bucketCount));
+      return Math.ceil((lowerBound + (upperBound - lowerBound) * fraction) * 1000);
+    }
+    lowerBound = upperBound;
+    lowerCumulative = cumulative;
+  }
+  return Math.ceil(finite[finite.length - 1][0] * 1000);
+}
+
+function operationTotal(completions, operation) {
+  return OUTCOMES.reduce((total, outcome) => total + completions[operation][outcome], 0);
+}
+
+function status(pass) {
+  return pass ? "pass" : "fail";
+}
+
+function evaluateHealth(observed) {
+  const degradationReasons = [];
+  if (
+    observed.preview_p95_ms > THRESHOLDS.preview_p95_ms ||
+    observed.runtime_error_rate > THRESHOLDS.runtime_error_rate_max
+  ) degradationReasons.push("provider_unhealthy");
+  if (observed.sanitize_failure_rate > THRESHOLDS.sanitize_failure_rate_max) {
+    degradationReasons.push("sanitize_backpressure");
+  }
+  if (observed.publish_p95_ms > THRESHOLDS.publish_p95_ms) {
+    degradationReasons.push("publish_backlog");
+  }
+  const state = degradationReasons.length === 0
+    ? "ready"
+    : observed.runtime_error_rate > THRESHOLDS.runtime_error_rate_max * 2.0
+      ? "unavailable"
+      : "degraded";
+  const sloEvaluation = {
+    preview_p95_ms: status(observed.preview_p95_ms <= THRESHOLDS.preview_p95_ms),
+    publish_p95_ms: status(observed.publish_p95_ms <= THRESHOLDS.publish_p95_ms),
+    sanitize_failure_rate: status(observed.sanitize_failure_rate <= THRESHOLDS.sanitize_failure_rate_max),
+    runtime_error_rate: status(observed.runtime_error_rate <= THRESHOLDS.runtime_error_rate_max),
+  };
+  sloEvaluation.overall = status(Object.values(sloEvaluation).every((value) => value === "pass"));
+  return {
+    snapshot: {
+      state,
+      degradation_reasons: degradationReasons,
+      thresholds: THRESHOLDS,
+      observed,
+    },
+    slo_evaluation: sloEvaluation,
+  };
+}
+
+function regularSourceHash(relativePath) {
+  const absolute = path.resolve(repoRoot, relativePath);
+  const relative = path.relative(repoRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) fail(`source file ${relativePath} escapes repository root`);
+  if (!existsSync(absolute)) fail(`source file ${relativePath} is missing`);
+  const link = lstatSync(absolute);
+  if (link.isSymbolicLink() || !link.isFile()) fail(`source file ${relativePath} must be a regular non-symlink file`);
+  const stats = statSync(absolute);
+  if (stats.size <= 0 || stats.size > MAX_SOURCE_BYTES) fail(`source file ${relativePath} is outside the bounded size`);
+  return sha256(readFileSync(absolute));
+}
+
+function sourceHashes(contract) {
+  return Object.fromEntries(contract.required_source_files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]));
+}
+
+function outputPath(contract, requested) {
+  const candidate = requested ?? contract.output.default_path;
+  const absolute = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) fail("evaluation output must remain inside repository target/");
+  return absolute;
+}
+
+function writeAtomic(location, document) {
+  mkdirSync(path.dirname(location), { recursive: true });
+  const temporary = `${location}.tmp-${process.pid}`;
+  rmSync(temporary, { force: true });
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+  renameSync(temporary, location);
+}
+
+async function evaluateTarget(target, context) {
+  const baseSelector = selector(
+    context.backendMap.commonMatchers,
+    context.backendMap.targetLabel,
+    target.target_label_value,
+  );
+  const currentBuild = await queryPrometheus(
+    context.prometheusUrl,
+    `rustok_page_builder_provider_build_info${selector(
+      context.backendMap.commonMatchers,
+      context.backendMap.targetLabel,
+      target.target_label_value,
+      { source_commit: context.identity.deployment.source_commit },
+    )}`,
+    context.credentials,
+    context.contract,
+  );
+  if (currentBuild.length !== 1 || numericSample(currentBuild[0], `${target.target_id} current build-info`) !== 1) {
+    fail(`${target.target_id} must expose exactly one current admitted build-info series equal to 1`);
+  }
+  const fingerprint = currentSeriesFingerprint(currentBuild[0].metric);
+
+  const admittedWindow = await queryPrometheus(
+    context.prometheusUrl,
+    `count_over_time(rustok_page_builder_provider_build_info${selector(
+      context.backendMap.commonMatchers,
+      context.backendMap.targetLabel,
+      target.target_label_value,
+      { source_commit: context.identity.deployment.source_commit },
+    )}[${context.windowSeconds}s])`,
+    context.credentials,
+    context.contract,
+  );
+  if (admittedWindow.length !== 1 || numericSample(admittedWindow[0], `${target.target_id} admitted source window`) <= 0) {
+    fail(`${target.target_id} has no admitted source build-info samples in the query window`);
+  }
+
+  const unexpectedWindow = await queryPrometheus(
+    context.prometheusUrl,
+    `count_over_time(rustok_page_builder_provider_build_info${baseSelector.replace(/}$/u, `,source_commit!="${context.identity.deployment.source_commit}"}`)}[${context.windowSeconds}s])`,
+    context.credentials,
+    context.contract,
+  );
+  if (unexpectedWindow.some((result) => numericSample(result, `${target.target_id} unexpected source window`) > 0)) {
+    fail(`${target.target_id} observed an unexpected source commit inside the query window`);
+  }
+
+  const freshness = parseFreshness(
+    await queryPrometheus(
+      context.prometheusUrl,
+      `rustok_page_builder_provider_last_observation_unix_seconds${baseSelector}`,
+      context.credentials,
+      context.contract,
+    ),
+    target.target_id,
+  );
+  const freshnessAges = {};
+  for (const operation of OPERATIONS) {
+    const timestamp = freshness.get(operation);
+    if (timestamp > context.backendNow + 5) fail(`${target.target_id} ${operation} freshness is in the future`);
+    const age = context.backendNow - timestamp;
+    if (age > context.freshnessSeconds) fail(`${target.target_id} ${operation} freshness is stale (${age}s)`);
+    freshnessAges[operation] = age;
+  }
+
+  const completions = parseCompletions(
+    await queryPrometheus(
+      context.prometheusUrl,
+      `increase(rustok_page_builder_provider_operation_completed_total${baseSelector}[${context.windowSeconds}s])`,
+      context.credentials,
+      context.contract,
+    ),
+    target.target_id,
+  );
+  const buckets = parseBuckets(
+    await queryPrometheus(
+      context.prometheusUrl,
+      `increase(rustok_page_builder_provider_operation_duration_seconds_bucket${baseSelector}[${context.windowSeconds}s])`,
+      context.credentials,
+      context.contract,
+    ),
+    target.target_id,
+  );
+
+  return {
+    target_id: target.target_id,
+    selector_sha256: sha256(baseSelector),
+    raw_selector_persisted: false,
+    backend_series_fingerprint_sha256: fingerprint,
+    current_source_commit_verified: true,
+    unexpected_source_in_window: false,
+    preview_freshness_age_seconds: freshnessAges.preview,
+    publish_freshness_age_seconds: freshnessAges.publish,
+    completions,
+    buckets,
+  };
+}
+
+async function mapWithConcurrency(items, limit, mapper) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const index = next;
+      next += 1;
+      if (index >= items.length) return;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return results;
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  for (const required of ["identity", "backendMap", "prometheusUrl", "windowSeconds", "freshnessSeconds"]) {
+    if (!options[required]) fail(`--${required.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)} is required`);
+  }
+
+  const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+  if (contract.status !== "source_ready_execution_pending") fail("evaluator source contract must remain execution-pending before runtime evaluation");
+  const head = currentCommit();
+  const identity = requireIdentity(regularJsonFile(options.identity, "identity packet"), head);
+  const backendMap = requireBackendMap(regularJsonFile(options.backendMap, "backend target map"), identity);
+  const prometheusUrl = requirePrometheusUrl(options.prometheusUrl);
+  const windowSeconds = boundedInteger(options.windowSeconds, "--window-seconds", 300, 86400);
+  const freshnessSeconds = boundedInteger(options.freshnessSeconds, "--freshness-seconds", 60, windowSeconds);
+  const credentials = credentialHeaders(contract);
+  const output = outputPath(contract, options.output);
+  rmSync(output, { force: true });
+
+  const timeResult = await queryPrometheus(prometheusUrl, "time()", credentials, contract);
+  if (timeResult.length !== 1) fail("Prometheus time() must return exactly one sample");
+  const backendNow = numericSample(timeResult[0], "Prometheus time()");
+  const identityAge = backendNow - identity.capturedAtSeconds;
+  if (identityAge < windowSeconds) fail("identity capture must predate the entire query window");
+  if (identityAge > contract.backend_query.identity_capture_maximum_age_seconds) fail("identity capture is older than the admitted maximum age");
+
+  const context = {
+    contract,
+    identity,
+    backendMap,
+    prometheusUrl,
+    credentials,
+    windowSeconds,
+    freshnessSeconds,
+    backendNow,
+  };
+  const targetResults = await mapWithConcurrency(
+    backendMap.targets,
+    contract.backend_query.maximum_parallel_queries,
+    (target) => evaluateTarget(target, context),
+  );
+  if (targetResults.length !== identity.targetIds.size) fail("partial target evaluation is forbidden");
+  const fingerprints = new Set();
+  for (const result of targetResults) {
+    if (fingerprints.has(result.backend_series_fingerprint_sha256)) {
+      fail("multiple expected target ids resolve to the same current backend series");
+    }
+    fingerprints.add(result.backend_series_fingerprint_sha256);
+  }
+
+  const completions = Object.fromEntries(OPERATIONS.map((operation) => [operation, Object.fromEntries(OUTCOMES.map((outcome) => [outcome, 0]))]));
+  const buckets = { preview: new Map(), publish: new Map() };
+  for (const target of targetResults) {
+    addCompletionTotals(completions, target.completions);
+    addBucketTotals(buckets, target.buckets);
+  }
+  const previewSamples = operationTotal(completions, "preview");
+  const publishSamples = operationTotal(completions, "publish");
+  if (previewSamples < MINIMUM_SAMPLES_PER_OPERATION || publishSamples < MINIMUM_SAMPLES_PER_OPERATION) {
+    fail(`deployment sample floor requires at least ${MINIMUM_SAMPLES_PER_OPERATION} preview and publish completions`);
+  }
+  const sanitizeFailures = completions.publish.sanitize_failed;
+  const runtimeFailures = completions.preview.runtime_failed + completions.publish.runtime_failed;
+  const observed = {
+    preview_p95_ms: histogramQuantile95(buckets.preview, "preview"),
+    publish_p95_ms: histogramQuantile95(buckets.publish, "publish"),
+    sanitize_failure_rate: sanitizeFailures / publishSamples,
+    runtime_error_rate: runtimeFailures / (previewSamples + publishSamples),
+  };
+  for (const [name, value] of Object.entries(observed)) {
+    if (!Number.isFinite(value) || value < 0) fail(`computed observation ${name} is non-finite or negative`);
+  }
+  const evaluated = evaluateHealth(observed);
+
+  writeAtomic(output, {
+    format: contract.output.format,
+    status: contract.output.status,
+    evaluated_at: new Date(backendNow * 1000).toISOString(),
+    deployment: {
+      deployment_id: identity.deployment.deployment_id,
+      deployment_image_digest: identity.deployment.deployment_image_digest,
+      source_commit: identity.deployment.source_commit,
+      identity_captured_at: new Date(identity.capturedAtSeconds * 1000).toISOString(),
+      identity_age_seconds: identityAge,
+      expected_target_count: identity.targetIds.size,
+      verified_backend_target_count: targetResults.length,
+      query_window_seconds: windowSeconds,
+      freshness_seconds: freshnessSeconds,
+    },
+    backend: {
+      prometheus_url_bytes: Buffer.byteLength(prometheusUrl.href),
+      prometheus_url_sha256: sha256(prometheusUrl.href),
+      raw_prometheus_url_persisted: false,
+      target_label_name: backendMap.targetLabel,
+      common_matcher_names: Object.keys(backendMap.commonMatchers).sort(),
+      raw_matcher_values_persisted: false,
+      raw_promql_persisted: false,
+      raw_backend_responses_persisted: false,
+      target_mapping_complete: true,
+    },
+    targets: targetResults.map(({ completions: _completions, buckets: _buckets, ...retained }) => retained),
+    samples: {
+      preview: previewSamples,
+      publish: publishSamples,
+      minimum_per_operation: MINIMUM_SAMPLES_PER_OPERATION,
+    },
+    ...evaluated,
+    source_files: sourceHashes(contract),
+    credentials: {
+      environment_names: credentials.environment_names,
+      values_persisted: false,
+    },
+    pages_provider_health_observed: false,
+    pages_reference_consumer_gate_accepted: false,
+    forum_wave_accepted: false,
+    ffa_promoted: false,
+    fba_promoted: false,
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder provider-health parity cursor after #3395.

#3395 established exact source/deployment identity and a complete expected-target inventory capture contract. This PR closes the next source-only gap by adding a fail-closed Prometheus-backed deployment health evaluator over those identity-admitted targets.

### Changes

- add `page_builder_provider_health_deployment_evaluator_source_v1` source contract;
- add `scripts/evidence/evaluate-page-builder-provider-health-deployment.mjs`;
- require a complete 1:1 backend target map instead of assuming a hardcoded Prometheus `instance`/`job` topology;
- require identity capture to predate the entire query window and be no older than 24h;
- use Prometheus `time()` as the freshness clock;
- verify current exact source build-info on every expected target;
- reject any unexpected source build-info observed anywhere inside the SLO query window;
- reject duplicate backend-series mappings and partial target success;
- require fresh Preview and Publish observations per target;
- use reset-aware `increase(...)` for completion counters and histogram buckets;
- require completion and histogram `+Inf` populations to agree;
- require at least 20 Preview and 20 Publish terminal completions;
- aggregate cumulative histogram buckets across admitted targets before p95 evaluation;
- apply the same 1500ms / 3000ms / 1% / 1% thresholds and state semantics as Rust `ProviderHealthSnapshot::evaluate`;
- retain deployment-bound snapshot/SLO evidence without raw Prometheus URL, raw PromQL, raw backend responses, raw target matcher values or credential values;
- add a fail-closed source verifier and dated actualization packet;
- advance Pages/Page Builder parity.

## Deliberate non-promotion

This PR makes the evaluator source-ready only. It does **not** execute identity capture or Prometheus queries and does not bind evaluator output into Pages.

Therefore:

- `provider_health_observed` remains `false`;
- Pages admin remains unobserved;
- `pages_reference_consumer_gate` remains unaccepted;
- Forum Wave remains blocked;
- FFA/FBA promotion remains unclaimed.

## Validation

Per maintainer instruction, tests/verifiers are intentionally not run by this implementation agent. No Cargo, Node verifier, formatting, build, metrics scrape/query, deployment identity capture, evaluator execution, GraphQL/HTTP, browser, workflow or CI execution was performed.

Suggested maintainer source checks:

```bash
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
```

## Next cursor

`process-local observation [source-ready] -> deployment metrics/freshness [source-ready] -> deployment identity/target inventory [source-ready] -> deployment health evaluator [source-ready] -> retained identity + evaluator runtime evidence [maintainer execution pending] -> Pages provider-status binding + owner acceptance [blocked] -> observed-health acceptance`