### PR TITLE
feat(forum): resolve bounded import application facts

### DIFF
--- a/crates/rustok-forum/src/import_resolution.rs
+++ b/crates/rustok-forum/src/import_resolution.rs
@@ -11,7 +11,7 @@ use crate::import_inspection::{
 use crate::import_mapping::{
     ForumImportCategoryCandidate, ForumImportEntityKind, ForumImportExternalRef,
     ForumImportPostCandidate, ForumImportPostRole, ForumImportTopicCandidate,
-    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH, FORUM_IMPORT_SOURCE_NODEBB,
+    FORUM_IMPORT_SOURCE_NODEBB, MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH,
 };
 
 pub const MAX_FORUM_IMPORT_RESOLUTION_BINDINGS_PER_BATCH: usize =
@@ -101,6 +101,8 @@ pub enum ForumImportResolutionError {
     TooManyCandidates { max: usize, actual: usize },
     #[error("Forum import resolution exceeds {max} identity bindings: {actual}")]
     TooManyBindings { max: usize, actual: usize },
+    #[error("Forum import resolution repeats source candidate {source:?}")]
+    DuplicateCandidateSource { source: ForumImportExternalRef },
     #[error("Forum import resolution contains duplicate binding for {source:?}")]
     DuplicateBinding { source: ForumImportExternalRef },
     #[error("Forum import resolution binding for {source:?} has nil target id")]
@@ -153,6 +155,16 @@ pub enum ForumImportResolutionError {
         target: ForumImportExternalRef,
         disposition: ForumImportDependencyDisposition,
     },
+    #[error(
+        "Forum import application batch requires in-batch {relation:?}: owner={owner:?} target={target:?}"
+    )]
+    CrossBatchDependency {
+        owner: ForumImportExternalRef,
+        relation: ForumImportDependencyRelation,
+        target: ForumImportExternalRef,
+    },
+    #[error("Forum import category parent cycle reaches {source:?}")]
+    CategoryCycle { source: ForumImportExternalRef },
     #[error("Forum import post role is unresolved for {source:?}")]
     UnresolvedPostRole { source: ForumImportExternalRef },
     #[error("Forum import topic {source:?} has no explicit main-post body source")]
