### PR TITLE
feat(forum): admit deleted reply tombstone enrichment

### DIFF
--- a/crates/rustok-forum/src/import_tombstone_preparation.rs
+++ b/crates/rustok-forum/src/import_tombstone_preparation.rs
@@ -1,0 +1,319 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::import_mapping::{
+    FORUM_IMPORT_SOURCE_NODEBB, ForumImportEntityKind, ForumImportExternalRef,
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH,
+};
+use crate::import_relation_preparation::ForumPreparedImportRelationBatch;
+use crate::state_machine::ReplyStatus;
+
+pub const MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH: usize =
+    MAX_FORUM_IMPORT_SOURCE_RECORDS_PER_BATCH;
+
+/// Explicit exporter/audit enrichment for one NodeBB reply tombstone.
+///
+/// Current NodeBB post state exposes the deleted flag but does not guarantee a
+/// deletion timestamp. This record is therefore a separate, opt-in source fact:
+/// callers must only populate it from an exporter or audit source that actually
+/// captured the historical deletion time.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodebbReplyTombstoneRecord {
+    pub pid: i64,
+    #[serde(rename = "deletedTimestamp", alias = "deleted_timestamp")]
+    pub deleted_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumImportReplyTombstoneFact {
+    pub source: ForumImportExternalRef,
+    pub deleted_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ForumPreparedDeletedReplyTombstone {
+    pub source: ForumImportExternalRef,
+    pub reply_id: Uuid,
+    pub deleted_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumImportTombstonePreparationRequest {
+    pub relations: ForumPreparedImportRelationBatch,
+    pub deleted_replies: Vec<ForumImportReplyTombstoneFact>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ForumPreparedImportTombstoneBatch {
+    pub relations: ForumPreparedImportRelationBatch,
+    pub deleted_replies: Vec<ForumPreparedDeletedReplyTombstone>,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum ForumImportTombstonePreparationError {
+    #[error("Forum import tombstone enrichment exceeds {max} records: {actual}")]
+    TooManyTombstones { max: usize, actual: usize },
+    #[error("NodeBB tombstone post id must be positive: {pid}")]
+    InvalidNodebbPostId { pid: i64 },
+    #[error("NodeBB tombstone timestamp must be non-negative for post {pid}: {deleted_at_ms}")]
+    NegativeNodebbTombstoneTimestamp { pid: i64, deleted_at_ms: i64 },
+    #[error("NodeBB tombstone timestamp is outside owner range for post {pid}: {deleted_at_ms}")]
+    NodebbTombstoneTimestampOutOfRange { pid: i64, deleted_at_ms: i64 },
+    #[error("NodeBB tombstone sidecar repeats post id {pid}")]
+    DuplicateNodebbPostId { pid: i64 },
+    #[error("Forum import tombstone requires a NodeBB Post source, got {source:?}")]
+    InvalidSource { source: ForumImportExternalRef },
+    #[error("Forum import tombstone source key is invalid: {source:?}")]
+    InvalidSourceKey { source: ForumImportExternalRef },
+    #[error("Forum import tombstone repeats reply source {source:?}")]
+    DuplicateTombstoneSource { source: ForumImportExternalRef },
+    #[error("Forum import relation batch repeats reply source {source:?}")]
+    DuplicateReplySource { source: ForumImportExternalRef },
+    #[error(
+        "Forum import relation count differs from prepared reply count: {relations} != {writes}"
+    )]
+    RelationCountMismatch { writes: usize, relations: usize },
+    #[error("Forum import relation facts do not align with reply {source:?}")]
+    RelationAlignmentMismatch { source: ForumImportExternalRef },
+    #[error("Forum import deleted reply is missing an admitted tombstone: {source:?}")]
+    MissingDeletedReplyTombstone { source: ForumImportExternalRef },
+    #[error("Forum import live reply cannot have a tombstone: {source:?}")]
+    LiveReplyHasTombstone { source: ForumImportExternalRef },
+    #[error("Forum import tombstone does not match a prepared reply: {source:?}")]
+    UnexpectedTombstone { source: ForumImportExternalRef },
+    #[error(
+        "Forum import tombstone predates reply creation for {source:?}: {deleted_at_ms} < {created_at_ms}"
+    )]
+    TombstonePredatesCreation {
+        source: ForumImportExternalRef,
+        created_at_ms: i64,
+        deleted_at_ms: i64,
+    },
+    #[error("Forum import tombstone timestamp is outside owner range for {source:?}: {deleted_at_ms}")]
+    TombstoneTimestampOutOfRange {
+        source: ForumImportExternalRef,
+        deleted_at_ms: i64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NodebbForumReplyTombstoneMapper;
+
+impl NodebbForumReplyTombstoneMapper {
+    pub fn map_batch(
+        &self,
+        records: &[NodebbReplyTombstoneRecord],
+    ) -> Result<Vec<ForumImportReplyTombstoneFact>, ForumImportTombstonePreparationError> {
+        if records.len() > MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH {
+            return Err(ForumImportTombstonePreparationError::TooManyTombstones {
+                max: MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH,
+                actual: records.len(),
+            });
+        }
+
+        let mut seen = BTreeSet::new();
+        let mut facts = Vec::with_capacity(records.len());
+        for record in records {
+            if record.pid <= 0 {
+                return Err(ForumImportTombstonePreparationError::InvalidNodebbPostId {
+                    pid: record.pid,
+                });
+            }
+            if !seen.insert(record.pid) {
+                return Err(ForumImportTombstonePreparationError::DuplicateNodebbPostId {
+                    pid: record.pid,
+                });
+            }
+            if record.deleted_at_ms < 0 {
+                return Err(
+                    ForumImportTombstonePreparationError::NegativeNodebbTombstoneTimestamp {
+                        pid: record.pid,
+                        deleted_at_ms: record.deleted_at_ms,
+                    },
+                );
+            }
+            if DateTime::<Utc>::from_timestamp_millis(record.deleted_at_ms).is_none() {
+                return Err(
+                    ForumImportTombstonePreparationError::NodebbTombstoneTimestampOutOfRange {
+                        pid: record.pid,
+                        deleted_at_ms: record.deleted_at_ms,
+                    },
+                );
+            }
+            facts.push(ForumImportReplyTombstoneFact {
+                source: ForumImportExternalRef {
+                    source: FORUM_IMPORT_SOURCE_NODEBB.to_owned(),
+                    kind: ForumImportEntityKind::Post,
+                    key: format!("post:{}", record.pid),
+                },
+                deleted_at_ms: record.deleted_at_ms,
+            });
+        }
+        Ok(facts)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForumImportTombstonePreparer;
+
+impl ForumImportTombstonePreparer {
+    pub fn prepare(
+        &self,
+        request: ForumImportTombstonePreparationRequest,
+    ) -> Result<ForumPreparedImportTombstoneBatch, ForumImportTombstonePreparationError> {
+        if request.deleted_replies.len() > MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH {
+            return Err(ForumImportTombstonePreparationError::TooManyTombstones {
+                max: MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH,
+                actual: request.deleted_replies.len(),
+            });
+        }
+        if request.relations.replies.len() != request.relations.writes.replies.len() {
+            return Err(ForumImportTombstonePreparationError::RelationCountMismatch {
+                writes: request.relations.writes.replies.len(),
+                relations: request.relations.replies.len(),
+            });
+        }
+
+        let mut reply_sources = BTreeSet::new();
+        for (reply, relation) in request
+            .relations
+            .writes
+            .replies
+            .iter()
+            .zip(&request.relations.replies)
+        {
+            validate_post_source(&reply.source)?;
+            if relation.source != reply.source
+                || relation.target != crate::mentions::ForumContentTarget::reply(reply.id)
+                || relation.locale != reply.locale
+            {
+                return Err(
+                    ForumImportTombstonePreparationError::RelationAlignmentMismatch {
+                        source: reply.source.clone(),
+                    },
+                );
+            }
+            if !reply_sources.insert(ref_key(&reply.source)) {
+                return Err(ForumImportTombstonePreparationError::DuplicateReplySource {
+                    source: reply.source.clone(),
+                });
+            }
+        }
+
+        let mut facts = BTreeMap::new();
+        for fact in &request.deleted_replies {
+            validate_post_source(&fact.source)?;
+            if fact.deleted_at_ms < 0
+                || DateTime::<Utc>::from_timestamp_millis(fact.deleted_at_ms).is_none()
+            {
+                return Err(
+                    ForumImportTombstonePreparationError::TombstoneTimestampOutOfRange {
+                        source: fact.source.clone(),
+                        deleted_at_ms: fact.deleted_at_ms,
+                    },
+                );
+            }
+            if facts.insert(ref_key(&fact.source), fact).is_some() {
+                return Err(
+                    ForumImportTombstonePreparationError::DuplicateTombstoneSource {
+                        source: fact.source.clone(),
+                    },
+                );
+            }
+        }
+
+        let mut prepared = Vec::new();
+        for reply in &request.relations.writes.replies {
+            let fact = facts.remove(&ref_key(&reply.source));
+            match (reply.status, fact) {
+                (ReplyStatus::Deleted, Some(fact)) => {
+                    if fact.deleted_at_ms < reply.created_at_ms {
+                        return Err(
+                            ForumImportTombstonePreparationError::TombstonePredatesCreation {
+                                source: reply.source.clone(),
+                                created_at_ms: reply.created_at_ms,
+                                deleted_at_ms: fact.deleted_at_ms,
+                            },
+                        );
+                    }
+                    prepared.push(ForumPreparedDeletedReplyTombstone {
+                        source: reply.source.clone(),
+                        reply_id: reply.id,
+                        deleted_at_ms: fact.deleted_at_ms,
+                    });
+                }
+                (ReplyStatus::Deleted, None) => {
+                    return Err(
+                        ForumImportTombstonePreparationError::MissingDeletedReplyTombstone {
+                            source: reply.source.clone(),
+                        },
+                    );
+                }
+                (_, Some(_)) => {
+                    return Err(
+                        ForumImportTombstonePreparationError::LiveReplyHasTombstone {
+                            source: reply.source.clone(),
+                        },
+                    );
+                }
+                (_, None) => {}
+            }
+        }
+
+        if let Some(fact) = facts.into_values().next() {
+            return Err(ForumImportTombstonePreparationError::UnexpectedTombstone {
+                source: fact.source.clone(),
+            });
+        }
+
+        Ok(ForumPreparedImportTombstoneBatch {
+            relations: request.relations,
+            deleted_replies: prepared,
+        })
+    }
+}
+
+fn validate_post_source(
+    source: &ForumImportExternalRef,
+) -> Result<(), ForumImportTombstonePreparationError> {
+    if source.source != FORUM_IMPORT_SOURCE_NODEBB || source.kind != ForumImportEntityKind::Post {
+        return Err(ForumImportTombstonePreparationError::InvalidSource {
+            source: source.clone(),
+        });
+    }
+    let Some(raw_id) = source.key.strip_prefix("post:") else {
+        return Err(ForumImportTombstonePreparationError::InvalidSourceKey {
+            source: source.clone(),
+        });
+    };
+    let Ok(id) = raw_id.parse::<i64>() else {
+        return Err(ForumImportTombstonePreparationError::InvalidSourceKey {
+            source: source.clone(),
+        });
+    };
+    if id <= 0 || source.key != format!("post:{id}") {
+        return Err(ForumImportTombstonePreparationError::InvalidSourceKey {
+            source: source.clone(),
+        });
+    }
+    Ok(())
+}
+
+type RefKey = (String, &'static str, String);
+
+fn ref_key(source: &ForumImportExternalRef) -> RefKey {
+    (
+        source.source.clone(),
+        match source.kind {
+            ForumImportEntityKind::Category => "category",
+            ForumImportEntityKind::Topic => "topic",
+            ForumImportEntityKind::Post => "post",
+            ForumImportEntityKind::User => "user",
+        },
+        source.key.clone(),
+    )
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -22,6 +22,7 @@ pub mod import_inspection;
 pub mod import_mapping;
 pub mod import_relation_preparation;
 pub mod import_resolution;
+pub mod import_tombstone_preparation;
 pub mod import_write_preparation;
 pub mod locale;
 pub mod mentions {
@@ -70,6 +71,7 @@ pub use import_inspection::*;
 pub use import_mapping::*;
 pub use import_relation_preparation::*;
 pub use import_resolution::*;
+pub use import_tombstone_preparation::*;
 pub use import_write_preparation::*;
 pub use mentions::*;
 pub use moderation_subject::{

--- a/docs/modules/forum-34-deleted-reply-tombstone-actualization-2026-08-09.md
+++ b/docs/modules/forum-34-deleted-reply-tombstone-actualization-2026-08-09.md
@@ -1,0 +1,149 @@
+# FORUM-34P deleted-reply tombstone admission actualization — 2026-08-09
+
+Status: `source-ready / maintainer-execution-open / tombstone-persistence-open / standard-nodebb-source-gap-explicit / shared-runner-blocked`
+
+## Fresh cursor
+
+FORUM-34A through FORUM-34O are merged before this slice. FORUM-34O merged as `80aca195c26e2b65414e83f1615271e3940ee4f9` and added the first bounded atomic Category/Topic/non-deleted Reply owner write path.
+
+34P started from fresh `main` `4df29ba6adddc6e4c5560956d1abee6fa539d75c` after Pages PR #3420. During preparation, `main` advanced through Commerce PR #3421 and Events/Index PR #3423 to `745b2357db84c75bc188de8c582bfb51751b9b46`; those changes do not modify Forum source. This packet records source recheck through that cursor. Immediate premerge freshness is enforced separately by requiring the feature branch to remain `behind 0`, so unrelated later mainline movement does not require rewriting historical source findings in this packet.
+
+The canonical Forum implementation-plan ledger still carries the stale FORUM-34 `planned` row. This dated packet records the truthful continuation without replacing the large roadmap wholesale.
+
+## Why 34P changed shape after recheck
+
+34O intentionally rejected every prepared `ReplyStatus::Deleted` because the import facts only carried a boolean deleted flag while the owner model persists a distinct `deleted_at` timestamp and delete revision.
+
+Before adding a timestamp field to the main NodeBB mapping, current NodeBB source was rechecked. The current post delete implementation writes the post `deleted` flag and `deleterUid`; it does not guarantee a historical deletion timestamp. Treating an invented `deletedTimestamp` field as part of the canonical NodeBB post record would therefore overstate source fidelity.
+
+34P consequently does **not** change `NodebbPostRecord`, does not infer deletion time from post creation time, and does not use migration execution time as historical truth.
+
+Instead, it defines a separate explicit exporter/audit enrichment contract. An operator may supply `deletedTimestamp` only when a legacy exporter, audit log, backup, or another source actually captured that fact. Standard NodeBB deleted posts without such enrichment remain intentionally blocked from exact tombstone persistence.
+
+## Public source-enrichment contract
+
+34P adds `import_tombstone_preparation` and re-exports it from the Forum root.
+
+The raw optional sidecar record is:
+
+```rust
+pub struct NodebbReplyTombstoneRecord {
+    pub pid: i64,
+    #[serde(rename = "deletedTimestamp", alias = "deleted_timestamp")]
+    pub deleted_at_ms: i64,
+}
+```
+
+`NodebbForumReplyTombstoneMapper::map_batch(...)` maps each sidecar row onto the same external identity namespace used by FORUM-34A:
+
+`nodebb / Post / post:<pid>`.
+
+The mapper is bounded by `MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH = 512` and rejects:
+
+- non-positive post IDs;
+- duplicate post IDs;
+- negative deletion timestamps;
+- timestamps outside the owner `DateTime<Utc>` range.
+
+It never converts a NodeBB pid into a RusTok UUID.
+
+## Admission over the prepared relation batch
+
+The second stage accepts the existing FORUM-34M prepared relation batch plus the optional tombstone facts:
+
+```rust
+pub struct ForumImportTombstonePreparationRequest {
+    pub relations: ForumPreparedImportRelationBatch,
+    pub deleted_replies: Vec<ForumImportReplyTombstoneFact>,
+}
+```
+
+and returns:
+
+```rust
+pub struct ForumPreparedImportTombstoneBatch {
+    pub relations: ForumPreparedImportRelationBatch,
+    pub deleted_replies: Vec<ForumPreparedDeletedReplyTombstone>,
+}
+```
+
+Each prepared tombstone contains only the already-admitted external Post source, already-admitted Reply UUID, and exact source-owned `deleted_at_ms`.
+
+The original 34M relation batch is preserved unchanged inside the wrapper.
+
+## Fail-closed rules
+
+The tombstone preparer independently rechecks the public in-process boundary rather than assuming the caller executed every predecessor immediately beforehand.
+
+It requires:
+
+- at most 512 tombstone facts;
+- every prepared reply source to be exact NodeBB `Post` with canonical `post:<positive id>` key;
+- relation count to match prepared reply count;
+- each relation source/target/locale to align with its prepared reply;
+- prepared reply source uniqueness;
+- tombstone source uniqueness;
+- each tombstone timestamp to be non-negative and inside the owner timestamp range;
+- every `ReplyStatus::Deleted` reply to have exactly one tombstone;
+- every non-deleted reply to have no tombstone;
+- every tombstone to match one prepared reply;
+- `deleted_at_ms >= created_at_ms` for the matched reply.
+
+Prepared tombstones preserve prepared-reply source order. No cross-batch lookup is performed.
+
+## What 34P deliberately does not do
+
+34P is side-effect-free. It performs no:
+
+- database access;
+- SeaORM operation;
+- transaction begin/commit;
+- owner reply mutation;
+- revision insertion/update;
+- UUID generation;
+- authorization or `SecurityContext` lookup;
+- event publication;
+- projection invalidation.
+
+The 34O atomic writer remains unchanged and therefore still rejects `ReplyStatus::Deleted`. This separation is intentional: source admission is closed first; owner persistence will consume only an already-admitted tombstone wrapper in the next slice.
+
+## Owner persistence recheck for the next slice
+
+Current owner soft-delete uses a separate `forum_replies.deleted_at` column. The normal interactive owner path marks it with `CURRENT_TIMESTAMP` and database triggers capture a `forum_reply_revisions` row with `revision_reason = 'delete'`.
+
+That normal command cannot be reused unchanged for historical import because both the tombstone and trigger-created revision time would reflect execution time rather than the admitted historical timestamp.
+
+The next owner primitive should therefore remain migration-specific but owner-local:
+
+1. insert the admitted Reply/body/relations inside the existing 34O transaction;
+2. keep Deleted replies out of Approved public counters and `ForumTopicReplied` events;
+3. set exact admitted `deleted_at` before commit through a Forum owner helper;
+4. preserve one delete revision for the persisted body and stamp that revision with the same admitted historical deletion time;
+5. suppress interactive mention-added notifications for content whose final imported state is deleted;
+6. continue using the same all-or-nothing content transaction.
+
+A historical child may legitimately reference a parent whose **final imported state** is deleted: interactive create forbids choosing an already-deleted parent, but existing children are not removed when a parent is later soft-deleted. The next slice must reconstruct final historical state without pretending that the child was interactively created after deletion.
+
+## Current FORUM-34 chain
+
+The bounded chain is now:
+
+`34A mapping -> 34B/34C inspection -> 34K application resolution -> 34L owner-write preparation -> 34M relation admission -> 34N relation persistence bridge -> 34O atomic non-deleted content application -> 34P optional deleted-reply tombstone enrichment admission`.
+
+Standard current NodeBB deleted posts without an independently captured deletion timestamp remain a truthful source-data limitation, not a value that Forum fills in.
+
+## Next cursor
+
+The next safe slice is **FORUM-34Q**: make the existing 34O owner write service consume `ForumPreparedImportTombstoneBatch`, persist admitted deleted replies with exact owner tombstone/revision time in the same atomic transaction, and keep missing tombstone enrichment fail-closed.
+
+Durable cross-batch checkpoint/replay execution remains separate and must wait for a genuinely shared owner-data migration runner contract rather than a Forum-local journal.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-deleted-reply-tombstone-source.mjs
+```

--- a/scripts/verify/verify-forum-deleted-reply-tombstone-source.mjs
+++ b/scripts/verify/verify-forum-deleted-reply-tombstone-source.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  lib: "crates/rustok-forum/src/lib.rs",
+  tombstone: "crates/rustok-forum/src/import_tombstone_preparation.rs",
+  mapping: "crates/rustok-forum/src/import_mapping.rs",
+  relation: "crates/rustok-forum/src/import_relation_preparation.rs",
+  write: "crates/rustok-forum/src/services/import_write.rs",
+  replyOwner: "crates/rustok-forum/src/services/reply_owner.rs",
+  replyImport: "crates/rustok-forum/src/services/reply_owner_import.rs",
+  pgSoftDelete: "crates/rustok-forum/src/migrations/m20260713_000009_add_forum_soft_delete_revisions/postgres_up.rs",
+  sqliteRevisions: "crates/rustok-forum/src/migrations/m20260713_000009_add_forum_soft_delete_revisions/sqlite_revisions.rs",
+  packet: "docs/modules/forum-34-deleted-reply-tombstone-actualization-2026-08-09.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  "pub mod import_tombstone_preparation;",
+  "pub use import_tombstone_preparation::*;",
+]) need(source.lib, marker, "FORUM-34P root wiring");
+
+for (const marker of [
+  "pub const MAX_FORUM_IMPORT_REPLY_TOMBSTONES_PER_BATCH: usize =",
+  "pub struct NodebbReplyTombstoneRecord",
+  'serde(rename = "deletedTimestamp", alias = "deleted_timestamp")',
+  "pub struct ForumImportReplyTombstoneFact",
+  "pub struct ForumPreparedDeletedReplyTombstone",
+  "pub struct ForumImportTombstonePreparationRequest",
+  "pub struct ForumPreparedImportTombstoneBatch",
+  "pub struct NodebbForumReplyTombstoneMapper",
+  "pub struct ForumImportTombstonePreparer",
+  "ForumImportEntityKind::Post",
+  'format!("post:{}", record.pid)',
+  "DateTime::<Utc>::from_timestamp_millis",
+  "MissingDeletedReplyTombstone",
+  "LiveReplyHasTombstone",
+  "UnexpectedTombstone",
+  "TombstonePredatesCreation",
+  "relation.target != crate::mentions::ForumContentTarget::reply(reply.id)",
+]) need(source.tombstone, marker, "FORUM-34P tombstone admission");
+
+for (const marker of [
+  "pub struct NodebbPostRecord",
+  "pub deleted: bool",
+]) need(source.mapping, marker, "FORUM-34A mapping baseline");
+forbid(
+  source.mapping,
+  "deletedTimestamp",
+  "canonical NodeBB post mapping must not pretend the optional sidecar is a core post field",
+);
+
+for (const marker of [
+  "pub struct ForumPreparedImportRelationBatch",
+  "pub writes: ForumPreparedImportWriteBatch",
+]) need(source.relation, marker, "FORUM-34M relation batch baseline");
+
+for (const marker of [
+  "reply.status == ReplyStatus::Deleted",
+  "tombstone timestamp is admitted",
+]) need(source.write, marker, "FORUM-34O deleted-reply fail-closed baseline");
+for (const marker of [
+  "SET status = 'deleted', deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP",
+  "remove_in_tx",
+]) need(source.replyOwner, marker, "interactive reply owner delete baseline");
+for (const marker of [
+  "record.status == ReplyStatus::Deleted",
+  "requires an admitted tombstone timestamp",
+]) need(source.replyImport, marker, "FORUM-34O reply import boundary baseline");
+for (const marker of [
+  "forum_guard_deleted_reply_update",
+  "revision_reason",
+  "'delete'",
+]) need(source.pgSoftDelete, marker, "Postgres delete-revision baseline");
+for (const marker of [
+  "forum_reply_delete_revision_update",
+  "OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL",
+  "'delete'",
+]) need(source.sqliteRevisions, marker, "SQLite delete-revision baseline");
+
+for (const marker of [
+  "FORUM-34P",
+  "does not guarantee a historical deletion timestamp",
+  "does **not** change `NodebbPostRecord`",
+  "separate explicit exporter/audit enrichment contract",
+  "every `ReplyStatus::Deleted` reply to have exactly one tombstone",
+  "34O atomic writer remains unchanged",
+  "FORUM-34Q",
+  "no tests, Cargo commands",
+]) need(source.packet, marker, "FORUM-34P actualization");
+
+for (const marker of [
+  "sea_orm",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "TransactionTrait",
+  "SecurityContext",
+  "TransactionalEventBus",
+  "Uuid::new_v4",
+  ".insert(",
+  ".update(",
+  ".delete(",
+  ".commit(",
+]) forbid(source.tombstone, marker, "side-effect-free tombstone admission");
+
+console.log("Forum FORUM-34P deleted reply tombstone admission source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with a bounded, side-effect-free admission boundary for exact deleted-reply tombstone timestamps.

- add `NodebbReplyTombstoneRecord` as an explicit exporter/audit enrichment sidecar using `deletedTimestamp` / `deleted_timestamp`;
- keep the canonical `NodebbPostRecord` mapping unchanged because current NodeBB post deletion does not guarantee a historical deletion timestamp;
- map positive NodeBB pids onto the existing external `nodebb / Post / post:<pid>` identity namespace without creating RusTok UUIDs;
- bound tombstone enrichment to 512 records and reject duplicate IDs, negative/out-of-owner-range timestamps and malformed source refs;
- wrap the existing 34M prepared relation batch without changing it;
- require exactly one tombstone for every prepared `ReplyStatus::Deleted`, no tombstone for live replies, exact relation source/target/locale alignment, and `deleted_at_ms >= created_at_ms`;
- preserve prepared-reply order in admitted tombstones;
- perform no DB/SeaORM/transaction/security/event/event-bus/UUID-generation work;
- leave the 34O writer unchanged and fail-closed for deleted replies until the next owner-persistence slice.

## Fresh source recheck

34P started from `main` `4df29ba6adddc6e4c5560956d1abee6fa539d75c` after Pages PR #3420. During preparation, `main` advanced through Commerce PR #3421 and Events/Index PR #3423 to `745b2357db84c75bc188de8c582bfb51751b9b46`; none overlaps Forum source. The branch has been replayed onto that cursor. Immediate premerge freshness is checked independently with `behind 0`.

Current NodeBB source was rechecked before changing the mapping. Its post soft-delete path writes `deleted` and `deleterUid` but does not guarantee a deletion timestamp. Therefore this PR does not pretend `deletedTimestamp` is a canonical `NodebbPostRecord` field. The sidecar may only be populated when an exporter, audit log, backup, or other source actually captured historical deletion time.

Standard current NodeBB deleted posts without such enrichment remain an explicit source-data limitation rather than receiving an invented timestamp.

## Boundary intentionally left open

The existing 34O atomic writer still rejects every deleted reply. FORUM-34Q should consume the new `ForumPreparedImportTombstoneBatch`, write exact `deleted_at` and exact delete-revision time inside the same Forum-owned transaction, suppress interactive notifications for final-deleted content, and continue to reject missing enrichment.

The canonical Forum roadmap still has the stale FORUM-34 `planned` row; the dated 34P actualization records the truthful cursor without replacing the roadmap wholesale.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run. The source guard was added but intentionally not executed.