### PR TITLE
feat(pages): align provider health capability preflight

### DIFF
--- a/apps/next-admin/tests/pages-builder-rollout-feature-preflight/feature-preflight.spec.ts
+++ b/apps/next-admin/tests/pages-builder-rollout-feature-preflight/feature-preflight.spec.ts
@@ -28,6 +28,8 @@ const updateSettingsMutation =
   "mutation RolloutPreflightUpdateSettings($moduleSlug: String!, $settings: String!) { updateModuleSettings(moduleSlug: $moduleSlug, settings: $settings) { moduleSlug enabled settings } }";
 const capabilityPreflightQuery =
   "query RolloutCapabilityPreflight { preview: pageBuilderCapabilityPreflight(capability: PREVIEW) { capability allowed errorKind errorCode } properties: pageBuilderCapabilityPreflight(capability: PROPERTIES) { capability allowed errorKind errorCode } publish: pageBuilderCapabilityPreflight(capability: PUBLISH) { capability allowed errorKind errorCode } }";
+const rolloutSnapshotQuery =
+  "query RolloutFeaturePreflightSnapshot { pageBuilderRolloutSnapshot { providerHealthObserved providerHealth { state } } }";
 
 type FileRecord = {
   path: string;
@@ -389,6 +391,31 @@ async function graphql(
   };
 }
 
