### PR TITLE
feat(commerce): route storefront product detail through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-storefront-product-detail-owner-read-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/rest-storefront-product-detail-owner-read-cutover-2026-08-09.md
@@ -1,0 +1,80 @@
+# Commerce REST storefront Product detail owner-read cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-09
+
+## Scope
+
+This bounded slice removes concrete Product service construction from the mounted
+`GET /store/products/{id}` handler.
+
+The storefront Product list remains outside this slice. Its legacy REST search
+semantics are still implemented directly in Commerce and require a separate parity
+proof before owner-port cutover.
+
+## Mounted path
+
+`crates/rustok-commerce/src/controllers/store/mod.rs` mounts
+`products::show_product` at `/store/products/{id}`.
+
+`crates/rustok-commerce/src/controllers/store/products.rs` now obtains the
+host-selected Product capability through `CommerceHttpRuntime::product_catalog_read_port()`
+and calls:
+
+- `ProductCatalogReadPort::read_storefront_product_projection`
+- `StorefrontProductProjectionSubject::ProductId`
+
+No `CatalogService::new(...)` remains in the mounted detail handler.
+
+## Preserved semantics
+
+The owner capability already centralizes the behavior previously split across the
+Commerce handler and Product service:
+
+- admitted tenant identity;
+- requested locale plus tenant default fallback locale;
+- published + active Product visibility;
+- public-channel metadata visibility;
+- public-channel inventory projection;
+- hidden or missing Product -> the existing `commerce_store_not_found` envelope.
+
+The request still passes the storefront channel admission guard before the owner read.
+The owner `PortContext` uses a stable Commerce service actor, request locale, normalized
+public channel when available, a Product-bound correlation id, and a two-second deadline.
+
+## Error boundary
+
+Product owner `PortError` values are mapped to the existing public REST families:
+
+- validation -> `400 commerce_store_product_invalid`;
+- not found -> `404 commerce_store_not_found`;
+- unavailable/timeout -> `503 commerce_store_product_unavailable`;
+- unexpected conflict/forbidden/invariant failures -> fail closed with
+  `500 commerce_store_product_failed`.
+
+The new owner-port mapper logs correlation id, owner error kind, retryability, and
+owner-code length. It does not log or expose `PortError.message` or another raw
+backend/owner message.
+
+## Deliberately unchanged
+
+`GET /store/products` remains on its existing legacy direct Product query/tag path in
+this slice. The owner already publishes a legacy storefront list capability, but the
+current REST search is locale-scoped while the compatibility owner helper must be
+rechecked for exact search parity before replacing the mounted list path.
+
+Region and shipping-option handlers in the same source file are unchanged.
+
+## Topology status
+
+The canonical ecommerce topology item remains open. This slice removes one mounted
+Product concrete-service construction, but other mounted Product/Order/Payment/
+Fulfillment consumer and orchestration paths still require audit/cutover.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter,
+REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart
+scenarios, or remote-adapter scenarios were executed. Source verifiers were updated
+or added but were not run.

