### PR TITLE
feat(fulfillment): publish shipping option admin command port

### DIFF
--- a/crates/rustok-fulfillment/docs/shipping-option-admin-command-owner-port-2026-08-09.md
+++ b/crates/rustok-fulfillment/docs/shipping-option-admin-command-owner-port-2026-08-09.md
@@ -1,0 +1,74 @@
+# Fulfillment shipping-option admin command owner port
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+This slice publishes the missing Fulfillment-owned command boundary required to remove mounted
+Commerce REST construction of `FulfillmentService` for shipping-option writes.
+
+`ShippingOptionAdminCommandPort` now owns the four owner-local operations used by Commerce admin
+shipping routes:
+
+- create shipping option;
+- update shipping option;
+- deactivate shipping option;
+- reactivate shipping option.
+
+The public `ShippingOptionAdminCommandRuntime` accepts an injected owner implementation and exposes
+an explicit in-process adapter for hosts that select the built-in Fulfillment implementation.
+
+## Admission and ownership
+
+Every command requires the canonical write `PortCallPolicy`. The tenant UUID is parsed only from the
+admitted `PortContext`; the in-process adapter does not accept a separate transport tenant argument.
+
+This capability does **not** claim durable idempotent replay for shipping-option create/update/state
+writes. A caller or host may carry an idempotency identity in `PortContext`, but this source slice does
+not consume it as an owner receipt. Durable replay semantics must be added explicitly before any
+exactly-once claim is made.
+
+The in-process implementation keeps `FulfillmentService` construction inside `rustok-fulfillment`.
+Shipping-option validation, persistence, activation state, translations, provider id, metadata, and
+response projection therefore remain owner-local.
+
+The request wrappers preserve the existing owner DTOs:
+
+- `CreateShippingOptionInput`;
+- `UpdateShippingOptionInput`;
+- `ShippingOptionResponse`.
+
+This slice does not add a new transport shape.
+
+## Bounded errors
+
+Owner `FulfillmentError` values are mapped to stable `PortError` families without exposing raw
+validation/database text:
+
+- validation -> `fulfillment.validation`;
+- missing shipping option -> `fulfillment.shipping_option_not_found`;
+- state conflict -> `fulfillment.invalid_transition`;
+- storage failure -> `fulfillment.database_unavailable`.
+
+Diagnostics retain bounded context/error facts and the stable public owner code. Raw backend errors
+are not logged by this boundary.
+
+## Deliberately still open
+
+Mounted Commerce admin REST `create_shipping_option`, `update_shipping_option`,
+`deactivate_shipping_option`, and `reactivate_shipping_option` still construct `FulfillmentService`
+directly in this capability-only slice. The next consumer cutover must host-compose
+`ShippingOptionAdminCommandRuntime` and route those four handlers through the new owner port while
+preserving shipping-profile validation, permissions, request context, responses, and public HTTP
+errors.
+
+The canonical ecommerce topology item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and
+Fulfillment concrete services behind host-composed owner ports` remains open.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted REST
+scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios
+were executed for this slice. The accompanying verifier is source-only evidence for maintainer
+execution.

--- a/crates/rustok-fulfillment/src/lib.rs
+++ b/crates/rustok-fulfillment/src/lib.rs
@@ -15,6 +15,7 @@ pub mod migrations;
 pub mod ports;
 pub mod providers;
 pub mod services;
+mod shipping_option_admin_command;
 mod shipping_option_read;
 pub mod status;
 
@@ -46,6 +47,12 @@ pub use fulfillment_read::{
 };
 pub use ports::*;
 pub use providers::*;
+pub use shipping_option_admin_command::{
+    CreateAdminShippingOptionRequest, DeactivateAdminShippingOptionRequest,
+    InProcessShippingOptionAdminCommandPort, ReactivateAdminShippingOptionRequest,
+    ShippingOptionAdminCommandPort, ShippingOptionAdminCommandRuntime,
+    UpdateAdminShippingOptionRequest, in_process_shipping_option_admin_command_port,
+};
 pub use shipping_option_read::{
     InProcessShippingOptionAdminReadPort, InProcessShippingOptionReadPort,
     ListAllShippingOptionProjectionsRequest, ListShippingOptionProjectionsRequest,

--- a/crates/rustok-fulfillment/src/shipping_option_admin_command.rs
+++ b/crates/rustok-fulfillment/src/shipping_option_admin_command.rs
@@ -1,0 +1,258 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::dto::{
+    CreateShippingOptionInput, ShippingOptionResponse, UpdateShippingOptionInput,
+};
+use crate::error::FulfillmentError;
+use crate::services::FulfillmentService;
+
+const SHIPPING_OPTION_ADMIN_COMMAND_BOUNDARY: &str = "fulfillment_shipping_option_admin_command_port";
+
+#[async_trait]
+pub trait ShippingOptionAdminCommandPort: Send + Sync {
+    async fn create_shipping_option(
+        &self,
+        context: PortContext,
+        request: CreateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError>;
+
+    async fn update_shipping_option(
+        &self,
+        context: PortContext,
+        request: UpdateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError>;
+
+    async fn deactivate_shipping_option(
+        &self,
+        context: PortContext,
+        request: DeactivateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError>;
+
+    async fn reactivate_shipping_option(
+        &self,
+        context: PortContext,
+        request: ReactivateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateAdminShippingOptionRequest {
+    pub input: CreateShippingOptionInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateAdminShippingOptionRequest {
+    pub shipping_option_id: Uuid,
+    pub input: UpdateShippingOptionInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeactivateAdminShippingOptionRequest {
+    pub shipping_option_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReactivateAdminShippingOptionRequest {
+    pub shipping_option_id: Uuid,
+}
+
+pub struct InProcessShippingOptionAdminCommandPort {
+    service: FulfillmentService,
+}
+
+impl InProcessShippingOptionAdminCommandPort {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self {
+            service: FulfillmentService::new(db),
+        }
+    }
+}
+
+pub fn in_process_shipping_option_admin_command_port(
+    db: DatabaseConnection,
+) -> Arc<dyn ShippingOptionAdminCommandPort> {
+    Arc::new(InProcessShippingOptionAdminCommandPort::new(db))
+}
+
+#[derive(Clone)]
+pub struct ShippingOptionAdminCommandRuntime {
+    command_port: Arc<dyn ShippingOptionAdminCommandPort>,
+}
+
+impl ShippingOptionAdminCommandRuntime {
+    pub fn new(command_port: Arc<dyn ShippingOptionAdminCommandPort>) -> Self {
+        Self { command_port }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(in_process_shipping_option_admin_command_port(db))
+    }
+
+    pub fn command_port(&self) -> Arc<dyn ShippingOptionAdminCommandPort> {
+        self.command_port.clone()
+    }
+}
+
+#[async_trait]
+impl ShippingOptionAdminCommandPort for InProcessShippingOptionAdminCommandPort {
+    async fn create_shipping_option(
+        &self,
+        context: PortContext,
+        request: CreateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError> {
+        const OPERATION: &str = "create_admin_shipping_option";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.service
+            .create_shipping_option(tenant_id, request.input)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))
+    }
+
+    async fn update_shipping_option(
+        &self,
+        context: PortContext,
+        request: UpdateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError> {
+        const OPERATION: &str = "update_admin_shipping_option";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.service
+            .update_shipping_option(tenant_id, request.shipping_option_id, request.input)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))
+    }
+
+    async fn deactivate_shipping_option(
+        &self,
+        context: PortContext,
+        request: DeactivateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError> {
+        const OPERATION: &str = "deactivate_admin_shipping_option";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.service
+            .deactivate_shipping_option(tenant_id, request.shipping_option_id)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))
+    }
+
+    async fn reactivate_shipping_option(
+        &self,
+        context: PortContext,
+        request: ReactivateAdminShippingOptionRequest,
+    ) -> Result<ShippingOptionResponse, PortError> {
+        const OPERATION: &str = "reactivate_admin_shipping_option";
+        require_write_admission(&context, OPERATION)?;
+        let tenant_id = parse_tenant_id(&context, OPERATION)?;
+        self.service
+            .reactivate_shipping_option(tenant_id, request.shipping_option_id)
+            .await
+            .map_err(|error| map_fulfillment_error(&context, OPERATION, error))
+    }
+}
+
+fn require_write_admission(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<(), PortError> {
+    context.require_policy(PortCallPolicy::write()).inspect_err(|error| {
+        log_port_error(context, operation, "policy", error);
+    })
+}
+
+fn parse_tenant_id(context: &PortContext, operation: &'static str) -> Result<Uuid, PortError> {
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        let error = PortError::validation(
+            "fulfillment.tenant_id_invalid",
+            "fulfillment command tenant context is invalid",
+        );
+        log_port_error(context, operation, "tenant_id", &error);
+        error
+    })
+}
+
+fn map_fulfillment_error(
+    context: &PortContext,
+    operation: &'static str,
+    error: FulfillmentError,
+) -> PortError {
+    let error_variant = fulfillment_error_variant(&error);
+    let mapped = match error {
+        FulfillmentError::Validation(_) => PortError::validation(
+            "fulfillment.validation",
+            "shipping option request is invalid",
+        ),
+        FulfillmentError::ShippingOptionNotFound(_) => PortError::not_found(
+            "fulfillment.shipping_option_not_found",
+            "shipping option was not found",
+        ),
+        FulfillmentError::FulfillmentNotFound(_) => PortError::not_found(
+            "fulfillment.not_found",
+            "fulfillment resource was not found",
+        ),
+        FulfillmentError::InvalidTransition { .. } => PortError::conflict(
+            "fulfillment.invalid_transition",
+            "fulfillment lifecycle conflicts with the requested operation",
+        ),
+        FulfillmentError::Database(_) => PortError::unavailable(
+            "fulfillment.database_unavailable",
+            "fulfillment storage is temporarily unavailable",
+        ),
+    };
+    tracing::warn!(
+        owner = "rustok_fulfillment",
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        error_variant,
+        public_code = %mapped.code,
+        retryable = mapped.retryable,
+        boundary = SHIPPING_OPTION_ADMIN_COMMAND_BOUNDARY,
+        "fulfillment shipping option admin command returned a bounded owner error"
+    );
+    mapped
+}
+
+fn fulfillment_error_variant(error: &FulfillmentError) -> &'static str {
+    match error {
+        FulfillmentError::Validation(_) => "validation",
+        FulfillmentError::ShippingOptionNotFound(_) => "shipping_option_not_found",
+        FulfillmentError::FulfillmentNotFound(_) => "fulfillment_not_found",
+        FulfillmentError::InvalidTransition { .. } => "invalid_transition",
+        FulfillmentError::Database(_) => "database",
+    }
+}
+
+fn log_port_error(
+    context: &PortContext,
+    operation: &'static str,
+    admission: &'static str,
+    error: &PortError,
+) {
+    tracing::warn!(
+        owner = "rustok_fulfillment",
+        operation,
+        admission,
+        correlation_id = %context.correlation_id,
+        tenant_id_length = context.tenant_id.chars().count(),
+        actor_id_length = context.actor.id.chars().count(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        code = %error.code,
+        retryable = error.retryable,
+        boundary = SHIPPING_OPTION_ADMIN_COMMAND_BOUNDARY,
+        "fulfillment shipping option admin command admission failed"
+    );
+}

--- a/scripts/verify/verify-fulfillment-shipping-option-admin-command-owner-port.mjs
+++ b/scripts/verify/verify-fulfillment-shipping-option-admin-command-owner-port.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+const failures = [];
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+const owner = read('crates/rustok-fulfillment/src/shipping_option_admin_command.rs');
+const lib = read('crates/rustok-fulfillment/src/lib.rs');
+const consumer = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-fulfillment/docs/shipping-option-admin-command-owner-port-2026-08-09.md',
+);
+
+for (const marker of [
+  'pub trait ShippingOptionAdminCommandPort',
+  'async fn create_shipping_option(',
+  'async fn update_shipping_option(',
+  'async fn deactivate_shipping_option(',
+  'async fn reactivate_shipping_option(',
+  'pub struct ShippingOptionAdminCommandRuntime',
+  'pub fn in_process(db: DatabaseConnection) -> Self',
+  'service: FulfillmentService',
+  'FulfillmentService::new(db)',
+  'context.require_policy(PortCallPolicy::write())',
+  'Uuid::parse_str(&context.tenant_id)',
+  'PortError::validation(',
+  'PortError::not_found(',
+  'PortError::conflict(',
+  'PortError::unavailable(',
+  'fulfillment.shipping_option_not_found',
+  'fulfillment.database_unavailable',
+  'error_variant = fulfillment_error_variant(&error)',
+]) need(owner, marker, 'shipping option owner command capability');
+
+for (const marker of [
+  'context.require_write_semantics()',
+  'error = ?error',
+  'error.to_string()',
+]) forbid(owner, marker, 'shipping option owner bounded replay/diagnostic contract');
+
+for (const marker of [
+  'mod shipping_option_admin_command;',
+  'ShippingOptionAdminCommandPort, ShippingOptionAdminCommandRuntime',
+  'in_process_shipping_option_admin_command_port',
+]) need(lib, marker, 'fulfillment public export');
+
+for (const marker of [
+  'let option = FulfillmentService::new(runtime.db_clone())\n        .create_shipping_option',
+  'let option = FulfillmentService::new(runtime.db_clone())\n        .update_shipping_option',
+  'let option = FulfillmentService::new(runtime.db_clone())\n        .deactivate_shipping_option',
+  'let option = FulfillmentService::new(runtime.db_clone())\n        .reactivate_shipping_option',
+]) need(consumer, marker, 'consumer cutover intentionally remains open');
+
+need(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,',
+  'canonical ecommerce topology P0 remains open',
+);
+
+for (const marker of [
+  'Status: `source_complete_unvalidated`',
+  '`ShippingOptionAdminCommandPort`',
+  '`ShippingOptionAdminCommandRuntime`',
+  'does **not** claim durable idempotent replay',
+  'still construct `FulfillmentService` directly',
+  'no tests, Cargo commands, Node verifiers, formatter',
+]) need(record, marker, 'dated source record');
+
+if (failures.length > 0) {
+  console.error('[verify-fulfillment-shipping-option-admin-command-owner-port] FAIL');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log('[verify-fulfillment-shipping-option-admin-command-owner-port] PASS');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce standalone/topology P0 by publishing the missing Fulfillment-owned boundary for mounted Commerce admin shipping-option writes.

- add `ShippingOptionAdminCommandPort` / `ShippingOptionAdminCommandRuntime` for create, update, deactivate, and reactivate shipping-option operations;
- keep concrete `FulfillmentService` construction inside `rustok-fulfillment` via the explicit in-process owner adapter;
- derive tenant ownership from admitted `PortContext` and require the canonical write call policy;
- preserve existing Fulfillment shipping-option DTOs and response projections without adding a transport-specific shape;
- map owner `FulfillmentError` values to bounded `PortError` families without exposing raw validation/database details;
- explicitly do **not** claim durable idempotent replay for shipping-option create/update/state writes in this capability-only slice;
- add a dated source record and source-only verifier;
- leave mounted Commerce REST consumer cutover for the next PR, and keep the broad topology P0 open.

## Source recheck

Mounted GraphQL legacy resolver source is wrapped by Order/Payment/Fulfillment owner-port shims, so textual `Service::new` calls in the included compatibility source are not concrete mounted owner construction. The confirmed remaining mounted gap selected here is `controllers/admin/shipping.rs`, where four shipping-option write handlers still construct `rustok_fulfillment::FulfillmentService` directly while the corresponding read paths already use owner ports.

No equivalent shipping-option admin command capability existed in `rustok-fulfillment`, so this PR publishes the owner contract first rather than mixing owner API design and Commerce transport cutover in one broad change.

The branch is one commit ahead and zero behind current `main` (`4a172cacce6c709a73616d4d30bc92c87f537ccf`) with exactly four changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted REST scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios were executed. The added verifier is source-only evidence for maintainer execution.