### PR TITLE
feat(commerce): route REST payment collection through owner ports

### DIFF
--- a/apps/server/src/services/commerce_provider_runtime.rs
+++ b/apps/server/src/services/commerce_provider_runtime.rs
@@ -44,6 +44,16 @@ pub fn attach_commerce_provider_registries(
         host.with_shared_value(runtime)
     };
 
+    #[cfg(all(feature = "mod-commerce", feature = "mod-payment"))]
+    let host = {
+        let runtime = host
+            .shared_get::<rustok_payment::PaymentCartReadRuntime>()
+            .or_else(|| server.shared_get::<rustok_payment::PaymentCartReadRuntime>())
+            .unwrap_or_else(|| rustok_payment::PaymentCartReadRuntime::in_process(server.db_clone()));
+        server.shared_insert(runtime.clone());
+        host.with_shared_value(runtime)
+    };
+
     #[cfg(feature = "mod-fulfillment")]
     let host = {
         let registry = server

--- a/crates/rustok-commerce/docs/rest-storefront-payment-collection-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/rest-storefront-payment-collection-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,100 @@
+# Commerce REST storefront payment-collection owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+The mounted Commerce REST `POST /store/payment-collections` handler no longer constructs
+`rustok_payment::PaymentService` and no longer consumes concrete `PaymentError` values.
+
+The route now uses two Payment-owned capabilities supplied through `CommerceHttpRuntime`:
+
+- `PaymentCartReadPort::find_reusable_collection_by_cart` for the pre-create reusable lookup;
+- `PaymentCollectionPort::create_or_reuse_collection` for owner-local collection creation and
+  concurrent create-race adoption.
+
+`CommerceHttpRuntime` now requires the corresponding `PaymentCartReadRuntime` and
+`PaymentCollectionRuntime` from `HostRuntimeContext` and exposes only their trait ports to mounted
+handlers. The application server host-composes both runtimes host-first, then server-shared, and only
+then falls back to the Payment-owned in-process adapters.
+
+No new Payment persistence or lifecycle policy is implemented in Commerce.
+
+## REST parity
+
+The existing route sequence is preserved:
+
+1. storefront channel admission;
+2. current customer resolution;
+3. cart read and customer access check;
+4. completed-cart rejection;
+5. cart repricing;
+6. StoreContext resolution;
+7. reusable Payment collection lookup;
+8. collection creation only after a reusable miss.
+
+A collection that already exists at the pre-create owner read still returns `200 OK`.
+
+After a reusable miss, the handler invokes `PaymentCollectionPort::create_or_reuse_collection` and
+returns `201 Created`. This preserves the old route behavior when a concurrent creator wins after the
+initial read: the Payment owner may adopt the reusable collection internally, while the REST handler
+still returns the post-miss `201 Created` response just as the previous `PaymentService::create_collection`
+race-recovery path did.
+
+The owner request preserves the prior projection: cart id, no order id, cart customer id, cart
+currency, repriced cart total, and the same merged caller/cart/StoreContext metadata.
+
+## Owner call context
+
+Both Payment owner calls carry trusted transport facts:
+
+- admitted tenant id;
+- authenticated user actor when present, otherwise the stable
+  `rustok-commerce.storefront-payment-collection` service actor;
+- request locale with `und` only for a blank locale;
+- request channel slug when present;
+- cart/operation-bound correlation id;
+- two-second deadline.
+
+The create/reuse call additionally carries the cart-bound write admission identity
+`storefront-payment-collection:{cart_id}`. It exists to satisfy the canonical write-port admission
+contract. This slice does **not** claim that the identity is a durable Payment receipt, an exactly-once
+transport record, or a new replay journal. Reuse and create-race adoption remain Payment-owned
+behavior.
+
+No public `Idempotency-Key` requirement is added to `POST /store/payment-collections` in this slice.
+
+## Error compatibility and diagnostics
+
+The REST boundary now maps bounded `PortError` facts while retaining the existing public families:
+
+- validation -> `payment_request_invalid` / 400;
+- missing resource -> `payment_resource_not_found` / 404;
+- lifecycle conflict -> `payment_state_conflict` / 409;
+- provider rejection -> `payment_provider_rejected` / 409;
+- provider outcome unknown or invalid response -> `payment_reconciliation_required` / 409;
+- provider/configuration/timeout availability failures -> `payment_temporarily_unavailable` / 503;
+- collection storage failure and the reusable-read `payment.cart_read_unavailable` owner code ->
+  `payment_storage_unavailable` / 503.
+
+Unexpected forbidden or invariant owner failures fail closed as `payment_operation_failed` / 500.
+
+Commerce diagnostics retain request-shape context, correlation id, bounded owner error kind, owner
+code length, retryability, selected public code, and status. Raw owner/backend error messages are not
+logged or returned by this mapper.
+
+## Deliberately still open
+
+This slice removes one mounted REST Payment concrete-service construction only. It does not claim
+that every mounted Commerce Product, Order, Payment, or Fulfillment construction has been removed.
+
+The canonical ecommerce topology item remains open.
+
+A fresh mounted-path audit is required before that broad P0 can be closed.
+
+## Validation status
+
+No tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database
+scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed for this
+slice, per maintainer instruction. The updated verifier is source-only evidence for maintainer
+execution.

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -33,6 +33,8 @@ pub struct CommerceHttpRuntime {
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
+    payment_cart_read_runtime: rustok_payment::PaymentCartReadRuntime,
+    payment_collection_runtime: rustok_payment::PaymentCollectionRuntime,
     payment_admin_read_runtime: rustok_payment::PaymentAdminReadRuntime,
     payment_admin_collection_command_runtime: rustok_payment::PaymentAdminCollectionCommandRuntime,
     payment_admin_refund_command_runtime: rustok_payment::PaymentAdminRefundCommandRuntime,
@@ -110,6 +112,14 @@ impl CommerceHttpRuntime {
 
     fn payment_order_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentOrderReadPort> {
         self.payment_order_read_runtime.read_port()
+    }
+
+    fn payment_cart_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentCartReadPort> {
+        self.payment_cart_read_runtime.read_port()
+    }
+
+    fn payment_collection_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentCollectionPort> {
+        self.payment_collection_runtime.port()
     }
 
     fn payment_admin_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentAdminReadPort> {
@@ -226,6 +236,20 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require PaymentOrderReadRuntime in HostRuntimeContext"
                 )
             })?;
+        let payment_cart_read_runtime = runtime
+            .shared_get::<rustok_payment::PaymentCartReadRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require PaymentCartReadRuntime in HostRuntimeContext"
+                )
+            })?;
+        let payment_collection_runtime = runtime
+            .shared_get::<rustok_payment::PaymentCollectionRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require PaymentCollectionRuntime in HostRuntimeContext"
+                )
+            })?;
         let payment_admin_read_runtime = runtime
             .shared_get::<rustok_payment::PaymentAdminReadRuntime>()
             .unwrap_or_else(|| rustok_payment::PaymentAdminReadRuntime::in_process(runtime.db_clone()));
