### PR TITLE
feat(commerce): route GraphQL payment collection through owner ports

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -32,6 +32,18 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(registry)
     };
 
+    #[cfg(all(feature = "mod-commerce", feature = "mod-payment"))]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_payment::PaymentCollectionRuntime>()
+            .or_else(|| server.shared_get::<rustok_payment::PaymentCollectionRuntime>())
+            .unwrap_or_else(|| {
+                rustok_payment::PaymentCollectionRuntime::in_process(server.db_clone())
+            });
+        server.shared_insert(runtime.clone());
+        host.with_shared_value(runtime)
+    };
+
     #[cfg(feature = "mod-fulfillment")]
     let host = {
         let registry = server

--- a/crates/rustok-commerce/docs/graphql-storefront-payment-collection-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/graphql-storefront-payment-collection-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,101 @@
+# Commerce GraphQL storefront payment-collection owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+The mounted Commerce GraphQL `createStorefrontPaymentCollection` mutation no longer constructs
+`rustok_payment::PaymentService`.
+
+The resolver now composes two existing Payment-owned capabilities:
+
+- `PaymentCartReadPort::find_reusable_collection_by_cart` for the pre-create reusable lookup;
+- `PaymentCollectionPort::create_or_reuse_collection` for owner-local creation and concurrent-race
+  adoption.
+
+`rustok-payment` now publishes the lightweight `PaymentCollectionRuntime` composition wrapper so a
+host can select an external `PaymentCollectionPort`. Its built-in in-process adapter is the only new
+place in this slice that constructs concrete `PaymentService` for this capability.
+
+`CommercePaymentCommandRuntime` carries the host-selected `PaymentCollectionRuntime` alongside the
+already existing Payment collection lifecycle and refund command runtimes. Mounted GraphQL receives
+that runtime from `GraphqlRuntimeInputs`; directly embedded compatibility schemas retain the explicit
+Payment-owned in-process fallback.
+
+The application server also publishes `PaymentCollectionRuntime` into `HostRuntimeContext`,
+preserving a host- or server-selected implementation before using the Payment-owned in-process
+adapter.
+
+## Resolver parity
+
+The old resolver performed its reusable lookup before parsing caller-provided payment metadata. This
+ordering is preserved deliberately:
+
+1. Commerce completes its existing storefront module/channel, cart access, repricing, and store
+   context resolution;
+2. the host-selected `PaymentCartReadPort` checks for a reusable collection;
+3. an existing collection is returned immediately, without parsing the new request metadata;
+4. only on a reusable miss does Commerce parse/merge metadata and call
+   `PaymentCollectionPort::create_or_reuse_collection`.
+
+The owner create/reuse operation performs its own reusable check and rechecks after a create failure,
+so a concurrent creator can be adopted inside the Payment owner instead of requiring Commerce to
+reimplement Payment persistence-race policy.
+
+The request projection remains unchanged: cart id, no order id, cart customer id, cart currency,
+repriced cart total, and the same merged cart/store-context metadata are sent to Payment.
+
+## Owner call context
+
+Both Payment owner calls receive trusted `PortContext` values derived from the admitted tenant and
+request data:
+
+- authenticated storefront requests use the validated user actor;
+- guest storefront requests use the stable
+  `rustok-commerce.graphql-storefront-payment-collection` service actor;
+- locale comes from `RequestContext`, falling back to `und` only when blank;
+- request channel is propagated when present;
+- read and write calls carry cart-bound correlation identities;
+- both calls use a two-second deadline.
+
+The create/reuse call also carries the stable cart-bound write identity
+`graphql-storefront-payment-collection:{cart_id}` to satisfy canonical write-port admission. This
+slice does **not** claim that this transport identity is a durable Payment receipt or exactly-once
+command record. Reuse and create-race adoption are provided by Payment's existing owner behavior,
+not by a new Commerce replay journal.
+
+## Public error compatibility
+
+Concrete `PaymentError` no longer crosses this mounted resolver boundary. The GraphQL mapper consumes
+bounded `PortError` facts and preserves the existing public envelope families where the owner code
+retains the distinction:
+
+- validation -> `payment_request_invalid`;
+- missing resource -> `payment_resource_not_found`;
+- lifecycle conflict -> `payment_state_conflict`;
+- provider rejection -> `payment_provider_rejected`;
+- provider outcome unknown / invalid response -> `payment_reconciliation_required`;
+- provider configuration/unavailable -> `payment_temporarily_unavailable`;
+- Payment storage failure -> `payment_storage_unavailable`.
+
+Unexpected forbidden/invariant failures fail closed as `payment_operation_failed`. Diagnostics expose
+only bounded owner kind/code length and request-context facts; raw owner/backend messages are not
+logged or returned by the Commerce mapper.
+
+## Deliberately still open
+
+This slice only removes the mounted GraphQL storefront payment-collection concrete Payment service
+construction. It does not claim that every remaining Commerce Product, Order, Payment, or Fulfillment
+transport/service construction has been removed.
+
+The canonical ecommerce topology item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and
+Fulfillment concrete services behind host-composed owner ports` therefore remains open pending a
+fresh mounted-path audit.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL
+scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or
+remote-adapter scenarios were executed for this slice. The accompanying verifier changes are
+source-only evidence for maintainer execution.

--- a/crates/rustok-commerce/src/graphql/mutations/checkout.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/checkout.rs
@@ -1,14 +1,17 @@
 use async_graphql::{Context, ErrorExtensions, Object, Result};
 use rustok_api::Permission;
 use rustok_api::{
-    AuthContext, PortActor, PortContext, RequestContext, graphql::require_module_enabled,
+    AuthContext, PortActor, PortContext, RequestContext, PortError, PortErrorKind,
+    graphql::require_module_enabled,
 };
 use rustok_cart::{CartStorefrontReadRequest, in_process_cart_storefront_port};
 use rustok_fulfillment::{
     CreateAdminShippingOptionRequest, DeactivateAdminShippingOptionRequest,
     ReactivateAdminShippingOptionRequest, UpdateAdminShippingOptionRequest,
 };
-use rustok_payment::{PaymentError, PaymentService};
+use rustok_payment::{
+    PaymentCollectionCreateOrReuseRequest, ReusablePaymentCollectionByCartRequest,
+};
 use uuid::Uuid;
 
 use crate::ShippingProfileService;
@@ -41,6 +44,60 @@ fn shipping_option_command_context(
         Some(channel) => context.with_channel(channel),
         None => context,
     })
+}
+
+fn storefront_payment_collection_actor(auth: Option<&AuthContext>) -> PortActor {
+    auth.map(|auth| PortActor::user(auth.user_id.to_string()))
+        .unwrap_or_else(|| {
+            PortActor::service("rustok-commerce.graphql-storefront-payment-collection")
+        })
+}
+
+fn storefront_payment_collection_locale(request: &RequestContext) -> &str {
+    if request.locale.trim().is_empty() {
+        "und"
+    } else {
+        request.locale.as_str()
+    }
+}
+
+fn storefront_payment_collection_read_context(
+    tenant_id: Uuid,
+    cart_id: Uuid,
+    request: &RequestContext,
+    auth: Option<&AuthContext>,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        storefront_payment_collection_actor(auth),
+        storefront_payment_collection_locale(request),
+        format!("commerce-graphql-storefront-payment-collection-read:{cart_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn storefront_payment_collection_command_context(
+    tenant_id: Uuid,
+    cart_id: Uuid,
+    request: &RequestContext,
+    auth: Option<&AuthContext>,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        storefront_payment_collection_actor(auth),
+        storefront_payment_collection_locale(request),
+        format!("commerce-graphql-storefront-payment-collection:{cart_id}"),
+    )
+    .with_idempotency_key(format!("graphql-storefront-payment-collection:{cart_id}"))
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
 }
 
 #[derive(Default)]
@@ -92,7 +149,7 @@ impl CommerceCheckoutMutation {
             cart,
         )
         .await?;
-        let context = crate::StoreContextService::new(
+        let store_context = crate::StoreContextService::new(
             db.clone(),
             std::sync::Arc::new(rustok_region::RegionService::new(db.clone())),
         )
@@ -124,46 +181,66 @@ impl CommerceCheckoutMutation {
                 })
         })?;
 
-        let service = PaymentService::new(db.clone());
-        if let Some(existing) = service
-            .find_reusable_collection_by_cart(tenant_id, cart.id)
-            .await
-            .map_err(|error| {
-                payment_collection_graphql_error(
-                    tenant_id,
-                    cart.id,
-                    "find_reusable_collection_by_cart",
-                    error,
-                )
-            })?
-        {
+        let read_context = storefront_payment_collection_read_context(
+            tenant_id,
+            cart.id,
+            request_context,
+            ctx.data_opt::<AuthContext>(),
+        );
+        if let Some(existing) = crate::graphql_runtime::payment_read_runtime_for_current_graphql_scope(
+            db.clone(),
+        )
+        .cart_read_port()
+        .find_reusable_collection_by_cart(
+            read_context.clone(),
+            ReusablePaymentCollectionByCartRequest { cart_id: cart.id },
+        )
+        .await
+        .map_err(|error| {
+            payment_collection_owner_graphql_error(
+                &read_context,
+                cart.id,
+                "find_reusable_collection_by_cart",
+                error,
+            )
+        })? {
             return Ok(existing.into());
         }
 
-        let collection = service
-            .create_collection(
-                tenant_id,
-                crate::dto::CreatePaymentCollectionInput {
-                    cart_id: Some(cart.id),
-                    order_id: None,
-                    customer_id: cart.customer_id,
-                    currency_code: cart.currency_code.clone(),
-                    amount: cart.total_amount,
-                    metadata: merge_graphql_metadata(
-                        parse_optional_metadata(input.metadata.as_deref())?,
-                        cart_context_metadata(&cart, &context),
-                    ),
-                },
+        let command_context = storefront_payment_collection_command_context(
+            tenant_id,
+            cart.id,
+            request_context,
+            ctx.data_opt::<AuthContext>(),
+        );
+        let collection = crate::graphql_runtime::payment_command_runtime_from_context(
+            ctx,
+            db.clone(),
+        )
+        .collection_create_or_reuse_port()
+        .create_or_reuse_collection(
+            command_context.clone(),
+            PaymentCollectionCreateOrReuseRequest {
+                cart_id: Some(cart.id),
+                order_id: None,
+                customer_id: cart.customer_id,
+                currency_code: cart.currency_code.clone(),
+                amount: cart.total_amount,
+                metadata: merge_graphql_metadata(
+                    parse_optional_metadata(input.metadata.as_deref())?,
+                    cart_context_metadata(&cart, &store_context),
+                ),
+            },
+        )
+        .await
+        .map_err(|error| {
+            payment_collection_owner_graphql_error(
+                &command_context,
+                cart.id,
+                "create_or_reuse_collection",
+                error,
             )
-            .await
-            .map_err(|error| {
-                payment_collection_graphql_error(
-                    tenant_id,
-                    cart.id,
-                    "create_collection",
-                    error,
-                )
-            })?;
+        })?;
 
         Ok(collection.into())
     }
@@ -572,66 +649,116 @@ fn storefront_checkout_graphql_error(
     })
 }
 
-fn payment_collection_graphql_error(
-    tenant_id: Uuid,
-    cart_id: Uuid,
-    operation: &'static str,
-    error: PaymentError,
-) -> async_graphql::Error {
-    tracing::error!(
-        error = ?error,
-        tenant_id = %tenant_id,
-        cart_id = %cart_id,
-        operation,
-        "storefront payment collection GraphQL operation failed"
-    );
-    let (code, message, retryable, reconciliation_required) = match error {
-        PaymentError::Validation(_) => (
+fn payment_collection_port_graphql_policy(
+    error: &PortError,
+) -> (&'static str, &'static str, bool, bool, &'static str) {
+    match &error.kind {
+        PortErrorKind::Validation => (
             "payment_request_invalid",
             "Payment collection request is invalid",
             false,
             false,
+            "validation",
         ),
-        PaymentError::PaymentCollectionNotFound(_)
-        | PaymentError::PaymentNotFound(_)
-        | PaymentError::RefundNotFound(_) => (
+        PortErrorKind::NotFound => (
             "payment_resource_not_found",
             "Payment resource was not found",
             false,
             false,
+            "not_found",
         ),
-        PaymentError::InvalidTransition { .. } => (
-            "payment_state_conflict",
-            "Payment lifecycle conflicts with the requested operation",
-            false,
-            false,
-        ),
-        PaymentError::ProviderUnavailable { .. } | PaymentError::ProviderConfiguration { .. } => (
-            "payment_temporarily_unavailable",
-            "Payment service is temporarily unavailable",
-            true,
-            false,
-        ),
-        PaymentError::ProviderRejected { .. } => (
+        PortErrorKind::Conflict if error.code == "payment.provider_rejected" => (
             "payment_provider_rejected",
             "Payment provider rejected the requested operation",
             false,
             false,
+            "provider_rejected",
         ),
-        PaymentError::ProviderInvalidResponse { .. }
-        | PaymentError::ProviderOutcomeUnknown { .. } => (
+        PortErrorKind::Conflict if error.code == "payment.provider_outcome_unknown" => (
             "payment_reconciliation_required",
             "Payment operation requires reconciliation",
             false,
             true,
+            "provider_outcome_unknown",
         ),
-        PaymentError::Database(_) => (
-            "payment_storage_unavailable",
+        PortErrorKind::Conflict => (
+            "payment_state_conflict",
+            "Payment lifecycle conflicts with the requested operation",
+            false,
+            false,
+            "state_conflict",
+        ),
+        PortErrorKind::Unavailable
+            if error.code == "payment.database_unavailable"
+                || error.code == "payment.cart_read_unavailable" =>
+        {
+            (
+                "payment_storage_unavailable",
+                "Payment service is temporarily unavailable",
+                true,
+                false,
+                "database",
+            )
+        }
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            "payment_temporarily_unavailable",
             "Payment service is temporarily unavailable",
             true,
             false,
+            "temporarily_unavailable",
         ),
-    };
+        PortErrorKind::InvariantViolation if error.code == "payment.provider_invalid_response" => (
+            "payment_reconciliation_required",
+            "Payment operation requires reconciliation",
+            false,
+            true,
+            "provider_invalid_response",
+        ),
+        PortErrorKind::InvariantViolation if error.code == "payment.provider_not_configured" => (
+            "payment_temporarily_unavailable",
+            "Payment service is temporarily unavailable",
+            true,
+            false,
+            "provider_configuration",
+        ),
+        PortErrorKind::Forbidden | PortErrorKind::InvariantViolation => (
+            "payment_operation_failed",
+            "Payment operation could not be completed safely",
+            false,
+            false,
+            "owner_operation_failed",
+        ),
+    }
+}
+
+fn payment_collection_owner_graphql_error(
+    context: &PortContext,
+    cart_id: Uuid,
+    operation: &'static str,
+    error: PortError,
+) -> async_graphql::Error {
+    let (code, message, retryable, reconciliation_required, error_kind) =
+        payment_collection_port_graphql_policy(&error);
+    tracing::error!(
+        owner = "rustok_payment.payment_collection_port",
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_present = !context.tenant_id.is_empty(),
+        actor_kind = ?context.actor.kind,
+        actor_id_present = !context.actor.id.is_empty(),
+        cart_id_non_nil = !cart_id.is_nil(),
+        channel_present = context.channel.is_some(),
+        locale_length = context.locale.chars().count(),
+        deadline_ms = ?context.deadline_ms,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        error_kind,
+        public_code = code,
+        retryable,
+        reconciliation_required,
+        boundary = "commerce_graphql_storefront_payment_collection",
+        "commerce GraphQL storefront payment collection owner call failed"
+    );
     async_graphql::Error::new(message).extend_with(|_, extensions| {
         extensions.set("code", code);
         extensions.set("retryable", retryable);

--- a/crates/rustok-commerce/src/graphql_runtime/payment_commands.rs
+++ b/crates/rustok-commerce/src/graphql_runtime/payment_commands.rs
@@ -2,29 +2,32 @@ use std::sync::Arc;
 
 use rustok_payment::{
     PaymentAdminCollectionCommandPort, PaymentAdminCollectionCommandRuntime,
-    PaymentAdminRefundCommandPort, PaymentAdminRefundCommandRuntime,
-    providers::PaymentProviderRegistry,
+    PaymentAdminRefundCommandPort, PaymentAdminRefundCommandRuntime, PaymentCollectionPort,
+    PaymentCollectionRuntime, providers::PaymentProviderRegistry,
 };
 use sea_orm::DatabaseConnection;
 
 /// Host-selected Payment owner commands consumed by mounted Commerce GraphQL mutations.
 ///
-/// Commerce composes the existing collection and refund command capabilities but does not own
-/// Payment persistence, provider journals, or provider execution. Hosts may inject either owner
-/// runtime independently; missing capabilities use the Payment-owned in-process adapters with the
-/// deployment-selected provider registry.
+/// Commerce composes the existing collection create/reuse, collection lifecycle, and refund
+/// capabilities but does not own Payment persistence, provider journals, or provider execution.
+/// Hosts may inject each owner runtime independently; missing capabilities use Payment-owned
+/// in-process adapters with the deployment-selected provider registry where applicable.
 #[derive(Clone)]
 pub struct CommercePaymentCommandRuntime {
+    collection_create_or_reuse: PaymentCollectionRuntime,
     collection_commands: PaymentAdminCollectionCommandRuntime,
     refund_commands: PaymentAdminRefundCommandRuntime,
 }
 
 impl CommercePaymentCommandRuntime {
     pub fn new(
+        collection_create_or_reuse: PaymentCollectionRuntime,
         collection_commands: PaymentAdminCollectionCommandRuntime,
         refund_commands: PaymentAdminRefundCommandRuntime,
     ) -> Self {
         Self {
+            collection_create_or_reuse,
             collection_commands,
             refund_commands,
         }
@@ -35,6 +38,7 @@ impl CommercePaymentCommandRuntime {
         provider_registry: PaymentProviderRegistry,
     ) -> Self {
         Self::new(
+            PaymentCollectionRuntime::in_process(db.clone()),
             PaymentAdminCollectionCommandRuntime::in_process(
                 db.clone(),
                 provider_registry.clone(),
@@ -49,6 +53,9 @@ impl CommercePaymentCommandRuntime {
         let provider_registry = inputs
             .shared_get::<PaymentProviderRegistry>()
             .unwrap_or_else(PaymentProviderRegistry::with_manual_provider);
+        let collection_create_or_reuse = inputs
+            .shared_get::<PaymentCollectionRuntime>()
+            .unwrap_or_else(|| PaymentCollectionRuntime::in_process(inputs.db_clone()));
         let collection_commands = inputs
             .shared_get::<PaymentAdminCollectionCommandRuntime>()
             .unwrap_or_else(|| {
@@ -65,7 +72,15 @@ impl CommercePaymentCommandRuntime {
                     provider_registry.clone(),
                 )
             });
-        Self::new(collection_commands, refund_commands)
+        Self::new(
+            collection_create_or_reuse,
+            collection_commands,
+            refund_commands,
+        )
+    }
+
+    pub fn collection_create_or_reuse_port(&self) -> Arc<dyn PaymentCollectionPort> {
+        self.collection_create_or_reuse.port()
     }
 
     pub fn collection_command_port(&self) -> Arc<dyn PaymentAdminCollectionCommandPort> {

--- a/crates/rustok-payment/src/collection_runtime.rs
+++ b/crates/rustok-payment/src/collection_runtime.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use sea_orm::DatabaseConnection;
+
+use crate::{PaymentService, ports::PaymentCollectionPort};
+
+/// Host-selectable owner runtime for transport-neutral payment collection create/reuse and status reads.
+///
+/// The runtime owns only the typed Payment boundary. Hosts may provide an external implementation,
+/// while the built-in adapter keeps concrete `PaymentService` construction inside `rustok-payment`.
+#[derive(Clone)]
+pub struct PaymentCollectionRuntime {
+    port: Arc<dyn PaymentCollectionPort>,
+}
+
+impl PaymentCollectionRuntime {
+    pub fn new(port: Arc<dyn PaymentCollectionPort>) -> Self {
+        Self { port }
+    }
+
+    pub fn in_process(db: DatabaseConnection) -> Self {
+        Self::new(Arc::new(PaymentService::new(db)))
+    }
+
+    pub fn port(&self) -> Arc<dyn PaymentCollectionPort> {
+        self.port.clone()
+    }
+}

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -14,6 +14,7 @@ pub mod checkout_compensation;
 mod checkout_compensation_context;
 #[allow(dead_code)]
 pub mod checkout_execution;
+mod collection_runtime;
 #[cfg(feature = "server")]
 pub mod controllers;
 pub mod dto;
@@ -59,6 +60,7 @@ pub use checkout_compensation::{
     InProcessCheckoutPaymentCompensationPort, in_process_checkout_payment_compensation_port,
 };
 pub use checkout_execution::*;
+pub use collection_runtime::PaymentCollectionRuntime;
 pub use dto::*;
 pub use entities::*;
 pub use order_read::{

--- a/scripts/verify/verify-commerce-graphql-storefront-payment-collection-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-storefront-payment-collection-owner-port-cutover.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+const failures = [];
+
+const ownerRuntime = read('crates/rustok-payment/src/collection_runtime.rs');
+const paymentLib = read('crates/rustok-payment/src/lib.rs');
+const paymentPort = read('crates/rustok-payment/src/ports.rs');
+const paymentCartRead = read('crates/rustok-payment/src/cart_read.rs');
+const paymentCommands = read('crates/rustok-commerce/src/graphql_runtime/payment_commands.rs');
+const server = read('apps/server/src/services/commerce_provider_runtime.rs');
+const checkout = read('crates/rustok-commerce/src/graphql/mutations/checkout.rs');
+const routing = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/graphql-storefront-payment-collection-owner-port-cutover-2026-08-09.md',
+);
+
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+const sliceBetween = (source, start, end) => {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  if (from < 0 || to < 0) return '';
+  return source.slice(from, to);
+};
+
+for (const marker of [
+  'pub struct PaymentCollectionRuntime',
+  'port: Arc<dyn PaymentCollectionPort>',
+  'pub fn new(port: Arc<dyn PaymentCollectionPort>)',
+  'pub fn in_process(db: DatabaseConnection)',
+  'PaymentService::new(db)',
+  'pub fn port(&self) -> Arc<dyn PaymentCollectionPort>',
+]) need(ownerRuntime, marker, 'Payment collection owner runtime');
+need(paymentLib, 'pub use collection_runtime::PaymentCollectionRuntime;', 'Payment public runtime export');
+
+for (const marker of [
+  'pub trait PaymentCollectionPort',
+  'async fn create_or_reuse_collection(',
+  '.require_policy(PortCallPolicy::write())',
+  'context.require_write_semantics()',
+  'find_reusable_collection_by_cart(tenant_id, cart_id)',
+  '"create_or_reuse_collection.adopt_race"',
+]) need(paymentPort, marker, 'Payment create/reuse owner contract');
+for (const marker of [
+  'pub trait PaymentCartReadPort',
+  'async fn find_reusable_collection_by_cart(',
+  '.require_policy(PortCallPolicy::read())',
+]) need(paymentCartRead, marker, 'Payment reusable read owner contract');
+
+for (const marker of [
+  'PaymentCollectionRuntime',
+  'collection_create_or_reuse: PaymentCollectionRuntime',
+  '.shared_get::<PaymentCollectionRuntime>()',
+  'PaymentCollectionRuntime::in_process(inputs.db_clone())',
+  'pub fn collection_create_or_reuse_port(&self) -> Arc<dyn PaymentCollectionPort>',
+]) need(paymentCommands, marker, 'Commerce Payment command composition');
+
+for (const marker of [
+  'shared_get::<rustok_payment::PaymentCollectionRuntime>()',
+  'server.shared_get::<rustok_payment::PaymentCollectionRuntime>()',
+  'rustok_payment::PaymentCollectionRuntime::in_process(server.db_clone())',
+  'server.shared_insert(runtime.clone());',
+  'host.with_shared_value(runtime)',
+]) need(server, marker, 'server Payment collection host composition');
+
+need(
+  routing,
+  '#[path = "safe_checkout.rs"]\npub mod checkout;',
+  'mounted checkout routing',
+);
+
+const resolver = sliceBetween(
+  checkout,
+  'async fn create_storefront_payment_collection(',
+  'async fn complete_storefront_checkout(',
+);
+if (!resolver) failures.push('unable to isolate mounted storefront payment collection resolver');
+
+for (const marker of [
+  'ReusablePaymentCollectionByCartRequest',
+  'PaymentCollectionCreateOrReuseRequest',
+  'storefront_payment_collection_read_context(',
+  'payment_read_runtime_for_current_graphql_scope(',
+  '.cart_read_port()',
+  '.find_reusable_collection_by_cart(',
+  'return Ok(existing.into());',
+  'storefront_payment_collection_command_context(',
+  'payment_command_runtime_from_context(',
+  '.collection_create_or_reuse_port()',
+  '.create_or_reuse_collection(',
+  'cart_id: Some(cart.id)',
+  'order_id: None',
+  'customer_id: cart.customer_id',
+  'currency_code: cart.currency_code.clone()',
+  'amount: cart.total_amount',
+  'cart_context_metadata(&cart, &store_context)',
+]) need(resolver, marker, 'mounted Payment collection owner cutover');
+
+const reusableIndex = resolver.indexOf('.find_reusable_collection_by_cart(');
+const metadataIndex = resolver.indexOf('parse_optional_metadata(input.metadata.as_deref())?');
+if (reusableIndex < 0 || metadataIndex < 0 || reusableIndex >= metadataIndex) {
+  failures.push('reusable Payment owner read must happen before GraphQL metadata parsing');
+}
+
+for (const marker of [
+  'fn storefront_payment_collection_actor(',
+  'PortActor::user(auth.user_id.to_string())',
+  'PortActor::service("rustok-commerce.graphql-storefront-payment-collection")',
+  'fn storefront_payment_collection_locale(',
+  '.with_deadline(std::time::Duration::from_secs(2))',
+  'request.channel_slug.as_deref()',
+  '.with_idempotency_key(format!("graphql-storefront-payment-collection:{cart_id}"))',
+]) need(checkout, marker, 'trusted Payment owner context');
+
+for (const marker of [
+  'fn payment_collection_port_graphql_policy(',
+  'PortErrorKind::Validation',
+  'PortErrorKind::NotFound',
+  'error.code == "payment.provider_rejected"',
+  'error.code == "payment.provider_outcome_unknown"',
+  'error.code == "payment.provider_invalid_response"',
+  'error.code == "payment.provider_not_configured"',
+  'error.code == "payment.database_unavailable"',
+  'error.code == "payment.cart_read_unavailable"',
+  '"payment_request_invalid"',
+  '"payment_resource_not_found"',
+  '"payment_state_conflict"',
+  '"payment_temporarily_unavailable"',
+  '"payment_provider_rejected"',
+  '"payment_reconciliation_required"',
+  '"payment_storage_unavailable"',
+  '"payment_operation_failed"',
+  'owner_error_kind = ?error.kind',
+  'owner_code_length = error.code.chars().count()',
+  'boundary = "commerce_graphql_storefront_payment_collection"',
+]) need(checkout, marker, 'bounded Payment GraphQL error compatibility');
+
+for (const marker of [
+  'PaymentService::new(',
+  'use rustok_payment::{PaymentError, PaymentService}',
+  '.create_collection(',
+]) forbid(resolver, marker, 'mounted Payment collection concrete owner boundary');
+for (const marker of [
+  'PaymentService::new(',
+  'use rustok_payment::{PaymentError, PaymentService}',
+]) forbid(checkout, marker, 'mounted checkout concrete Payment owner construction');
+
+const paymentMapperStart = checkout.indexOf('fn payment_collection_owner_graphql_error(');
+const paymentMapper = paymentMapperStart < 0 ? '' : checkout.slice(paymentMapperStart);
+if (!paymentMapper) failures.push('unable to isolate Payment collection GraphQL owner mapper');
+for (const marker of [
+  'error = ?error',
+  'owner_message = %error.message',
+  'message = %error.message',
+]) forbid(paymentMapper, marker, 'bounded Payment owner diagnostics');
+
+need(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'canonical topology item remains open',
+);
+
+for (const marker of [
+  '# Commerce GraphQL storefront payment-collection owner-port cutover',
+  'Status: `source_complete_unvalidated`',
+  '`PaymentCartReadPort::find_reusable_collection_by_cart`',
+  '`PaymentCollectionPort::create_or_reuse_collection`',
+  '`PaymentCollectionRuntime`',
+  'without parsing the new request metadata',
+  'does **not** claim',
+  'The canonical ecommerce topology item',
+  'no tests, Cargo commands, Node verifiers, formatter',
+]) need(record, marker, 'truthful source record');
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL storefront payment collection owner-port cutover verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ mounted GraphQL storefront payment collection preserves reusable-first parity and routes Payment reads/writes through host-composed owner ports',
+);

--- a/scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
+++ b/scripts/verify/verify-commerce-storefront-staged-checkout-cutover.mjs
@@ -81,7 +81,10 @@ for (const [source, value, label] of [
   [graphqlCheckout, 'complete_storefront_checkout_input(', 'GraphQL resolver-scoped checkout entrypoint'],
   [graphqlCheckout, 'payment_provider_registry_from_context(ctx)', 'GraphQL host provider registry'],
   [graphqlCheckout, 'storefront_checkout_graphql_error', 'GraphQL stable checkout mapper'],
-  [graphqlCheckout, 'payment_collection_graphql_error(', 'GraphQL stable payment collection mapper'],
+  [graphqlCheckout, 'PaymentCollectionCreateOrReuseRequest', 'GraphQL payment collection owner request'],
+  [graphqlCheckout, '.collection_create_or_reuse_port()', 'GraphQL payment collection owner port'],
+  [graphqlCheckout, '.create_or_reuse_collection(', 'GraphQL payment collection owner operation'],
+  [graphqlCheckout, 'payment_collection_owner_graphql_error(', 'GraphQL stable payment collection mapper'],
   [graphqlCheckout, 'extensions.set("code", code)', 'GraphQL public error code extension'],
   [graphqlCheckout, 'extensions.set("retryable", retryable)', 'GraphQL public retryability extension'],
   [graphqlCheckout, 'extensions.set("reconciliation_required", reconciliation_required)', 'GraphQL payment reconciliation extension'],
@@ -131,6 +134,7 @@ for (const [source, value, label] of [
   [restCheckout, 'recovering_checkout_http_error', 'REST private staged error mapper drift'],
   [restCheckout, 'staged_checkout_http_error', 'REST private checkout error mapper drift'],
   [restCheckout, 'err.to_string()', 'REST raw payment error display'],
+  [graphqlCheckout, 'PaymentService::new(', 'GraphQL concrete Payment service construction'],
   [graphqlCheckout, 'Error::new(error.to_string())', 'GraphQL raw checkout error display'],
   [graphqlCheckout, '.find_reusable_collection_by_cart(tenant_id, cart.id)\n            .await?', 'GraphQL raw reusable payment error propagation'],
   [nativeCheckout, 'ServerFnError::new(error.to_string())', 'native raw checkout error display'],
@@ -163,5 +167,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ REST, GraphQL, native, and mounted storefront checkout delegate to the shared staged runtime with host-selected Product ports; recovery failures retain typed correlation context without raw stderr output',
+  '✔ REST, GraphQL, native, and mounted storefront checkout delegate to typed owner boundaries with host-selected Product/Payment capabilities; recovery failures retain typed correlation context without raw stderr output',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by removing concrete `PaymentService` construction from mounted GraphQL `createStorefrontPaymentCollection`.

- publish a lightweight Payment-owned `PaymentCollectionRuntime` around the existing `PaymentCollectionPort`;
- host-compose that runtime in the application server and fold it into `CommercePaymentCommandRuntime` while preserving external host/server selections;
- preserve the legacy reusable-first behavior with the already host-selected `PaymentCartReadPort`, including returning an existing collection before parsing new request metadata;
- on reusable miss, route creation through `PaymentCollectionPort::create_or_reuse_collection`, keeping Payment-owned concurrent create/race adoption inside the owner;
- preserve the existing cart/customer access, repricing, StoreContext resolution, collection request projection, and GraphQL response shape;
- carry authenticated user or stable guest service actor, admitted tenant, request locale/channel, cart-bound correlation, two-second deadline, and a stable cart-bound write identity across owner boundaries;
- use the write identity only for canonical write admission and explicitly do **not** claim a durable Payment receipt or exactly-once transport replay record;
- replace concrete `PaymentError` handling in this resolver with bounded code-aware `PortError` mapping while preserving `payment_request_invalid`, `payment_resource_not_found`, `payment_state_conflict`, `payment_temporarily_unavailable`, `payment_provider_rejected`, `payment_reconciliation_required`, and `payment_storage_unavailable` compatibility;
- keep unexpected forbidden/invariant failures fail-closed as `payment_operation_failed` and avoid raw owner/backend message logging;
- update the existing staged-checkout source guard and add a dated source record plus dedicated source-only verifier;
- keep the broad ecommerce topology P0 open pending a fresh mounted-path audit.

The branch is one clean commit ahead and zero behind current `main` (`dcd2e57e060530ad62ac9c940d97f1b67834f5a4`) with exactly eight changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, mounted GraphQL scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Verifier changes are source-only evidence for maintainer execution.