### PR TITLE
feat(pages): add typed provider health transport

### DIFF
--- a/crates/rustok-pages/admin/src/builder_rollout_settings.rs
+++ b/crates/rustok-pages/admin/src/builder_rollout_settings.rs
@@ -1,11 +1,22 @@
 use fly_ui::CapabilityState;
+use rustok_page_builder::health::ProviderHealthSnapshot;
 use rustok_page_builder::rollout::BuilderCapabilityFlags;
 use rustok_page_builder_admin::PageBuilderAdminProviderStatus;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PagesBuilderRolloutSnapshot {
     pub flags: BuilderCapabilityFlags,
     pub tenant_slug: String,
+    pub provider_health: Option<ProviderHealthSnapshot>,
+}
+
+impl PagesBuilderRolloutSnapshot {
+    pub fn provider_status(&self) -> PageBuilderAdminProviderStatus {
+        match self.provider_health.clone() {
+            Some(health) => PageBuilderAdminProviderStatus::observed(self.flags.clone(), health),
+            None => PageBuilderAdminProviderStatus::unobserved(self.flags.clone()),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -28,7 +39,7 @@ pub async fn fetch_pages_builder_rollout_snapshot(
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
         .ok_or(PagesBuilderRolloutSnapshotError::MissingTenant)?;
-    let (routed_tenant, flags) = crate::transport::fetch_page_builder_rollout_snapshot(
+    let (routed_tenant, flags, provider_health) = crate::transport::fetch_page_builder_rollout_snapshot(
         token,
         Some(requested_tenant.clone()),
     )
@@ -43,6 +54,7 @@ pub async fn fetch_pages_builder_rollout_snapshot(
     Ok(PagesBuilderRolloutSnapshot {
         flags,
         tenant_slug: routed_tenant,
+        provider_health,
     })
 }
 
@@ -53,9 +65,20 @@ pub fn pages_editor_capabilities_for_rollout(
     PageBuilderAdminProviderStatus::unobserved(flags.clone()).limit_capabilities(capabilities)
 }
 
+/// Apply a fully validated provider-health snapshot when a future caller has explicit owner
+/// authority to consume it. Current Pages UI/SSR call sites intentionally continue using the
+/// rollout-only helper above until retained deployment evaluator evidence is accepted and bound.
+pub fn pages_editor_capabilities_for_snapshot(
+    capabilities: CapabilityState,
+    snapshot: &PagesBuilderRolloutSnapshot,
+) -> CapabilityState {
+    snapshot.provider_status().limit_capabilities(capabilities)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustok_page_builder::health::ProviderSloObservations;
     use rustok_page_builder::rollout::BuilderToggleProfile;
 
     #[test]
@@ -80,5 +103,26 @@ mod tests {
         let builder_off =
             pages_editor_capabilities_for_rollout(full, &BuilderToggleProfile::BuilderOff.flags());
         assert_eq!(builder_off, CapabilityState::read_only());
+    }
+
+    #[test]
+    fn validated_observed_snapshot_can_narrow_capabilities_without_changing_rollout_flags() {
+        let health = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_600,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.0,
+        });
+        let snapshot = PagesBuilderRolloutSnapshot {
+            flags: BuilderCapabilityFlags::default(),
+            tenant_slug: "pages-tenant".to_string(),
+            provider_health: Some(health),
+        };
+        let effective =
+            pages_editor_capabilities_for_snapshot(CapabilityState::full(), &snapshot);
+        assert!(effective.edit);
+        assert!(effective.properties);
+        assert!(!effective.publish);
+        assert_eq!(snapshot.flags, BuilderCapabilityFlags::default());
     }
 }

--- a/crates/rustok-pages/admin/src/lib.rs
+++ b/crates/rustok-pages/admin/src/lib.rs
@@ -41,6 +41,7 @@ pub use builder::PagesBuilderSaveSnapshot;
 pub use builder_rollout_settings::{
     PagesBuilderRolloutSnapshot, PagesBuilderRolloutSnapshotError,
     fetch_pages_builder_rollout_snapshot, pages_editor_capabilities_for_rollout,
+    pages_editor_capabilities_for_snapshot,
 };
 pub use contribution_browser_intent::{
     PagesBrowserIntentAccessError, dispatch_pages_browser_intent,

--- a/crates/rustok-pages/admin/src/transport/builder_rollout_adapter.rs
+++ b/crates/rustok-pages/admin/src/transport/builder_rollout_adapter.rs
@@ -39,8 +39,8 @@ struct PageBuilderRolloutPayload {
 struct PageBuilderProviderHealthPayload {
     state: String,
     degradation_reasons: Vec<String>,
-    preview_p95_ms: i64,
-    publish_p95_ms: i64,
+    preview_p95_ms: u64,
+    publish_p95_ms: u64,
     sanitize_failure_rate: f64,
     runtime_error_rate: f64,
 }
@@ -85,10 +85,6 @@ fn parse_provider_health(
             "providerHealthObserved is true but providerHealth payload is missing",
         )),
         (true, Some(payload)) => {
-            let preview_p95_ms = u64::try_from(payload.preview_p95_ms)
-                .map_err(|_| health_transport_error("previewP95Ms must be non-negative"))?;
-            let publish_p95_ms = u64::try_from(payload.publish_p95_ms)
-                .map_err(|_| health_transport_error("publishP95Ms must be non-negative"))?;
             for (name, value) in [
                 ("sanitizeFailureRate", payload.sanitize_failure_rate),
                 ("runtimeErrorRate", payload.runtime_error_rate),
@@ -101,8 +97,8 @@ fn parse_provider_health(
             }
 
             let snapshot = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
-                preview_p95_ms,
-                publish_p95_ms,
+                preview_p95_ms: payload.preview_p95_ms,
+                publish_p95_ms: payload.publish_p95_ms,
                 sanitize_failure_rate: payload.sanitize_failure_rate,
                 runtime_error_rate: payload.runtime_error_rate,
             });

--- a/crates/rustok-pages/admin/src/transport/builder_rollout_adapter.rs
+++ b/crates/rustok-pages/admin/src/transport/builder_rollout_adapter.rs
@@ -1,11 +1,14 @@
 #[cfg(target_arch = "wasm32")]
 use leptos::web_sys;
 use rustok_graphql::{GraphqlHttpError, GraphqlRequest, execute as execute_graphql};
-use rustok_page_builder::rollout::BuilderCapabilityFlags;
+use rustok_page_builder::{
+    health::{ProviderHealthSnapshot, ProviderSloObservations},
+    rollout::BuilderCapabilityFlags,
+};
 use serde::Deserialize;
 use serde_json::json;
 
-const PAGE_BUILDER_ROLLOUT_QUERY: &str = "query PageBuilderRolloutSnapshot { pageBuilderRolloutSnapshot { tenantSlug builderEnabled previewEnabled propertiesEnabled publishEnabled providerHealthObserved } }";
+const PAGE_BUILDER_ROLLOUT_QUERY: &str = "query PageBuilderRolloutSnapshot { pageBuilderRolloutSnapshot { tenantSlug builderEnabled previewEnabled propertiesEnabled publishEnabled providerHealthObserved providerHealth { state degradationReasons previewP95Ms publishP95Ms sanitizeFailureRate runtimeErrorRate } } }";
 
 #[derive(Debug, Deserialize)]
 struct PageBuilderRolloutResponse {
@@ -27,6 +30,19 @@ struct PageBuilderRolloutPayload {
     publish_enabled: bool,
     #[serde(rename = "providerHealthObserved")]
     provider_health_observed: bool,
+    #[serde(rename = "providerHealth")]
+    provider_health: Option<PageBuilderProviderHealthPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageBuilderProviderHealthPayload {
+    state: String,
+    degradation_reasons: Vec<String>,
+    preview_p95_ms: i64,
+    publish_p95_ms: i64,
+    sanitize_failure_rate: f64,
+    runtime_error_rate: f64,
 }
 
 fn graphql_url() -> String {
@@ -49,10 +65,73 @@ fn graphql_url() -> String {
     }
 }
 
+fn health_transport_error(message: impl Into<String>) -> GraphqlHttpError {
+    GraphqlHttpError::Graphql(format!(
+        "Pages rollout provider health transport is invalid: {}",
+        message.into()
+    ))
+}
+
+fn parse_provider_health(
+    provider_health_observed: bool,
+    payload: Option<PageBuilderProviderHealthPayload>,
+) -> Result<Option<ProviderHealthSnapshot>, GraphqlHttpError> {
+    match (provider_health_observed, payload) {
+        (false, None) => Ok(None),
+        (false, Some(_)) => Err(health_transport_error(
+            "providerHealth payload is present while providerHealthObserved is false",
+        )),
+        (true, None) => Err(health_transport_error(
+            "providerHealthObserved is true but providerHealth payload is missing",
+        )),
+        (true, Some(payload)) => {
+            let preview_p95_ms = u64::try_from(payload.preview_p95_ms)
+                .map_err(|_| health_transport_error("previewP95Ms must be non-negative"))?;
+            let publish_p95_ms = u64::try_from(payload.publish_p95_ms)
+                .map_err(|_| health_transport_error("publishP95Ms must be non-negative"))?;
+            for (name, value) in [
+                ("sanitizeFailureRate", payload.sanitize_failure_rate),
+                ("runtimeErrorRate", payload.runtime_error_rate),
+            ] {
+                if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+                    return Err(health_transport_error(format!(
+                        "{name} must be finite and between 0 and 1"
+                    )));
+                }
+            }
+
+            let snapshot = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+                preview_p95_ms,
+                publish_p95_ms,
+                sanitize_failure_rate: payload.sanitize_failure_rate,
+                runtime_error_rate: payload.runtime_error_rate,
+            });
+            if payload.state != snapshot.state.as_str() {
+                return Err(health_transport_error(format!(
+                    "state `{}` does not match canonical evaluation `{}`",
+                    payload.state,
+                    snapshot.state.as_str()
+                )));
+            }
+            let expected_reasons: Vec<_> = snapshot
+                .degradation_reasons
+                .iter()
+                .map(|reason| reason.as_str().to_string())
+                .collect();
+            if payload.degradation_reasons != expected_reasons {
+                return Err(health_transport_error(
+                    "degradationReasons do not match canonical evaluation",
+                ));
+            }
+            Ok(Some(snapshot))
+        }
+    }
+}
+
 pub async fn fetch(
     token: Option<String>,
     tenant_slug: Option<String>,
-) -> Result<(String, BuilderCapabilityFlags), GraphqlHttpError> {
+) -> Result<(String, BuilderCapabilityFlags, Option<ProviderHealthSnapshot>), GraphqlHttpError> {
     let response: PageBuilderRolloutResponse = execute_graphql(
         &graphql_url(),
         GraphqlRequest::new(PAGE_BUILDER_ROLLOUT_QUERY, Some(json!({}))),
@@ -62,11 +141,10 @@ pub async fn fetch(
     )
     .await?;
     let payload = response.page_builder_rollout_snapshot;
-    if payload.provider_health_observed {
-        return Err(GraphqlHttpError::Graphql(
-            "Pages rollout snapshot unexpectedly claimed observed provider health".to_string(),
-        ));
-    }
+    let provider_health = parse_provider_health(
+        payload.provider_health_observed,
+        payload.provider_health,
+    )?;
     let flags = BuilderCapabilityFlags {
         builder_enabled: payload.builder_enabled,
         preview_enabled: payload.preview_enabled,
@@ -76,5 +154,48 @@ pub async fn fetch(
     flags
         .validate()
         .map_err(|error| GraphqlHttpError::Graphql(error.to_string()))?;
-    Ok((payload.tenant_slug, flags))
+    Ok((payload.tenant_slug, flags, provider_health))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn health_payload(
+        state: &str,
+        degradation_reasons: Vec<&str>,
+    ) -> PageBuilderProviderHealthPayload {
+        PageBuilderProviderHealthPayload {
+            state: state.to_string(),
+            degradation_reasons: degradation_reasons.into_iter().map(str::to_string).collect(),
+            preview_p95_ms: 1_600,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.0,
+        }
+    }
+
+    #[test]
+    fn provider_health_transport_requires_boolean_payload_consistency() {
+        assert!(parse_provider_health(false, None).unwrap().is_none());
+        assert!(parse_provider_health(false, Some(health_payload("degraded", vec!["provider_unhealthy"]))).is_err());
+        assert!(parse_provider_health(true, None).is_err());
+    }
+
+    #[test]
+    fn provider_health_transport_recomputes_canonical_state_and_reasons() {
+        let snapshot = parse_provider_health(
+            true,
+            Some(health_payload("degraded", vec!["provider_unhealthy"])),
+        )
+        .expect("valid transport")
+        .expect("observed health");
+        assert_eq!(snapshot.state.as_str(), "degraded");
+
+        assert!(parse_provider_health(
+            true,
+            Some(health_payload("ready", vec![])),
+        )
+        .is_err());
+    }
 }

--- a/crates/rustok-pages/admin/src/transport/mod.rs
+++ b/crates/rustok-pages/admin/src/transport/mod.rs
@@ -9,6 +9,7 @@ use crate::model::{
     CreatePageDraft, PageBuilderScenarioReleaseStatus, PageDetail, PageList, PageMutationResult,
     PagePublicationResult,
 };
+use rustok_page_builder::health::ProviderHealthSnapshot;
 use rustok_page_builder::rollout::BuilderCapabilityFlags;
 use rustok_page_builder::runtime_scenario_release::RuntimeScenarioReleaseBaseline;
 use serde_json::Value;
@@ -33,7 +34,7 @@ pub async fn fetch_page(
 pub async fn fetch_page_builder_rollout_snapshot(
     token: Option<String>,
     tenant_slug: Option<String>,
-) -> Result<(String, BuilderCapabilityFlags), TransportError> {
+) -> Result<(String, BuilderCapabilityFlags, Option<ProviderHealthSnapshot>), TransportError> {
     builder_rollout_adapter::fetch(token, tenant_slug).await
 }
 

--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-transport-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-transport-source.json
@@ -1,0 +1,88 @@
+{
+  "format": "pages_builder_provider_health_transport_source_v1",
+  "status": "typed_transport_source_ready_server_binding_blocked_execution_pending",
+  "provider": "page_builder",
+  "predecessors": [
+    "page_builder_provider_health_deployment_identity_source_v1",
+    "page_builder_provider_health_deployment_evaluator_source_v1"
+  ],
+  "graphql_owner": {
+    "query": "pageBuilderRolloutSnapshot",
+    "observed_flag": "providerHealthObserved",
+    "health_payload": "providerHealth",
+    "health_fields": [
+      "state",
+      "degradationReasons",
+      "previewP95Ms",
+      "publishP95Ms",
+      "sanitizeFailureRate",
+      "runtimeErrorRate"
+    ],
+    "current_server_observed_value": false,
+    "current_server_health_payload": null,
+    "owner_binding_to_retained_evaluator_packet_present": false
+  },
+  "admin_transport": {
+    "observed_false_requires_payload_absent": true,
+    "observed_true_requires_payload_present": true,
+    "latency_milliseconds_must_be_non_negative": true,
+    "failure_rates_must_be_finite": true,
+    "failure_rates_minimum": 0.0,
+    "failure_rates_maximum": 1.0,
+    "canonical_snapshot_recomputed_client_side": true,
+    "state_must_equal_canonical_recalculation": true,
+    "degradation_reasons_must_equal_canonical_recalculation": true,
+    "thresholds_taken_from_provider_health_snapshot_evaluate": true,
+    "raw_metric_or_prometheus_input_accepted": false
+  },
+  "admin_snapshot": {
+    "validated_health_retained_as_optional_provider_health_snapshot": true,
+    "provider_status_helper_uses_observed_only_when_health_present": true,
+    "rollout_only_helper_remains_unobserved": true,
+    "workspace_currently_consumes_flags_only": true,
+    "standalone_browser_intent_currently_consumes_flags_only": true,
+    "authoritative_ssr_currently_consumes_flags_only": true
+  },
+  "anti_promotion": {
+    "runtime_identity_capture_executed": false,
+    "runtime_deployment_evaluator_executed": false,
+    "retained_deployment_health_packet_present": false,
+    "owner_acceptance_present": false,
+    "pages_graphql_provider_health_observed": false,
+    "pages_ui_provider_health_bound": false,
+    "pages_ssr_provider_health_bound": false,
+    "standalone_browser_intent_provider_health_bound": false,
+    "pages_reference_consumer_gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "validation": {
+    "tests_run": false,
+    "node_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "graphql_request_run": false,
+    "browser_run": false,
+    "workflow_or_ci_run": false
+  },
+  "production_sources": [
+    "crates/rustok-pages/src/graphql/builder_rollout.rs",
+    "crates/rustok-pages/admin/src/transport/builder_rollout_adapter.rs",
+    "crates/rustok-pages/admin/src/transport/mod.rs",
+    "crates/rustok-pages/admin/src/builder_rollout_settings.rs"
+  ],
+  "current_unbound_consumers": [
+    "crates/rustok-pages/admin/src/composition.rs",
+    "crates/rustok-pages/admin/src/builder.rs",
+    "apps/admin/src/main.rs"
+  ],
+  "verifier": "crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs",
+  "next_cursor": {
+    "typed_provider_health_transport": "source_ready",
+    "retained_identity_and_evaluator_runtime_evidence": "maintainer_execution_pending",
+    "owner_acceptance_and_server_binding": "blocked_on_retained_runtime_evidence",
+    "ui_ssr_browser_intent_health_binding": "blocked_on_server_owner_binding",
+    "observed_health_acceptance": "pending"
+  }
+}

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  owner: "crates/rustok-pages/src/graphql/builder_rollout.rs",
+  transport: "crates/rustok-pages/admin/src/transport/builder_rollout_adapter.rs",
+  transportMod: "crates/rustok-pages/admin/src/transport/mod.rs",
+  snapshot: "crates/rustok-pages/admin/src/builder_rollout_settings.rs",
+  composition: "crates/rustok-pages/admin/src/composition.rs",
+  builder: "crates/rustok-pages/admin/src/builder.rs",
+  adminMain: "apps/admin/src/main.rs",
+  evidence: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-transport-source.json",
+  overlay: "docs/modules/pages-page-builder-provider-health-transport-actualization-2026-08-09.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+
+const sources = failures.length === 0
+  ? Object.fromEntries(Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]))
+  : {};
+let evidence = {};
+if (failures.length === 0) {
+  try {
+    evidence = JSON.parse(sources.evidence);
+  } catch (error) {
+    failures.push(`evidence: invalid JSON: ${error.message}`);
+  }
+}
+
+if (evidence.format !== "pages_builder_provider_health_transport_source_v1") {
+  failures.push("evidence format drifted");
+}
+if (evidence.status !== "typed_transport_source_ready_server_binding_blocked_execution_pending") {
+  failures.push("evidence status drifted");
+}
+
+for (const [object, key, expected] of [
+  [evidence.graphql_owner, "current_server_observed_value", false],
+  [evidence.graphql_owner, "current_server_health_payload", null],
+  [evidence.graphql_owner, "owner_binding_to_retained_evaluator_packet_present", false],
+  [evidence.admin_transport, "observed_false_requires_payload_absent", true],
+  [evidence.admin_transport, "observed_true_requires_payload_present", true],
+  [evidence.admin_transport, "canonical_snapshot_recomputed_client_side", true],
+  [evidence.admin_transport, "state_must_equal_canonical_recalculation", true],
+  [evidence.admin_transport, "degradation_reasons_must_equal_canonical_recalculation", true],
+  [evidence.admin_snapshot, "workspace_currently_consumes_flags_only", true],
+  [evidence.admin_snapshot, "standalone_browser_intent_currently_consumes_flags_only", true],
+  [evidence.anti_promotion, "pages_graphql_provider_health_observed", false],
+  [evidence.anti_promotion, "owner_acceptance_present", false],
+  [evidence.anti_promotion, "pages_reference_consumer_gate_accepted", false],
+  [evidence.validation, "tests_run", false],
+  [evidence.validation, "node_verifier_run", false],
+  [evidence.validation, "cargo_run", false],
+]) {
+  if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
+}
+
+for (const marker of [
+  "GqlPageBuilderProviderHealthSnapshot",
+  "pub provider_health: Option<GqlPageBuilderProviderHealthSnapshot>",
+  "provider_health_observed: false",
+  "provider_health: None",
+  "ProviderHealthSnapshot::from",
+  ".with_provider_health",
+]) {
+  if (marker === "ProviderHealthSnapshot::from") continue;
+  need(sources.owner ?? "", marker, "Pages GraphQL health shape");
+}
+need(sources.owner ?? "", "GqlPageBuilderProviderHealthSnapshot::from(health)", "Pages GraphQL health mapping");
+forbid(sources.owner ?? "", "page_builder_provider_health_deployment_evaluation_v1", "Pages GraphQL must not load evaluator evidence directly");
+
+for (const marker of [
+  "providerHealthObserved providerHealth { state degradationReasons previewP95Ms publishP95Ms sanitizeFailureRate runtimeErrorRate }",
+  "fn parse_provider_health(",
+  "(false, None) => Ok(None)",
+  "(false, Some(_)) => Err",
+  "(true, None) => Err",
+  "ProviderHealthSnapshot::evaluate(ProviderSloObservations",
+  "must be finite and between 0 and 1",
+  "does not match canonical evaluation",
+  "degradationReasons do not match canonical evaluation",
+  "payload.provider_health_observed",
+  "payload.provider_health",
+]) need(sources.transport ?? "", marker, "admin health transport");
+for (const forbidden of [
+  "rustok_page_builder_provider_operation_duration_seconds",
+  "rustok_page_builder_provider_operation_completed_total",
+  "rustok_page_builder_provider_last_observation_unix_seconds",
+  "prometheus",
+]) forbid(sources.transport ?? "", forbidden, "admin transport must not consume raw metrics");
+
+for (const marker of [
+  "Option<ProviderHealthSnapshot>",
+  "builder_rollout_adapter::fetch(token, tenant_slug).await",
+]) need(sources.transportMod ?? "", marker, "transport health propagation");
+
+for (const marker of [
+  "pub provider_health: Option<ProviderHealthSnapshot>",
+  "pub fn provider_status(&self) -> PageBuilderAdminProviderStatus",
+  "PageBuilderAdminProviderStatus::observed(self.flags.clone(), health)",
+  "PageBuilderAdminProviderStatus::unobserved(self.flags.clone())",
+  "pages_editor_capabilities_for_rollout(",
+  "pages_editor_capabilities_for_snapshot(",
+]) need(sources.snapshot ?? "", marker, "validated admin snapshot");
+
+// The transport is source-ready, but no current production consumer may activate observed health.
+for (const marker of [
+  ".flags;",
+  "provider_flags: BuilderCapabilityFlags",
+  ".with_provider_flags(provider_flags)",
+]) need(sources.composition ?? "", marker, "workspace remains rollout-only");
+need(sources.builder ?? "", ".map(PageBuilderAdminProviderStatus::unobserved)", "SSR facade remains unobserved");
+for (const marker of [
+  "pages_editor_capabilities_for_rollout(",
+  "&rollout.flags",
+]) need(sources.adminMain ?? "", marker, "standalone browser intent remains rollout-only");
+for (const source of [sources.composition ?? "", sources.builder ?? "", sources.adminMain ?? ""]) {
+  forbid(source, "pages_editor_capabilities_for_snapshot(", "observed health consumer binding must remain absent");
+}
+
+for (const marker of [
+  "typed-observed-health-transport-source-ready",
+  "server-owner-health-binding-blocked",
+  "boolean/payload consistency",
+  "canonical `ProviderHealthSnapshot::evaluate`",
+  "Pages remains `unobserved`",
+  "tests were not run",
+]) need(sources.overlay ?? "", marker, "health transport actualization");
+
+for (const marker of [
+  "provider-health-transport-source-ready",
+  "pages-page-builder-provider-health-transport-actualization-2026-08-09.md",
+  "typed observed-health transport",
+  "Pages remains `unobserved`",
+]) need(sources.parity ?? "", marker, "plan parity actualization");
+
+if (evidence.next_cursor?.typed_provider_health_transport !== "source_ready") {
+  failures.push("typed provider-health transport must be source-ready");
+}
+if (evidence.next_cursor?.retained_identity_and_evaluator_runtime_evidence !== "maintainer_execution_pending") {
+  failures.push("runtime evidence must remain maintainer-execution pending");
+}
+if (evidence.next_cursor?.owner_acceptance_and_server_binding !== "blocked_on_retained_runtime_evidence") {
+  failures.push("server owner binding must remain blocked on retained runtime evidence");
+}
+
+if (failures.length > 0) {
+  console.error("[verify-pages-builder-provider-health-transport] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log("[verify-pages-builder-provider-health-transport] PASS transport=source_ready server_binding=blocked pages_health=unobserved");

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
@@ -81,25 +81,29 @@ for (const [object, key, expected] of [
 
 for (const marker of [
   "GqlPageBuilderProviderHealthSnapshot",
+  "pub preview_p95_ms: u64",
+  "pub publish_p95_ms: u64",
   "pub provider_health: Option<GqlPageBuilderProviderHealthSnapshot>",
   "provider_health_observed: false",
   "provider_health: None",
-  "ProviderHealthSnapshot::from",
+  "preview_p95_ms: snapshot.observed.preview_p95_ms",
+  "publish_p95_ms: snapshot.observed.publish_p95_ms",
+  "GqlPageBuilderProviderHealthSnapshot::from(health)",
   ".with_provider_health",
-]) {
-  if (marker === "ProviderHealthSnapshot::from") continue;
-  need(sources.owner ?? "", marker, "Pages GraphQL health shape");
-}
-need(sources.owner ?? "", "GqlPageBuilderProviderHealthSnapshot::from(health)", "Pages GraphQL health mapping");
+]) need(sources.owner ?? "", marker, "Pages GraphQL health shape");
 forbid(sources.owner ?? "", "page_builder_provider_health_deployment_evaluation_v1", "Pages GraphQL must not load evaluator evidence directly");
 
 for (const marker of [
   "providerHealthObserved providerHealth { state degradationReasons previewP95Ms publishP95Ms sanitizeFailureRate runtimeErrorRate }",
+  "preview_p95_ms: u64",
+  "publish_p95_ms: u64",
   "fn parse_provider_health(",
   "(false, None) => Ok(None)",
   "(false, Some(_)) => Err",
   "(true, None) => Err",
   "ProviderHealthSnapshot::evaluate(ProviderSloObservations",
+  "preview_p95_ms: payload.preview_p95_ms",
+  "publish_p95_ms: payload.publish_p95_ms",
   "must be finite and between 0 and 1",
   "does not match canonical evaluation",
   "degradationReasons do not match canonical evaluation",

--- a/crates/rustok-pages/src/graphql/builder_rollout.rs
+++ b/crates/rustok-pages/src/graphql/builder_rollout.rs
@@ -18,8 +18,8 @@ const MODULE_SLUG: &str = "pages";
 pub struct GqlPageBuilderProviderHealthSnapshot {
     pub state: String,
     pub degradation_reasons: Vec<String>,
-    pub preview_p95_ms: i64,
-    pub publish_p95_ms: i64,
+    pub preview_p95_ms: u64,
+    pub publish_p95_ms: u64,
     pub sanitize_failure_rate: f64,
     pub runtime_error_rate: f64,
 }
@@ -33,8 +33,8 @@ impl From<&ProviderHealthSnapshot> for GqlPageBuilderProviderHealthSnapshot {
                 .iter()
                 .map(|reason| reason.as_str().to_string())
                 .collect(),
-            preview_p95_ms: snapshot.observed.preview_p95_ms.min(i64::MAX as u64) as i64,
-            publish_p95_ms: snapshot.observed.publish_p95_ms.min(i64::MAX as u64) as i64,
+            preview_p95_ms: snapshot.observed.preview_p95_ms,
+            publish_p95_ms: snapshot.observed.publish_p95_ms,
             sanitize_failure_rate: snapshot.observed.sanitize_failure_rate,
             runtime_error_rate: snapshot.observed.runtime_error_rate,
         }

--- a/crates/rustok-pages/src/graphql/builder_rollout.rs
+++ b/crates/rustok-pages/src/graphql/builder_rollout.rs
@@ -7,13 +7,41 @@ use rustok_page_builder::{
     dto::{
         BuilderCapabilityKind, PAGE_BUILDER_FEATURE_DISABLED_ERROR_CODE, PageBuilderErrorKind,
     },
+    health::ProviderHealthSnapshot,
     rollout::{BuilderCapabilityFlags, BuilderRolloutError, ensure_capability},
 };
 use sea_orm::DatabaseConnection;
 
 const MODULE_SLUG: &str = "pages";
 
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, SimpleObject)]
+pub struct GqlPageBuilderProviderHealthSnapshot {
+    pub state: String,
+    pub degradation_reasons: Vec<String>,
+    pub preview_p95_ms: i64,
+    pub publish_p95_ms: i64,
+    pub sanitize_failure_rate: f64,
+    pub runtime_error_rate: f64,
+}
+
+impl From<&ProviderHealthSnapshot> for GqlPageBuilderProviderHealthSnapshot {
+    fn from(snapshot: &ProviderHealthSnapshot) -> Self {
+        Self {
+            state: snapshot.state.as_str().to_string(),
+            degradation_reasons: snapshot
+                .degradation_reasons
+                .iter()
+                .map(|reason| reason.as_str().to_string())
+                .collect(),
+            preview_p95_ms: snapshot.observed.preview_p95_ms.min(i64::MAX as u64) as i64,
+            publish_p95_ms: snapshot.observed.publish_p95_ms.min(i64::MAX as u64) as i64,
+            sanitize_failure_rate: snapshot.observed.sanitize_failure_rate,
+            runtime_error_rate: snapshot.observed.runtime_error_rate,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, SimpleObject)]
 pub struct GqlPageBuilderRolloutSnapshot {
     pub tenant_slug: String,
     pub builder_enabled: bool,
@@ -21,6 +49,7 @@ pub struct GqlPageBuilderRolloutSnapshot {
     pub properties_enabled: bool,
     pub publish_enabled: bool,
     pub provider_health_observed: bool,
+    pub provider_health: Option<GqlPageBuilderProviderHealthSnapshot>,
 }
 
 impl GqlPageBuilderRolloutSnapshot {
@@ -32,7 +61,20 @@ impl GqlPageBuilderRolloutSnapshot {
             properties_enabled: flags.properties_enabled,
             publish_enabled: flags.publish_enabled,
             provider_health_observed: false,
+            provider_health: None,
         }
+    }
+
+    /// Build the transport shape for a deployment-bound provider-health snapshot.
+    ///
+    /// The live Pages query intentionally does not call this until retained deployment evaluator
+    /// evidence has been owner-accepted and bound by server-owned authority. Keeping the mapping
+    /// here makes the future transport explicit without converting source readiness into an
+    /// observed-health claim.
+    pub fn with_provider_health(mut self, health: &ProviderHealthSnapshot) -> Self {
+        self.provider_health = Some(GqlPageBuilderProviderHealthSnapshot::from(health));
+        self.provider_health_observed = self.provider_health.is_some();
+        self
     }
 }
 
@@ -100,6 +142,8 @@ impl PageBuilderRolloutQuery {
         ensure_pages_read_authority(auth, tenant)?;
         let flags = load_rollout_flags(db, tenant).await?;
 
+        // Provider health remains deliberately unobserved. A later server-owned binding may call
+        // `with_provider_health` only after retained deployment evaluation and owner acceptance.
         Ok(GqlPageBuilderRolloutSnapshot::new(tenant, flags))
     }
 
@@ -205,6 +249,7 @@ fn ensure_pages_read_authority(auth: &AuthContext, tenant: &TenantContext) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustok_page_builder::health::{ProviderHealthState, ProviderSloObservations};
     use uuid::Uuid;
 
     fn tenant(id: Uuid) -> TenantContext {
@@ -286,5 +331,28 @@ mod tests {
         assert!(allowed.allowed);
         assert!(allowed.error_kind.is_none());
         assert!(allowed.error_code.is_none());
+    }
+
+    #[test]
+    fn observed_transport_mapping_is_derived_from_canonical_health_snapshot() {
+        let tenant = tenant(Uuid::new_v4());
+        let health = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_600,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.0,
+        });
+        assert_eq!(health.state, ProviderHealthState::Degraded);
+
+        let payload = GqlPageBuilderRolloutSnapshot::new(
+            &tenant,
+            BuilderCapabilityFlags::default(),
+        )
+        .with_provider_health(&health);
+        assert!(payload.provider_health_observed);
+        let transported = payload.provider_health.expect("health payload");
+        assert_eq!(transported.state, "degraded");
+        assert_eq!(transported.preview_p95_ms, 1_600);
+        assert_eq!(transported.degradation_reasons, vec!["provider_unhealthy"]);
     }
 }

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,19 +1,20 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / provider-health-transport-source-ready / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has six source actualizations:
+This parity packet now has seven source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
 - `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which supersedes older rollout-specific wording after PRs #3333, #3337, #3345 and #3353;
 - `docs/modules/page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`, which introduced bounded process-local runtime observation source;
 - `docs/modules/page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`, which exports the same terminal observations through platform-owned deployment-aggregatable Prometheus metrics and a per-operation freshness signal;
 - `docs/modules/page-builder-provider-health-deployment-identity-actualization-2026-08-09.md`, which defines the exact source/deployment identity and expected-target inventory capture contract;
-- `docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md`, which defines the fail-closed backend evaluator over identity-admitted targets while leaving execution, Pages binding and observed-health acceptance pending.
+- `docs/modules/page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md`, which defines the fail-closed backend evaluator over identity-admitted targets;
+- `docs/modules/pages-page-builder-provider-health-transport-actualization-2026-08-09.md`, which defines a typed observed-health GraphQL/admin transport with canonical client revalidation while deliberately leaving server owner binding and production consumer activation blocked.
 
-The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation, deployment-aggregatable metrics/freshness, exact source/deployment identity + expected-target inventory, and the deployment-health evaluator are source-ready. Pages remains `unobserved` because the exact identity/evaluator packets have not been executed and retained for an admitted deployment, and no owner acceptance/binding step has occurred.
+The larger shared/local/central plans remain useful for the full Pages/Page Builder programme. Where an older paragraph still refers to hardcoded Pages rollout flags, rollout binding as pending, a matrix that is only executable but not source-defined, or a reference candidate that consumes only artifact/browser evidence, the rollout actualization is the current source cursor. Where older text says there is no live provider-health observation source or transport at all, the 2026-08-09 provider-health overlays are the current refinement: local Preview/Publish observation, deployment-aggregatable metrics/freshness, exact source/deployment identity + expected-target inventory, the deployment-health evaluator, and typed observed-health transport are source-ready. Pages remains `unobserved` because the exact identity/evaluator packets have not been executed and retained for an admitted deployment, no owner acceptance/server binding exists, and current production consumers still use rollout-only status.
 
 ## Current source truth
 
@@ -39,11 +40,15 @@ The synchronized source boundary is now:
 - Prometheus `time()` is the evaluator clock; the query window is explicitly bounded to 300..86400 seconds and Preview/Publish freshness is required for every expected target with an explicit freshness bound no larger than that window;
 - evaluator aggregation is reset-aware through `increase(...)`, requires at least 20 Preview and 20 Publish terminal completions, sums cumulative histogram buckets across admitted targets before p95 evaluation, and applies the same 1500ms / 3000ms / 1% / 1% provider-health policy as Rust `ProviderHealthSnapshot::evaluate`;
 - a retained deployment health evaluator packet can therefore contain a deployment-bound provider snapshot and SLO evaluation without raw Prometheus URL, raw PromQL, raw backend responses, raw target matcher values or credential values;
+- Pages GraphQL now has a typed optional provider-health payload alongside `providerHealthObserved`, while the current server owner still returns literal `provider_health_observed: false` plus `provider_health: None`;
+- the stateless admin transport enforces boolean/payload consistency, rejects negative latency or non-finite/out-of-range failure rates, recomputes canonical `ProviderHealthSnapshot::evaluate`, and rejects transported state/reasons that do not match that canonical result;
+- `PagesBuilderRolloutSnapshot` can retain validated optional health and derive `PageBuilderAdminProviderStatus`, but current workspace, authoritative SSR facade and standalone browser-intent paths deliberately continue to consume flags only;
+- typed observed-health transport therefore cannot silently promote health before retained runtime evidence and owner acceptance/server binding exist;
 - raw metrics target URLs, metric bodies and credential values are not retained by identity capture; target URL/body digests and credential environment names are retained instead;
 - the image RepoDigest association remains a maintainer-reviewed external fact because the running process cannot cryptographically derive its post-push RepoDigest from source SHA alone;
 - source inspection does not execute target identity capture, Prometheus queries or the deployment evaluator and does not produce runtime health evidence;
 - the process-local window remains restartable and is not deployment-wide health authority; pre-telemetry validation/inspection is outside its current measurement boundary;
-- Pages remains `unobserved`: `provider_health_observed = false` and admin provider health are intentionally not promoted until a retained deployment health evaluator packet exists for the admitted deployment and owner acceptance/binding is explicit;
+- Pages remains `unobserved`: `provider_health_observed = false` and current admin provider health are intentionally not promoted until a retained deployment health evaluator packet exists for the admitted deployment and owner acceptance/server binding is explicit;
 - `pages_reference_consumer_gate` remains `accepted = false` and `execution_gate = pending`;
 - Forum browser/runtime/deployment evidence and observed Wave remain blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
@@ -72,12 +77,14 @@ bounded process-local Preview/Publish observation [source-ready]
 -> deployment-aggregatable metrics + freshness signal [source-ready]
 -> exact source/deployment identity + expected-target inventory contract [source-ready]
 -> deployment health backend evaluator [source-ready]
+-> typed observed-health transport [source-ready]
 -> live exact-target identity capture + retained deployment health evaluator packet [maintainer execution pending]
--> Pages provider-status transport/binding + owner acceptance [blocked]
+-> owner acceptance + server provider-health binding [blocked]
+-> UI / SSR / browser-intent provider-health binding [blocked]
 -> observed-health acceptance decision [pending]
 ```
 
-Source inspection alone must not mark any execution or acceptance step complete. Raw/process-local, unbound Prometheus observations, a source-ready inventory contract without a live complete target capture, or a source-ready evaluator without retained runtime output must not be substituted for exact deployment provider-health evidence.
+Source inspection alone must not mark any execution or acceptance step complete. Raw/process-local, unbound Prometheus observations, a source-ready inventory contract without a live complete target capture, a source-ready evaluator without retained runtime output, or a typed transport without owner-bound server authority must not be substituted for exact deployment provider-health evidence.
 
 ## Anti-drift guard
 
@@ -101,9 +108,10 @@ crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-ru
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
 crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
 ```
 
-The first guard locks the bounded process-local window. The second locks platform metric names, bounded label vocabulary, registry wiring and reset-aware aggregation/freshness source. The third locks release source identity, build-info, complete expected-target inventory and fail-closed direct capture. The fourth locks complete backend target mapping, exact-source window admission, backend-clock freshness, sample floors, histogram aggregation, Rust health-policy parity and continued non-promotion of Pages health.
+The first guard locks the bounded process-local window. The second locks platform metric names, bounded label vocabulary, registry wiring and reset-aware aggregation/freshness source. The third locks release source identity, build-info, complete expected-target inventory and fail-closed direct capture. The fourth locks complete backend target mapping, exact-source window admission, backend-clock freshness, sample floors, histogram aggregation and Rust health-policy parity. The fifth locks the typed GraphQL/admin health shape, boolean/payload consistency, canonical client re-evaluation and the continued absence of server/UI/SSR/browser-intent health binding.
 
 The Pages reference-consumer gate continues to list the plan-parity verifier as a required source guard.
 
@@ -119,6 +127,9 @@ node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-heal
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-metrics.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-identity.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-binding.mjs
 ```
 
 All execution and acceptance evidence remains maintainer-owned.

--- a/docs/modules/pages-page-builder-provider-health-transport-actualization-2026-08-09.md
+++ b/docs/modules/pages-page-builder-provider-health-transport-actualization-2026-08-09.md
@@ -1,0 +1,162 @@
+# Pages / Page Builder provider-health transport actualization — 2026-08-09
+
+Status: `typed-observed-health-transport-source-ready / canonical-client-revalidation-source-ready / server-owner-health-binding-blocked / runtime-evidence-pending / pages-health-unobserved`.
+
+## Cursor
+
+This packet continues the provider-health source chain after:
+
+- `page-builder-provider-health-runtime-observation-actualization-2026-08-09.md`;
+- `page-builder-provider-health-deployment-metrics-actualization-2026-08-09.md`;
+- `page-builder-provider-health-deployment-identity-actualization-2026-08-09.md`;
+- `page-builder-provider-health-deployment-evaluator-actualization-2026-08-09.md`.
+
+The predecessor slice made a deployment-bound evaluator source-ready, but Pages still had no typed transport for an owner-accepted `ProviderHealthSnapshot`. The existing GraphQL snapshot exposed only `providerHealthObserved`, and the admin adapter rejected any `true` value.
+
+This slice closes that transport-only source gap. It does **not** execute deployment evidence, accept a health packet, or bind observed health into any production Pages consumer.
+
+## Server-owned GraphQL shape
+
+`pageBuilderRolloutSnapshot` now exposes the existing boolean plus an optional typed health payload:
+
+```text
+providerHealthObserved
+providerHealth {
+  state
+  degradationReasons
+  previewP95Ms
+  publishP95Ms
+  sanitizeFailureRate
+  runtimeErrorRate
+}
+```
+
+The payload is derived from the canonical `rustok_page_builder::health::ProviderHealthSnapshot` rather than defining a second health policy.
+
+The **current live query path remains deliberately unobserved**:
+
+```text
+provider_health_observed: false
+provider_health: None
+```
+
+A future server-owned binding may map an owner-accepted retained evaluator packet into this shape. This slice does not provide that authority and does not load evaluator artifacts from GraphQL code.
+
+## Boolean/payload consistency
+
+The stateless admin transport is fail-closed over the two fields:
+
+| `providerHealthObserved` | `providerHealth` | Result |
+|---|---|---|
+| `false` | absent | accepted as unobserved |
+| `false` | present | rejected |
+| `true` | absent | rejected |
+| `true` | present | validated as an observed candidate |
+
+This prevents a boolean-only healthy claim and prevents a hidden health payload from being consumed while the server still reports unobserved state.
+
+## Canonical client revalidation
+
+Even when a future server binding returns `observed=true`, the admin transport does not trust the state/reason labels independently.
+
+It validates:
+
+- Preview and Publish p95 values are non-negative;
+- sanitize/runtime failure rates are finite and inside `[0, 1]`;
+- the observation values are fed back through canonical `ProviderHealthSnapshot::evaluate`;
+- transported `state` must equal the canonical result;
+- transported `degradationReasons` must equal the canonical ordered reason set.
+
+Thresholds are therefore not accepted from the wire. They remain owned by `ProviderSloThresholds::PILOT` through canonical evaluation.
+
+The transport never consumes Prometheus metrics, raw evaluator queries, target mappings or deployment credentials.
+
+## Admin snapshot seam
+
+`PagesBuilderRolloutSnapshot` now retains:
+
+```text
+flags: BuilderCapabilityFlags
+provider_health: Option<ProviderHealthSnapshot>
+```
+
+and exposes a canonical `provider_status()` helper:
+
+- health present -> `PageBuilderAdminProviderStatus::observed(...)`;
+- health absent -> `PageBuilderAdminProviderStatus::unobserved(...)`.
+
+A separate `pages_editor_capabilities_for_snapshot(...)` helper is source-ready for the eventual owner binding.
+
+The existing `pages_editor_capabilities_for_rollout(...)` helper remains unchanged and unobserved.
+
+## Deliberately unbound production consumers
+
+This slice does not activate the new helper in current production paths.
+
+The Pages workspace still:
+
+- extracts `.flags` from the server snapshot;
+- passes `provider_flags: BuilderCapabilityFlags`;
+- composes the facade with `.with_provider_flags(provider_flags)`.
+
+The authoritative SSR facade still resolves missing health through `PageBuilderAdminProviderStatus::unobserved`.
+
+The standalone browser-intent preflight still calls `pages_editor_capabilities_for_rollout(..., &rollout.flags)`.
+
+Therefore transport readiness cannot silently change editing, preview or publish behavior before evidence and acceptance exist.
+
+## Why owner binding remains blocked
+
+The required runtime sequence is still maintainer-owned:
+
+1. execute exact deployment identity capture;
+2. retain a deployment evaluator packet over the same admitted deployment;
+3. review/accept the resulting source SHA, RepoDigest, target inventory, freshness window and SLO result;
+4. only then bind the accepted snapshot into the server-owned Pages rollout query;
+5. only after server binding may UI/SSR/browser-intent consumers switch from rollout-only to validated provider status.
+
+Source inspection cannot substitute for steps 1–3.
+
+## Source evidence
+
+Machine contract:
+
+```text
+crates/rustok-pages/contracts/evidence/pages-builder-provider-health-transport-source.json
+```
+
+Fail-closed source guard:
+
+```text
+crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
+```
+
+The guard locks the GraphQL shape, boolean/payload consistency, canonical re-evaluation, optional admin snapshot seam and continued absence of production health binding.
+
+## Next cursor
+
+```text
+bounded runtime observation [source-ready]
+-> deployment metrics/freshness [source-ready]
+-> exact deployment identity + target inventory [source-ready]
+-> deployment health evaluator [source-ready]
+-> typed observed-health transport [source-ready]
+-> retained identity + evaluator runtime evidence [maintainer execution pending]
+-> owner acceptance + server health binding [blocked]
+-> UI / SSR / browser-intent health binding [blocked]
+-> observed-health acceptance [pending]
+```
+
+## Validation boundary
+
+Per maintainer instruction, tests were not run. No Node verifier, Cargo command, formatting, build, GraphQL request, Prometheus query, deployment capture/evaluator execution, browser run, workflow or CI was executed by this slice.
+
+Suggested maintainer source checks, intentionally not run:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-binding.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
+node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+```


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder provider-health parity cursor after #3399.

#3399 made the deployment-bound evaluator source-ready, but Pages still exposed only a boolean `providerHealthObserved` and the admin transport rejected any observed state. This PR closes that transport-only gap without promoting provider health.

### Changes

- add an optional typed `providerHealth` payload to `pageBuilderRolloutSnapshot`;
- keep the current server response literally `provider_health_observed: false` + `provider_health: None`;
- map canonical `ProviderHealthSnapshot` into the future GraphQL transport shape without loading evaluator evidence in the query;
- make the stateless admin adapter fail closed on boolean/payload inconsistency;
- reject negative latency and non-finite/out-of-range failure rates;
- recompute canonical `ProviderHealthSnapshot::evaluate` client-side and reject state/reason drift;
- carry validated optional health through `PagesBuilderRolloutSnapshot` and expose a canonical `provider_status()` seam;
- keep workspace, authoritative SSR facade and standalone browser-intent consumers rollout-only;
- add machine evidence, a source guard and a dated parity overlay.

## Deliberate non-promotion

This PR does not execute deployment identity capture or the health evaluator, does not accept a retained health packet, and does not bind observed health into production Pages consumers.

Therefore:

- live GraphQL health remains unobserved;
- current UI/SSR/browser-intent behavior remains rollout-only;
- `pages_reference_consumer_gate` remains unaccepted;
- Forum Wave remains blocked;
- FFA/FBA remain unpromoted.

## Validation

Per maintainer instruction, tests/verifiers are intentionally not run by this implementation agent. No Cargo, Node verifier, formatting, GraphQL/HTTP, browser, Prometheus/evaluator, workflow or CI execution was performed.

Suggested maintainer source checks:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-server-snapshot.mjs
node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-binding.mjs
node crates/rustok-page-builder/scripts/verify/verify-page-builder-provider-health-deployment-evaluator.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
```

## Next cursor

`deployment evaluator [source-ready] -> typed observed-health transport [source-ready] -> retained identity + evaluator runtime evidence [maintainer execution pending] -> owner acceptance + server health binding [blocked] -> UI/SSR/browser-intent health binding [blocked] -> observed-health acceptance`