@@ -280,6 +304,8 @@ impl CommerceHttpRuntime {
             order_read_runtime,
             order_admin_command_runtime,
             payment_order_read_runtime,
+            payment_cart_read_runtime,
+            payment_collection_runtime,
             payment_admin_read_runtime,
             payment_admin_collection_command_runtime,
             payment_admin_refund_command_runtime,

--- a/crates/rustok-commerce/src/controllers/store/checkout.rs
+++ b/crates/rustok-commerce/src/controllers/store/checkout.rs
@@ -3,9 +3,14 @@ use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
 };
-use rustok_api::{OptionalAuthContext, RequestContext, TenantContext};
+use rustok_api::{
+    AuthContext, OptionalAuthContext, PortActor, PortContext, PortError, PortErrorKind,
+    RequestContext, TenantContext,
+};
 use rustok_cart::{CartStorefrontReadRequest, in_process_cart_storefront_port};
-use rustok_payment::{PaymentError, PaymentService};
+use rustok_payment::{
+    PaymentCollectionCreateOrReuseRequest, ReusablePaymentCollectionByCartRequest,
+};
 use rustok_web::{HttpError, HttpResult};
 use uuid::Uuid;
 
@@ -18,7 +23,7 @@ const IDEMPOTENCY_KEY_HEADER: &str = "idempotency-key";
 const MAX_IDEMPOTENCY_KEY_LENGTH: usize = 191;
 const STOREFRONT_CHECKOUT_OWNER: &str = "rustok_commerce.storefront_staged_checkout_runtime";
 const STOREFRONT_CHECKOUT_BOUNDARY: &str = "commerce_storefront_checkout_http";
-const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.storefront_payment_collections";
+const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.payment_collection_ports";
 const STOREFRONT_PAYMENT_COLLECTION_BOUNDARY: &str =
     "commerce_storefront_payment_collection_http";
 
@@ -114,14 +119,41 @@ struct StorefrontCheckoutRuntimeErrorFacts {
     text_total_length: usize,
 }
 
-#[derive(Clone, Copy)]
-struct StorefrontPaymentCollectionErrorFacts {
-    error_variant: &'static str,
-    text_field_count: usize,
-    text_total_length: usize,
-    uuid_field_count: usize,
-    uuid_non_nil_count: usize,
-    opaque_payload_present: bool,
+fn storefront_payment_collection_actor(auth: Option<&AuthContext>) -> PortActor {
+    auth.map(|auth| PortActor::user(auth.user_id.to_string()))
+        .unwrap_or_else(|| PortActor::service("rustok-commerce.storefront-payment-collection"))
+}
+
+fn storefront_payment_collection_port_context(
+    tenant_id: Uuid,
+    cart_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<&AuthContext>,
+    operation: &'static str,
+    is_write: bool,
+) -> PortContext {
+    let locale = if request_context.locale.trim().is_empty() {
+        "und"
+    } else {
+        request_context.locale.as_str()
+    };
+    let correlation_id = format!("commerce-storefront-payment-collection:{operation}:{cart_id}");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        storefront_payment_collection_actor(auth),
+        locale,
+        correlation_id,
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    let context = match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    };
+    if is_write {
+        context.with_idempotency_key(format!("storefront-payment-collection:{cart_id}"))
+    } else {
+        context
+    }
 }
 
 /// Create payment collection from storefront cart
