### PR TITLE
feat(commerce): route shipping option writes through owner port

### DIFF
--- a/crates/rustok-commerce/docs/admin-shipping-option-command-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/admin-shipping-option-command-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,69 @@
+# Admin shipping-option command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+Mounted Commerce admin REST shipping-option writes now execute through the Fulfillment-owned
+`ShippingOptionAdminCommandPort` published in the preceding owner-capability slice.
+
+The cutover covers the four mounted handlers in `controllers/admin/shipping.rs`:
+
+- `create_shipping_option`;
+- `update_shipping_option`;
+- `deactivate_shipping_option`;
+- `reactivate_shipping_option`.
+
+Those handlers no longer construct `rustok_fulfillment::FulfillmentService`.
+
+## Runtime composition
+
+`CommerceHttpRuntime` now carries a `ShippingOptionAdminCommandRuntime` and exposes only its typed
+command port to the mounted handlers. A host-supplied runtime from `HostRuntimeContext` is preferred;
+when none is supplied, Commerce selects the Fulfillment-owned in-process runtime, matching the
+existing Fulfillment admin-command composition pattern.
+
+Concrete `FulfillmentService` construction therefore remains inside `rustok-fulfillment` for this
+command path.
+
+## Preserved transport admission
+
+The existing permissions and response envelopes remain unchanged:
+
+- create requires `FULFILLMENTS_CREATE` and still returns `201` plus `ShippingOptionResponse`;
+- update/deactivate/reactivate require `FULFILLMENTS_UPDATE` and still return
+  `ShippingOptionResponse`;
+- create/update still validate Commerce-owned shipping-profile slugs before crossing the owner
+  boundary.
+
+Each owner call now receives a bounded `PortContext` carrying the admitted tenant, authenticated
+user actor, effective request locale, optional request channel, a stable correlation identity, a
+two-second deadline, and a payload-bound deterministic idempotency identity required by the owner
+write policy.
+
+The deterministic transport identity is admission metadata only. This slice does **not** claim that
+shipping-option create/update/state commands have durable owner receipt/replay semantics; the owner
+capability record from the preceding slice remains authoritative on that limitation.
+
+## Error boundary
+
+The existing stable Commerce HTTP error families are preserved through the shared `PortError`
+mapper. Raw owner/database details are not returned to clients. The mapper is shared by the existing
+shipping-option reads and the new command calls and logs only bounded owner/context facts.
+
+## Still open
+
+The canonical ecommerce topology item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and
+Fulfillment concrete services behind host-composed owner ports` remains open because other mounted
+concrete owner construction still requires separate source slices.
+
+Shipping-profile CRUD remains Commerce-owned and is intentionally outside this Fulfillment owner
+cutover.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted REST
+scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios
+were executed for this slice. The accompanying verifier is source-only evidence for maintainer
+execution.

--- a/crates/rustok-commerce/src/controllers/admin/shipping.rs
+++ b/crates/rustok-commerce/src/controllers/admin/shipping.rs
@@ -7,12 +7,14 @@ use rustok_api::{
     AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
     TenantContext,
 };
-use rustok_fulfillment::error::FulfillmentError;
 use rustok_fulfillment::{
-    FulfillmentService, ListAllShippingOptionProjectionsRequest,
-    ReadShippingOptionProjectionRequest,
+    CreateAdminShippingOptionRequest, DeactivateAdminShippingOptionRequest,
+    ListAllShippingOptionProjectionsRequest, ReactivateAdminShippingOptionRequest,
+    ReadShippingOptionProjectionRequest, UpdateAdminShippingOptionRequest,
 };
 use rustok_web::{HttpError, HttpResult};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::{
@@ -187,51 +189,44 @@ fn map_shipping_profile_error(error: CommerceError) -> HttpError {
     HttpError::new(status, code, message)
 }
 
-fn map_admin_shipping_option_error(
-    context: AdminShippingOptionErrorContext,
-    error: FulfillmentError,
-) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
-        FulfillmentError::Validation(_) => (
-            StatusCode::BAD_REQUEST,
-            "commerce_admin_fulfillment_invalid",
-            "Fulfillment request is invalid",
-            "validation",
-        ),
-        FulfillmentError::ShippingOptionNotFound(_) | FulfillmentError::FulfillmentNotFound(_) => (
-            StatusCode::NOT_FOUND,
-            "commerce_admin_not_found",
-            "Commerce resource not found",
-            "not_found",
-        ),
-        FulfillmentError::InvalidTransition { .. } => (
-            StatusCode::CONFLICT,
-            "commerce_admin_fulfillment_state_conflict",
-            "Fulfillment operation conflicts with the current state",
-            "state_conflict",
-        ),
-        FulfillmentError::Database(_) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "commerce_admin_fulfillment_storage_unavailable",
-            "Fulfillment storage is temporarily unavailable",
-            "database",
-        ),
-    };
-    let context = AdminShippingOptionDiagnosticContext::from(&context);
-    let error = AdminShippingDiagnosticError;
-    tracing::error!(
-        error = ?error,
-        owner = ADMIN_SHIPPING_OPTION_OWNER,
-        tenant_id = %context.tenant_id,
-        shipping_option_id = ?context.shipping_option_id,
-        operation = %context.operation,
-        error_kind,
-        public_code = code,
-        status = %status,
-        boundary = ADMIN_SHIPPING_BOUNDARY,
-        "commerce admin shipping option operation failed"
-    );
-    HttpError::new(status, code, message)
+fn admin_shipping_option_command_idempotency_key<T: Serialize>(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    shipping_option_id: Option<Uuid>,
+    operation: &'static str,
+    payload: &T,
+) -> HttpResult<String> {
+    let payload = serde_json::to_vec(payload).map_err(|_| {
+        let error = AdminShippingDiagnosticError;
+        tracing::error!(
+            error = ?error,
+            owner = ADMIN_SHIPPING_OPTION_OWNER,
+            tenant_id = %uuid_shape(tenant_id),
+            shipping_option_id = %optional_uuid_shape(shipping_option_id),
+            operation,
+            error_kind = "request_identity_serialization",
+            public_code = "commerce_admin_fulfillment_failed",
+            boundary = ADMIN_SHIPPING_BOUNDARY,
+            "commerce admin shipping option command identity could not be materialized"
+        );
+        HttpError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_fulfillment_failed",
+            "Fulfillment operation could not be completed safely",
+        )
+    })?;
+    let mut digest = Sha256::new();
+    digest.update(tenant_id.as_bytes());
+    digest.update(actor_id.as_bytes());
+    digest.update(operation.as_bytes());
+    if let Some(shipping_option_id) = shipping_option_id {
+        digest.update(shipping_option_id.as_bytes());
+    }
+    digest.update(payload);
+    Ok(format!(
+        "commerce-admin-shipping-option:{operation}:{}",
+        hex::encode(digest.finalize())
+    ))
 }
 
 fn admin_shipping_option_read_port_context(
@@ -253,6 +248,24 @@ fn admin_shipping_option_read_port_context(
         Some(channel) => context.with_channel(channel),
         None => context,
     }
+}
+
+fn admin_shipping_option_command_port_context(
+    tenant_id: Uuid,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    shipping_option_id: Option<Uuid>,
+    operation: &'static str,
+    idempotency_key: String,
+) -> PortContext {
+    admin_shipping_option_read_port_context(
+        tenant_id,
+        auth,
+        request_context,
+        shipping_option_id,
+        operation,
+    )
+    .with_idempotency_key(idempotency_key)
 }
 
 fn map_admin_shipping_option_port_error(
@@ -323,7 +336,7 @@ fn map_admin_shipping_option_port_error(
         public_code = code,
         status = %status,
         boundary = ADMIN_SHIPPING_BOUNDARY,
-        "commerce admin shipping option read failed"
+        "commerce admin shipping option owner call failed"
     );
     HttpError::new(status, code, message)
 }
@@ -652,6 +665,7 @@ pub async fn create_shipping_option(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Json(input): Json<CreateShippingOptionInput>,
 ) -> HttpResult<(StatusCode, Json<ShippingOptionResponse>)> {
     ensure_permissions(
@@ -667,12 +681,31 @@ pub async fn create_shipping_option(
     )
     .await?;
 
-    let option = FulfillmentService::new(runtime.db_clone())
-        .create_shipping_option(tenant.id, input)
+    let request = CreateAdminShippingOptionRequest { input };
+    let idempotency_key = admin_shipping_option_command_idempotency_key(
+        tenant.id,
+        auth.user_id,
+        None,
+        "create_shipping_option",
+        &request,
+    )?;
+    let command_context = admin_shipping_option_command_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        None,
+        "create_shipping_option",
+        idempotency_key,
+    );
+    let option = runtime
+        .shipping_option_admin_command_port()
+        .create_shipping_option(command_context.clone(), request)
         .await
         .map_err(|error| {
-            map_admin_shipping_option_error(
+            map_admin_shipping_option_port_error(
                 AdminShippingOptionErrorContext::new(tenant.id, None, "create_shipping_option"),
+                &command_context,
+                "create_admin_shipping_option",
                 error,
             )
         })?;
@@ -752,6 +785,7 @@ pub async fn update_shipping_option(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
     Json(input): Json<UpdateShippingOptionInput>,
 ) -> HttpResult<Json<ShippingOptionResponse>> {
@@ -768,12 +802,34 @@ pub async fn update_shipping_option(
     )
     .await?;
 
-    let option = FulfillmentService::new(runtime.db_clone())
-        .update_shipping_option(tenant.id, id, input)
+    let request = UpdateAdminShippingOptionRequest {
+        shipping_option_id: id,
+        input,
+    };
+    let idempotency_key = admin_shipping_option_command_idempotency_key(
+        tenant.id,
+        auth.user_id,
+        Some(id),
+        "update_shipping_option",
+        &request,
+    )?;
+    let command_context = admin_shipping_option_command_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "update_shipping_option",
+        idempotency_key,
+    );
+    let option = runtime
+        .shipping_option_admin_command_port()
+        .update_shipping_option(command_context.clone(), request)
         .await
         .map_err(|error| {
-            map_admin_shipping_option_error(
+            map_admin_shipping_option_port_error(
                 AdminShippingOptionErrorContext::new(tenant.id, Some(id), "update_shipping_option"),
+                &command_context,
+                "update_admin_shipping_option",
                 error,
             )
         })?;
@@ -797,6 +853,7 @@ pub async fn deactivate_shipping_option(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ShippingOptionResponse>> {
     ensure_permissions(
@@ -805,16 +862,37 @@ pub async fn deactivate_shipping_option(
         "Permission denied: fulfillments:update required",
     )?;
 
-    let option = FulfillmentService::new(runtime.db_clone())
-        .deactivate_shipping_option(tenant.id, id)
+    let request = DeactivateAdminShippingOptionRequest {
+        shipping_option_id: id,
+    };
+    let idempotency_key = admin_shipping_option_command_idempotency_key(
+        tenant.id,
+        auth.user_id,
+        Some(id),
+        "deactivate_shipping_option",
+        &request,
+    )?;
+    let command_context = admin_shipping_option_command_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "deactivate_shipping_option",
+        idempotency_key,
+    );
+    let option = runtime
+        .shipping_option_admin_command_port()
+        .deactivate_shipping_option(command_context.clone(), request)
         .await
         .map_err(|error| {
-            map_admin_shipping_option_error(
+            map_admin_shipping_option_port_error(
                 AdminShippingOptionErrorContext::new(
                     tenant.id,
                     Some(id),
                     "deactivate_shipping_option",
                 ),
+                &command_context,
+                "deactivate_admin_shipping_option",
                 error,
             )
         })?;
@@ -838,6 +916,7 @@ pub async fn reactivate_shipping_option(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
 ) -> HttpResult<Json<ShippingOptionResponse>> {
     ensure_permissions(
@@ -846,16 +925,37 @@ pub async fn reactivate_shipping_option(
         "Permission denied: fulfillments:update required",
     )?;
 
-    let option = FulfillmentService::new(runtime.db_clone())
-        .reactivate_shipping_option(tenant.id, id)
+    let request = ReactivateAdminShippingOptionRequest {
+        shipping_option_id: id,
+    };
+    let idempotency_key = admin_shipping_option_command_idempotency_key(
+        tenant.id,
+        auth.user_id,
+        Some(id),
+        "reactivate_shipping_option",
+        &request,
+    )?;
+    let command_context = admin_shipping_option_command_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        Some(id),
+        "reactivate_shipping_option",
+        idempotency_key,
+    );
+    let option = runtime
+        .shipping_option_admin_command_port()
+        .reactivate_shipping_option(command_context.clone(), request)
         .await
         .map_err(|error| {
-            map_admin_shipping_option_error(
+            map_admin_shipping_option_port_error(
                 AdminShippingOptionErrorContext::new(
                     tenant.id,
                     Some(id),
                     "reactivate_shipping_option",
                 ),
+                &command_context,
+                "reactivate_admin_shipping_option",
                 error,
             )
         })?;

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -24,6 +24,7 @@ pub struct CommerceHttpRuntime {
     payment_provider_registry: PaymentProviderRegistry,
     fulfillment_provider_registry: FulfillmentProviderRegistry,
     shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime,
+    shipping_option_admin_command_runtime: rustok_fulfillment::ShippingOptionAdminCommandRuntime,
     fulfillment_lifecycle_read_runtime:
         crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime,
     fulfillment_admin_command_runtime: rustok_fulfillment::FulfillmentAdminCommandRuntime,
@@ -74,6 +75,12 @@ impl CommerceHttpRuntime {
     ) -> std::sync::Arc<dyn rustok_fulfillment::ShippingOptionAdminReadPort> {
         self.shipping_option_read_runtime
             .shipping_option_admin_read_port()
+    }
+
+    fn shipping_option_admin_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_fulfillment::ShippingOptionAdminCommandPort> {
+        self.shipping_option_admin_command_runtime.command_port()
     }
 
     fn fulfillment_read_port(&self) -> std::sync::Arc<dyn rustok_fulfillment::FulfillmentReadPort> {
@@ -168,6 +175,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require CommerceShippingOptionReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let shipping_option_admin_command_runtime = runtime
+            .shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()
+            .unwrap_or_else(|| {
+                rustok_fulfillment::ShippingOptionAdminCommandRuntime::in_process(
+                    runtime.db_clone(),
+                )
+            });
         let fulfillment_lifecycle_read_runtime = runtime
             .shared_get::<crate::graphql_runtime::CommerceFulfillmentLifecycleReadRuntime>()
             .ok_or_else(|| {
@@ -259,6 +273,7 @@ impl CommerceHttpRuntime {
             payment_provider_registry,
             fulfillment_provider_registry,
             shipping_option_read_runtime,
+            shipping_option_admin_command_runtime,
             fulfillment_lifecycle_read_runtime,
             fulfillment_admin_command_runtime,
             fulfillment_admin_create_command_runtime,

--- a/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-http-error-safety.mjs
@@ -39,20 +39,14 @@ const requireBefore = (content, first, second, label) => {
 const profileMapper = between(
   shipping,
   'fn map_shipping_profile_error(',
-  'fn map_admin_shipping_option_error(',
+  'fn admin_shipping_option_command_idempotency_key',
   'shipping-profile mapper',
 );
-const mutationMapper = between(
-  shipping,
-  'fn map_admin_shipping_option_error(',
-  'fn admin_shipping_option_read_port_context(',
-  'shipping-option mutation mapper',
-);
-const readMapper = between(
+const ownerMapper = between(
   shipping,
   'fn map_admin_shipping_option_port_error(',
   'async fn validate_shipping_option_profile_inputs(',
-  'shipping-option read mapper',
+  'shipping-option owner-port mapper',
 );
 const validationHelper = between(
   shipping,
@@ -95,38 +89,23 @@ requireBefore(
 );
 
 for (const [value, label] of [
-  ['FulfillmentError::Validation(_)', 'mutation validation mapping'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'mutation not-found mapping'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'mutation fulfillment mapping'],
-  ['FulfillmentError::InvalidTransition { .. }', 'mutation conflict mapping'],
-  ['FulfillmentError::Database(_)', 'mutation unavailable mapping'],
-  ['"commerce_admin_fulfillment_invalid"', 'mutation invalid code'],
-  ['"commerce_admin_not_found"', 'mutation not-found code'],
-  ['"commerce_admin_fulfillment_state_conflict"', 'mutation conflict code'],
-  ['"commerce_admin_fulfillment_storage_unavailable"', 'mutation unavailable code'],
-  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'mutation context projection'],
-  ['let error = AdminShippingDiagnosticError;', 'mutation diagnostic shadow'],
-  ['HttpError::new(status, code, message)', 'mutation static envelope'],
-]) requireText(mutationMapper, value, label);
-
-for (const [value, label] of [
-  ['PortErrorKind::Validation', 'read validation kind'],
-  ['PortErrorKind::NotFound', 'read not-found kind'],
-  ['PortErrorKind::Conflict', 'read conflict kind'],
-  ['PortErrorKind::Forbidden', 'read forbidden kind'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'read unavailable kinds'],
-  ['PortErrorKind::InvariantViolation', 'read invariant kind'],
-  ['StatusCode::UNAUTHORIZED', 'read forbidden status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'read invariant status'],
-  ['"commerce_permission_denied"', 'read forbidden code'],
-  ['"commerce_admin_fulfillment_failed"', 'read invariant code'],
-  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'read route context projection'],
-  ['let port_context = AdminShippingOptionPortDiagnosticContext::from(port_context);', 'read port context projection'],
-  ['let error = AdminShippingOptionPortDiagnosticError {', 'read diagnostic error shadow'],
-  ['internal_code = %error.code', 'read stable owner code'],
-  ['retryable = error.retryable', 'read retryability'],
-  ['HttpError::new(status, code, message)', 'read static envelope'],
-]) requireText(readMapper, value, label);
+  ['PortErrorKind::Validation', 'owner validation kind'],
+  ['PortErrorKind::NotFound', 'owner not-found kind'],
+  ['PortErrorKind::Conflict', 'owner conflict kind'],
+  ['PortErrorKind::Forbidden', 'owner forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'owner unavailable kinds'],
+  ['PortErrorKind::InvariantViolation', 'owner invariant kind'],
+  ['StatusCode::UNAUTHORIZED', 'owner forbidden status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'owner invariant status'],
+  ['"commerce_permission_denied"', 'owner forbidden code'],
+  ['"commerce_admin_fulfillment_failed"', 'owner invariant code'],
+  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'owner route context projection'],
+  ['let port_context = AdminShippingOptionPortDiagnosticContext::from(port_context);', 'owner port context projection'],
+  ['let error = AdminShippingOptionPortDiagnosticError {', 'owner diagnostic error shadow'],
+  ['internal_code = %error.code', 'owner stable code'],
+  ['retryable = error.retryable', 'owner retryability'],
+  ['HttpError::new(status, code, message)', 'owner static envelope'],
+]) requireText(ownerMapper, value, label);
 
 for (const [value, label] of [
   ['ShippingProfileService::new(db.clone())', 'profile validation service'],
@@ -159,11 +138,14 @@ for (const [value, label] of [
   ['.list_all_shipping_option_projections(', 'admin list read operation'],
   ['.shipping_option_read_port()', 'detail read port'],
   ['.read_shipping_option_projection(', 'detail read operation'],
-  ['FulfillmentService::new(runtime.db_clone())', 'shipping-option mutation owner'],
-  ['.create_shipping_option(tenant.id, input)', 'create option operation'],
-  ['.update_shipping_option(tenant.id, id, input)', 'update option operation'],
-  ['.deactivate_shipping_option(tenant.id, id)', 'deactivate option operation'],
-  ['.reactivate_shipping_option(tenant.id, id)', 'reactivate option operation'],
+  ['.shipping_option_admin_command_port()', 'shipping-option command owner'],
+  ['.create_shipping_option(command_context.clone(), request)', 'create option operation'],
+  ['.update_shipping_option(command_context.clone(), request)', 'update option operation'],
+  ['.deactivate_shipping_option(command_context.clone(), request)', 'deactivate option operation'],
+  ['.reactivate_shipping_option(command_context.clone(), request)', 'reactivate option operation'],
+  ['admin_shipping_option_command_idempotency_key(', 'write admission identity'],
+  ['admin_shipping_option_command_port_context(', 'write port context'],
+  ['.with_idempotency_key(idempotency_key)', 'write idempotency context'],
   ['ShippingProfileService::new(runtime.db_clone())', 'shipping-profile owner'],
   ['.list_shipping_profiles(', 'list profile operation'],
   ['.create_shipping_profile(tenant.id, input)', 'create profile operation'],
@@ -188,19 +170,18 @@ for (const value of [
   'format!("{}: {}", error.code, error.message)',
   'HttpError::bad_request("commerce_operation_failed"',
   '.map_err(super::map_fulfillment_error)?;',
-]) forbidText(shipping, value, 'unsafe admin shipping public conversion');
+  'use rustok_fulfillment::error::FulfillmentError;',
+  'FulfillmentService::new(runtime.db_clone())',
+  'map_admin_shipping_option_error(',
+]) forbidText(shipping, value, 'unsafe or legacy admin shipping public conversion');
 
 const profileMapperUses = shipping.match(/map_shipping_profile_error/g) ?? [];
 if (profileMapperUses.length !== 8) {
   failures.push(`expected profile mapper definition plus seven uses, found ${profileMapperUses.length}`);
 }
-const mutationMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
-if (mutationMapperUses.length !== 5) {
-  failures.push(`expected mutation mapper definition plus four uses, found ${mutationMapperUses.length}`);
-}
-const readMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g) ?? [];
-if (readMapperUses.length !== 3) {
-  failures.push(`expected read mapper definition plus two uses, found ${readMapperUses.length}`);
+const ownerMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g) ?? [];
+if (ownerMapperUses.length !== 7) {
+  failures.push(`expected owner mapper definition plus six uses, found ${ownerMapperUses.length}`);
 }
 const validationUses = shipping.match(/validate_shipping_option_profile_inputs\(/g) ?? [];
 if (validationUses.length !== 3) {
@@ -222,5 +203,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping profiles and options preserve HTTP policy while emitting only bounded diagnostics',
+  '✔ Commerce admin shipping profiles and options preserve HTTP policy through bounded owner ports',
 );

--- a/scripts/verify/verify-commerce-admin-shipping-option-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-option-command-owner-port-cutover.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+const failures = [];
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+const runtime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const shipping = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
+const owner = read('crates/rustok-fulfillment/src/shipping_option_admin_command.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/admin-shipping-option-command-owner-port-cutover-2026-08-09.md',
+);
+
+for (const marker of [
+  'shipping_option_admin_command_runtime: rustok_fulfillment::ShippingOptionAdminCommandRuntime',
+  'fn shipping_option_admin_command_port(',
+  'shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()',
+  'rustok_fulfillment::ShippingOptionAdminCommandRuntime::in_process(',
+]) need(runtime, marker, 'commerce HTTP runtime composition');
+
+for (const marker of [
+  'CreateAdminShippingOptionRequest',
+  'UpdateAdminShippingOptionRequest',
+  'DeactivateAdminShippingOptionRequest',
+  'ReactivateAdminShippingOptionRequest',
+  'admin_shipping_option_command_idempotency_key(',
+  '.with_idempotency_key(idempotency_key)',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  '.shipping_option_admin_command_port()',
+  '.create_shipping_option(command_context.clone(), request)',
+  '.update_shipping_option(command_context.clone(), request)',
+  '.deactivate_shipping_option(command_context.clone(), request)',
+  '.reactivate_shipping_option(command_context.clone(), request)',
+  'validate_shipping_option_profile_inputs(',
+  'map_admin_shipping_option_port_error(',
+]) need(shipping, marker, 'mounted shipping-option command cutover');
+
+for (const marker of [
+  'FulfillmentService::new(runtime.db_clone())\n        .create_shipping_option',
+  'FulfillmentService::new(runtime.db_clone())\n        .update_shipping_option',
+  'FulfillmentService::new(runtime.db_clone())\n        .deactivate_shipping_option',
+  'FulfillmentService::new(runtime.db_clone())\n        .reactivate_shipping_option',
+  'use rustok_fulfillment::error::FulfillmentError;',
+]) forbid(shipping, marker, 'mounted shipping-option direct owner construction');
+
+for (const marker of [
+  'context.require_policy(PortCallPolicy::write())',
+  'pub trait ShippingOptionAdminCommandPort',
+]) need(owner, marker, 'fulfillment owner write admission');
+
+need(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,',
+  'canonical ecommerce topology P0 remains open',
+);
+
+for (const marker of [
+  'Status: `source_complete_unvalidated`',
+  '`ShippingOptionAdminCommandPort`',
+  'Those handlers no longer construct `rustok_fulfillment::FulfillmentService`',
+  'does **not** claim',
+  'no tests, Cargo commands, Node verifiers, formatter',
+]) need(record, marker, 'dated source record');
+
+if (failures.length > 0) {
+  console.error('[verify-commerce-admin-shipping-option-command-owner-port-cutover] FAIL');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log('[verify-commerce-admin-shipping-option-command-owner-port-cutover] PASS');

--- a/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-shipping-option-error-context.mjs
@@ -42,17 +42,23 @@ const diagnosticProjection = between(
   'fn map_shipping_profile_error(',
   'admin shipping diagnostic projection',
 );
-const mutationMapper = between(
+const identityBuilder = between(
   shipping,
-  'fn map_admin_shipping_option_error(',
+  'fn admin_shipping_option_command_idempotency_key',
   'fn admin_shipping_option_read_port_context(',
-  'admin shipping-option mutation mapper',
+  'admin shipping-option command identity builder',
 );
 const readContextBuilder = between(
   shipping,
   'fn admin_shipping_option_read_port_context(',
-  'fn map_admin_shipping_option_port_error(',
+  'fn admin_shipping_option_command_port_context(',
   'admin shipping-option read context builder',
+);
+const commandContextBuilder = between(
+  shipping,
+  'fn admin_shipping_option_command_port_context(',
+  'fn map_admin_shipping_option_port_error(',
+  'admin shipping-option command context builder',
 );
 const portMapper = between(
   shipping,
@@ -132,38 +138,27 @@ for (const [value, label] of [
 ]) requireText(diagnosticProjection, value, label);
 
 for (const [value, label] of [
+  ['serde_json::to_vec(payload)', 'payload-bound command identity'],
+  ['digest.update(tenant_id.as_bytes())', 'tenant-bound identity'],
+  ['digest.update(actor_id.as_bytes())', 'actor-bound identity'],
+  ['digest.update(operation.as_bytes())', 'operation-bound identity'],
+  ['digest.update(shipping_option_id.as_bytes())', 'resource-bound identity'],
+  ['digest.update(payload)', 'payload digest'],
+  ['commerce-admin-shipping-option:{operation}:', 'scoped command identity prefix'],
+]) requireText(identityBuilder, value, label);
+
+for (const [value, label] of [
   ['PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
   ['request_context.locale.as_str()', 'request locale'],
   ['format!("commerce-admin-shipping-option:{operation}:{resource_id}")', 'resource correlation id'],
-  ['with_deadline(std::time::Duration::from_secs(2))', 'read deadline'],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'deadline'],
   ['request_context.channel_slug.as_deref()', 'channel propagation'],
 ]) requireText(readContextBuilder, value, label);
 
 for (const [value, label] of [
-  ['FulfillmentError::Validation(_)', 'mutation validation variant'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'mutation option not-found variant'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'mutation fulfillment not-found variant'],
-  ['FulfillmentError::InvalidTransition { .. }', 'mutation conflict variant'],
-  ['FulfillmentError::Database(_)', 'mutation database variant'],
-  ['let context = AdminShippingOptionDiagnosticContext::from(&context);', 'mutation context shadow'],
-  ['let error = AdminShippingDiagnosticError;', 'mutation error shadow'],
-  ['error = ?error', 'redacted mutation error event'],
-  ['tenant_id = %context.tenant_id', 'bounded mutation tenant event'],
-  ['shipping_option_id = ?context.shipping_option_id', 'bounded mutation option event'],
-  ['HttpError::new(status, code, message)', 'mutation static envelope'],
-]) requireText(mutationMapper, value, label);
-requireBefore(
-  mutationMapper,
-  'FulfillmentError::Validation(_)',
-  'let context = AdminShippingOptionDiagnosticContext::from(&context);',
-  'mutation typed policy selection',
-);
-requireBefore(
-  mutationMapper,
-  'let error = AdminShippingDiagnosticError;',
-  'tracing::error!(',
-  'mutation diagnostic shadow',
-);
+  ['admin_shipping_option_read_port_context(', 'shared bounded context'],
+  ['.with_idempotency_key(idempotency_key)', 'write policy identity'],
+]) requireText(commandContextBuilder, value, label);
 
 for (const [value, label] of [
   ['PortErrorKind::Validation', 'port validation kind'],
@@ -185,6 +180,7 @@ for (const [value, label] of [
   ['internal_code = %error.code', 'stable code event'],
   ['retryable = error.retryable', 'retryability event'],
   ['HttpError::new(status, code, message)', 'port static envelope'],
+  ['"commerce admin shipping option owner call failed"', 'shared owner-call diagnostic'],
 ]) requireText(portMapper, value, label);
 requireBefore(
   portMapper,
@@ -222,15 +218,20 @@ for (const [block, operation, request, label] of [
   forbidText(block, 'FulfillmentService::new(', `${label} concrete service`);
 }
 
-for (const [block, operation, label] of [
-  [createRoute, '.create_shipping_option(tenant.id, input)', 'create route'],
-  [updateRoute, '.update_shipping_option(tenant.id, id, input)', 'update route'],
-  [deactivateRoute, '.deactivate_shipping_option(tenant.id, id)', 'deactivate route'],
-  [reactivateRoute, '.reactivate_shipping_option(tenant.id, id)', 'reactivate route'],
+for (const [block, request, operation, label] of [
+  [createRoute, 'CreateAdminShippingOptionRequest { input }', '.create_shipping_option(command_context.clone(), request)', 'create route'],
+  [updateRoute, 'UpdateAdminShippingOptionRequest {', '.update_shipping_option(command_context.clone(), request)', 'update route'],
+  [deactivateRoute, 'DeactivateAdminShippingOptionRequest {', '.deactivate_shipping_option(command_context.clone(), request)', 'deactivate route'],
+  [reactivateRoute, 'ReactivateAdminShippingOptionRequest {', '.reactivate_shipping_option(command_context.clone(), request)', 'reactivate route'],
 ]) {
-  requireText(block, 'FulfillmentService::new(runtime.db_clone())', `${label} lifecycle service`);
-  requireText(block, operation, `${label} service operation`);
-  requireText(block, 'map_admin_shipping_option_error(', `${label} typed mapper`);
+  requireText(block, 'admin_shipping_option_command_idempotency_key(', `${label} command identity`);
+  requireText(block, 'admin_shipping_option_command_port_context(', `${label} command context`);
+  requireText(block, '.shipping_option_admin_command_port()', `${label} owner command port`);
+  requireText(block, request, `${label} typed request`);
+  requireText(block, operation, `${label} owner operation`);
+  requireText(block, 'map_admin_shipping_option_port_error(', `${label} typed mapper`);
+  forbidText(block, 'FulfillmentService::new(', `${label} concrete service`);
+  forbidText(block, 'map_admin_shipping_option_error(', `${label} legacy mutation mapper`);
 }
 
 for (const value of [
@@ -240,15 +241,20 @@ for (const value of [
   'error.message',
   'format!("{}: {}", error.code, error.message)',
   '.map_err(super::map_fulfillment_error)?;',
+  'use rustok_fulfillment::error::FulfillmentError;',
 ]) forbidText(shipping, value, 'unsafe admin shipping-option public conversion');
 
-const mutationMapperUses = shipping.match(/map_admin_shipping_option_error\(/g) ?? [];
-if (mutationMapperUses.length !== 5) {
-  failures.push(`expected mutation mapper definition plus four uses, found ${mutationMapperUses.length}`);
-}
 const portMapperUses = shipping.match(/map_admin_shipping_option_port_error\(/g) ?? [];
-if (portMapperUses.length !== 3) {
-  failures.push(`expected port mapper definition plus two read uses, found ${portMapperUses.length}`);
+if (portMapperUses.length !== 7) {
+  failures.push(`expected port mapper definition plus six route uses, found ${portMapperUses.length}`);
+}
+const commandContextUses = shipping.match(/admin_shipping_option_command_port_context\(/g) ?? [];
+if (commandContextUses.length !== 5) {
+  failures.push(`expected command context definition plus four uses, found ${commandContextUses.length}`);
+}
+const commandIdentityUses = shipping.match(/admin_shipping_option_command_idempotency_key\(/g) ?? [];
+if (commandIdentityUses.length !== 5) {
+  failures.push(`expected command identity definition plus four uses, found ${commandIdentityUses.length}`);
 }
 
 if (failures.length > 0) {
@@ -258,5 +264,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce admin shipping-option reads and mutations retain typed policy while emitting only bounded diagnostics',
+  '✔ Commerce admin shipping-option reads and commands use bounded owner-port context and diagnostics',
 );

--- a/scripts/verify/verify-fulfillment-shipping-option-admin-command-owner-port.mjs
+++ b/scripts/verify/verify-fulfillment-shipping-option-admin-command-owner-port.mjs
@@ -13,10 +13,14 @@ const forbid = (source, marker, label) => {
 
 const owner = read('crates/rustok-fulfillment/src/shipping_option_admin_command.rs');
 const lib = read('crates/rustok-fulfillment/src/lib.rs');
+const runtime = read('crates/rustok-commerce/src/controllers/mod.rs');
 const consumer = read('crates/rustok-commerce/src/controllers/admin/shipping.rs');
 const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
 const record = read(
   'crates/rustok-fulfillment/docs/shipping-option-admin-command-owner-port-2026-08-09.md',
+);
+const cutoverRecord = read(
+  'crates/rustok-commerce/docs/admin-shipping-option-command-owner-port-cutover-2026-08-09.md',
 );
 
 for (const marker of [
@@ -53,11 +57,27 @@ for (const marker of [
 ]) need(lib, marker, 'fulfillment public export');
 
 for (const marker of [
-  'let option = FulfillmentService::new(runtime.db_clone())\n        .create_shipping_option',
-  'let option = FulfillmentService::new(runtime.db_clone())\n        .update_shipping_option',
-  'let option = FulfillmentService::new(runtime.db_clone())\n        .deactivate_shipping_option',
-  'let option = FulfillmentService::new(runtime.db_clone())\n        .reactivate_shipping_option',
-]) need(consumer, marker, 'consumer cutover intentionally remains open');
+  'shipping_option_admin_command_runtime: rustok_fulfillment::ShippingOptionAdminCommandRuntime',
+  'fn shipping_option_admin_command_port(',
+  'shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()',
+]) need(runtime, marker, 'commerce HTTP runtime selection');
+
+for (const marker of [
+  '.shipping_option_admin_command_port()',
+  '.create_shipping_option(command_context.clone(), request)',
+  '.update_shipping_option(command_context.clone(), request)',
+  '.deactivate_shipping_option(command_context.clone(), request)',
+  '.reactivate_shipping_option(command_context.clone(), request)',
+  'admin_shipping_option_command_idempotency_key(',
+  'admin_shipping_option_command_port_context(',
+]) need(consumer, marker, 'mounted consumer owner-port cutover');
+
+for (const marker of [
+  'FulfillmentService::new(runtime.db_clone())\n        .create_shipping_option',
+  'FulfillmentService::new(runtime.db_clone())\n        .update_shipping_option',
+  'FulfillmentService::new(runtime.db_clone())\n        .deactivate_shipping_option',
+  'FulfillmentService::new(runtime.db_clone())\n        .reactivate_shipping_option',
+]) forbid(consumer, marker, 'mounted consumer concrete owner construction');
 
 need(
   plan,
@@ -70,9 +90,14 @@ for (const marker of [
   '`ShippingOptionAdminCommandPort`',
   '`ShippingOptionAdminCommandRuntime`',
   'does **not** claim durable idempotent replay',
-  'still construct `FulfillmentService` directly',
   'no tests, Cargo commands, Node verifiers, formatter',
-]) need(record, marker, 'dated source record');
+]) need(record, marker, 'owner capability source record');
+
+for (const marker of [
+  'Status: `source_complete_unvalidated`',
+  'Those handlers no longer construct `rustok_fulfillment::FulfillmentService`',
+  'does **not** claim',
+]) need(cutoverRecord, marker, 'consumer cutover source record');
 
 if (failures.length > 0) {
   console.error('[verify-fulfillment-shipping-option-admin-command-owner-port] FAIL');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by cutting the four mounted Commerce admin REST shipping-option writes over to the Fulfillment-owned `ShippingOptionAdminCommandPort` published in #3404.

- host-select `ShippingOptionAdminCommandRuntime` through `CommerceHttpRuntime`, preserving externally supplied `HostRuntimeContext` implementations with an explicit Fulfillment-owned in-process fallback;
- route `create_shipping_option`, `update_shipping_option`, `deactivate_shipping_option`, and `reactivate_shipping_option` through the typed owner command port;
- preserve existing `FULFILLMENTS_CREATE` / `FULFILLMENTS_UPDATE` admission and response envelopes;
- preserve Commerce-owned shipping-profile slug validation before create/update owner calls;
- carry authenticated actor, tenant, request locale/channel, correlation identity, two-second deadline, and payload-bound deterministic idempotency identity across the owner boundary;
- use that deterministic identity only to satisfy canonical write-port admission and explicitly do **not** claim durable owner receipt/replay semantics;
- preserve stable public HTTP error families through the shared bounded `PortError` mapper;
- update existing shipping source guards whose old expectations intentionally encoded direct `FulfillmentService` construction, plus add a bounded cutover verifier and dated source record;
- keep the broad ecommerce topology P0 open for remaining mounted owner construction.

The branch is one clean commit over current `main` (`f62b70af0fc71f9c5e7ac444b6f732e37688cc47`) with exactly seven changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted REST scenarios, workflows, CI reruns, database scenarios, restart scenarios, or remote-adapter scenarios were executed. Verifier changes are source-only evidence for maintainer execution.