### PR TITLE
feat(forum): prepare bounded import owner writes

### DIFF
--- a/crates/rustok-forum/src/import_write_preparation.rs
+++ b/crates/rustok-forum/src/import_write_preparation.rs
@@ -1,0 +1,755 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use rustok_api::RichTextDocument;
+use rustok_content::normalize_locale_code;
+use serde_json::Value;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::import_mapping::{
+    ForumImportEntityKind, ForumImportExternalRef, FORUM_IMPORT_SOURCE_NODEBB,
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH,
+};
+use crate::import_resolution::{
+    ForumResolvedImportApplicationBatch, ForumResolvedImportAuthor, ForumResolvedImportCategory,
+    ForumResolvedImportReply, ForumResolvedImportTopic,
+};
+use crate::state_machine::{ReplyStatus, TopicStatus};
+
+pub const MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH: usize =
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ForumImportWriteEventMode {
+    SuppressInteractiveEvents,
+    EmitDomainEvents,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumImportCategoryWriteDecision {
+    pub source: ForumImportExternalRef,
+    pub slug: String,
+    pub position: i32,
+    pub moderated: bool,
+    pub icon: Option<String>,
+    pub color: Option<String>,
+    pub created_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumImportTopicWriteDecision {
+    pub source: ForumImportExternalRef,
+    pub body: RichTextDocument,
+    pub status: TopicStatus,
+    pub metadata: Value,
+    pub tags: Vec<String>,
+    pub channel_slugs: Option<Vec<String>>,
+    pub created_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumImportReplyWriteDecision {
+    pub source: ForumImportExternalRef,
+    pub content: RichTextDocument,
+    pub status: ReplyStatus,
+    pub parent_reply_id: Option<Uuid>,
+    pub created_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumImportWritePreparationRequest {
+    pub resolved: ForumResolvedImportApplicationBatch,
+    pub event_mode: ForumImportWriteEventMode,
+    pub categories: Vec<ForumImportCategoryWriteDecision>,
+    pub topics: Vec<ForumImportTopicWriteDecision>,
+    pub replies: Vec<ForumImportReplyWriteDecision>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumPreparedImportCategory {
+    pub source: ForumImportExternalRef,
+    pub id: Uuid,
+    pub parent_id: Option<Uuid>,
+    pub locale: String,
+    pub name: String,
+    pub slug: String,
+    pub description: Option<String>,
+    pub position: i32,
+    pub moderated: bool,
+    pub icon: Option<String>,
+    pub color: Option<String>,
+    pub created_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumPreparedImportTopic {
+    pub source: ForumImportExternalRef,
+    pub id: Uuid,
+    pub category_id: Uuid,
+    pub author: Option<ForumResolvedImportAuthor>,
+    pub locale: String,
+    pub title: String,
+    pub slug: Option<String>,
+    pub body_source: ForumImportExternalRef,
+    pub body: RichTextDocument,
+    pub status: TopicStatus,
+    pub metadata: Value,
+    pub tags: Vec<String>,
+    pub channel_slugs: Option<Vec<String>>,
+    pub is_pinned: bool,
+    pub is_locked: bool,
+    pub created_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumPreparedImportReply {
+    pub source: ForumImportExternalRef,
+    pub id: Uuid,
+    pub topic_id: Uuid,
+    pub author: Option<ForumResolvedImportAuthor>,
+    pub locale: String,
+    pub content: RichTextDocument,
+    pub status: ReplyStatus,
+    pub parent_reply_id: Option<Uuid>,
+    pub created_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumPreparedImportWriteBatch {
+    pub tenant_id: Uuid,
+    pub locale: String,
+    pub event_mode: ForumImportWriteEventMode,
+    pub categories: Vec<ForumPreparedImportCategory>,
+    pub topics: Vec<ForumPreparedImportTopic>,
+    pub replies: Vec<ForumPreparedImportReply>,
+}
+
+#[derive(Debug, Error)]
+pub enum ForumImportWritePreparationError {
+    #[error("Forum import write preparation requires a non-nil tenant id")]
+    NilTenantId,
+    #[error("Forum import write preparation requires at least one resolved record")]
+    EmptyBatch,
+    #[error("Forum import write preparation exceeds {max} resolved records: {actual}")]
+    TooManyRecords { max: usize, actual: usize },
+    #[error("Forum import write preparation locale is invalid: {locale}")]
+    InvalidLocale { locale: String },
+    #[error("Forum import write preparation locale must already be normalized: {actual} -> {normalized}")]
+    LocaleNotNormalized { actual: String, normalized: String },
+    #[error("Forum import write preparation has nil {kind} target id for {source:?}")]
+    NilTargetId {
+        kind: &'static str,
+        source: ForumImportExternalRef,
+    },
+    #[error("Forum import write preparation repeats {kind} target id {id}")]
+    DuplicateTargetId { kind: &'static str, id: Uuid },
+    #[error("Forum import write preparation has nil user id for {source:?}")]
+    NilAuthorId { source: ForumImportExternalRef },
+    #[error("Forum import write preparation requires NodeBB {expected:?} source, got {source:?}")]
+    InvalidSourceRef {
+        expected: ForumImportEntityKind,
+        source: ForumImportExternalRef,
+    },
+    #[error("Forum import write preparation contains duplicate {kind} decision for {source:?}")]
+    DuplicateDecision {
+        kind: &'static str,
+        source: ForumImportExternalRef,
+    },
+    #[error("Forum import write preparation is missing {kind} decision for {source:?}")]
+    MissingDecision {
+        kind: &'static str,
+        source: ForumImportExternalRef,
+    },
+    #[error("Forum import write preparation contains unused {kind} decision for {source:?}")]
+    UnexpectedDecision {
+        kind: &'static str,
+        source: ForumImportExternalRef,
+    },
+    #[error("Forum import category slug is empty for {source:?}")]
+    EmptyCategorySlug { source: ForumImportExternalRef },
+    #[error("Forum import category position must be non-negative for {source:?}: {position}")]
+    NegativeCategoryPosition {
+        source: ForumImportExternalRef,
+        position: i32,
+    },
+    #[error("Forum import source category position is outside owner range for {source:?}: {position}")]
+    SourceCategoryPositionOutOfRange {
+        source: ForumImportExternalRef,
+        position: i64,
+    },
+    #[error("Forum import category position decision differs from source for {source:?}: {source_position} != {decision_position}")]
+    CategoryPositionChanged {
+        source: ForumImportExternalRef,
+        source_position: i64,
+        decision_position: i32,
+    },
+    #[error("Forum import write timestamp must be non-negative for {kind} {source:?}: {timestamp_ms}")]
+    NegativeTimestamp {
+        kind: &'static str,
+        source: ForumImportExternalRef,
+        timestamp_ms: i64,
+    },
+    #[error("Forum import write timestamp differs from source for {kind} {source:?}: {source_timestamp_ms} != {decision_timestamp_ms}")]
+    TimestampChanged {
+        kind: &'static str,
+        source: ForumImportExternalRef,
+        source_timestamp_ms: i64,
+        decision_timestamp_ms: i64,
+    },
+    #[error("Forum import reply deleted fact requires deleted status for {source:?}")]
+    DeletedReplyStatusRequired { source: ForumImportExternalRef },
+    #[error("Forum import live reply cannot be prepared with deleted status for {source:?}")]
+    LiveReplyCannotBeDeleted { source: ForumImportExternalRef },
+    #[error("Forum import category parent {parent_id} is outside the bounded batch for {source:?}")]
+    CategoryParentOutsideBatch {
+        source: ForumImportExternalRef,
+        parent_id: Uuid,
+    },
+    #[error("Forum import category target cycle reaches {id}")]
+    CategoryCycle { id: Uuid },
+    #[error("Forum import topic category {category_id} is outside the bounded batch for {source:?}")]
+    TopicCategoryOutsideBatch {
+        source: ForumImportExternalRef,
+        category_id: Uuid,
+    },
+    #[error("Forum import reply topic {topic_id} is outside the bounded batch for {source:?}")]
+    ReplyTopicOutsideBatch {
+        source: ForumImportExternalRef,
+        topic_id: Uuid,
+    },
+    #[error("Forum import reply parent {parent_reply_id} is outside the bounded batch for {source:?}")]
+    ReplyParentOutsideBatch {
+        source: ForumImportExternalRef,
+        parent_reply_id: Uuid,
+    },
+    #[error("Forum import reply parent {parent_reply_id} belongs to another topic for {source:?}")]
+    ReplyParentTopicMismatch {
+        source: ForumImportExternalRef,
+        parent_reply_id: Uuid,
+    },
+    #[error("Forum import reply cannot parent itself for {source:?}")]
+    ReplySelfParent { source: ForumImportExternalRef },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForumImportWritePreparer;
+
+impl ForumImportWritePreparer {
+    pub fn prepare(
+        &self,
+        request: &ForumImportWritePreparationRequest,
+    ) -> Result<ForumPreparedImportWriteBatch, ForumImportWritePreparationError> {
+        let locale = validate_batch(&request.resolved)?;
+        let category_ids = validate_target_ids(
+            "category",
+            request
+                .resolved
+                .categories
+                .iter()
+                .map(|record| (&record.source, record.id)),
+        )?;
+        let topic_ids = validate_target_ids(
+            "topic",
+            request
+                .resolved
+                .topics
+                .iter()
+                .map(|record| (&record.source, record.id)),
+        )?;
+        let reply_ids = validate_target_ids(
+            "reply",
+            request
+                .resolved
+                .replies
+                .iter()
+                .map(|record| (&record.source, record.id)),
+        )?;
+        validate_author_ids(&request.resolved)?;
+        validate_relations(&request.resolved, &category_ids, &topic_ids, &reply_ids)?;
+
+        let mut category_decisions = DecisionIndex::new("category", &request.categories)?;
+        let mut topic_decisions = DecisionIndex::new("topic", &request.topics)?;
+        let mut reply_decisions = DecisionIndex::new("reply", &request.replies)?;
+
+        let categories = request
+            .resolved
+            .categories
+            .iter()
+            .map(|record| prepare_category(record, &locale, &mut category_decisions))
+            .collect::<Result<Vec<_>, _>>()?;
+        let topics = request
+            .resolved
+            .topics
+            .iter()
+            .map(|record| prepare_topic(record, &locale, &mut topic_decisions))
+            .collect::<Result<Vec<_>, _>>()?;
+        let replies = request
+            .resolved
+            .replies
+            .iter()
+            .map(|record| prepare_reply(record, &locale, &mut reply_decisions))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        category_decisions.reject_unused()?;
+        topic_decisions.reject_unused()?;
+        reply_decisions.reject_unused()?;
+        validate_prepared_reply_parents(&replies)?;
+
+        Ok(ForumPreparedImportWriteBatch {
+            tenant_id: request.resolved.tenant_id,
+            locale,
+            event_mode: request.event_mode,
+            categories,
+            topics,
+            replies,
+        })
+    }
+}
+
+trait DecisionSource {
+    fn source(&self) -> &ForumImportExternalRef;
+}
+
+impl DecisionSource for ForumImportCategoryWriteDecision {
+    fn source(&self) -> &ForumImportExternalRef {
+        &self.source
+    }
+}
+
+impl DecisionSource for ForumImportTopicWriteDecision {
+    fn source(&self) -> &ForumImportExternalRef {
+        &self.source
+    }
+}
+
+impl DecisionSource for ForumImportReplyWriteDecision {
+    fn source(&self) -> &ForumImportExternalRef {
+        &self.source
+    }
+}
+
+struct DecisionIndex<'a, T> {
+    kind: &'static str,
+    by_source: BTreeMap<RefKey, &'a T>,
+    used: BTreeSet<RefKey>,
+}
+
+impl<'a, T: DecisionSource> DecisionIndex<'a, T> {
+    fn new(kind: &'static str, decisions: &'a [T]) -> Result<Self, ForumImportWritePreparationError> {
+        let mut by_source = BTreeMap::new();
+        for decision in decisions {
+            let source = decision.source();
+            let key = ref_key(source);
+            if by_source.insert(key, decision).is_some() {
+                return Err(ForumImportWritePreparationError::DuplicateDecision {
+                    kind,
+                    source: source.clone(),
+                });
+            }
+        }
+        Ok(Self {
+            kind,
+            by_source,
+            used: BTreeSet::new(),
+        })
+    }
+
+    fn require(
+        &mut self,
+        source: &ForumImportExternalRef,
+    ) -> Result<&'a T, ForumImportWritePreparationError> {
+        let key = ref_key(source);
+        let Some(decision) = self.by_source.get(&key).copied() else {
+            return Err(ForumImportWritePreparationError::MissingDecision {
+                kind: self.kind,
+                source: source.clone(),
+            });
+        };
+        self.used.insert(key);
+        Ok(decision)
+    }
+
+    fn reject_unused(&self) -> Result<(), ForumImportWritePreparationError> {
+        for (key, decision) in &self.by_source {
+            if !self.used.contains(key) {
+                return Err(ForumImportWritePreparationError::UnexpectedDecision {
+                    kind: self.kind,
+                    source: decision.source().clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_batch(
+    batch: &ForumResolvedImportApplicationBatch,
+) -> Result<String, ForumImportWritePreparationError> {
+    if batch.tenant_id.is_nil() {
+        return Err(ForumImportWritePreparationError::NilTenantId);
+    }
+    let actual = batch
+        .categories
+        .len()
+        .saturating_add(batch.topics.len())
+        .saturating_add(batch.replies.len());
+    if actual == 0 {
+        return Err(ForumImportWritePreparationError::EmptyBatch);
+    }
+    if actual > MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH {
+        return Err(ForumImportWritePreparationError::TooManyRecords {
+            max: MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH,
+            actual,
+        });
+    }
+    let normalized = normalize_locale_code(&batch.locale).ok_or_else(|| {
+        ForumImportWritePreparationError::InvalidLocale {
+            locale: batch.locale.clone(),
+        }
+    })?;
+    if normalized != batch.locale {
+        return Err(ForumImportWritePreparationError::LocaleNotNormalized {
+            actual: batch.locale.clone(),
+            normalized,
+        });
+    }
+    Ok(batch.locale.clone())
+}
+
+fn validate_target_ids<'a>(
+    kind: &'static str,
+    records: impl IntoIterator<Item = (&'a ForumImportExternalRef, Uuid)>,
+) -> Result<BTreeSet<Uuid>, ForumImportWritePreparationError> {
+    let mut ids = BTreeSet::new();
+    for (source, id) in records {
+        if id.is_nil() {
+            return Err(ForumImportWritePreparationError::NilTargetId {
+                kind,
+                source: source.clone(),
+            });
+        }
+        if !ids.insert(id) {
+            return Err(ForumImportWritePreparationError::DuplicateTargetId { kind, id });
+        }
+    }
+    Ok(ids)
+}
+
+fn validate_author_ids(
+    batch: &ForumResolvedImportApplicationBatch,
+) -> Result<(), ForumImportWritePreparationError> {
+    for topic in &batch.topics {
+        validate_author(topic.author.as_ref())?;
+    }
+    for reply in &batch.replies {
+        validate_author(reply.author.as_ref())?;
+    }
+    Ok(())
+}
+
+fn validate_author(
+    author: Option<&ForumResolvedImportAuthor>,
+) -> Result<(), ForumImportWritePreparationError> {
+    let Some(author) = author else {
+        return Ok(());
+    };
+    validate_source_ref(&author.source, ForumImportEntityKind::User)?;
+    if author.user_id.is_nil() {
+        return Err(ForumImportWritePreparationError::NilAuthorId {
+            source: author.source.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_relations(
+    batch: &ForumResolvedImportApplicationBatch,
+    category_ids: &BTreeSet<Uuid>,
+    topic_ids: &BTreeSet<Uuid>,
+    reply_ids: &BTreeSet<Uuid>,
+) -> Result<(), ForumImportWritePreparationError> {
+    let mut parent_by_category = BTreeMap::new();
+    for category in &batch.categories {
+        validate_source_ref(&category.source, ForumImportEntityKind::Category)?;
+        if let Some(parent_id) = category.parent_id {
+            if !category_ids.contains(&parent_id) {
+                return Err(ForumImportWritePreparationError::CategoryParentOutsideBatch {
+                    source: category.source.clone(),
+                    parent_id,
+                });
+            }
+        }
+        parent_by_category.insert(category.id, category.parent_id);
+    }
+    validate_category_cycles(&parent_by_category)?;
+
+    for topic in &batch.topics {
+        validate_source_ref(&topic.source, ForumImportEntityKind::Topic)?;
+        validate_source_ref(&topic.body_source, ForumImportEntityKind::Post)?;
+        if !category_ids.contains(&topic.category_id) {
+            return Err(ForumImportWritePreparationError::TopicCategoryOutsideBatch {
+                source: topic.source.clone(),
+                category_id: topic.category_id,
+            });
+        }
+    }
+    for reply in &batch.replies {
+        validate_source_ref(&reply.source, ForumImportEntityKind::Post)?;
+        if !topic_ids.contains(&reply.topic_id) {
+            return Err(ForumImportWritePreparationError::ReplyTopicOutsideBatch {
+                source: reply.source.clone(),
+                topic_id: reply.topic_id,
+            });
+        }
+    }
+
+    if reply_ids.len() != batch.replies.len() {
+        return Err(ForumImportWritePreparationError::TooManyRecords {
+            max: MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH,
+            actual: batch.replies.len(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_category_cycles(
+    parent_by_category: &BTreeMap<Uuid, Option<Uuid>>,
+) -> Result<(), ForumImportWritePreparationError> {
+    for start in parent_by_category.keys().copied() {
+        let mut seen = BTreeSet::new();
+        let mut current = start;
+        loop {
+            if !seen.insert(current) {
+                return Err(ForumImportWritePreparationError::CategoryCycle { id: current });
+            }
+            let Some(Some(parent)) = parent_by_category.get(&current).copied() else {
+                break;
+            };
+            current = parent;
+        }
+    }
+    Ok(())
+}
+
+fn prepare_category(
+    record: &ForumResolvedImportCategory,
+    locale: &str,
+    decisions: &mut DecisionIndex<'_, ForumImportCategoryWriteDecision>,
+) -> Result<ForumPreparedImportCategory, ForumImportWritePreparationError> {
+    let decision = decisions.require(&record.source)?;
+    validate_source_ref(&decision.source, ForumImportEntityKind::Category)?;
+    let slug = decision.slug.trim();
+    if slug.is_empty() {
+        return Err(ForumImportWritePreparationError::EmptyCategorySlug {
+            source: record.source.clone(),
+        });
+    }
+    if decision.position < 0 {
+        return Err(ForumImportWritePreparationError::NegativeCategoryPosition {
+            source: record.source.clone(),
+            position: decision.position,
+        });
+    }
+    if let Some(source_position) = record.position {
+        let expected = i32::try_from(source_position).map_err(|_| {
+            ForumImportWritePreparationError::SourceCategoryPositionOutOfRange {
+                source: record.source.clone(),
+                position: source_position,
+            }
+        })?;
+        if expected < 0 {
+            return Err(ForumImportWritePreparationError::SourceCategoryPositionOutOfRange {
+                source: record.source.clone(),
+                position: source_position,
+            });
+        }
+        if expected != decision.position {
+            return Err(ForumImportWritePreparationError::CategoryPositionChanged {
+                source: record.source.clone(),
+                source_position,
+                decision_position: decision.position,
+            });
+        }
+    }
+    validate_timestamp("category", &record.source, None, decision.created_at_ms)?;
+
+    Ok(ForumPreparedImportCategory {
+        source: record.source.clone(),
+        id: record.id,
+        parent_id: record.parent_id,
+        locale: locale.to_owned(),
+        name: record.name.clone(),
+        slug: slug.to_owned(),
+        description: record.description.clone(),
+        position: decision.position,
+        moderated: decision.moderated,
+        icon: decision.icon.clone(),
+        color: decision.color.clone(),
+        created_at_ms: decision.created_at_ms,
+    })
+}
+
+fn prepare_topic(
+    record: &ForumResolvedImportTopic,
+    locale: &str,
+    decisions: &mut DecisionIndex<'_, ForumImportTopicWriteDecision>,
+) -> Result<ForumPreparedImportTopic, ForumImportWritePreparationError> {
+    let decision = decisions.require(&record.source)?;
+    validate_source_ref(&decision.source, ForumImportEntityKind::Topic)?;
+    validate_timestamp(
+        "topic",
+        &record.source,
+        record.created_at_ms,
+        decision.created_at_ms,
+    )?;
+
+    Ok(ForumPreparedImportTopic {
+        source: record.source.clone(),
+        id: record.id,
+        category_id: record.category_id,
+        author: record.author.clone(),
+        locale: locale.to_owned(),
+        title: record.title.clone(),
+        slug: record.slug.clone(),
+        body_source: record.body_source.clone(),
+        body: decision.body.clone(),
+        status: decision.status,
+        metadata: decision.metadata.clone(),
+        tags: decision.tags.clone(),
+        channel_slugs: decision.channel_slugs.clone(),
+        is_pinned: record.is_pinned,
+        is_locked: record.is_locked,
+        created_at_ms: decision.created_at_ms,
+    })
+}
+
+fn prepare_reply(
+    record: &ForumResolvedImportReply,
+    locale: &str,
+    decisions: &mut DecisionIndex<'_, ForumImportReplyWriteDecision>,
+) -> Result<ForumPreparedImportReply, ForumImportWritePreparationError> {
+    let decision = decisions.require(&record.source)?;
+    validate_source_ref(&decision.source, ForumImportEntityKind::Post)?;
+    validate_timestamp(
+        "reply",
+        &record.source,
+        record.created_at_ms,
+        decision.created_at_ms,
+    )?;
+    match (record.deleted, decision.status) {
+        (true, ReplyStatus::Deleted) => {}
+        (true, _) => {
+            return Err(ForumImportWritePreparationError::DeletedReplyStatusRequired {
+                source: record.source.clone(),
+            });
+        }
+        (false, ReplyStatus::Deleted) => {
+            return Err(ForumImportWritePreparationError::LiveReplyCannotBeDeleted {
+                source: record.source.clone(),
+            });
+        }
+        (false, _) => {}
+    }
+
+    Ok(ForumPreparedImportReply {
+        source: record.source.clone(),
+        id: record.id,
+        topic_id: record.topic_id,
+        author: record.author.clone(),
+        locale: locale.to_owned(),
+        content: decision.content.clone(),
+        status: decision.status,
+        parent_reply_id: decision.parent_reply_id,
+        created_at_ms: decision.created_at_ms,
+    })
+}
+
+fn validate_timestamp(
+    kind: &'static str,
+    source: &ForumImportExternalRef,
+    source_timestamp_ms: Option<i64>,
+    decision_timestamp_ms: i64,
+) -> Result<(), ForumImportWritePreparationError> {
+    if decision_timestamp_ms < 0 {
+        return Err(ForumImportWritePreparationError::NegativeTimestamp {
+            kind,
+            source: source.clone(),
+            timestamp_ms: decision_timestamp_ms,
+        });
+    }
+    if let Some(source_timestamp_ms) = source_timestamp_ms {
+        if source_timestamp_ms != decision_timestamp_ms {
+            return Err(ForumImportWritePreparationError::TimestampChanged {
+                kind,
+                source: source.clone(),
+                source_timestamp_ms,
+                decision_timestamp_ms,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_prepared_reply_parents(
+    replies: &[ForumPreparedImportReply],
+) -> Result<(), ForumImportWritePreparationError> {
+    let topic_by_reply = replies
+        .iter()
+        .map(|reply| (reply.id, reply.topic_id))
+        .collect::<BTreeMap<_, _>>();
+    for reply in replies {
+        let Some(parent_reply_id) = reply.parent_reply_id else {
+            continue;
+        };
+        if parent_reply_id == reply.id {
+            return Err(ForumImportWritePreparationError::ReplySelfParent {
+                source: reply.source.clone(),
+            });
+        }
+        let Some(parent_topic_id) = topic_by_reply.get(&parent_reply_id).copied() else {
+            return Err(ForumImportWritePreparationError::ReplyParentOutsideBatch {
+                source: reply.source.clone(),
+                parent_reply_id,
+            });
+        };
+        if parent_topic_id != reply.topic_id {
+            return Err(ForumImportWritePreparationError::ReplyParentTopicMismatch {
+                source: reply.source.clone(),
+                parent_reply_id,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_ref(
+    source: &ForumImportExternalRef,
+    expected: ForumImportEntityKind,
+) -> Result<(), ForumImportWritePreparationError> {
+    if source.source != FORUM_IMPORT_SOURCE_NODEBB || source.kind != expected {
+        return Err(ForumImportWritePreparationError::InvalidSourceRef {
+            expected,
+            source: source.clone(),
+        });
+    }
+    Ok(())
+}
+
+type RefKey = (String, &'static str, String);
+
+fn ref_key(source: &ForumImportExternalRef) -> RefKey {
+    (
+        source.source.clone(),
+        source_kind_label(source.kind),
+        source.key.clone(),
+    )
+}
+
+const fn source_kind_label(kind: ForumImportEntityKind) -> &'static str {
+    match kind {
+        ForumImportEntityKind::Category => "category",
+        ForumImportEntityKind::Topic => "topic",
+        ForumImportEntityKind::Post => "post",
+        ForumImportEntityKind::User => "user",
+    }
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -21,6 +21,7 @@ pub mod graphql;
 pub mod import_inspection;
 pub mod import_mapping;
 pub mod import_resolution;
+pub mod import_write_preparation;
 pub mod locale;
 pub mod mentions;
 pub mod migrations;
@@ -64,6 +65,7 @@ pub use graphql::{ForumMutation, ForumQuery};
 pub use import_inspection::*;
 pub use import_mapping::*;
 pub use import_resolution::*;
+pub use import_write_preparation::*;
 pub use mentions::*;
 pub use moderation_subject::{
     FORUM_MODERATION_MODULE, ForumModerationSubjectAdapterFactory,

--- a/docs/modules/forum-34-import-write-preparation-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-import-write-preparation-actualization-2026-08-09.md
@@ -1,0 +1,152 @@
+# FORUM-34L bounded import write preparation actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / owner-write-adapter-open / shared-runner-blocked`
+
+## Cursor and recheck
+
+FORUM-34A through FORUM-34K are merged before this slice. Fresh `main` for 34L is `1d5553f4b6bba52dd9ccee41ae6c3f5108081b6b`. The commits after 34K are Pages/Commerce work and do not overlap Forum import/export source.
+
+Repository recheck still finds no neutral shared `ImportRunner` / `ImportJob` contract suitable for checkpoint, receipt, replay or recovery ownership. The canonical Forum implementation-plan ledger still carries the old `FORUM-34` planned cursor; this dated packet records the truthful 34L source cursor without replacing the large roadmap wholesale.
+
+## Why 34L prepares before persistence
+
+34K resolves source identities and dependencies, but its facts are intentionally not yet sufficient to write owner storage safely.
+
+Existing interactive Forum create commands cannot simply be reused for migration because they generate new entity UUIDs and derive topic/reply authors from `SecurityContext`. A separate raw SeaORM writer would be worse: it would duplicate owner validation, category/topic/reply counters, state-machine behavior, outbox/domain-event semantics, taxonomy/flex hooks and future invariants.
+
+A second recheck also found source-policy gaps that must be explicit before any write adapter exists:
+
+- NodeBB category mapping has no owner-required category slug;
+- category position may be absent or outside the owner `i32` range;
+- category moderation/icon/color policy is not a source fact;
+- NodeBB body text is still raw source text, not an admitted `RichTextDocument`;
+- imported topic status is not currently a NodeBB source fact;
+- non-deleted reply moderation status is not currently a NodeBB source fact;
+- reply parent identity is not currently mapped from NodeBB;
+- category timestamps can be absent from the current source mapping;
+- historical import event/notification behavior must not be silently treated as interactive posting behavior.
+
+34L therefore adds a side-effect-free **owner-write preparation** boundary rather than guessing those values inside a database writer.
+
+## Public in-process contract
+
+`ForumImportWritePreparer::prepare(...)` accepts `ForumImportWritePreparationRequest` containing:
+
+- one already-resolved 34K `ForumResolvedImportApplicationBatch`;
+- one explicit `ForumImportWriteEventMode`;
+- exactly one category write decision per resolved category;
+- exactly one topic write decision per resolved topic;
+- exactly one reply write decision per resolved reply.
+
+The request, decisions and prepared output are in-process only. No serde or transport contract is added.
+
+The prepared output is `ForumPreparedImportWriteBatch` with explicit owner-ready category/topic/reply facts while preserving the 34K target IDs, source refs, authors and dependency identities.
+
+## Bound and identity checks
+
+34L keeps the existing source bound: at most `MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH = 512` prepared owner records across categories, topics and replies.
+
+It rejects:
+
+- nil tenant IDs;
+- empty batches;
+- invalid or non-normalized batch locale;
+- nil category/topic/reply target UUIDs;
+- duplicate target UUIDs within one owner kind;
+- nil resolved author UUIDs;
+- non-NodeBB or wrong-kind source references;
+- missing, duplicate or unused preparation decisions.
+
+The preparation boundary does not generate any entity UUID.
+
+## Dependency recheck
+
+34L rechecks target-side dependency closure instead of trusting a forgeable resolved DTO blindly:
+
+- category parent IDs must point to categories in the same bounded batch;
+- category target parent chains must remain acyclic;
+- every topic category ID must point to a category in the same batch;
+- every reply topic ID must point to a topic in the same batch;
+- an explicit reply parent must point to another prepared reply in the same batch and same topic;
+- self-parent replies are rejected.
+
+Cross-batch dependency assembly remains a shared-runner concern. The current 34K/34L path intentionally accepts only self-contained application batches.
+
+## Explicit category decisions
+
+Each category decision must provide the facts the source mapping does not own:
+
+- non-empty slug;
+- final non-negative `i32` position;
+- moderation flag;
+- optional icon/color;
+- explicit non-negative creation timestamp.
+
+When NodeBB already supplied a category position, 34L does not silently rewrite it: the value must fit the owner `i32` range, remain non-negative and equal the preparation decision. When source position is absent, the caller must explicitly choose the owner position.
+
+## Explicit topic decisions
+
+Each topic decision provides:
+
+- admitted `RichTextDocument` body transformation;
+- explicit `TopicStatus`;
+- explicit metadata;
+- explicit tags;
+- explicit channel slugs;
+- explicit creation timestamp.
+
+If 34K preserved a source timestamp, the decision must use exactly that timestamp. The preparer preserves the resolved topic ID, category ID, optional source author, title/slug, `body_source`, pin/lock facts and source order.
+
+34L does not claim that a raw NodeBB body has been semantically converted merely because a caller supplied a RichText document; the source adapter/maintainer still owns that transformation policy.
+
+## Explicit reply decisions
+
+Each reply decision provides:
+
+- admitted `RichTextDocument` content;
+- explicit `ReplyStatus`;
+- optional resolved parent reply UUID;
+- explicit creation timestamp.
+
+If a source reply is marked deleted, its prepared status must be `ReplyStatus::Deleted`. A live source reply cannot be prepared as deleted. Source timestamps, when present, cannot be rewritten by the decision.
+
+## Event mode
+
+`ForumImportWriteEventMode` is explicit and has no default:
+
+- `SuppressInteractiveEvents` records the intent that historical import must not masquerade as interactive posting notifications/events;
+- `EmitDomainEvents` records the intent that a future owner adapter should emit the normal domain-event path.
+
+34L carries the decision only. It does not publish events, notifications or Search work itself.
+
+The exact production behavior for `SuppressInteractiveEvents` still needs the owner write adapter to distinguish required consistency/rebuild signals from user-facing interactive side effects.
+
+## Storage boundary
+
+`import_write_preparation.rs` imports no SeaORM/database types, `SecurityContext`, owner service, event bus, runtime extension, transport or migration API. It performs no create/update/delete and no transaction.
+
+This is deliberate. The next persistence slice must first factor or expose owner-owned in-transaction creation primitives so the import adapter can preserve admitted IDs/authors/timestamps/status while reusing Forum invariants rather than duplicating them.
+
+## Current FORUM-34 import chain
+
+The source-ready bounded import path is now:
+
+`34A NodeBB mapping -> 34B/34C inspection -> 34K identity/application resolution -> 34L owner-write preparation`.
+
+No persistence, durable checkpoint, receipt, replay or cross-batch source assembly is claimed yet.
+
+## Next FORUM-34 cursor
+
+The next safe slice should be **FORUM-34M**: factor the smallest Forum-owned in-transaction category/topic/reply import application primitives behind a write adapter consuming `ForumPreparedImportWriteBatch`.
+
+That adapter must preserve category/topic/reply counters and owner validation, use caller-admitted entity IDs/authors/timestamps/status, define the explicit event-mode behavior, and apply one prepared batch atomically. It must not create a Forum-local runner/checkpoint/receipt system.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-import-write-preparation-source.mjs
+```

--- a/scripts/verify/verify-forum-import-write-preparation-source.mjs
+++ b/scripts/verify/verify-forum-import-write-preparation-source.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  lib: "crates/rustok-forum/src/lib.rs",
+  resolution: "crates/rustok-forum/src/import_resolution.rs",
+  preparation: "crates/rustok-forum/src/import_write_preparation.rs",
+  packet: "docs/modules/forum-34-import-write-preparation-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  "pub mod import_write_preparation;",
+  "pub use import_write_preparation::*;",
+]) need(source.lib, marker, "forum import write preparation export");
+
+for (const marker of [
+  "pub const MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH: usize =",
+  "MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH",
+  "pub enum ForumImportWriteEventMode",
+  "SuppressInteractiveEvents",
+  "EmitDomainEvents",
+  "pub struct ForumImportCategoryWriteDecision",
+  "pub struct ForumImportTopicWriteDecision",
+  "pub struct ForumImportReplyWriteDecision",
+  "pub struct ForumImportWritePreparationRequest",
+  "pub struct ForumPreparedImportCategory",
+  "pub struct ForumPreparedImportTopic",
+  "pub struct ForumPreparedImportReply",
+  "pub struct ForumPreparedImportWriteBatch",
+  "pub enum ForumImportWritePreparationError",
+  "pub struct ForumImportWritePreparer",
+  "pub fn prepare(",
+  "normalize_locale_code(&batch.locale)",
+  "EmptyBatch",
+  "TooManyRecords",
+  "LocaleNotNormalized",
+  "DuplicateTargetId",
+  "NilAuthorId",
+  "DuplicateDecision",
+  "MissingDecision",
+  "UnexpectedDecision",
+  "EmptyCategorySlug",
+  "SourceCategoryPositionOutOfRange",
+  "CategoryPositionChanged",
+  "TimestampChanged",
+  "DeletedReplyStatusRequired",
+  "LiveReplyCannotBeDeleted",
+  "CategoryParentOutsideBatch",
+  "CategoryCycle",
+  "TopicCategoryOutsideBatch",
+  "ReplyTopicOutsideBatch",
+  "ReplyParentOutsideBatch",
+  "ReplyParentTopicMismatch",
+  "ReplySelfParent",
+  "ReplyStatus::Deleted",
+  "body: decision.body.clone()",
+  "content: decision.content.clone()",
+  "event_mode: request.event_mode",
+]) need(source.preparation, marker, "FORUM-34L preparation source");
+
+for (const marker of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "Entity::",
+  "ActiveModel",
+  "TransactionalEventBus",
+  "SecurityContext",
+  "CategoryService",
+  "TopicService",
+  "ReplyService",
+  "Uuid::new_v4",
+  "Serialize",
+  "Deserialize",
+  "#[serde(",
+  ".insert(",
+  ".update(",
+  ".delete(",
+]) forbid(source.preparation, marker, "preparation side-effect/non-wire boundary");
+
+for (const marker of [
+  "pub struct ForumResolvedImportApplicationBatch",
+  "pub struct ForumResolvedImportCategory",
+  "pub struct ForumResolvedImportTopic",
+  "pub struct ForumResolvedImportReply",
+  "ForumImportTargetIdentityKind",
+]) need(source.resolution, marker, "34K resolution baseline");
+
+for (const marker of [
+  "FORUM-34L",
+  "FORUM-34A through FORUM-34K",
+  "owner-write preparation",
+  "NodeBB category mapping has no owner-required category slug",
+  "raw source text, not an admitted `RichTextDocument`",
+  "at most `MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH = 512`",
+  "does not generate any entity UUID",
+  "Cross-batch dependency assembly remains a shared-runner concern",
+  "`ForumImportWriteEventMode` is explicit and has no default",
+  "imports no SeaORM/database types",
+  "34A NodeBB mapping -> 34B/34C inspection -> 34K identity/application resolution -> 34L owner-write preparation",
+  "FORUM-34M",
+  "no tests, Cargo commands",
+]) need(source.packet, marker, "FORUM-34L packet");
+
+const libWiringCount = source.lib.split("import_write_preparation").length - 1;
+if (libWiringCount !== 2) {
+  throw new Error(`forum import write preparation wiring count: ${libWiringCount}`);
+}
+
+console.log("Forum FORUM-34L bounded import write preparation source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with a bounded side-effect-free owner-write preparation boundary after 34K identity/application resolution.

- add `ForumImportWritePreparer::prepare` over one resolved 34K batch;
- keep the existing 512-record bound and reject empty/nil/non-normalized/duplicate target state;
- require exact per-record preparation decisions instead of inventing owner facts absent from NodeBB mapping;
- require category slug/position/moderation/icon/color/timestamp decisions;
- require topic RichText/status/metadata/tags/channel/timestamp decisions while preserving resolved IDs/authors/body source/pin/lock facts;
- require reply RichText/status/parent/timestamp decisions and enforce deleted-source/status consistency;
- recheck target-side category/topic/reply dependency closure and reply-parent topic identity;
- carry explicit `ForumImportWriteEventMode` with no default;
- add no SeaORM/database path, owner service call, transaction, event publication, transport, migration, checkpoint, receipt or runner.

## Recheck

Fresh `main` for this slice is `1d5553f4b6bba52dd9ccee41ae6c3f5108081b6b`; the commits after FORUM-34K are Pages/Commerce only and do not overlap Forum import/export source. Final compare before opening this PR is `behind 0` with exactly four Forum files changed; `crates/rustok-forum/src/lib.rs` changes by only two module/re-export lines.

Repository search still finds no neutral shared `ImportRunner` / `ImportJob` contract suitable for checkpoint/receipt/replay ownership. The canonical Forum plan still carries the stale FORUM-34 planned cursor; the dated packet records 34L without replacing the large roadmap wholesale.

## Why this is not the DB writer yet

34K facts still omit owner-required or policy-sensitive values: category slug/moderation, admitted RichText conversion, topic/reply status, reply parent mapping, some timestamps, and historical event/notification behavior. Reusing interactive create commands would replace caller-admitted IDs/authors, while a raw SeaORM writer would duplicate counters/outbox/state-machine/taxonomy/flex invariants. 34L therefore makes those decisions explicit before an owner adapter exists.

The next slice should factor the smallest Forum-owned in-transaction import primitives and consume `ForumPreparedImportWriteBatch` atomically without creating a Forum-local runner.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, DB scenario, workflow, CI command, lock generation or `git diff --check` was run. Maintainer will run tests.