### PR TITLE
feat(forum): apply bounded prepared imports

### DIFF
--- a/crates/rustok-forum/src/services/category_import.rs
+++ b/crates/rustok-forum/src/services/category_import.rs
@@ -1,0 +1,88 @@
+impl CategoryService {
+    pub(crate) async fn insert_import_category_in_tx(
+        txn: &DatabaseTransaction,
+        tenant_id: Uuid,
+        record: &crate::import_write_preparation::ForumPreparedImportCategory,
+    ) -> ForumResult<()> {
+        if tenant_id.is_nil() || record.id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum import category insert requires non-nil tenant and category IDs".to_string(),
+            ));
+        }
+        validate_category_name(&record.name)?;
+        let locale = normalize_locale(&record.locale)?;
+        if locale != record.locale {
+            return Err(ForumError::Validation(
+                "Forum import category locale must already be normalized".to_string(),
+            ));
+        }
+        let slug = normalize_required_slug(&record.slug)?;
+        if slug != record.slug {
+            return Err(ForumError::Validation(
+                "Forum import category slug must already be owner-normalized".to_string(),
+            ));
+        }
+        if record.position < 0 {
+            return Err(ForumError::Validation(
+                "Forum import category position cannot be negative".to_string(),
+            ));
+        }
+        let created_at = chrono::DateTime::<Utc>::from_timestamp_millis(record.created_at_ms)
+            .ok_or_else(|| {
+                ForumError::Validation(
+                    "Forum import category creation timestamp is outside owner range".to_string(),
+                )
+            })?;
+
+        lock_category_tree_in_tx(txn, tenant_id).await?;
+        if let Some(parent_id) = record.parent_id {
+            Self::find_category_in_tx(txn, tenant_id, parent_id).await?;
+        }
+        shift_siblings_for_insert_in_tx(
+            txn,
+            tenant_id,
+            record.parent_id,
+            record.position,
+            Utc::now(),
+        )
+        .await?;
+
+        forum_category::ActiveModel {
+            id: Set(record.id),
+            tenant_id: Set(tenant_id),
+            parent_id: Set(record.parent_id),
+            position: Set(record.position),
+            icon: Set(record.icon.clone()),
+            color: Set(record.color.clone()),
+            moderated: Set(record.moderated),
+            topic_count: Set(0),
+            reply_count: Set(0),
+            created_at: Set(created_at.clone().into()),
+            updated_at: Set(created_at.into()),
+        }
+        .insert(txn)
+        .await?;
+
+        super::category_route::ForumCategoryRouteService::ensure_current_route_key_available_in_tx(
+            txn,
+            tenant_id,
+            record.id,
+            &locale,
+            &slug,
+        )
+        .await?;
+        forum_category_translation::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            category_id: Set(record.id),
+            tenant_id: Set(tenant_id),
+            locale: Set(locale),
+            name: Set(record.name.clone()),
+            slug: Set(slug),
+            description: Set(record.description.clone()),
+        }
+        .insert(txn)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/rustok-forum/src/services/import_write.rs
+++ b/crates/rustok-forum/src/services/import_write.rs
@@ -1,0 +1,556 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use rustok_api::{Action, Resource};
+use rustok_content::normalize_locale_code;
+use rustok_core::{PermissionScope, SecurityContext};
+use rustok_outbox::TransactionalEventBus;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, TransactionTrait};
+use uuid::Uuid;
+
+use crate::entities::{forum_category, forum_reply, forum_topic};
+use crate::error::{ForumError, ForumResult};
+use crate::import_mapping::{
+    FORUM_IMPORT_SOURCE_NODEBB, ForumImportEntityKind, ForumImportExternalRef,
+};
+use crate::import_relation_preparation::{
+    ForumImportRelationEventMode, ForumPreparedImportRelationBatch,
+};
+use crate::import_resolution::ForumResolvedImportAuthor;
+use crate::import_write_preparation::{
+    ForumImportWriteEventMode, ForumPreparedImportCategory, ForumPreparedImportReply,
+    MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH,
+};
+use crate::state_machine::ReplyStatus;
+
+pub const MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH: usize =
+    MAX_FORUM_IMPORT_WRITE_RECORDS_PER_BATCH;
+
+/// Immediate result of one successful atomic import application.
+///
+/// This is not a durable receipt, replay token or checkpoint. The shared
+/// migration runner remains responsible for durable execution semantics.
+#[derive(Clone, Debug)]
+pub struct ForumImportWriteResult {
+    pub tenant_id: Uuid,
+    pub category_ids: Vec<Uuid>,
+    pub topic_ids: Vec<Uuid>,
+    pub reply_ids: Vec<Uuid>,
+}
+
+#[derive(Clone)]
+pub struct ForumImportWriteService {
+    db: DatabaseConnection,
+    event_bus: TransactionalEventBus,
+}
+
+impl ForumImportWriteService {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self {
+        Self { db, event_bus }
+    }
+
+    /// Applies one bounded, self-contained 34M relation batch in exactly one
+    /// Forum-owned transaction.
+    ///
+    /// Historical source authors are data, not authorization identities. The
+    /// importing operator therefore needs tenant-wide Manage scope for every
+    /// owner kind present in the batch.
+    pub async fn apply_prepared_batch(
+        &self,
+        security: &SecurityContext,
+        batch: &ForumPreparedImportRelationBatch,
+    ) -> ForumResult<ForumImportWriteResult> {
+        validate_batch_shape(security, batch)?;
+        validate_relation_alignment(batch)?;
+        let category_order = ordered_category_indices(&batch.writes.categories)?;
+        let reply_order = ordered_reply_indices(&batch.writes.replies)?;
+
+        let topic_service =
+            super::topic::TopicService::new(self.db.clone(), self.event_bus.clone());
+        let reply_service =
+            super::reply_owner::ReplyService::new(self.db.clone(), self.event_bus.clone());
+        let relation_service = super::mention_relation::MentionRelationService::new(self.db.clone());
+
+        // Re-run owner content admission before opening the transaction. These
+        // preparations read current owner schemas but do not mutate Forum state.
+        let mut prepared_topics = Vec::with_capacity(batch.writes.topics.len());
+        for record in &batch.writes.topics {
+            prepared_topics.push(
+                topic_service
+                    .prepare_import_topic(batch.writes.tenant_id, record)
+                    .await?,
+            );
+        }
+        let mut prepared_replies = Vec::with_capacity(batch.writes.replies.len());
+        for record in &batch.writes.replies {
+            prepared_replies.push(
+                reply_service.prepare_import_reply(batch.writes.tenant_id, record)?,
+            );
+        }
+
+        let txn = self.db.begin().await?;
+        ensure_target_ids_absent_in_tx(&txn, batch).await?;
+
+        for index in category_order {
+            super::category::CategoryService::insert_import_category_in_tx(
+                &txn,
+                batch.writes.tenant_id,
+                &batch.writes.categories[index],
+            )
+            .await?;
+        }
+
+        for (index, prepared) in prepared_topics.iter().enumerate() {
+            topic_service
+                .insert_import_topic_in_tx(
+                    &txn,
+                    batch.writes.tenant_id,
+                    prepared,
+                    &batch.topics[index],
+                    &relation_service,
+                    batch.relation_event_mode,
+                    batch.writes.event_mode,
+                )
+                .await?;
+        }
+
+        for index in reply_order {
+            reply_service
+                .insert_import_reply_in_tx(
+                    &txn,
+                    batch.writes.tenant_id,
+                    &prepared_replies[index],
+                    &batch.replies[index],
+                    batch.relation_event_mode,
+                    batch.writes.event_mode,
+                )
+                .await?;
+        }
+
+        let reply_aggregates = approved_reply_aggregates(&prepared_replies)?;
+        for prepared in &prepared_topics {
+            let (count, last_reply_at) = reply_aggregates
+                .get(&prepared.id())
+                .cloned()
+                .unwrap_or((0, None));
+            super::topic::TopicService::finalize_import_topic_in_tx(
+                &txn,
+                batch.writes.tenant_id,
+                prepared,
+                count,
+                last_reply_at,
+            )
+            .await?;
+        }
+
+        // Projection invalidation is a consistency signal, not an interactive
+        // historical event. It is always emitted even when import events are
+        // suppressed, and it is attributed to the importing operator.
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            batch.writes.tenant_id,
+            security.user_id,
+        )
+        .await?;
+
+        txn.commit().await?;
+
+        Ok(ForumImportWriteResult {
+            tenant_id: batch.writes.tenant_id,
+            category_ids: batch.writes.categories.iter().map(|record| record.id).collect(),
+            topic_ids: batch.writes.topics.iter().map(|record| record.id).collect(),
+            reply_ids: batch.writes.replies.iter().map(|record| record.id).collect(),
+        })
+    }
+}
+
+fn validate_batch_shape(
+    security: &SecurityContext,
+    batch: &ForumPreparedImportRelationBatch,
+) -> ForumResult<()> {
+    if batch.writes.tenant_id.is_nil() {
+        return Err(ForumError::Validation(
+            "Forum import application requires a non-nil tenant ID".to_string(),
+        ));
+    }
+    let total = batch
+        .writes
+        .categories
+        .len()
+        .saturating_add(batch.writes.topics.len())
+        .saturating_add(batch.writes.replies.len());
+    if total == 0 || total > MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH {
+        return Err(ForumError::Validation(format!(
+            "Forum import application requires 1..={MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH} owner records"
+        )));
+    }
+
+    let locale = normalize_locale_code(&batch.writes.locale).ok_or_else(|| {
+        ForumError::Validation("Forum import application requires a valid locale".to_string())
+    })?;
+    if locale != batch.writes.locale {
+        return Err(ForumError::Validation(
+            "Forum import application locale must already be normalized".to_string(),
+        ));
+    }
+
+    if !batch.writes.categories.is_empty() {
+        require_all_manage(security, Resource::ForumCategories)?;
+    }
+    if !batch.writes.topics.is_empty() {
+        require_all_manage(security, Resource::ForumTopics)?;
+    }
+    if !batch.writes.replies.is_empty() {
+        require_all_manage(security, Resource::ForumReplies)?;
+    }
+
+    let expected_relation_event_mode = match batch.writes.event_mode {
+        ForumImportWriteEventMode::SuppressInteractiveEvents => {
+            ForumImportRelationEventMode::SuppressAddedTargetEvents
+        }
+        ForumImportWriteEventMode::EmitDomainEvents => {
+            ForumImportRelationEventMode::EmitAddedTargetEvents
+        }
+    };
+    if batch.relation_event_mode != expected_relation_event_mode {
+        return Err(ForumError::Validation(
+            "Forum import relation event mode differs from prepared write event mode".to_string(),
+        ));
+    }
+
+    let category_ids = unique_ids(
+        "category",
+        batch.writes.categories.iter().map(|record| record.id),
+    )?;
+    let topic_ids = unique_ids("topic", batch.writes.topics.iter().map(|record| record.id))?;
+    let reply_ids = unique_ids("reply", batch.writes.replies.iter().map(|record| record.id))?;
+
+    for category in &batch.writes.categories {
+        validate_source_ref(&category.source, ForumImportEntityKind::Category)?;
+        validate_record_locale(&batch.writes.locale, &category.source, &category.locale)?;
+        validate_timestamp("category", &category.source, category.created_at_ms)?;
+    }
+
+    for topic in &batch.writes.topics {
+        validate_source_ref(&topic.source, ForumImportEntityKind::Topic)?;
+        validate_source_ref(&topic.body_source, ForumImportEntityKind::Post)?;
+        validate_record_locale(&batch.writes.locale, &topic.source, &topic.locale)?;
+        validate_author(topic.author.as_ref())?;
+        validate_timestamp("topic", &topic.source, topic.created_at_ms)?;
+        if !category_ids.contains(&topic.category_id) {
+            return Err(ForumError::Validation(
+                "Forum import topic category must be inside the bounded batch".to_string(),
+            ));
+        }
+    }
+
+    for reply in &batch.writes.replies {
+        validate_source_ref(&reply.source, ForumImportEntityKind::Post)?;
+        validate_record_locale(&batch.writes.locale, &reply.source, &reply.locale)?;
+        validate_author(reply.author.as_ref())?;
+        validate_timestamp("reply", &reply.source, reply.created_at_ms)?;
+        if reply.status == ReplyStatus::Deleted {
+            return Err(ForumError::Validation(
+                "Forum import deleted replies remain blocked until a tombstone timestamp is admitted"
+                    .to_string(),
+            ));
+        }
+        if !topic_ids.contains(&reply.topic_id) {
+            return Err(ForumError::Validation(
+                "Forum import reply topic must be inside the bounded batch".to_string(),
+            ));
+        }
+        if let Some(parent_reply_id) = reply.parent_reply_id {
+            if !reply_ids.contains(&parent_reply_id) {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent must be inside the bounded batch".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_relation_alignment(batch: &ForumPreparedImportRelationBatch) -> ForumResult<()> {
+    if batch.topics.len() != batch.writes.topics.len()
+        || batch.replies.len() != batch.writes.replies.len()
+    {
+        return Err(ForumError::Validation(
+            "Forum import relation facts must match every prepared topic and reply exactly"
+                .to_string(),
+        ));
+    }
+
+    for (record, relation) in batch.writes.topics.iter().zip(&batch.topics) {
+        if relation.source != record.source
+            || relation.target != crate::mentions::ForumContentTarget::topic(record.id)
+            || relation.locale != record.locale
+        {
+            return Err(ForumError::Validation(
+                "Forum import topic relation facts are not aligned with prepared writes".to_string(),
+            ));
+        }
+    }
+    for (record, relation) in batch.writes.replies.iter().zip(&batch.replies) {
+        if relation.source != record.source
+            || relation.target != crate::mentions::ForumContentTarget::reply(record.id)
+            || relation.locale != record.locale
+        {
+            return Err(ForumError::Validation(
+                "Forum import reply relation facts are not aligned with prepared writes".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_ref(
+    source: &ForumImportExternalRef,
+    expected: ForumImportEntityKind,
+) -> ForumResult<()> {
+    if source.source != FORUM_IMPORT_SOURCE_NODEBB || source.kind != expected {
+        return Err(ForumError::Validation(format!(
+            "Forum import application requires NodeBB {expected:?} source identity"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_record_locale(
+    batch_locale: &str,
+    source: &ForumImportExternalRef,
+    locale: &str,
+) -> ForumResult<()> {
+    if locale != batch_locale {
+        return Err(ForumError::Validation(format!(
+            "Forum import record locale differs from batch locale for {source:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_author(author: Option<&ForumResolvedImportAuthor>) -> ForumResult<()> {
+    let Some(author) = author else {
+        return Ok(());
+    };
+    validate_source_ref(&author.source, ForumImportEntityKind::User)?;
+    if author.user_id.is_nil() {
+        return Err(ForumError::Validation(
+            "Forum import author target ID cannot be nil".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_timestamp(
+    kind: &'static str,
+    source: &ForumImportExternalRef,
+    timestamp_ms: i64,
+) -> ForumResult<()> {
+    if timestamp_ms < 0 {
+        return Err(ForumError::Validation(format!(
+            "Forum import {kind} timestamp cannot be negative for {source:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn require_all_manage(security: &SecurityContext, resource: Resource) -> ForumResult<()> {
+    if security.get_scope(resource, Action::Manage) != PermissionScope::All {
+        return Err(ForumError::forbidden(
+            "Forum historical import requires tenant-wide Manage permission",
+        ));
+    }
+    Ok(())
+}
+
+fn unique_ids(
+    kind: &'static str,
+    ids: impl IntoIterator<Item = Uuid>,
+) -> ForumResult<BTreeSet<Uuid>> {
+    let mut unique = BTreeSet::new();
+    for id in ids {
+        if id.is_nil() {
+            return Err(ForumError::Validation(format!(
+                "Forum import {kind} target ID cannot be nil"
+            )));
+        }
+        if !unique.insert(id) {
+            return Err(ForumError::Validation(format!(
+                "Forum import repeats {kind} target ID {id}"
+            )));
+        }
+    }
+    Ok(unique)
+}
+
+fn ordered_category_indices(records: &[ForumPreparedImportCategory]) -> ForumResult<Vec<usize>> {
+    let mut parents = BTreeMap::new();
+    let mut placements = BTreeSet::new();
+    for record in records {
+        parents.insert(record.id, record.parent_id);
+        if record.position < 0 {
+            return Err(ForumError::Validation(
+                "Forum import category position cannot be negative".to_string(),
+            ));
+        }
+        if !placements.insert((record.parent_id, record.position)) {
+            return Err(ForumError::Validation(
+                "Forum import categories cannot claim the same sibling position".to_string(),
+            ));
+        }
+    }
+
+    let mut keyed = Vec::with_capacity(records.len());
+    for (index, record) in records.iter().enumerate() {
+        let mut depth = 0usize;
+        let mut current = record.id;
+        let mut seen = BTreeSet::new();
+        seen.insert(current);
+        loop {
+            let parent = parents.get(&current).copied().flatten();
+            let Some(parent) = parent else { break };
+            if !parents.contains_key(&parent) {
+                return Err(ForumError::Validation(
+                    "Forum import category parent must be inside the bounded batch".to_string(),
+                ));
+            }
+            if !seen.insert(parent) {
+                return Err(ForumError::Validation(
+                    "Forum import category parent graph contains a cycle".to_string(),
+                ));
+            }
+            depth = depth.saturating_add(1);
+            current = parent;
+        }
+        keyed.push((depth, record.parent_id, record.position, record.id, index));
+    }
+    keyed.sort_by_key(|item| (item.0, item.1, item.2, item.3));
+    Ok(keyed.into_iter().map(|item| item.4).collect())
+}
+
+fn ordered_reply_indices(records: &[ForumPreparedImportReply]) -> ForumResult<Vec<usize>> {
+    let by_id = records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| (record.id, index))
+        .collect::<BTreeMap<_, _>>();
+    let mut keyed = Vec::with_capacity(records.len());
+
+    for (index, record) in records.iter().enumerate() {
+        let mut depth = 0usize;
+        let mut current = record;
+        let mut seen = BTreeSet::new();
+        seen.insert(record.id);
+        while let Some(parent_id) = current.parent_reply_id {
+            let Some(parent_index) = by_id.get(&parent_id).copied() else {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent must be inside the bounded batch".to_string(),
+                ));
+            };
+            let parent = &records[parent_index];
+            if parent.topic_id != record.topic_id {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent belongs to another topic".to_string(),
+                ));
+            }
+            if !seen.insert(parent.id) {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent graph contains a cycle".to_string(),
+                ));
+            }
+            depth = depth.saturating_add(1);
+            current = parent;
+        }
+        keyed.push((record.topic_id, depth, index));
+    }
+
+    keyed.sort_by_key(|item| (item.0, item.1, item.2));
+    Ok(keyed.into_iter().map(|item| item.2).collect())
+}
+
+async fn ensure_target_ids_absent_in_tx(
+    txn: &sea_orm::DatabaseTransaction,
+    batch: &ForumPreparedImportRelationBatch,
+) -> ForumResult<()> {
+    let category_ids = batch
+        .writes
+        .categories
+        .iter()
+        .map(|record| record.id)
+        .collect::<Vec<_>>();
+    if !category_ids.is_empty()
+        && forum_category::Entity::find()
+            .filter(forum_category::Column::Id.is_in(category_ids))
+            .one(txn)
+            .await?
+            .is_some()
+    {
+        return Err(ForumError::Validation(
+            "Forum import category target ID already exists".to_string(),
+        ));
+    }
+
+    let topic_ids = batch
+        .writes
+        .topics
+        .iter()
+        .map(|record| record.id)
+        .collect::<Vec<_>>();
+    if !topic_ids.is_empty()
+        && forum_topic::Entity::find()
+            .filter(forum_topic::Column::Id.is_in(topic_ids))
+            .one(txn)
+            .await?
+            .is_some()
+    {
+        return Err(ForumError::Validation(
+            "Forum import topic target ID already exists".to_string(),
+        ));
+    }
+
+    let reply_ids = batch
+        .writes
+        .replies
+        .iter()
+        .map(|record| record.id)
+        .collect::<Vec<_>>();
+    if !reply_ids.is_empty()
+        && forum_reply::Entity::find()
+            .filter(forum_reply::Column::Id.is_in(reply_ids))
+            .one(txn)
+            .await?
+            .is_some()
+    {
+        return Err(ForumError::Validation(
+            "Forum import reply target ID already exists".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn approved_reply_aggregates(
+    replies: &[super::reply_owner::PreparedImportReplyInsert],
+) -> ForumResult<BTreeMap<Uuid, (i32, Option<DateTime<Utc>>)>> {
+    let mut aggregates = BTreeMap::new();
+    for reply in replies {
+        if reply.status() != ReplyStatus::Approved {
+            continue;
+        }
+        let entry = aggregates.entry(reply.topic_id()).or_insert((0i32, None));
+        entry.0 = entry.0.checked_add(1).ok_or_else(|| {
+            ForumError::Validation("Forum imported reply count exceeds i32 range".to_string())
+        })?;
+        let created_at = reply.created_at();
+        let should_replace = match entry.1.as_ref() {
+            Some(current) => created_at > *current,
+            None => true,
+        };
+        if should_replace {
+            entry.1 = Some(created_at);
+        }
+    }
+    Ok(aggregates)
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -2,6 +2,7 @@
 
 mod bounded_compat;
 mod category {
+    include!("category_import.rs");
     include!("category.rs");
     include!("category_locale_enumeration.rs");
     include!("category_projection_owner.rs");
@@ -48,6 +49,7 @@ mod category_visibility;
 mod counter_reconciliation;
 mod solution_reconciliation;
 pub mod event;
+mod import_write;
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]
 mod mention_relation {
     include!("mention_relation_import.rs");
@@ -93,6 +95,7 @@ mod reply_audience_read;
 mod reply_create_audience_authorization;
 mod reply_facade;
 mod reply_owner {
+    include!("reply_owner_import.rs");
     include!("reply_owner.rs");
     include!("reply_owner_inline.rs");
 }
@@ -105,6 +108,7 @@ pub mod storefront_read_state {
 pub mod subscription;
 #[allow(clippy::collapsible_if)]
 mod topic {
+    include!("topic_import.rs");
     include!("topic.rs");
     include!("topic_locale_enumeration.rs");
     include!("topic_inline.rs");
@@ -200,6 +204,9 @@ pub use solution_reconciliation::{
     ForumSolutionReconciliationService,
 };
 pub use event::ForumEventService;
+pub use import_write::{
+    ForumImportWriteResult, ForumImportWriteService, MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH,
+};
 #[allow(unused_imports)]
 pub(crate) use mention_relation::MentionRelationService;
 pub use moderation::ModerationService;

--- a/crates/rustok-forum/src/services/reply_owner_import.rs
+++ b/crates/rustok-forum/src/services/reply_owner_import.rs
@@ -1,0 +1,183 @@
+pub(crate) struct PreparedImportReplyInsert {
+    record: crate::import_write_preparation::ForumPreparedImportReply,
+    document: rustok_api::RichTextDocument,
+    stored_body: String,
+    created_at: chrono::DateTime<Utc>,
+}
+
+impl PreparedImportReplyInsert {
+    pub(crate) fn id(&self) -> Uuid {
+        self.record.id
+    }
+
+    pub(crate) fn topic_id(&self) -> Uuid {
+        self.record.topic_id
+    }
+
+    pub(crate) fn source(&self) -> &crate::import_mapping::ForumImportExternalRef {
+        &self.record.source
+    }
+
+    pub(crate) fn parent_reply_id(&self) -> Option<Uuid> {
+        self.record.parent_reply_id
+    }
+
+    pub(crate) fn status(&self) -> ReplyStatus {
+        self.record.status
+    }
+
+    pub(crate) fn created_at(&self) -> chrono::DateTime<Utc> {
+        self.created_at.clone()
+    }
+}
+
+impl ReplyService {
+    pub(crate) fn prepare_import_reply(
+        &self,
+        tenant_id: Uuid,
+        record: &crate::import_write_preparation::ForumPreparedImportReply,
+    ) -> ForumResult<PreparedImportReplyInsert> {
+        if tenant_id.is_nil() || record.id.is_nil() || record.topic_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum import reply preparation requires non-nil tenant, reply and topic IDs"
+                    .to_string(),
+            ));
+        }
+        if record.status == ReplyStatus::Deleted {
+            return Err(ForumError::Validation(
+                "Forum import deleted reply requires an admitted tombstone timestamp before persistence"
+                    .to_string(),
+            ));
+        }
+        let locale = normalize_locale(&record.locale)?;
+        if locale != record.locale {
+            return Err(ForumError::Validation(
+                "Forum import reply locale must already be normalized".to_string(),
+            ));
+        }
+        let document = crate::richtext::normalize_discussion(record.content.clone())?;
+        let stored_body = crate::richtext::serialize_discussion(document.clone())?;
+        let created_at = chrono::DateTime::<Utc>::from_timestamp_millis(record.created_at_ms)
+            .ok_or_else(|| {
+                ForumError::Validation(
+                    "Forum import reply creation timestamp is outside owner range".to_string(),
+                )
+            })?;
+
+        Ok(PreparedImportReplyInsert {
+            record: record.clone(),
+            document,
+            stored_body,
+            created_at,
+        })
+    }
+
+    pub(crate) async fn insert_import_reply_in_tx(
+        &self,
+        txn: &DatabaseTransaction,
+        tenant_id: Uuid,
+        prepared: &PreparedImportReplyInsert,
+        relation: &crate::import_relation_preparation::ForumPreparedImportContentRelations,
+        relation_event_mode: crate::import_relation_preparation::ForumImportRelationEventMode,
+        write_event_mode: crate::import_write_preparation::ForumImportWriteEventMode,
+    ) -> ForumResult<()> {
+        if relation.source != prepared.record.source
+            || relation.target != ForumContentTarget::reply(prepared.record.id)
+            || relation.locale != prepared.record.locale
+        {
+            return Err(ForumError::Validation(
+                "Forum import reply relation admission does not match prepared reply".to_string(),
+            ));
+        }
+
+        let topic = TopicService::find_topic_in_tx(txn, tenant_id, prepared.record.topic_id).await?;
+        if topic.status != TopicStatus::Open || topic.is_locked {
+            return Err(ForumError::Validation(
+                "Forum import reply insertion requires the private provisional topic state"
+                    .to_string(),
+            ));
+        }
+
+        if let Some(parent_reply_id) = prepared.record.parent_reply_id {
+            let parent = reply::ReplyService::find_reply_in_tx(txn, tenant_id, parent_reply_id).await?;
+            if parent.topic_id != prepared.record.topic_id {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent belongs to another topic".to_string(),
+                ));
+            }
+            if parent.status == ReplyStatus::Deleted {
+                return Err(ForumError::Validation(
+                    "Forum import reply cannot use a deleted parent without tombstone admission"
+                        .to_string(),
+                ));
+            }
+        }
+
+        let position = allocate_reply_position_in_tx(txn, tenant_id, prepared.record.topic_id).await?;
+        let author_id = prepared.record.author.as_ref().map(|author| author.user_id);
+
+        forum_reply::ActiveModel {
+            id: Set(prepared.record.id),
+            tenant_id: Set(tenant_id),
+            topic_id: Set(prepared.record.topic_id),
+            author_id: Set(author_id),
+            parent_reply_id: Set(prepared.record.parent_reply_id),
+            status: Set(prepared.record.status),
+            position: Set(position),
+            created_at: Set(prepared.created_at.clone().into()),
+            updated_at: Set(prepared.created_at.clone().into()),
+        }
+        .insert(txn)
+        .await?;
+
+        forum_reply_body::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            reply_id: Set(prepared.record.id),
+            tenant_id: Set(tenant_id),
+            locale: Set(prepared.record.locale.clone()),
+            body: Set(prepared.stored_body.clone()),
+            created_at: Set(prepared.created_at.clone().into()),
+            updated_at: Set(prepared.created_at.clone().into()),
+        }
+        .insert(txn)
+        .await?;
+
+        self.relations
+            .persist_import_admitted_in_tx(
+                txn,
+                tenant_id,
+                relation,
+                &prepared.document,
+                author_id,
+                relation_event_mode,
+            )
+            .await?;
+
+        if prepared.record.status == ReplyStatus::Approved {
+            TopicService::adjust_reply_count_in_tx(txn, tenant_id, prepared.record.topic_id, 1)
+                .await?;
+            CategoryService::adjust_counters_in_tx(txn, tenant_id, topic.category_id, 0, 1)
+                .await?;
+            UserStatsService::adjust_reply_count_in_tx(txn, tenant_id, author_id, 1).await?;
+
+            if write_event_mode
+                == crate::import_write_preparation::ForumImportWriteEventMode::EmitDomainEvents
+            {
+                self.event_bus
+                    .publish_in_tx(
+                        txn,
+                        tenant_id,
+                        author_id,
+                        DomainEvent::ForumTopicReplied {
+                            topic_id: prepared.record.topic_id,
+                            reply_id: prepared.record.id,
+                            author_id,
+                        },
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rustok-forum/src/services/topic_import.rs
+++ b/crates/rustok-forum/src/services/topic_import.rs
@@ -1,0 +1,259 @@
+pub(crate) struct PreparedImportTopicInsert {
+    record: crate::import_write_preparation::ForumPreparedImportTopic,
+    document: RichTextDocument,
+    stored_body: String,
+    normalized_slug: Option<String>,
+    normalized_tags: Vec<String>,
+    prepared_custom_fields: flex::PreparedAttachedValuesWrite,
+    created_at: chrono::DateTime<Utc>,
+}
+
+impl PreparedImportTopicInsert {
+    pub(crate) fn id(&self) -> Uuid {
+        self.record.id
+    }
+
+    pub(crate) fn category_id(&self) -> Uuid {
+        self.record.category_id
+    }
+
+    pub(crate) fn source(&self) -> &crate::import_mapping::ForumImportExternalRef {
+        &self.record.source
+    }
+
+    pub(crate) fn locale(&self) -> &str {
+        &self.record.locale
+    }
+
+    pub(crate) fn author_id(&self) -> Option<Uuid> {
+        self.record.author.as_ref().map(|author| author.user_id)
+    }
+
+    pub(crate) fn final_status(&self) -> TopicStatus {
+        self.record.status
+    }
+
+    pub(crate) fn final_locked(&self) -> bool {
+        self.record.is_locked
+    }
+
+    pub(crate) fn created_at(&self) -> chrono::DateTime<Utc> {
+        self.created_at.clone()
+    }
+}
+
+impl TopicService {
+    pub(crate) async fn prepare_import_topic(
+        &self,
+        tenant_id: Uuid,
+        record: &crate::import_write_preparation::ForumPreparedImportTopic,
+    ) -> ForumResult<PreparedImportTopicInsert> {
+        if tenant_id.is_nil() || record.id.is_nil() || record.category_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum import topic preparation requires non-nil tenant, topic and category IDs"
+                    .to_string(),
+            ));
+        }
+        validate_topic_title(&record.title)?;
+        let locale = normalize_locale(&record.locale)?;
+        if locale != record.locale {
+            return Err(ForumError::Validation(
+                "Forum import topic locale must already be normalized".to_string(),
+            ));
+        }
+        let normalized_tags = normalize_tags(&record.tags);
+        validate_normalized_topic_tags(&normalized_tags)?;
+        let document = crate::richtext::normalize_discussion(record.body.clone())?;
+        let stored_body = crate::richtext::serialize_discussion(document.clone())?;
+        let prepared_custom_fields = self
+            .prepare_topic_custom_fields_for_create(tenant_id, &locale, record.metadata.clone())
+            .await?;
+        let normalized_slug = record
+            .slug
+            .as_ref()
+            .map(|value| normalize_slug(value))
+            .filter(|value| !value.is_empty());
+        let created_at = chrono::DateTime::<Utc>::from_timestamp_millis(record.created_at_ms)
+            .ok_or_else(|| {
+                ForumError::Validation(
+                    "Forum import topic creation timestamp is outside owner range".to_string(),
+                )
+            })?;
+
+        Ok(PreparedImportTopicInsert {
+            record: record.clone(),
+            document,
+            stored_body,
+            normalized_slug,
+            normalized_tags,
+            prepared_custom_fields,
+            created_at,
+        })
+    }
+
+    pub(crate) async fn insert_import_topic_in_tx(
+        &self,
+        txn: &DatabaseTransaction,
+        tenant_id: Uuid,
+        prepared: &PreparedImportTopicInsert,
+        relation: &crate::import_relation_preparation::ForumPreparedImportContentRelations,
+        relations: &super::mention_relation::MentionRelationService,
+        relation_event_mode: crate::import_relation_preparation::ForumImportRelationEventMode,
+        write_event_mode: crate::import_write_preparation::ForumImportWriteEventMode,
+    ) -> ForumResult<()> {
+        if relation.source != prepared.record.source
+            || relation.target != crate::mentions::ForumContentTarget::topic(prepared.record.id)
+            || relation.locale != prepared.record.locale
+        {
+            return Err(ForumError::Validation(
+                "Forum import topic relation admission does not match prepared topic".to_string(),
+            ));
+        }
+
+        CategoryService::ensure_exists_in_tx(txn, tenant_id, prepared.record.category_id).await?;
+        let author_id = prepared.author_id();
+
+        // Topics are materialized open/unlocked inside the private transaction so
+        // owner reply-insert guards can admit historical replies. The exact
+        // prepared status/lock is restored by finalize_import_topic_in_tx before
+        // the transaction can commit.
+        forum_topic::ActiveModel {
+            id: Set(prepared.record.id),
+            tenant_id: Set(tenant_id),
+            category_id: Set(prepared.record.category_id),
+            author_id: Set(author_id),
+            status: Set(TopicStatus::Open),
+            metadata: Set(prepared
+                .prepared_custom_fields
+                .metadata
+                .clone()
+                .unwrap_or_else(|| serde_json::json!({}))),
+            is_pinned: Set(prepared.record.is_pinned),
+            is_locked: Set(false),
+            reply_count: Set(0),
+            created_at: Set(prepared.created_at.clone().into()),
+            updated_at: Set(prepared.created_at.clone().into()),
+            last_reply_at: Set(None),
+        }
+        .insert(txn)
+        .await?;
+
+        super::topic_tag_lock::lock_active_topic_tag_write_in_tx(
+            txn,
+            tenant_id,
+            prepared.record.id,
+        )
+        .await?;
+        super::topic_tag_lock::lock_topic_tag_scopes_in_tx(
+            txn,
+            tenant_id,
+            &[prepared.record.id],
+        )
+        .await?;
+
+        forum_topic_translation::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            topic_id: Set(prepared.record.id),
+            tenant_id: Set(tenant_id),
+            locale: Set(prepared.record.locale.clone()),
+            title: Set(prepared.record.title.clone()),
+            slug: Set(prepared.normalized_slug.clone()),
+            body: Set(prepared.stored_body.clone()),
+            created_at: Set(prepared.created_at.clone().into()),
+            updated_at: Set(prepared.created_at.clone().into()),
+        }
+        .insert(txn)
+        .await?;
+
+        relations
+            .persist_import_admitted_in_tx(
+                txn,
+                tenant_id,
+                relation,
+                &prepared.document,
+                author_id,
+                relation_event_mode,
+            )
+            .await?;
+
+        if let (Some(persist_locale), Some(values)) = (
+            prepared.prepared_custom_fields.locale.as_deref(),
+            prepared.prepared_custom_fields.localized_values.as_ref(),
+        ) {
+            persist_localized_values(
+                txn,
+                tenant_id,
+                "topic",
+                prepared.record.id,
+                persist_locale,
+                values,
+            )
+            .await
+            .map_err(|error| ForumError::Validation(error.to_string()))?;
+        }
+
+        self.sync_channel_access_in_tx(
+            txn,
+            tenant_id,
+            prepared.record.id,
+            prepared.record.channel_slugs.as_deref(),
+        )
+        .await?;
+        self.sync_topic_tags_in_tx(
+            txn,
+            tenant_id,
+            prepared.record.id,
+            &prepared.record.locale,
+            &prepared.normalized_tags,
+        )
+        .await?;
+
+        CategoryService::adjust_counters_in_tx(
+            txn,
+            tenant_id,
+            prepared.record.category_id,
+            1,
+            0,
+        )
+        .await?;
+        UserStatsService::adjust_topic_count_in_tx(txn, tenant_id, author_id, 1).await?;
+
+        if write_event_mode
+            == crate::import_write_preparation::ForumImportWriteEventMode::EmitDomainEvents
+        {
+            self.event_bus
+                .publish_in_tx(
+                    txn,
+                    tenant_id,
+                    author_id,
+                    DomainEvent::ForumTopicCreated {
+                        topic_id: prepared.record.id,
+                        category_id: prepared.record.category_id,
+                        author_id,
+                        locale: prepared.record.locale.clone(),
+                    },
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn finalize_import_topic_in_tx(
+        txn: &DatabaseTransaction,
+        tenant_id: Uuid,
+        prepared: &PreparedImportTopicInsert,
+        approved_reply_count: i32,
+        last_reply_at: Option<chrono::DateTime<Utc>>,
+    ) -> ForumResult<()> {
+        let topic = Self::find_topic_in_tx(txn, tenant_id, prepared.record.id).await?;
+        let mut active: forum_topic::ActiveModel = topic.into();
+        active.status = Set(prepared.record.status);
+        active.is_locked = Set(prepared.record.is_locked);
+        active.reply_count = Set(approved_reply_count.max(0));
+        active.last_reply_at = Set(last_reply_at.map(Into::into));
+        active.updated_at = Set(prepared.created_at.clone().into());
+        active.update(txn).await?;
+        Ok(())
+    }
+}

--- a/docs/modules/forum-34-atomic-import-content-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-atomic-import-content-actualization-2026-08-09.md
@@ -1,0 +1,226 @@
+# FORUM-34O atomic prepared import content actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / deleted-tombstone-admission-open / shared-runner-blocked`
+
+## Cursor and fresh recheck
+
+FORUM-34A through FORUM-34N are merged before this slice. 34O started from `b821161ab07bf45d3c8c57d4ff44d5935b27a464` after Commerce-only PR #3416. While the slice was being prepared, `main` first advanced through Pages-only PR #3417 and then through the Alloy/module-control-plane merge plus Commerce PR #3418 to `4699fee7c4aa820f8956e097eebf7eabbb14f3c8`. None of those commits changes `crates/rustok-forum` source. The working branch is rebased onto the final fresh `main` before PR review.
+
+The canonical Forum implementation-plan ledger still carries the stale FORUM-34 `planned` cursor. This dated packet records the truthful source cursor without replacing that large roadmap wholesale.
+
+### Fresh shared-runner recheck
+
+The new Alloy work adds `AlloyReleaseImporter` under `crates/alloy/src/runner/import.rs`, so the earlier assumption about runner availability was rechecked rather than carried forward blindly.
+
+That importer is explicitly scoped to one exact eligible **published Rhai release**: it loads immutable release/workspace bytes, imports an Alloy draft through `ScriptRegistry`, and owns Alloy-specific draft lineage/idempotency conflicts. It is not a neutral owner-data migration runner or a generic checkpoint/replay contract that Forum can implement.
+
+FORUM-34 therefore still must not invent a Forum-local durable runner. The owner write boundary in 34O remains useful independently; durable cross-batch execution stays blocked on a genuinely shared migration runner contract.
+
+## What 34O closes
+
+34N made admitted mention/audience relation persistence available inside a caller-owned transaction. 34O adds the smallest Forum-owned content primitives and composes them into one bounded atomic application service.
+
+Public owner surface:
+
+```rust
+pub const MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH: usize = 512;
+
+pub struct ForumImportWriteService { /* owner DB + event bus */ }
+
+impl ForumImportWriteService {
+    pub fn new(db: DatabaseConnection, event_bus: TransactionalEventBus) -> Self;
+
+    pub async fn apply_prepared_batch(
+        &self,
+        security: &SecurityContext,
+        batch: &ForumPreparedImportRelationBatch,
+    ) -> ForumResult<ForumImportWriteResult>;
+}
+```
+
+`ForumImportWriteResult` only reports the entity IDs that this immediate call committed. It is explicitly **not** a durable receipt, replay identity, checkpoint or exactly-once record.
+
+## Authorization boundary
+
+Historical source authors are imported data, not the identity of the operator running the migration. `Own` scope therefore cannot safely authorize this operation.
+
+For each non-empty owner kind, 34O requires exact `PermissionScope::All` for `Action::Manage`:
+
+- categories -> `Resource::ForumCategories`;
+- topics -> `Resource::ForumTopics`;
+- replies -> `Resource::ForumReplies`.
+
+The historical author UUID is never substituted as the authorization actor.
+
+## Independent boundary revalidation
+
+`ForumPreparedImportRelationBatch` is an in-process public DTO and can be manually constructed. The write adapter therefore does not blindly trust that 34L/34M ran immediately beforehand.
+
+Before any mutation it independently rechecks:
+
+- non-nil tenant ID;
+- 1..=512 total category/topic/reply records;
+- valid, already-normalized batch locale;
+- every category/topic/reply locale equals the batch locale;
+- NodeBB source namespace and exact Category/Topic/Post kinds;
+- topic body source remains a NodeBB Post ref;
+- optional authors remain NodeBB User refs with non-nil admitted User UUIDs;
+- non-negative admitted creation timestamps;
+- non-nil, unique target IDs per owner kind;
+- every topic category is inside the bounded batch;
+- every reply topic and optional parent is inside the bounded batch;
+- relation arrays exactly align source/target/locale with every topic/reply;
+- relation event mode still matches the explicit 34L write event mode.
+
+## Insert-only semantics
+
+34O is a single-attempt insert path, not an idempotency ledger.
+
+Inside the transaction it checks that none of the admitted category/topic/reply target IDs already exist in their owner tables. Existing IDs fail the whole batch. Normal primary/unique constraints remain the race-time barrier.
+
+No Forum-local retry receipt, checkpoint or replay journal is introduced.
+
+## Category primitive
+
+`CategoryService::insert_import_category_in_tx(...)` remains inside the existing category owner module so it can reuse private category invariants.
+
+It:
+
+- preserves the admitted category UUID;
+- preserves admitted parent, position, moderation/icon/color and creation time;
+- re-runs category name, locale and required-slug normalization;
+- locks the category tree through the established owner helper;
+- requires the parent row to exist before child insertion;
+- shifts siblings through the established owner placement helper;
+- checks the current category route key before inserting the translation.
+
+Categories are applied in deterministic parent-before-child order. Within a parent, the adapter orders by admitted position then UUID and rejects two imported siblings claiming the same position.
+
+The generated category-translation UUID is an owner-internal row identity. It is not the imported category entity identity and does not replace the source-admitted category UUID.
+
+## Topic primitive
+
+Topic preparation runs before the transaction and reuses the established owner admission code for:
+
+- title validation;
+- locale normalization;
+- canonical RichText normalization/serialization;
+- topic tag normalization and the existing tag-count bound;
+- flex/custom-field create preparation.
+
+Inside the transaction the primitive preserves the admitted Topic UUID, category, author, metadata decisions, pin flag and historical creation time, then reuses existing owner helpers for:
+
+- active-topic tag locks;
+- translation persistence;
+- 34N relation persistence against the exact persisted RichText body;
+- localized flex values;
+- channel access;
+- taxonomy tags;
+- category topic count;
+- author topic UserStats.
+
+### Provisional topic state
+
+The current database/owner reply-create invariant refuses insertion when a topic is not `Open` or is locked. Historical imports can legitimately contain replies under a topic whose final imported state is `Closed`, `Archived`, or locked.
+
+34O therefore inserts each topic as `Open` and unlocked **only inside the uncommitted private transaction**. After all replies are inserted, `finalize_import_topic_in_tx` restores the exact admitted topic status and lock state before commit.
+
+No provisional state is externally observable.
+
+## Reply primitive
+
+The reply owner primitive:
+
+- preserves admitted Reply UUID, topic, parent, author, status and creation time;
+- normalizes and serializes the admitted RichText;
+- validates parent existence/same-topic ownership;
+- uses the existing owner monotonic `allocate_reply_position_in_tx` path instead of inventing source positions;
+- writes the body with an owner-internal body-row UUID;
+- persists exact 34N admitted relations in the same transaction.
+
+Parented replies are inserted parent-before-child deterministically. NodeBB mapping does not claim an owner reply-position identity, so position remains owner-allocated.
+
+## Public reply accounting
+
+Fresh owner and trigger recheck confirms that only `ReplyStatus::Approved` contributes to public reply accounting.
+
+34O therefore increments topic/category/UserStats reply counts only for imported `Approved` replies. Pending, Rejected, Hidden and Flagged replies persist but do not contribute to public counts.
+
+After all reply inserts, the topic finalizer sets:
+
+- `reply_count` to the number of imported Approved replies for that topic;
+- `last_reply_at` to the maximum historical creation timestamp of those Approved replies;
+- the exact final imported topic status/lock.
+
+Supported-database owner triggers remain the final consistency barrier.
+
+## Event and projection semantics
+
+`SuppressInteractiveEvents` suppresses historical topic-created, topic-replied and added-target mention events.
+
+`EmitDomainEvents` emits the established create-style owner events only:
+
+- `ForumTopicCreated` for imported topics;
+- `ForumTopicReplied` for imported Approved replies;
+- 34N added-target relation events for materialized mentions/audiences.
+
+34O does not synthesize lifecycle-transition history that was not present in the import facts.
+
+Forum search/projection invalidation is a consistency signal, not an optional interactive notification. The adapter always calls `publish_forum_projection_scope_direct_in_tx(...)` before commit, even when interactive events are suppressed. That invalidation is attributed to the importing operator rather than a historical author.
+
+## Atomicity
+
+One `apply_prepared_batch` call has one content transaction:
+
+1. validate authorization and bounded facts;
+2. run read-only topic/reply owner preparation;
+3. begin one transaction;
+4. fail if target entity IDs already exist;
+5. insert categories parent-first;
+6. insert topics with private provisional Open/unlocked state;
+7. insert replies parent-first through the owner position allocator;
+8. finalize exact topic state/count/last-reply facts;
+9. publish required Forum projection invalidation;
+10. commit once.
+
+Any failure before commit rolls back category/topic/reply, relation, counter/UserStats, event and projection work together.
+
+## Deleted reply boundary remains fail-closed
+
+34L currently carries a deleted boolean/status but **does not carry the owner `deleted_at` tombstone timestamp**.
+
+Fresh soft-delete migration and owner-path review confirms that `deleted_at` is a separate persisted owner fact. The normal owner soft-delete path sets it explicitly and captures delete revisions. Merely inserting `ReplyStatus::Deleted` does not safely reconstruct that state.
+
+34O therefore rejects every prepared `ReplyStatus::Deleted` before opening the write transaction. It does not invent a tombstone time from `created_at`, import execution time or any other surrogate.
+
+This means a bounded batch containing a deleted reply is rejected atomically rather than partially importing the remaining records.
+
+## Internal generated IDs
+
+34O never generates imported Category, Topic or Reply UUIDs. Those remain the caller-admitted identities from 34K/34L.
+
+Owner-internal child rows such as category translations, topic translations, reply bodies and taxonomy links may continue using their existing internal identity allocation. Those IDs have never been claimed as source entity identities.
+
+## Current FORUM-34 import chain
+
+The bounded import chain is now:
+
+`34A mapping -> 34B/34C inspection -> 34K identity/application resolution -> 34L owner-write preparation -> 34M relation admission -> 34N relation persistence bridge -> 34O atomic non-deleted content application`.
+
+The remaining deleted-reply gap is explicit rather than silently degraded.
+
+## Next FORUM-34 cursor
+
+The next safe slice should be **FORUM-34P**: extend the NodeBB mapping/inspection/resolution/write-preparation chain with a real admitted reply tombstone/deletion timestamp, then enable owner-equivalent deleted-reply persistence and delete-revision capture without inventing historical facts.
+
+The fresh Alloy importer is not the neutral shared migration runner FORUM-34 needs. After the tombstone gap closes, durable checkpoint/replay execution should wait for a genuinely shared owner-data migration runner contract rather than introducing a Forum-local journal.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-atomic-import-content-source.mjs
+```

--- a/scripts/verify/verify-forum-atomic-import-content-source.mjs
+++ b/scripts/verify/verify-forum-atomic-import-content-source.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  services: "crates/rustok-forum/src/services/mod.rs",
+  categoryImport: "crates/rustok-forum/src/services/category_import.rs",
+  topicImport: "crates/rustok-forum/src/services/topic_import.rs",
+  replyImport: "crates/rustok-forum/src/services/reply_owner_import.rs",
+  importWrite: "crates/rustok-forum/src/services/import_write.rs",
+  relationImport: "crates/rustok-forum/src/services/mention_relation_import.rs",
+  categoryOwner: "crates/rustok-forum/src/services/category_projection_owner.rs",
+  topicOwner: "crates/rustok-forum/src/services/topic_inline.rs",
+  replyOwner: "crates/rustok-forum/src/services/reply_owner_inline.rs",
+  packet: "docs/modules/forum-34-atomic-import-content-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  'include!("category_import.rs");',
+  'mod import_write;',
+  'include!("reply_owner_import.rs");',
+  'include!("topic_import.rs");',
+  'ForumImportWriteResult, ForumImportWriteService, MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH',
+]) need(source.services, marker, "FORUM-34O service wiring");
+
+for (const marker of [
+  "pub const MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH: usize =",
+  "pub struct ForumImportWriteResult",
+  "pub struct ForumImportWriteService",
+  "pub async fn apply_prepared_batch(",
+  "PermissionScope::All",
+  "Action::Manage",
+  "normalize_locale_code(&batch.writes.locale)",
+  "FORUM_IMPORT_SOURCE_NODEBB",
+  "ForumImportEntityKind::Category",
+  "ForumImportEntityKind::Topic",
+  "ForumImportEntityKind::Post",
+  "ForumImportEntityKind::User",
+  "ForumImportRelationEventMode::SuppressAddedTargetEvents",
+  "ForumImportRelationEventMode::EmitAddedTargetEvents",
+  "ordered_category_indices",
+  "ordered_reply_indices",
+  "ensure_target_ids_absent_in_tx",
+  "reply.status == ReplyStatus::Deleted",
+  "let txn = self.db.begin().await?;",
+  "publish_forum_projection_scope_direct_in_tx(",
+  "txn.commit().await?;",
+]) need(source.importWrite, marker, "FORUM-34O atomic import adapter");
+
+const beginCount = source.importWrite.split("self.db.begin().await?").length - 1;
+const commitCount = source.importWrite.split("txn.commit().await?").length - 1;
+if (beginCount !== 1 || commitCount !== 1) {
+  throw new Error(`atomic adapter transaction count begin=${beginCount} commit=${commitCount}`);
+}
+
+for (const marker of [
+  "insert_import_category_in_tx(",
+  "id: Set(record.id)",
+  "lock_category_tree_in_tx(txn, tenant_id)",
+  "shift_siblings_for_insert_in_tx(",
+  "ensure_current_route_key_available_in_tx(",
+]) need(source.categoryImport, marker, "FORUM-34O category owner primitive");
+
+for (const marker of [
+  "prepare_import_topic(",
+  "validate_topic_title(&record.title)?;",
+  "normalize_discussion(record.body.clone())?",
+  "prepare_topic_custom_fields_for_create",
+  "validate_normalized_topic_tags",
+  "insert_import_topic_in_tx(",
+  "id: Set(prepared.record.id)",
+  "status: Set(TopicStatus::Open)",
+  "is_locked: Set(false)",
+  "persist_import_admitted_in_tx(",
+  "sync_channel_access_in_tx(",
+  "sync_topic_tags_in_tx(",
+  "adjust_topic_count_in_tx",
+  "DomainEvent::ForumTopicCreated",
+  "finalize_import_topic_in_tx(",
+]) need(source.topicImport, marker, "FORUM-34O topic owner primitive");
+
+for (const marker of [
+  "prepare_import_reply(",
+  "record.status == ReplyStatus::Deleted",
+  "requires an admitted tombstone timestamp",
+  "insert_import_reply_in_tx(",
+  "allocate_reply_position_in_tx(",
+  "id: Set(prepared.record.id)",
+  "persist_import_admitted_in_tx(",
+  "prepared.record.status == ReplyStatus::Approved",
+  "adjust_reply_count_in_tx",
+  "DomainEvent::ForumTopicReplied",
+]) need(source.replyImport, marker, "FORUM-34O reply owner primitive");
+
+for (const marker of [
+  "persist_import_admitted_in_tx(",
+  "self.persist_in_tx(txn, prepared).await?",
+]) need(source.relationImport, marker, "FORUM-34N relation bridge baseline");
+
+for (const marker of [
+  "ensure_current_route_key_available_in_tx",
+  "publish_forum_projection_scope_direct_in_tx",
+]) need(source.categoryOwner, marker, "category owner baseline");
+for (const marker of [
+  "validate_normalized_topic_tags",
+  "sync_channel_access_in_tx",
+  "sync_topic_tags_in_tx",
+  "ForumTopicCreated",
+]) need(source.topicOwner, marker, "topic owner baseline");
+for (const marker of [
+  "allocate_reply_position_in_tx",
+  "status == ReplyStatus::Approved",
+  "ForumTopicReplied",
+]) need(source.replyOwner, marker, "reply owner baseline");
+
+for (const marker of [
+  "FORUM-34O",
+  "FORUM-34A through FORUM-34N",
+  "exact `PermissionScope::All`",
+  "Provisional topic state",
+  "only `ReplyStatus::Approved`",
+  "always calls `publish_forum_projection_scope_direct_in_tx",
+  "rejects every prepared `ReplyStatus::Deleted` before opening the write transaction",
+  "one content transaction",
+  "FORUM-34P",
+  "no tests, Cargo commands",
+]) need(source.packet, marker, "FORUM-34O packet");
+
+for (const marker of [
+  "checkpoint table",
+  "receipt table",
+  "replay journal table",
+]) forbid(source.importWrite, marker, "Forum-local durable runner boundary");
+
+// Imported entity UUIDs must come from admitted records. Internal owner rows
+// intentionally retain their existing UUID allocation, so Uuid::new_v4 is not
+// globally forbidden in the owner primitive files.
+for (const [label, text] of [
+  ["category", source.categoryImport],
+  ["topic", source.topicImport],
+  ["reply", source.replyImport],
+]) {
+  if (!text.includes("id: Set(record.id)") && !text.includes("id: Set(prepared.record.id)")) {
+    throw new Error(`${label} imported entity ID is not visibly caller-admitted`);
+  }
+}
+
+console.log("Forum FORUM-34O atomic prepared import content source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with the first bounded atomic category/topic/reply content application over the 34M/34N prepared relation batch.

- add `ForumImportWriteService::apply_prepared_batch` with a 512 owner-record bound;
- require exact tenant-wide `PermissionScope::All` Manage for each non-empty Category/Topic/Reply owner kind;
- independently revalidate normalized locale, NodeBB Category/Topic/Post/User source identities, admitted author UUIDs, timestamps, dependency closure and exact relation alignment;
- preserve admitted Category/Topic/Reply entity UUIDs, historical authors, creation timestamps and final topic/reply statuses;
- insert categories parent-first through the existing tree lock, sibling placement and route-key owner helpers;
- re-run topic title/RichText/flex/tag admission, persist channels/taxonomy and route admitted relations through the existing 34N owner relation bridge;
- insert topics provisionally Open/unlocked only inside the private transaction so existing reply guards can admit historical replies, then restore the exact prepared status/lock before commit;
- allocate reply positions through the existing owner monotonic position path and insert parents before children;
- count only `ReplyStatus::Approved` replies in topic/category/UserStats public counters and set historical `last_reply_at` to the latest Approved reply timestamp;
- always publish Forum projection invalidation as a consistency signal even when interactive historical events are suppressed;
- perform one begin / one commit for the whole bounded content batch and fail on pre-existing target entity IDs;
- keep deleted replies fail-closed before the transaction because the current import facts do not carry the owner `deleted_at` tombstone timestamp;
- add no Forum-local checkpoint, receipt or replay journal.

## Fresh recheck

The slice started from `b821161ab07bf45d3c8c57d4ff44d5935b27a464`. While it was prepared, `main` advanced through Pages #3417, the Alloy/module-control-plane merge, and Commerce #3418 to `4699fee7c4aa820f8956e097eebf7eabbb14f3c8`. None of those commits changes `crates/rustok-forum`; the branch was replayed onto current main and final compare before opening this PR is `behind 0` with exactly seven files changed.

The new `AlloyReleaseImporter` was explicitly rechecked. It imports exact published Rhai releases into Alloy drafts and owns Alloy-specific lineage/idempotency; it is not a neutral owner-data migration runner for Forum. FORUM-34 therefore still does not introduce a local durable runner.

The canonical Forum implementation plan still has the stale FORUM-34 `planned` ledger row; the dated 34O packet records the truthful cursor without replacing the roadmap wholesale.

## Intentional open boundary

A prepared `ReplyStatus::Deleted` causes the whole batch to fail before `begin()`. The current import chain lacks the separate historical `deleted_at` owner fact used by normal soft-delete/revision capture, and 34O does not invent one from creation time or execution time.

Next safe slice: FORUM-34P admits the real deleted/tombstone timestamp through mapping -> inspection/resolution -> write preparation, then enables owner-equivalent deleted-reply persistence.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run. Maintainer will run tests.