+async function assertProviderHealthUnobserved(
+  context: BrowserContext,
+  label: string,
+): Promise<Record<string, unknown>> {
+  const result = await graphql(context, rolloutSnapshotQuery, {}, label);
+  const snapshot = objectValue(
+    result.data.pageBuilderRolloutSnapshot,
+    `${label} rollout snapshot`,
+  );
+  if (
+    snapshot.providerHealthObserved !== false ||
+    snapshot.providerHealth !== null
+  ) {
+    fail(`${label} requires provider health to remain unobserved for rollout-only evidence`);
+  }
+  return {
+    status: result.status,
+    response_body_bytes: result.responseBytes,
+    response_body_sha256: result.responseSha256,
+    provider_health_observed: false,
+    provider_health_payload_present: false,
+    raw_request_or_response_persisted: false,
+  };
+}
+
 async function loadPagesModule(
   context: BrowserContext,
 ): Promise<{ settings: Record<string, unknown>; read: GraphqlResult }> {
@@ -582,7 +609,15 @@ test("Pages canonical Page Builder feature preflight matches all rollout profile
     for (const profile of profiles) {
       const settings = withProfile(original.settings, profile.flags);
       const settingsWrite = await writePagesSettings(context, settings);
+      const providerHealthBefore = await assertProviderHealthUnobserved(
+        context,
+        `${profile.id} provider health before feature preflight`,
+      );
       const capabilityPreflight = await runCapabilityPreflight(context, profile);
+      const providerHealthAfter = await assertProviderHealthUnobserved(
+        context,
+        `${profile.id} provider health after feature preflight`,
+      );
       profileObservations[profile.id] = {
         flags: {
           builder_enabled: profile.flags[0],
@@ -591,7 +626,9 @@ test("Pages canonical Page Builder feature preflight matches all rollout profile
           publish_enabled: profile.flags[3],
         },
         settings_write: responseRecord(settingsWrite),
+        provider_health_before: providerHealthBefore,
         capability_preflight: capabilityPreflight,
+        provider_health_after: providerHealthAfter,
       };
     }
   } finally {
@@ -674,6 +711,7 @@ test("Pages canonical Page Builder feature preflight matches all rollout profile
       tokens_or_session_ids_persisted: false,
       raw_module_settings_persisted: false,
       raw_graphql_bodies_persisted: false,
+      provider_health_payload_persisted: false,
       database_urls_persisted: false,
       traces_persisted: false,
       screenshots_persisted: false,

--- a/crates/rustok-page-builder/admin/src/provider_status.rs
+++ b/crates/rustok-page-builder/admin/src/provider_status.rs
@@ -1,6 +1,8 @@
 use fly_ui::{CapabilityState, EditorProviderState};
 use rustok_page_builder::health::{ProviderHealthSnapshot, ProviderHealthState};
-use rustok_page_builder::rollout::BuilderCapabilityFlags;
+use rustok_page_builder::rollout::{
+    BuilderCapabilityFlags, effective_provider_runtime_flags,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PageBuilderAdminProviderState {
@@ -95,28 +97,12 @@ impl PageBuilderAdminProviderStatus {
             && self.state() != PageBuilderAdminProviderState::Unavailable
     }
 
-    /// Derive the Page Builder runtime guard flags from the same provider status used by the UI.
+    /// Derive runtime guard flags through the shared Page Builder core policy.
     ///
-    /// Rollout flags remain the configured authority and health may only narrow them. Observed
-    /// degradation disables publish, while observed unavailability (or invalid/disabled rollout)
-    /// disables the entire builder. `Unobserved` and `Ready` preserve the configured flags.
+    /// Keeping this method as the admin facade seam preserves the existing UI/consumer API while
+    /// preventing Pages or another consumer from reimplementing provider-health narrowing.
     pub fn effective_runtime_flags(&self) -> BuilderCapabilityFlags {
-        match self.state() {
-            PageBuilderAdminProviderState::Unavailable => BuilderCapabilityFlags {
-                builder_enabled: false,
-                preview_enabled: false,
-                properties_enabled: false,
-                publish_enabled: false,
-            },
-            PageBuilderAdminProviderState::Degraded => {
-                let mut flags = self.flags.clone();
-                flags.publish_enabled = false;
-                flags
-            }
-            PageBuilderAdminProviderState::Ready | PageBuilderAdminProviderState::Unobserved => {
-                self.flags.clone()
-            }
-        }
+        effective_provider_runtime_flags(&self.flags, self.health.as_ref())
     }
 
     pub fn limit_capabilities(&self, capabilities: CapabilityState) -> CapabilityState {

--- a/crates/rustok-page-builder/contracts/evidence/page-builder-admin-provider-status-source.json
+++ b/crates/rustok-page-builder/contracts/evidence/page-builder-admin-provider-status-source.json
@@ -11,6 +11,8 @@
     "provider_status_only_narrows_host_capabilities": true,
     "provider_status_only_narrows_runtime_flags": true,
     "effective_runtime_flags_are_canonical": true,
+    "effective_runtime_flags_delegate_to_shared_page_builder_policy": true,
+    "shared_runtime_policy": "rustok_page_builder::rollout::effective_provider_runtime_flags",
     "invalid_rollout_flags_fail_closed_to_unavailable": true,
     "builder_disabled_forces_read_only": true,
     "observed_unavailable_health_forces_read_only": true,

--- a/crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
+++ b/crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const failures = [];
 const files = {
+  coreRollout: "crates/rustok-page-builder/src/rollout.rs",
   status: "crates/rustok-page-builder/admin/src/provider_status.rs",
   facade: "crates/rustok-page-builder/admin/src/transport/mod.rs",
   canvas: "crates/rustok-page-builder/admin/src/editor/modular_canvas.rs",
@@ -68,6 +69,7 @@ for (const key of [
   "provider_status_only_narrows_host_capabilities",
   "provider_status_only_narrows_runtime_flags",
   "effective_runtime_flags_are_canonical",
+  "effective_runtime_flags_delegate_to_shared_page_builder_policy",
   "invalid_rollout_flags_fail_closed_to_unavailable",
   "builder_disabled_forces_read_only",
   "observed_unavailable_health_forces_read_only",
@@ -85,6 +87,10 @@ for (const key of [
 ]) {
   if (evidence.source_contract?.[key] !== true) failures.push(`source_contract.${key} must be true`);
 }
+if (
+  evidence.source_contract?.shared_runtime_policy !==
+  "rustok_page_builder::rollout::effective_provider_runtime_flags"
+) failures.push("shared Page Builder runtime policy identity drifted");
 for (const key of ["tests_run", "static_verifier_run", "cargo_run", "formatting_run", "browser_run", "workflows_or_ci_run"]) {
   if (evidence.source_contract?.[key] !== false) failures.push(`source_contract.${key} must remain false`);
 }
@@ -94,6 +100,15 @@ if (consumerEvidence.format !== "pages_builder_provider_health_consumer_binding_
 if (consumerEvidence.status !== "source_ready_runtime_activation_pending") {
   failures.push("Pages provider-health consumer runtime activation must remain pending");
 }
+
+for (const marker of [
+  "pub fn effective_provider_runtime_flags(",
+  "flags.validate().is_err()",
+  "ProviderHealthState::Unavailable",
+  "ProviderHealthState::Degraded",
+  "effective.publish_enabled = false",
+  "provider_health_runtime_flags_only_narrow_configured_rollout",
+]) need(sources.coreRollout, marker, "shared runtime flag policy");
 
 for (const marker of [
   "pub enum PageBuilderAdminProviderState",
@@ -109,13 +124,15 @@ for (const marker of [
   "!self.flags.publish_enabled",
   "pub fn preview_enabled",
   "pub fn effective_runtime_flags(&self) -> BuilderCapabilityFlags",
-  "PageBuilderAdminProviderState::Unavailable => BuilderCapabilityFlags",
-  "PageBuilderAdminProviderState::Degraded =>",
-  "flags.publish_enabled = false",
-  "PageBuilderAdminProviderState::Ready | PageBuilderAdminProviderState::Unobserved",
+  "effective_provider_runtime_flags(&self.flags, self.health.as_ref())",
   "pub fn limit_capabilities",
   "CapabilityState::read_only()",
 ]) need(sources.status, marker, "provider status contract");
+forbid(
+  sources.status,
+  "PageBuilderAdminProviderState::Unavailable => BuilderCapabilityFlags",
+  "admin provider status must delegate runtime flag derivation to shared core policy",
+);
 
 for (const marker of [
   "unobserved_all_on_status_does_not_claim_healthy_or_reduce_capabilities",
@@ -211,4 +228,4 @@ if (failures.length > 0) {
   failures.forEach((failure) => console.error(`- ${failure}`));
   process.exit(Math.min(failures.length, 255));
 }
-console.log("[verify-page-builder-admin-provider-status] PASS source_ready=true runtime_narrowing=canonical execution=pending");
+console.log("[verify-page-builder-admin-provider-status] PASS source_ready=true runtime_narrowing=shared execution=pending");

--- a/crates/rustok-page-builder/src/rollout.rs
+++ b/crates/rustok-page-builder/src/rollout.rs
@@ -1,4 +1,5 @@
 use crate::dto::BuilderCapabilityKind;
+use crate::health::{ProviderHealthSnapshot, ProviderHealthState};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -280,9 +281,40 @@ pub fn ensure_capability(
     }
 }
 
+/// Derive the effective runtime guard flags from configured rollout plus optional provider health.
+///
+/// Configured rollout remains authoritative and provider state may only narrow it. Invalid or
+/// disabled rollout and observed provider unavailability fail closed to builder-off. Any degraded
+/// provider-control state disables publish while preserving already-disabled rollout capabilities.
+/// Missing health and observed Ready health never grant capabilities beyond configured rollout.
+pub fn effective_provider_runtime_flags(
+    flags: &BuilderCapabilityFlags,
+    health: Option<&ProviderHealthSnapshot>,
+) -> BuilderCapabilityFlags {
+    if flags.validate().is_err()
+        || !flags.builder_enabled
+        || health.is_some_and(|snapshot| snapshot.state == ProviderHealthState::Unavailable)
+    {
+        return BuilderToggleProfile::BuilderOff.flags();
+    }
+
+    let degraded = !flags.preview_enabled
+        || !flags.properties_enabled
+        || !flags.publish_enabled
+        || health.is_some_and(|snapshot| snapshot.state == ProviderHealthState::Degraded);
+    if degraded {
+        let mut effective = flags.clone();
+        effective.publish_enabled = false;
+        effective
+    } else {
+        flags.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::health::{ProviderHealthSnapshot, ProviderSloObservations};
     use serde_json::json;
 
     #[test]
@@ -315,5 +347,57 @@ mod tests {
         ] {
             assert!(BuilderCapabilityFlags::from_module_settings(&settings).is_err());
         }
+    }
+
+    #[test]
+    fn provider_health_runtime_flags_only_narrow_configured_rollout() {
+        let ready = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_000,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.0,
+        });
+        assert_eq!(
+            effective_provider_runtime_flags(&BuilderCapabilityFlags::default(), Some(&ready)),
+            BuilderCapabilityFlags::default()
+        );
+        assert_eq!(
+            effective_provider_runtime_flags(&BuilderToggleProfile::PreviewOff.flags(), Some(&ready)),
+            BuilderToggleProfile::PreviewOff.flags()
+        );
+
+        let degraded = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_600,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.0,
+        });
+        assert_eq!(
+            effective_provider_runtime_flags(&BuilderCapabilityFlags::default(), Some(&degraded)),
+            BuilderToggleProfile::PublishOff.flags()
+        );
+
+        let unavailable = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_000,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.03,
+        });
+        assert_eq!(
+            effective_provider_runtime_flags(&BuilderCapabilityFlags::default(), Some(&unavailable)),
+            BuilderToggleProfile::BuilderOff.flags()
+        );
+
+        let properties_off = BuilderCapabilityFlags {
+            builder_enabled: true,
+            preview_enabled: true,
+            properties_enabled: false,
+            publish_enabled: true,
+        };
+        let effective = effective_provider_runtime_flags(&properties_off, None);
+        assert!(effective.builder_enabled);
+        assert!(effective.preview_enabled);
+        assert!(!effective.properties_enabled);
+        assert!(!effective.publish_enabled);
     }
 }

--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json
@@ -42,6 +42,10 @@
   "rollout_feature_preflight_isolation": {
     "existing_four_profile_harness_remains_rollout_only": true,
     "existing_harness_claims_provider_health_observed": false,
+    "existing_harness_observes_unobserved_health_before_each_profile": true,
+    "existing_harness_observes_unobserved_health_after_each_profile": true,
+    "existing_harness_fails_closed_if_health_is_observed": true,
+    "existing_harness_retains_raw_health_payload": false,
     "observed_health_runtime_evidence_requires_separate_harness": true
   },
   "anti_promotion": {

--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json
@@ -1,0 +1,83 @@
+{
+  "format": "pages_builder_provider_health_capability_preflight_source_v1",
+  "status": "source_ready_runtime_execution_pending",
+  "provider": "page_builder",
+  "predecessors": [
+    "pages_builder_provider_health_server_binding_source_v1",
+    "pages_builder_provider_health_consumer_binding_source_v1"
+  ],
+  "shared_runtime_policy": {
+    "owner": "rustok_page_builder::rollout::effective_provider_runtime_flags",
+    "configured_rollout_flags_remain_authoritative": true,
+    "provider_health_may_only_narrow": true,
+    "invalid_or_builder_disabled_rollout_fails_closed_to_builder_off": true,
+    "unobserved_preserves_configured_rollout": true,
+    "ready_preserves_configured_rollout": true,
+    "degraded_disables_publish_without_reenabling_other_capabilities": true,
+    "unavailable_disables_builder": true,
+    "admin_provider_status_delegates_to_shared_policy": true,
+    "authoritative_ssr_consumes_shared_policy_through_pages_snapshot": true
+  },
+  "graphql_preflight": {
+    "operation": "pageBuilderCapabilityPreflight",
+    "non_mutating": true,
+    "permission_mapping_checked_before_capability_result": true,
+    "configured_rollout_loaded_server_side": true,
+    "provider_health_source": "PagesGraphqlRuntimeData",
+    "fresh_authority_read_per_preflight_request": true,
+    "uses_shared_runtime_policy": true,
+    "uses_canonical_ensure_capability_guard": true,
+    "disabled_error_kind": "feature-disabled",
+    "disabled_error_code": "FEATURE_DISABLED",
+    "unobserved_behavior_matches_rollout_only_preflight": true,
+    "ready_behavior_matches_rollout_only_preflight": true,
+    "degraded_all_on_publish_is_feature_disabled": true,
+    "degraded_all_on_preview_remains_allowed": true,
+    "unavailable_all_on_preview_is_feature_disabled": true,
+    "unavailable_all_on_publish_is_feature_disabled": true,
+    "health_cannot_reenable_rollout_disabled_capability": true,
+    "snapshot_continues_to_return_configured_flags_separately_from_health": true,
+    "raw_acceptance_packet_or_environment_read_in_query": false
+  },
+  "rollout_feature_preflight_isolation": {
+    "existing_four_profile_harness_remains_rollout_only": true,
+    "existing_harness_claims_provider_health_observed": false,
+    "observed_health_runtime_evidence_requires_separate_harness": true
+  },
+  "anti_promotion": {
+    "runtime_identity_capture_executed": false,
+    "runtime_deployment_evaluator_executed": false,
+    "owner_acceptance_executed": false,
+    "accepted_packet_installed": false,
+    "observed_graphql_preflight_executed": false,
+    "observed_workspace_behavior_executed": false,
+    "observed_ssr_behavior_executed": false,
+    "observed_browser_intent_behavior_executed": false,
+    "pages_reference_consumer_gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false
+  },
+  "validation": {
+    "tests_run": false,
+    "node_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "graphql_or_http_run": false,
+    "browser_run": false,
+    "workflow_or_ci_run": false
+  },
+  "production_sources": [
+    "crates/rustok-page-builder/src/rollout.rs",
+    "crates/rustok-page-builder/admin/src/provider_status.rs",
+    "crates/rustok-pages/src/graphql/builder_rollout.rs",
+    "crates/rustok-pages/admin/src/builder.rs"
+  ],
+  "verifier": "crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs",
+  "next_cursor": {
+    "provider_health_capability_preflight": "source_ready_runtime_execution_pending",
+    "observed_health_runtime_evidence_harness": "source_open",
+    "retained_identity_evaluator_owner_acceptance": "maintainer_execution_pending",
+    "observed_health_acceptance": "pending"
+  }
+}

--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-consumer-binding-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-consumer-binding-source.json
@@ -15,7 +15,8 @@
     "degraded_disables_publish": true,
     "unavailable_disables_builder": true,
     "invalid_rollout_disables_builder": true,
-    "runtime_flags_method": "effective_runtime_flags"
+    "runtime_flags_method": "effective_runtime_flags",
+    "runtime_flags_shared_policy": "rustok_page_builder::rollout::effective_provider_runtime_flags"
   },
   "workspace_binding": {
     "fetches_server_owned_rollout_snapshot": true,
@@ -40,12 +41,22 @@
     "unavailable_health_forces_read_only_intent_capabilities": true,
     "missing_health_preserves_rollout_only_behavior": true
   },
+  "non_mutating_capability_preflight": {
+    "operation": "pageBuilderCapabilityPreflight",
+    "uses_server_owned_rollout": true,
+    "uses_fresh_provider_health_authority": true,
+    "uses_shared_runtime_flags_policy": true,
+    "uses_canonical_feature_disabled_guard": true,
+    "permission_denial_remains_separate": true,
+    "raw_acceptance_packet_read_in_query": false
+  },
   "anti_promotion": {
     "runtime_identity_capture_executed": false,
     "runtime_deployment_evaluator_executed": false,
     "owner_acceptance_executed": false,
     "accepted_packet_installed": false,
     "observed_graphql_request_executed": false,
+    "observed_capability_preflight_executed": false,
     "health_driven_workspace_behavior_executed": false,
     "health_driven_ssr_behavior_executed": false,
     "health_driven_browser_intent_behavior_executed": false,
@@ -64,7 +75,9 @@
     "workflow_or_ci_run": false
   },
   "production_sources": [
+    "crates/rustok-page-builder/src/rollout.rs",
     "crates/rustok-page-builder/admin/src/provider_status.rs",
+    "crates/rustok-pages/src/graphql/builder_rollout.rs",
     "crates/rustok-pages/admin/src/builder_rollout_settings.rs",
     "crates/rustok-pages/admin/src/builder.rs",
     "crates/rustok-pages/admin/src/composition.rs",
@@ -73,6 +86,8 @@
   "verifier": "crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs",
   "next_cursor": {
     "provider_health_consumer_binding": "source_ready_runtime_activation_pending",
+    "provider_health_capability_preflight": "source_ready_runtime_execution_pending",
+    "observed_health_runtime_evidence_harness": "source_open",
     "retained_identity_evaluator_owner_acceptance": "maintainer_execution_pending",
     "observed_provider_health_runtime_behavior": "maintainer_execution_pending",
     "observed_health_acceptance": "pending"

--- a/crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-execution-contract.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-execution-contract.json
@@ -67,8 +67,20 @@
     "permission_mapping_reference_is_source_locked": true,
     "server_feature_dependency_required_in_pages": false,
     "rollout_guard_owner": "rustok_page_builder::rollout::ensure_capability",
+    "provider_runtime_policy_owner": "rustok_page_builder::rollout::effective_provider_runtime_flags",
     "feature_disabled_kind": "feature-disabled",
     "feature_disabled_code": "FEATURE_DISABLED"
+  },
+  "provider_health_boundary": {
+    "harness_purpose": "rollout_only",
+    "provider_health_must_remain_unobserved": true,
+    "observation_operation": "pageBuilderRolloutSnapshot",
+    "observe_before_each_profile_preflight": true,
+    "observe_after_each_profile_preflight": true,
+    "provider_health_payload_must_be_absent": true,
+    "fail_if_provider_health_is_observed": true,
+    "retained_health_payload": false,
+    "retained_observation": "http_status_body_hash_and_unobserved_boolean_only"
   },
   "profiles": [
     {"id":"all_on","flags":[true,true,true,true],"preview":"allowed","properties":"allowed","publish":"allowed"},
@@ -109,7 +121,7 @@
   ],
   "forbidden_retained_data": [
     "tenant slugs","tenant ids","authorization headers","cookies","storage state contents","session ids",
-    "access tokens","refresh tokens","raw module settings","raw GraphQL request or response bodies","database urls"
+    "access tokens","refresh tokens","raw module settings","raw GraphQL request or response bodies","provider health payload","database urls"
   ],
   "not_claimed": [
     "owner sign-off","rollback keep decision","pages_reference_consumer_gate accepted",

--- a/crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-harness-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-harness-source.json
@@ -8,11 +8,17 @@
     "preflight_requires_exact_routed_tenant": true,
     "preflight_uses_page_builder_permission_mapping": true,
     "preflight_uses_shared_rollout_guard": true,
+    "preflight_uses_shared_provider_runtime_policy": true,
     "preflight_allowed_path_has_no_error_contract": true,
     "preflight_disabled_kind_is_feature_disabled": true,
     "preflight_disabled_code_is_FEATURE_DISABLED": true,
     "preflight_does_not_invoke_preview_renderer": true,
     "preflight_does_not_invoke_publish_store": true,
+    "rollout_only_harness_requires_provider_health_unobserved": true,
+    "provider_health_observed_before_each_profile": true,
+    "provider_health_observed_after_each_profile": true,
+    "provider_health_payload_must_be_absent": true,
+    "raw_provider_health_payload_persisted": false,
     "browser_predecessor_required": true,
     "rollout_matrix_predecessor_required": true,
     "predecessors_same_source_required": true,
@@ -64,5 +70,5 @@
     "candidate_observed": false,
     "gate_accepted": false
   },
-  "next_cursor": "maintainer executes exact-source browser -> rollout matrix -> feature preflight; the reference candidate then consumes all three execution layers plus artifact/HTTP"
+  "next_cursor": "maintainer executes exact-source browser -> rollout matrix -> feature preflight with provider health observed as unobserved before and after each profile; the reference candidate then consumes all three execution layers plus artifact/HTTP"
 }

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
@@ -14,7 +14,9 @@ const files = {
   runtimeData: "crates/rustok-pages/src/graphql/runtime_data.rs",
   pagesSnapshot: "crates/rustok-pages/admin/src/builder_rollout_settings.rs",
   pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
+  rolloutHarnessContract: "crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-execution-contract.json",
   rolloutHarnessEvidence: "crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-harness-source.json",
+  rolloutHarnessSpec: "apps/next-admin/tests/pages-builder-rollout-feature-preflight/feature-preflight.spec.ts",
   consumerBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-consumer-binding-source.json",
   serverBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-server-binding-source.json",
   gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
@@ -51,6 +53,7 @@ const sources = Object.fromEntries(
   Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
 );
 const contract = JSON.parse(sources.contract);
+const rolloutHarnessContract = JSON.parse(sources.rolloutHarnessContract);
 const rolloutHarnessEvidence = JSON.parse(sources.rolloutHarnessEvidence);
 const consumerBinding = JSON.parse(sources.consumerBinding);
 const serverBinding = JSON.parse(sources.serverBinding);
@@ -79,6 +82,10 @@ for (const [object, key, expected] of [
   [contract.graphql_preflight, "snapshot_continues_to_return_configured_flags_separately_from_health", true],
   [contract.rollout_feature_preflight_isolation, "existing_four_profile_harness_remains_rollout_only", true],
   [contract.rollout_feature_preflight_isolation, "existing_harness_claims_provider_health_observed", false],
+  [contract.rollout_feature_preflight_isolation, "existing_harness_observes_unobserved_health_before_each_profile", true],
+  [contract.rollout_feature_preflight_isolation, "existing_harness_observes_unobserved_health_after_each_profile", true],
+  [contract.rollout_feature_preflight_isolation, "existing_harness_fails_closed_if_health_is_observed", true],
+  [contract.rollout_feature_preflight_isolation, "existing_harness_retains_raw_health_payload", false],
   [contract.anti_promotion, "observed_graphql_preflight_executed", false],
   [contract.anti_promotion, "pages_reference_consumer_gate_accepted", false],
   [contract.validation, "tests_run", false],
@@ -147,9 +154,39 @@ for (const marker of [
   "compose_fly_page_builder_handlers(store, renderer, effective_flags)",
 ]) need(sources.pagesFacade, marker, "authoritative SSR shared-policy path");
 
-if (rolloutHarnessEvidence.source_contract?.provider_health_observed !== false) {
-  failures.push("existing four-profile feature preflight harness must remain provider-health unobserved");
+if (
+  rolloutHarnessContract.provider_health_boundary?.harness_purpose !== "rollout_only" ||
+  rolloutHarnessContract.provider_health_boundary?.provider_health_must_remain_unobserved !== true ||
+  rolloutHarnessContract.provider_health_boundary?.observe_before_each_profile_preflight !== true ||
+  rolloutHarnessContract.provider_health_boundary?.observe_after_each_profile_preflight !== true ||
+  rolloutHarnessContract.provider_health_boundary?.provider_health_payload_must_be_absent !== true ||
+  rolloutHarnessContract.provider_health_boundary?.fail_if_provider_health_is_observed !== true ||
+  rolloutHarnessContract.provider_health_boundary?.retained_health_payload !== false
+) failures.push("existing rollout feature-preflight provider-health boundary drifted");
+for (const key of [
+  "rollout_only_harness_requires_provider_health_unobserved",
+  "provider_health_observed_before_each_profile",
+  "provider_health_observed_after_each_profile",
+  "provider_health_payload_must_be_absent",
+]) {
+  if (rolloutHarnessEvidence.source_contract?.[key] !== true) {
+    failures.push(`rollout harness source_contract.${key} must be true`);
+  }
 }
+if (
+  rolloutHarnessEvidence.source_contract?.provider_health_observed !== false ||
+  rolloutHarnessEvidence.source_contract?.raw_provider_health_payload_persisted !== false
+) failures.push("existing rollout feature-preflight must remain provider-health-unobserved without raw health retention");
+for (const marker of [
+  "pageBuilderRolloutSnapshot { providerHealthObserved providerHealth { state } }",
+  "async function assertProviderHealthUnobserved(",
+  "snapshot.providerHealthObserved !== false",
+  "snapshot.providerHealth !== null",
+  "provider_health_before: providerHealthBefore",
+  "provider_health_after: providerHealthAfter",
+  "provider_health_payload_persisted: false",
+]) need(sources.rolloutHarnessSpec, marker, "rollout-only live provider-health proof");
+
 if (consumerBinding.format !== "pages_builder_provider_health_consumer_binding_source_v1") {
   failures.push("consumer-binding predecessor format drifted");
 }
@@ -189,4 +226,4 @@ if (failures.length) {
   failures.forEach((failure) => console.error(`- ${failure}`));
   process.exit(Math.min(failures.length, 255));
 }
-console.log("[verify-pages-builder-provider-health-capability-preflight] PASS source_ready=true runtime_execution=pending");
+console.log("[verify-pages-builder-provider-health-capability-preflight] PASS source_ready=true rollout_harness_health=fail_closed_unobserved runtime_execution=pending");

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  contract: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json",
+  coreRollout: "crates/rustok-page-builder/src/rollout.rs",
+  providerStatus: "crates/rustok-page-builder/admin/src/provider_status.rs",
+  owner: "crates/rustok-pages/src/graphql/builder_rollout.rs",
+  runtimeData: "crates/rustok-pages/src/graphql/runtime_data.rs",
+  pagesSnapshot: "crates/rustok-pages/admin/src/builder_rollout_settings.rs",
+  pagesFacade: "crates/rustok-pages/admin/src/builder.rs",
+  rolloutHarnessEvidence: "crates/rustok-pages/contracts/evidence/pages-builder-rollout-feature-preflight-harness-source.json",
+  consumerBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-consumer-binding-source.json",
+  serverBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-server-binding-source.json",
+  gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
+  overlay: "docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+};
+
+const absolute = (relativePath) => path.join(repoRoot, relativePath);
+const read = (relativePath) => fs.readFileSync(absolute(relativePath), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(absolute(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(absolute(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length) {
+  console.error("[verify-pages-builder-provider-health-capability-preflight] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const contract = JSON.parse(sources.contract);
+const rolloutHarnessEvidence = JSON.parse(sources.rolloutHarnessEvidence);
+const consumerBinding = JSON.parse(sources.consumerBinding);
+const serverBinding = JSON.parse(sources.serverBinding);
+const gate = JSON.parse(sources.gate);
+
+if (contract.format !== "pages_builder_provider_health_capability_preflight_source_v1") {
+  failures.push("provider-health capability preflight contract format drifted");
+}
+if (contract.status !== "source_ready_runtime_execution_pending") {
+  failures.push("provider-health capability preflight must remain source-ready/runtime-execution-pending");
+}
+for (const [object, key, expected] of [
+  [contract.shared_runtime_policy, "owner", "rustok_page_builder::rollout::effective_provider_runtime_flags"],
+  [contract.shared_runtime_policy, "configured_rollout_flags_remain_authoritative", true],
+  [contract.shared_runtime_policy, "provider_health_may_only_narrow", true],
+  [contract.shared_runtime_policy, "admin_provider_status_delegates_to_shared_policy", true],
+  [contract.graphql_preflight, "operation", "pageBuilderCapabilityPreflight"],
+  [contract.graphql_preflight, "non_mutating", true],
+  [contract.graphql_preflight, "provider_health_source", "PagesGraphqlRuntimeData"],
+  [contract.graphql_preflight, "fresh_authority_read_per_preflight_request", true],
+  [contract.graphql_preflight, "uses_shared_runtime_policy", true],
+  [contract.graphql_preflight, "disabled_error_kind", "feature-disabled"],
+  [contract.graphql_preflight, "disabled_error_code", "FEATURE_DISABLED"],
+  [contract.graphql_preflight, "degraded_all_on_publish_is_feature_disabled", true],
+  [contract.graphql_preflight, "unavailable_all_on_preview_is_feature_disabled", true],
+  [contract.graphql_preflight, "snapshot_continues_to_return_configured_flags_separately_from_health", true],
+  [contract.rollout_feature_preflight_isolation, "existing_four_profile_harness_remains_rollout_only", true],
+  [contract.rollout_feature_preflight_isolation, "existing_harness_claims_provider_health_observed", false],
+  [contract.anti_promotion, "observed_graphql_preflight_executed", false],
+  [contract.anti_promotion, "pages_reference_consumer_gate_accepted", false],
+  [contract.validation, "tests_run", false],
+  [contract.validation, "node_verifier_run", false],
+]) {
+  if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
+}
+
+for (const marker of [
+  "pub fn effective_provider_runtime_flags(",
+  "flags.validate().is_err()",
+  "ProviderHealthState::Unavailable",
+  "ProviderHealthState::Degraded",
+  "effective.publish_enabled = false",
+  "provider_health_runtime_flags_only_narrow_configured_rollout",
+]) need(sources.coreRollout, marker, "shared Page Builder runtime policy");
+
+for (const marker of [
+  "effective_provider_runtime_flags",
+  "pub fn effective_runtime_flags(&self) -> BuilderCapabilityFlags",
+  "effective_provider_runtime_flags(&self.flags, self.health.as_ref())",
+]) need(sources.providerStatus, marker, "admin provider status delegation");
+forbid(
+  sources.providerStatus,
+  "PageBuilderAdminProviderState::Unavailable => BuilderCapabilityFlags",
+  "admin provider status must not retain a second runtime-flag policy",
+);
+
+for (const marker of [
+  "fn provider_health_snapshot(ctx: &Context<'_>) -> Option<ProviderHealthSnapshot>",
+  "PagesGraphqlRuntimeData::provider_health_snapshot",
+  "async fn page_builder_capability_preflight(",
+  "let required_permission = required_page_builder_permission(capability_kind);",
+  "let flags = load_rollout_flags(db, tenant).await?;",
+  "let provider_health = provider_health_snapshot(ctx);",
+  "effective_provider_runtime_flags(&flags, provider_health.as_ref())",
+  "ensure_capability(&effective_flags, capability_kind)",
+  "PageBuilderErrorKind::FeatureDisabled.as_str()",
+  "PAGE_BUILDER_FEATURE_DISABLED_ERROR_CODE",
+]) need(sources.owner, marker, "Pages GraphQL provider-health preflight");
+
+const snapshotStart = sources.owner.indexOf("async fn page_builder_rollout_snapshot(");
+const preflightStart = sources.owner.indexOf("async fn page_builder_capability_preflight(");
+const mappingStart = sources.owner.indexOf("\nfn required_page_builder_permission(", preflightStart);
+if (snapshotStart < 0 || preflightStart <= snapshotStart || mappingStart <= preflightStart) {
+  failures.push("GraphQL rollout/preflight source slices could not be isolated");
+} else {
+  const snapshotSlice = sources.owner.slice(snapshotStart, preflightStart);
+  const preflightSlice = sources.owner.slice(preflightStart, mappingStart);
+  forbid(snapshotSlice, "effective_provider_runtime_flags", "rollout snapshot must expose configured flags separately from health");
+  for (const marker of ["save_project(", "render_preview(", ".publish(", "save_document(", "std::fs::", "RUSTOK_PAGES_PROVIDER_HEALTH_ACCEPTANCE_PATH"]) {
+    forbid(preflightSlice, marker, "non-mutating provider-health capability preflight");
+  }
+}
+
+for (const marker of [
+  "provider_health_authority",
+  "authority.current_snapshot()",
+]) need(sources.runtimeData, marker, "fresh GraphQL runtime health authority");
+
+for (const marker of [
+  "self.provider_status().effective_runtime_flags()",
+]) need(sources.pagesSnapshot, marker, "Pages snapshot runtime-policy delegation");
+for (const marker of [
+  "let effective_flags = trusted_rollout.effective_runtime_flags();",
+  "compose_fly_page_builder_handlers(store, renderer, effective_flags)",
+]) need(sources.pagesFacade, marker, "authoritative SSR shared-policy path");
+
+if (rolloutHarnessEvidence.source_contract?.provider_health_observed !== false) {
+  failures.push("existing four-profile feature preflight harness must remain provider-health unobserved");
+}
+if (consumerBinding.format !== "pages_builder_provider_health_consumer_binding_source_v1") {
+  failures.push("consumer-binding predecessor format drifted");
+}
+if (serverBinding.format !== "pages_builder_provider_health_server_binding_source_v1") {
+  failures.push("server-binding predecessor format drifted");
+}
+if (gate.accepted !== false || gate.current_boundary?.provider_health !== "unobserved") {
+  failures.push("Pages reference-consumer gate must remain unaccepted/provider-health-unobserved in retained execution evidence");
+}
+
+for (const marker of [
+  "provider-health-capability-preflight-source-ready",
+  "shared Page Builder runtime policy",
+  "pageBuilderCapabilityPreflight",
+  "FEATURE_DISABLED",
+  "runtime execution remains maintainer-owned",
+  "Tests were not run",
+]) need(sources.overlay, marker, "provider-health preflight actualization");
+for (const marker of [
+  "provider-health-capability-preflight-source-ready",
+  "pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md",
+  "health-aware non-mutating capability preflight [source-ready]",
+]) need(sources.parity, marker, "plan parity actualization");
+
+if (contract.next_cursor?.provider_health_capability_preflight !== "source_ready_runtime_execution_pending") {
+  failures.push("provider-health capability preflight cursor drifted");
+}
+if (contract.next_cursor?.observed_health_runtime_evidence_harness !== "source_open") {
+  failures.push("observed-health runtime evidence harness must remain the next source cursor");
+}
+if (contract.next_cursor?.observed_health_acceptance !== "pending") {
+  failures.push("observed-health acceptance must remain pending");
+}
+
+if (failures.length) {
+  console.error("[verify-pages-builder-provider-health-capability-preflight] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+console.log("[verify-pages-builder-provider-health-capability-preflight] PASS source_ready=true runtime_execution=pending");

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
@@ -8,13 +8,16 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const failures = [];
 const files = {
   contract: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-consumer-binding-source.json",
+  coreRollout: "crates/rustok-page-builder/src/rollout.rs",
   providerStatus: "crates/rustok-page-builder/admin/src/provider_status.rs",
+  owner: "crates/rustok-pages/src/graphql/builder_rollout.rs",
   rollout: "crates/rustok-pages/admin/src/builder_rollout_settings.rs",
   facade: "crates/rustok-pages/admin/src/builder.rs",
   composition: "crates/rustok-pages/admin/src/composition.rs",
   adminMain: "apps/admin/src/main.rs",
   serverBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-server-binding-source.json",
   transport: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-transport-source.json",
+  preflightEvidence: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json",
   gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
   overlay: "docs/modules/pages-page-builder-provider-health-consumer-binding-actualization-2026-08-09.md",
   parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
@@ -46,12 +49,14 @@ const sources = failures.length === 0
 let contract = {};
 let serverBinding = {};
 let transport = {};
+let preflightEvidence = {};
 let gate = {};
 if (failures.length === 0) {
   for (const [label, assign] of [
     ["contract", (value) => (contract = value)],
     ["serverBinding", (value) => (serverBinding = value)],
     ["transport", (value) => (transport = value)],
+    ["preflightEvidence", (value) => (preflightEvidence = value)],
     ["gate", (value) => (gate = value)],
   ]) {
     try {
@@ -74,6 +79,9 @@ if (serverBinding.format !== "pages_builder_provider_health_server_binding_sourc
 if (transport.format !== "pages_builder_provider_health_transport_source_v1") {
   failures.push("transport predecessor format drifted");
 }
+if (preflightEvidence.format !== "pages_builder_provider_health_capability_preflight_source_v1") {
+  failures.push("provider-health capability preflight continuation is missing");
+}
 
 for (const [object, key, expected] of [
   [contract.canonical_provider_status, "configured_rollout_flags_remain_authoritative", true],
@@ -83,6 +91,7 @@ for (const [object, key, expected] of [
   [contract.canonical_provider_status, "degraded_disables_publish", true],
   [contract.canonical_provider_status, "unavailable_disables_builder", true],
   [contract.canonical_provider_status, "runtime_flags_method", "effective_runtime_flags"],
+  [contract.canonical_provider_status, "runtime_flags_shared_policy", "rustok_page_builder::rollout::effective_provider_runtime_flags"],
   [contract.workspace_binding, "fetches_server_owned_rollout_snapshot", true],
   [contract.workspace_binding, "uses_validated_provider_status", true],
   [contract.workspace_binding, "facade_receives_provider_status", true],
@@ -91,23 +100,38 @@ for (const [object, key, expected] of [
   [contract.authoritative_ssr_binding, "missing_health_uses_configured_rollout_flags", true],
   [contract.standalone_browser_intent_binding, "uses_pages_editor_capabilities_for_snapshot", true],
   [contract.standalone_browser_intent_binding, "role_capabilities_evaluated_before_provider_narrowing", true],
+  [contract.non_mutating_capability_preflight, "operation", "pageBuilderCapabilityPreflight"],
+  [contract.non_mutating_capability_preflight, "uses_fresh_provider_health_authority", true],
+  [contract.non_mutating_capability_preflight, "uses_shared_runtime_flags_policy", true],
+  [contract.non_mutating_capability_preflight, "uses_canonical_feature_disabled_guard", true],
   [contract.anti_promotion, "accepted_packet_installed", false],
+  [contract.anti_promotion, "observed_capability_preflight_executed", false],
   [contract.anti_promotion, "pages_reference_consumer_gate_accepted", false],
-  [contract.anti_promotion, "forum_wave_accepted", false],
   [contract.validation, "tests_run", false],
   [contract.validation, "node_verifier_run", false],
-  [contract.validation, "cargo_run", false],
 ]) {
   if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
 }
 
 for (const marker of [
+  "pub fn effective_provider_runtime_flags(",
+  "effective.publish_enabled = false",
+]) need(sources.coreRollout ?? "", marker, "shared Page Builder provider runtime policy");
+
+for (const marker of [
   "pub fn effective_runtime_flags(&self) -> BuilderCapabilityFlags",
-  "PageBuilderAdminProviderState::Unavailable => BuilderCapabilityFlags",
-  "PageBuilderAdminProviderState::Degraded =>",
-  "flags.publish_enabled = false",
-  "PageBuilderAdminProviderState::Ready | PageBuilderAdminProviderState::Unobserved",
+  "effective_provider_runtime_flags(&self.flags, self.health.as_ref())",
 ]) need(sources.providerStatus ?? "", marker, "canonical provider status runtime flags");
+
+for (const marker of [
+  "fn provider_health_snapshot(ctx: &Context<'_>) -> Option<ProviderHealthSnapshot>",
+  "let provider_health = provider_health_snapshot(ctx);",
+  "effective_provider_runtime_flags(&flags, provider_health.as_ref())",
+  "ensure_capability(&effective_flags, capability_kind)",
+]) need(sources.owner ?? "", marker, "non-mutating provider-health preflight");
+for (const forbidden of ["std::fs::", "RUSTOK_PAGES_PROVIDER_HEALTH_ACCEPTANCE_PATH"]) {
+  forbid(sources.owner ?? "", forbidden, "GraphQL query must consume typed runtime authority");
+}
 
 for (const marker of [
   "pub fn provider_status(&self) -> PageBuilderAdminProviderStatus",
@@ -156,24 +180,25 @@ if (gate.current_boundary?.provider_health !== "unobserved") {
 
 for (const marker of [
   "consumer-provider-health-binding-source-ready",
-  "workspace-observed-health-source-ready",
   "authoritative-ssr-health-guard-source-ready",
-  "browser-intent-health-preflight-source-ready",
-  "Pages remains `unobserved` without a live accepted packet",
-  "Tests were not run",
+  "runtime activation remains maintainer-owned",
 ]) need(sources.overlay ?? "", marker, "consumer binding actualization");
 
 for (const marker of [
   "provider-health-consumer-binding-source-ready",
+  "provider-health-capability-preflight-source-ready",
   "pages-page-builder-provider-health-consumer-binding-actualization-2026-08-09.md",
-  "UI / SSR / browser-intent provider-health binding [source-ready]",
+  "health-aware non-mutating capability preflight [source-ready]",
 ]) need(sources.parity ?? "", marker, "plan parity actualization");
 
 if (contract.next_cursor?.provider_health_consumer_binding !== "source_ready_runtime_activation_pending") {
   failures.push("consumer binding cursor drifted");
 }
-if (contract.next_cursor?.retained_identity_evaluator_owner_acceptance !== "maintainer_execution_pending") {
-  failures.push("maintainer runtime evidence cursor drifted");
+if (contract.next_cursor?.provider_health_capability_preflight !== "source_ready_runtime_execution_pending") {
+  failures.push("provider-health capability preflight cursor drifted");
+}
+if (contract.next_cursor?.observed_health_runtime_evidence_harness !== "source_open") {
+  failures.push("observed-health runtime evidence harness must remain next source cursor");
 }
 if (contract.next_cursor?.observed_health_acceptance !== "pending") {
   failures.push("observed health acceptance must remain pending");
@@ -185,4 +210,4 @@ if (failures.length > 0) {
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log("[verify-pages-builder-provider-health-consumer-binding] PASS consumers=workspace+ssr+browser_intent source_ready=true runtime_activation=pending");
+console.log("[verify-pages-builder-provider-health-consumer-binding] PASS consumers=workspace+ssr+browser_intent preflight=health_aware source_ready=true runtime_activation=pending");

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
@@ -135,7 +135,9 @@ for (const marker of [
   "pub struct GqlPageBuilderCapabilityPreflight",
   "async fn page_builder_capability_preflight(",
   "let required_permission = required_page_builder_permission(capability_kind);",
-  "ensure_capability(&flags, capability_kind)",
+  "let provider_health = provider_health_snapshot(ctx);",
+  "effective_provider_runtime_flags(&flags, provider_health.as_ref())",
+  "ensure_capability(&effective_flags, capability_kind)",
   "PageBuilderErrorKind::FeatureDisabled.as_str()",
   "PAGE_BUILDER_FEATURE_DISABLED_ERROR_CODE",
   "fn required_page_builder_permission(capability: BuilderCapabilityKind) -> Permission",
@@ -151,7 +153,7 @@ if (preflightStart < 0 || permissionMappingStart <= preflightStart) {
   failures.push("non-mutating preflight source slice could not be isolated");
 } else {
   const preflight = owner.slice(preflightStart, permissionMappingStart);
-  for (const marker of ["save_project(", "render_preview(", ".publish(", "save_document("]) {
+  for (const marker of ["save_project(", "render_preview(", ".publish(", "save_document(", "std::fs::"]) {
     forbid(preflight, marker, "non-mutating feature preflight");
   }
 }
@@ -169,7 +171,9 @@ for (const marker of [
 for (const marker of [
   "pub fn ensure_capability(",
   "Err(BuilderRolloutError::CapabilityDisabled(capability.as_str()))",
-]) need(rollout, marker, "shared rollout guard");
+  "pub fn effective_provider_runtime_flags(",
+  "provider_health_runtime_flags_only_narrow_configured_rollout",
+]) need(rollout, marker, "shared rollout/provider guard");
 for (const marker of [
   "Self::CapabilityDisabled(_) => PageBuilderErrorKind::FeatureDisabled",
   "Self::CapabilityDisabled(_) => Some(PAGE_BUILDER_FEATURE_DISABLED_ERROR_CODE)",

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
@@ -80,9 +80,21 @@ if (
   contract.capability_preflight?.permission_mapping_reference_is_source_locked !== true ||
   contract.capability_preflight?.server_feature_dependency_required_in_pages !== false ||
   contract.capability_preflight?.rollout_guard_owner !== "rustok_page_builder::rollout::ensure_capability" ||
+  contract.capability_preflight?.provider_runtime_policy_owner !== "rustok_page_builder::rollout::effective_provider_runtime_flags" ||
   contract.capability_preflight?.feature_disabled_kind !== "feature-disabled" ||
   contract.capability_preflight?.feature_disabled_code !== "FEATURE_DISABLED"
 ) failures.push("canonical feature preflight contract drifted");
+
+if (
+  contract.provider_health_boundary?.harness_purpose !== "rollout_only" ||
+  contract.provider_health_boundary?.provider_health_must_remain_unobserved !== true ||
+  contract.provider_health_boundary?.observation_operation !== "pageBuilderRolloutSnapshot" ||
+  contract.provider_health_boundary?.observe_before_each_profile_preflight !== true ||
+  contract.provider_health_boundary?.observe_after_each_profile_preflight !== true ||
+  contract.provider_health_boundary?.provider_health_payload_must_be_absent !== true ||
+  contract.provider_health_boundary?.fail_if_provider_health_is_observed !== true ||
+  contract.provider_health_boundary?.retained_health_payload !== false
+) failures.push("rollout-only provider-health observation boundary drifted");
 
 if (
   contract.settings_authority?.read_operation !== "tenantModules" ||
@@ -107,6 +119,13 @@ for (const marker of [
   "pageBuilderCapabilityPreflight(capability: PREVIEW)",
   "pageBuilderCapabilityPreflight(capability: PROPERTIES)",
   "pageBuilderCapabilityPreflight(capability: PUBLISH)",
+  "pageBuilderRolloutSnapshot { providerHealthObserved providerHealth { state } }",
+  "async function assertProviderHealthUnobserved(",
+  "snapshot.providerHealthObserved !== false",
+  "snapshot.providerHealth !== null",
+  "provider_health_payload_present: false",
+  "provider_health_before: providerHealthBefore",
+  "provider_health_after: providerHealthAfter",
   'result.errorKind !== "feature-disabled"',
   'result.errorCode !== "FEATURE_DISABLED"',
   "matrixBrowser.sha256 !== browser.record.sha256",
@@ -121,6 +140,7 @@ for (const marker of [
   "feature_preflight_executed: true",
   "gate_accepted: false",
   "provider_health_observed: false",
+  "provider_health_payload_persisted: false",
   "renameSync(temporary, location)",
 ]) need(spec, marker, "feature preflight spec");
 for (const marker of [
@@ -193,17 +213,20 @@ for (const [key, value] of Object.entries(evidence.validation ?? {})) if (value 
 for (const key of [
   "server_owned_non_mutating_preflight_added", "preflight_requires_exact_routed_tenant",
   "preflight_uses_page_builder_permission_mapping", "preflight_uses_shared_rollout_guard",
-  "preflight_allowed_path_has_no_error_contract", "preflight_disabled_kind_is_feature_disabled",
-  "preflight_disabled_code_is_FEATURE_DISABLED", "browser_predecessor_required",
-  "rollout_matrix_predecessor_required", "predecessors_same_source_required",
+  "preflight_uses_shared_provider_runtime_policy", "preflight_allowed_path_has_no_error_contract",
+  "preflight_disabled_kind_is_feature_disabled", "preflight_disabled_code_is_FEATURE_DISABLED",
+  "rollout_only_harness_requires_provider_health_unobserved", "provider_health_observed_before_each_profile",
+  "provider_health_observed_after_each_profile", "provider_health_payload_must_be_absent",
+  "browser_predecessor_required", "rollout_matrix_predecessor_required", "predecessors_same_source_required",
   "rollout_matrix_must_bind_exact_browser_hash", "api_origin_and_deployment_digest_must_match_predecessors",
   "original_settings_restored_in_finally", "restore_semantically_verified", "output_is_atomic",
 ]) if (evidence.source_contract?.[key] !== true) failures.push(`source_contract.${key} must be true`);
 for (const key of [
   "direct_sql_used", "raw_database_access_used", "raw_module_settings_persisted",
-  "raw_graphql_bodies_persisted", "credentials_or_storage_contents_persisted",
-  "automatic_gate_acceptance", "automatic_source_mutation", "automatic_ffa_fba_promotion",
-  "provider_health_observed", "gate_accepted", "forum_wave_accepted", "ffa_promoted", "fba_promoted",
+  "raw_graphql_bodies_persisted", "raw_provider_health_payload_persisted",
+  "credentials_or_storage_contents_persisted", "automatic_gate_acceptance", "automatic_source_mutation",
+  "automatic_ffa_fba_promotion", "provider_health_observed", "gate_accepted", "forum_wave_accepted",
+  "ffa_promoted", "fba_promoted",
 ]) if (evidence.source_contract?.[key] !== false) failures.push(`source_contract.${key} must remain false`);
 
 for (const marker of [
@@ -217,4 +240,4 @@ if (failures.length) {
   failures.forEach((failure) => console.error(`- ${failure}`));
   process.exit(Math.min(failures.length, 255));
 }
-console.log("[verify-pages-builder-rollout-feature-preflight-harness] PASS source_ready=true execution=not_run gate_accepted=false");
+console.log("[verify-pages-builder-rollout-feature-preflight-harness] PASS source_ready=true health=verified_unobserved execution=not_run gate_accepted=false");

--- a/crates/rustok-pages/src/graphql/builder_rollout.rs
+++ b/crates/rustok-pages/src/graphql/builder_rollout.rs
@@ -8,7 +8,10 @@ use rustok_page_builder::{
         BuilderCapabilityKind, PAGE_BUILDER_FEATURE_DISABLED_ERROR_CODE, PageBuilderErrorKind,
     },
     health::ProviderHealthSnapshot,
-    rollout::{BuilderCapabilityFlags, BuilderRolloutError, ensure_capability},
+    rollout::{
+        BuilderCapabilityFlags, BuilderRolloutError, effective_provider_runtime_flags,
+        ensure_capability,
+    },
 };
 use sea_orm::DatabaseConnection;
 
@@ -125,6 +128,11 @@ impl GqlPageBuilderCapabilityPreflight {
     }
 }
 
+fn provider_health_snapshot(ctx: &Context<'_>) -> Option<ProviderHealthSnapshot> {
+    ctx.data_opt::<PagesGraphqlRuntimeData>()
+        .and_then(PagesGraphqlRuntimeData::provider_health_snapshot)
+}
+
 #[derive(Default)]
 pub struct PageBuilderRolloutQuery;
 
@@ -141,22 +149,21 @@ impl PageBuilderRolloutQuery {
         ensure_pages_read_authority(auth, tenant)?;
         let flags = load_rollout_flags(db, tenant).await?;
         let snapshot = GqlPageBuilderRolloutSnapshot::new(tenant, flags);
-        let provider_health = ctx
-            .data_opt::<PagesGraphqlRuntimeData>()
-            .and_then(PagesGraphqlRuntimeData::provider_health_snapshot);
 
-        Ok(match provider_health {
+        Ok(match provider_health_snapshot(ctx) {
             Some(health) => snapshot.with_provider_health(&health),
             None => snapshot,
         })
     }
 
-    /// Non-mutating rollout/RBAC preflight for canonical Page Builder capability evidence.
+    /// Non-mutating rollout/RBAC/provider-health preflight for canonical Page Builder capability
+    /// evidence.
     ///
-    /// The permission check mirrors the Page Builder authorizer mapping and is source-locked
-    /// against `PageBuilderCapabilityPermissions` by the feature-preflight verifier. The shared
-    /// rollout guard then yields the canonical `feature-disabled / FEATURE_DISABLED` contract
-    /// without invoking preview rendering or publish persistence.
+    /// Permission checks mirror the Page Builder authorizer mapping. Configured rollout flags are
+    /// loaded server-side, then the same shared Page Builder provider-runtime policy used by Pages
+    /// authoritative SSR narrows them with a fresh owner-accepted provider-health snapshot when one
+    /// exists. `ensure_capability` therefore yields the canonical
+    /// `feature-disabled / FEATURE_DISABLED` result without rendering preview or persisting publish.
     async fn page_builder_capability_preflight(
         &self,
         ctx: &Context<'_>,
@@ -178,7 +185,9 @@ impl PageBuilderRolloutQuery {
         }
 
         let flags = load_rollout_flags(db, tenant).await?;
-        match ensure_capability(&flags, capability_kind) {
+        let provider_health = provider_health_snapshot(ctx);
+        let effective_flags = effective_provider_runtime_flags(&flags, provider_health.as_ref());
+        match ensure_capability(&effective_flags, capability_kind) {
             Ok(()) => Ok(GqlPageBuilderCapabilityPreflight::allow(capability)),
             Err(BuilderRolloutError::CapabilityDisabled(_)) => Ok(
                 GqlPageBuilderCapabilityPreflight::feature_disabled(capability),
@@ -254,6 +263,7 @@ fn ensure_pages_read_authority(auth: &AuthContext, tenant: &TenantContext) -> Re
 mod tests {
     use super::*;
     use rustok_page_builder::health::{ProviderHealthState, ProviderSloObservations};
+    use rustok_page_builder::rollout::BuilderToggleProfile;
     use uuid::Uuid;
 
     fn tenant(id: Uuid) -> TenantContext {
@@ -292,7 +302,7 @@ mod tests {
         assert!(
             ensure_pages_read_authority(
                 &auth(Uuid::new_v4(), vec![Permission::PAGES_READ]),
-                &tenant,
+                &tenant
             )
             .is_err()
         );
@@ -335,6 +345,45 @@ mod tests {
         assert!(allowed.allowed);
         assert!(allowed.error_kind.is_none());
         assert!(allowed.error_code.is_none());
+    }
+
+    #[test]
+    fn provider_health_preflight_flags_match_authoritative_runtime_policy() {
+        let degraded = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_600,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.0,
+        });
+        let degraded_flags = effective_provider_runtime_flags(
+            &BuilderCapabilityFlags::default(),
+            Some(&degraded),
+        );
+        assert_eq!(degraded_flags, BuilderToggleProfile::PublishOff.flags());
+        assert!(ensure_capability(&degraded_flags, BuilderCapabilityKind::Preview).is_ok());
+        assert_eq!(
+            ensure_capability(&degraded_flags, BuilderCapabilityKind::Publish),
+            Err(BuilderRolloutError::CapabilityDisabled("publish"))
+        );
+
+        let unavailable = ProviderHealthSnapshot::evaluate(ProviderSloObservations {
+            preview_p95_ms: 1_000,
+            publish_p95_ms: 2_000,
+            sanitize_failure_rate: 0.0,
+            runtime_error_rate: 0.03,
+        });
+        assert_eq!(unavailable.state, ProviderHealthState::Unavailable);
+        let unavailable_flags = effective_provider_runtime_flags(
+            &BuilderCapabilityFlags::default(),
+            Some(&unavailable),
+        );
+        assert_eq!(unavailable_flags, BuilderToggleProfile::BuilderOff.flags());
+        assert!(
+            ensure_capability(&unavailable_flags, BuilderCapabilityKind::Preview).is_err()
+        );
+        assert!(
+            ensure_capability(&unavailable_flags, BuilderCapabilityKind::Publish).is_err()
+        );
     }
 
     #[test]

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,10 +1,10 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / provider-health-transport-source-ready / provider-health-owner-acceptance-source-ready / provider-health-server-binding-source-ready / provider-health-consumer-binding-source-ready / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / provider-health-transport-source-ready / provider-health-owner-acceptance-source-ready / provider-health-server-binding-source-ready / provider-health-consumer-binding-source-ready / provider-health-capability-preflight-source-ready / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has ten source actualizations:
+This parity packet now has eleven source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
 - `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, which remains the current rollout-specific authority after PRs #3333, #3337, #3345 and #3353;
@@ -15,7 +15,8 @@ This parity packet now has ten source actualizations:
 - `docs/modules/pages-page-builder-provider-health-transport-actualization-2026-08-09.md`;
 - `docs/modules/pages-page-builder-provider-health-owner-acceptance-actualization-2026-08-09.md`;
 - `docs/modules/pages-page-builder-provider-health-server-binding-actualization-2026-08-09.md`;
-- `docs/modules/pages-page-builder-provider-health-consumer-binding-actualization-2026-08-09.md`, which supersedes the earlier consumer-open wording and closes workspace, authoritative SSR and standalone browser-intent provider-health source binding.
+- `docs/modules/pages-page-builder-provider-health-consumer-binding-actualization-2026-08-09.md`, which closes workspace, authoritative SSR and standalone browser-intent provider-health source binding;
+- `docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md`, which removes the remaining non-mutating preflight drift by putting admin/SSR/preflight runtime narrowing behind one shared Page Builder core policy.
 
 Older shared/local/central plans remain useful for programme history. Where they conflict with the dated actualizations above, this packet and the newest relevant overlay are the current source truth.
 
@@ -37,13 +38,19 @@ The synchronized Pages / Page Builder source boundary is now:
 - Pages server binding is opt-in and fail-closed over the accepted packet, exact `RUSTOK_SOURCE_COMMIT`, deployment id and immutable RepoDigest; missing, rejected, malformed, mismatched or expired evidence returns the default unobserved GraphQL shape;
 - the accepted packet path is reread on each rollout-status request, so accept/reject/remove/reaccept can revoke or restore observed transport without a process restart;
 - typed admin transport still enforces boolean/payload consistency and independently recomputes canonical `ProviderHealthSnapshot::evaluate` before retaining optional health;
-- `PagesBuilderRolloutSnapshot::provider_status()` is now the canonical Pages consumer seam; missing health yields explicit `Unobserved`, never implicit healthy;
-- `PageBuilderAdminProviderStatus::effective_runtime_flags()` is the single runtime narrowing policy: Ready/Unobserved preserve configured rollout, Degraded disables Publish, and Unavailable disables the builder entirely;
-- Pages workspace now passes the validated full provider status into `PagesBuilderFacade`, so canonical Page Builder admin controls can display observed state/reasons and apply their existing degraded/read-only narrowing;
-- authoritative Preview/Publish SSR rereads the server-owned snapshot per capability request, verifies the routed tenant, derives health-limited runtime flags, and composes the existing canonical Page Builder guards from those flags;
+- `PagesBuilderRolloutSnapshot::provider_status()` remains the canonical Pages consumer seam; missing health yields explicit `Unobserved`, never implicit healthy;
+- provider/rollout runtime narrowing now has one core owner: `rustok_page_builder::rollout::effective_provider_runtime_flags`;
+- that shared policy keeps configured rollout as the upper bound, fails invalid/builder-off or observed Unavailable state to builder-off, and makes every degraded provider-control state publish-off while preserving already-disabled rollout capabilities;
+- `PageBuilderAdminProviderStatus::effective_runtime_flags()` delegates to the shared core policy rather than retaining a second runtime policy implementation;
+- Pages workspace passes the validated full provider status into `PagesBuilderFacade`, so canonical Page Builder admin controls can display observed state/reasons and apply their existing degraded/read-only narrowing;
+- authoritative Preview/Publish SSR rereads the server-owned snapshot per capability request, verifies the routed tenant, derives health-limited runtime flags through the shared policy, and composes the existing canonical Page Builder guards from those flags;
 - therefore observed Degraded health makes Publish reach the existing `FEATURE_DISABLED` guard, while observed Unavailable health makes the builder unavailable through the same guard rather than a parallel Pages-only error path;
 - standalone browser-intent preflight evaluates role capabilities first and then applies `pages_editor_capabilities_for_snapshot`, so provider health can only narrow role/rollout capability state;
-- UI / SSR / browser-intent provider-health binding [source-ready] does not itself prove that a live accepted packet exists or that observed behavior has executed;
+- the non-mutating GraphQL `pageBuilderCapabilityPreflight` now also reads fresh `PagesGraphqlRuntimeData` health and applies `effective_provider_runtime_flags` before canonical `ensure_capability`, eliminating a prior possibility that preflight said Publish was allowed while authoritative SSR denied it under observed Degraded health;
+- permission denial remains separate from provider/rollout capability denial, and `pageBuilderCapabilityPreflight` remains non-mutating with canonical `feature-disabled / FEATURE_DISABLED` output;
+- `pageBuilderRolloutSnapshot` continues to return configured rollout flags separately from optional health; it does not rewrite transport flags to effective values;
+- the existing four-profile rollout feature-preflight harness remains rollout-only and its retained evidence continues to claim provider health `unobserved`; observed-health execution requires a separate evidence harness;
+- UI / SSR / browser-intent provider-health binding [source-ready] and health-aware non-mutating capability preflight [source-ready] do not prove that a live accepted packet exists or that observed behavior has executed;
 - Pages remains `unobserved` in retained execution evidence because live identity capture, evaluator execution, owner acceptance, accepted packet installation and observed consumer behavior have not been executed/retained by this implementation agent;
 - `pages_reference_consumer_gate` remains `accepted = false` with execution pending;
 - Forum observed Wave remains blocked by the Pages gate;
@@ -77,11 +84,13 @@ bounded process-local Preview/Publish observation [source-ready]
 -> owner acceptance packet + exact health_valid_until [source-ready]
 -> server provider-health binding + hot revoke + remaining-freshness lease [source-ready]
 -> UI / SSR / browser-intent provider-health binding [source-ready]
+-> health-aware non-mutating capability preflight [source-ready]
+-> observed-health runtime evidence harness [source-open]
 -> live exact-target identity capture + retained evaluator + accepted owner packet + observed consumer behavior [maintainer execution pending]
 -> observed-health acceptance decision [pending]
 ```
 
-Source inspection alone must not mark execution or acceptance complete. In particular, source-ready health binding cannot replace live exact-deployment evidence or owner acceptance.
+Source inspection alone must not mark execution or acceptance complete. In particular, source-ready health binding or preflight cannot replace live exact-deployment evidence or owner acceptance.
 
 ## Anti-drift guards
 
@@ -99,10 +108,11 @@ crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transpor
 crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-owner-acceptance.mjs
 crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-server-binding.mjs
 crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
+crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
 crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-binding.mjs
 ```
 
-The new consumer guard locks one shared provider-status policy across workspace UI, authoritative SSR and standalone browser-intent, while preserving the no-live-packet `Unobserved` fallback and all execution/non-promotion claims as false.
+The consumer guard locks workspace/SSR/browser-intent to the shared provider-status path. The provider-health capability-preflight guard locks the shared core runtime policy, GraphQL runtime-health authority, non-mutating canonical `FEATURE_DISABLED` path and the separation between configured snapshot flags and effective runtime flags.
 
 ## Execution boundary
 
@@ -113,10 +123,12 @@ Suggested maintainer commands, intentionally not run:
 ```bash
 node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
 node crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-server-binding.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-transport.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-owner-acceptance.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-binding.mjs
 ```
 

--- a/docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md
+++ b/docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md
@@ -1,6 +1,6 @@
 # Pages / Page Builder provider-health capability preflight actualization — 2026-08-09
 
-Status: `provider-health-capability-preflight-source-ready / shared-runtime-policy-source-ready / non-mutating-health-preflight-source-ready / runtime-execution-pending / observed-health-acceptance-pending`.
+Status: `provider-health-capability-preflight-source-ready / shared-runtime-policy-source-ready / non-mutating-health-preflight-source-ready / rollout-only-preflight-health-boundary-source-ready / runtime-execution-pending / observed-health-acceptance-pending`.
 
 ## Why this continuation exists
 
@@ -71,7 +71,9 @@ The rollout snapshot continues to expose the configured flags and provider healt
 
 The existing four-profile rollout feature-preflight harness remains a rollout-only acceptance input and continues to claim provider health as `unobserved`.
 
-The GraphQL operation is now health-aware because production semantics require that parity, but observed-health execution belongs to a separate provider-health evidence harness. The existing rollout matrix/preflight packets must not be reinterpreted as observed SLO evidence.
+Because the production GraphQL preflight is now health-aware, that claim is no longer accepted as a static assumption. The harness now reads `pageBuilderRolloutSnapshot` immediately before and after each profile capability preflight and fails closed unless `providerHealthObserved=false` and the health payload is absent on both observations. The retained profile record contains only HTTP status, bounded response-body size/hash and explicit unobserved/payload-absent booleans; the provider-health payload itself is not retained.
+
+This prevents observed `Ready` health from being silently indistinguishable from rollout-only all-on behavior in a packet that claims provider health was unobserved. Observed-health execution still belongs to a separate provider-health evidence harness. The existing rollout matrix/preflight packets must not be reinterpreted as observed SLO evidence.
 
 ## Runtime evidence boundary
 

--- a/docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md
+++ b/docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md
@@ -1,0 +1,131 @@
+# Pages / Page Builder provider-health capability preflight actualization — 2026-08-09
+
+Status: `provider-health-capability-preflight-source-ready / shared-runtime-policy-source-ready / non-mutating-health-preflight-source-ready / runtime-execution-pending / observed-health-acceptance-pending`.
+
+## Why this continuation exists
+
+PR #3417 closed provider-health source binding for the Pages workspace, authoritative Preview/Publish SSR and standalone browser-intent path. One source inconsistency remained: the non-mutating GraphQL `pageBuilderCapabilityPreflight` still evaluated only configured rollout flags.
+
+That could make evidence disagree with the real server guard after a fresh accepted provider-health packet was installed. With all rollout flags enabled and observed `Degraded` health, authoritative SSR correctly disables Publish, while the old preflight could still report Publish as allowed.
+
+This slice removes that drift without executing any runtime evidence.
+
+## Shared Page Builder runtime policy
+
+The health/rollout narrowing rule now lives in Page Builder core as:
+
+```text
+rustok_page_builder::rollout::effective_provider_runtime_flags
+```
+
+The function takes configured `BuilderCapabilityFlags` plus optional `ProviderHealthSnapshot` and can only narrow configured capabilities:
+
+```text
+invalid rollout or builder disabled -> BuilderOff
+observed Unavailable                -> BuilderOff
+observed Degraded                   -> preserve rollout, force publish=false
+rollout-degraded state              -> preserve disabled rollout fields, force publish=false
+observed Ready                      -> configured rollout unchanged
+Unobserved                          -> configured rollout unchanged
+```
+
+This preserves the policy already used by the Page Builder admin provider status, including partial rollout states such as Properties disabled while Preview remains available. Health cannot re-enable a rollout-disabled capability.
+
+`PageBuilderAdminProviderStatus::effective_runtime_flags()` remains the stable admin-facing seam but now delegates directly to this shared core policy. Pages authoritative SSR continues to call the snapshot/admin seam, so existing consumer code does not gain a second policy implementation.
+
+## Health-aware non-mutating preflight
+
+`pageBuilderCapabilityPreflight` now evaluates in this order:
+
+1. Pages module and routed tenant admission;
+2. canonical Page Builder permission mapping;
+3. server-owned configured rollout read;
+4. fresh optional provider health from `PagesGraphqlRuntimeData`;
+5. shared `effective_provider_runtime_flags` narrowing;
+6. canonical `ensure_capability` result.
+
+The preflight remains non-mutating. It does not render Preview, save Publish data, read the retained acceptance packet directly or inspect provider-health environment configuration.
+
+Disabled capabilities still return the existing Page Builder contract:
+
+```text
+errorKind = feature-disabled
+errorCode = FEATURE_DISABLED
+```
+
+Permission denial remains a separate `FORBIDDEN` boundary and is checked before a capability result is returned.
+
+## Expected observed behavior
+
+With all configured rollout flags enabled:
+
+- `Ready`: Preview, Properties and Publish remain allowed;
+- `Degraded`: Preview and Properties remain allowed, Publish is `FEATURE_DISABLED`;
+- `Unavailable`: Preview, Properties and Publish are `FEATURE_DISABLED`.
+
+With rollout restrictions already present, health may only keep or further narrow those restrictions.
+
+The rollout snapshot continues to expose the configured flags and provider health separately. It does **not** replace its configured flag fields with health-limited effective flags. This keeps the transport auditable and lets clients independently validate the same provider status.
+
+## Existing rollout feature-preflight harness
+
+The existing four-profile rollout feature-preflight harness remains a rollout-only acceptance input and continues to claim provider health as `unobserved`.
+
+The GraphQL operation is now health-aware because production semantics require that parity, but observed-health execution belongs to a separate provider-health evidence harness. The existing rollout matrix/preflight packets must not be reinterpreted as observed SLO evidence.
+
+## Runtime evidence boundary
+
+This source slice does not install or execute a provider-health acceptance packet. It does not call GraphQL, HTTP, browser, Prometheus or the deployment evaluator.
+
+The next source-only cursor is a bounded observed-health runtime evidence harness that can bind:
+
+```text
+exact deployment identity
++ retained deployment evaluator
++ accepted owner packet
++ observed GraphQL health/preflight
++ workspace provider controls
++ authoritative SSR outcome
++ standalone browser-intent outcome
+```
+
+into one owner-review-pending packet without accepting the result automatically.
+
+Runtime execution remains maintainer-owned.
+
+## Non-promotion
+
+This slice does not claim:
+
+- deployment identity capture execution;
+- deployment evaluator execution;
+- owner acceptance execution;
+- accepted packet installation;
+- observed GraphQL/preflight behavior;
+- observed workspace/SSR/browser-intent behavior;
+- Pages reference-consumer gate acceptance;
+- Forum Wave acceptance;
+- FFA/FBA promotion.
+
+Pages remains `unobserved` in retained execution evidence until the exact live chain is executed and retained.
+
+## Source evidence
+
+```text
+crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json
+crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
+```
+
+## Validation boundary
+
+Tests were not run. Node verifiers, Cargo commands, formatting, builds, GraphQL/HTTP requests, Playwright/browser runs, deployment identity capture, Prometheus queries, evaluator execution, owner acceptance, workflows and CI were intentionally not executed.
+
+Suggested maintainer source checks, intentionally not run:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
+node crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
+node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+```


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder provider-health parity cursor after #3417.

#3417 made workspace, authoritative SSR, and standalone browser-intent capability handling health-aware. This PR closes the remaining non-mutating evidence/preflight drift: `pageBuilderCapabilityPreflight` now evaluates the same fresh provider-health authority and shared runtime narrowing policy as authoritative SSR.

### Changes

- move rollout + optional provider-health runtime narrowing into shared Page Builder core `rustok_page_builder::rollout::effective_provider_runtime_flags`;
- make `PageBuilderAdminProviderStatus::effective_runtime_flags()` delegate to that core policy instead of retaining a second implementation;
- make `pageBuilderCapabilityPreflight` load server-owned rollout, read fresh optional `PagesGraphqlRuntimeData` health, apply the shared runtime policy, then use canonical `ensure_capability`;
- preserve configured rollout flags separately in `pageBuilderRolloutSnapshot`; effective health-limited flags are not written back into the transport shape;
- keep permission denial separate as `FORBIDDEN` and capability denial as canonical `feature-disabled / FEATURE_DISABLED`;
- harden the existing rollout-only feature-preflight Playwright harness so it observes `pageBuilderRolloutSnapshot` before and after every profile and fails closed if provider health is observed or a health payload is present;
- retain only HTTP status/body hashes and explicit unobserved/payload-absent booleans for those rollout-only health observations;
- add dedicated provider-health capability-preflight source evidence/verifier and advance the canonical parity cursor.

## Deliberate non-promotion

No deployment identity capture, Prometheus evaluation, owner acceptance, accepted-packet installation, observed GraphQL/provider-health execution, observed workspace/SSR/browser-intent behavior, Pages reference-consumer gate acceptance, Forum Wave, FFA or FBA promotion is claimed.

The existing four-profile rollout preflight remains rollout-only evidence and now explicitly proves provider health is unobserved around each preflight observation. Observed-health runtime evidence still requires a separate harness.

## Validation

Per maintainer instruction, tests/verifiers are intentionally not run by this implementation agent. No Node verifier, Cargo command, formatter, build, GraphQL/HTTP request, Playwright/browser run, Prometheus/evaluator execution, owner-acceptance execution, workflow or CI run was performed.

Suggested maintainer source checks:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
node crates/rustok-page-builder/scripts/verify/verify-page-builder-admin-provider-status.mjs
node crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-feature-preflight-harness.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
```

## Next cursor

`provider observation -> deployment metrics/identity/evaluator -> typed transport -> owner acceptance -> server binding -> UI/SSR/browser-intent binding -> health-aware non-mutating capability preflight [all source-ready] -> observed-health runtime evidence harness [source-open] -> live exact-deployment evidence + observed consumer behavior [maintainer execution pending] -> observed-health acceptance`