### PR TITLE
feat(forum): compose bounded export pages

### DIFF
--- a/crates/rustok-forum/src/export_page.rs
+++ b/crates/rustok-forum/src/export_page.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeSet;
+
+use rustok_core::SecurityContext;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::services::{CategoryService, ReplyService, TopicService};
+
+use super::{
+    ForumExportSourceInventoryError, ForumExportSourceInventoryPage,
+    ForumExportSourceInventoryRequest, ForumExportSourceInventoryService,
+    ForumExportTargetPlanError, ForumExportTargetPlanner,
+};
+use super::super::{
+    ForumExportFragment, ForumExportReadError, ForumExportReadTargetKind, ForumOwnerExportReader,
+};
+
+#[derive(Clone, Debug)]
+pub struct ForumExportPage {
+    pub source: ForumExportSourceInventoryPage,
+    pub fragment: Option<ForumExportFragment>,
+}
+
+#[derive(Debug, Error)]
+pub enum ForumExportPageComposeError {
+    #[error(transparent)]
+    Inventory(#[from] ForumExportSourceInventoryError),
+    #[error(transparent)]
+    Plan(#[from] ForumExportTargetPlanError),
+    #[error(transparent)]
+    Read(#[from] ForumExportReadError),
+    #[error("Forum export page returned an empty source page while claiming more rows")]
+    EmptyPageHasMore,
+    #[error("Forum export page fragment tenant changed from {expected} to {actual}")]
+    FragmentTenantChanged { expected: Uuid, actual: Uuid },
+    #[error("Forum export page fragment contains records outside requested {kind} kind")]
+    FragmentKindContaminated { kind: &'static str },
+    #[error("Forum export page fragment source identities differ from the inventory {kind} page")]
+    FragmentSourceIdentityChanged { kind: &'static str },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForumExportPageComposer;
+
+impl ForumExportPageComposer {
+    pub async fn compose_page(
+        &self,
+        inventory: &ForumExportSourceInventoryService,
+        categories: &CategoryService,
+        topics: &TopicService,
+        replies: &ReplyService,
+        security: &SecurityContext,
+        request: &ForumExportSourceInventoryRequest,
+    ) -> Result<ForumExportPage, ForumExportPageComposeError> {
+        let source = inventory.list_page(security, request).await?;
+        let Some(plan_request) = source.target_plan_request() else {
+            if source.has_more {
+                return Err(ForumExportPageComposeError::EmptyPageHasMore);
+            }
+            return Ok(ForumExportPage {
+                source,
+                fragment: None,
+            });
+        };
+
+        let read_batch = ForumExportTargetPlanner
+            .plan_fragment(
+                categories,
+                topics,
+                replies,
+                security,
+                &plan_request,
+            )
+            .await?;
+        let fragment = ForumOwnerExportReader
+            .read_fragment(categories, topics, replies, security, &read_batch)
+            .await?;
+        validate_fragment(&source, &fragment)?;
+
+        Ok(ForumExportPage {
+            source,
+            fragment: Some(fragment),
+        })
+    }
+}
+
+fn validate_fragment(
+    source: &ForumExportSourceInventoryPage,
+    fragment: &ForumExportFragment,
+) -> Result<(), ForumExportPageComposeError> {
+    if fragment.tenant_id != source.tenant_id {
+        return Err(ForumExportPageComposeError::FragmentTenantChanged {
+            expected: source.tenant_id,
+            actual: fragment.tenant_id,
+        });
+    }
+
+    let actual_ids = match source.kind {
+        ForumExportReadTargetKind::Category => {
+            if !fragment.topics.is_empty() || !fragment.replies.is_empty() {
+                return Err(ForumExportPageComposeError::FragmentKindContaminated {
+                    kind: kind_label(source.kind),
+                });
+            }
+            unique_ids(fragment.categories.iter().map(|record| record.id))
+        }
+        ForumExportReadTargetKind::Topic => {
+            if !fragment.categories.is_empty() || !fragment.replies.is_empty() {
+                return Err(ForumExportPageComposeError::FragmentKindContaminated {
+                    kind: kind_label(source.kind),
+                });
+            }
+            unique_ids(fragment.topics.iter().map(|record| record.id))
+        }
+        ForumExportReadTargetKind::Reply => {
+            if !fragment.categories.is_empty() || !fragment.topics.is_empty() {
+                return Err(ForumExportPageComposeError::FragmentKindContaminated {
+                    kind: kind_label(source.kind),
+                });
+            }
+            unique_ids(fragment.replies.iter().map(|record| record.id))
+        }
+    };
+
+    if actual_ids != source.ids {
+        return Err(ForumExportPageComposeError::FragmentSourceIdentityChanged {
+            kind: kind_label(source.kind),
+        });
+    }
+    Ok(())
+}
+
+fn unique_ids(ids: impl IntoIterator<Item = Uuid>) -> Vec<Uuid> {
+    let mut seen = BTreeSet::new();
+    let mut unique = Vec::new();
+    for id in ids {
+        if seen.insert(id) {
+            unique.push(id);
+        }
+    }
+    unique
+}
+
+const fn kind_label(kind: ForumExportReadTargetKind) -> &'static str {
+    match kind {
+        ForumExportReadTargetKind::Category => "category",
+        ForumExportReadTargetKind::Topic => "topic",
+        ForumExportReadTargetKind::Reply => "reply",
+    }
+}

--- a/crates/rustok-forum/src/export_planner.rs
+++ b/crates/rustok-forum/src/export_planner.rs
@@ -304,3 +304,7 @@ const fn kind_label(kind: ForumExportReadTargetKind) -> &'static str {
 #[path = "export_inventory.rs"]
 mod inventory;
 pub use inventory::*;
+
+#[path = "export_page.rs"]
+mod page;
+pub use page::*;

--- a/docs/modules/.forum-34j-pr-ready
+++ b/docs/modules/.forum-34j-pr-ready
@@ -1,1 +1,0 @@
-FORUM-34J source-ready on a1ceae709b6dfd359b1ba6053f49b3dffdb926bd

--- a/docs/modules/.forum-34j-pr-ready
+++ b/docs/modules/.forum-34j-pr-ready
@@ -1,0 +1,1 @@
+FORUM-34J source-ready on a1ceae709b6dfd359b1ba6053f49b3dffdb926bd

--- a/docs/modules/forum-34-export-page-composer-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-export-page-composer-actualization-2026-08-09.md
@@ -1,0 +1,92 @@
+# FORUM-34J bounded export page composer actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34I are merged before this slice. Fresh `main` for 34J is `a1ceae709b6dfd359b1ba6053f49b3dffdb926bd`, the 34I merge commit; no later Forum import/export commit was present when this slice started.
+
+The canonical Forum implementation-plan ledger still labels `FORUM-34` as `planned`. This dated packet records the truthful 34J cursor without replacing the large concurrently edited roadmap from a partial whole-file image.
+
+## Purpose
+
+34I can enumerate one bounded live page of candidate source IDs. 34H expands explicit source IDs into exact stored-locale read targets. 34F performs exact owner reads and 34D maps those already-authorized owner views into `rustok.forum.export.v1`.
+
+34J adds the missing read-only composition boundary for one page. It does not add another storage path or duplicate any mapping logic.
+
+## Public in-process contract
+
+`ForumExportPageComposer::compose_page(...)` accepts the existing:
+
+- `ForumExportSourceInventoryService`;
+- category/topic/reply owner services;
+- `SecurityContext`;
+- `ForumExportSourceInventoryRequest`.
+
+It returns `ForumExportPage` containing the exact 34I `source` page plus `fragment: Option<ForumExportFragment>`.
+
+For a non-empty source page the only data path is:
+
+`34I list_page -> 34H target_plan_request/plan_fragment -> 34F read_fragment -> 34D mapping`.
+
+For an empty terminal source page, `fragment` is `None`. The composer does not manufacture an empty 34H request that would violate 34H's `EmptySources` contract. An impossible empty page with `has_more=true` fails closed.
+
+The page wrapper and composer contract are non-wire and add no serde/transport contract.
+
+## Authorization
+
+34J does not weaken or reinterpret authorization. The first stage is still 34I, which requires a non-public operator context and `PermissionScope::All` for the requested resource kind's exact `Action::Manage`. 34H and 34F then repeat their existing requested-kind manage admission.
+
+The composer adds no bypass around those owner boundaries.
+
+## Bounded behavior
+
+34I still limits one source page to at most 512 IDs. 34H/34F still limit the expanded localized target batch to at most 512 targets.
+
+A page with many locales can therefore be valid at the source-ID layer but exceed the localized-target cap. 34J deliberately propagates `ForumExportTargetPlanError::TooManyTargets`; it does not truncate locales, split one source page invisibly, or advance the source cursor after a failed plan. A caller may retry the same `after_id` with a smaller source limit.
+
+## Composition integrity checks
+
+After 34F/34D returns a fragment, 34J validates:
+
+- fragment tenant ID equals the 34I page tenant;
+- the fragment contains records only for the requested resource kind;
+- the ordered unique source IDs in the fragment equal the ordered 34I source IDs.
+
+These checks protect the composition boundary from accidental cross-kind contamination, source identity substitution, or ordering/cardinality drift. They do not replace the stricter exact-locale and exact-owner checks already enforced by 34H/34F.
+
+## Live-read consistency boundary
+
+34J does **not** claim a frozen database snapshot, even within one composed page. Inventory, locale enumeration and exact owner reads remain separate owner calls. Concurrent archive/restore/delete/merge/content changes can therefore race the composition pipeline.
+
+Some races fail closed through existing not-found/canonical/exact-locale checks; other live-state transitions can produce a fragment reflecting a later state than the inventory query. A neutral shared migration runner must own quiescence or snapshot semantics, durable checkpoints, retry identity and receipts before FORUM-34 can claim a complete resumable tenant export.
+
+The returned source cursor is still only the 34I live keyset position, not durable job state.
+
+## Storage and transport boundaries
+
+`export_page.rs` imports no SeaORM/database types and issues no storage query itself. It owns orchestration only. It does not call `ForumOwnerExportMapper` directly; mapping remains inside 34F's established reader path.
+
+34J adds no GraphQL/REST/CLI endpoint, schema migration, background job, checkpoint table, audit/receipt persistence or shared runner implementation.
+
+## Current source-ready export chain
+
+The bounded current-state export path is now composed end-to-end for one resource-kind page:
+
+`34J page composer -> 34I bounded candidate IDs -> 34H exact-locale targets -> 34F exact owner reads -> 34D export mapping`.
+
+Cross-page completeness, frozen snapshot semantics and durable resume remain intentionally open. Import persistence, external-user identity resolution, history/revisions, votes/reputation, attachments, merge/route history and Search rebuild orchestration also remain open.
+
+## Next FORUM-34 cursor
+
+With the bounded current-state export page now composed, the next safe Forum-owned slice should move back to the import side: define a bounded resolved import-application boundary that consumes already-inspected dependencies/identities without inventing the absent durable shared runner. External-user resolution must remain explicit rather than fabricating RusTok user IDs.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-export-page-composer-source.mjs
+```

--- a/scripts/verify/verify-forum-export-page-composer-source.mjs
+++ b/scripts/verify/verify-forum-export-page-composer-source.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  planner: "crates/rustok-forum/src/export_planner.rs",
+  page: "crates/rustok-forum/src/export_page.rs",
+  inventory: "crates/rustok-forum/src/export_inventory.rs",
+  packet: "docs/modules/forum-34-export-page-composer-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  '#[path = "export_page.rs"]',
+  "mod page;",
+  "pub use page::*;",
+]) {
+  need(source.planner, marker, "export page wiring");
+}
+
+for (const marker of [
+  "pub struct ForumExportPage",
+  "pub source: ForumExportSourceInventoryPage",
+  "pub fragment: Option<ForumExportFragment>",
+  "pub enum ForumExportPageComposeError",
+  "pub struct ForumExportPageComposer",
+  "pub async fn compose_page(",
+  "inventory.list_page(security, request).await?",
+  "source.target_plan_request()",
+  "if source.has_more",
+  "EmptyPageHasMore",
+  "fragment: None",
+  "ForumExportTargetPlanner",
+  ".plan_fragment(",
+  "ForumOwnerExportReader",
+  ".read_fragment(",
+  "validate_fragment(&source, &fragment)?",
+  "fragment: Some(fragment)",
+  "FragmentTenantChanged",
+  "FragmentKindContaminated",
+  "FragmentSourceIdentityChanged",
+  "unique_ids(fragment.categories.iter().map(|record| record.id))",
+  "unique_ids(fragment.topics.iter().map(|record| record.id))",
+  "unique_ids(fragment.replies.iter().map(|record| record.id))",
+  "if actual_ids != source.ids",
+]) {
+  need(source.page, marker, "export page composer");
+}
+
+for (const marker of [
+  "sea_orm",
+  "DatabaseConnection",
+  "ConnectionTrait",
+  "Entity::",
+  "crate::entities",
+  "Serialize",
+  "Deserialize",
+  "#[serde(",
+  "ForumOwnerExportMapper",
+  "get_with_locale_fallback",
+  "available_locales_for_categories",
+  "available_locales_for_topics",
+  "available_locales_for_replies",
+]) {
+  forbid(source.page, marker, "composer orchestration-only boundary");
+}
+
+for (const marker of [
+  "PermissionScope::All",
+  "Action::Manage",
+  "request.limit == 0",
+  "MAX_FORUM_EXPORT_SOURCE_INVENTORY_LIMIT",
+]) {
+  need(source.inventory, marker, "34I authorization/bound baseline");
+}
+
+for (const marker of [
+  "FORUM-34J",
+  "FORUM-34A through FORUM-34I",
+  "still labels `FORUM-34` as `planned`",
+  "34I list_page -> 34H target_plan_request/plan_fragment -> 34F read_fragment -> 34D mapping",
+  "fragment` is `None`",
+  "PermissionScope::All",
+  "TooManyTargets",
+  "retry the same `after_id` with a smaller source limit",
+  "ordered unique source IDs",
+  "does **not** claim a frozen database snapshot",
+  "imports no SeaORM/database types",
+  "does not call `ForumOwnerExportMapper` directly",
+  "34J page composer -> 34I bounded candidate IDs -> 34H exact-locale targets -> 34F exact owner reads -> 34D export mapping",
+  "no tests, Cargo commands",
+]) {
+  need(source.packet, marker, "FORUM-34J packet");
+}
+
+const inventoryCalls = source.page.split(".list_page(").length - 1;
+const plannerCalls = source.page.split(".plan_fragment(").length - 1;
+const readerCalls = source.page.split(".read_fragment(").length - 1;
+if (inventoryCalls !== 1 || plannerCalls !== 1 || readerCalls !== 1) {
+  throw new Error(
+    `export page composer: expected one inventory/planner/reader call, found ${inventoryCalls}/${plannerCalls}/${readerCalls}`,
+  );
+}
+
+console.log("Forum FORUM-34J bounded export page composer source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with a bounded read-only page composer over the already-merged export slices.

- add `ForumExportPageComposer::compose_page` over `34I inventory -> 34H target planner -> 34F owner reader -> 34D mapper`;
- keep the request/page wrapper non-wire and add no storage or transport path in the composer;
- return `fragment: None` for an empty terminal inventory page instead of manufacturing an invalid empty 34H request;
- fail closed if an impossible empty page claims `has_more`;
- preserve 34I all-scope `*:manage` tenant-wide discovery and the existing 34H/34F manage admission;
- validate fragment tenant, requested resource kind, and ordered unique source IDs against the 34I page;
- propagate localized-target overflow instead of truncating/splitting a page silently, so callers can retry the same cursor with a smaller source limit;
- explicitly keep page composition as live reads, not a frozen snapshot or durable checkpoint;
- add a dated FORUM-34J actualization packet and source-only verifier.

## Recheck

The branch is based on current `main` at `a1ceae709b6dfd359b1ba6053f49b3dffdb926bd`, the FORUM-34I merge. The final compare before this PR is `behind 0` with exactly four Forum files changed; `export_planner.rs` changes by only four wiring lines.

The canonical Forum implementation plan still labels `FORUM-34` as `planned`; the dated packet records the truthful 34J cursor without replacing the large roadmap wholesale.

## Consistency boundary

The composer does not claim a transactionally frozen snapshot, even within one page: inventory, locale discovery and exact owner reads remain separate owner calls. Concurrent lifecycle/content changes may race the pipeline. The absent neutral shared migration runner still owns quiescence/snapshot/checkpoint/receipt semantics.

## Non-goals

No durable runner, cross-page snapshot, checkpoint/receipt/replay/audit persistence, import write adapter, identity resolution, history/revision transfer, votes/reputation, attachments, merge/route history, Search rebuild orchestration, GraphQL/REST/CLI transport or schema migration is added.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, DB scenario, workflow, CI command, lock generation or `git diff --check` was run. Maintainer will run tests.