### PR TITLE
feat(commerce): route GraphQL shipping option writes through owner port

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::services::server_runtime_context::ServerRuntimeContext;
 
-/// Attach the host-composed commerce provider registries and owner read runtimes to a capability
+/// Attach the host-composed commerce provider registries and owner runtimes to a capability
 /// runtime.
 ///
 /// Values already installed in `ServerRuntimeContext` or `HostRuntimeContext` are always preserved
@@ -56,6 +56,20 @@ pub fn attach_commerce_provider_registries(
                 server.shared_insert(runtime.clone());
                 runtime
             });
+        host.with_shared_value(runtime)
+    };
+
+    #[cfg(all(feature = "mod-commerce", feature = "mod-fulfillment"))]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()
+            .or_else(|| server.shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>())
+            .unwrap_or_else(|| {
+                rustok_fulfillment::ShippingOptionAdminCommandRuntime::in_process(
+                    server.db_clone(),
+                )
+            });
+        server.shared_insert(runtime.clone());
         host.with_shared_value(runtime)
     };
 

--- a/crates/rustok-commerce/docs/graphql-shipping-option-command-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-shipping-option-command-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,91 @@
+# Commerce GraphQL shipping-option command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+The four mounted Commerce GraphQL shipping-option writes now execute through the Fulfillment-owned
+`ShippingOptionAdminCommandPort` / `ShippingOptionAdminCommandRuntime` published in the preceding
+owner-capability slice.
+
+The cutover covers the mounted `CommerceCheckoutMutation` fields backed by
+`graphql/mutations/checkout.rs`:
+
+- `createShippingOption`;
+- `updateShippingOption`;
+- `deactivateShippingOption`;
+- `reactivateShippingOption`.
+
+Those resolver paths no longer construct `rustok_fulfillment::FulfillmentService`.
+
+## Host and schema composition
+
+The application server now composes `ShippingOptionAdminCommandRuntime` into the shared
+`HostRuntimeContext`, preserving a runtime supplied by the host or `ServerRuntimeContext` and using
+the Fulfillment-owned in-process adapter only when no external runtime was selected.
+
+`CommerceGraphqlRuntimeData` requires that shared runtime for mounted schema construction and exposes
+it to checkout resolvers. `shipping_option_admin_command_runtime_from_context` retains an explicit
+in-process fallback only for directly embedded compatibility schemas that do not install mounted
+Commerce GraphQL runtime data.
+
+The existing Commerce HTTP runtime also consumes `ShippingOptionAdminCommandRuntime`, so the normal
+server composition now selects one owner runtime for both mounted REST and GraphQL shipping-option
+write transports.
+
+## Preserved admission and request semantics
+
+Existing Commerce permission and tenant admission remains in front of every owner call:
+
+- create requires `FULFILLMENTS_CREATE`;
+- update/deactivate/reactivate require `FULFILLMENTS_UPDATE`;
+- `current_tenant_scope` remains authoritative for the admitted tenant;
+- create/update still validate Commerce-owned shipping-profile slugs before crossing the owner
+  boundary.
+
+Each command receives a trusted `PortContext` derived from `AuthContext` and `RequestContext` with:
+
+- authenticated user actor;
+- admitted tenant id;
+- request locale, falling back to `und` only when unavailable/blank;
+- request channel when present;
+- operation/resource correlation identity;
+- a two-second deadline;
+- a fresh non-empty idempotency identity required by the canonical write policy.
+
+The fresh GraphQL idempotency identity is admission metadata only. This slice does **not** claim
+durable shipping-option receipt/replay or exactly-once semantics; the owner capability still does
+not persist command receipts for these operations.
+
+## Error boundary
+
+The mounted safe checkout facade now consumes bounded `PortError` rather than concrete
+`FulfillmentError` for these four owner calls. Public GraphQL compatibility is preserved:
+
+- validation -> `SHIPPING_OPTION_REQUEST_INVALID`;
+- owner shipping-option not found -> `SHIPPING_OPTION_NOT_FOUND`;
+- conflict -> `SHIPPING_OPTION_STATE_CONFLICT`;
+- unavailable/timeout -> `SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE`;
+- unexpected not-found/forbidden/invariant failures -> `SHIPPING_OPTION_OPERATION_FAILED`.
+
+Diagnostics contain only bounded context, owner kind/code length, retryability, operation, and public
+classification. Raw owner/backend messages are not logged or exposed by this boundary.
+
+## Deliberately still open
+
+Shipping-profile CRUD remains Commerce-owned and intentionally continues to use
+`ShippingProfileService`.
+
+`createStorefrontPaymentCollection` in the same resolver source still constructs `PaymentService`;
+that mounted Payment topology gap is a separate owner-port slice.
+
+The canonical ecommerce topology item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and
+Fulfillment concrete services behind host-composed owner ports` remains open.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL
+scenarios, workflows, CI reruns, database scenarios, restart scenarios, provider calls, or
+remote-adapter scenarios were executed for this slice. The accompanying verifier and updated
+checkout error-safety verifier are source-only evidence for maintainer execution.

--- a/crates/rustok-commerce/src/graphql/mutations/checkout.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/checkout.rs
@@ -1,15 +1,47 @@
 use async_graphql::{Context, ErrorExtensions, Object, Result};
 use rustok_api::Permission;
-use rustok_api::{AuthContext, RequestContext, graphql::require_module_enabled};
+use rustok_api::{
+    AuthContext, PortActor, PortContext, RequestContext, graphql::require_module_enabled,
+};
 use rustok_cart::{CartStorefrontReadRequest, in_process_cart_storefront_port};
+use rustok_fulfillment::{
+    CreateAdminShippingOptionRequest, DeactivateAdminShippingOptionRequest,
+    ReactivateAdminShippingOptionRequest, UpdateAdminShippingOptionRequest,
+};
 use rustok_payment::{PaymentError, PaymentService};
 use uuid::Uuid;
 
 use crate::ShippingProfileService;
-use rustok_fulfillment::FulfillmentService;
 
 use super::super::{MODULE_SLUG, current_tenant_scope, require_commerce_permission, types::*};
 use super::helpers::*;
+
+fn shipping_option_command_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    shipping_option_id: Option<Uuid>,
+    operation: &'static str,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let resource_id = shipping_option_id.unwrap_or(tenant_id);
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-shipping-option-command:{operation}:{resource_id}"),
+    )
+    .with_idempotency_key(Uuid::new_v4().to_string())
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
+}
 
 #[derive(Default)]
 pub struct CommerceCheckoutMutation;
@@ -210,26 +242,39 @@ impl CommerceCheckoutMutation {
             input.allowed_shipping_profile_slugs.as_ref(),
         )
         .await?;
-        let option = FulfillmentService::new(db.clone())
-            .create_shipping_option(
-                tenant_id,
-                crate::dto::CreateShippingOptionInput {
-                    translations: input
-                        .translations
-                        .into_iter()
-                        .map(|translation| crate::dto::ShippingOptionTranslationInput {
-                            locale: translation.locale,
-                            name: translation.name,
-                        })
-                        .collect(),
-                    currency_code: input.currency_code,
-                    amount: parse_decimal(&input.amount)?,
-                    provider_id: input.provider_id,
-                    allowed_shipping_profile_slugs: input.allowed_shipping_profile_slugs,
-                    metadata: parse_optional_metadata(input.metadata.as_deref())?,
-                },
+        let request = CreateAdminShippingOptionRequest {
+            input: crate::dto::CreateShippingOptionInput {
+                translations: input
+                    .translations
+                    .into_iter()
+                    .map(|translation| crate::dto::ShippingOptionTranslationInput {
+                        locale: translation.locale,
+                        name: translation.name,
+                    })
+                    .collect(),
+                currency_code: input.currency_code,
+                amount: parse_decimal(&input.amount)?,
+                provider_id: input.provider_id,
+                allowed_shipping_profile_slugs: input.allowed_shipping_profile_slugs,
+                metadata: parse_optional_metadata(input.metadata.as_deref())?,
+            },
+        };
+        let command_context =
+            shipping_option_command_context(ctx, tenant_id, None, "create_shipping_option")?;
+        let option = crate::graphql_runtime::shipping_option_admin_command_runtime_from_context(
+            ctx,
+            db.clone(),
+        )
+        .command_port()
+        .create_shipping_option(command_context.clone(), request)
+        .await
+        .map_err(|error| {
+            checkout_boundary::shipping_option_port_error(
+                &command_context,
+                "create_admin_shipping_option",
+                error,
             )
-            .await?;
+        })?;
 
         Ok(option.into())
     }
@@ -256,36 +301,49 @@ impl CommerceCheckoutMutation {
             input.allowed_shipping_profile_slugs.as_ref(),
         )
         .await?;
-        let option = FulfillmentService::new(db.clone())
-            .update_shipping_option(
-                tenant_id,
-                id,
-                crate::dto::UpdateShippingOptionInput {
-                    translations: input.translations.map(|translations| {
-                        translations
-                            .into_iter()
-                            .map(|translation| crate::dto::ShippingOptionTranslationInput {
-                                locale: translation.locale,
-                                name: translation.name,
-                            })
-                            .collect()
-                    }),
-                    currency_code: input.currency_code,
-                    amount: parse_optional_decimal(input.amount.as_deref())?,
-                    provider_id: input.provider_id,
-                    allowed_shipping_profile_slugs: input.allowed_shipping_profile_slugs,
-                    metadata: input
-                        .metadata
-                        .as_deref()
-                        .map(|value| {
-                            serde_json::from_str(value).map_err(|_| {
-                                async_graphql::Error::new("Invalid JSON metadata payload")
-                            })
+        let request = UpdateAdminShippingOptionRequest {
+            shipping_option_id: id,
+            input: crate::dto::UpdateShippingOptionInput {
+                translations: input.translations.map(|translations| {
+                    translations
+                        .into_iter()
+                        .map(|translation| crate::dto::ShippingOptionTranslationInput {
+                            locale: translation.locale,
+                            name: translation.name,
                         })
-                        .transpose()?,
-                },
+                        .collect()
+                }),
+                currency_code: input.currency_code,
+                amount: parse_optional_decimal(input.amount.as_deref())?,
+                provider_id: input.provider_id,
+                allowed_shipping_profile_slugs: input.allowed_shipping_profile_slugs,
+                metadata: input
+                    .metadata
+                    .as_deref()
+                    .map(|value| {
+                        serde_json::from_str(value).map_err(|_| {
+                            async_graphql::Error::new("Invalid JSON metadata payload")
+                        })
+                    })
+                    .transpose()?,
+            },
+        };
+        let command_context =
+            shipping_option_command_context(ctx, tenant_id, Some(id), "update_shipping_option")?;
+        let option = crate::graphql_runtime::shipping_option_admin_command_runtime_from_context(
+            ctx,
+            db.clone(),
+        )
+        .command_port()
+        .update_shipping_option(command_context.clone(), request)
+        .await
+        .map_err(|error| {
+            checkout_boundary::shipping_option_port_error(
+                &command_context,
+                "update_admin_shipping_option",
+                error,
             )
-            .await?;
+        })?;
 
         Ok(option.into())
     }
@@ -432,9 +490,29 @@ impl CommerceCheckoutMutation {
         let tenant_id = current_tenant_scope(ctx, Some(tenant_id), "Shipping option deactivation")?;
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let option = FulfillmentService::new(db.clone())
-            .deactivate_shipping_option(tenant_id, id)
-            .await?;
+        let request = DeactivateAdminShippingOptionRequest {
+            shipping_option_id: id,
+        };
+        let command_context = shipping_option_command_context(
+            ctx,
+            tenant_id,
+            Some(id),
+            "deactivate_shipping_option",
+        )?;
+        let option = crate::graphql_runtime::shipping_option_admin_command_runtime_from_context(
+            ctx,
+            db.clone(),
+        )
+        .command_port()
+        .deactivate_shipping_option(command_context.clone(), request)
+        .await
+        .map_err(|error| {
+            checkout_boundary::shipping_option_port_error(
+                &command_context,
+                "deactivate_admin_shipping_option",
+                error,
+            )
+        })?;
 
         Ok(option.into())
     }
@@ -454,9 +532,29 @@ impl CommerceCheckoutMutation {
         let tenant_id = current_tenant_scope(ctx, Some(tenant_id), "Shipping option reactivation")?;
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let option = FulfillmentService::new(db.clone())
-            .reactivate_shipping_option(tenant_id, id)
-            .await?;
+        let request = ReactivateAdminShippingOptionRequest {
+            shipping_option_id: id,
+        };
+        let command_context = shipping_option_command_context(
+            ctx,
+            tenant_id,
+            Some(id),
+            "reactivate_shipping_option",
+        )?;
+        let option = crate::graphql_runtime::shipping_option_admin_command_runtime_from_context(
+            ctx,
+            db.clone(),
+        )
+        .command_port()
+        .reactivate_shipping_option(command_context.clone(), request)
+        .await
+        .map_err(|error| {
+            checkout_boundary::shipping_option_port_error(
+                &command_context,
+                "reactivate_admin_shipping_option",
+                error,
+            )
+        })?;
 
         Ok(option.into())
     }

--- a/crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs
@@ -1,6 +1,6 @@
 mod checkout_boundary {
     use ::async_graphql::{Error, ErrorExtensions};
-    use ::rustok_fulfillment::error::FulfillmentError;
+    use ::rustok_api::{PortContext, PortError, PortErrorKind};
 
     use crate::CommerceError;
 
@@ -84,35 +84,37 @@ mod checkout_boundary {
         }
     }
 
-    fn fulfillment_error_envelope(
-        error: &FulfillmentError,
+    fn shipping_option_port_error_envelope(
+        error: &PortError,
     ) -> (&'static str, &'static str, bool, &'static str) {
-        match error {
-            FulfillmentError::Validation(_) => (
+        match &error.kind {
+            PortErrorKind::Validation => (
                 "Shipping option request is invalid",
                 "SHIPPING_OPTION_REQUEST_INVALID",
                 false,
                 "validation",
             ),
-            FulfillmentError::ShippingOptionNotFound(_) => (
+            PortErrorKind::NotFound if error.code == "fulfillment.shipping_option_not_found" => (
                 "Shipping option was not found",
                 "SHIPPING_OPTION_NOT_FOUND",
                 false,
                 "not_found",
             ),
-            FulfillmentError::InvalidTransition { .. } => (
+            PortErrorKind::Conflict => (
                 "Shipping option operation conflicts with the current state",
                 "SHIPPING_OPTION_STATE_CONFLICT",
                 false,
                 "conflict",
             ),
-            FulfillmentError::Database(_) => (
+            PortErrorKind::Unavailable | PortErrorKind::Timeout => (
                 "Shipping option service is temporarily unavailable",
                 "SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE",
                 true,
-                "database",
+                "temporarily_unavailable",
             ),
-            FulfillmentError::FulfillmentNotFound(_) => (
+            PortErrorKind::NotFound
+            | PortErrorKind::Forbidden
+            | PortErrorKind::InvariantViolation => (
                 "Shipping option operation could not be completed safely",
                 "SHIPPING_OPTION_OPERATION_FAILED",
                 false,
@@ -142,24 +144,35 @@ mod checkout_boundary {
         }
     }
 
-    impl From<FulfillmentError> for BoundaryError {
-        fn from(error: FulfillmentError) -> Self {
-            let (message, code, retryable, error_kind) = fulfillment_error_envelope(&error);
-            let diagnostic_error = CheckoutServiceDiagnosticError;
-            tracing::error!(
-                error = ?diagnostic_error,
-                owner = "rustok_fulfillment",
-                error_kind,
-                public_code = code,
-                retryable,
-                boundary = CHECKOUT_ERROR_BOUNDARY,
-                "commerce GraphQL checkout shipping option operation failed"
-            );
-            Self::Public {
-                message,
-                code,
-                retryable,
-            }
+    pub(crate) fn shipping_option_port_error(
+        context: &PortContext,
+        owner_operation: &'static str,
+        error: PortError,
+    ) -> BoundaryError {
+        let (message, code, retryable, error_kind) = shipping_option_port_error_envelope(&error);
+        let diagnostic_error = CheckoutServiceDiagnosticError;
+        tracing::error!(
+            error = ?diagnostic_error,
+            owner = "rustok_fulfillment.shipping_option_admin_command",
+            owner_operation,
+            correlation_id = %context.correlation_id,
+            tenant_id_present = !context.tenant_id.is_empty(),
+            actor_id_present = !context.actor.id.is_empty(),
+            channel_present = context.channel.is_some(),
+            locale_length = context.locale.chars().count(),
+            deadline_ms = ?context.deadline_ms,
+            owner_error_kind = ?error.kind,
+            owner_code_length = error.code.chars().count(),
+            error_kind,
+            public_code = code,
+            retryable,
+            boundary = CHECKOUT_ERROR_BOUNDARY,
+            "commerce GraphQL checkout shipping option owner command failed"
+        );
+        BoundaryError::Public {
+            message,
+            code,
+            retryable,
         }
     }
 

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -7,9 +7,9 @@ use async_graphql::{Context, ServerResult, Value};
 use rustok_api::{AuthContext, PortActor, RequestContext};
 use rustok_fulfillment::providers::FulfillmentProviderRegistry;
 use rustok_fulfillment::{
-    FulfillmentReadPort, ShippingOptionAdminReadPort, ShippingOptionReadPort,
-    in_process_fulfillment_read_port, in_process_shipping_option_admin_read_port,
-    in_process_shipping_option_read_port,
+    FulfillmentReadPort, ShippingOptionAdminCommandRuntime, ShippingOptionAdminReadPort,
+    ShippingOptionReadPort, in_process_fulfillment_read_port,
+    in_process_shipping_option_admin_read_port, in_process_shipping_option_read_port,
 };
 use rustok_order::{
     OrderAdminCommandRuntime, OrderPostOrderCommandRuntime, OrderReadPort,
@@ -336,8 +336,9 @@ pub(crate) fn product_catalog_command_runtime_for_current_graphql_scope(
 ///
 /// Hosts supply composed capabilities through `HostRuntimeContext`. The built-in manual provider
 /// registries remain deterministic fallbacks. Mounted Payment/Fulfillment reads and commands,
-/// shipping-option, Product catalog, and order reads/commands consume host-selected runtime data.
-/// Directly embedded compatibility schemas retain explicit in-process owner-runtime fallbacks.
+/// shipping-option reads/commands, Product catalog, and order reads/commands consume host-selected
+/// runtime data. Directly embedded compatibility schemas retain explicit in-process owner-runtime
+/// fallbacks.
 #[derive(Clone)]
 pub struct CommerceGraphqlRuntimeData {
     payment_provider_registry: PaymentProviderRegistry,
@@ -348,6 +349,7 @@ pub struct CommerceGraphqlRuntimeData {
     payment_command_runtime: CommercePaymentCommandRuntime,
     fulfillment_command_runtime: CommerceFulfillmentCommandRuntime,
     shipping_option_read_runtime: CommerceShippingOptionReadRuntime,
+    shipping_option_admin_command_runtime: ShippingOptionAdminCommandRuntime,
     fulfillment_lifecycle_read_runtime: CommerceFulfillmentLifecycleReadRuntime,
     order_read_runtime: CommerceOrderReadRuntime,
     order_admin_command_runtime: OrderAdminCommandRuntime,
@@ -384,6 +386,10 @@ impl CommerceGraphqlRuntimeData {
 
     pub fn shipping_option_read_runtime(&self) -> CommerceShippingOptionReadRuntime {
         self.shipping_option_read_runtime.clone()
+    }
+
+    pub fn shipping_option_admin_command_runtime(&self) -> ShippingOptionAdminCommandRuntime {
+        self.shipping_option_admin_command_runtime.clone()
     }
 
     pub fn fulfillment_lifecycle_read_runtime(&self) -> CommerceFulfillmentLifecycleReadRuntime {
@@ -462,6 +468,12 @@ pub fn attach_schema_data(
                 "commerce GraphQL requires CommerceShippingOptionReadRuntime in host composition"
                     .to_string()
             })?,
+        shipping_option_admin_command_runtime: inputs
+            .shared_get::<ShippingOptionAdminCommandRuntime>()
+            .ok_or_else(|| {
+                "commerce GraphQL requires ShippingOptionAdminCommandRuntime in host composition"
+                    .to_string()
+            })?,
         fulfillment_lifecycle_read_runtime: inputs
             .shared_get::<CommerceFulfillmentLifecycleReadRuntime>()
             .unwrap_or_else(|| {
@@ -486,8 +498,7 @@ pub fn attach_schema_data(
         product_catalog_read_runtime: inputs
             .shared_get::<ProductCatalogReadRuntime>()
             .ok_or_else(|| {
-                "commerce GraphQL requires ProductCatalogReadRuntime in host composition"
-                    .to_string()
+                "commerce GraphQL requires ProductCatalogReadRuntime in host composition".to_string()
             })?,
         product_catalog_command_runtime: inputs
             .shared_get::<ProductCatalogCommandRuntime>()
@@ -531,6 +542,15 @@ pub(crate) fn fulfillment_command_runtime_from_context(
                 .unwrap_or_else(FulfillmentProviderRegistry::with_manual_provider);
             CommerceFulfillmentCommandRuntime::in_process(db, provider_registry)
         })
+}
+
+pub(crate) fn shipping_option_admin_command_runtime_from_context(
+    ctx: &Context<'_>,
+    db: DatabaseConnection,
+) -> ShippingOptionAdminCommandRuntime {
+    ctx.data_opt::<CommerceGraphqlRuntimeData>()
+        .map(CommerceGraphqlRuntimeData::shipping_option_admin_command_runtime)
+        .unwrap_or_else(|| ShippingOptionAdminCommandRuntime::in_process(db))
 }
 
 pub(crate) fn order_admin_command_runtime_from_context(

--- a/scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
+++ b/scripts/verify/verify-commerce-graphql-checkout-service-error-safety.mjs
@@ -34,6 +34,7 @@ if (checkoutModuleDeclarations.length !== 1) {
 
 for (const [value, label] of [
   ['mod checkout_boundary {', 'checkout boundary module'],
+  ['use ::rustok_api::{PortContext, PortError, PortErrorKind};', 'typed owner port errors'],
   ['const CHECKOUT_ERROR_BOUNDARY: &str = "commerce_graphql_checkout";', 'checkout boundary constant'],
   ['struct CheckoutServiceDiagnosticError;', 'redacted diagnostic token'],
   ['impl std::fmt::Debug for CheckoutServiceDiagnosticError', 'diagnostic Debug implementation'],
@@ -44,39 +45,39 @@ for (const [value, label] of [
   ['Public {', 'cloneable public envelope variant'],
   ['impl From<Error> for BoundaryError', 'GraphQL conversion'],
   ['impl From<CommerceError> for BoundaryError', 'commerce conversion'],
-  ['impl From<FulfillmentError> for BoundaryError', 'fulfillment conversion'],
-  ['Self::Public {', 'owner error envelope storage'],
-  ['impl From<BoundaryError> for Error', 'public GraphQL conversion'],
-  ['BoundaryError::Graphql(error) => error', 'existing GraphQL error preservation'],
-  ['BoundaryError::Public {', 'public envelope restoration'],
-  ['fn commerce_error_envelope(', 'shipping profile mapper'],
-  ['fn fulfillment_error_envelope(', 'shipping option mapper'],
+  ['pub(crate) fn shipping_option_port_error(', 'shipping option port mapper'],
+  ['fn shipping_option_port_error_envelope(', 'shipping option envelope mapper'],
+  ['PortErrorKind::Validation', 'shipping option validation mapping'],
+  ['PortErrorKind::NotFound if error.code == "fulfillment.shipping_option_not_found"', 'shipping option not-found mapping'],
+  ['PortErrorKind::Conflict', 'shipping option conflict mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'shipping option temporary mapping'],
+  ['PortErrorKind::Forbidden', 'shipping option forbidden fallback'],
+  ['PortErrorKind::InvariantViolation', 'shipping option invariant fallback'],
+  ['owner = "rustok_fulfillment.shipping_option_admin_command"', 'shipping option owner diagnostic'],
+  ['owner_operation,', 'shipping option owner operation diagnostic'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
   ['extensions.set("code", code)', 'stable code extension'],
   ['extensions.set("retryable", retryable)', 'retryability extension'],
-  ['let diagnostic_error = CheckoutServiceDiagnosticError;', 'diagnostic source consumption'],
-  ['error = ?diagnostic_error', 'redacted diagnostic field'],
-  ['owner = "rustok_commerce"', 'commerce owner logging'],
-  ['owner = "rustok_fulfillment"', 'fulfillment owner logging'],
-  ['error_kind,', 'owner error kind logging'],
-  ['public_code = code', 'public code logging'],
-  ['boundary = CHECKOUT_ERROR_BOUNDARY', 'checkout boundary logging'],
+  ['impl From<BoundaryError> for Error', 'public GraphQL conversion'],
+  ['BoundaryError::Graphql(error) => error', 'existing GraphQL error preservation'],
   ['mod async_graphql_shim {', 'async GraphQL result shim'],
-  ['pub use ::async_graphql::{Context, Error, ErrorExtensions, Object};', 'GraphQL API re-export'],
   [
     'pub type Result<T> = std::result::Result<T, super::checkout_boundary::BoundaryError>;',
     'custom checkout result',
   ],
-  ['use self::async_graphql_shim as async_graphql;', 'shim alias'],
-  ['include!("checkout.rs");', 'unchanged checkout resolver inclusion'],
+  ['include!("checkout.rs");', 'checkout resolver inclusion'],
 ]) {
   requireText(facade, value, label);
 }
 
 for (const value of [
-  'Commerce(CommerceError)',
-  'Fulfillment(FulfillmentError)',
+  'FulfillmentError',
   'error = ?error',
   'error = %error',
+  'owner_message = %error.message',
+  'message = %error.message',
   'async_graphql::Error::new(error.to_string())',
   'async_graphql::Error::new(err.to_string())',
   'Error::new(error.to_string())',
@@ -85,44 +86,8 @@ for (const value of [
 ]) {
   forbidText(facade, value, 'checkout facade public and diagnostic boundary');
 }
-for (const value of [
-  'async_graphql::Error::new(error.to_string())',
-  'async_graphql::Error::new(err.to_string())',
-  'Error::new(error.to_string())',
-  'Error::new(err.to_string())',
-  'format!("{error}")',
-]) {
-  forbidText(source, value, 'checkout resolver public boundary');
-}
-
-const redactedDiagnosticFields = facade.match(/error = \?diagnostic_error/g) ?? [];
-if (redactedDiagnosticFields.length !== 2) {
-  failures.push(
-    `expected two redacted checkout service diagnostic fields, found ${redactedDiagnosticFields.length}`,
-  );
-}
 
 for (const [value, label] of [
-  ['CommerceError::Validation(_)', 'commerce validation mapping'],
-  ['CommerceError::InvalidPrice(_)', 'commerce invalid-price mapping'],
-  ['CommerceError::InvalidOptionCombination', 'commerce option mapping'],
-  ['CommerceError::NoVariants', 'commerce no-variants mapping'],
-  ['CommerceError::ShippingProfileNotFound(_)', 'profile not-found mapping'],
-  ['CommerceError::DuplicateShippingProfileSlug(_)', 'profile conflict mapping'],
-  ['CommerceError::Database(_)', 'profile database mapping'],
-  ['CommerceError::ProductNotFound(_)', 'commerce product fallback'],
-  ['CommerceError::VariantNotFound(_)', 'commerce variant fallback'],
-  ['CommerceError::DuplicateHandle { .. }', 'commerce handle fallback'],
-  ['CommerceError::DuplicateSku(_)', 'commerce SKU fallback'],
-  ['CommerceError::InsufficientInventory { .. }', 'commerce inventory fallback'],
-  ['CommerceError::CannotDeletePublished', 'commerce published fallback'],
-  ['CommerceError::Rich(_)', 'commerce rich fallback'],
-  ['CommerceError::Core(_)', 'commerce core fallback'],
-  ['FulfillmentError::Validation(_)', 'fulfillment validation mapping'],
-  ['FulfillmentError::ShippingOptionNotFound(_)', 'shipping option not-found mapping'],
-  ['FulfillmentError::InvalidTransition { .. }', 'shipping option conflict mapping'],
-  ['FulfillmentError::Database(_)', 'shipping option database mapping'],
-  ['FulfillmentError::FulfillmentNotFound(_)', 'fulfillment fallback mapping'],
   ['"SHIPPING_PROFILE_REQUEST_INVALID"', 'profile validation code'],
   ['"SHIPPING_PROFILE_NOT_FOUND"', 'profile not-found code'],
   ['"SHIPPING_PROFILE_STATE_CONFLICT"', 'profile conflict code'],
@@ -139,12 +104,23 @@ for (const [value, label] of [
 
 for (const [value, label] of [
   ['use async_graphql::{Context, ErrorExtensions, Object, Result};', 'resolver Result import'],
+  ['AuthContext, PortActor, PortContext, RequestContext', 'trusted owner call facts'],
+  ['CreateAdminShippingOptionRequest', 'create owner request'],
+  ['UpdateAdminShippingOptionRequest', 'update owner request'],
+  ['DeactivateAdminShippingOptionRequest', 'deactivate owner request'],
+  ['ReactivateAdminShippingOptionRequest', 'reactivate owner request'],
+  ['fn shipping_option_command_context(', 'shipping option command context'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated owner actor'],
+  ['.with_idempotency_key(Uuid::new_v4().to_string())', 'ephemeral write identity'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'owner deadline'],
+  ['request.channel_slug.as_deref()', 'owner channel propagation'],
+  ['shipping_option_admin_command_runtime_from_context(', 'host-selected owner runtime'],
+  ['.create_shipping_option(command_context.clone(), request)', 'create owner call'],
+  ['.update_shipping_option(command_context.clone(), request)', 'update owner call'],
+  ['.deactivate_shipping_option(command_context.clone(), request)', 'deactivate owner call'],
+  ['.reactivate_shipping_option(command_context.clone(), request)', 'reactivate owner call'],
+  ['checkout_boundary::shipping_option_port_error(', 'bounded owner error mapper'],
   ['use crate::ShippingProfileService;', 'shipping profile service import'],
-  ['use rustok_fulfillment::FulfillmentService;', 'fulfillment service import'],
-  ['async fn create_shipping_option(', 'create shipping option mutation'],
-  ['async fn update_shipping_option(', 'update shipping option mutation'],
-  ['async fn deactivate_shipping_option(', 'deactivate shipping option mutation'],
-  ['async fn reactivate_shipping_option(', 'reactivate shipping option mutation'],
   ['async fn create_shipping_profile(', 'create shipping profile mutation'],
   ['async fn update_shipping_profile(', 'update shipping profile mutation'],
   ['async fn deactivate_shipping_profile(', 'deactivate shipping profile mutation'],
@@ -153,9 +129,21 @@ for (const [value, label] of [
   requireText(source, value, label);
 }
 
-const fulfillmentServiceCalls = source.match(/FulfillmentService::new\(/g) ?? [];
-if (fulfillmentServiceCalls.length !== 4) {
-  failures.push(`expected four shipping-option service call sites, found ${fulfillmentServiceCalls.length}`);
+for (const value of [
+  'use rustok_fulfillment::FulfillmentService;',
+  'FulfillmentService::new(',
+  'async_graphql::Error::new(error.to_string())',
+  'async_graphql::Error::new(err.to_string())',
+  'Error::new(error.to_string())',
+  'Error::new(err.to_string())',
+  'format!("{error}")',
+]) {
+  forbidText(source, value, 'checkout resolver direct owner/public boundary');
+}
+
+const ownerRuntimeCalls = source.match(/shipping_option_admin_command_runtime_from_context\(/g) ?? [];
+if (ownerRuntimeCalls.length !== 4) {
+  failures.push(`expected four shipping-option owner runtime call sites, found ${ownerRuntimeCalls.length}`);
 }
 const shippingProfileServiceCalls = source.match(/ShippingProfileService::new\(/g) ?? [];
 if (shippingProfileServiceCalls.length !== 4) {
@@ -169,5 +157,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce GraphQL checkout shipping services retain typed public envelopes and emit only redacted owner diagnostics while preserving existing GraphQL errors',
+  '✔ Commerce GraphQL shipping-option writes use the owner command port with bounded errors while Commerce-owned shipping-profile envelopes remain intact',
 );

--- a/scripts/verify/verify-commerce-graphql-shipping-option-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-shipping-option-command-owner-port-cutover.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const server = read('apps/server/src/services/commerce_provider_runtime.rs');
+const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const routing = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const checkout = read('crates/rustok-commerce/src/graphql/mutations/checkout.rs');
+const safeCheckout = read('crates/rustok-commerce/src/graphql/mutations/safe_checkout.rs');
+const owner = read('crates/rustok-fulfillment/src/shipping_option_admin_command.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/graphql-shipping-option-command-owner-port-cutover-2026-08-09.md',
+);
+
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const marker of [
+  'shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()',
+  'server.shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()',
+  'rustok_fulfillment::ShippingOptionAdminCommandRuntime::in_process(',
+  'server.shared_insert(runtime.clone());',
+  'host.with_shared_value(runtime)',
+]) need(server, marker, 'server host composition');
+
+for (const marker of [
+  'ShippingOptionAdminCommandRuntime',
+  'shipping_option_admin_command_runtime: ShippingOptionAdminCommandRuntime',
+  'pub fn shipping_option_admin_command_runtime(&self) -> ShippingOptionAdminCommandRuntime',
+  '.shared_get::<ShippingOptionAdminCommandRuntime>()',
+  'commerce GraphQL requires ShippingOptionAdminCommandRuntime in host composition',
+  'pub(crate) fn shipping_option_admin_command_runtime_from_context(',
+  '.map(CommerceGraphqlRuntimeData::shipping_option_admin_command_runtime)',
+  'ShippingOptionAdminCommandRuntime::in_process(db)',
+]) need(graphqlRuntime, marker, 'GraphQL runtime composition');
+
+for (const marker of [
+  'shipping_option_admin_command_runtime: rustok_fulfillment::ShippingOptionAdminCommandRuntime',
+  'shared_get::<rustok_fulfillment::ShippingOptionAdminCommandRuntime>()',
+  'fn shipping_option_admin_command_port(',
+]) need(httpRuntime, marker, 'REST runtime shares owner capability');
+
+need(
+  routing,
+  '#[path = "safe_checkout.rs"]\npub mod checkout;',
+  'mounted safe checkout routing',
+);
+
+for (const marker of [
+  'CreateAdminShippingOptionRequest',
+  'UpdateAdminShippingOptionRequest',
+  'DeactivateAdminShippingOptionRequest',
+  'ReactivateAdminShippingOptionRequest',
+  'fn shipping_option_command_context(',
+  'PortActor::user(auth.user_id.to_string())',
+  '.with_idempotency_key(Uuid::new_v4().to_string())',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'request.channel_slug.as_deref()',
+  'shipping_option_admin_command_runtime_from_context(',
+  '.create_shipping_option(command_context.clone(), request)',
+  '.update_shipping_option(command_context.clone(), request)',
+  '.deactivate_shipping_option(command_context.clone(), request)',
+  '.reactivate_shipping_option(command_context.clone(), request)',
+  'validate_shipping_option_profile_inputs(',
+  'checkout_boundary::shipping_option_port_error(',
+]) need(checkout, marker, 'mounted shipping-option command cutover');
+
+for (const marker of [
+  'FulfillmentService::new(',
+  'use rustok_fulfillment::FulfillmentService;',
+]) forbid(checkout, marker, 'mounted GraphQL concrete Fulfillment owner construction');
+
+for (const marker of [
+  'use ::rustok_api::{PortContext, PortError, PortErrorKind};',
+  'fn shipping_option_port_error_envelope(',
+  'pub(crate) fn shipping_option_port_error(',
+  'PortErrorKind::Validation',
+  'PortErrorKind::NotFound if error.code == "fulfillment.shipping_option_not_found"',
+  'PortErrorKind::Conflict',
+  'PortErrorKind::Unavailable | PortErrorKind::Timeout',
+  'PortErrorKind::Forbidden',
+  'PortErrorKind::InvariantViolation',
+  '"SHIPPING_OPTION_REQUEST_INVALID"',
+  '"SHIPPING_OPTION_NOT_FOUND"',
+  '"SHIPPING_OPTION_STATE_CONFLICT"',
+  '"SHIPPING_OPTION_TEMPORARILY_UNAVAILABLE"',
+  '"SHIPPING_OPTION_OPERATION_FAILED"',
+  'owner_error_kind = ?error.kind',
+  'owner_code_length = error.code.chars().count()',
+  'boundary = CHECKOUT_ERROR_BOUNDARY',
+]) need(safeCheckout, marker, 'bounded GraphQL owner error boundary');
+
+for (const marker of [
+  'FulfillmentError',
+  'owner_message = %error.message',
+  'message = %error.message',
+  'error.to_string()',
+]) forbid(safeCheckout, marker, 'raw owner error leakage');
+
+for (const marker of [
+  'pub trait ShippingOptionAdminCommandPort',
+  'context.require_policy(PortCallPolicy::write())',
+]) need(owner, marker, 'Fulfillment owner command admission');
+
+need(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'canonical topology item remains open',
+);
+
+for (const marker of [
+  '# Commerce GraphQL shipping-option command owner-port cutover',
+  'Status: `source_complete_unvalidated`',
+  '`createShippingOption`',
+  '`updateShippingOption`',
+  '`deactivateShippingOption`',
+  '`reactivateShippingOption`',
+  'does **not** claim',
+  '`createStorefrontPaymentCollection` in the same resolver source still constructs `PaymentService`',
+  'no tests, Cargo commands, Node verifiers, formatter',
+]) need(record, marker, 'truthful source record');
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL shipping-option command owner-port cutover verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ Commerce GraphQL shipping-option writes use the host-composed Fulfillment owner command runtime with bounded public errors',
+);


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by cutting the four mounted Commerce GraphQL shipping-option writes over to the Fulfillment-owned `ShippingOptionAdminCommandPort` published in #3404 and already used by mounted admin REST after #3407.

- host-compose `ShippingOptionAdminCommandRuntime` in the application server while preserving externally supplied host/server runtimes;
- require that runtime in mounted `CommerceGraphqlRuntimeData`, with an explicit in-process fallback only for directly embedded compatibility schemas;
- route `createShippingOption`, `updateShippingOption`, `deactivateShippingOption`, and `reactivateShippingOption` through typed Fulfillment owner requests;
- preserve `FULFILLMENTS_CREATE` / `FULFILLMENTS_UPDATE`, tenant scope, and Commerce-owned shipping-profile slug validation;
- carry authenticated actor, locale, optional channel, correlation identity, two-second deadline, and a fresh non-empty write identity across the port boundary;
- explicitly do **not** claim durable shipping-option receipt/replay or exactly-once semantics;
- replace the safe checkout `FulfillmentError` adaptation for these writes with bounded `PortError` mapping while preserving existing public `SHIPPING_OPTION_*` GraphQL envelopes;
- keep shipping-profile CRUD and the still-direct `createStorefrontPaymentCollection` Payment path outside this slice;
- update the existing checkout error-safety source guard and add a dated source record plus dedicated source-only cutover verifier;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind current `main` (`d18ba5daeb1ce1978539fb5002b914ea838fc83e`) with exactly seven changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL scenarios, workflows, CI reruns, database scenarios, restart scenarios, provider calls, or remote-adapter scenarios were executed. Verifier changes are source-only evidence for maintainer execution.