@@ -177,13 +209,24 @@ pub async fn create_payment_collection(
         cart,
     )
     .await?;
-    let context =
+    let store_context =
         super::resolve_context_from_cart_for_db(runtime.db(), tenant.id, &request_context, &cart)
             .await?;
 
-    let service = PaymentService::new(runtime.db_clone());
-    if let Some(existing) = service
-        .find_reusable_collection_by_cart(tenant.id, cart.id)
+    let read_context = storefront_payment_collection_port_context(
+        tenant.id,
+        cart.id,
+        &request_context,
+        auth.0.as_ref(),
+        "find_reusable_collection_by_cart",
+        false,
+    );
+    if let Some(existing) = runtime
+        .payment_cart_read_port()
+        .find_reusable_collection_by_cart(
+            read_context.clone(),
+            ReusablePaymentCollectionByCartRequest { cart_id: cart.id },
+        )
         .await
         .map_err(|error| {
             payment_collection_http_error(
@@ -195,16 +238,27 @@ pub async fn create_payment_collection(
                     &request_context,
                     "find_reusable_collection_by_cart",
                 ),
+                &read_context,
                 error,
             )
         })?
     {
         return Ok((StatusCode::OK, Json(existing)));
     }
-    let collection = service
-        .create_collection(
-            tenant.id,
-            rustok_payment::dto::CreatePaymentCollectionInput {
+
+    let command_context = storefront_payment_collection_port_context(
+        tenant.id,
+        cart.id,
+        &request_context,
+        auth.0.as_ref(),
+        "create_or_reuse_collection",
+        true,
+    );
+    let collection = runtime
+        .payment_collection_port()
+        .create_or_reuse_collection(
+            command_context.clone(),
+            PaymentCollectionCreateOrReuseRequest {
                 cart_id: Some(cart.id),
                 order_id: None,
                 customer_id: cart.customer_id,
@@ -212,7 +266,7 @@ pub async fn create_payment_collection(
                 amount: cart.total_amount,
                 metadata: super::merge_metadata(
                     input.metadata,
-                    super::cart_context_metadata(&cart, &context),
+                    super::cart_context_metadata(&cart, &store_context),
                 ),
             },
         )
@@ -225,8 +279,9 @@ pub async fn create_payment_collection(
                     cart.id,
                     cart.customer_id,
                     &request_context,
-                    "create_collection",
+                    "create_or_reuse_collection",
                 ),
+                &command_context,
                 error,
             )
         })?;
@@ -459,185 +514,85 @@ fn storefront_checkout_http_error(
     HttpError::new(status, code, message)
 }
 
