### PR TITLE
feat(commerce): route storefront order access through owner read port

### DIFF
--- a/crates/rustok-commerce/docs/graphql-storefront-order-access-owner-read-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-storefront-order-access-owner-read-cutover-2026-08-09.md
@@ -1,0 +1,73 @@
+# Commerce GraphQL storefront order access owner-read cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+This slice continues the canonical ecommerce standalone/topology P0 after #3398 routed the five
+mounted GraphQL owner-local return/change writes through `OrderPostOrderCommandPort`.
+
+The remaining storefront ownership helper `ensure_storefront_order_access` no longer constructs a
+foreign `OrderService` to read the order. It now consumes the already host-composed
+`CommerceOrderReadRuntime` / `OrderReadPort` and requests the complete Order owner projection through
+`ReadOrderProjectionRequest`.
+
+## Admission and semantics
+
+The helper still resolves the current storefront customer through the existing customer helper and
+still admits the caller only when the owner projection has `customer_id == current customer_id`.
+A mismatch continues to return the existing GraphQL permission-denied response.
+
+The owner read context derives only trusted request facts:
+
+- tenant from the resolved Commerce tenant scope supplied to the helper;
+- actor from authenticated `AuthContext`;
+- tenant default locale from `TenantContext`, preserving the former `OrderService::get_order` read semantics;
+- channel from `RequestContext` when present;
+- a bounded two-second deadline;
+- a correlation identity scoped to the storefront order-access read.
+
+The read uses the resolver-scoped host-selected `CommerceOrderReadRuntime`. Directly embedded
+compatibility schemas retain the runtime helper's existing explicit in-process Order-owned fallback.
+
+The owner projection is requested with the tenant default locale as the primary locale and no second
+fallback locale. This matches the former `OrderService::get_order` behavior while moving the actual
+read behind the owner port; the access check still consumes only owner identity fields.
+
+## Error boundary
+
+The previous helper mapped a concrete `OrderError` and logged the raw error object. The cutover maps
+`PortErrorKind` directly to the existing public GraphQL Order families:
+
+- `ORDER_REQUEST_INVALID`;
+- `ORDER_RESOURCE_NOT_FOUND`;
+- `ORDER_STATE_CONFLICT`;
+- `ORDER_TEMPORARILY_UNAVAILABLE`;
+- `ORDER_OPERATION_FAILED`.
+
+Diagnostics retain bounded facts such as identity presence, owner error kind, owner-code length,
+correlation id, public code, and retryability. Raw owner/backend messages are not logged or exposed by
+this boundary.
+
+## Deliberately unchanged
+
+This slice does not change:
+
+- storefront customer resolution;
+- the customer/order ownership comparison;
+- tenant-default-locale projection semantics;
+- post-order command admission added in #3398;
+- cross-domain return/change payment/refund orchestration;
+- shipping-profile helper behavior in the same source file.
+
+The broad implementation-plan item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and
+Fulfillment concrete services behind host-composed owner ports` remains open. Other mounted concrete
+service construction must be re-audited separately before that P0 can be checked.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL
+scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios
+were executed for this slice. The accompanying verifier is source-only evidence for maintainer
+execution.

--- a/crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs
@@ -1,6 +1,9 @@
 use async_graphql::{Context, ErrorExtensions, FieldError, Result};
-use rustok_api::{AuthContext, graphql::GraphQLError};
-use rustok_order::{OrderError, OrderService};
+use rustok_api::{
+    AuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext,
+    graphql::GraphQLError,
+};
+use rustok_order::ReadOrderProjectionRequest;
 use uuid::Uuid;
 
 pub(crate) use super::cart_safe_helpers::*;
@@ -86,88 +89,94 @@ fn public_graphql_error(
     })
 }
 
-fn storefront_order_graphql_error_policy(
-    context: &mut StorefrontOrderGraphqlErrorContext,
-    error: &OrderError,
-) -> StorefrontGraphqlPolicy {
-    match error {
-        OrderError::Validation(_) => (
+fn storefront_order_graphql_error_policy(error: &PortError) -> StorefrontGraphqlPolicy {
+    match &error.kind {
+        PortErrorKind::Validation | PortErrorKind::Forbidden => (
             "Order request is invalid",
             "ORDER_REQUEST_INVALID",
             false,
             "validation",
         ),
-        OrderError::OrderNotFound(order_id) => {
-            context.order_id = Some(*order_id);
-            (
-                "Order resource was not found",
-                "ORDER_RESOURCE_NOT_FOUND",
-                false,
-                "order_not_found",
-            )
-        }
-        OrderError::OrderReturnNotFound(order_return_id) => {
-            context.order_return_id = Some(*order_return_id);
-            (
-                "Order resource was not found",
-                "ORDER_RESOURCE_NOT_FOUND",
-                false,
-                "order_return_not_found",
-            )
-        }
-        OrderError::OrderChangeNotFound(order_change_id) => {
-            context.order_change_id = Some(*order_change_id);
-            (
-                "Order resource was not found",
-                "ORDER_RESOURCE_NOT_FOUND",
-                false,
-                "order_change_not_found",
-            )
-        }
-        OrderError::InvalidTransition { .. } => (
+        PortErrorKind::NotFound => (
+            "Order resource was not found",
+            "ORDER_RESOURCE_NOT_FOUND",
+            false,
+            "order_not_found",
+        ),
+        PortErrorKind::Conflict => (
             "Order operation conflicts with the current state",
             "ORDER_STATE_CONFLICT",
             false,
             "state_conflict",
         ),
-        OrderError::Database(_) => (
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
             "Order service is temporarily unavailable",
             "ORDER_TEMPORARILY_UNAVAILABLE",
             true,
-            "database",
+            "temporarily_unavailable",
         ),
-        OrderError::Core(_) => (
+        PortErrorKind::InvariantViolation => (
             "Order operation could not be completed safely",
             "ORDER_OPERATION_FAILED",
             false,
-            "core",
+            "invariant_violation",
         ),
     }
 }
 
 fn order_graphql_error(
-    mut context: StorefrontOrderGraphqlErrorContext,
-    error: OrderError,
+    context: StorefrontOrderGraphqlErrorContext,
+    port_context: &PortContext,
+    error: PortError,
 ) -> async_graphql::Error {
-    let (message, code, retryable, error_kind) =
-        storefront_order_graphql_error_policy(&mut context, &error);
+    let (message, code, retryable, error_kind) = storefront_order_graphql_error_policy(&error);
     tracing::error!(
-        error = ?error,
         owner = STOREFRONT_ORDER_GRAPHQL_OWNER,
-        tenant_id = %context.tenant_id,
-        actor_id = %context.actor_id,
-        customer_id = %context.customer_id,
-        order_id = ?context.order_id,
-        order_return_id = ?context.order_return_id,
-        order_change_id = ?context.order_change_id,
+        tenant_id_non_nil = !context.tenant_id.is_nil(),
+        actor_id_non_nil = !context.actor_id.is_nil(),
+        customer_id_non_nil = !context.customer_id.is_nil(),
+        order_id_non_nil = context.order_id.is_some_and(|value| !value.is_nil()),
+        order_return_id_present = context.order_return_id.is_some(),
+        order_change_id_present = context.order_change_id.is_some(),
         operation = %context.operation,
+        correlation_id = %port_context.correlation_id,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
         error_kind,
         public_code = code,
         retryable,
         boundary = STOREFRONT_GRAPHQL_HELPER_BOUNDARY,
-        "commerce GraphQL storefront order helper failed"
+        "commerce GraphQL storefront order owner read failed"
     );
     public_graphql_error(message, code, retryable)
+}
+
+fn storefront_order_read_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    tenant_default_locale: &str,
+    order_id: Uuid,
+) -> PortContext {
+    let locale = if tenant_default_locale.trim().is_empty() {
+        "und"
+    } else {
+        tenant_default_locale
+    };
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-storefront-order-access:{order_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match ctx
+        .data_opt::<RequestContext>()
+        .and_then(|request| request.channel_slug.as_deref())
+    {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
 }
 
 fn shipping_profile_graphql_error_policy(
@@ -269,6 +278,7 @@ pub(crate) async fn ensure_storefront_order_access(
     let auth = ctx
         .data::<AuthContext>()
         .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    let tenant = ctx.data::<TenantContext>()?;
     let customer_id = super::cart_safe_helpers::resolve_optional_storefront_customer_id(
         db,
         tenant_id,
@@ -277,8 +287,26 @@ pub(crate) async fn ensure_storefront_order_access(
     .await?
     .ok_or_else(|| <FieldError as GraphQLError>::unauthenticated())?;
 
-    let order = OrderService::new(db.clone(), event_bus.clone())
-        .get_order(tenant_id, order_id)
+    let runtime = crate::graphql_runtime::order_read_runtime_for_current_graphql_scope(
+        db.clone(),
+        event_bus.clone(),
+    );
+    let port_context = storefront_order_read_context(
+        ctx,
+        tenant_id,
+        auth,
+        tenant.default_locale.as_str(),
+        order_id,
+    );
+    let order = runtime
+        .order_read_port()
+        .read_order_projection(
+            port_context.clone(),
+            ReadOrderProjectionRequest {
+                order_id,
+                tenant_default_locale: None,
+            },
+        )
         .await
         .map_err(|error| {
             order_graphql_error(
@@ -289,6 +317,7 @@ pub(crate) async fn ensure_storefront_order_access(
                     order_id,
                     "ensure_storefront_order_access",
                 ),
+                &port_context,
                 error,
             )
         })?;

--- a/scripts/verify/verify-commerce-graphql-storefront-order-access-owner-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-storefront-order-access-owner-read-cutover.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+const failures = [];
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+const helper = read('crates/rustok-commerce/src/graphql/mutations/safe_order_helpers.rs');
+const runtime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const owner = read('crates/rustok-order/src/order_read.rs');
+const orderService = read('crates/rustok-order/src/services/order.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/graphql-storefront-order-access-owner-read-cutover-2026-08-09.md',
+);
+
+for (const marker of [
+  'TenantContext',
+  'use rustok_order::ReadOrderProjectionRequest;',
+  'order_read_runtime_for_current_graphql_scope(',
+  '.order_read_port()',
+  '.read_order_projection(',
+  'ReadOrderProjectionRequest {',
+  'tenant_default_locale: None',
+  'tenant.default_locale.as_str()',
+  'PortActor::user(auth.user_id.to_string())',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'request.channel_slug.as_deref()',
+  'order.customer_id != Some(customer_id)',
+  'owner_error_kind = ?error.kind',
+  'owner_code_length = error.code.chars().count()',
+  'ORDER_RESOURCE_NOT_FOUND',
+  'ORDER_TEMPORARILY_UNAVAILABLE',
+]) need(helper, marker, 'storefront order access helper');
+
+for (const marker of [
+  'OrderService::new(db.clone(), event_bus.clone())',
+  'use rustok_order::{OrderError, OrderService};',
+]) forbid(helper, marker, 'storefront order access concrete path');
+
+for (const marker of [
+  'pub struct CommerceOrderReadRuntime',
+  'pub(crate) fn order_read_runtime_for_current_graphql_scope(',
+  'CURRENT_COMMERCE_ORDER_READ_RUNTIME',
+]) need(runtime, marker, 'commerce host-selected order runtime');
+
+for (const marker of [
+  'pub trait OrderReadPort',
+  'async fn read_order_projection(',
+  'pub struct ReadOrderProjectionRequest',
+  'context.require_policy(PortCallPolicy::read())?',
+]) need(owner, marker, 'order owner read contract');
+
+for (const marker of [
+  'pub async fn get_order(&self, tenant_id: Uuid, order_id: Uuid)',
+  'let default_locale = load_tenant_default_locale(&self.db, tenant_id).await?;',
+  'self.get_order_with_locale_fallback(tenant_id, order_id, default_locale.as_str(), None)',
+]) need(orderService, marker, 'legacy storefront access locale parity source');
+
+need(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,',
+  'canonical broad topology P0 remains open',
+);
+
+for (const marker of [
+  'Status: `source_complete_unvalidated`',
+  '`CommerceOrderReadRuntime` / `OrderReadPort`',
+  'tenant default locale from `TenantContext`',
+  'matches the former `OrderService::get_order` behavior',
+  'Raw owner/backend messages are not logged or exposed',
+  'broad implementation-plan item',
+  'no tests, Cargo commands, Node verifiers, formatter',
+]) need(record, marker, 'dated source record');
+
+if (failures.length > 0) {
+  console.error('[verify-commerce-graphql-storefront-order-access-owner-read-cutover] FAIL');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log('[verify-commerce-graphql-storefront-order-access-owner-read-cutover] PASS');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce standalone/topology P0 after #3398.

- remove direct `OrderService` construction from `ensure_storefront_order_access`;
- read the complete Order projection through the resolver-scoped host-selected `CommerceOrderReadRuntime` / `OrderReadPort`;
- preserve storefront customer resolution and the existing `order.customer_id == current customer_id` ownership check;
- preserve the former `OrderService::get_order` tenant-default-locale projection semantics through `TenantContext.default_locale`;
- derive tenant, authenticated actor, channel, correlation identity, and a bounded two-second deadline from trusted request context;
- map owner `PortErrorKind` values to the existing GraphQL Order error families;
- stop logging raw Order owner/backend errors in this helper and keep only bounded diagnostic facts;
- add a source-only verifier and dated source record;
- keep the broad mounted concrete-service topology P0 open for the remaining independently scoped paths.

## Source recheck

#3398 explicitly left storefront access/read helpers as follow-up. `OrderReadPort::read_order_projection` already owns the required tenant-scoped complete projection read, and `CommerceOrderReadRuntime` is already host-composed and resolver-scoped, so no new runtime/server capability is needed for this cutover.

Source review also confirmed that the prior `OrderService::get_order` selected the tenant default locale before hydration. This PR keeps that behavior by using `TenantContext.default_locale` as the owner read context locale and no secondary fallback locale.

The branch is on current `main` (`a0d8054e02296fa43a81d9dd53d4b616c231d0d7`) after unrelated Page Builder #3399. It is one commit ahead and zero behind with exactly three changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatting, mounted GraphQL scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios were executed. The added verifier is source-only evidence for maintainer execution.