### PR TITLE
feat(commerce): route admin post-order writes through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-admin-post-order-command-owner-port-cutover-2026-08-09.md
+++ b/crates/rustok-commerce/docs/rest-admin-post-order-command-owner-port-cutover-2026-08-09.md
@@ -1,0 +1,99 @@
+# Commerce REST admin post-order command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-09
+
+## Scope
+
+This bounded slice moves four mounted admin REST Order writes behind the existing
+Order-owned `OrderPostOrderCommandPort`:
+
+- `POST /admin/orders/{id}/changes` -> `create_change`;
+- `POST /admin/order-changes/{id}/cancel` -> `cancel_change`;
+- `POST /admin/orders/{id}/returns` -> `create_return`;
+- `POST /admin/returns/{id}/cancel` -> `cancel_return`.
+
+The owner capability already delegates these operations to the canonical Order
+service inside `rustok-order`; Commerce no longer constructs that concrete owner
+service on these mounted routes.
+
+## Host composition
+
+`apps/server/src/services/commerce_provider_runtime.rs` already composes
+`OrderPostOrderCommandRuntime`, preserving a runtime supplied by either
+`HostRuntimeContext` or `ServerRuntimeContext` before installing the deterministic
+in-process baseline.
+
+`CommerceHttpRuntime` now requires that host-selected runtime and exposes only its
+`Arc<dyn OrderPostOrderCommandPort>` to the mounted handlers. The REST path therefore
+uses the same host-selected owner capability already required by mounted Commerce
+GraphQL post-order commands.
+
+## Request context and write admission
+
+Each mounted REST call preserves `ORDERS_UPDATE` admission and constructs a bounded
+`PortContext` with:
+
+- the admitted tenant;
+- the authenticated user actor;
+- the request locale;
+- the request channel when present;
+- a resource/operation-bound correlation id;
+- a two-second deadline;
+- a non-empty generated idempotency identity required by the owner write policy.
+
+These legacy REST endpoints do not expose a caller idempotency key. The generated
+UUID is therefore write-admission metadata only. This slice does **not** claim
+durable replay or exactly-once semantics for repeated HTTP requests.
+
+## Preserved public behavior
+
+The success status and DTO shapes remain unchanged:
+
+- create change / create return -> `201 Created`;
+- cancel change / cancel return -> `200 OK`.
+
+The owner `PortError` mapper preserves the existing REST error families for the
+Order variants previously exposed by the direct service path:
+
+- validation -> `400 commerce_admin_order_invalid`;
+- missing Order/change/return -> `404 commerce_admin_not_found`;
+- lifecycle conflict -> `409 commerce_admin_order_state_conflict`;
+- unavailable/timeout -> `503 commerce_admin_order_storage_unavailable`;
+- invariant failure -> `500 commerce_admin_order_failed`.
+
+A host-selected owner may additionally return `Forbidden`; that fails closed through
+the existing `401 commerce_permission_denied` family after Commerce permission
+admission.
+
+Diagnostics include only bounded owner kind/code-length/retryability/correlation and
+non-nil identity facts. `PortError.message` and raw backend/owner causes are not logged
+or exposed by the new mounted boundary.
+
+## Deliberately unchanged
+
+Payment-coupled post-order orchestration is outside this owner-command slice and stays
+on its existing Commerce services:
+
+- return decision creation;
+- order-change apply;
+- return completion.
+
+The old `changes.rs` and `returns.rs` create/cancel functions remain compiled
+compatibility source, but `admin::axum_router()` no longer mounts those four legacy
+handlers. Existing post-order GET routes continue to use `post_order_reads`.
+
+## Topology status
+
+The canonical broad item
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment,
+and Fulfillment concrete services behind host-composed owner ports` remains open.
+Other mounted ecommerce orchestration/consumer paths still require audit and cutover.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST
+scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios,
+or remote-adapter scenarios were executed. The dedicated source verifier added with
+this slice was source-reviewed but not run.

--- a/crates/rustok-commerce/src/controllers/admin/mod.rs
+++ b/crates/rustok-commerce/src/controllers/admin/mod.rs
@@ -9,6 +9,7 @@ pub mod orders;
 mod payments_legacy;
 #[path = "payments_owner_reads.rs"]
 pub mod payments;
+pub mod post_order_commands;
 pub mod post_order_reads;
 pub mod products;
 pub mod returns;
@@ -192,7 +193,7 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
         )
         .route(
             "/orders/{id}/returns",
-            axum::routing::post(returns::create_order_return),
+            axum::routing::post(post_order_commands::create_order_return),
         )
         .route(
             "/orders/{id}/returns/decision",
@@ -200,7 +201,7 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
         )
         .route(
             "/orders/{id}/changes",
-            axum::routing::post(changes::create_order_change),
+            axum::routing::post(post_order_commands::create_order_change),
         )
         .route(
             "/order-changes",
@@ -216,7 +217,7 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
         )
         .route(
             "/order-changes/{id}/cancel",
-            axum::routing::post(changes::cancel_order_change),
+            axum::routing::post(post_order_commands::cancel_order_change),
         )
         .route(
             "/returns",
@@ -232,7 +233,7 @@ pub fn axum_router() -> axum::Router<super::CommerceHttpRuntime> {
         )
         .route(
             "/returns/{id}/cancel",
-            axum::routing::post(returns::cancel_order_return),
+            axum::routing::post(post_order_commands::cancel_order_return),
         )
         .route(
             "/payment-collections",

--- a/crates/rustok-commerce/src/controllers/admin/post_order_commands.rs
+++ b/crates/rustok-commerce/src/controllers/admin/post_order_commands.rs
@@ -1,0 +1,328 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_order::{
+    CancelOrderChangeRequest as OwnerCancelOrderChangeRequest,
+    CancelOrderReturnRequest as OwnerCancelOrderReturnRequest,
+    CreateOrderChangeRequest as OwnerCreateOrderChangeRequest,
+    CreateOrderReturnRequest as OwnerCreateOrderReturnRequest,
+};
+use rustok_web::{HttpError, HttpResult};
+use uuid::Uuid;
+
+use super::super::{
+    CommerceHttpRuntime,
+    common::ensure_permissions,
+};
+use crate::dto::{
+    CancelOrderChangeInput, CancelOrderReturnInput, CreateOrderChangeInput, CreateOrderReturnInput,
+    OrderChangeResponse, OrderReturnResponse,
+};
+
+const ADMIN_POST_ORDER_OWNER: &str = "rustok_order.post_order_command";
+const ADMIN_POST_ORDER_BOUNDARY: &str = "commerce_admin_post_order_command_http";
+
+fn admin_post_order_command_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    resource_id: Uuid,
+    operation: &'static str,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-post-order:{operation}:{resource_id}"),
+    )
+    // The owner write policy requires an idempotency identity. These legacy REST
+    // endpoints do not expose a caller idempotency key, so this value is admission
+    // metadata only and does not claim durable replay/exactly-once semantics.
+    .with_idempotency_key(Uuid::new_v4().to_string())
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn map_admin_post_order_port_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    resource_id: Uuid,
+    operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "temporarily_unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "invariant_violation",
+        ),
+    };
+
+    tracing::error!(
+        owner = ADMIN_POST_ORDER_OWNER,
+        operation,
+        correlation_id = %context.correlation_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_POST_ORDER_BOUNDARY,
+        "commerce admin post-order owner command failed"
+    );
+
+    HttpError::new(status, code, message)
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/orders/{id}/changes",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    request_body = CreateOrderChangeInput,
+    responses(
+        (status = 201, description = "Order change created", body = OrderChangeResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn create_order_change(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CreateOrderChangeInput>,
+) -> HttpResult<(StatusCode, Json<OrderChangeResponse>)> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_post_order_command_context(&tenant, &auth, &request_context, id, "create_change");
+    let created = runtime
+        .order_post_order_command_port()
+        .create_change(
+            context.clone(),
+            OwnerCreateOrderChangeRequest {
+                order_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "create_change",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/order-changes/{id}/cancel",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order change ID")),
+    request_body = CancelOrderChangeInput,
+    responses(
+        (status = 200, description = "Order change cancelled", body = OrderChangeResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order change not found")
+    )
+)]
+pub async fn cancel_order_change(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CancelOrderChangeInput>,
+) -> HttpResult<Json<OrderChangeResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_post_order_command_context(&tenant, &auth, &request_context, id, "cancel_change");
+    let item = runtime
+        .order_post_order_command_port()
+        .cancel_change(
+            context.clone(),
+            OwnerCancelOrderChangeRequest {
+                change_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "cancel_change",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(item))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/orders/{id}/returns",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Order ID")),
+    request_body = CreateOrderReturnInput,
+    responses(
+        (status = 201, description = "Return created", body = OrderReturnResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Order not found")
+    )
+)]
+pub async fn create_order_return(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CreateOrderReturnInput>,
+) -> HttpResult<(StatusCode, Json<OrderReturnResponse>)> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_post_order_command_context(&tenant, &auth, &request_context, id, "create_return");
+    let created = runtime
+        .order_post_order_command_port()
+        .create_return(
+            context.clone(),
+            OwnerCreateOrderReturnRequest {
+                order_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "create_return",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+#[utoipa::path(
+    post,
+    path = "/admin/returns/{id}/cancel",
+    tag = "admin",
+    params(("id" = Uuid, Path, description = "Return ID")),
+    request_body = CancelOrderReturnInput,
+    responses(
+        (status = 200, description = "Return cancelled", body = OrderReturnResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Return not found")
+    )
+)]
+pub async fn cancel_order_return(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: AuthContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+    Json(input): Json<CancelOrderReturnInput>,
+) -> HttpResult<Json<OrderReturnResponse>> {
+    ensure_permissions(
+        &auth,
+        &[Permission::ORDERS_UPDATE],
+        "Permission denied: orders:update required",
+    )?;
+
+    let context =
+        admin_post_order_command_context(&tenant, &auth, &request_context, id, "cancel_return");
+    let item = runtime
+        .order_post_order_command_port()
+        .cancel_return(
+            context.clone(),
+            OwnerCancelOrderReturnRequest {
+                return_id: id,
+                input,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_admin_post_order_port_error(
+                tenant.id,
+                auth.user_id,
+                id,
+                "cancel_return",
+                &context,
+                error,
+            )
+        })?;
+
+    Ok(Json(item))
+}

--- a/crates/rustok-commerce/src/controllers/mod.rs
+++ b/crates/rustok-commerce/src/controllers/mod.rs
@@ -32,6 +32,7 @@ pub struct CommerceHttpRuntime {
         rustok_fulfillment::FulfillmentAdminCreateCommandRuntime,
     order_read_runtime: crate::graphql_runtime::CommerceOrderReadRuntime,
     order_admin_command_runtime: rustok_order::OrderAdminCommandRuntime,
+    order_post_order_command_runtime: rustok_order::OrderPostOrderCommandRuntime,
     payment_order_read_runtime: rustok_payment::PaymentOrderReadRuntime,
     payment_cart_read_runtime: rustok_payment::PaymentCartReadRuntime,
     payment_collection_runtime: rustok_payment::PaymentCollectionRuntime,
@@ -70,6 +71,8 @@ impl CommerceHttpRuntime {
             crate::graphql_runtime::CommerceOrderReadRuntime::in_process(db.clone(), event_bus.clone());
         let order_admin_command_runtime =
             rustok_order::OrderAdminCommandRuntime::in_process(db.clone(), event_bus.clone());
+        let order_post_order_command_runtime =
+            rustok_order::OrderPostOrderCommandRuntime::in_process(db.clone(), event_bus.clone());
         let payment_order_read_runtime =
             rustok_payment::PaymentOrderReadRuntime::in_process(db.clone());
         let payment_cart_read_runtime =
@@ -108,6 +111,7 @@ impl CommerceHttpRuntime {
             fulfillment_admin_create_command_runtime,
             order_read_runtime,
             order_admin_command_runtime,
+            order_post_order_command_runtime,
             payment_order_read_runtime,
             payment_cart_read_runtime,
             payment_collection_runtime,
@@ -184,6 +188,12 @@ impl CommerceHttpRuntime {
 
     fn order_admin_command_port(&self) -> std::sync::Arc<dyn rustok_order::OrderAdminCommandPort> {
         self.order_admin_command_runtime.command_port()
+    }
+
+    fn order_post_order_command_port(
+        &self,
+    ) -> std::sync::Arc<dyn rustok_order::OrderPostOrderCommandPort> {
+        self.order_post_order_command_runtime.command_port()
     }
 
     fn payment_order_read_port(&self) -> std::sync::Arc<dyn rustok_payment::PaymentOrderReadPort> {
@@ -305,6 +315,13 @@ impl CommerceHttpRuntime {
                     "Commerce HTTP routes require OrderAdminCommandRuntime in HostRuntimeContext"
                 )
             })?;
+        let order_post_order_command_runtime = runtime
+            .shared_get::<rustok_order::OrderPostOrderCommandRuntime>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Commerce HTTP routes require OrderPostOrderCommandRuntime in HostRuntimeContext"
+                )
+            })?;
         let payment_order_read_runtime = runtime
             .shared_get::<rustok_payment::PaymentOrderReadRuntime>()
             .ok_or_else(|| {
@@ -379,6 +396,7 @@ impl CommerceHttpRuntime {
             fulfillment_admin_create_command_runtime,
             order_read_runtime,
             order_admin_command_runtime,
+            order_post_order_command_runtime,
             payment_order_read_runtime,
             payment_cart_read_runtime,
             payment_collection_runtime,

--- a/scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-admin-post-order-read-cutover.mjs
@@ -30,17 +30,18 @@ const count = (source, value) => source.split(value).length - 1;
 
 for (const [source, value, label] of [
   [router, 'pub mod post_order_reads;', 'mounted admin read module'],
+  [router, 'pub mod post_order_commands;', 'mounted admin command module'],
   [router, 'axum::routing::get(post_order_reads::list_order_returns)', 'mounted return list'],
   [router, 'axum::routing::get(post_order_reads::show_order_return)', 'mounted return detail'],
   [router, 'axum::routing::get(post_order_reads::list_order_changes)', 'mounted change list'],
   [router, 'axum::routing::get(post_order_reads::show_order_change)', 'mounted change detail'],
-  [router, 'axum::routing::post(returns::create_order_return)', 'return creation remains mounted mutation'],
+  [router, 'axum::routing::post(post_order_commands::create_order_return)', 'return creation owner mutation'],
   [router, 'axum::routing::post(returns::create_order_return_decision)', 'return decision remains mounted orchestration'],
   [router, 'axum::routing::post(returns::complete_order_return)', 'return completion remains mounted orchestration'],
-  [router, 'axum::routing::post(returns::cancel_order_return)', 'return cancel remains mounted mutation'],
-  [router, 'axum::routing::post(changes::create_order_change)', 'change creation remains mounted mutation'],
+  [router, 'axum::routing::post(post_order_commands::cancel_order_return)', 'return cancel owner mutation'],
+  [router, 'axum::routing::post(post_order_commands::create_order_change)', 'change creation owner mutation'],
   [router, 'axum::routing::post(changes::apply_order_change)', 'change apply remains mounted orchestration'],
-  [router, 'axum::routing::post(changes::cancel_order_change)', 'change cancel remains mounted mutation'],
+  [router, 'axum::routing::post(post_order_commands::cancel_order_change)', 'change cancel owner mutation'],
   [reads, 'ListOrderReturnProjectionsRequest {', 'typed return list request'],
   [reads, 'ReadOrderReturnProjectionRequest { return_id: id }', 'typed return detail request'],
   [reads, 'ListOrderChangeProjectionsRequest {', 'typed change list request'],
@@ -58,12 +59,12 @@ for (const [source, value, label] of [
   [reads, 'per_page: pagination.limit()', 'clamped owner page size'],
   [reads, 'data: page.items,', 'typed page items'],
   [reads, 'page.total', 'owner pagination total'],
-  [returns, '.create_return(tenant.id, id, input)', 'return mutation remains concrete owner command'],
+  [returns, '.create_return(tenant.id, id, input)', 'legacy return mutation compatibility source'],
   [returns, '.complete_return(tenant.id, auth.user_id, id, command)', 'return completion remains orchestration'],
-  [returns, '.cancel_return(tenant.id, id, input)', 'return cancel remains concrete owner command'],
-  [changes, '.create_order_change(tenant.id, actor_id, id, input)', 'change creation remains concrete owner command'],
+  [returns, '.cancel_return(tenant.id, id, input)', 'legacy return cancel compatibility source'],
+  [changes, '.create_order_change(tenant.id, actor_id, id, input)', 'legacy change mutation compatibility source'],
   [changes, '.apply_order_change(tenant.id, id, input.difference_refund, input.metadata)', 'change apply remains orchestration'],
-  [changes, '.cancel_order_change(tenant.id, id, input)', 'change cancel remains concrete owner command'],
+  [changes, '.cancel_order_change(tenant.id, id, input)', 'legacy change cancel compatibility source'],
   [note, '## Admin post-order read cutover', 'focused admin cutover note'],
   [note, 'all mounted complete/post-order reads cut over, unvalidated', 'focused status'],
 ]) requireText(source, value, label);
@@ -131,5 +132,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Mounted admin return/order-change list and detail routes use typed owner projections with preserved ORDERS_READ, filters, pagination, actor/channel/locale/deadline context, while POST mutations remain unchanged',
+  '✔ Mounted admin return/order-change reads use typed owner projections while create/cancel writes use the owner command module and payment-coupled orchestration remains unchanged',
 );

--- a/scripts/verify/verify-commerce-rest-admin-post-order-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-admin-post-order-command-owner-port-cutover.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const router = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const commands = read('crates/rustok-commerce/src/controllers/admin/post_order_commands.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const owner = read('crates/rustok-order/src/post_order_command.rs');
+const server = read('apps/server/src/services/commerce_provider_runtime.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-admin-post-order-command-owner-port-cutover-2026-08-09.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['pub mod post_order_commands;', 'mounted post-order command module'],
+  ['axum::routing::post(post_order_commands::create_order_change)', 'create change route'],
+  ['axum::routing::post(post_order_commands::cancel_order_change)', 'cancel change route'],
+  ['axum::routing::post(post_order_commands::create_order_return)', 'create return route'],
+  ['axum::routing::post(post_order_commands::cancel_order_return)', 'cancel return route'],
+  ['axum::routing::post(changes::apply_order_change)', 'apply orchestration retained'],
+  ['axum::routing::post(returns::create_order_return_decision)', 'return decision orchestration retained'],
+  ['axum::routing::post(returns::complete_order_return)', 'return completion orchestration retained'],
+  ['axum::routing::get(post_order_reads::list_order_changes)', 'change reads remain owner-read mounted'],
+  ['axum::routing::get(post_order_reads::list_order_returns)', 'return reads remain owner-read mounted'],
+]) requireText(router, value, label);
+
+for (const value of [
+  'axum::routing::post(changes::create_order_change)',
+  'axum::routing::post(changes::cancel_order_change)',
+  'axum::routing::post(returns::create_order_return)',
+  'axum::routing::post(returns::cancel_order_return)',
+]) forbidText(router, value, 'stale mounted direct Order handler');
+
+for (const [value, label] of [
+  ['AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,', 'typed request/port imports'],
+  ['OwnerCreateOrderChangeRequest', 'owner create-change request'],
+  ['OwnerCancelOrderChangeRequest', 'owner cancel-change request'],
+  ['OwnerCreateOrderReturnRequest', 'owner create-return request'],
+  ['OwnerCancelOrderReturnRequest', 'owner cancel-return request'],
+  ['admin_post_order_command_context(', 'shared owner context builder'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
+  ['request_context.locale.as_str()', 'request locale'],
+  ['request_context.channel_slug.as_deref()', 'request channel'],
+  ['with_idempotency_key(Uuid::new_v4().to_string())', 'write admission identity'],
+  ['with_deadline(std::time::Duration::from_secs(2))', 'bounded deadline'],
+  ['[Permission::ORDERS_UPDATE]', 'order update admission'],
+  ['.order_post_order_command_port()', 'host-selected owner port accessor'],
+  ['.create_change(', 'create-change owner call'],
+  ['.cancel_change(', 'cancel-change owner call'],
+  ['.create_return(', 'create-return owner call'],
+  ['.cancel_return(', 'cancel-return owner call'],
+  ['StatusCode::CREATED', 'create success status'],
+]) requireText(commands, value, label);
+
+for (const value of [
+  'OrderService::new(',
+  '.create_order_change(tenant.id,',
+  '.cancel_order_change(tenant.id,',
+  '.create_return(tenant.id,',
+  '.cancel_return(tenant.id,',
+]) forbidText(commands, value, 'concrete Order service construction');
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'validation mapping'],
+  ['PortErrorKind::NotFound', 'not-found mapping'],
+  ['PortErrorKind::Conflict', 'conflict mapping'],
+  ['PortErrorKind::Forbidden', 'forbidden mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable mapping'],
+  ['PortErrorKind::InvariantViolation', 'invariant mapping'],
+  ['"commerce_admin_order_invalid"', 'validation public code'],
+  ['"commerce_admin_not_found"', 'not-found public code'],
+  ['"commerce_admin_order_state_conflict"', 'conflict public code'],
+  ['"commerce_permission_denied"', 'forbidden public code'],
+  ['"commerce_admin_order_storage_unavailable"', 'storage public code'],
+  ['"commerce_admin_order_failed"', 'fail-closed public code'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['owner_error_kind = ?error.kind', 'owner error-kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner-code diagnostic'],
+  ['retryable = error.retryable', 'retryability diagnostic'],
+]) requireText(commands, value, label);
+
+for (const value of [
+  'error = ?error',
+  'error.message',
+  'error.to_string()',
+  'err.to_string()',
+]) forbidText(commands, value, 'raw owner diagnostic');
+
+for (const [value, label] of [
+  ['order_post_order_command_runtime: rustok_order::OrderPostOrderCommandRuntime', 'HTTP runtime field'],
+  ['fn order_post_order_command_port(', 'HTTP owner accessor'],
+  ['std::sync::Arc<dyn rustok_order::OrderPostOrderCommandPort>', 'HTTP trait object'],
+  ['self.order_post_order_command_runtime.command_port()', 'HTTP selected command port'],
+  ['shared_get::<rustok_order::OrderPostOrderCommandRuntime>()', 'HTTP host runtime requirement'],
+  ['"Commerce HTTP routes require OrderPostOrderCommandRuntime in HostRuntimeContext"', 'HTTP fail-closed host requirement'],
+]) requireText(httpRuntime, value, label);
+
+for (const [value, label] of [
+  ['shared_get::<rustok_order::OrderPostOrderCommandRuntime>()', 'server preserves host runtime'],
+  ['server.shared_get::<rustok_order::OrderPostOrderCommandRuntime>()', 'server preserves server runtime'],
+  ['rustok_order::OrderPostOrderCommandRuntime::in_process(', 'server deterministic baseline'],
+  ['host.with_shared_value(runtime)', 'server attaches runtime to host'],
+]) requireText(server, value, label);
+
+for (const [value, label] of [
+  ['pub trait OrderPostOrderCommandPort: Send + Sync', 'owner trait'],
+  ['async fn create_change(', 'owner create change capability'],
+  ['async fn cancel_change(', 'owner cancel change capability'],
+  ['async fn create_return(', 'owner create return capability'],
+  ['async fn cancel_return(', 'owner cancel return capability'],
+  ['context.require_policy(PortCallPolicy::write())', 'owner write admission'],
+  ['inner: OrderService', 'concrete service retained inside owner'],
+]) requireText(owner, value, label);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology item remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST admin post-order command owner-port cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['`POST /admin/orders/{id}/changes`', 'record create-change route'],
+  ['`POST /admin/returns/{id}/cancel`', 'record cancel-return route'],
+  ['write-admission metadata only', 'record replay limitation'],
+  ['The canonical broad item', 'record broad topology status'],
+  ['no tests, Cargo commands, Node verifiers, formatter', 'record validation status'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST admin post-order owner command cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted admin post-order create/cancel writes use the host-selected Order owner port');


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with one bounded mounted Order post-order command cutover.

- route mounted admin REST create/cancel order-change and return writes through the existing host-selected `OrderPostOrderCommandPort`;
- move `POST /admin/orders/{id}/changes`, `POST /admin/order-changes/{id}/cancel`, `POST /admin/orders/{id}/returns`, and `POST /admin/returns/{id}/cancel` to a dedicated owner-command module;
- preserve `ORDERS_UPDATE`, authenticated actor, tenant, request locale/channel, two-second deadline, success statuses/DTOs, and existing Order REST public error families;
- use a generated non-empty idempotency identity only to satisfy owner write admission; these legacy REST endpoints still do not claim durable replay/exactly-once semantics;
- require `OrderPostOrderCommandRuntime` in `CommerceHttpRuntime`, expose only its trait port, and include it in the new in-process HTTP scaffolding added on current `main`;
- preserve server host/server supplied runtime selection already present in `commerce_provider_runtime`;
- keep return-decision, order-change apply, and return-completion payment-coupled Commerce orchestration unchanged;
- keep raw owner/backend messages out of the new mounted error boundary and log bounded correlation/kind/code-length/retryability facts;
- update the existing post-order read guard for the new route targets, add a dedicated source guard, and add a dated source record;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind current `main` (`e8736805b6bbaa828d641f27c795e79c04b0e104`) with exactly six changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source verifiers were updated/added but not run.