--- a/crates/rustok-commerce/src/controllers/store/products.rs
+++ b/crates/rustok-commerce/src/controllers/store/products.rs
@@ -10,7 +10,8 @@ use rustok_api::{
 use rustok_cart::{CartStorefrontReadRequest, in_process_cart_storefront_port};
 use rustok_fulfillment::ListShippingOptionProjectionsRequest;
 use rustok_product::{
-    CatalogService, CommerceError as ProductError,
+    CatalogService, CommerceError as ProductError, StorefrontProductProjectionRequest,
+    StorefrontProductProjectionSubject,
     entities::{product, product_translation},
 };
 use rustok_region::{RegionListRequest, RegionReadPort};
@@ -26,10 +27,7 @@ use crate::controllers::{CommerceHttpRuntime, products::ProductListItem};
 use crate::{
     CommerceError,
     dto::{ProductResponse, RegionResponse, ShippingOptionResponse},
-    storefront_channel::{
-        apply_public_channel_inventory_to_product, is_metadata_visible_for_public_channel,
-        public_channel_slug_from_request,
-    },
+    storefront_channel::{is_metadata_visible_for_public_channel, public_channel_slug_from_request},
     storefront_shipping::{
         is_shipping_option_compatible_with_profiles, load_cart_shipping_profile_slugs,
         shipping_profile_slug_from_product_metadata,
@@ -98,6 +96,76 @@ fn map_storefront_product_database_error(
         tenant_id,
         product_id,
     )
+}
+
+fn storefront_product_port_context(
+    tenant_id: Uuid,
+    request_context: &RequestContext,
+    public_channel_slug: Option<&str>,
+    product_id: Uuid,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service("rustok-commerce.storefront-product"),
+        request_context.locale.as_str(),
+        format!("commerce-storefront-product:read:{product_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match public_channel_slug {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_storefront_product_port_error(
+    error: PortError,
+    context: &PortContext,
+    operation: &'static str,
+    tenant_id: Uuid,
+    product_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_store_product_invalid",
+            "Product request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_store_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_product_unavailable",
+            "Product service is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::Conflict | PortErrorKind::Forbidden | PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_product_failed",
+            "Product operation could not be completed safely",
+            "owner_failure",
+        ),
+    };
+    tracing::error!(
+        owner = "rustok_product",
+        owner_operation = operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        product_id_non_nil = !product_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = "commerce_storefront_product_http",
+        "storefront product owner read failed with bounded diagnostics"
+    );
+    HttpError::new(status, code, message)
 }
 
 fn map_storefront_auxiliary_port_error(
@@ -468,43 +536,37 @@ pub async fn show_product(
 ) -> HttpResult<Json<ProductResponse>> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    let service = CatalogService::new(runtime.db_clone(), runtime.event_bus());
     let public_channel_slug = public_channel_slug_from_request(&request_context);
-    let mut product = service
-        .get_product_with_locale_fallback(
-            tenant.id,
-            id,
-            request_context.locale.as_str(),
-            Some(tenant.default_locale.as_str()),
+    let port_context = storefront_product_port_context(
+        tenant.id,
+        &request_context,
+        public_channel_slug.as_deref(),
+        id,
+    );
+    let product = runtime
+        .product_catalog_read_port()
+        .read_storefront_product_projection(
+            port_context.clone(),
+            StorefrontProductProjectionRequest {
+                subject: StorefrontProductProjectionSubject::ProductId { product_id: id },
+                locale: Some(request_context.locale.clone()),
+                fallback_locale: Some(tenant.default_locale.clone()),
+                public_channel_slug,
+            },
         )
         .await
         .map_err(|error| {
-            map_storefront_product_error(error, "show_product", tenant.id, Some(id))
+            map_storefront_product_port_error(
+                error,
+                &port_context,
+                "read_storefront_product_projection",
+                tenant.id,
+                id,
+            )
+        })?
+        .ok_or_else(|| {
+            HttpError::not_found("commerce_store_not_found", "Commerce resource not found")
         })?;
-
-    if product.status != product::ProductStatus::Active
-        || product.published_at.is_none()
-        || !is_metadata_visible_for_public_channel(
-            &product.metadata,
-            public_channel_slug.as_deref(),
-        )
-    {
-        return Err(HttpError::not_found(
-            "commerce_store_not_found",
-            "Commerce resource not found",
-        ));
-    }
-
-    apply_public_channel_inventory_to_product(
-        runtime.db(),
-        tenant.id,
-        &mut product,
-        public_channel_slug.as_deref(),
-    )
-    .await
-    .map_err(|error| {
-        map_storefront_product_database_error(error, "show_product_inventory", tenant.id, Some(id))
-    })?;
 
     Ok(Json(product))
 }

--- a/scripts/verify/verify-commerce-rest-storefront-product-detail-owner-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-storefront-product-detail-owner-read-cutover.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/products.rs');
+const storeRouter = read('crates/rustok-commerce/src/controllers/store/mod.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const productPorts = read('crates/rustok-product/src/ports.rs');
+const productQueries = read('crates/rustok-product/src/services/catalog/queries.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-storefront-product-detail-owner-read-cutover-2026-08-09.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const detail = between(
+  controller,
+  'pub async fn show_product(',
+  '/// List available storefront regions',
+  'mounted storefront product detail',
+);
+const ownerMapper = between(
+  controller,
+  'fn map_storefront_product_port_error(',
+  'fn map_storefront_auxiliary_port_error(',
+  'storefront Product owner mapper',
+);
+const listHandler = between(
+  controller,
+  'pub async fn list_products(',
+  '/// Show published storefront product',
+  'storefront Product list compatibility path',
+);
+
+for (const [value, label] of [
+  ['.route("/products/{id}", axum::routing::get(products::show_product))', 'mounted detail route'],
+  ['pub mod products;', 'mounted products module'],
+]) requireText(storeRouter, value, label);
+
+for (const [value, label] of [
+  ['runtime\n        .product_catalog_read_port()', 'host-selected Product read port'],
+  ['.read_storefront_product_projection(', 'owner storefront detail call'],
+  ['StorefrontProductProjectionRequest {', 'typed owner detail request'],
+  ['StorefrontProductProjectionSubject::ProductId { product_id: id }', 'typed Product subject'],
+  ['locale: Some(request_context.locale.clone())', 'requested locale forwarding'],
+  ['fallback_locale: Some(tenant.default_locale.clone())', 'tenant locale forwarding'],
+  ['public_channel_slug,', 'public channel forwarding'],
+  ['storefront_product_port_context(', 'bounded Product call context'],
+  ['"read_storefront_product_projection"', 'owner operation identity'],
+  ['HttpError::not_found("commerce_store_not_found", "Commerce resource not found")', 'hidden/missing public envelope'],
+]) requireText(detail, value, label);
+
+for (const value of [
+  'CatalogService::new(',
+  '.get_product_with_locale_fallback(',
+  'product.status != product::ProductStatus::Active',
+  'apply_public_channel_inventory_to_product(',
+  'show_product_inventory',
+]) forbidText(detail, value, 'stale concrete Product detail path');
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'validation mapping'],
+  ['PortErrorKind::NotFound', 'not-found mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable mapping'],
+  ['PortErrorKind::Conflict | PortErrorKind::Forbidden | PortErrorKind::InvariantViolation', 'fail-closed mapping'],
+  ['"commerce_store_product_invalid"', 'validation code'],
+  ['"commerce_store_not_found"', 'not-found code'],
+  ['"commerce_store_product_unavailable"', 'unavailable code'],
+  ['"commerce_store_product_failed"', 'fail-closed code'],
+  ['owner = "rustok_product"', 'owner identity diagnostic'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['owner_error_kind = ?error.kind', 'owner error kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
+  ['retryable = error.retryable', 'retryable diagnostic'],
+]) requireText(ownerMapper, value, label);
+
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'err.to_string()']) {
+  forbidText(ownerMapper, value, 'raw Product owner diagnostic');
+}
+
+for (const [value, label] of [
+  ['fn product_catalog_read_port(', 'HTTP Product read accessor'],
+  ['self.product_catalog_read_runtime.read_port()', 'HTTP Product read projection'],
+  ['shared_get::<rustok_product::ProductCatalogReadRuntime>()', 'host-selected Product runtime'],
+]) requireText(httpRuntime, value, label);
+
+for (const [value, label] of [
+  ['pub trait ProductCatalogReadPort', 'Product owner read port'],
+  ['async fn read_storefront_product_projection(', 'Product owner storefront detail capability'],
+  ['context\n            .require_policy(PortCallPolicy::read())', 'Product read admission'],
+  ['StorefrontProductProjectionSubject::ProductId { product_id }', 'Product owner product-id dispatch'],
+  ['get_published_product_by_id_with_locale_fallback(', 'Product owner published detail implementation'],
+]) requireText(productPorts, value, label);
+
+for (const [value, label] of [
+  ['product.status != entities::product::ProductStatus::Active', 'owner active visibility'],
+  ['product.published_at.is_none()', 'owner published visibility'],
+  ['is_metadata_visible_for_public_channel(&product.metadata, public_channel_slug)', 'owner channel visibility'],
+  ['apply_public_channel_inventory_to_product(', 'owner public inventory projection'],
+]) requireText(productQueries, value, label);
+
+for (const [value, label] of [
+  ['CatalogService::new(runtime.db_clone(), runtime.event_bus())', 'legacy list concrete Product service remains explicit'],
+  ['product_translation_title_search_condition(', 'legacy REST localized search remains explicit'],
+]) requireText(listHandler, value, label);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology item remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST storefront Product detail owner-read cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['`ProductCatalogReadPort::read_storefront_product_projection`', 'record owner operation'],
+  ['The storefront Product list remains outside this slice', 'record explicit list exclusion'],
+  ['The canonical ecommerce topology item remains open', 'record broad P0 open'],
+  ['no tests, Cargo commands, Node verifiers, formatter', 'record no validation execution'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST storefront Product detail owner-read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted REST storefront Product detail uses the host-selected Product owner read port');

--- a/scripts/verify/verify-commerce-storefront-product-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-product-http-error-safety.mjs
@@ -14,6 +14,7 @@ const controller = read('crates/rustok-commerce/src/controllers/store/products.r
 const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
 const catalogService = read('crates/rustok-product/src/services/catalog.rs');
 const catalogTags = read('crates/rustok-product/src/services/catalog/tags.rs');
+const productPorts = read('crates/rustok-product/src/ports.rs');
 const storefrontChannel = read('crates/rustok-commerce/src/storefront_channel.rs');
 const failures = [];
 
@@ -57,20 +58,21 @@ const showHandler = between(
   '/// List available storefront regions',
   'storefront product detail handler',
 );
+const ownerMapper = between(
+  controller,
+  'fn map_storefront_product_port_error(',
+  'fn map_storefront_auxiliary_port_error(',
+  'storefront product owner mapper',
+);
 
 for (const [value, label] of [
   ['http::StatusCode', 'HTTP status import'],
   ['CommerceError,', 'typed commerce error import'],
   ['fn map_storefront_product_error(', 'typed storefront product mapper'],
   ['fn map_storefront_product_database_error(', 'direct database mapper'],
+  ['fn map_storefront_product_port_error(', 'owner port mapper'],
   ['CommerceError::Database(error)', 'database owner wrapping'],
-  ['error = ?error', 'raw internal error logging'],
   ['operation,', 'operation logging'],
-  ['tenant_id = %tenant_id', 'tenant logging'],
-  ['product_id = ?product_id', 'optional product logging'],
-  ['error_kind,', 'error-kind logging'],
-  ['public_code = code', 'public-code logging'],
-  ['status = %status', 'status logging'],
   ['boundary = "commerce_storefront_product_http"', 'product boundary logging'],
   ['HttpError::new(status, code, message)', 'static HTTP envelope construction'],
 ]) {
@@ -116,7 +118,6 @@ for (const value of [
   'err.to_string()',
   'error.to_string()',
   'error.message',
-  'error.code',
   'HttpError::bad_request(',
 ]) {
   forbidText(productBoundary, value, 'unsafe storefront product public conversion');
@@ -148,33 +149,60 @@ for (const [value, label] of [
 
 for (const [value, label] of [
   ['ensure_storefront_channel_enabled_for_db(', 'detail channel guard'],
-  ['.get_product_with_locale_fallback(', 'localized product read'],
-  ['tenant.id,', 'detail tenant argument'],
-  ['request_context.locale.as_str()', 'detail locale argument'],
-  ['Some(tenant.default_locale.as_str())', 'detail fallback locale'],
-  ['"show_product"', 'detail operation label'],
-  ['product.status != product::ProductStatus::Active', 'active visibility check'],
-  ['product.published_at.is_none()', 'published visibility check'],
+  ['runtime\n        .product_catalog_read_port()', 'host-selected product read port'],
+  ['.read_storefront_product_projection(', 'owner detail read'],
+  ['StorefrontProductProjectionSubject::ProductId { product_id: id }', 'detail product identity'],
+  ['locale: Some(request_context.locale.clone())', 'detail requested locale'],
+  ['fallback_locale: Some(tenant.default_locale.clone())', 'detail tenant fallback locale'],
+  ['public_channel_slug,', 'detail public channel'],
+  ['"read_storefront_product_projection"', 'owner operation label'],
   ['"commerce_store_not_found"', 'hidden product not-found code'],
-  ['apply_public_channel_inventory_to_product(', 'public inventory projection'],
-  ['public_channel_slug.as_deref()', 'public channel inventory argument'],
-  ['"show_product_inventory"', 'inventory operation label'],
   ['Ok(Json(product))', 'detail response'],
 ]) {
   requireText(showHandler, value, label);
 }
+for (const value of [
+  'CatalogService::new(',
+  '.get_product_with_locale_fallback(',
+  'product.status != product::ProductStatus::Active',
+  'apply_public_channel_inventory_to_product(',
+  'show_product_inventory',
+]) {
+  forbidText(showHandler, value, 'stale concrete product detail path');
+}
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'owner validation mapping'],
+  ['PortErrorKind::NotFound', 'owner not-found mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'owner unavailable mapping'],
+  ['PortErrorKind::Conflict | PortErrorKind::Forbidden | PortErrorKind::InvariantViolation', 'owner fail-closed mapping'],
+  ['owner = "rustok_product"', 'owner diagnostic identity'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['owner_error_kind = ?error.kind', 'owner error-kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
+  ['retryable = error.retryable', 'owner retryability diagnostic'],
+]) {
+  requireText(ownerMapper, value, label);
+}
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'err.to_string()']) {
+  forbidText(ownerMapper, value, 'raw owner detail diagnostic');
+}
 
 const serviceMapperUses = productBoundary.match(/map_storefront_product_error\(/g) ?? [];
-if (serviceMapperUses.length !== 4) {
+if (serviceMapperUses.length !== 3) {
   failures.push(
-    `expected service mapper definition, database delegation, tag callsite, and detail callsite, found ${serviceMapperUses.length}`,
+    `expected service mapper definition, database delegation, and tag callsite, found ${serviceMapperUses.length}`,
   );
 }
 const databaseMapperUses = productBoundary.match(/map_storefront_product_database_error\(/g) ?? [];
-if (databaseMapperUses.length !== 4) {
+if (databaseMapperUses.length !== 3) {
   failures.push(
-    `expected database mapper definition plus product page, translations, and inventory callsites, found ${databaseMapperUses.length}`,
+    `expected database mapper definition plus product page and translations callsites, found ${databaseMapperUses.length}`,
   );
+}
+const ownerMapperUses = productBoundary.match(/map_storefront_product_port_error\(/g) ?? [];
+if (ownerMapperUses.length !== 2) {
+  failures.push(`expected owner mapper definition plus detail callsite, found ${ownerMapperUses.length}`);
 }
 
 for (const [value, label] of [
@@ -204,6 +232,9 @@ for (const [content, value, label] of [
   [catalogTags, 'pub async fn load_product_tag_map(', 'catalog tag operation'],
   [catalogTags, '-> CommerceResult<HashMap<Uuid, Vec<String>>>', 'typed tag result'],
   [catalogTags, 'CommerceError::Validation(error.to_string())', 'taxonomy error ownership'],
+  [productPorts, 'async fn read_storefront_product_projection(', 'owner storefront detail capability'],
+  [productPorts, 'StorefrontProductProjectionSubject::ProductId { product_id }', 'owner product-id subject'],
+  [productPorts, 'get_published_product_by_id_with_locale_fallback(', 'owner published detail implementation'],
   [storefrontChannel, 'pub(crate) async fn apply_public_channel_inventory_to_product(', 'inventory projection operation'],
   [storefrontChannel, '-> Result<(), sea_orm::DbErr>', 'typed inventory database result'],
   [storefrontChannel, 'load_inventory_projection_by_variant_for_public_channel(', 'inventory owner call'],


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with one bounded mounted Product read cutover.

- route mounted `GET /store/products/{id}` through the host-selected `ProductCatalogReadPort::read_storefront_product_projection` capability;
- preserve the storefront-channel admission guard, tenant scope, request locale, tenant fallback locale, public-channel visibility, active/published visibility, and public-channel inventory projection through the existing Product owner implementation;
- carry a Product-bound `PortContext` with stable Commerce service actor, request locale/channel, correlation identity, and a two-second deadline;
- preserve the existing public REST families: validation -> `commerce_store_product_invalid`, missing/hidden -> `commerce_store_not_found`, unavailable/timeout -> `commerce_store_product_unavailable`, and fail closed for unexpected external owner failures;
- keep owner/backend messages out of the new mounted diagnostic path; log bounded owner kind/code-length/retryability/correlation facts instead;
- deliberately leave mounted `GET /store/products` on its current direct legacy Product query/tag path because its locale-scoped search semantics still need exact owner-port parity proof;
- update the existing storefront Product source guard, add a dedicated topology verifier, and add a dated source record;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind `main` (`4df29ba6adddc6e4c5560956d1abee6fa539d75c`) with exactly four changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source verifiers were updated/added but not run.