### PR TITLE
feat(commerce): route storefront cart shipping reads through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-storefront-cart-shipping-owner-read-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/rest-storefront-cart-shipping-owner-read-cutover-2026-08-09.md
@@ -1,0 +1,90 @@
+# Commerce REST storefront cart shipping owner-read cutover
+
+Status: `source_complete_unvalidated`
+
+## Scope
+
+Mounted Commerce REST cart handlers now route Fulfillment shipping-option reads through the
+host-selected `ShippingOptionReadPort` already carried by `CommerceHttpRuntime`.
+
+The cutover covers two mounted cart behaviors:
+
+- cart shipping enrichment uses `ShippingOptionReadPort::list_shipping_option_projections`;
+- selected shipping-option validation during `POST /store/carts/{id}` uses
+  `ShippingOptionReadPort::read_shipping_option_projection`.
+
+No new Fulfillment owner contract is introduced. `CommerceShippingOptionReadRuntime` remains the
+existing host-composed capability and the server composition remains unchanged in this slice.
+
+## Mounted REST parity
+
+The following mounted handlers now obtain `runtime.shipping_option_read_port()` before shipping
+projection work:
+
+- `POST /store/carts`;
+- `GET /store/carts/{id}`;
+- `POST /store/carts/{id}`;
+- `POST /store/carts/{id}/line-items`;
+- `POST /store/carts/{id}/line-items/{line_id}`;
+- `DELETE /store/carts/{id}/line-items/{line_id}`.
+
+Cart context update preserves the previous operation order: resolve requested StoreContext, validate
+selected shipping options, update Cart owner context, reprice line items, then enrich shipping
+projections.
+
+The selected-option compatibility policy is unchanged:
+
+- multi-delivery-group carts still reject the legacy single selected-option shortcut;
+- option currency must match cart currency case-insensitively;
+- option metadata must be visible for the current public channel;
+- option shipping-profile compatibility still uses normalized profile slugs with `default` fallback.
+
+Shipping enrichment preserves currency filtering, public-channel filtering, shipping-profile
+compatibility, delivery-group projection, and single-group selected-option reconciliation.
+
+## Owner call context
+
+Fulfillment owner reads reuse the existing storefront cart `PortContext` builder. Calls carry:
+
+- admitted tenant id;
+- authenticated user actor when present, otherwise the existing stable storefront service actor;
+- request locale;
+- request channel slug when present;
+- cart/operation-bound correlation identity;
+- two-second deadline.
+
+The calls are reads and do not add an idempotency key.
+
+## Error compatibility
+
+The REST shipping boundary maps bounded `PortError` kinds to the established public families:
+
+- validation -> `commerce_store_shipping_invalid` / 400;
+- not found -> `commerce_store_not_found` / 404;
+- conflict -> `commerce_store_shipping_state_conflict` / 409;
+- unavailable or timeout -> `commerce_store_shipping_unavailable` / 503.
+
+Unexpected forbidden or invariant owner failures fail closed as
+`commerce_store_shipping_failed` / 500.
+
+Diagnostics retain correlation identity, non-sensitive tenant/cart shape, owner error kind, owner
+code length, retryability, selected public code, and status. Raw owner/backend messages are not
+logged or returned by the new mounted helper.
+
+## Deliberately still open
+
+This is a bounded mounted REST cart slice. Existing compatibility/shared helpers outside the new
+mounted cart adapter are not removed in this change, and GraphQL/shared shipping compatibility
+source is not promoted or rewritten here.
+
+The canonical ecommerce topology item remains open:
+
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports.`
+
+A fresh mounted-path audit is still required before closing that broad P0.
+
+## Validation status
+
+No tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database
+scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed for this
+slice, per maintainer instruction. The source verifiers are retained for maintainer execution.

--- a/crates/rustok-commerce/src/controllers/store/carts.rs
+++ b/crates/rustok-commerce/src/controllers/store/carts.rs
@@ -21,6 +21,7 @@ use rustok_cart::{
 use rustok_pricing::{ResolveProductPriceRequest, in_process_pricing_read_port};
 
 use super::line_item_resolution;
+mod shipping_owner_reads;
 
 fn map_cart_port_error(
     error: PortError,
@@ -115,10 +116,12 @@ pub async fn create_cart(
         )
         .await
         .map_err(|error| map_cart_port_error(error, "create_cart", tenant.id, None))?;
-    let cart = super::enrich_storefront_cart_for_db(
-        runtime.db(),
+    let shipping_option_read_port = runtime.shipping_option_read_port();
+    let cart = shipping_owner_reads::enrich_storefront_cart(
+        shipping_option_read_port.as_ref(),
         tenant.id,
         &request_context,
+        auth.0.as_ref(),
         tenant.default_locale.as_str(),
         cart,
     )
@@ -168,11 +171,13 @@ pub async fn get_cart(
         .await
         .map_err(|error| map_cart_port_error(error, "get_cart", tenant.id, Some(id)))?;
     super::ensure_store_cart_access(&cart, customer_id)?;
+    let shipping_option_read_port = runtime.shipping_option_read_port();
     Ok(Json(
-        super::enrich_storefront_cart_for_db(
-            runtime.db(),
+        shipping_owner_reads::enrich_storefront_cart(
+            shipping_option_read_port.as_ref(),
             tenant.id,
             &request_context,
+            auth.0.as_ref(),
             tenant.default_locale.as_str(),
             cart,
         )
@@ -223,11 +228,14 @@ pub async fn update_cart_context(
         })?;
     super::ensure_store_cart_access(&cart, customer_id)?;
 
-    let updated = super::apply_cart_context_patch_for_db(
+    let shipping_option_read_port = runtime.shipping_option_read_port();
+    let updated = shipping_owner_reads::apply_cart_context_patch(
         runtime.db(),
         runtime.event_bus(),
+        shipping_option_read_port.as_ref(),
         tenant.id,
         &request_context,
+        auth.0.as_ref(),
         tenant.default_locale.as_str(),
         &cart,
         StoreCartContextPatch {
@@ -333,11 +341,13 @@ pub async fn add_cart_line_item(
         )
         .await
         .map_err(|error| map_cart_port_error(error, "add_cart_line_item", tenant.id, Some(id)))?;
+    let shipping_option_read_port = runtime.shipping_option_read_port();
     Ok(Json(
-        super::enrich_storefront_cart_for_db(
-            runtime.db(),
+        shipping_owner_reads::enrich_storefront_cart(
+            shipping_option_read_port.as_ref(),
             tenant.id,
             &request_context,
+            auth.0.as_ref(),
             tenant.default_locale.as_str(),
             cart,
         )
@@ -483,11 +493,13 @@ pub async fn update_cart_line_item(
                 map_cart_port_error(error, "update_cart_line_item_quantity", tenant.id, Some(id))
             })?
     };
+    let shipping_option_read_port = runtime.shipping_option_read_port();
     Ok(Json(
-        super::enrich_storefront_cart_for_db(
-            runtime.db(),
+        shipping_owner_reads::enrich_storefront_cart(
+            shipping_option_read_port.as_ref(),
             tenant.id,
             &request_context,
+            auth.0.as_ref(),
             tenant.default_locale.as_str(),
             cart,
         )
@@ -559,11 +571,13 @@ pub async fn remove_cart_line_item(
         .map_err(|error| {
             map_cart_port_error(error, "remove_cart_line_item", tenant.id, Some(id))
         })?;
+    let shipping_option_read_port = runtime.shipping_option_read_port();
     Ok(Json(
-        super::enrich_storefront_cart_for_db(
-            runtime.db(),
+        shipping_owner_reads::enrich_storefront_cart(
+            shipping_option_read_port.as_ref(),
             tenant.id,
             &request_context,
+            auth.0.as_ref(),
             tenant.default_locale.as_str(),
             cart,
         )

--- a/crates/rustok-commerce/src/controllers/store/carts/shipping_owner_reads.rs
+++ b/crates/rustok-commerce/src/controllers/store/carts/shipping_owner_reads.rs
@@ -1,0 +1,365 @@
+use rustok_api::{AuthContext, PortContext, PortError, PortErrorKind, RequestContext};
+use rustok_cart::{CartStorefrontContextUpdateRequest, in_process_cart_storefront_port};
+use rustok_fulfillment::{
+    ListShippingOptionProjectionsRequest, ReadShippingOptionProjectionRequest,
+    ShippingOptionReadPort,
+};
+use rustok_web::{HttpError, HttpResult};
+use sea_orm::DatabaseConnection;
+use std::collections::BTreeSet;
+use uuid::Uuid;
+
+use crate::{
+    dto::{CartResponse, UpdateCartContextInput},
+    storefront_channel::is_metadata_visible_for_public_channel,
+    storefront_shipping::{
+        enrich_cart_delivery_groups_from_options, is_shipping_option_compatible_with_profiles,
+        normalize_shipping_profile_slug,
+    },
+};
+
+use super::super::{
+    SelectedShippingOptionValidation, StoreCartContextPatch, StoreCartResponse,
+};
+
+const STOREFRONT_CART_SHIPPING_OWNER: &str = "rustok_fulfillment";
+const STOREFRONT_CART_SHIPPING_BOUNDARY: &str = "commerce_storefront_cart_shipping_http";
+
+fn shipping_read_context(
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<&AuthContext>,
+    cart_id: Uuid,
+    operation: &str,
+) -> PortContext {
+    super::super::storefront_cart_port_context(
+        tenant_id,
+        request_context,
+        auth,
+        cart_id,
+        operation,
+        false,
+    )
+}
+
+fn map_shipping_port_error(
+    error: PortError,
+    context: &PortContext,
+    operation: &'static str,
+    tenant_id: Uuid,
+    cart_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "commerce_store_shipping_invalid",
+            "Shipping request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            axum::http::StatusCode::NOT_FOUND,
+            "commerce_store_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            axum::http::StatusCode::CONFLICT,
+            "commerce_store_shipping_state_conflict",
+            "Shipping operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_shipping_unavailable",
+            "Shipping service is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::Forbidden | PortErrorKind::InvariantViolation => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_shipping_failed",
+            "Shipping operation could not be completed safely",
+            "owner_failure",
+        ),
+    };
+
+    tracing::error!(
+        owner = STOREFRONT_CART_SHIPPING_OWNER,
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        cart_id_non_nil = !cart_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = status.as_u16(),
+        boundary = STOREFRONT_CART_SHIPPING_BOUNDARY,
+        "storefront cart shipping owner read failed with bounded diagnostics"
+    );
+
+    HttpError::new(status, code, message)
+}
+
+pub(super) async fn enrich_storefront_cart(
+    shipping_option_read_port: &dyn ShippingOptionReadPort,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<&AuthContext>,
+    tenant_default_locale: &str,
+    cart: CartResponse,
+) -> HttpResult<CartResponse> {
+    let public_channel_slug =
+        super::super::storefront_public_channel_slug_for_cart(&cart, request_context);
+    let cart_id = cart.id;
+    let context = shipping_read_context(
+        tenant_id,
+        request_context,
+        auth,
+        cart_id,
+        "shipping-options-list",
+    );
+    let options = shipping_option_read_port
+        .list_shipping_option_projections(
+            context.clone(),
+            ListShippingOptionProjectionsRequest {
+                requested_locale: Some(request_context.locale.clone()),
+                tenant_default_locale: Some(tenant_default_locale.to_string()),
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_shipping_port_error(
+                error,
+                &context,
+                "list_shipping_option_projections",
+                tenant_id,
+                cart_id,
+            )
+        })?;
+
+    let mut cart =
+        enrich_cart_delivery_groups_from_options(cart, options, public_channel_slug.as_deref());
+
+    if cart.delivery_groups.len() == 1 {
+        let is_compatible = |opt_id: Uuid| {
+            cart.delivery_groups[0]
+                .available_shipping_options
+                .iter()
+                .any(|opt| opt.id == opt_id)
+        };
+        let selected_id = cart.delivery_groups[0]
+            .selected_shipping_option_id
+            .filter(|id| is_compatible(*id))
+            .or_else(|| {
+                cart.selected_shipping_option_id
+                    .filter(|id| is_compatible(*id))
+            });
+
+        cart.delivery_groups[0].selected_shipping_option_id = selected_id;
+        cart.selected_shipping_option_id = selected_id;
+    }
+
+    Ok(cart)
+}
+
+async fn validate_selected_shipping_option(
+    shipping_option_read_port: &dyn ShippingOptionReadPort,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<&AuthContext>,
+    cart: &CartResponse,
+    validation: SelectedShippingOptionValidation<'_>,
+) -> HttpResult<()> {
+    let selections = if let Some(shipping_selections) = validation.shipping_selections {
+        shipping_selections.to_vec()
+    } else if let Some(selected_shipping_option_id) = validation.selected_shipping_option_id {
+        if cart.delivery_groups.len() > 1 {
+            return Err(HttpError::bad_request(
+                "commerce_store_invalid",
+                "selected_shipping_option_id can only be used for carts with a single delivery group"
+                    .to_string(),
+            ));
+        }
+        cart.delivery_groups
+            .first()
+            .map(|group| {
+                vec![crate::dto::CartShippingSelectionInput {
+                    shipping_profile_slug: group.shipping_profile_slug.clone(),
+                    seller_id: group.seller_id.clone(),
+                    seller_scope: None,
+                    selected_shipping_option_id: Some(selected_shipping_option_id),
+                }]
+            })
+            .unwrap_or_default()
+    } else {
+        super::super::current_shipping_selections(cart)
+    };
+
+    for selection in selections {
+        let Some(selected_shipping_option_id) = selection.selected_shipping_option_id else {
+            continue;
+        };
+        let required_shipping_profiles = BTreeSet::from([normalize_shipping_profile_slug(
+            selection.shipping_profile_slug.as_str(),
+        )
+        .unwrap_or_else(|| "default".to_string())]);
+        let context = shipping_read_context(
+            tenant_id,
+            request_context,
+            auth,
+            cart.id,
+            "shipping-option-read",
+        );
+        let option = shipping_option_read_port
+            .read_shipping_option_projection(
+                context.clone(),
+                ReadShippingOptionProjectionRequest {
+                    shipping_option_id: selected_shipping_option_id,
+                    requested_locale: validation.requested_locale.map(str::to_string),
+                    tenant_default_locale: validation.tenant_default_locale.map(str::to_string),
+                },
+            )
+            .await
+            .map_err(|error| {
+                map_shipping_port_error(
+                    error,
+                    &context,
+                    "read_shipping_option_projection",
+                    tenant_id,
+                    cart.id,
+                )
+            })?;
+        if !option
+            .currency_code
+            .eq_ignore_ascii_case(validation.currency_code)
+        {
+            return Err(HttpError::bad_request(
+                "commerce_store_invalid",
+                format!(
+                    "Shipping option {} uses currency {}, expected {}",
+                    option.id, option.currency_code, validation.currency_code
+                ),
+            ));
+        }
+        if !is_metadata_visible_for_public_channel(&option.metadata, validation.public_channel_slug)
+        {
+            return Err(HttpError::bad_request(
+                "commerce_store_invalid",
+                format!(
+                    "Shipping option {} is not available for the current channel",
+                    option.id
+                ),
+            ));
+        }
+        if !is_shipping_option_compatible_with_profiles(&option, &required_shipping_profiles) {
+            return Err(HttpError::bad_request(
+                "commerce_store_invalid",
+                format!(
+                    "Shipping option {} is not compatible with shipping profile {}",
+                    option.id, selection.shipping_profile_slug
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn apply_cart_context_patch(
+    db: &DatabaseConnection,
+    event_bus: rustok_outbox::TransactionalEventBus,
+    shipping_option_read_port: &dyn ShippingOptionReadPort,
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    auth: Option<&AuthContext>,
+    tenant_default_locale: &str,
+    cart: &CartResponse,
+    patch: StoreCartContextPatch,
+) -> HttpResult<StoreCartResponse> {
+    let requested = super::super::requested_cart_context(cart, request_context, patch);
+
+    let context = super::super::resolve_context_for_db(
+        db,
+        tenant_id,
+        request_context,
+        requested.region_id,
+        requested.country_code.clone(),
+        requested.locale,
+        Some(cart.currency_code.clone()),
+    )
+    .await?;
+
+    let public_channel_slug =
+        super::super::storefront_public_channel_slug_for_cart(cart, request_context);
+    validate_selected_shipping_option(
+        shipping_option_read_port,
+        tenant_id,
+        request_context,
+        auth,
+        cart,
+        SelectedShippingOptionValidation {
+            selected_shipping_option_id: requested.selected_shipping_option_id,
+            shipping_selections: Some(requested.shipping_selections.as_slice()),
+            currency_code: &cart.currency_code,
+            public_channel_slug: public_channel_slug.as_deref(),
+            requested_locale: Some(request_context.locale.as_str()),
+            tenant_default_locale: Some(tenant_default_locale),
+        },
+    )
+    .await?;
+
+    let storefront_port = in_process_cart_storefront_port(db.clone());
+    let updated_cart = storefront_port
+        .update_storefront_context(
+            super::super::storefront_cart_port_context(
+                tenant_id,
+                request_context,
+                None,
+                cart.id,
+                "update-context",
+                true,
+            ),
+            CartStorefrontContextUpdateRequest {
+                cart_id: cart.id,
+                input: UpdateCartContextInput {
+                    email: requested.email,
+                    region_id: context.region.as_ref().map(|region| region.id),
+                    country_code: context
+                        .region
+                        .as_ref()
+                        .and_then(|region| region.countries.first().cloned())
+                        .or(requested.country_code),
+                    locale_code: Some(context.locale.clone()),
+                    selected_shipping_option_id: requested.selected_shipping_option_id,
+                    shipping_selections: Some(requested.shipping_selections.clone()),
+                },
+            },
+        )
+        .await
+        .map_err(rustok_web::port_error_to_http_error)?;
+    let updated_cart = super::super::reprice_storefront_cart_line_items_for_db(
+        db,
+        event_bus,
+        tenant_id,
+        request_context,
+        storefront_port.as_ref(),
+        updated_cart,
+    )
+    .await?;
+    let updated_cart = enrich_storefront_cart(
+        shipping_option_read_port,
+        tenant_id,
+        request_context,
+        auth,
+        tenant_default_locale,
+        updated_cart,
+    )
+    .await?;
+
+    Ok(StoreCartResponse {
+        cart: updated_cart,
+        context,
+    })
+}

--- a/scripts/verify/verify-commerce-rest-storefront-cart-shipping-owner-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-storefront-cart-shipping-owner-read-cutover.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const carts = read('crates/rustok-commerce/src/controllers/store/carts.rs');
+const helper = read(
+  'crates/rustok-commerce/src/controllers/store/carts/shipping_owner_reads.rs',
+);
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const shippingOwner = read('crates/rustok-fulfillment/src/shipping_option_read.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-storefront-cart-shipping-owner-read-cutover-2026-08-09.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['mod shipping_owner_reads;', 'mounted helper module'],
+  ['runtime.shipping_option_read_port()', 'host-selected shipping port access'],
+  ['shipping_owner_reads::enrich_storefront_cart(', 'mounted enrichment handoff'],
+  ['shipping_owner_reads::apply_cart_context_patch(', 'mounted context validation handoff'],
+]) requireText(carts, value, label);
+
+const runtimePortUses = carts.match(/runtime\.shipping_option_read_port\(\)/g) ?? [];
+if (runtimePortUses.length !== 6) {
+  failures.push(`expected six mounted shipping read-port acquisitions, found ${runtimePortUses.length}`);
+}
+
+for (const value of [
+  'super::enrich_storefront_cart_for_db(',
+  'super::apply_cart_context_patch_for_db(',
+  'FulfillmentService::new(',
+  'rustok_fulfillment::FulfillmentService',
+]) forbidText(carts, value, 'stale mounted Fulfillment construction');
+
+for (const [value, label] of [
+  ['fn shipping_read_context(', 'shipping read context builder'],
+  ['super::super::storefront_cart_port_context(', 'trusted storefront context reuse'],
+  ['false,', 'read policy context'],
+  ['ShippingOptionReadPort', 'owner read trait'],
+  ['ListShippingOptionProjectionsRequest', 'owner list request'],
+  ['.list_shipping_option_projections(', 'owner list call'],
+  ['ReadShippingOptionProjectionRequest', 'owner detail request'],
+  ['.read_shipping_option_projection(', 'owner detail call'],
+  ['requested_locale: Some(request_context.locale.clone())', 'requested locale forwarding'],
+  ['tenant_default_locale: Some(tenant_default_locale.to_string())', 'tenant locale forwarding'],
+  ['enrich_cart_delivery_groups_from_options(', 'existing enrichment projection reuse'],
+  ['normalize_shipping_profile_slug(', 'profile normalization'],
+  ['is_metadata_visible_for_public_channel(', 'public channel validation'],
+  ['is_shipping_option_compatible_with_profiles(', 'profile compatibility validation'],
+  ['eq_ignore_ascii_case(validation.currency_code)', 'currency compatibility validation'],
+  ['super::super::requested_cart_context(', 'existing requested cart context'],
+  ['super::super::resolve_context_for_db(', 'StoreContext resolution order'],
+  ['.update_storefront_context(', 'Cart owner context update'],
+  ['super::super::reprice_storefront_cart_line_items_for_db(', 'repricing order'],
+  ['enrich_storefront_cart(', 'post-reprice enrichment'],
+]) requireText(helper, value, label);
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'validation mapping'],
+  ['PortErrorKind::NotFound', 'not-found mapping'],
+  ['PortErrorKind::Conflict', 'conflict mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable mapping'],
+  ['PortErrorKind::Forbidden | PortErrorKind::InvariantViolation', 'fail-closed mapping'],
+  ['"commerce_store_shipping_invalid"', 'validation public code'],
+  ['"commerce_store_not_found"', 'not-found public code'],
+  ['"commerce_store_shipping_state_conflict"', 'conflict public code'],
+  ['"commerce_store_shipping_unavailable"', 'unavailable public code'],
+  ['"commerce_store_shipping_failed"', 'unexpected owner failure public code'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostics'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
+  ['retryable = error.retryable', 'retryability diagnostic'],
+  ['HttpError::new(status, code, message)', 'stable public envelope'],
+]) requireText(helper, value, label);
+
+for (const value of [
+  'FulfillmentService::new(',
+  'FulfillmentError',
+  'error = ?error',
+  'error.message',
+  'error.to_string()',
+  'err.to_string()',
+]) forbidText(helper, value, 'raw or concrete Fulfillment dependency');
+
+for (const [value, label] of [
+  ['shipping_option_read_runtime: crate::graphql_runtime::CommerceShippingOptionReadRuntime', 'HTTP runtime shipping capability'],
+  ['fn shipping_option_read_port(', 'HTTP runtime read-port accessor'],
+  ['self.shipping_option_read_runtime\n            .shipping_option_read_port()', 'HTTP runtime trait projection'],
+  ['shared_get::<crate::graphql_runtime::CommerceShippingOptionReadRuntime>()', 'host-selected HTTP runtime'],
+]) requireText(httpRuntime, value, label);
+
+for (const [value, label] of [
+  ['pub trait ShippingOptionReadPort', 'Fulfillment owner read port'],
+  ['async fn list_shipping_option_projections(', 'Fulfillment owner list operation'],
+  ['async fn read_shipping_option_projection(', 'Fulfillment owner detail operation'],
+  ['context.require_policy(PortCallPolicy::read())?', 'Fulfillment read admission'],
+]) requireText(shippingOwner, value, label);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology item remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST storefront cart shipping owner-read cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record source status'],
+  ['`ShippingOptionReadPort::list_shipping_option_projections`', 'record owner list'],
+  ['`ShippingOptionReadPort::read_shipping_option_projection`', 'record owner detail'],
+  ['The canonical ecommerce topology item remains open', 'record broad P0 open'],
+  ['No tests, Cargo commands, Node verifiers, formatter', 'record no validation execution'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST storefront cart shipping owner-read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log(
+  '✔ mounted REST cart shipping validation and enrichment use host-selected Fulfillment owner reads',
+);

--- a/scripts/verify/verify-commerce-storefront-cart-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-cart-http-error-safety.mjs
@@ -53,6 +53,7 @@ const updateLineHandler = between(
 for (const [value, label] of [
   ['OptionalAuthContext, PortError, RequestContext, TenantContext', 'typed port error import'],
   ['port_error_to_http_error', 'shared port HTTP mapper import'],
+  ['mod shipping_owner_reads;', 'mounted shipping owner read helper'],
   ['fn map_cart_port_error(', 'cart port mapper'],
   ['error = ?error', 'raw internal error logging'],
   ['owner = "rustok_cart"', 'cart owner logging'],
@@ -138,10 +139,20 @@ for (const [value, label] of [
   ['ensure_storefront_channel_enabled_for_db(', 'channel guard'],
   ['current_customer_id_for_db(', 'customer lookup'],
   ['ensure_store_cart_access(', 'cart ownership guard'],
-  ['enrich_storefront_cart_for_db(', 'cart enrichment'],
+  ['runtime.shipping_option_read_port()', 'host-selected Fulfillment shipping read port'],
+  ['shipping_owner_reads::enrich_storefront_cart(', 'cart shipping enrichment'],
+  ['shipping_owner_reads::apply_cart_context_patch(', 'cart context shipping validation'],
   ['storefront_cart_port_context(', 'cart port context'],
 ]) {
   requireText(controller, value, label);
+}
+
+for (const value of [
+  'super::enrich_storefront_cart_for_db(',
+  'super::apply_cart_context_patch_for_db(',
+  'FulfillmentService::new(',
+]) {
+  forbidText(controller, value, 'stale mounted storefront shipping construction');
 }
 
 for (const [value, label] of [
@@ -196,4 +207,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('✔ Storefront cart handlers use typed safe public envelopes and diagnostics');
+console.log('✔ Storefront cart handlers use typed safe public envelopes, host-selected shipping reads, and diagnostics');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 by removing mounted REST cart shipping reads from direct Fulfillment service construction.

- route all mounted storefront cart shipping enrichment through the existing host-selected `ShippingOptionReadPort::list_shipping_option_projections` capability;
- route selected shipping-option validation during `POST /store/carts/{id}` through `ShippingOptionReadPort::read_shipping_option_projection`;
- reuse the existing storefront cart `PortContext` builder so Fulfillment reads carry admitted tenant, authenticated user or stable service actor, request locale/channel, cart-bound correlation identity, and two-second deadlines;
- preserve cart context update ordering: StoreContext resolution, selected-option validation, Cart owner write, repricing, then shipping enrichment;
- preserve currency, public-channel, shipping-profile compatibility, delivery-group projection, and single-group selected-option reconciliation semantics;
- preserve the existing public REST shipping families for validation/not-found/conflict/unavailable and fail closed on unexpected forbidden/invariant owner failures;
- avoid raw owner/backend message logging in the new mounted helper;
- keep old compatibility/shared helpers outside the mounted cart adapter unchanged in this bounded slice;
- update the existing storefront cart verifier, add a dedicated topology verifier, and add a dated source record;
- keep the broad ecommerce topology P0 open pending a fresh mounted-path audit.

The branch is one clean commit ahead and zero behind `main` (`78a4eec43f649673d8bc3b9463c661df6cf6a629`) with exactly five changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source verifiers were updated/added but not run.