@@ -187,7 +199,7 @@ impl ForumImportApplicationResolver {
         &self,
         request: &ForumImportApplicationResolutionRequest,
     ) -> Result<ForumResolvedImportApplicationBatch, ForumImportResolutionError> {
-        validate_request(request)?;
+        let locale = validate_request(request)?;
         reject_non_author_dependency_issues(&request.inspection.unresolved_dependencies)?;
         validate_candidate_sources(&request.inspection)?;
 
@@ -199,7 +211,7 @@ impl ForumImportApplicationResolver {
 
         Ok(ForumResolvedImportApplicationBatch {
             tenant_id: request.tenant_id,
-            locale: normalize_locale_code(&request.locale).expect("validated locale"),
+            locale,
             categories,
             topics,
             replies,
@@ -280,14 +292,12 @@ impl BindingIndex {
     }
 
     fn reject_unused(&self) -> Result<(), ForumImportResolutionError> {
-        if let Some((_, binding)) = self
-            .by_source
-            .iter()
-            .find(|(key, _)| !self.used.contains(*key))
-        {
-            return Err(ForumImportResolutionError::UnexpectedBinding {
-                source: binding.source.clone(),
-            });
+        for (key, binding) in &self.by_source {
+            if !self.used.contains(key) {
+                return Err(ForumImportResolutionError::UnexpectedBinding {
+                    source: binding.source.clone(),
+                });
+            }
         }
         Ok(())
     }
@@ -295,15 +305,15 @@ impl BindingIndex {
 
 fn validate_request(
     request: &ForumImportApplicationResolutionRequest,
-) -> Result<(), ForumImportResolutionError> {
+) -> Result<String, ForumImportResolutionError> {
     if request.tenant_id.is_nil() {
         return Err(ForumImportResolutionError::NilTenantId);
     }
-    if normalize_locale_code(&request.locale).is_none() {
-        return Err(ForumImportResolutionError::InvalidLocale {
+    let locale = normalize_locale_code(&request.locale).ok_or_else(|| {
+        ForumImportResolutionError::InvalidLocale {
             locale: request.locale.clone(),
-        });
-    }
+        }
+    })?;
 
     let candidate_count = request
         .inspection
@@ -324,7 +334,7 @@ fn validate_request(
             actual: request.bindings.len(),
         });
     }
-    Ok(())
+    Ok(locale)
 }
 
 fn reject_non_author_dependency_issues(
@@ -349,14 +359,25 @@ fn reject_non_author_dependency_issues(
 fn validate_candidate_sources(
     inspection: &NodebbForumImportInspection,
 ) -> Result<(), ForumImportResolutionError> {
+    let mut all_sources = BTreeSet::new();
+    let mut category_sources = BTreeSet::new();
+    let mut topic_sources = BTreeSet::new();
+    let mut post_sources = BTreeSet::new();
+    let mut category_by_key = BTreeMap::new();
+
     for category in &inspection.candidates.categories {
         validate_external_ref(&category.source, ForumImportEntityKind::Category)?;
+        insert_candidate_source(&mut all_sources, &category.source)?;
+        category_sources.insert(ref_key(&category.source));
+        category_by_key.insert(ref_key(&category.source), category);
         if let Some(parent) = category.parent_source.as_ref() {
             validate_external_ref(parent, ForumImportEntityKind::Category)?;
         }
     }
     for topic in &inspection.candidates.topics {
         validate_external_ref(&topic.source, ForumImportEntityKind::Topic)?;
+        insert_candidate_source(&mut all_sources, &topic.source)?;
+        topic_sources.insert(ref_key(&topic.source));
         validate_external_ref(&topic.category_source, ForumImportEntityKind::Category)?;
         if let Some(author) = topic.author_source.as_ref() {
             validate_external_ref(author, ForumImportEntityKind::User)?;
@@ -367,6 +388,8 @@ fn validate_candidate_sources(
     }
     for post in &inspection.candidates.posts {
         validate_external_ref(&post.source, ForumImportEntityKind::Post)?;
+        insert_candidate_source(&mut all_sources, &post.source)?;
+        post_sources.insert(ref_key(&post.source));
         validate_external_ref(&post.topic_source, ForumImportEntityKind::Topic)?;
         if let Some(author) = post.author_source.as_ref() {
             validate_external_ref(author, ForumImportEntityKind::User)?;
@@ -375,6 +398,90 @@ fn validate_candidate_sources(
             return Err(ForumImportResolutionError::UnresolvedPostRole {
                 source: post.source.clone(),
             });
+        }
+    }
+
+    for category in &inspection.candidates.categories {
+        if let Some(parent) = category.parent_source.as_ref() {
+            if !category_sources.contains(&ref_key(parent)) {
+                return Err(ForumImportResolutionError::CrossBatchDependency {
+                    owner: category.source.clone(),
+                    relation: ForumImportDependencyRelation::CategoryParent,
+                    target: parent.clone(),
+                });
+            }
+        }
+    }
+    validate_category_acyclic(&inspection.candidates.categories, &category_by_key)?;
+
+    for topic in &inspection.candidates.topics {
+        if !category_sources.contains(&ref_key(&topic.category_source)) {
+            return Err(ForumImportResolutionError::CrossBatchDependency {
+                owner: topic.source.clone(),
+                relation: ForumImportDependencyRelation::TopicCategory,
+                target: topic.category_source.clone(),
+            });
+        }
+        let body_source = topic.body_post_source.as_ref().ok_or_else(|| {
+            ForumImportResolutionError::MissingTopicBodySource {
+                source: topic.source.clone(),
+            }
+        })?;
+        if !post_sources.contains(&ref_key(body_source)) {
+            return Err(ForumImportResolutionError::CrossBatchDependency {
+                owner: topic.source.clone(),
+                relation: ForumImportDependencyRelation::TopicMainPost,
+                target: body_source.clone(),
+            });
+        }
+    }
+
+    for post in &inspection.candidates.posts {
+        if !topic_sources.contains(&ref_key(&post.topic_source)) {
+            return Err(ForumImportResolutionError::CrossBatchDependency {
+                owner: post.source.clone(),
+                relation: ForumImportDependencyRelation::PostTopic,
+                target: post.topic_source.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn insert_candidate_source(
+    seen: &mut BTreeSet<RefKey>,
+    source: &ForumImportExternalRef,
+) -> Result<(), ForumImportResolutionError> {
+    if !seen.insert(ref_key(source)) {
+        return Err(ForumImportResolutionError::DuplicateCandidateSource {
+            source: source.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_category_acyclic(
+    categories: &[ForumImportCategoryCandidate],
+    category_by_key: &BTreeMap<RefKey, &ForumImportCategoryCandidate>,
+) -> Result<(), ForumImportResolutionError> {
+    for category in categories {
+        let mut seen = BTreeSet::new();
+        let mut current = category;
+        loop {
+            let current_key = ref_key(&current.source);
+            if !seen.insert(current_key) {
+                return Err(ForumImportResolutionError::CategoryCycle {
+                    source: current.source.clone(),
+                });
+            }
+            let Some(parent_source) = current.parent_source.as_ref() else {
+                break;
+            };
+            let Some(parent) = category_by_key.get(&ref_key(parent_source)).copied() else {
+                break;
+            };
+            current = parent;
         }
     }
     Ok(())
@@ -492,9 +599,7 @@ fn resolve_replies(
     for candidate in &inspection.candidates.posts {
         match candidate.role {
             ForumImportPostRole::TopicBody => continue,
-            ForumImportPostRole::Reply => {
-                replies.push(resolve_reply(candidate, bindings)?);
-            }
+            ForumImportPostRole::Reply => replies.push(resolve_reply(candidate, bindings)?),
             ForumImportPostRole::Unresolved => {
                 return Err(ForumImportResolutionError::UnresolvedPostRole {
                     source: candidate.source.clone(),

--- a/crates/rustok-forum/src/import_resolution.rs
+++ b/crates/rustok-forum/src/import_resolution.rs
@@ -1,0 +1,575 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use rustok_content::normalize_locale_code;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::import_inspection::{
+    ForumImportDependencyDisposition, ForumImportDependencyIssue, ForumImportDependencyRelation,
+    NodebbForumImportInspection,
+};
+use crate::import_mapping::{
+    ForumImportCategoryCandidate, ForumImportEntityKind, ForumImportExternalRef,
+    ForumImportPostCandidate, ForumImportPostRole, ForumImportTopicCandidate,
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH, FORUM_IMPORT_SOURCE_NODEBB,
+};
+
+pub const MAX_FORUM_IMPORT_RESOLUTION_BINDINGS_PER_BATCH: usize =
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH * 2;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ForumImportTargetIdentityKind {
+    Category,
+    Topic,
+    Reply,
+    User,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumImportIdentityBinding {
+    pub source: ForumImportExternalRef,
+    pub target_kind: ForumImportTargetIdentityKind,
+    pub target_id: Uuid,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumImportApplicationResolutionRequest {
+    pub tenant_id: Uuid,
+    pub locale: String,
+    pub inspection: NodebbForumImportInspection,
+    pub bindings: Vec<ForumImportIdentityBinding>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumResolvedImportAuthor {
+    pub source: ForumImportExternalRef,
+    pub user_id: Uuid,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumResolvedImportCategory {
+    pub source: ForumImportExternalRef,
+    pub id: Uuid,
+    pub parent_id: Option<Uuid>,
+    pub name: String,
+    pub description: Option<String>,
+    pub position: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumResolvedImportTopic {
+    pub source: ForumImportExternalRef,
+    pub id: Uuid,
+    pub category_id: Uuid,
+    pub author: Option<ForumResolvedImportAuthor>,
+    pub title: String,
+    pub slug: Option<String>,
+    pub body_source: ForumImportExternalRef,
+    pub body: String,
+    pub created_at_ms: Option<i64>,
+    pub is_pinned: bool,
+    pub is_locked: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumResolvedImportReply {
+    pub source: ForumImportExternalRef,
+    pub id: Uuid,
+    pub topic_id: Uuid,
+    pub author: Option<ForumResolvedImportAuthor>,
+    pub body: String,
+    pub created_at_ms: Option<i64>,
+    pub deleted: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumResolvedImportApplicationBatch {
+    pub tenant_id: Uuid,
+    pub locale: String,
+    pub categories: Vec<ForumResolvedImportCategory>,
+    pub topics: Vec<ForumResolvedImportTopic>,
+    pub replies: Vec<ForumResolvedImportReply>,
+}
+
+#[derive(Debug, Error)]
+pub enum ForumImportResolutionError {
+    #[error("Forum import resolution requires a non-nil tenant id")]
+    NilTenantId,
+    #[error("Forum import resolution locale is invalid: {locale}")]
+    InvalidLocale { locale: String },
+    #[error("Forum import resolution exceeds {max} source candidates: {actual}")]
+    TooManyCandidates { max: usize, actual: usize },
+    #[error("Forum import resolution exceeds {max} identity bindings: {actual}")]
+    TooManyBindings { max: usize, actual: usize },
+    #[error("Forum import resolution contains duplicate binding for {source:?}")]
+    DuplicateBinding { source: ForumImportExternalRef },
+    #[error("Forum import resolution binding for {source:?} has nil target id")]
+    NilBindingTarget { source: ForumImportExternalRef },
+    #[error(
+        "Forum import resolution maps multiple {kind:?} sources onto target {target_id}: {first:?} and {second:?}"
+    )]
+    TargetIdentityCollision {
+        kind: ForumImportTargetIdentityKind,
+        target_id: Uuid,
+        first: ForumImportExternalRef,
+        second: ForumImportExternalRef,
+    },
+    #[error("Forum import resolution is missing {expected:?} binding for {source:?}")]
+    MissingBinding {
+        source: ForumImportExternalRef,
+        expected: ForumImportTargetIdentityKind,
+    },
+    #[error(
+        "Forum import resolution binding for {source:?} targets {actual:?}, expected {expected:?}"
+    )]
+    BindingKindMismatch {
+        source: ForumImportExternalRef,
+        expected: ForumImportTargetIdentityKind,
+        actual: ForumImportTargetIdentityKind,
+    },
+    #[error("Forum import resolution contains unused binding for {source:?}")]
+    UnexpectedBinding { source: ForumImportExternalRef },
+    #[error(
+        "Forum import resolution requires NodeBB source namespace for {reference:?}, got {actual}"
+    )]
+    SourceNamespaceMismatch {
+        reference: ForumImportExternalRef,
+        actual: String,
+    },
+    #[error(
+        "Forum import resolution reference {reference:?} has kind {actual:?}, expected {expected:?}"
+    )]
+    SourceKindMismatch {
+        reference: ForumImportExternalRef,
+        expected: ForumImportEntityKind,
+        actual: ForumImportEntityKind,
+    },
+    #[error(
+        "Forum import dependency remains unresolved for application: {relation:?}/{disposition:?} owner={owner:?} target={target:?}"
+    )]
+    UnresolvedDependency {
+        owner: ForumImportExternalRef,
+        relation: ForumImportDependencyRelation,
+        target: ForumImportExternalRef,
+        disposition: ForumImportDependencyDisposition,
+    },
+    #[error("Forum import post role is unresolved for {source:?}")]
+    UnresolvedPostRole { source: ForumImportExternalRef },
+    #[error("Forum import topic {source:?} has no explicit main-post body source")]
+    MissingTopicBodySource { source: ForumImportExternalRef },
+    #[error("Forum import topic {topic:?} body post {post:?} is absent from the bounded batch")]
+    TopicBodyPostMissing {
+        topic: ForumImportExternalRef,
+        post: ForumImportExternalRef,
+    },
+    #[error("Forum import topic {topic:?} body post {post:?} is not classified as topic_body")]
+    TopicBodyRoleMismatch {
+        topic: ForumImportExternalRef,
+        post: ForumImportExternalRef,
+    },
+    #[error("Forum import topic {topic:?} body post {post:?} is marked deleted")]
+    DeletedTopicBody {
+        topic: ForumImportExternalRef,
+        post: ForumImportExternalRef,
+    },
+    #[error("Forum import topic {topic:?} and body post {post:?} resolve to different authors")]
+    TopicBodyAuthorMismatch {
+        topic: ForumImportExternalRef,
+        post: ForumImportExternalRef,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForumImportApplicationResolver;
+
+impl ForumImportApplicationResolver {
+    pub fn resolve_batch(
+        &self,
+        request: &ForumImportApplicationResolutionRequest,
+    ) -> Result<ForumResolvedImportApplicationBatch, ForumImportResolutionError> {
+        validate_request(request)?;
+        reject_non_author_dependency_issues(&request.inspection.unresolved_dependencies)?;
+        validate_candidate_sources(&request.inspection)?;
+
+        let mut bindings = BindingIndex::new(&request.bindings)?;
+        let categories = resolve_categories(&request.inspection, &mut bindings)?;
+        let topics = resolve_topics(&request.inspection, &mut bindings)?;
+        let replies = resolve_replies(&request.inspection, &mut bindings)?;
+        bindings.reject_unused()?;
+
+        Ok(ForumResolvedImportApplicationBatch {
+            tenant_id: request.tenant_id,
+            locale: normalize_locale_code(&request.locale).expect("validated locale"),
+            categories,
+            topics,
+            replies,
+        })
+    }
+}
+
+type RefKey = (String, &'static str, String);
+
+struct BindingIndex {
+    by_source: BTreeMap<RefKey, ForumImportIdentityBinding>,
+    used: BTreeSet<RefKey>,
+}
+
+impl BindingIndex {
+    fn new(bindings: &[ForumImportIdentityBinding]) -> Result<Self, ForumImportResolutionError> {
+        let mut by_source = BTreeMap::new();
+        let mut by_target = BTreeMap::<
+            (ForumImportTargetIdentityKind, Uuid),
+            ForumImportExternalRef,
+        >::new();
+
+        for binding in bindings {
+            validate_external_ref(&binding.source, binding.source.kind)?;
+            if binding.target_id.is_nil() {
+                return Err(ForumImportResolutionError::NilBindingTarget {
+                    source: binding.source.clone(),
+                });
+            }
+            let key = ref_key(&binding.source);
+            if by_source.insert(key, binding.clone()).is_some() {
+                return Err(ForumImportResolutionError::DuplicateBinding {
+                    source: binding.source.clone(),
+                });
+            }
+            if let Some(first) = by_target.insert(
+                (binding.target_kind, binding.target_id),
+                binding.source.clone(),
+            ) {
+                if first != binding.source {
+                    return Err(ForumImportResolutionError::TargetIdentityCollision {
+                        kind: binding.target_kind,
+                        target_id: binding.target_id,
+                        first,
+                        second: binding.source.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(Self {
+            by_source,
+            used: BTreeSet::new(),
+        })
+    }
+
+    fn require(
+        &mut self,
+        source: &ForumImportExternalRef,
+        expected: ForumImportTargetIdentityKind,
+    ) -> Result<Uuid, ForumImportResolutionError> {
+        let key = ref_key(source);
+        let Some(binding) = self.by_source.get(&key) else {
+            return Err(ForumImportResolutionError::MissingBinding {
+                source: source.clone(),
+                expected,
+            });
+        };
+        if binding.target_kind != expected {
+            return Err(ForumImportResolutionError::BindingKindMismatch {
+                source: source.clone(),
+                expected,
+                actual: binding.target_kind,
+            });
+        }
+        self.used.insert(key);
+        Ok(binding.target_id)
+    }
+
+    fn reject_unused(&self) -> Result<(), ForumImportResolutionError> {
+        if let Some((_, binding)) = self
+            .by_source
+            .iter()
+            .find(|(key, _)| !self.used.contains(*key))
+        {
+            return Err(ForumImportResolutionError::UnexpectedBinding {
+                source: binding.source.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn validate_request(
+    request: &ForumImportApplicationResolutionRequest,
+) -> Result<(), ForumImportResolutionError> {
+    if request.tenant_id.is_nil() {
+        return Err(ForumImportResolutionError::NilTenantId);
+    }
+    if normalize_locale_code(&request.locale).is_none() {
+        return Err(ForumImportResolutionError::InvalidLocale {
+            locale: request.locale.clone(),
+        });
+    }
+
+    let candidate_count = request
+        .inspection
+        .candidates
+        .categories
+        .len()
+        .saturating_add(request.inspection.candidates.topics.len())
+        .saturating_add(request.inspection.candidates.posts.len());
+    if candidate_count > MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH {
+        return Err(ForumImportResolutionError::TooManyCandidates {
+            max: MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH,
+            actual: candidate_count,
+        });
+    }
+    if request.bindings.len() > MAX_FORUM_IMPORT_RESOLUTION_BINDINGS_PER_BATCH {
+        return Err(ForumImportResolutionError::TooManyBindings {
+            max: MAX_FORUM_IMPORT_RESOLUTION_BINDINGS_PER_BATCH,
+            actual: request.bindings.len(),
+        });
+    }
+    Ok(())
+}
+
+fn reject_non_author_dependency_issues(
+    issues: &[ForumImportDependencyIssue],
+) -> Result<(), ForumImportResolutionError> {
+    for issue in issues {
+        if issue.relation == ForumImportDependencyRelation::AuthorUser
+            && issue.disposition == ForumImportDependencyDisposition::ExternalOwnerResolution
+        {
+            continue;
+        }
+        return Err(ForumImportResolutionError::UnresolvedDependency {
+            owner: issue.owner.clone(),
+            relation: issue.relation,
+            target: issue.target.clone(),
+            disposition: issue.disposition,
+        });
+    }
+    Ok(())
+}
+
+fn validate_candidate_sources(
+    inspection: &NodebbForumImportInspection,
+) -> Result<(), ForumImportResolutionError> {
+    for category in &inspection.candidates.categories {
+        validate_external_ref(&category.source, ForumImportEntityKind::Category)?;
+        if let Some(parent) = category.parent_source.as_ref() {
+            validate_external_ref(parent, ForumImportEntityKind::Category)?;
+        }
+    }
+    for topic in &inspection.candidates.topics {
+        validate_external_ref(&topic.source, ForumImportEntityKind::Topic)?;
+        validate_external_ref(&topic.category_source, ForumImportEntityKind::Category)?;
+        if let Some(author) = topic.author_source.as_ref() {
+            validate_external_ref(author, ForumImportEntityKind::User)?;
+        }
+        if let Some(body) = topic.body_post_source.as_ref() {
+            validate_external_ref(body, ForumImportEntityKind::Post)?;
+        }
+    }
+    for post in &inspection.candidates.posts {
+        validate_external_ref(&post.source, ForumImportEntityKind::Post)?;
+        validate_external_ref(&post.topic_source, ForumImportEntityKind::Topic)?;
+        if let Some(author) = post.author_source.as_ref() {
+            validate_external_ref(author, ForumImportEntityKind::User)?;
+        }
+        if post.role == ForumImportPostRole::Unresolved {
+            return Err(ForumImportResolutionError::UnresolvedPostRole {
+                source: post.source.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn resolve_categories(
+    inspection: &NodebbForumImportInspection,
+    bindings: &mut BindingIndex,
+) -> Result<Vec<ForumResolvedImportCategory>, ForumImportResolutionError> {
+    inspection
+        .candidates
+        .categories
+        .iter()
+        .map(|candidate| resolve_category(candidate, bindings))
+        .collect()
+}
+
+fn resolve_category(
+    candidate: &ForumImportCategoryCandidate,
+    bindings: &mut BindingIndex,
+) -> Result<ForumResolvedImportCategory, ForumImportResolutionError> {
+    let id = bindings.require(&candidate.source, ForumImportTargetIdentityKind::Category)?;
+    let parent_id = candidate
+        .parent_source
+        .as_ref()
+        .map(|source| bindings.require(source, ForumImportTargetIdentityKind::Category))
+        .transpose()?;
+    Ok(ForumResolvedImportCategory {
+        source: candidate.source.clone(),
+        id,
+        parent_id,
+        name: candidate.name.clone(),
+        description: candidate.description.clone(),
+        position: candidate.position,
+    })
+}
+
+fn resolve_topics(
+    inspection: &NodebbForumImportInspection,
+    bindings: &mut BindingIndex,
+) -> Result<Vec<ForumResolvedImportTopic>, ForumImportResolutionError> {
+    inspection
+        .candidates
+        .topics
+        .iter()
+        .map(|candidate| resolve_topic(candidate, inspection, bindings))
+        .collect()
+}
+
+fn resolve_topic(
+    candidate: &ForumImportTopicCandidate,
+    inspection: &NodebbForumImportInspection,
+    bindings: &mut BindingIndex,
+) -> Result<ForumResolvedImportTopic, ForumImportResolutionError> {
+    let id = bindings.require(&candidate.source, ForumImportTargetIdentityKind::Topic)?;
+    let category_id = bindings.require(
+        &candidate.category_source,
+        ForumImportTargetIdentityKind::Category,
+    )?;
+    let author = resolve_author(candidate.author_source.as_ref(), bindings)?;
+    let body_source = candidate.body_post_source.as_ref().ok_or_else(|| {
+        ForumImportResolutionError::MissingTopicBodySource {
+            source: candidate.source.clone(),
+        }
+    })?;
+    let body_post = inspection
+        .candidates
+        .posts
+        .iter()
+        .find(|post| post.source == *body_source)
+        .ok_or_else(|| ForumImportResolutionError::TopicBodyPostMissing {
+            topic: candidate.source.clone(),
+            post: body_source.clone(),
+        })?;
+    if body_post.role != ForumImportPostRole::TopicBody || body_post.topic_source != candidate.source {
+        return Err(ForumImportResolutionError::TopicBodyRoleMismatch {
+            topic: candidate.source.clone(),
+            post: body_post.source.clone(),
+        });
+    }
+    if body_post.deleted {
+        return Err(ForumImportResolutionError::DeletedTopicBody {
+            topic: candidate.source.clone(),
+            post: body_post.source.clone(),
+        });
+    }
+    let body_author = resolve_author(body_post.author_source.as_ref(), bindings)?;
+    if author.as_ref().map(|value| value.user_id) != body_author.as_ref().map(|value| value.user_id) {
+        return Err(ForumImportResolutionError::TopicBodyAuthorMismatch {
+            topic: candidate.source.clone(),
+            post: body_post.source.clone(),
+        });
+    }
+
+    Ok(ForumResolvedImportTopic {
+        source: candidate.source.clone(),
+        id,
+        category_id,
+        author,
+        title: candidate.title.clone(),
+        slug: candidate.slug.clone(),
+        body_source: body_post.source.clone(),
+        body: body_post.body.clone(),
+        created_at_ms: candidate.created_at_ms,
+        is_pinned: candidate.is_pinned,
+        is_locked: candidate.is_locked,
+    })
+}
+
+fn resolve_replies(
+    inspection: &NodebbForumImportInspection,
+    bindings: &mut BindingIndex,
+) -> Result<Vec<ForumResolvedImportReply>, ForumImportResolutionError> {
+    let mut replies = Vec::new();
+    for candidate in &inspection.candidates.posts {
+        match candidate.role {
+            ForumImportPostRole::TopicBody => continue,
+            ForumImportPostRole::Reply => {
+                replies.push(resolve_reply(candidate, bindings)?);
+            }
+            ForumImportPostRole::Unresolved => {
+                return Err(ForumImportResolutionError::UnresolvedPostRole {
+                    source: candidate.source.clone(),
+                });
+            }
+        }
+    }
+    Ok(replies)
+}
+
+fn resolve_reply(
+    candidate: &ForumImportPostCandidate,
+    bindings: &mut BindingIndex,
+) -> Result<ForumResolvedImportReply, ForumImportResolutionError> {
+    let id = bindings.require(&candidate.source, ForumImportTargetIdentityKind::Reply)?;
+    let topic_id = bindings.require(&candidate.topic_source, ForumImportTargetIdentityKind::Topic)?;
+    let author = resolve_author(candidate.author_source.as_ref(), bindings)?;
+    Ok(ForumResolvedImportReply {
+        source: candidate.source.clone(),
+        id,
+        topic_id,
+        author,
+        body: candidate.body.clone(),
+        created_at_ms: candidate.created_at_ms,
+        deleted: candidate.deleted,
+    })
+}
+
+fn resolve_author(
+    source: Option<&ForumImportExternalRef>,
+    bindings: &mut BindingIndex,
+) -> Result<Option<ForumResolvedImportAuthor>, ForumImportResolutionError> {
+    source
+        .map(|source| {
+            Ok(ForumResolvedImportAuthor {
+                source: source.clone(),
+                user_id: bindings.require(source, ForumImportTargetIdentityKind::User)?,
+            })
+        })
+        .transpose()
+}
+
+fn validate_external_ref(
+    reference: &ForumImportExternalRef,
+    expected: ForumImportEntityKind,
+) -> Result<(), ForumImportResolutionError> {
+    if reference.source != FORUM_IMPORT_SOURCE_NODEBB {
+        return Err(ForumImportResolutionError::SourceNamespaceMismatch {
+            reference: reference.clone(),
+            actual: reference.source.clone(),
+        });
+    }
+    if reference.kind != expected {
+        return Err(ForumImportResolutionError::SourceKindMismatch {
+            reference: reference.clone(),
+            expected,
+            actual: reference.kind,
+        });
+    }
+    Ok(())
+}
+
+fn ref_key(reference: &ForumImportExternalRef) -> RefKey {
+    (
+        reference.source.clone(),
+        source_kind_label(reference.kind),
+        reference.key.clone(),
+    )
+}
+
+const fn source_kind_label(kind: ForumImportEntityKind) -> &'static str {
+    match kind {
+        ForumImportEntityKind::Category => "category",
+        ForumImportEntityKind::Topic => "topic",
+        ForumImportEntityKind::Post => "post",
+        ForumImportEntityKind::User => "user",
+    }
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -20,6 +20,7 @@ pub mod export_mapping;
 pub mod graphql;
 pub mod import_inspection;
 pub mod import_mapping;
+pub mod import_resolution;
 pub mod locale;
 pub mod mentions;
 pub mod migrations;
@@ -62,6 +63,7 @@ pub use export_mapping::*;
 pub use graphql::{ForumMutation, ForumQuery};
 pub use import_inspection::*;
 pub use import_mapping::*;
+pub use import_resolution::*;
 pub use mentions::*;
 pub use moderation_subject::{
     FORUM_MODERATION_MODULE, ForumModerationSubjectAdapterFactory,

--- a/docs/modules/forum-34-import-application-resolution-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-import-application-resolution-actualization-2026-08-09.md
@@ -1,0 +1,130 @@
+# FORUM-34K bounded import application resolution actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34J are merged before this slice. Fresh `main` for 34K is `bc7fec764589b64b257340572cb0a1611c27db65`; the commit after 34J is Commerce/Fulfillment-only and does not overlap Forum import/export source.
+
+Repository recheck still finds no neutral shared `ImportRunner` / `ImportJob` / migration-runner contract suitable for Forum checkpoint, receipt, replay or recovery ownership. The canonical Forum implementation-plan ledger still labels `FORUM-34` as `planned`; this dated packet records the truthful 34K cursor without replacing the large roadmap wholesale.
+
+## Why 34K resolves before it writes
+
+The existing Forum owner create APIs are correct interactive commands, but they are not yet a migration application port:
+
+- category/topic/reply create paths generate fresh UUIDs internally;
+- topic/reply authors are derived from `SecurityContext` rather than an admitted source-user binding;
+- the interactive commands do not preserve imported timestamps/deleted state as caller-supplied owner facts;
+- NodeBB source IDs must never be converted directly into RusTok IDs.
+
+Writing through those APIs now would lose the explicit external-to-owner identity map or misrepresent the importing operator as the source author. 34K therefore adds a side-effect-free resolution boundary first.
+
+## Public in-process contract
+
+`ForumImportApplicationResolver::resolve_batch(...)` accepts `ForumImportApplicationResolutionRequest` containing:
+
+- one non-nil tenant ID;
+- one explicit import locale, normalized through the existing content locale normalizer;
+- one already-inspected `NodebbForumImportInspection`;
+- bounded explicit `ForumImportIdentityBinding` values.
+
+The request and resolved application types are in-process only and add no serde/transport contract.
+
+The binding cap is `MAX_FORUM_IMPORT_RESOLUTION_BINDINGS_PER_BATCH = 1024`, derived as twice the existing 512 source-record bound. A bounded batch can require at most one owner identity per source record plus one external user binding per topic/post source record.
+
+## Typed identity admission
+
+A binding contains the original `ForumImportExternalRef`, a typed owner target kind and a non-nil UUID. Target kinds are deliberately explicit:
+
+- category source -> `Category` UUID;
+- topic source -> `Topic` UUID;
+- reply-classified NodeBB post -> `Reply` UUID;
+- external NodeBB user -> `User` UUID.
+
+The resolver never calls `Uuid::new_v4` and never derives a RusTok UUID from NodeBB numeric IDs.
+
+Bindings fail closed on duplicate source refs, nil target UUIDs, target-kind mismatches, unused bindings, missing required bindings and same-kind target collisions. Same-kind collision rejection prevents two distinct source identities from silently collapsing onto one category/topic/reply/user identity without a future explicit merge policy.
+
+## Topic-body identity boundary
+
+A NodeBB `post` classified as `TopicBody` does **not** receive a `Reply` UUID. Forum stores the topic body as localized topic content, not as a separate reply entity.
+
+34K therefore consumes the confirmed `mainPid` body post into `ForumResolvedImportTopic.body` and preserves its `body_source` external reference. That source can later be recorded as an alias/reference to the owning topic by the shared identity ledger; the resolver does not invent a standalone Forum reply identity for it.
+
+Reply-classified posts do require explicit `Reply` target UUIDs and become `ForumResolvedImportReply` application facts.
+
+## Dependency admission
+
+34K deliberately accepts only a structurally self-contained bounded application batch.
+
+The only unresolved inspection issue admitted past 34C is `AuthorUser / ExternalOwnerResolution`, and every such source user must have an explicit `User` binding.
+
+The resolver independently rechecks candidate structure instead of trusting a forgeable inspection object blindly:
+
+- category parents must be present in the same bounded category set;
+- category parent chains must remain acyclic;
+- topic categories must be present in the same batch;
+- topic main posts must be present in the same batch;
+- post topics must be present in the same batch;
+- all source refs must remain in the `nodebb` namespace with the expected entity kind;
+- duplicate candidate source refs are rejected;
+- `ForumImportPostRole::Unresolved` is rejected.
+
+Cross-batch category/topic/post resolution remains runner-owned. An identity binding alone is not enough to prove absent source content or topic-body classification.
+
+## Topic body and author integrity
+
+Every topic must carry an explicit body-post source, and the referenced post must:
+
+- be present in the bounded batch;
+- be classified as `TopicBody`;
+- point back to the same source topic;
+- not be marked deleted.
+
+The topic author and its main-post author must resolve to the same optional owner user ID. 34K does not guess between conflicting source author facts.
+
+Guest/no-author facts remain `None`; positive NodeBB user refs require explicit external owner resolution.
+
+## Resolved application facts
+
+The resolver emits deterministic source-order `ForumResolvedImportApplicationBatch` facts:
+
+- categories with admitted owner ID and resolved parent owner ID;
+- topics with admitted owner ID, category ID, optional resolved author, source title/slug/body/timestamp/pin/lock facts and the exact body source ref;
+- replies with admitted owner ID, topic ID, optional resolved author, body/timestamp and deleted flag.
+
+The normalized import locale is carried once on the batch because the current NodeBB source mapping has no per-record locale fact.
+
+These are resolution/application facts, not persistence DTOs. 34K does not invent missing category icon/color/moderation policy, rich-text conversion policy, imported status defaults, or owner-event semantics.
+
+## Storage and ownership boundary
+
+`import_resolution.rs` imports no SeaORM/database type, owner service, event bus, transport or migration runtime. It performs no create/update/delete operation and no UUID generation.
+
+The next persistence slice must still enter a Forum-owned command boundary that can preserve admitted identities/authors and imported lifecycle facts without bypassing Forum invariants. Generic retry/checkpoint/receipt/audit semantics remain blocked on the absent shared runner.
+
+## Current FORUM-34 chains
+
+Export is source-ready for one live bounded page through:
+
+`34J page composer -> 34I candidate IDs -> 34H exact locales -> 34F owner reads -> 34D export mapping`.
+
+Import is now source-ready through identity/dependency resolution for one self-contained bounded batch:
+
+`34A NodeBB mapping -> 34B/34C inspection -> 34K explicit owner identity + application fact resolution`.
+
+## Next FORUM-34 cursor
+
+The next safe slice should inspect and define the smallest Forum-owned **import write port** capable of consuming `ForumResolvedImportApplicationBatch` with caller-admitted IDs/authors while preserving owner invariants. It must not reuse interactive create APIs if doing so would replace imported identity/author/timestamp/deleted facts, and it must not add runner checkpoints or receipts locally.
+
+Cross-batch source assembly and durable identity-ledger persistence still belong to shared composition/runner work.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-import-application-resolution-source.mjs
+```

--- a/scripts/verify/verify-forum-import-application-resolution-source.mjs
+++ b/scripts/verify/verify-forum-import-application-resolution-source.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  lib: "crates/rustok-forum/src/lib.rs",
+  resolution: "crates/rustok-forum/src/import_resolution.rs",
+  inspection: "crates/rustok-forum/src/import_inspection.rs",
+  mapping: "crates/rustok-forum/src/import_mapping.rs",
+  packet: "docs/modules/forum-34-import-application-resolution-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  "pub mod import_resolution;",
+  "pub use import_resolution::*;",
+]) need(source.lib, marker, "forum import resolution export");
+
+for (const marker of [
+  "pub const MAX_FORUM_IMPORT_RESOLUTION_BINDINGS_PER_BATCH: usize =",
+  "MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH * 2",
+  "pub enum ForumImportTargetIdentityKind",
+  "Category,",
+  "Topic,",
+  "Reply,",
+  "User,",
+  "pub struct ForumImportIdentityBinding",
+  "pub struct ForumImportApplicationResolutionRequest",
+  "pub struct ForumResolvedImportApplicationBatch",
+  "pub struct ForumImportApplicationResolver",
+  "pub fn resolve_batch(",
+  "normalize_locale_code(&request.locale)",
+  "request.tenant_id.is_nil()",
+  "TooManyCandidates",
+  "TooManyBindings",
+  "DuplicateCandidateSource",
+  "DuplicateBinding",
+  "NilBindingTarget",
+  "TargetIdentityCollision",
+  "MissingBinding",
+  "BindingKindMismatch",
+  "UnexpectedBinding",
+  "SourceNamespaceMismatch",
+  "SourceKindMismatch",
+  "UnresolvedDependency",
+  "CrossBatchDependency",
+  "CategoryCycle",
+  "UnresolvedPostRole",
+  "MissingTopicBodySource",
+  "DeletedTopicBody",
+  "TopicBodyAuthorMismatch",
+  "ForumImportDependencyRelation::AuthorUser",
+  "ForumImportDependencyDisposition::ExternalOwnerResolution",
+  "ForumImportTargetIdentityKind::Category",
+  "ForumImportTargetIdentityKind::Topic",
+  "ForumImportTargetIdentityKind::Reply",
+  "ForumImportTargetIdentityKind::User",
+  "ForumImportPostRole::TopicBody => continue",
+  "body_source: body_post.source.clone()",
+  "body: body_post.body.clone()",
+  "deleted: candidate.deleted",
+]) need(source.resolution, marker, "FORUM-34K resolution source");
+
+for (const marker of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "Entity::",
+  "ActiveModel",
+  "TransactionalEventBus",
+  "CategoryService",
+  "TopicService",
+  "ReplyService",
+  "Uuid::new_v4",
+  "Serialize",
+  "Deserialize",
+  "#[serde(",
+]) forbid(source.resolution, marker, "resolution side-effect/non-wire boundary");
+
+for (const marker of [
+  "MissingBatchRecord",
+  "MismatchedBatchRecord",
+  "CyclicBatchRelation",
+  "ExternalOwnerResolution",
+  "AuthorUser",
+]) need(source.inspection, marker, "34B/34C inspection baseline");
+
+for (const marker of [
+  "MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH: usize = 512",
+  "ForumImportPostRole",
+  "TopicBody",
+  "Reply",
+  "Unresolved",
+  "FORUM_IMPORT_SOURCE_NODEBB",
+]) need(source.mapping, marker, "34A mapping baseline");
+
+for (const marker of [
+  "FORUM-34K",
+  "FORUM-34A through FORUM-34J",
+  "still labels `FORUM-34` as `planned`",
+  "no neutral shared `ImportRunner` / `ImportJob`",
+  "generate fresh UUIDs internally",
+  "derived from `SecurityContext`",
+  "never calls `Uuid::new_v4`",
+  "A NodeBB `post` classified as `TopicBody` does **not** receive a `Reply` UUID",
+  "structurally self-contained bounded application batch",
+  "Cross-batch category/topic/post resolution remains runner-owned",
+  "topic author and its main-post author must resolve to the same optional owner user ID",
+  "imports no SeaORM/database type",
+  "34A NodeBB mapping -> 34B/34C inspection -> 34K explicit owner identity + application fact resolution",
+  "no tests, Cargo commands",
+]) need(source.packet, marker, "FORUM-34K packet");
+
+const newUuidCalls = source.resolution.split("Uuid::new_v4").length - 1;
+if (newUuidCalls !== 0) {
+  throw new Error(`resolution boundary generated UUIDs: ${newUuidCalls}`);
+}
+
+console.log("Forum FORUM-34K bounded import application resolution source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with a side-effect-free bounded import application resolution boundary over the already-merged NodeBB mapping/inspection slices.

- add `ForumImportApplicationResolver::resolve_batch` over one already-inspected bounded NodeBB candidate batch;
- require explicit typed owner identity bindings for categories, topics, reply-classified posts and external users;
- cap source candidates at the existing 512 bound and identity bindings at 1024;
- normalize one explicit import locale and keep all resolution/application types in-process and non-wire;
- never generate RusTok UUIDs from source IDs or via `Uuid::new_v4`;
- allow only `AuthorUser / ExternalOwnerResolution` inspection issues through resolution, requiring explicit User bindings;
- independently reject cross-batch category/topic/post dependencies, category cycles, duplicate source candidates and unresolved post roles;
- consume a confirmed NodeBB `TopicBody` post into the resolved topic body without assigning that post a Forum Reply UUID;
- reject missing/mismatched/deleted topic bodies and topic/main-post author disagreement;
- preserve source order plus admitted owner IDs, source refs, timestamps, deleted reply facts, pin/lock facts and body-source identity;
- add no database write path, owner service call, event bus, transport, migration, checkpoint, receipt or durable runner.

## Recheck

The branch is based on current `main` at `bc7fec764589b64b257340572cb0a1611c27db65`; the commit after FORUM-34J is Commerce/Fulfillment-only and does not overlap Forum import/export source. Final compare before opening this PR is `behind 0` with exactly four Forum files changed; `crates/rustok-forum/src/lib.rs` changes by only two module/re-export lines.

Repository search still finds no neutral shared `ImportRunner` / `ImportJob` contract suitable for Forum checkpoint/receipt/replay ownership. The canonical Forum implementation plan still labels `FORUM-34` as `planned`; the dated actualization packet records the truthful 34K cursor without replacing the large roadmap wholesale.

## Ownership boundary

Existing interactive category/topic/reply create commands generate new UUIDs internally, and topic/reply authors are derived from `SecurityContext`. Reusing them directly for migration would lose caller-admitted source identity/author facts or misattribute the importing operator as the source author. 34K therefore resolves application facts only; the next persistence slice must define a Forum-owned migration write boundary that accepts admitted IDs/authors while preserving owner invariants.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run. Maintainer will run tests.