### PR TITLE
feat(forum): plan bounded export read targets

### DIFF
--- a/crates/rustok-forum/src/export_mapping.rs
+++ b/crates/rustok-forum/src/export_mapping.rs
@@ -413,3 +413,7 @@ mod tests {
 #[path = "export_reader.rs"]
 mod reader;
 pub use reader::*;
+
+#[path = "export_planner.rs"]
+mod planner;
+pub use planner::*;

--- a/crates/rustok-forum/src/export_planner.rs
+++ b/crates/rustok-forum/src/export_planner.rs
@@ -1,0 +1,302 @@
+use std::collections::BTreeSet;
+
+use rustok_api::{Action, Resource};
+use rustok_content::normalize_locale_code;
+use rustok_core::{PermissionScope, SecurityContext};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::error::ForumError;
+use crate::services::{CategoryService, ReplyService, TopicService};
+
+use super::{
+    ForumExportReadBatch, ForumExportReadTarget, ForumExportReadTargetKind,
+    MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT,
+};
+
+pub const MAX_FORUM_EXPORT_PLAN_SOURCE_IDS_PER_FRAGMENT: usize =
+    MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT;
+
+#[derive(Clone, Debug)]
+pub struct ForumExportTargetPlanRequest {
+    pub tenant_id: Uuid,
+    pub category_ids: Vec<Uuid>,
+    pub topic_ids: Vec<Uuid>,
+    pub reply_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Error)]
+pub enum ForumExportTargetPlanError {
+    #[error("Forum export target planning requires an authenticated operator context")]
+    OperatorContextRequired,
+    #[error("Forum export target planning requires {resource}:manage")]
+    ManagePermissionRequired { resource: &'static str },
+    #[error("Forum export target planning requires a non-nil tenant id")]
+    NilTenantId,
+    #[error("Forum export target planning requires at least one source id")]
+    EmptySources,
+    #[error("Forum export target planning exceeds {max} source ids: {actual}")]
+    TooManySourceIds { max: usize, actual: usize },
+    #[error("Forum export target planning requires a non-nil {kind} id")]
+    NilSourceId { kind: &'static str },
+    #[error("Forum export target planning repeats {kind} id {id}")]
+    DuplicateSourceId { kind: &'static str, id: Uuid },
+    #[error(
+        "Forum export {kind} locale enumeration changed cardinality: expected {expected}, actual {actual}"
+    )]
+    LocaleFactCountChanged {
+        kind: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    #[error(
+        "Forum export {kind} locale enumeration changed identity from {expected_id} to {actual_id}"
+    )]
+    LocaleFactIdentityChanged {
+        kind: &'static str,
+        expected_id: Uuid,
+        actual_id: Uuid,
+    },
+    #[error("Forum export {kind} {id} locale enumeration returned no stored locales")]
+    EmptyLocaleFacts { kind: &'static str, id: Uuid },
+    #[error("Forum export {kind} {id} locale enumeration returned invalid locale {locale}")]
+    InvalidLocaleFact {
+        kind: &'static str,
+        id: Uuid,
+        locale: String,
+    },
+    #[error("Forum export {kind} {id} locale enumeration repeats normalized locale {locale}")]
+    DuplicateLocaleFact {
+        kind: &'static str,
+        id: Uuid,
+        locale: String,
+    },
+    #[error("Forum export target planning exceeds {max} localized targets: {actual}")]
+    TooManyTargets { max: usize, actual: usize },
+    #[error(transparent)]
+    Owner(#[from] ForumError),
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForumExportTargetPlanner;
+
+impl ForumExportTargetPlanner {
+    pub async fn plan_fragment(
+        &self,
+        categories: &CategoryService,
+        topics: &TopicService,
+        replies: &ReplyService,
+        security: &SecurityContext,
+        request: &ForumExportTargetPlanRequest,
+    ) -> Result<ForumExportReadBatch, ForumExportTargetPlanError> {
+        validate_plan_request(security, request)?;
+        require_requested_manage_scopes(security, request)?;
+
+        let mut targets = Vec::new();
+        if !request.category_ids.is_empty() {
+            let facts = categories
+                .available_locales_for_categories(
+                    request.tenant_id,
+                    security.clone(),
+                    &request.category_ids,
+                )
+                .await?;
+            append_locale_facts(
+                ForumExportReadTargetKind::Category,
+                &request.category_ids,
+                facts,
+                &mut targets,
+            )?;
+        }
+        if !request.topic_ids.is_empty() {
+            let facts = topics
+                .available_locales_for_topics(
+                    request.tenant_id,
+                    security.clone(),
+                    &request.topic_ids,
+                )
+                .await?;
+            append_locale_facts(
+                ForumExportReadTargetKind::Topic,
+                &request.topic_ids,
+                facts,
+                &mut targets,
+            )?;
+        }
+        if !request.reply_ids.is_empty() {
+            let facts = replies
+                .available_locales_for_replies(
+                    request.tenant_id,
+                    security.clone(),
+                    &request.reply_ids,
+                )
+                .await?;
+            append_locale_facts(
+                ForumExportReadTargetKind::Reply,
+                &request.reply_ids,
+                facts,
+                &mut targets,
+            )?;
+        }
+
+        Ok(ForumExportReadBatch {
+            tenant_id: request.tenant_id,
+            targets,
+        })
+    }
+}
+
+fn validate_plan_request(
+    security: &SecurityContext,
+    request: &ForumExportTargetPlanRequest,
+) -> Result<(), ForumExportTargetPlanError> {
+    if security.is_public_read() {
+        return Err(ForumExportTargetPlanError::OperatorContextRequired);
+    }
+    if request.tenant_id.is_nil() {
+        return Err(ForumExportTargetPlanError::NilTenantId);
+    }
+
+    let source_count = request
+        .category_ids
+        .len()
+        .saturating_add(request.topic_ids.len())
+        .saturating_add(request.reply_ids.len());
+    if source_count == 0 {
+        return Err(ForumExportTargetPlanError::EmptySources);
+    }
+    if source_count > MAX_FORUM_EXPORT_PLAN_SOURCE_IDS_PER_FRAGMENT {
+        return Err(ForumExportTargetPlanError::TooManySourceIds {
+            max: MAX_FORUM_EXPORT_PLAN_SOURCE_IDS_PER_FRAGMENT,
+            actual: source_count,
+        });
+    }
+
+    validate_source_ids("category", &request.category_ids)?;
+    validate_source_ids("topic", &request.topic_ids)?;
+    validate_source_ids("reply", &request.reply_ids)?;
+    Ok(())
+}
+
+fn require_requested_manage_scopes(
+    security: &SecurityContext,
+    request: &ForumExportTargetPlanRequest,
+) -> Result<(), ForumExportTargetPlanError> {
+    for (requested, resource, label) in [
+        (
+            !request.category_ids.is_empty(),
+            Resource::ForumCategories,
+            "forum_categories",
+        ),
+        (
+            !request.topic_ids.is_empty(),
+            Resource::ForumTopics,
+            "forum_topics",
+        ),
+        (
+            !request.reply_ids.is_empty(),
+            Resource::ForumReplies,
+            "forum_replies",
+        ),
+    ] {
+        if requested
+            && matches!(
+                security.get_scope(resource, Action::Manage),
+                PermissionScope::None
+            )
+        {
+            return Err(ForumExportTargetPlanError::ManagePermissionRequired {
+                resource: label,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_ids(
+    kind: &'static str,
+    ids: &[Uuid],
+) -> Result<(), ForumExportTargetPlanError> {
+    let mut seen = BTreeSet::new();
+    for id in ids {
+        if id.is_nil() {
+            return Err(ForumExportTargetPlanError::NilSourceId { kind });
+        }
+        if !seen.insert(*id) {
+            return Err(ForumExportTargetPlanError::DuplicateSourceId { kind, id: *id });
+        }
+    }
+    Ok(())
+}
+
+fn append_locale_facts(
+    kind: ForumExportReadTargetKind,
+    expected_ids: &[Uuid],
+    facts: Vec<(Uuid, Vec<String>)>,
+    targets: &mut Vec<ForumExportReadTarget>,
+) -> Result<(), ForumExportTargetPlanError> {
+    let label = kind_label(kind);
+    if facts.len() != expected_ids.len() {
+        return Err(ForumExportTargetPlanError::LocaleFactCountChanged {
+            kind: label,
+            expected: expected_ids.len(),
+            actual: facts.len(),
+        });
+    }
+
+    for (expected_id, (actual_id, locales)) in expected_ids.iter().copied().zip(facts) {
+        if actual_id != expected_id {
+            return Err(ForumExportTargetPlanError::LocaleFactIdentityChanged {
+                kind: label,
+                expected_id,
+                actual_id,
+            });
+        }
+        if locales.is_empty() {
+            return Err(ForumExportTargetPlanError::EmptyLocaleFacts {
+                kind: label,
+                id: actual_id,
+            });
+        }
+
+        let mut seen_locales = BTreeSet::new();
+        for locale in locales {
+            let normalized = normalize_locale_code(&locale).ok_or_else(|| {
+                ForumExportTargetPlanError::InvalidLocaleFact {
+                    kind: label,
+                    id: actual_id,
+                    locale: locale.clone(),
+                }
+            })?;
+            if !seen_locales.insert(normalized.clone()) {
+                return Err(ForumExportTargetPlanError::DuplicateLocaleFact {
+                    kind: label,
+                    id: actual_id,
+                    locale: normalized,
+                });
+            }
+
+            let actual = targets.len().saturating_add(1);
+            if actual > MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT {
+                return Err(ForumExportTargetPlanError::TooManyTargets {
+                    max: MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT,
+                    actual,
+                });
+            }
+            targets.push(ForumExportReadTarget {
+                kind,
+                id: actual_id,
+                locale: normalized,
+            });
+        }
+    }
+    Ok(())
+}
+
+const fn kind_label(kind: ForumExportReadTargetKind) -> &'static str {
+    match kind {
+        ForumExportReadTargetKind::Category => "category",
+        ForumExportReadTargetKind::Topic => "topic",
+        ForumExportReadTargetKind::Reply => "reply",
+    }
+}

--- a/docs/modules/forum-34-export-target-planner-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-export-target-planner-actualization-2026-08-09.md
@@ -1,0 +1,79 @@
+# FORUM-34H bounded export target planner actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34G are merged before this slice. 34E added bounded exact stored-locale enumeration for replies, 34F added the bounded owner export reader over explicit localized targets, and 34G added matching bounded exact stored-locale enumeration for categories and topics.
+
+Fresh `main` for this slice is `a0d8054e02296fa43a81d9dd53d4b616c231d0d7`. The commits after 34G are Commerce and Page Builder work and do not overlap Forum import/export source.
+
+The canonical Forum implementation-plan ledger still labels `FORUM-34` as `planned` even though 34A-34G are merged. Safe synchronization of that large concurrently edited source remains open; this dated packet records the truthful 34H cursor without replacing a partial/truncated roadmap image.
+
+## Gap selected
+
+34F accepts an explicit `ForumExportReadBatch`, while 34E/34G expose exact stored locales for known reply/category/topic IDs. Before 34H, callers still had to duplicate the expansion logic that turns source IDs into one exact localized read target per stored locale and had no shared boundary tying discovery size to the 34F fragment limit.
+
+34H adds a Forum-owned, non-wire planner that composes those existing locale-enumeration APIs into the exact input shape consumed by 34F.
+
+## Public in-process contract
+
+`ForumExportTargetPlanRequest` carries one tenant ID plus category, topic and reply ID vectors. `ForumExportTargetPlanner::plan_fragment(...)` accepts the three existing owner facades, `SecurityContext`, and the request, and returns `ForumExportReadBatch`.
+
+The request and resulting read batch remain in-process composition types. 34H does not derive `Serialize` or `Deserialize`, add a file format, or introduce GraphQL/REST/CLI transport.
+
+## Admission and bounds
+
+Planning fails closed before locale discovery when the context is public-read, the tenant ID is nil, no source IDs are supplied, the combined category + topic + reply source-ID count exceeds 512, any source ID is nil, an ID repeats within its resource kind, or any requested resource kind lacks its exact `*:manage` scope.
+
+The manage checks are preflighted for every requested kind before the first owner locale query, so a mixed-scope request does not perform partial discovery work before failing authorization.
+
+The combined source-ID bound is intentionally the same 512 ceiling as `MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT`. Since each valid source has at least one stored locale, a source batch above 512 could never produce a valid 34F fragment and is rejected before any discovery call.
+
+## Exact locale expansion
+
+For each non-empty resource kind, in deterministic order `category -> topic -> reply`, the planner calls exactly one existing owner locale-enumeration API: `CategoryService::available_locales_for_categories`, `TopicService::available_locales_for_topics`, or `ReplyService::available_locales_for_replies`.
+
+The planner preserves caller source-ID order inside each kind and preserves the owner locale-fact order while normalizing every locale through `normalize_locale_code`.
+
+It defensively rejects locale-fact contract drift when returned fact count differs from requested ID count, a returned ID differs from the corresponding requested ID, a source returns no locales, a locale is invalid, or two returned strings collapse to the same normalized locale.
+
+Each normalized locale becomes one `ForumExportReadTarget { kind, id, locale }`.
+
+## Localized target ceiling
+
+Expansion is bounded independently from the source-ID ceiling. If multilingual expansion would produce more than 512 localized targets, planning fails with `TooManyTargets` as soon as target 513 would be appended.
+
+This means a request with a small number of highly multilingual resources cannot silently create a read batch that 34F would reject later. Once the 512 ceiling is reached, later resource kinds are not queried.
+
+## Ownership and side effects
+
+`export_planner.rs` contains no SeaORM/database/entity access. It does not call category/topic/reply full owner `get`, does not call `ForumOwnerExportReader::read_fragment`, and does not map export records itself.
+
+Its only owner reads are the three established exact stored-locale enumeration APIs from 34E/34G. Export eligibility remains a 34F concern: archived, hidden, deleted, merged/canonicalized, or otherwise non-readable owner content may still fail when the planned target is passed to the exact owner reader. 34H does not weaken that boundary.
+
+34H performs no writes and adds no checkpoint, receipt, replay, audit, durable job, or migration state.
+
+## Determinism
+
+For the same tenant, source-ID vectors, security authority, and stored locale facts, target ordering is deterministic: all category targets in category input order, then topics, then replies; locales for each source retain the order returned by the exact owner locale API. No sorting by presentation fields, viewer state, timestamps, votes, or fallback locale is introduced.
+
+## Non-goals
+
+34H adds no tenant-wide category/topic/reply enumeration, durable migration/export runner, checkpoint or continuation cursor, import persistence adapter, external user/identity resolution, history/revision, votes/reputation, attachment or route-alias transfer, Search rebuild orchestration, export file transport, GraphQL/REST/CLI surface, or schema migration.
+
+## Next FORUM-34 cursor
+
+With 34H, callers that already possess bounded owner IDs can now compose exact locale discovery -> bounded localized target planning -> 34F exact owner reads -> 34D export mapping without duplicating storage access or fallback semantics.
+
+The next safe slice should inspect how bounded source IDs can be enumerated with explicit lifecycle/history policy. A tenant-wide cursor/checkpoint/receipt contract should not be invented inside Forum while the neutral shared migration runner remains absent.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-export-target-planner-source.mjs
+```

--- a/docs/modules/forum-34-export-target-planner-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-export-target-planner-actualization-2026-08-09.md
@@ -44,7 +44,7 @@ Each normalized locale becomes one `ForumExportReadTarget { kind, id, locale }`.
 
 Expansion is bounded independently from the source-ID ceiling. If multilingual expansion would produce more than 512 localized targets, planning fails with `TooManyTargets` as soon as target 513 would be appended.
 
-This means a request with a small number of highly multilingual resources cannot silently create a read batch that 34F would reject later. Once the 512 ceiling is reached, later resource kinds are not queried.
+This means a request with a small number of highly multilingual resources cannot silently create a read batch that 34F would reject later. If overflow occurs while expanding one resource kind, later kinds are not queried. If an earlier kind finishes at exactly 512 targets and a later kind is requested, that later locale query may still run before its first target is rejected as target 513.
 
 ## Ownership and side effects
 

--- a/scripts/verify/verify-forum-export-target-planner-source.mjs
+++ b/scripts/verify/verify-forum-export-target-planner-source.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  mapping: "crates/rustok-forum/src/export_mapping.rs",
+  planner: "crates/rustok-forum/src/export_planner.rs",
+  categoryLocales: "crates/rustok-forum/src/services/category_owner_locale_enumeration.rs",
+  topicLocales: "crates/rustok-forum/src/services/topic_facade_locale_enumeration.rs",
+  replyLocales: "crates/rustok-forum/src/services/reply_facade.rs",
+  packet: "docs/modules/forum-34-export-target-planner-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  '#[path = "export_planner.rs"]',
+  "mod planner;",
+  "pub use planner::*;",
+  '#[path = "export_reader.rs"]',
+  "pub use reader::*;",
+]) {
+  need(source.mapping, marker, "export mapping composition");
+}
+
+for (const marker of [
+  "pub const MAX_FORUM_EXPORT_PLAN_SOURCE_IDS_PER_FRAGMENT: usize =",
+  "MAX_FORUM_EXPORT_READ_TARGETS_PER_FRAGMENT;",
+  "pub struct ForumExportTargetPlanRequest",
+  "pub enum ForumExportTargetPlanError",
+  "pub struct ForumExportTargetPlanner;",
+  "pub async fn plan_fragment(",
+  "if security.is_public_read()",
+  "ForumExportTargetPlanError::OperatorContextRequired",
+  "ForumExportTargetPlanError::EmptySources",
+  "ForumExportTargetPlanError::TooManySourceIds",
+  "validate_source_ids(\"category\"",
+  "validate_source_ids(\"topic\"",
+  "validate_source_ids(\"reply\"",
+  "require_requested_manage_scopes(security, request)?;",
+  "Resource::ForumCategories",
+  "Resource::ForumTopics",
+  "Resource::ForumReplies",
+  "Action::Manage",
+  "PermissionScope::None",
+  ".available_locales_for_categories(",
+  ".available_locales_for_topics(",
+  ".available_locales_for_replies(",
+  "LocaleFactCountChanged",
+  "LocaleFactIdentityChanged",
+  "EmptyLocaleFacts",
+  "normalize_locale_code(&locale)",
+  "DuplicateLocaleFact",
+  "ForumExportTargetPlanError::TooManyTargets",
+  "ForumExportReadTarget {",
+  "ForumExportReadBatch {",
+]) {
+  need(source.planner, marker, "export planner");
+}
+
+for (const [method, label] of [
+  [".available_locales_for_categories(", "category locale call"],
+  [".available_locales_for_topics(", "topic locale call"],
+  [".available_locales_for_replies(", "reply locale call"],
+]) {
+  const count = source.planner.split(method).length - 1;
+  if (count !== 1) throw new Error(`export planner: expected exactly one ${label}, found ${count}`);
+}
+
+const requestStart = source.planner.indexOf("#[derive(Clone, Debug)]\npub struct ForumExportTargetPlanRequest");
+const errorStart = source.planner.indexOf("#[derive(Debug, Error)]", requestStart);
+if (requestStart < 0 || errorStart <= requestStart) {
+  throw new Error("export planner: request non-wire boundary is invalid");
+}
+const requestContract = source.planner.slice(requestStart, errorStart);
+for (const marker of ["Serialize", "Deserialize", "#[serde("]) {
+  forbid(requestContract, marker, "export planner request must remain non-wire");
+}
+
+for (const marker of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "crate::entities",
+  "Entity::",
+  "QueryFilter",
+  ".get_with_locale_fallback(",
+  ".read_fragment(",
+  "ForumOwnerExportMapper",
+  "ForumExportCategoryRecord {",
+  "ForumExportTopicRecord {",
+  "ForumExportReplyRecord {",
+  "Serialize",
+  "Deserialize",
+]) {
+  forbid(source.planner, marker, "export planner ownership boundary");
+}
+
+for (const [text, method, label] of [
+  [source.categoryLocales, "pub async fn available_locales_for_categories(", "category locale API"],
+  [source.topicLocales, "pub async fn available_locales_for_topics(", "topic locale API"],
+  [source.replyLocales, "pub async fn available_locales_for_replies(", "reply locale API"],
+]) {
+  need(text, method, label);
+  need(text, "Action::Manage", label);
+}
+
+for (const marker of [
+  "FORUM-34H",
+  "FORUM-34A through FORUM-34G",
+  "still labels `FORUM-34` as `planned`",
+  "combined category + topic + reply source-ID count exceeds 512",
+  "preflighted for every requested kind before the first owner locale query",
+  "category -> topic -> reply",
+  "normalize_locale_code",
+  "target 513",
+  "contains no SeaORM/database/entity access",
+  "does not call `ForumOwnerExportReader::read_fragment`",
+  "Export eligibility remains a 34F concern",
+  "neutral shared migration runner remains absent",
+  "no tests, Cargo commands",
+]) {
+  need(source.packet, marker, "FORUM-34H packet");
+}
+
+console.log("Forum FORUM-34H bounded export target planner source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with a bounded non-wire target planner that composes the exact stored-locale discovery APIs from 34E/34G into the `ForumExportReadBatch` consumed by 34F.

- add `ForumExportTargetPlanRequest` for bounded category/topic/reply source IDs;
- cap the combined source-ID request at 512 before locale discovery;
- reject public-read, nil tenant, empty sources, nil IDs and duplicates;
- preflight exact `forum_categories:manage`, `forum_topics:manage` and `forum_replies:manage` for every requested kind before the first owner read;
- call each existing owner locale-enumeration API at most once and only for non-empty kinds;
- preserve deterministic category -> topic -> reply and caller ID ordering;
- normalize locale facts, reject cardinality/identity drift, empty/invalid/normalized-duplicate locales;
- cap multilingual expansion at the same 512 localized-target ceiling as 34F;
- keep export eligibility in the 34F exact owner reader and keep DB access out of the planner;
- add a dated FORUM-34H actualization packet and source-only verifier.

## Recheck

The branch is rebased onto current `main` at `a0d8054e02296fa43a81d9dd53d4b616c231d0d7`. Commits after 34G are Commerce/Page Builder only and do not overlap Forum import/export source.

The canonical Forum implementation plan still labels `FORUM-34` as `planned`; the dated packet records the truthful 34H cursor without replacing the large plan through a whole-file update.

## Non-goals

No tenant-wide enumeration, shared/durable migration runner, checkpoint/receipt/replay/audit state, import persistence adapter, lifecycle/history policy expansion, user resolution, attachment/vote/reputation transfer, Search rebuild orchestration, GraphQL/REST/CLI transport or schema migration is added.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, DB scenario, workflow, CI command, lock generation, or `git diff --check` was run. Maintainer will run tests.