-fn payment_collection_error_policy(error: &PaymentError) -> StorefrontPaymentCollectionHttpPolicy {
-    match error {
-        PaymentError::Validation(_) => (
+fn payment_collection_error_policy(error: &PortError) -> StorefrontPaymentCollectionHttpPolicy {
+    match &error.kind {
+        PortErrorKind::Validation => (
             StatusCode::BAD_REQUEST,
             "payment_request_invalid",
             "Payment collection request is invalid",
             "validation",
         ),
-        PaymentError::PaymentCollectionNotFound(_)
-        | PaymentError::PaymentNotFound(_)
-        | PaymentError::RefundNotFound(_) => (
+        PortErrorKind::NotFound => (
             StatusCode::NOT_FOUND,
             "payment_resource_not_found",
             "Payment resource was not found",
             "not_found",
         ),
-        PaymentError::InvalidTransition { .. } => (
-            StatusCode::CONFLICT,
-            "payment_state_conflict",
-            "Payment lifecycle conflicts with the requested operation",
-            "state_conflict",
-        ),
-        PaymentError::ProviderUnavailable { .. } => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "payment_temporarily_unavailable",
-            "Payment service is temporarily unavailable",
-            "provider_unavailable",
-        ),
-        PaymentError::ProviderConfiguration { .. } => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "payment_temporarily_unavailable",
-            "Payment service is temporarily unavailable",
-            "provider_configuration",
-        ),
-        PaymentError::ProviderRejected { .. } => (
+        PortErrorKind::Conflict if error.code == "payment.provider_rejected" => (
             StatusCode::CONFLICT,
             "payment_provider_rejected",
             "Payment provider rejected the requested operation",
             "provider_rejected",
         ),
-        PaymentError::ProviderInvalidResponse { .. } => (
-            StatusCode::CONFLICT,
-            "payment_reconciliation_required",
-            "Payment operation requires reconciliation",
-            "provider_invalid_response",
-        ),
-        PaymentError::ProviderOutcomeUnknown { .. } => (
+        PortErrorKind::Conflict if error.code == "payment.provider_outcome_unknown" => (
             StatusCode::CONFLICT,
             "payment_reconciliation_required",
             "Payment operation requires reconciliation",
             "provider_outcome_unknown",
         ),
-        PaymentError::Database(_) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "payment_storage_unavailable",
-            "Payment service is temporarily unavailable",
-            "database",
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "payment_state_conflict",
+            "Payment lifecycle conflicts with the requested operation",
+            "state_conflict",
         ),
-    }
-}
-
-fn storefront_payment_collection_error_facts(
-    error: &PaymentError,
-) -> StorefrontPaymentCollectionErrorFacts {
-    let (
-        error_variant,
-        text_field_count,
-        text_total_length,
-        uuid_field_count,
-        uuid_non_nil_count,
-        opaque_payload_present,
-    ) = match error {
-        PaymentError::Validation(value) => {
-            ("validation", 1, value.chars().count(), 0, 0, false)
+        PortErrorKind::Unavailable
+            if error.code == "payment.database_unavailable"
+                || error.code == "payment.cart_read_unavailable" =>
+        {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "payment_storage_unavailable",
+                "Payment service is temporarily unavailable",
+                "database",
+            )
         }
-        PaymentError::PaymentCollectionNotFound(id) => (
-            "payment_collection_not_found",
-            0,
-            0,
-            1,
-            if id.is_nil() { 0 } else { 1 },
-            false,
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "payment_temporarily_unavailable",
+            "Payment service is temporarily unavailable",
+            "temporarily_unavailable",
         ),
-        PaymentError::PaymentNotFound(id) => (
-            "payment_not_found",
-            0,
-            0,
-            1,
-            if id.is_nil() { 0 } else { 1 },
-            false,
-        ),
-        PaymentError::RefundNotFound(id) => (
-            "refund_not_found",
-            0,
-            0,
-            1,
-            if id.is_nil() { 0 } else { 1 },
-            false,
-        ),
-        PaymentError::InvalidTransition { from, to } => (
-            "invalid_transition",
-            2,
-            from.chars().count() + to.chars().count(),
-            0,
-            0,
-            false,
-        ),
-        PaymentError::ProviderUnavailable {
-            provider_id,
-            operation,
-        } => (
-            "provider_unavailable",
-            2,
-            provider_id.chars().count() + operation.chars().count(),
-            0,
-            0,
-            false,
-        ),
-        PaymentError::ProviderRejected {
-            provider_id,
-            operation,
-        } => (
-            "provider_rejected",
-            2,
-            provider_id.chars().count() + operation.chars().count(),
-            0,
-            0,
-            false,
-        ),
-        PaymentError::ProviderInvalidResponse {
-            provider_id,
-            operation,
-        } => (
+        PortErrorKind::InvariantViolation if error.code == "payment.provider_invalid_response" => (
+            StatusCode::CONFLICT,
+            "payment_reconciliation_required",
+            "Payment operation requires reconciliation",
             "provider_invalid_response",
-            2,
-            provider_id.chars().count() + operation.chars().count(),
-            0,
-            0,
-            false,
         ),
-        PaymentError::ProviderOutcomeUnknown {
-            provider_id,
-            operation,
-        } => (
-            "provider_outcome_unknown",
-            2,
-            provider_id.chars().count() + operation.chars().count(),
-            0,
-            0,
-            false,
-        ),
-        PaymentError::ProviderConfiguration { provider_id } => (
+        PortErrorKind::InvariantViolation if error.code == "payment.provider_not_configured" => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "payment_temporarily_unavailable",
+            "Payment service is temporarily unavailable",
             "provider_configuration",
-            1,
-            provider_id.chars().count(),
-            0,
-            0,
-            false,
         ),
-        PaymentError::Database(_) => ("database", 0, 0, 0, 0, true),
-    };
-    StorefrontPaymentCollectionErrorFacts {
-        error_variant,
-        text_field_count,
-        text_total_length,
-        uuid_field_count,
-        uuid_non_nil_count,
-        opaque_payload_present,
+        PortErrorKind::Forbidden | PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "payment_operation_failed",
+            "Payment operation could not be completed safely",
+            "owner_operation_failed",
+        ),
     }
 }
 
 fn payment_collection_http_error(
     context: StorefrontPaymentCollectionErrorContext,
-    error: PaymentError,
+    port_context: &PortContext,
+    error: PortError,
 ) -> HttpError {
     let (status, code, message, error_kind) = payment_collection_error_policy(&error);
-    let error_facts = storefront_payment_collection_error_facts(&error);
     tracing::error!(
         owner = STOREFRONT_PAYMENT_COLLECTION_OWNER,
+        correlation_id = %port_context.correlation_id,
         tenant_id_non_nil = context.tenant_id_non_nil,
         actor_id_non_nil = context.actor_id_non_nil,
         cart_id_non_nil = context.cart_id_non_nil,
@@ -649,17 +604,14 @@ fn payment_collection_http_error(
         channel_slug_length = ?context.channel_slug_length,
         locale_length = context.locale_length,
         operation = context.operation,
-        error_variant = error_facts.error_variant,
-        error_text_field_count = error_facts.text_field_count,
-        error_text_total_length = error_facts.text_total_length,
-        error_uuid_field_count = error_facts.uuid_field_count,
-        error_uuid_non_nil_count = error_facts.uuid_non_nil_count,
-        error_opaque_payload_present = error_facts.opaque_payload_present,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
         error_kind,
         public_code = code,
         status = status.as_u16(),
         boundary = STOREFRONT_PAYMENT_COLLECTION_BOUNDARY,
-        "storefront payment collection operation failed with bounded diagnostics"
+        "storefront payment collection owner call failed with bounded diagnostics"
     );
     HttpError::new(status, code, message)
 }

--- a/scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-payment-collection-error-context.mjs
@@ -11,7 +11,14 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const checkout = read('crates/rustok-commerce/src/controllers/store/checkout.rs');
-const paymentError = read('crates/rustok-payment/src/error.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const serverRuntime = read('apps/server/src/services/commerce_provider_runtime.rs');
+const paymentPort = read('crates/rustok-payment/src/ports.rs');
+const paymentCartRead = read('crates/rustok-payment/src/cart_read.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-storefront-payment-collection-owner-port-cutover-2026-08-09.md',
+);
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -36,214 +43,129 @@ const route = between(
   '/// Complete storefront cart checkout',
   'payment collection route',
 );
-const policy = between(
-  checkout,
-  'fn payment_collection_error_policy(',
-  'fn payment_collection_http_error(',
-  'payment collection policy',
-);
-const mapper = checkout.slice(
-  checkout.indexOf('fn payment_collection_http_error('),
-);
+const mapper = checkout.slice(checkout.indexOf('fn payment_collection_error_policy('));
 
 for (const [value, label] of [
-  [
-    'const STOREFRONT_PAYMENT_COLLECTION_OWNER: &str = "rustok_payment.storefront_payment_collections";',
-    'payment owner constant',
-  ],
-  [
-    'const STOREFRONT_PAYMENT_COLLECTION_BOUNDARY: &str =',
-    'payment boundary constant',
-  ],
-  [
-    '"commerce_storefront_payment_collection_http";',
-    'payment boundary value',
-  ],
-  [
-    'type StorefrontPaymentCollectionHttpPolicy = (',
-    'payment policy type',
-  ],
-  [
-    'struct StorefrontPaymentCollectionErrorContext<\'a> {',
-    'typed payment context',
-  ],
-  ['tenant_id: Uuid,', 'tenant context field'],
-  ['actor_id: Uuid,', 'actor context field'],
-  ['cart_id: Uuid,', 'cart context field'],
-  ['customer_id: Option<Uuid>,', 'customer context field'],
-  ['channel_id: Option<Uuid>,', 'channel id context field'],
-  ['channel_slug: Option<&\'a str>,', 'channel slug context field'],
-  ['locale: &\'a str,', 'locale context field'],
-  ['operation: &\'static str,', 'operation context field'],
-  ['channel_id: request_context.channel_id,', 'channel id adoption'],
-  [
-    'channel_slug: request_context.channel_slug.as_deref(),',
-    'channel slug adoption',
-  ],
-  ['locale: request_context.locale.as_str(),', 'locale adoption'],
-]) requireText(checkout, value, label);
+  ['PaymentCartReadRuntime', 'HTTP Payment cart read runtime field'],
+  ['PaymentCollectionRuntime', 'HTTP Payment collection runtime field'],
+  ['fn payment_cart_read_port(', 'HTTP Payment cart read accessor'],
+  ['fn payment_collection_port(', 'HTTP Payment collection accessor'],
+  ['shared_get::<rustok_payment::PaymentCartReadRuntime>()', 'HTTP host-selected cart read runtime'],
+  ['shared_get::<rustok_payment::PaymentCollectionRuntime>()', 'HTTP host-selected collection runtime'],
+]) requireText(httpRuntime, value, label);
 
 for (const [value, label] of [
-  [
-    'super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;',
-    'storefront channel guard',
-  ],
-  [
-    'let actor_id = super::checkout_actor_id(auth.0.as_ref());',
-    'actor resolution',
-  ],
-  [
-    'super::current_customer_id_for_db(runtime.db(), tenant.id, auth.0.as_ref()).await?;',
-    'customer resolution',
-  ],
+  ['shared_get::<rustok_payment::PaymentCartReadRuntime>()', 'server cart read host selection'],
+  ['server.shared_get::<rustok_payment::PaymentCartReadRuntime>()', 'server cart read reuse'],
+  ['rustok_payment::PaymentCartReadRuntime::in_process(server.db_clone())', 'server cart read owner fallback'],
+  ['shared_get::<rustok_payment::PaymentCollectionRuntime>()', 'server collection host selection'],
+  ['server.shared_get::<rustok_payment::PaymentCollectionRuntime>()', 'server collection reuse'],
+  ['rustok_payment::PaymentCollectionRuntime::in_process(server.db_clone())', 'server collection owner fallback'],
+]) requireText(serverRuntime, value, label);
+
+for (const [value, label] of [
+  ['super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;', 'storefront channel guard'],
+  ['super::current_customer_id_for_db(runtime.db(), tenant.id, auth.0.as_ref()).await?;', 'customer resolution'],
   ['in_process_cart_storefront_port(runtime.db_clone())', 'cart storefront port'],
-  ['CartStorefrontReadRequest {', 'cart read request'],
-  ['cart_id: input.cart_id,', 'input cart identity'],
   ['super::ensure_store_cart_access(&cart, customer_id)?;', 'cart access guard'],
-  [
-    'super::ensure_cart_allows_payment_collection(&cart)?;',
-    'payment collection lifecycle guard',
-  ],
-  [
-    'super::reprice_storefront_cart_line_items_for_db(',
-    'cart repricing',
-  ],
-  [
-    'super::resolve_context_from_cart_for_db(runtime.db(), tenant.id, &request_context, &cart)',
-    'cart context resolution',
-  ],
-  [
-    '.find_reusable_collection_by_cart(tenant.id, cart.id)',
-    'reusable collection lookup',
-  ],
-  ['.create_collection(', 'collection creation'],
-  ['cart_id: Some(cart.id),', 'created collection cart id'],
-  ['order_id: None,', 'created collection order contract'],
-  ['customer_id: cart.customer_id,', 'created collection customer id'],
-  ['currency_code: cart.currency_code.clone(),', 'currency forwarding'],
-  ['amount: cart.total_amount,', 'amount forwarding'],
-  ['super::cart_context_metadata(&cart, &context)', 'metadata forwarding'],
-  ['return Ok((StatusCode::OK, Json(existing)));', 'reusable response'],
-  ['Ok((StatusCode::CREATED, Json(collection)))', 'created response'],
-  [
-    '"find_reusable_collection_by_cart"',
-    'reusable lookup operation',
-  ],
-  ['"create_collection"', 'create operation'],
+  ['super::ensure_cart_allows_payment_collection(&cart)?;', 'payment collection lifecycle guard'],
+  ['super::reprice_storefront_cart_line_items_for_db(', 'cart repricing'],
+  ['super::resolve_context_from_cart_for_db(runtime.db(), tenant.id, &request_context, &cart)', 'store context resolution'],
+  ['ReusablePaymentCollectionByCartRequest { cart_id: cart.id }', 'owner reusable request'],
+  ['runtime\n        .payment_cart_read_port()', 'host-selected reusable read port'],
+  ['.find_reusable_collection_by_cart(', 'owner reusable lookup'],
+  ['return Ok((StatusCode::OK, Json(existing)));', 'pre-existing reusable response'],
+  ['PaymentCollectionCreateOrReuseRequest {', 'owner create/reuse request'],
+  ['runtime\n        .payment_collection_port()', 'host-selected collection port'],
+  ['.create_or_reuse_collection(', 'owner create/reuse call'],
+  ['cart_id: Some(cart.id)', 'created collection cart id'],
+  ['order_id: None', 'created collection order contract'],
+  ['customer_id: cart.customer_id', 'created collection customer id'],
+  ['currency_code: cart.currency_code.clone()', 'currency forwarding'],
+  ['amount: cart.total_amount', 'amount forwarding'],
+  ['super::cart_context_metadata(&cart, &store_context)', 'metadata forwarding'],
+  ['Ok((StatusCode::CREATED, Json(collection)))', 'post-miss response parity'],
 ]) requireText(route, value, label);
 
 for (const [value, label] of [
-  ['PaymentError::Validation(_)', 'validation variant'],
-  ['"payment_request_invalid"', 'validation code'],
-  ['"Payment collection request is invalid"', 'validation message'],
-  ['"validation"', 'validation kind'],
-  ['PaymentError::PaymentCollectionNotFound(_)', 'collection missing variant'],
-  ['PaymentError::PaymentNotFound(_)', 'payment missing variant'],
-  ['PaymentError::RefundNotFound(_)', 'refund missing variant'],
-  ['StatusCode::NOT_FOUND', 'missing status'],
-  ['"payment_resource_not_found"', 'missing code'],
-  ['"Payment resource was not found"', 'missing message'],
-  ['"not_found"', 'missing kind'],
-  ['PaymentError::InvalidTransition { .. }', 'transition variant'],
-  ['"payment_state_conflict"', 'transition code'],
-  [
-    '"Payment lifecycle conflicts with the requested operation"',
-    'transition message',
-  ],
-  ['"state_conflict"', 'transition kind'],
-  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
-  ['"provider_unavailable"', 'provider unavailable kind'],
-  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration variant'],
-  ['"provider_configuration"', 'provider configuration kind'],
-  ['"payment_temporarily_unavailable"', 'temporary code'],
-  ['"Payment service is temporarily unavailable"', 'temporary message'],
-  ['PaymentError::ProviderRejected { .. }', 'provider rejected variant'],
-  ['"payment_provider_rejected"', 'provider rejected code'],
-  [
-    '"Payment provider rejected the requested operation"',
-    'provider rejected message',
-  ],
-  ['"provider_rejected"', 'provider rejected kind'],
-  [
-    'PaymentError::ProviderInvalidResponse { .. }',
-    'invalid provider response variant',
-  ],
-  ['"provider_invalid_response"', 'invalid provider response kind'],
-  [
-    'PaymentError::ProviderOutcomeUnknown { .. }',
-    'unknown provider outcome variant',
-  ],
-  ['"provider_outcome_unknown"', 'unknown provider outcome kind'],
-  ['"payment_reconciliation_required"', 'reconciliation code'],
-  [
-    '"Payment operation requires reconciliation"',
-    'reconciliation message',
-  ],
-  ['PaymentError::Database(_)', 'database variant'],
-  ['"payment_storage_unavailable"', 'database code'],
-  ['"database"', 'database kind'],
-  ['StatusCode::BAD_REQUEST', 'bad request status'],
-  ['StatusCode::CONFLICT', 'conflict status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
-]) requireText(policy, value, label);
+  ['fn storefront_payment_collection_actor(', 'owner actor helper'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated owner actor'],
+  ['PortActor::service("rustok-commerce.storefront-payment-collection")', 'guest owner actor'],
+  ['fn storefront_payment_collection_port_context(', 'owner context helper'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'bounded owner deadline'],
+  ['request_context.channel_slug.as_deref()', 'request channel propagation'],
+  ['.with_idempotency_key(format!("storefront-payment-collection:{cart_id}"))', 'cart-bound write admission identity'],
+]) requireText(checkout, value, label);
 
 for (const [value, label] of [
-  ['error = ?error', 'typed payment cause log'],
-  ['owner = STOREFRONT_PAYMENT_COLLECTION_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['actor_id = %context.actor_id', 'actor log'],
-  ['cart_id = %context.cart_id', 'cart log'],
-  ['customer_id = ?context.customer_id', 'customer log'],
-  ['channel_id = ?context.channel_id', 'channel id log'],
-  ['channel = ?context.channel_slug', 'channel slug log'],
-  ['locale = %context.locale', 'locale log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error kind log'],
-  ['public_code = code', 'public code log'],
-  ['status = %status', 'status log'],
-  ['boundary = STOREFRONT_PAYMENT_COLLECTION_BOUNDARY', 'boundary log'],
-  ['HttpError::new(status, code, message)', 'stable public envelope'],
+  ['fn payment_collection_error_policy(error: &PortError)', 'typed owner error policy'],
+  ['PortErrorKind::Validation', 'validation mapping'],
+  ['PortErrorKind::NotFound', 'not-found mapping'],
+  ['error.code == "payment.provider_rejected"', 'provider rejection mapping'],
+  ['error.code == "payment.provider_outcome_unknown"', 'provider unknown mapping'],
+  ['error.code == "payment.provider_invalid_response"', 'invalid provider response mapping'],
+  ['error.code == "payment.provider_not_configured"', 'provider configuration mapping'],
+  ['error.code == "payment.database_unavailable"', 'collection storage mapping'],
+  ['error.code == "payment.cart_read_unavailable"', 'reusable read storage mapping'],
+  ['"payment_request_invalid"', 'validation public code'],
+  ['"payment_resource_not_found"', 'not-found public code'],
+  ['"payment_state_conflict"', 'state conflict public code'],
+  ['"payment_provider_rejected"', 'provider rejection public code'],
+  ['"payment_reconciliation_required"', 'reconciliation public code'],
+  ['"payment_temporarily_unavailable"', 'temporary public code'],
+  ['"payment_storage_unavailable"', 'storage public code'],
+  ['"payment_operation_failed"', 'unexpected owner failure code'],
+  ['owner_error_kind = ?error.kind', 'bounded owner error kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
+  ['retryable = error.retryable', 'owner retryability diagnostic'],
+  ['HttpError::new(status, code, message)', 'stable public HTTP envelope'],
 ]) requireText(mapper, value, label);
 
 for (const value of [
-  'Validation(String),',
-  'PaymentCollectionNotFound(Uuid),',
-  'PaymentNotFound(Uuid),',
-  'RefundNotFound(Uuid),',
-  'InvalidTransition { from: String, to: String },',
-  'ProviderUnavailable {',
-  'ProviderRejected {',
-  'ProviderInvalidResponse {',
-  'ProviderOutcomeUnknown {',
-  'ProviderConfiguration { provider_id: String },',
-  'Database(#[from] DbErr),',
-]) requireText(paymentError, value, 'payment source enum');
-
-const mapperUses =
-  route.match(
-    /payment_collection_http_error\(\s+StorefrontPaymentCollectionErrorContext::new\(/g,
-  ) ?? [];
-if (mapperUses.length !== 2) {
-  failures.push(
-    `expected two context-aware payment collection mapper callsites, found ${mapperUses.length}`,
-  );
-}
-
-for (const value of [
-  'payment_collection_http_error(tenant.id, cart.id',
-  'payment_collection_http_error(\n                tenant.id',
+  'PaymentService::new(',
+  'use rustok_payment::{PaymentError, PaymentService}',
+  '.create_collection(',
+  'error = ?error',
+  'owner_message = %error.message',
+  'message = %error.message',
   'error.to_string()',
   'err.to_string()',
-  'HttpError::bad_request(error',
-  'HttpError::internal(error',
-]) forbidText(checkout, value, 'stale or unsafe payment collection mapping');
+]) forbidText(route, value, 'mounted storefront Payment concrete/raw owner boundary');
+
+for (const [value, label] of [
+  ['pub trait PaymentCollectionPort', 'Payment collection owner port'],
+  ['async fn create_or_reuse_collection(', 'Payment owner create/reuse operation'],
+  ['"create_or_reuse_collection.adopt_race"', 'Payment owner race adoption'],
+]) requireText(paymentPort, value, label);
+for (const [value, label] of [
+  ['pub trait PaymentCartReadPort', 'Payment cart owner read port'],
+  ['async fn find_reusable_collection_by_cart(', 'Payment owner reusable read'],
+]) requireText(paymentCartRead, value, label);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology item remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST storefront payment-collection owner-port cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record validation status'],
+  ['`PaymentCartReadPort::find_reusable_collection_by_cart`', 'record reusable owner read'],
+  ['`PaymentCollectionPort::create_or_reuse_collection`', 'record create/reuse owner call'],
+  ['`200 OK`', 'record reusable response parity'],
+  ['`201 Created`', 'record post-miss response parity'],
+  ['does **not** claim', 'record replay non-claim'],
+  ['The canonical ecommerce topology item remains open.', 'record broad item remains open'],
+  ['No tests, Cargo commands, Node verifiers, formatter', 'record validation non-execution'],
+]) requireText(record, value, label);
 
 if (failures.length > 0) {
-  console.error('Commerce storefront payment collection error-context verification failed:');
+  console.error('Commerce storefront payment collection owner-port verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
 console.log(
-  '✔ Storefront payment collection failures retain typed route context and stable public contracts',
+  '✔ mounted REST storefront payment collection preserves 200/201 parity and routes Payment reuse/create through host-composed owner ports',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by removing concrete `PaymentService` construction from mounted REST `POST /store/payment-collections`.

- host-compose `PaymentCartReadRuntime` alongside the already published `PaymentCollectionRuntime`, preserving host-selected and server-shared implementations before Payment-owned in-process fallback;
- require both runtimes in `CommerceHttpRuntime` and expose only `PaymentCartReadPort` / `PaymentCollectionPort` trait objects to mounted handlers;
- preserve the existing storefront channel, customer, cart access, completed-cart rejection, repricing, and StoreContext sequence;
- preserve `200 OK` when the pre-create owner read finds a reusable collection;
- after a reusable miss, call `PaymentCollectionPort::create_or_reuse_collection` and preserve the existing post-miss `201 Created` behavior, including concurrent create-race adoption inside Payment;
- preserve cart/customer/currency/amount/metadata projection;
- carry admitted tenant, authenticated user or stable guest service actor, request locale/channel, cart-bound correlation, two-second deadlines, and a cart-bound write admission identity;
- do not add a public `Idempotency-Key` requirement and do **not** claim a durable Payment receipt or exactly-once transport journal for that internal admission identity;
- replace concrete `PaymentError` handling in this route with bounded code-aware `PortError` mapping while preserving the existing payment public HTTP families, including `payment_storage_unavailable` for collection/reusable-read storage failure;
- fail closed on unexpected owner forbidden/invariant failures without raw owner/backend message logging;
- update the existing source-only payment-collection verifier and add a dated source record;
- keep the broad ecommerce topology P0 open pending a fresh mounted-path audit.

The branch is one clean commit ahead and zero behind `main` (`188eac1de346cb1b1ad6c3f4146b9be4bdf1131f`) with exactly five changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. The verifier change is source-only evidence for maintainer execution.