### PR TITLE
test(pages): add observed health owner acceptance

### DIFF
--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json
@@ -14,6 +14,7 @@
     "source_commit_must_equal_checkout_head": true,
     "source_hashes_must_match_runtime_execution_contract_and_checkout": true,
     "identity_evaluation_binding_acceptance_hashes_must_match_supplied_packets": true,
+    "supplied_predecessor_source_hashes_must_match_contracts_and_checkout": true,
     "deployment_id_and_repo_digest_must_match_all_supplied_packets": true,
     "accepted_health_snapshot_and_slo_must_match_binding_acceptance": true,
     "health_valid_until_must_match_binding_acceptance": true,
@@ -24,6 +25,7 @@
     "configured_rollout_all_on_required": true,
     "graphql_provider_health_observed_required": true,
     "graphql_provider_state_must_match_accepted_snapshot": true,
+    "graphql_http_status_and_body_hashes_revalidated": true,
     "canonical_feature_disabled_contract_required_when_narrowed": true,
     "workspace_controls_must_match_accepted_state": true,
     "authoritative_ssr_preview_behavior_must_match_accepted_state": true,
@@ -36,17 +38,20 @@
   "supplied_predecessor_packets": {
     "deployment_identity": {
       "format": "page_builder_provider_health_deployment_identity_v1",
-      "status": "deployment_identity_verified_health_evaluation_pending"
+      "status": "deployment_identity_verified_health_evaluation_pending",
+      "source_contract": "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json"
     },
     "deployment_evaluation": {
       "format": "page_builder_provider_health_deployment_evaluation_v1",
-      "status": "deployment_health_evaluated_pages_binding_pending"
+      "status": "deployment_health_evaluated_pages_binding_pending",
+      "source_contract": "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json"
     },
     "binding_owner_acceptance": {
       "format": "pages_builder_provider_health_owner_acceptance_v1",
       "status": "owner_accepted_server_binding_pending",
       "decision": "accept_for_pages_binding",
-      "rollback_action": "restore_unobserved_provider_health"
+      "rollback_action": "restore_unobserved_provider_health",
+      "source_contract": "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json"
     }
   },
   "owner_decision": {
@@ -111,6 +116,8 @@
     "workflow_or_ci_run": false
   },
   "required_source_files": [
+    "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+    "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
     "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json",
     "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-harness-source.json",
     "apps/next-admin/tests/pages-builder-provider-health-runtime/runtime.spec.ts",

--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json
@@ -1,0 +1,131 @@
+{
+  "format": "pages_builder_provider_health_observed_acceptance_source_v1",
+  "status": "source_ready_maintainer_execution_pending",
+  "provider": "page_builder",
+  "predecessors": [
+    "pages_builder_provider_health_runtime_harness_source_v1",
+    "pages_builder_provider_health_owner_acceptance_source_v1"
+  ],
+  "runtime_evidence_input": {
+    "format": "pages_builder_provider_health_runtime_evidence_v1",
+    "required_status": "observed_runtime_evidence_owner_review_pending",
+    "must_be_regular_non_symlink_file": true,
+    "maximum_bytes": 8388608,
+    "source_commit_must_equal_checkout_head": true,
+    "source_hashes_must_match_runtime_execution_contract_and_checkout": true,
+    "identity_evaluation_binding_acceptance_hashes_must_match_supplied_packets": true,
+    "deployment_id_and_repo_digest_must_match_all_supplied_packets": true,
+    "accepted_health_snapshot_and_slo_must_match_binding_acceptance": true,
+    "health_valid_until_must_match_binding_acceptance": true,
+    "runtime_generated_at_must_be_canonical_iso": true,
+    "runtime_generated_at_must_not_exceed_health_valid_until_plus_skew": true,
+    "health_may_be_expired_at_owner_review": true,
+    "health_lease_must_not_be_restarted_or_extended": true,
+    "configured_rollout_all_on_required": true,
+    "graphql_provider_health_observed_required": true,
+    "graphql_provider_state_must_match_accepted_snapshot": true,
+    "canonical_feature_disabled_contract_required_when_narrowed": true,
+    "workspace_controls_must_match_accepted_state": true,
+    "authoritative_ssr_preview_behavior_must_match_accepted_state": true,
+    "standalone_browser_intent_behavior_must_match_accepted_state": true,
+    "publish_mutation_executed_must_be_false": true,
+    "rollout_settings_mutated_must_be_false": true,
+    "privacy_nonretention_flags_must_all_be_false": true,
+    "prior_owner_acceptance_and_gate_promotion_claims_must_be_false": true
+  },
+  "supplied_predecessor_packets": {
+    "deployment_identity": {
+      "format": "page_builder_provider_health_deployment_identity_v1",
+      "status": "deployment_identity_verified_health_evaluation_pending"
+    },
+    "deployment_evaluation": {
+      "format": "page_builder_provider_health_deployment_evaluation_v1",
+      "status": "deployment_health_evaluated_pages_binding_pending"
+    },
+    "binding_owner_acceptance": {
+      "format": "pages_builder_provider_health_owner_acceptance_v1",
+      "status": "owner_accepted_server_binding_pending",
+      "decision": "accept_for_pages_binding",
+      "rollback_action": "restore_unobserved_provider_health"
+    }
+  },
+  "owner_decision": {
+    "runner": "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs",
+    "owner_id": "bounded_operator_asserted_identifier",
+    "owner_id_pattern": "^[A-Za-z0-9._-]{1,64}$",
+    "decisions": [
+      "accept_observed_runtime_evidence",
+      "reject"
+    ],
+    "acceptance_meaning": "accept_retrospective_exact_deployment_runtime_evidence_for_gate_review",
+    "acceptance_does_not_assert_current_provider_health": true,
+    "acceptance_does_not_authorize_or_extend_server_binding": true,
+    "acceptance_does_not_accept_pages_reference_consumer_gate": true,
+    "free_text_reason_retained": false,
+    "cryptographic_signature_required": false,
+    "owner_identity_is_operator_assertion": true
+  },
+  "output": {
+    "format": "pages_builder_provider_health_observed_acceptance_v1",
+    "accepted_status": "owner_accepted_observed_runtime_evidence_gate_review_pending",
+    "rejected_status": "owner_rejected_observed_runtime_evidence",
+    "default_path": "target/pages-builder-provider-health-observed-acceptance.json",
+    "atomic_replace": true,
+    "runtime_evidence_sha256_retained": true,
+    "predecessor_packet_sha256_retained": true,
+    "source_commit_retained": true,
+    "deployment_id_retained": true,
+    "deployment_image_digest_retained": true,
+    "health_valid_until_retained_as_historical_lease_deadline": true,
+    "provider_health_snapshot_retained": true,
+    "slo_evaluation_retained": true,
+    "owner_id_retained": true,
+    "decision_retained": true,
+    "raw_input_paths_retained": false,
+    "raw_http_or_browser_bodies_retained": false
+  },
+  "gate_boundary": {
+    "accepted_packet_is_eligible_input_for_pages_gate_review": true,
+    "accepted_packet_does_not_accept_pages_gate": true,
+    "accepted_packet_does_not_satisfy_reference_gate_owner_signoff_or_rollback_by_itself": true,
+    "pages_reference_consumer_gate_must_remain_accepted_false_in_source": true,
+    "forum_wave_must_remain_blocked": true,
+    "ffa_fba_promotion_must_remain_unclaimed": true
+  },
+  "non_claims": {
+    "runtime_evidence_executed_by_this_slice": false,
+    "observed_health_owner_acceptance_executed": false,
+    "current_provider_health_asserted": false,
+    "health_lease_extended": false,
+    "server_binding_changed": false,
+    "pages_reference_consumer_gate_accepted": false,
+    "forum_wave_accepted": false,
+    "ffa_promoted": false,
+    "fba_promoted": false,
+    "tests_run": false,
+    "node_verifier_run": false,
+    "cargo_run": false,
+    "formatting_run": false,
+    "graphql_or_http_run": false,
+    "browser_run": false,
+    "workflow_or_ci_run": false
+  },
+  "required_source_files": [
+    "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json",
+    "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-harness-source.json",
+    "apps/next-admin/tests/pages-builder-provider-health-runtime/runtime.spec.ts",
+    "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json",
+    "scripts/evidence/accept-pages-builder-provider-health-deployment.mjs",
+    "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json",
+    "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs",
+    "crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs",
+    "docs/modules/pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md",
+    "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md"
+  ],
+  "next_cursor": {
+    "observed_health_owner_acceptance": "source_ready_maintainer_execution_pending",
+    "live_identity_evaluator_binding_acceptance_runtime_evidence": "maintainer_execution_pending",
+    "accepted_observed_health_gate_input": "blocked_on_maintainer_execution_and_decision",
+    "pages_reference_consumer_gate_acceptance": "pending"
+  }
+}

--- a/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-harness-source.json
+++ b/crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-harness-source.json
@@ -31,6 +31,16 @@
     "automatic_forum_wave_acceptance": false,
     "automatic_ffa_fba_promotion": false
   },
+  "observed_owner_acceptance": {
+    "source_contract": "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json",
+    "runner": "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs",
+    "output_format": "pages_builder_provider_health_observed_acceptance_v1",
+    "accepted_status": "owner_accepted_observed_runtime_evidence_gate_review_pending",
+    "source_ready": true,
+    "execution_pending": true,
+    "health_lease_extended": false,
+    "automatic_pages_gate_acceptance": false
+  },
   "execution": [],
   "validation": {
     "tests_run": false,
@@ -50,7 +60,8 @@
   },
   "next_cursor": {
     "observed_health_runtime_evidence_harness": "source_ready_maintainer_execution_pending",
+    "observed_health_owner_acceptance": "source_ready_maintainer_execution_pending",
     "live_identity_evaluator_owner_acceptance_and_observed_consumers": "maintainer_execution_pending",
-    "observed_health_owner_acceptance": "pending"
+    "accepted_observed_health_gate_input": "blocked_on_maintainer_execution_and_decision"
   }
 }

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
@@ -11,7 +11,9 @@ const files = {
   runner: "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs",
   runtimeContract: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json",
   runtimeSource: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-harness-source.json",
-  bindingAcceptance: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json",
+  identitySource: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
+  evaluatorSource: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
+  bindingSource: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json",
   runtimeVerifier: "crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs",
   gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
   overlay: "docs/modules/pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md",
@@ -19,22 +21,13 @@ const files = {
 };
 const abs = (value) => path.join(repoRoot, value);
 const read = (value) => fs.readFileSync(abs(value), "utf8");
-const need = (source, marker, label) => {
-  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
-};
-const forbid = (source, marker, label) => {
-  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
-};
+const need = (source, marker, label) => { if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`); };
+const forbid = (source, marker, label) => { if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`); };
 
 for (const [label, relativePath] of Object.entries(files)) {
-  if (!fs.existsSync(abs(relativePath))) {
-    failures.push(`${label}: missing ${relativePath}`);
-    continue;
-  }
+  if (!fs.existsSync(abs(relativePath))) { failures.push(`${label}: missing ${relativePath}`); continue; }
   const stats = fs.lstatSync(abs(relativePath));
-  if (!stats.isFile() || stats.isSymbolicLink()) {
-    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
-  }
+  if (!stats.isFile() || stats.isSymbolicLink()) failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
 }
 if (failures.length) {
   console.error("[verify-pages-builder-provider-health-observed-acceptance] FAIL");
@@ -42,31 +35,21 @@ if (failures.length) {
   process.exit(Math.min(failures.length, 255));
 }
 
-const sources = Object.fromEntries(
-  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
-);
+const sources = Object.fromEntries(Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]));
 const contract = JSON.parse(sources.contract);
 const runtimeContract = JSON.parse(sources.runtimeContract);
 const runtimeSource = JSON.parse(sources.runtimeSource);
-const bindingAcceptance = JSON.parse(sources.bindingAcceptance);
+const identitySource = JSON.parse(sources.identitySource);
+const evaluatorSource = JSON.parse(sources.evaluatorSource);
+const bindingSource = JSON.parse(sources.bindingSource);
 const gate = JSON.parse(sources.gate);
 
-if (
-  contract.format !== "pages_builder_provider_health_observed_acceptance_source_v1" ||
-  contract.status !== "source_ready_maintainer_execution_pending"
-) failures.push("observed-health acceptance source identity drifted");
-if (
-  runtimeContract.packet !== "pages-builder-provider-health-runtime-evidence" ||
-  runtimeContract.output?.format !== "pages_builder_provider_health_runtime_evidence_v1" ||
-  runtimeContract.output?.status !== "observed_runtime_evidence_owner_review_pending"
-) failures.push("runtime evidence predecessor contract drifted");
-if (
-  runtimeSource.format !== "pages_builder_provider_health_runtime_harness_source_v1" ||
-  runtimeSource.status !== "source_ready_maintainer_execution_pending"
-) failures.push("runtime harness predecessor source drifted");
-if (bindingAcceptance.format !== "pages_builder_provider_health_owner_acceptance_source_v1") {
-  failures.push("binding owner-acceptance predecessor source drifted");
-}
+if (contract.format !== "pages_builder_provider_health_observed_acceptance_source_v1" || contract.status !== "source_ready_maintainer_execution_pending") failures.push("observed-health acceptance source identity drifted");
+if (runtimeContract.packet !== "pages-builder-provider-health-runtime-evidence" || runtimeContract.output?.format !== "pages_builder_provider_health_runtime_evidence_v1" || runtimeContract.output?.status !== "observed_runtime_evidence_owner_review_pending") failures.push("runtime evidence predecessor contract drifted");
+if (runtimeSource.format !== "pages_builder_provider_health_runtime_harness_source_v1" || runtimeSource.status !== "source_ready_maintainer_execution_pending") failures.push("runtime harness predecessor source drifted");
+if (identitySource.format !== "page_builder_provider_health_deployment_identity_source_v1") failures.push("identity source contract drifted");
+if (evaluatorSource.format !== "page_builder_provider_health_deployment_evaluator_source_v1") failures.push("evaluator source contract drifted");
+if (bindingSource.format !== "pages_builder_provider_health_owner_acceptance_source_v1") failures.push("binding owner-acceptance source contract drifted");
 
 for (const [object, key, expected] of [
   [contract.runtime_evidence_input, "format", "pages_builder_provider_health_runtime_evidence_v1"],
@@ -74,9 +57,12 @@ for (const [object, key, expected] of [
   [contract.runtime_evidence_input, "source_commit_must_equal_checkout_head", true],
   [contract.runtime_evidence_input, "source_hashes_must_match_runtime_execution_contract_and_checkout", true],
   [contract.runtime_evidence_input, "identity_evaluation_binding_acceptance_hashes_must_match_supplied_packets", true],
+  [contract.runtime_evidence_input, "supplied_predecessor_source_hashes_must_match_contracts_and_checkout", true],
   [contract.runtime_evidence_input, "health_may_be_expired_at_owner_review", true],
   [contract.runtime_evidence_input, "health_lease_must_not_be_restarted_or_extended", true],
   [contract.runtime_evidence_input, "configured_rollout_all_on_required", true],
+  [contract.runtime_evidence_input, "graphql_provider_health_observed_required", true],
+  [contract.runtime_evidence_input, "graphql_http_status_and_body_hashes_revalidated", true],
   [contract.runtime_evidence_input, "canonical_feature_disabled_contract_required_when_narrowed", true],
   [contract.runtime_evidence_input, "publish_mutation_executed_must_be_false", true],
   [contract.runtime_evidence_input, "rollout_settings_mutated_must_be_false", true],
@@ -95,101 +81,55 @@ for (const [object, key, expected] of [
   [contract.non_claims, "pages_reference_consumer_gate_accepted", false],
   [contract.non_claims, "tests_run", false],
   [contract.non_claims, "node_verifier_run", false],
-]) {
-  if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
-}
+]) if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
 
-if (
-  !Array.isArray(contract.owner_decision?.decisions) ||
-  !contract.owner_decision.decisions.includes("accept_observed_runtime_evidence") ||
-  !contract.owner_decision.decisions.includes("reject")
-) failures.push("observed-health owner decision set drifted");
-if (
-  contract.supplied_predecessor_packets?.binding_owner_acceptance?.decision !== "accept_for_pages_binding" ||
-  contract.supplied_predecessor_packets?.binding_owner_acceptance?.rollback_action !== "restore_unobserved_provider_health"
-) failures.push("binding acceptance lineage drifted");
+for (const [node, expectedPath, label] of [
+  [contract.supplied_predecessor_packets?.deployment_identity, files.identitySource, "identity"],
+  [contract.supplied_predecessor_packets?.deployment_evaluation, files.evaluatorSource, "evaluation"],
+  [contract.supplied_predecessor_packets?.binding_owner_acceptance, files.bindingSource, "binding acceptance"],
+]) if (node?.source_contract !== expectedPath) failures.push(`${label} source-contract path drifted`);
+if (contract.supplied_predecessor_packets?.binding_owner_acceptance?.decision !== "accept_for_pages_binding" || contract.supplied_predecessor_packets?.binding_owner_acceptance?.rollback_action !== "restore_unobserved_provider_health") failures.push("binding acceptance lineage drifted");
+if (!contract.owner_decision?.decisions?.includes("accept_observed_runtime_evidence") || !contract.owner_decision?.decisions?.includes("reject")) failures.push("observed-health owner decision set drifted");
 
 for (const marker of [
-  '"--runtime-evidence"',
-  '"--identity"',
-  '"--evaluation"',
-  '"--binding-acceptance"',
-  'const ACCEPT_DECISION = "accept_observed_runtime_evidence"',
-  'const REJECT_DECISION = "reject"',
-  "git", ["rev-parse", "HEAD"],
-].filter((marker) => typeof marker === "string")) need(sources.runner, marker, "observed acceptance runner");
-for (const marker of [
-  "verifyRuntimeSourceHashes(runtime, runtimeContract)",
-  "runtime source SHA set differs from runtime execution contract",
-  "runtime identity packet",
-  "runtime evaluation packet",
-  "runtime binding acceptance packet",
+  '"--runtime-evidence"', '"--identity"', '"--evaluation"', '"--binding-acceptance"',
+  'const ACCEPT_DECISION = "accept_observed_runtime_evidence"', 'const REJECT_DECISION = "reject"',
+  'spawnSync("git", ["rev-parse", "HEAD"]',
+  'verifyRetainedSourceHashes(runtime, runtimeContract, "source_sha256", "runtime evidence")',
+  'verifyRetainedSourceHashes(identity, identitySource, "source_files", "identity packet")',
+  'verifyRetainedSourceHashes(evaluation, evaluatorSource, "source_files", "evaluation packet")',
+  'verifyRetainedSourceHashes(binding, bindingSource, "source_files", "binding owner-acceptance packet")',
+  "runtime identity packet", "runtime evaluation packet", "runtime binding acceptance packet",
   "bindingEvaluation.evaluation_sha256 !== evaluationRecord.sha256",
   "runtime health_valid_until differs from binding acceptance",
   "runtime evidence was generated after its admitted health lease deadline",
-  'result.error_kind !== "feature-disabled"',
-  'result.error_code !== "FEATURE_DISABLED"',
-  "requireWorkspaceState(",
-  "requireSsrState(",
-  "requireBrowserState(",
-  "provider_health_still_observed",
-  "rollout_settings_mutated",
-  "publish_mutation_executed",
-  "owner_observed_health_acceptance",
-  "pages_reference_consumer_gate_accepted",
-  'live_binding_action: "unchanged"',
-  "health_lease_extended: false",
-  "current_provider_health_asserted: false",
-  "eligible_for_pages_gate_review: accepted",
-  "reference_gate_owner_signoff_satisfied: false",
-  "reference_gate_rollback_decision_satisfied: false",
-  "source_files: sourceHashes(contract)",
+  'requireHttpRecord(observations.graphql, "runtime GraphQL observation", 200)',
+  'result.error_kind !== "feature-disabled"', 'result.error_code !== "FEATURE_DISABLED"',
+  "requireWorkspaceState(", "requireSsrState(", "requireBrowserState(",
+  'requireHttpRecord(observations.graphql_after_consumers, "post-consumer GraphQL observation", 200)',
+  "provider_health_still_observed", "rollout_settings_mutated", "publish_mutation_executed",
+  "owner_observed_health_acceptance", "pages_reference_consumer_gate_accepted",
+  'live_binding_action: "unchanged"', "health_lease_extended: false", "current_provider_health_asserted: false",
+  "predecessor_source_hashes_verified_against_checkout: true",
+  "eligible_for_pages_gate_review: accepted", "reference_gate_owner_signoff_satisfied: false",
+  "reference_gate_rollback_decision_satisfied: false", "source_files: sourceHashes(contract)",
   "raw_input_paths_persisted: false",
 ]) need(sources.runner, marker, "observed acceptance runner");
 for (const marker of [
-  "fetch(",
-  "updateModuleSettings",
-  "writePagesSettings",
-  "playwright",
-  "pages_reference_consumer_gate_accepted: true",
-  "health_lease_extended: true",
-  'live_binding_action: "activate"',
-  "current_provider_health_asserted: true",
+  "fetch(", "updateModuleSettings", "writePagesSettings(", "@playwright/test",
+  "pages_reference_consumer_gate_accepted: true", "health_lease_extended: true",
+  'live_binding_action: "activate"', "current_provider_health_asserted: true",
 ]) forbid(sources.runner, marker, "observed acceptance runner");
 
-if (
-  runtimeSource.observed_owner_acceptance?.source_contract !==
-    "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json" ||
-  runtimeSource.observed_owner_acceptance?.runner !==
-    "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs" ||
-  runtimeSource.observed_owner_acceptance?.source_ready !== true ||
-  runtimeSource.observed_owner_acceptance?.execution_pending !== true ||
-  runtimeSource.observed_owner_acceptance?.health_lease_extended !== false ||
-  runtimeSource.observed_owner_acceptance?.automatic_pages_gate_acceptance !== false
-) failures.push("runtime harness observed-owner-acceptance continuation drifted");
-if (
-  runtimeSource.next_cursor?.observed_health_owner_acceptance !==
-  "source_ready_maintainer_execution_pending"
-) failures.push("runtime harness observed-health owner acceptance cursor drifted");
+if (runtimeSource.observed_owner_acceptance?.source_contract !== files.contract || runtimeSource.observed_owner_acceptance?.runner !== files.runner || runtimeSource.observed_owner_acceptance?.source_ready !== true || runtimeSource.observed_owner_acceptance?.execution_pending !== true || runtimeSource.observed_owner_acceptance?.health_lease_extended !== false || runtimeSource.observed_owner_acceptance?.automatic_pages_gate_acceptance !== false) failures.push("runtime harness observed-owner-acceptance continuation drifted");
+if (runtimeSource.next_cursor?.observed_health_owner_acceptance !== "source_ready_maintainer_execution_pending") failures.push("runtime harness observed-health owner acceptance cursor drifted");
+if (gate.accepted !== false || gate.current_boundary?.provider_health !== "unobserved") failures.push("Pages reference-consumer gate must remain accepted=false/provider-health-unobserved in retained source evidence");
+if (!gate.forbidden_claims?.includes("observed provider health")) failures.push("Pages gate must continue forbidding fabricated observed-health claims");
 
-if (gate.accepted !== false || gate.current_boundary?.provider_health !== "unobserved") {
-  failures.push("Pages reference-consumer gate must remain accepted=false/provider-health-unobserved in retained source evidence");
-}
-if (!Array.isArray(gate.forbidden_claims) || !gate.forbidden_claims.includes("observed provider health")) {
-  failures.push("Pages reference-consumer gate must continue forbidding fabricated observed-health claims");
-}
-
+for (const marker of ["source_ready_maintainer_execution_pending", "observed-health owner acceptance"]) need(sources.runtimeVerifier, marker, "runtime harness verifier continuation");
 for (const marker of [
-  "source_ready_maintainer_execution_pending",
-  "observed-health owner acceptance",
-]) need(sources.runtimeVerifier, marker, "runtime harness verifier continuation");
-for (const marker of [
-  "provider-health-observed-acceptance-source-ready",
-  "accept_observed_runtime_evidence",
-  "retrospective",
-  "does not extend",
-  "does not accept the Pages reference-consumer gate",
-  "Tests were not run",
+  "provider-health-observed-acceptance-source-ready", "accept_observed_runtime_evidence", "retrospective",
+  "health_lease_extended = false", "does not accept the Pages reference-consumer gate", "Tests were not run",
 ]) need(sources.overlay, marker, "observed-health acceptance actualization");
 for (const marker of [
   "provider-health-observed-acceptance-source-ready",
@@ -197,13 +137,8 @@ for (const marker of [
   "observed-health owner acceptance [source-ready / maintainer execution pending]",
 ]) need(sources.parity, marker, "plan parity actualization");
 
-if (
-  contract.next_cursor?.observed_health_owner_acceptance !==
-  "source_ready_maintainer_execution_pending"
-) failures.push("observed-health acceptance source cursor drifted");
-if (contract.next_cursor?.pages_reference_consumer_gate_acceptance !== "pending") {
-  failures.push("Pages reference-consumer gate acceptance must remain pending");
-}
+if (contract.next_cursor?.observed_health_owner_acceptance !== "source_ready_maintainer_execution_pending") failures.push("observed-health acceptance source cursor drifted");
+if (contract.next_cursor?.pages_reference_consumer_gate_acceptance !== "pending") failures.push("Pages reference-consumer gate acceptance must remain pending");
 
 if (failures.length) {
   console.error("[verify-pages-builder-provider-health-observed-acceptance] FAIL");

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const failures = [];
+const files = {
+  contract: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json",
+  runner: "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs",
+  runtimeContract: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json",
+  runtimeSource: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-harness-source.json",
+  bindingAcceptance: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json",
+  runtimeVerifier: "crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs",
+  gate: "crates/rustok-pages/contracts/evidence/pages-reference-consumer-gate-source.json",
+  overlay: "docs/modules/pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md",
+  parity: "docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md",
+};
+const abs = (value) => path.join(repoRoot, value);
+const read = (value) => fs.readFileSync(abs(value), "utf8");
+const need = (source, marker, label) => {
+  if (!source.includes(marker)) failures.push(`${label}: missing ${marker}`);
+};
+const forbid = (source, marker, label) => {
+  if (source.includes(marker)) failures.push(`${label}: forbidden ${marker}`);
+};
+
+for (const [label, relativePath] of Object.entries(files)) {
+  if (!fs.existsSync(abs(relativePath))) {
+    failures.push(`${label}: missing ${relativePath}`);
+    continue;
+  }
+  const stats = fs.lstatSync(abs(relativePath));
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${label}: ${relativePath} must be a regular non-symlink file`);
+  }
+}
+if (failures.length) {
+  console.error("[verify-pages-builder-provider-health-observed-acceptance] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([label, relativePath]) => [label, read(relativePath)]),
+);
+const contract = JSON.parse(sources.contract);
+const runtimeContract = JSON.parse(sources.runtimeContract);
+const runtimeSource = JSON.parse(sources.runtimeSource);
+const bindingAcceptance = JSON.parse(sources.bindingAcceptance);
+const gate = JSON.parse(sources.gate);
+
+if (
+  contract.format !== "pages_builder_provider_health_observed_acceptance_source_v1" ||
+  contract.status !== "source_ready_maintainer_execution_pending"
+) failures.push("observed-health acceptance source identity drifted");
+if (
+  runtimeContract.packet !== "pages-builder-provider-health-runtime-evidence" ||
+  runtimeContract.output?.format !== "pages_builder_provider_health_runtime_evidence_v1" ||
+  runtimeContract.output?.status !== "observed_runtime_evidence_owner_review_pending"
+) failures.push("runtime evidence predecessor contract drifted");
+if (
+  runtimeSource.format !== "pages_builder_provider_health_runtime_harness_source_v1" ||
+  runtimeSource.status !== "source_ready_maintainer_execution_pending"
+) failures.push("runtime harness predecessor source drifted");
+if (bindingAcceptance.format !== "pages_builder_provider_health_owner_acceptance_source_v1") {
+  failures.push("binding owner-acceptance predecessor source drifted");
+}
+
+for (const [object, key, expected] of [
+  [contract.runtime_evidence_input, "format", "pages_builder_provider_health_runtime_evidence_v1"],
+  [contract.runtime_evidence_input, "required_status", "observed_runtime_evidence_owner_review_pending"],
+  [contract.runtime_evidence_input, "source_commit_must_equal_checkout_head", true],
+  [contract.runtime_evidence_input, "source_hashes_must_match_runtime_execution_contract_and_checkout", true],
+  [contract.runtime_evidence_input, "identity_evaluation_binding_acceptance_hashes_must_match_supplied_packets", true],
+  [contract.runtime_evidence_input, "health_may_be_expired_at_owner_review", true],
+  [contract.runtime_evidence_input, "health_lease_must_not_be_restarted_or_extended", true],
+  [contract.runtime_evidence_input, "configured_rollout_all_on_required", true],
+  [contract.runtime_evidence_input, "canonical_feature_disabled_contract_required_when_narrowed", true],
+  [contract.runtime_evidence_input, "publish_mutation_executed_must_be_false", true],
+  [contract.runtime_evidence_input, "rollout_settings_mutated_must_be_false", true],
+  [contract.owner_decision, "acceptance_does_not_assert_current_provider_health", true],
+  [contract.owner_decision, "acceptance_does_not_authorize_or_extend_server_binding", true],
+  [contract.owner_decision, "acceptance_does_not_accept_pages_reference_consumer_gate", true],
+  [contract.output, "accepted_status", "owner_accepted_observed_runtime_evidence_gate_review_pending"],
+  [contract.output, "rejected_status", "owner_rejected_observed_runtime_evidence"],
+  [contract.gate_boundary, "accepted_packet_is_eligible_input_for_pages_gate_review", true],
+  [contract.gate_boundary, "accepted_packet_does_not_accept_pages_gate", true],
+  [contract.gate_boundary, "accepted_packet_does_not_satisfy_reference_gate_owner_signoff_or_rollback_by_itself", true],
+  [contract.non_claims, "observed_health_owner_acceptance_executed", false],
+  [contract.non_claims, "current_provider_health_asserted", false],
+  [contract.non_claims, "health_lease_extended", false],
+  [contract.non_claims, "server_binding_changed", false],
+  [contract.non_claims, "pages_reference_consumer_gate_accepted", false],
+  [contract.non_claims, "tests_run", false],
+  [contract.non_claims, "node_verifier_run", false],
+]) {
+  if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
+}
+
+if (
+  !Array.isArray(contract.owner_decision?.decisions) ||
+  !contract.owner_decision.decisions.includes("accept_observed_runtime_evidence") ||
+  !contract.owner_decision.decisions.includes("reject")
+) failures.push("observed-health owner decision set drifted");
+if (
+  contract.supplied_predecessor_packets?.binding_owner_acceptance?.decision !== "accept_for_pages_binding" ||
+  contract.supplied_predecessor_packets?.binding_owner_acceptance?.rollback_action !== "restore_unobserved_provider_health"
+) failures.push("binding acceptance lineage drifted");
+
+for (const marker of [
+  '"--runtime-evidence"',
+  '"--identity"',
+  '"--evaluation"',
+  '"--binding-acceptance"',
+  'const ACCEPT_DECISION = "accept_observed_runtime_evidence"',
+  'const REJECT_DECISION = "reject"',
+  "git", ["rev-parse", "HEAD"],
+].filter((marker) => typeof marker === "string")) need(sources.runner, marker, "observed acceptance runner");
+for (const marker of [
+  "verifyRuntimeSourceHashes(runtime, runtimeContract)",
+  "runtime source SHA set differs from runtime execution contract",
+  "runtime identity packet",
+  "runtime evaluation packet",
+  "runtime binding acceptance packet",
+  "bindingEvaluation.evaluation_sha256 !== evaluationRecord.sha256",
+  "runtime health_valid_until differs from binding acceptance",
+  "runtime evidence was generated after its admitted health lease deadline",
+  'result.error_kind !== "feature-disabled"',
+  'result.error_code !== "FEATURE_DISABLED"',
+  "requireWorkspaceState(",
+  "requireSsrState(",
+  "requireBrowserState(",
+  "provider_health_still_observed",
+  "rollout_settings_mutated",
+  "publish_mutation_executed",
+  "owner_observed_health_acceptance",
+  "pages_reference_consumer_gate_accepted",
+  'live_binding_action: "unchanged"',
+  "health_lease_extended: false",
+  "current_provider_health_asserted: false",
+  "eligible_for_pages_gate_review: accepted",
+  "reference_gate_owner_signoff_satisfied: false",
+  "reference_gate_rollback_decision_satisfied: false",
+  "source_files: sourceHashes(contract)",
+  "raw_input_paths_persisted: false",
+]) need(sources.runner, marker, "observed acceptance runner");
+for (const marker of [
+  "fetch(",
+  "updateModuleSettings",
+  "writePagesSettings",
+  "playwright",
+  "pages_reference_consumer_gate_accepted: true",
+  "health_lease_extended: true",
+  'live_binding_action: "activate"',
+  "current_provider_health_asserted: true",
+]) forbid(sources.runner, marker, "observed acceptance runner");
+
+if (
+  runtimeSource.observed_owner_acceptance?.source_contract !==
+    "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json" ||
+  runtimeSource.observed_owner_acceptance?.runner !==
+    "scripts/evidence/accept-pages-builder-provider-health-runtime.mjs" ||
+  runtimeSource.observed_owner_acceptance?.source_ready !== true ||
+  runtimeSource.observed_owner_acceptance?.execution_pending !== true ||
+  runtimeSource.observed_owner_acceptance?.health_lease_extended !== false ||
+  runtimeSource.observed_owner_acceptance?.automatic_pages_gate_acceptance !== false
+) failures.push("runtime harness observed-owner-acceptance continuation drifted");
+if (
+  runtimeSource.next_cursor?.observed_health_owner_acceptance !==
+  "source_ready_maintainer_execution_pending"
+) failures.push("runtime harness observed-health owner acceptance cursor drifted");
+
+if (gate.accepted !== false || gate.current_boundary?.provider_health !== "unobserved") {
+  failures.push("Pages reference-consumer gate must remain accepted=false/provider-health-unobserved in retained source evidence");
+}
+if (!Array.isArray(gate.forbidden_claims) || !gate.forbidden_claims.includes("observed provider health")) {
+  failures.push("Pages reference-consumer gate must continue forbidding fabricated observed-health claims");
+}
+
+for (const marker of [
+  "source_ready_maintainer_execution_pending",
+  "observed-health owner acceptance",
+]) need(sources.runtimeVerifier, marker, "runtime harness verifier continuation");
+for (const marker of [
+  "provider-health-observed-acceptance-source-ready",
+  "accept_observed_runtime_evidence",
+  "retrospective",
+  "does not extend",
+  "does not accept the Pages reference-consumer gate",
+  "Tests were not run",
+]) need(sources.overlay, marker, "observed-health acceptance actualization");
+for (const marker of [
+  "provider-health-observed-acceptance-source-ready",
+  "pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md",
+  "observed-health owner acceptance [source-ready / maintainer execution pending]",
+]) need(sources.parity, marker, "plan parity actualization");
+
+if (
+  contract.next_cursor?.observed_health_owner_acceptance !==
+  "source_ready_maintainer_execution_pending"
+) failures.push("observed-health acceptance source cursor drifted");
+if (contract.next_cursor?.pages_reference_consumer_gate_acceptance !== "pending") {
+  failures.push("Pages reference-consumer gate acceptance must remain pending");
+}
+
+if (failures.length) {
+  console.error("[verify-pages-builder-provider-health-observed-acceptance] FAIL");
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(Math.min(failures.length, 255));
+}
+console.log("[verify-pages-builder-provider-health-observed-acceptance] PASS source_ready=true execution=pending gate_acceptance=pending");

--- a/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs
+++ b/crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs
@@ -14,6 +14,7 @@ const files = {
   identity: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json",
   evaluator: "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json",
   acceptance: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json",
+  observedAcceptance: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json",
   serverBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-server-binding-source.json",
   consumerBinding: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-consumer-binding-source.json",
   preflight: "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-capability-preflight-source.json",
@@ -44,6 +45,7 @@ const source = JSON.parse(sources.source);
 const identity = JSON.parse(sources.identity);
 const evaluator = JSON.parse(sources.evaluator);
 const acceptance = JSON.parse(sources.acceptance);
+const observedAcceptance = JSON.parse(sources.observedAcceptance);
 const serverBinding = JSON.parse(sources.serverBinding);
 const consumerBinding = JSON.parse(sources.consumerBinding);
 const preflight = JSON.parse(sources.preflight);
@@ -58,6 +60,7 @@ for (const value of Object.values(source.validation ?? {})) if (value !== false)
 if (identity.format !== "page_builder_provider_health_deployment_identity_source_v1") failures.push("identity predecessor source drifted");
 if (evaluator.format !== "page_builder_provider_health_deployment_evaluator_source_v1") failures.push("evaluator predecessor source drifted");
 if (acceptance.format !== "pages_builder_provider_health_owner_acceptance_source_v1") failures.push("owner acceptance predecessor source drifted");
+if (observedAcceptance.format !== "pages_builder_provider_health_observed_acceptance_source_v1" || observedAcceptance.status !== "source_ready_maintainer_execution_pending") failures.push("observed-health owner acceptance continuation drifted");
 if (serverBinding.format !== "pages_builder_provider_health_server_binding_source_v1") failures.push("server binding predecessor source drifted");
 if (consumerBinding.format !== "pages_builder_provider_health_consumer_binding_source_v1") failures.push("consumer binding predecessor source drifted");
 if (preflight.format !== "pages_builder_provider_health_capability_preflight_source_v1") failures.push("capability-preflight predecessor source drifted");
@@ -81,6 +84,10 @@ for (const [object, key, expected] of [
   [source.source_contract, "publish_mutation_is_never_executed", true],
   [source.source_contract, "automatic_owner_acceptance", false],
   [source.source_contract, "automatic_pages_gate_acceptance", false],
+  [source.observed_owner_acceptance, "source_ready", true],
+  [source.observed_owner_acceptance, "execution_pending", true],
+  [source.observed_owner_acceptance, "health_lease_extended", false],
+  [source.observed_owner_acceptance, "automatic_pages_gate_acceptance", false],
 ]) if (object?.[key] !== expected) failures.push(`${key} must equal ${JSON.stringify(expected)}`);
 
 for (const marker of [
@@ -141,7 +148,8 @@ if (!(contract.required_source_files ?? []).includes("apps/next-admin/tests/page
 if (preflight.next_cursor?.observed_health_runtime_evidence_harness !== "source_ready_maintainer_execution_pending") failures.push("capability-preflight cursor must point to source-ready runtime harness");
 if (consumerBinding.next_cursor?.observed_health_runtime_evidence_harness !== "source_ready_maintainer_execution_pending") failures.push("consumer-binding cursor must point to source-ready runtime harness");
 if (source.next_cursor?.observed_health_runtime_evidence_harness !== "source_ready_maintainer_execution_pending") failures.push("runtime harness cursor drifted");
-if (source.next_cursor?.observed_health_owner_acceptance !== "pending") failures.push("observed-health owner acceptance must remain pending");
+if (source.next_cursor?.observed_health_owner_acceptance !== "source_ready_maintainer_execution_pending") failures.push("observed-health owner acceptance must be source-ready/execution-pending");
+if (observedAcceptance.next_cursor?.observed_health_owner_acceptance !== "source_ready_maintainer_execution_pending") failures.push("observed-health owner acceptance source cursor drifted");
 
 for (const marker of [
   "provider-health-runtime-evidence-harness-source-ready",
@@ -152,8 +160,10 @@ for (const marker of [
 ]) need(sources.overlay, marker, "runtime harness actualization");
 for (const marker of [
   "provider-health-runtime-evidence-harness-source-ready",
+  "provider-health-observed-acceptance-source-ready",
   "pages-page-builder-provider-health-runtime-evidence-harness-actualization-2026-08-09.md",
   "observed-health runtime evidence harness [source-ready / maintainer execution pending]",
+  "observed-health owner acceptance [source-ready / maintainer execution pending]",
 ]) need(sources.parity, marker, "plan parity actualization");
 
 if (failures.length) {
@@ -161,4 +171,4 @@ if (failures.length) {
   failures.forEach((failure) => console.error(`- ${failure}`));
   process.exit(Math.min(failures.length, 255));
 }
-console.log("[verify-pages-builder-provider-health-runtime-harness] PASS source_ready=true execution=pending owner_acceptance=pending");
+console.log("[verify-pages-builder-provider-health-runtime-harness] PASS source_ready=true execution=pending owner_acceptance=source_ready_execution_pending");

--- a/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
+++ b/docs/modules/pages-page-builder-plan-parity-actualization-2026-08-08.md
@@ -1,10 +1,10 @@
 # Pages / Page Builder plan parity actualization — 2026-08-08
 
-Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / provider-health-transport-source-ready / provider-health-owner-acceptance-source-ready / provider-health-server-binding-source-ready / provider-health-consumer-binding-source-ready / provider-health-capability-preflight-source-ready / provider-health-runtime-evidence-harness-source-ready / execution-acceptance-pending`.
+Status: `canonical-plan-parity-source-ready / forum-runtime-composition-source-ready / pages-reference-consumer-rollout-source-ready / provider-runtime-observation-source-ready / deployment-metrics-source-ready / freshness-signal-source-ready / deployment-identity-contract-source-ready / expected-target-inventory-contract-source-ready / deployment-health-evaluator-source-ready / provider-health-transport-source-ready / provider-health-owner-acceptance-source-ready / provider-health-server-binding-source-ready / provider-health-consumer-binding-source-ready / provider-health-capability-preflight-source-ready / provider-health-runtime-evidence-harness-source-ready / provider-health-observed-acceptance-source-ready / execution-acceptance-pending`.
 
 ## Current authority
 
-This parity packet now has twelve source actualizations:
+This parity packet now has thirteen source actualizations:
 
 - the earlier Forum composition reconciliation through PR #3320;
 - `docs/modules/pages-page-builder-rollout-plan-actualization-2026-08-08.md`, current rollout authority after PRs #3333, #3337, #3345 and #3353;
@@ -17,7 +17,8 @@ This parity packet now has twelve source actualizations:
 - `docs/modules/pages-page-builder-provider-health-server-binding-actualization-2026-08-09.md`;
 - `docs/modules/pages-page-builder-provider-health-consumer-binding-actualization-2026-08-09.md`;
 - `docs/modules/pages-page-builder-provider-health-capability-preflight-actualization-2026-08-09.md`;
-- `docs/modules/pages-page-builder-provider-health-runtime-evidence-harness-actualization-2026-08-09.md`, which closes the remaining provider-health source-only evidence-harness gap without claiming execution or acceptance.
+- `docs/modules/pages-page-builder-provider-health-runtime-evidence-harness-actualization-2026-08-09.md`;
+- `docs/modules/pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md`, which closes the observed-health owner-decision source gap without claiming runtime execution, current health or Pages gate acceptance.
 
 Older shared/local/central plans remain programme history. This packet and the newest relevant dated overlay are the current source truth where wording differs.
 
@@ -34,20 +35,23 @@ The synchronized Pages / Page Builder boundary is now:
 - bounded process-local Preview/Publish observations are not deployment authority;
 - deployment metrics/freshness, exact source/deployment identity, complete expected-target inventory and the reset-aware deployment evaluator are source-ready;
 - the evaluator applies the canonical 1500ms Preview p95, 3000ms Publish p95, 1% sanitize-failure and 1% runtime-error provider policy with target/source/freshness/sample admission;
-- owner acceptance revalidates the evaluator and retains the exact remaining-freshness `health_valid_until`; it cannot restart freshness;
+- binding owner acceptance revalidates the evaluator and retains the exact remaining-freshness `health_valid_until`; it cannot restart freshness;
 - Pages server binding is opt-in/fail-closed over the accepted packet, `RUSTOK_SOURCE_COMMIT`, deployment id and immutable RepoDigest, rereading the packet on each rollout-status request;
 - typed transport keeps configured rollout flags separate from optional validated provider health;
 - `rustok_page_builder::rollout::effective_provider_runtime_flags` is the single provider/rollout runtime narrowing owner;
 - Ready/Unobserved preserve configured rollout, Degraded disables Publish, and Unavailable fails the builder closed without re-enabling an already-disabled rollout capability;
 - workspace, authoritative SSR and standalone browser-intent use the validated provider-status path;
 - health-aware non-mutating `pageBuilderCapabilityPreflight` uses the same runtime narrowing before canonical `ensure_capability` and keeps permission denial separate;
-- the existing rollout feature-preflight remains rollout-only and now fails closed unless provider health is unobserved before and after each profile;
-- the observed-health runtime evidence harness [source-ready / maintainer execution pending] requires exact identity -> evaluator -> accepted owner packet, all-on configured rollout and a still-live `health_valid_until`;
+- the existing rollout feature-preflight remains rollout-only and fails closed unless provider health is unobserved before and after each profile;
+- the observed-health runtime evidence harness [source-ready / maintainer execution pending] requires exact identity -> evaluator -> accepted binding-owner packet, all-on configured rollout and a still-live `health_valid_until` during observation;
 - that harness compares GraphQL observed health to the accepted snapshot, checks non-mutating capability preflight, workspace provider/capability controls, safe authoritative SSR Preview and health-limited standalone browser-intent behavior;
 - browser-intent probes use an intentionally mismatched envelope page id so capability denial is observed first, while unexpected lease expiry/revoke falls through to PageMismatch before document mutation;
 - no Publish mutation or rollout-settings mutation is part of the provider-health runtime harness;
-- successful execution would produce `pages_builder_provider_health_runtime_evidence_v1` with status `observed_runtime_evidence_owner_review_pending`, not an acceptance decision;
-- Pages remains `unobserved` in retained execution evidence because this implementation agent did not execute identity capture, evaluator, owner acceptance, packet installation or the runtime harness;
+- successful runtime execution produces `pages_builder_provider_health_runtime_evidence_v1 / observed_runtime_evidence_owner_review_pending`, not an acceptance decision;
+- observed-health owner acceptance [source-ready / maintainer execution pending] revalidates that runtime packet, exact predecessor packet hashes, source hashes and canonical consumer outcomes before allowing an explicit `accept_observed_runtime_evidence` or `reject` decision;
+- observed-health acceptance is retrospective: it may review evidence after the historical health lease expires, but it does not extend `health_valid_until`, assert current provider health, change live binding, accept the Pages gate, or satisfy the reference-gate owner sign-off/rollback decision by itself;
+- accepted observed-health output is `pages_builder_provider_health_observed_acceptance_v1 / owner_accepted_observed_runtime_evidence_gate_review_pending` and is only eligible input for later gate review;
+- Pages remains `unobserved` in retained execution evidence because this implementation agent did not execute identity capture, evaluator, binding owner acceptance, packet installation, runtime harness or observed-health owner acceptance;
 - `pages_reference_consumer_gate` remains `accepted = false` with execution pending;
 - Forum observed Wave remains blocked by the Pages gate;
 - FFA/FBA promotion remains unclaimed.
@@ -77,16 +81,18 @@ bounded process-local Preview/Publish observation [source-ready]
 -> exact source/deployment identity + expected-target inventory contract [source-ready]
 -> deployment health backend evaluator [source-ready]
 -> typed observed-health transport [source-ready]
--> owner acceptance packet + exact health_valid_until [source-ready]
+-> binding owner acceptance packet + exact health_valid_until [source-ready]
 -> server provider-health binding + hot revoke + remaining-freshness lease [source-ready]
 -> UI / SSR / browser-intent provider-health binding [source-ready]
 -> health-aware non-mutating capability preflight [source-ready]
 -> observed-health runtime evidence harness [source-ready / maintainer execution pending]
--> live exact-target identity capture + retained evaluator + accepted owner packet + observed consumer behavior [maintainer execution pending]
--> observed-health owner acceptance decision [pending]
+-> observed-health owner acceptance [source-ready / maintainer execution pending]
+-> live exact-target identity capture + retained evaluator + accepted binding-owner packet + observed consumer behavior + observed-evidence owner decision [maintainer execution pending]
+-> accepted observed-health evidence available for Pages gate review [blocked on maintainer execution and decision]
+-> Pages reference-consumer gate acceptance [pending]
 ```
 
-Source inspection alone must not mark execution or acceptance complete.
+Source inspection alone must not mark execution, current health, observed-health acceptance or Pages gate acceptance complete.
 
 ## Anti-drift guards
 
@@ -106,19 +112,21 @@ crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-server-b
 crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs
 crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
 crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs
+crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
 crates/rustok-pages/scripts/verify/verify-pages-builder-rollout-binding.mjs
 ```
 
-The runtime-harness guard locks the exact evidence chain, all-on isolation, no-mutation probes, privacy boundary, non-promotion state and owner-review-pending output.
+The observed-acceptance guard locks retrospective lease semantics, exact predecessor/source hashes, canonical runtime outcomes, privacy, non-promotion and the explicit separation between accepted evidence and Pages gate acceptance.
 
 ## Execution boundary
 
-No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, deployment identity captures, evaluator executions, owner acceptance executions, accepted packet installations, observed GraphQL/HTTP requests, Playwright/browser runs, workflows, CI, migrations or runtime evidence were executed by this slice.
+No tests, Node verifiers, Cargo commands, formatting, builds, Prometheus scrapes, backend queries, deployment identity captures, evaluator executions, binding owner acceptance executions, accepted packet installations, observed GraphQL/HTTP requests, Playwright/browser runs, observed-health owner acceptance, workflows, CI, migrations or runtime evidence were executed by this slice.
 
 Suggested maintainer source commands, intentionally not run:
 
 ```bash
 node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-capability-preflight.mjs
 node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-consumer-binding.mjs

--- a/docs/modules/pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md
+++ b/docs/modules/pages-page-builder-provider-health-observed-acceptance-actualization-2026-08-10.md
@@ -1,0 +1,125 @@
+# Pages / Page Builder observed-health owner acceptance actualization — 2026-08-10
+
+Status: `provider-health-observed-acceptance-source-ready / retrospective-runtime-evidence-review-source-ready / exact-predecessor-chain-source-ready / health-lease-non-extension-source-ready / maintainer-execution-pending / pages-gate-acceptance-pending`.
+
+## Why this continuation exists
+
+PR #3424 made the observed provider-health runtime evidence harness source-ready. A successful maintainer run can now produce `pages_builder_provider_health_runtime_evidence_v1` with status `observed_runtime_evidence_owner_review_pending`, but that packet intentionally does not contain an owner decision.
+
+This slice closes that final provider-health source gap with an explicit observed-health owner acceptance runner. It does not execute the runtime harness or make the decision for the maintainer.
+
+## Acceptance meaning
+
+The accepted decision is:
+
+```text
+accept_observed_runtime_evidence
+```
+
+This is a **retrospective evidence decision**. It means the owner accepts that the exact-deployment runtime evidence is internally consistent and suitable as an input to later Pages gate review.
+
+It does **not** mean:
+
+- the provider is currently `Ready`;
+- the historical `health_valid_until` lease is still live;
+- the lease is restarted or extended;
+- Pages server binding is newly authorized or changed;
+- the Pages reference-consumer gate is accepted;
+- the reference-gate owner sign-off or rollback decision is satisfied.
+
+`Degraded` or `Unavailable` runtime evidence may therefore be accepted when the observed consumers correctly enforce the canonical narrowing policy. Acceptance is about the evidence and behavior, not promotion of the health state.
+
+## Exact predecessor chain
+
+The runner requires four maintainer-supplied evidence packets:
+
+```text
+page_builder_provider_health_deployment_identity_v1
+page_builder_provider_health_deployment_evaluation_v1
+pages_builder_provider_health_owner_acceptance_v1
+pages_builder_provider_health_runtime_evidence_v1
+```
+
+It fails closed unless:
+
+- runtime `source_commit` equals checkout `HEAD`;
+- source hashes retained by the runtime packet exactly match the runtime execution contract and checkout;
+- runtime-retained identity/evaluation/binding-acceptance byte lengths and SHA-256 values match the supplied packets;
+- source commit, deployment id and immutable RepoDigest match across all four packets;
+- the binding owner packet is the accepted `accept_for_pages_binding` packet with rollback `restore_unobserved_provider_health`;
+- the binding packet's evaluation SHA matches the supplied evaluation;
+- runtime accepted health/SLO and `health_valid_until` match the binding packet;
+- runtime `generated_at` is inside the historical health deadline plus the existing five-second clock-skew tolerance.
+
+The current wall clock may be later than `health_valid_until`. Owner review is retrospective and must not manufacture a new lease.
+
+## Runtime behavior revalidation
+
+The acceptance runner revalidates the retained runtime behavior rather than trusting a single boolean:
+
+- configured rollout was `all_on`;
+- GraphQL observed provider health and state match the accepted snapshot;
+- Preview/Properties/Publish preflight results match canonical Ready/Degraded/Unavailable behavior;
+- narrowed capabilities use `feature-disabled / FEATURE_DISABLED`;
+- workspace provider/capability controls match the state;
+- authoritative SSR Preview is allowed for Ready/Degraded and blocked before dispatch for Unavailable;
+- standalone browser-intent denials match Degraded/Unavailable expectations and retain the mismatched-page-id non-mutating fallback;
+- provider health is still observed after the consumer probes;
+- rollout settings and Publish persistence were not mutated;
+- privacy/non-retention and anti-promotion flags remain fail-closed.
+
+The runner performs no GraphQL, HTTP, browser, Prometheus, deployment or binding request itself.
+
+## Output
+
+Accepted output:
+
+```text
+format = pages_builder_provider_health_observed_acceptance_v1
+status = owner_accepted_observed_runtime_evidence_gate_review_pending
+```
+
+Rejected output:
+
+```text
+status = owner_rejected_observed_runtime_evidence
+```
+
+The output retains exact source/deployment identity, hashes of all supplied evidence packets, the historical health deadline, accepted health/SLO snapshot and the bounded operator-asserted owner id. Raw input paths, HTTP bodies, browser bodies, credentials, cookies and storage-state contents are not retained.
+
+The output explicitly records:
+
+```text
+live_binding_action = unchanged
+health_lease_extended = false
+current_provider_health_asserted = false
+pages_reference_consumer_gate_accepted = false
+```
+
+## Pages gate boundary
+
+An accepted packet is eligible for a future Pages reference-consumer gate review, but this slice does not accept the Pages reference-consumer gate. The existing gate remains `accepted = false` and retains `provider_health = unobserved` in source/retained execution state until maintainers execute the exact chain and separately review the gate.
+
+Forum Wave therefore remains blocked, and FFA/FBA promotion remains unclaimed.
+
+## Source evidence
+
+```text
+crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json
+scripts/evidence/accept-pages-builder-provider-health-runtime.mjs
+crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
+```
+
+## Validation boundary
+
+Tests were not run. Node verifiers, Cargo commands, formatting, builds, GraphQL/HTTP requests, Playwright/browser runs, deployment identity capture, Prometheus queries, evaluator execution, binding owner acceptance, observed runtime evidence and observed-health owner acceptance were intentionally not executed.
+
+Suggested maintainer source checks, intentionally not run:
+
+```bash
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
+node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs
+node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
+```
+
+Runtime execution and the owner decision remain maintainer-owned.

--- a/scripts/evidence/accept-pages-builder-provider-health-runtime.mjs
+++ b/scripts/evidence/accept-pages-builder-provider-health-runtime.mjs
@@ -16,14 +16,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
-const contractPath = path.join(
-  repoRoot,
-  "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json",
-);
-const runtimeContractPath = path.join(
-  repoRoot,
-  "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json",
-);
+const contractPath = path.join(repoRoot, "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json");
+const runtimeContractPath = path.join(repoRoot, "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json");
+const identitySourcePath = path.join(repoRoot, "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-identity-source.json");
+const evaluatorSourcePath = path.join(repoRoot, "crates/rustok-page-builder/contracts/evidence/page-builder-provider-health-deployment-evaluator-source.json");
+const bindingSourcePath = path.join(repoRoot, "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-owner-acceptance-source.json");
 const MAX_INPUT_BYTES = 8 * 1024 * 1024;
 const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
 const CLOCK_SKEW_MS = 5_000;
@@ -36,22 +33,26 @@ const BINDING_ROLLBACK = "restore_unobserved_provider_health";
 function fail(message) {
   throw new Error(`Pages Page Builder observed-health owner acceptance failed: ${message}`);
 }
-
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
 }
-
+function objectValue(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+function canonicalJson(value) {
+  const normalize = (input) => {
+    if (Array.isArray(input)) return input.map(normalize);
+    if (input !== null && typeof input === "object") {
+      return Object.fromEntries(Object.entries(input).sort(([a], [b]) => a.localeCompare(b)).map(([key, nested]) => [key, normalize(nested)]));
+    }
+    return input;
+  };
+  return JSON.stringify(normalize(value));
+}
 function parseArguments(argv) {
   const options = {};
-  const accepted = new Set([
-    "--runtime-evidence",
-    "--identity",
-    "--evaluation",
-    "--binding-acceptance",
-    "--owner-id",
-    "--decision",
-    "--output",
-  ]);
+  const accepted = new Set(["--runtime-evidence", "--identity", "--evaluation", "--binding-acceptance", "--owner-id", "--decision", "--output"]);
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--help" || argument === "-h") {
@@ -65,260 +66,164 @@ function parseArguments(argv) {
     if (!accepted.has(argument)) fail(`unknown argument ${argument}`);
     const value = argv[index + 1];
     if (!value) fail(`${argument} requires a value`);
-    options[
-      argument
-        .slice(2)
-        .replace(/-([a-z])/gu, (_, letter) => letter.toUpperCase())
-    ] = value;
+    options[argument.slice(2).replace(/-([a-z])/gu, (_, letter) => letter.toUpperCase())] = value;
     index += 1;
   }
   return options;
 }
-
 function currentCommit() {
-  const result = spawnSync("git", ["rev-parse", "HEAD"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
   if (result.status !== 0) fail("git rev-parse HEAD failed");
   const commit = result.stdout.trim().toLowerCase();
   if (!/^[0-9a-f]{40}$/u.test(commit)) fail("checkout HEAD is not a canonical Git commit");
   return commit;
 }
-
 function resolveInput(candidate, label) {
-  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
-    fail(`${label} path is invalid`);
-  }
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) fail(`${label} path is invalid`);
   return path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
 }
-
 function regularFile(location, label, maximumBytes = MAX_INPUT_BYTES) {
   if (!existsSync(location)) fail(`${label} is missing`);
   const metadata = lstatSync(location);
-  if (!metadata.isFile() || metadata.isSymbolicLink()) {
-    fail(`${label} must be a regular non-symlink file`);
-  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) fail(`${label} must be a regular non-symlink file`);
   const size = statSync(location).size;
   if (size <= 0 || size > maximumBytes) fail(`${label} is outside the bounded size`);
   const bytes = readFileSync(location);
   return { bytes, size, sha256: sha256(bytes) };
 }
-
 function jsonInput(candidate, label) {
-  const location = resolveInput(candidate, label);
-  const record = regularFile(location, label);
+  const record = regularFile(resolveInput(candidate, label), label);
   try {
     const document = JSON.parse(record.bytes.toString("utf8"));
-    if (document === null || typeof document !== "object" || Array.isArray(document)) {
-      fail(`${label} must contain a JSON object`);
-    }
+    objectValue(document, label);
     return { document, ...record };
   } catch (error) {
     fail(`${label} is invalid JSON: ${error.message}`);
   }
 }
-
-function objectValue(value, label) {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    fail(`${label} must be an object`);
+function jsonSource(location, label) {
+  const record = regularFile(location, label, MAX_SOURCE_BYTES);
+  try {
+    return JSON.parse(record.bytes.toString("utf8"));
+  } catch (error) {
+    fail(`${label} is invalid JSON: ${error.message}`);
   }
-  return value;
 }
-
 function canonicalCommit(value, label) {
-  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
-    fail(`${label} must be a lowercase 40-character Git SHA`);
-  }
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) fail(`${label} must be a lowercase 40-character Git SHA`);
   return value;
 }
-
 function canonicalRepoDigest(value, label) {
-  if (typeof value !== "string" || value.length > 1024 || !/^[^\s@]+@sha256:[0-9a-f]{64}$/u.test(value)) {
-    fail(`${label} must be REPOSITORY@sha256:<64 lowercase hex>`);
-  }
+  if (typeof value !== "string" || value.length > 1024 || !/^[^\s@]+@sha256:[0-9a-f]{64}$/u.test(value)) fail(`${label} must be REPOSITORY@sha256:<64 lowercase hex>`);
   return value;
 }
-
 function canonicalIso(value, label) {
-  if (typeof value !== "string" || value.length === 0 || value.length > 128) {
-    fail(`${label} is invalid`);
-  }
+  if (typeof value !== "string" || value.length === 0 || value.length > 128) fail(`${label} is invalid`);
   const milliseconds = Date.parse(value);
-  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
-    fail(`${label} must be canonical ISO-8601 UTC`);
-  }
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) fail(`${label} must be canonical ISO-8601 UTC`);
   return milliseconds;
 }
-
-function boundedOwnerId(value) {
-  if (typeof value !== "string" || !OWNER_ID_PATTERN.test(value)) {
-    fail("--owner-id must match ^[A-Za-z0-9._-]{1,64}$");
-  }
-  return value;
-}
-
-function canonicalJson(value) {
-  const normalize = (input) => {
-    if (Array.isArray(input)) return input.map(normalize);
-    if (input !== null && typeof input === "object") {
-      return Object.fromEntries(
-        Object.entries(input)
-          .sort(([left], [right]) => left.localeCompare(right))
-          .map(([key, nested]) => [key, normalize(nested)]),
-      );
-    }
-    return input;
-  };
-  return JSON.stringify(normalize(value));
-}
-
 function requireSha256(value, label) {
-  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
-    fail(`${label} must be a lowercase SHA-256`);
-  }
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) fail(`${label} must be a lowercase SHA-256`);
   return value;
 }
-
 function requirePositiveInteger(value, label) {
   if (!Number.isSafeInteger(value) || value <= 0) fail(`${label} must be a positive safe integer`);
   return value;
 }
-
+function boundedOwnerId(value) {
+  if (typeof value !== "string" || !OWNER_ID_PATTERN.test(value)) fail("--owner-id must match ^[A-Za-z0-9._-]{1,64}$");
+  return value;
+}
 function regularSourceHash(relativePath) {
-  if (typeof relativePath !== "string" || relativePath.length === 0 || relativePath.length > 4096) {
-    fail("source path is invalid");
-  }
+  if (typeof relativePath !== "string" || relativePath.length === 0 || relativePath.length > 4096) fail("source path is invalid");
   const absolute = path.resolve(repoRoot, relativePath);
   const relative = path.relative(repoRoot, absolute);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    fail(`source file ${relativePath} escapes repository root`);
-  }
+  if (relative.startsWith("..") || path.isAbsolute(relative)) fail(`source file ${relativePath} escapes repository root`);
   return sha256(regularFile(absolute, `source file ${relativePath}`, MAX_SOURCE_BYTES).bytes);
 }
-
-function sourceHashes(contract) {
-  const files = contract.required_source_files;
-  if (!Array.isArray(files) || files.length === 0 || files.length > 64) {
-    fail("observed acceptance source contract has invalid required_source_files");
-  }
-  return Object.fromEntries(files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]));
+function expectedSourceFiles(sourceContract, label) {
+  const expected = sourceContract.required_source_files;
+  if (!Array.isArray(expected) || expected.length === 0 || expected.length > 64) fail(`${label} required_source_files is invalid`);
+  return [...expected].sort();
 }
-
-function verifyRuntimeSourceHashes(runtime, runtimeContract) {
-  const retained = objectValue(runtime.source_sha256, "runtime source_sha256");
-  const expected = runtimeContract.required_source_files;
-  if (!Array.isArray(expected) || expected.length === 0 || expected.length > 64) {
-    fail("runtime execution contract required source-file set is invalid");
-  }
+function verifyRetainedSourceHashes(document, sourceContract, field, label) {
+  const retained = objectValue(document[field], `${label}.${field}`);
+  const expectedNames = expectedSourceFiles(sourceContract, label);
   const actualNames = Object.keys(retained).sort();
-  const expectedNames = [...expected].sort();
-  if (canonicalJson(actualNames) !== canonicalJson(expectedNames)) {
-    fail("runtime source SHA set differs from runtime execution contract");
-  }
+  if (canonicalJson(actualNames) !== canonicalJson(expectedNames)) fail(`${label} source SHA set differs from source contract`);
   for (const relativePath of expectedNames) {
-    const retainedSha = requireSha256(retained[relativePath], `runtime source SHA ${relativePath}`);
-    if (regularSourceHash(relativePath) !== retainedSha) {
-      fail(`runtime source SHA for ${relativePath} does not match checkout`);
+    if (requireSha256(retained[relativePath], `${label} source SHA ${relativePath}`) !== regularSourceHash(relativePath)) {
+      fail(`${label} source SHA for ${relativePath} does not match checkout`);
     }
   }
 }
-
+function sourceHashes(contract) {
+  return Object.fromEntries(expectedSourceFiles(contract, "observed acceptance source contract").map((relativePath) => [relativePath, regularSourceHash(relativePath)]));
+}
 function requirePacketHash(record, retained, label) {
   const node = objectValue(retained, label);
-  if (requirePositiveInteger(node.bytes, `${label}.bytes`) !== record.size) {
-    fail(`${label} byte length does not match supplied packet`);
-  }
-  if (requireSha256(node.sha256, `${label}.sha256`) !== record.sha256) {
-    fail(`${label} SHA-256 does not match supplied packet`);
-  }
+  if (requirePositiveInteger(node.bytes, `${label}.bytes`) !== record.size) fail(`${label} byte length does not match supplied packet`);
+  if (requireSha256(node.sha256, `${label}.sha256`) !== record.sha256) fail(`${label} SHA-256 does not match supplied packet`);
 }
-
+function requireHttpRecord(value, label, exactStatus = null) {
+  const record = objectValue(value, label);
+  if (exactStatus === null) {
+    if (!Number.isSafeInteger(record.status) || record.status < 200 || record.status >= 400) fail(`${label} status must be successful`);
+  } else if (record.status !== exactStatus) {
+    fail(`${label} status must equal ${exactStatus}`);
+  }
+  requirePositiveInteger(record.response_body_bytes, `${label} response bytes`);
+  requireSha256(record.response_body_sha256, `${label} response SHA-256`);
+  return record;
+}
 function requireCapability(value, capability, expected) {
   const result = objectValue(value, `${capability} preflight observation`);
   if (result.capability !== capability) fail(`${capability} preflight capability drifted`);
   if (expected === "allowed") {
-    if (result.allowed !== true || result.error_kind !== null || result.error_code !== null) {
-      fail(`${capability} preflight must be allowed`);
-    }
-    return;
-  }
-  if (
-    result.allowed !== false ||
-    result.error_kind !== "feature-disabled" ||
-    result.error_code !== "FEATURE_DISABLED"
-  ) {
+    if (result.allowed !== true || result.error_kind !== null || result.error_code !== null) fail(`${capability} preflight must be allowed`);
+  } else if (result.allowed !== false || result.error_kind !== "feature-disabled" || result.error_code !== "FEATURE_DISABLED") {
     fail(`${capability} preflight must be feature-disabled / FEATURE_DISABLED`);
   }
 }
-
 function expectedForHealth(state) {
-  if (state === "ready") {
-    return { preview: "allowed", properties: "allowed", publish: "allowed" };
-  }
-  if (state === "degraded") {
-    return { preview: "allowed", properties: "allowed", publish: "feature_disabled" };
-  }
-  if (state === "unavailable") {
-    return { preview: "feature_disabled", properties: "feature_disabled", publish: "feature_disabled" };
-  }
+  if (state === "ready") return { preview: "allowed", properties: "allowed", publish: "allowed" };
+  if (state === "degraded") return { preview: "allowed", properties: "allowed", publish: "feature_disabled" };
+  if (state === "unavailable") return { preview: "feature_disabled", properties: "feature_disabled", publish: "feature_disabled" };
   fail(`unsupported accepted provider health state ${state}`);
 }
-
 function requireWorkspaceState(value, expected, state) {
   const workspace = objectValue(value, "workspace observation");
-  if (workspace.provider_control_state !== state || workspace.provider_health !== state) {
-    fail("workspace provider state does not match accepted health");
-  }
-  if (workspace.preview_enabled !== (expected.preview === "allowed")) {
-    fail("workspace preview state does not match accepted health");
-  }
-  const allowedState = (actual, allowed, label) => {
+  if (workspace.provider_control_state !== state || workspace.provider_health !== state) fail("workspace provider state does not match accepted health");
+  if (workspace.preview_enabled !== (expected.preview === "allowed")) fail("workspace preview state does not match accepted health");
+  const requireFieldset = (actual, allowed, label) => {
     if (allowed && actual !== "enabled") fail(`${label} must be enabled`);
     if (!allowed && !["disabled", "hidden"].includes(actual)) fail(`${label} must be disabled or hidden`);
   };
-  allowedState(workspace.properties, expected.properties === "allowed", "workspace properties");
-  allowedState(workspace.publish, expected.publish === "allowed", "workspace publish");
+  requireFieldset(workspace.properties, expected.properties === "allowed", "workspace properties");
+  requireFieldset(workspace.publish, expected.publish === "allowed", "workspace publish");
 }
-
 function requireSsrState(value, state) {
   const ssr = objectValue(value, "authoritative SSR preview observation");
   if (state === "unavailable") {
-    if (ssr.request_attempted !== false || ssr.ui_blocked !== true || ssr.mutation_possible !== false) {
-      fail("unavailable health must block SSR Preview before request dispatch");
-    }
+    if (ssr.request_attempted !== false || ssr.ui_blocked !== true || ssr.mutation_possible !== false) fail("unavailable health must block SSR Preview before request dispatch");
     return;
   }
-  if (
-    ssr.request_attempted !== true ||
-    ssr.capability_disabled !== false ||
-    ssr.mutation_possible !== false ||
-    ssr.raw_request_or_response_persisted !== false
-  ) {
+  if (ssr.request_attempted !== true || ssr.capability_disabled !== false || ssr.mutation_possible !== false || ssr.raw_request_or_response_persisted !== false) {
     fail("ready/degraded health SSR Preview observation drifted");
   }
-  requirePositiveInteger(ssr.status, "SSR Preview HTTP status");
-  requirePositiveInteger(ssr.response_body_bytes, "SSR Preview response bytes");
-  requireSha256(ssr.response_body_sha256, "SSR Preview response SHA-256");
+  requireHttpRecord(ssr, "SSR Preview observation");
 }
-
 function requireBrowserDenial(value, intent, capability) {
-  const denial = objectValue(value, `${intent} browser-intent denial`);
+  const denial = requireHttpRecord(value, `${intent} browser-intent denial`, 403);
   if (
-    denial.status !== 403 ||
     denial.code !== "FLY_CAPABILITY_DENIED" ||
     denial.intent !== intent ||
     denial.capability !== capability ||
     denial.mismatch_page_id_used_as_non_mutating_fallback !== true ||
     denial.raw_request_or_response_persisted !== false
-  ) {
-    fail(`${intent} browser-intent denial drifted`);
-  }
-  requirePositiveInteger(denial.response_body_bytes, `${intent} denial response bytes`);
-  requireSha256(denial.response_body_sha256, `${intent} denial response SHA-256`);
+  ) fail(`${intent} browser-intent denial drifted`);
 }
-
 function requireBrowserState(value, state) {
   if (!Array.isArray(value)) fail("standalone browser-intent observation must be an array");
   if (state === "ready") {
@@ -334,21 +239,18 @@ function requireBrowserState(value, state) {
   requireBrowserDenial(value[0], "save", "publish");
   requireBrowserDenial(value[1], "rename_page", "properties");
 }
-
-function requireRuntimeEvidence(runtimeRecord, identityRecord, evaluationRecord, bindingRecord, contract, runtimeContract, head) {
+function requireRuntimeEvidence(records, contracts, contract, head) {
+  const { runtimeRecord, identityRecord, evaluationRecord, bindingRecord } = records;
+  const { runtimeContract, identitySource, evaluatorSource, bindingSource } = contracts;
   const runtime = runtimeRecord.document;
-  if (runtime.format !== contract.runtime_evidence_input.format || runtime.status !== contract.runtime_evidence_input.required_status) {
-    fail("runtime evidence format/status drifted");
-  }
+  if (runtime.format !== contract.runtime_evidence_input.format || runtime.status !== contract.runtime_evidence_input.required_status) fail("runtime evidence format/status drifted");
   const sourceCommit = canonicalCommit(runtime.source_commit, "runtime source_commit");
   if (sourceCommit !== head) fail("runtime source commit does not equal checkout HEAD");
-  verifyRuntimeSourceHashes(runtime, runtimeContract);
+  verifyRetainedSourceHashes(runtime, runtimeContract, "source_sha256", "runtime evidence");
 
   const runtimeDeployment = objectValue(runtime.deployment, "runtime deployment");
   const deploymentId = runtimeDeployment.deployment_id;
-  if (typeof deploymentId !== "string" || deploymentId.length === 0 || deploymentId.length > 256) {
-    fail("runtime deployment id is invalid");
-  }
+  if (typeof deploymentId !== "string" || deploymentId.length === 0 || deploymentId.length > 256) fail("runtime deployment id is invalid");
   const deploymentDigest = canonicalRepoDigest(runtimeDeployment.deployment_image_digest, "runtime deployment image digest");
 
   const identity = identityRecord.document;
@@ -360,12 +262,13 @@ function requireRuntimeEvidence(runtimeRecord, identityRecord, evaluationRecord,
   if (identity.format !== identitySpec.format || identity.status !== identitySpec.status) fail("identity packet format/status drifted");
   if (evaluation.format !== evaluationSpec.format || evaluation.status !== evaluationSpec.status) fail("evaluation packet format/status drifted");
   if (binding.format !== bindingSpec.format || binding.status !== bindingSpec.status) fail("binding owner-acceptance packet format/status drifted");
+  verifyRetainedSourceHashes(identity, identitySource, "source_files", "identity packet");
+  verifyRetainedSourceHashes(evaluation, evaluatorSource, "source_files", "evaluation packet");
+  verifyRetainedSourceHashes(binding, bindingSource, "source_files", "binding owner-acceptance packet");
 
   for (const [document, label] of [[identity, "identity"], [evaluation, "evaluation"], [binding, "binding acceptance"]]) {
     const deployment = objectValue(document.deployment, `${label} deployment`);
-    if (deployment.source_commit !== sourceCommit || deployment.deployment_id !== deploymentId || deployment.deployment_image_digest !== deploymentDigest) {
-      fail(`${label} deployment identity differs from runtime evidence`);
-    }
+    if (deployment.source_commit !== sourceCommit || deployment.deployment_id !== deploymentId || deployment.deployment_image_digest !== deploymentDigest) fail(`${label} deployment identity differs from runtime evidence`);
   }
 
   const inputPackets = objectValue(runtime.input_packets, "runtime input_packets");
@@ -381,13 +284,9 @@ function requireRuntimeEvidence(runtimeRecord, identityRecord, evaluationRecord,
     bindingDecision.owner_identity_is_operator_assertion !== true ||
     bindingDecision.cryptographic_signature_present !== false ||
     bindingDecision.free_text_reason_retained !== false
-  ) {
-    fail("binding owner decision contract drifted");
-  }
+  ) fail("binding owner decision contract drifted");
   const bindingEvaluation = objectValue(binding.evaluation, "binding acceptance evaluation");
-  if (bindingEvaluation.evaluation_sha256 !== evaluationRecord.sha256) {
-    fail("binding owner acceptance is not bound to supplied evaluation packet");
-  }
+  if (bindingEvaluation.evaluation_sha256 !== evaluationRecord.sha256) fail("binding owner acceptance is not bound to supplied evaluation packet");
   const bindingBoundary = objectValue(binding.binding, "binding acceptance boundary");
   if (
     bindingBoundary.server_binding_authorized !== true ||
@@ -395,35 +294,22 @@ function requireRuntimeEvidence(runtimeRecord, identityRecord, evaluationRecord,
     bindingBoundary.required_live_source_commit !== sourceCommit ||
     bindingBoundary.required_deployment_image_digest !== deploymentDigest ||
     bindingBoundary.failure_action !== BINDING_ROLLBACK
-  ) {
-    fail("binding owner acceptance boundary drifted");
-  }
+  ) fail("binding owner acceptance boundary drifted");
 
   const acceptedHealth = objectValue(runtime.accepted_health, "runtime accepted_health");
   const healthValidUntil = acceptedHealth.health_valid_until;
   const healthValidUntilMs = canonicalIso(healthValidUntil, "runtime health_valid_until");
   if (bindingEvaluation.health_valid_until !== healthValidUntil) fail("runtime health_valid_until differs from binding acceptance");
-  if (canonicalJson(acceptedHealth.snapshot) !== canonicalJson(bindingEvaluation.snapshot)) {
-    fail("runtime accepted health snapshot differs from binding acceptance");
-  }
-  if (canonicalJson(acceptedHealth.slo_evaluation) !== canonicalJson(bindingEvaluation.slo_evaluation)) {
-    fail("runtime accepted SLO evaluation differs from binding acceptance");
-  }
+  if (canonicalJson(acceptedHealth.snapshot) !== canonicalJson(bindingEvaluation.snapshot)) fail("runtime accepted health snapshot differs from binding acceptance");
+  if (canonicalJson(acceptedHealth.slo_evaluation) !== canonicalJson(bindingEvaluation.slo_evaluation)) fail("runtime accepted SLO evaluation differs from binding acceptance");
   const generatedAtMs = canonicalIso(runtime.generated_at, "runtime generated_at");
-  if (generatedAtMs > healthValidUntilMs + CLOCK_SKEW_MS) {
-    fail("runtime evidence was generated after its admitted health lease deadline");
-  }
+  if (generatedAtMs > healthValidUntilMs + CLOCK_SKEW_MS) fail("runtime evidence was generated after its admitted health lease deadline");
 
   const state = objectValue(acceptedHealth.snapshot, "accepted health snapshot").state;
   const expected = expectedForHealth(state);
   const observations = objectValue(runtime.observations, "runtime observations");
-  const graphql = objectValue(observations.graphql, "runtime GraphQL observation");
-  if (
-    graphql.configured_rollout_all_on !== true ||
-    graphql.provider_health_observed !== true ||
-    graphql.provider_state !== state ||
-    graphql.raw_request_or_response_persisted !== false
-  ) {
+  const graphql = requireHttpRecord(observations.graphql, "runtime GraphQL observation", 200);
+  if (graphql.configured_rollout_all_on !== true || graphql.provider_health_observed !== true || graphql.provider_state !== state || graphql.raw_request_or_response_persisted !== false) {
     fail("runtime GraphQL provider-health observation drifted");
   }
   requireCapability(graphql.preview, "preview", expected.preview);
@@ -433,63 +319,30 @@ function requireRuntimeEvidence(runtimeRecord, identityRecord, evaluationRecord,
   requireSsrState(observations.authoritative_ssr_preview, state);
   requireBrowserState(observations.standalone_browser_intent, state);
 
-  const graphqlAfter = objectValue(observations.graphql_after_consumers, "post-consumer GraphQL observation");
+  const graphqlAfter = requireHttpRecord(observations.graphql_after_consumers, "post-consumer GraphQL observation", 200);
   if (graphqlAfter.provider_health_still_observed !== true) fail("provider health was not observed after consumer probes");
-  requirePositiveInteger(graphqlAfter.status, "post-consumer GraphQL status");
-  requirePositiveInteger(graphqlAfter.response_body_bytes, "post-consumer GraphQL response bytes");
-  requireSha256(graphqlAfter.response_body_sha256, "post-consumer GraphQL response SHA-256");
 
   const boundaries = objectValue(runtime.boundaries, "runtime boundaries");
-  for (const key of [
-    "exact_identity_evaluator_acceptance_chain_verified",
-    "accepted_packet_runtime_observed",
-    "configured_rollout_all_on",
-    "mismatched_page_id_protects_browser_intent_probe_if_health_revoked",
-  ]) {
+  for (const key of ["exact_identity_evaluator_acceptance_chain_verified", "accepted_packet_runtime_observed", "configured_rollout_all_on", "mismatched_page_id_protects_browser_intent_probe_if_health_revoked"]) {
     if (boundaries[key] !== true) fail(`runtime boundary ${key} must be true`);
   }
-  for (const key of [
-    "rollout_settings_mutated",
-    "publish_mutation_executed",
-    "owner_observed_health_acceptance",
-    "pages_reference_consumer_gate_accepted",
-    "forum_wave_accepted",
-    "ffa_promoted",
-    "fba_promoted",
-    "canonical_source_mutated",
-  ]) {
+  for (const key of ["rollout_settings_mutated", "publish_mutation_executed", "owner_observed_health_acceptance", "pages_reference_consumer_gate_accepted", "forum_wave_accepted", "ffa_promoted", "fba_promoted", "canonical_source_mutated"]) {
     if (boundaries[key] !== false) fail(`runtime boundary ${key} must be false`);
   }
   const privacy = objectValue(runtime.privacy, "runtime privacy");
-  for (const [key, value] of Object.entries(privacy)) {
-    if (value !== false) fail(`runtime privacy flag ${key} must be false`);
-  }
+  for (const [key, value] of Object.entries(privacy)) if (value !== false) fail(`runtime privacy flag ${key} must be false`);
 
-  return {
-    sourceCommit,
-    deploymentId,
-    deploymentDigest,
-    generatedAt: runtime.generated_at,
-    healthValidUntil,
-    snapshot: acceptedHealth.snapshot,
-    sloEvaluation: acceptedHealth.slo_evaluation,
-  };
+  return { sourceCommit, deploymentId, deploymentDigest, generatedAt: runtime.generated_at, healthValidUntil, snapshot: acceptedHealth.snapshot, sloEvaluation: acceptedHealth.slo_evaluation };
 }
-
 function outputPath(contract, requested) {
   const candidate = requested ?? contract.output.default_path;
-  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
-    fail("output path is invalid");
-  }
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) fail("output path is invalid");
   const absolute = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
   const targetRoot = path.resolve(repoRoot, "target");
   const relative = path.relative(targetRoot, absolute);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    fail("observed-health owner acceptance output must remain under repository target/");
-  }
+  if (relative.startsWith("..") || path.isAbsolute(relative)) fail("observed-health owner acceptance output must remain under repository target/");
   return absolute;
 }
-
 function writeAtomic(location, document) {
   mkdirSync(path.dirname(location), { recursive: true });
   const temporary = `${location}.tmp-${process.pid}`;
@@ -497,50 +350,36 @@ function writeAtomic(location, document) {
   writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
   renameSync(temporary, location);
 }
-
 function main() {
   const options = parseArguments(process.argv.slice(2));
   for (const required of ["runtimeEvidence", "identity", "evaluation", "bindingAcceptance", "ownerId", "decision"]) {
     if (!options[required]) fail(`--${required.replace(/[A-Z]/gu, (letter) => `-${letter.toLowerCase()}`)} is required`);
   }
-  if (![ACCEPT_DECISION, REJECT_DECISION].includes(options.decision)) {
-    fail(`--decision must be ${ACCEPT_DECISION} or ${REJECT_DECISION}`);
-  }
+  if (![ACCEPT_DECISION, REJECT_DECISION].includes(options.decision)) fail(`--decision must be ${ACCEPT_DECISION} or ${REJECT_DECISION}`);
   const ownerId = boundedOwnerId(options.ownerId);
-  const contract = JSON.parse(readFileSync(contractPath, "utf8"));
-  const runtimeContract = JSON.parse(readFileSync(runtimeContractPath, "utf8"));
-  if (contract.status !== "source_ready_maintainer_execution_pending") {
-    fail("observed-health acceptance source contract must remain execution-pending before owner decision");
-  }
-  if (runtimeContract.status !== "source_ready_maintainer_execution_pending") {
-    fail("runtime evidence execution contract drifted");
-  }
+  const contract = jsonSource(contractPath, "observed-health acceptance source contract");
+  const runtimeContract = jsonSource(runtimeContractPath, "runtime execution contract");
+  const identitySource = jsonSource(identitySourcePath, "identity source contract");
+  const evaluatorSource = jsonSource(evaluatorSourcePath, "evaluator source contract");
+  const bindingSource = jsonSource(bindingSourcePath, "binding owner-acceptance source contract");
+  if (contract.status !== "source_ready_maintainer_execution_pending") fail("observed-health acceptance source contract must remain execution-pending before owner decision");
+  if (runtimeContract.status !== "source_ready_maintainer_execution_pending") fail("runtime evidence execution contract drifted");
   if (
-    contract.owner_decision?.decisions?.[0] !== ACCEPT_DECISION ||
+    !contract.owner_decision?.decisions?.includes(ACCEPT_DECISION) ||
     !contract.owner_decision?.decisions?.includes(REJECT_DECISION) ||
     contract.supplied_predecessor_packets?.binding_owner_acceptance?.decision !== BINDING_DECISION ||
     contract.supplied_predecessor_packets?.binding_owner_acceptance?.rollback_action !== BINDING_ROLLBACK
-  ) {
-    fail("observed-health owner-decision policy drifted");
-  }
+  ) fail("observed-health owner-decision policy drifted");
 
-  const runtimeRecord = jsonInput(options.runtimeEvidence, "runtime evidence");
-  const identityRecord = jsonInput(options.identity, "deployment identity evidence");
-  const evaluationRecord = jsonInput(options.evaluation, "deployment evaluation evidence");
-  const bindingRecord = jsonInput(options.bindingAcceptance, "binding owner acceptance evidence");
-  const admitted = requireRuntimeEvidence(
-    runtimeRecord,
-    identityRecord,
-    evaluationRecord,
-    bindingRecord,
-    contract,
-    runtimeContract,
-    currentCommit(),
-  );
+  const records = {
+    runtimeRecord: jsonInput(options.runtimeEvidence, "runtime evidence"),
+    identityRecord: jsonInput(options.identity, "deployment identity evidence"),
+    evaluationRecord: jsonInput(options.evaluation, "deployment evaluation evidence"),
+    bindingRecord: jsonInput(options.bindingAcceptance, "binding owner acceptance evidence"),
+  };
+  const admitted = requireRuntimeEvidence(records, { runtimeContract, identitySource, evaluatorSource, bindingSource }, contract, currentCommit());
   const decidedAt = new Date();
-  if (decidedAt.getTime() < canonicalIso(admitted.generatedAt, "runtime generated_at")) {
-    fail("owner decision predates runtime evidence generation");
-  }
+  if (decidedAt.getTime() < canonicalIso(admitted.generatedAt, "runtime generated_at")) fail("owner decision predates runtime evidence generation");
 
   const accepted = options.decision === ACCEPT_DECISION;
   const output = outputPath(contract, options.output);
@@ -558,20 +397,18 @@ function main() {
       acceptance_meaning: contract.owner_decision.acceptance_meaning,
     },
     source_commit: admitted.sourceCommit,
-    deployment: {
-      deployment_id: admitted.deploymentId,
-      deployment_image_digest: admitted.deploymentDigest,
-    },
+    deployment: { deployment_id: admitted.deploymentId, deployment_image_digest: admitted.deploymentDigest },
     runtime_evidence: {
-      format: runtimeRecord.document.format,
-      status: runtimeRecord.document.status,
+      format: records.runtimeRecord.document.format,
+      status: records.runtimeRecord.document.status,
       generated_at: admitted.generatedAt,
-      runtime_evidence_sha256: runtimeRecord.sha256,
-      deployment_identity_sha256: identityRecord.sha256,
-      deployment_evaluation_sha256: evaluationRecord.sha256,
-      binding_owner_acceptance_sha256: bindingRecord.sha256,
+      runtime_evidence_sha256: records.runtimeRecord.sha256,
+      deployment_identity_sha256: records.identityRecord.sha256,
+      deployment_evaluation_sha256: records.evaluationRecord.sha256,
+      binding_owner_acceptance_sha256: records.bindingRecord.sha256,
       health_valid_until: admitted.healthValidUntil,
       source_hashes_verified_against_checkout: true,
+      predecessor_source_hashes_verified_against_checkout: true,
       raw_input_paths_persisted: false,
     },
     observed_health: {

--- a/scripts/evidence/accept-pages-builder-provider-health-runtime.mjs
+++ b/scripts/evidence/accept-pages-builder-provider-health-runtime.mjs
@@ -1,0 +1,611 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const contractPath = path.join(
+  repoRoot,
+  "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-observed-acceptance-source.json",
+);
+const runtimeContractPath = path.join(
+  repoRoot,
+  "crates/rustok-pages/contracts/evidence/pages-builder-provider-health-runtime-execution-contract.json",
+);
+const MAX_INPUT_BYTES = 8 * 1024 * 1024;
+const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+const CLOCK_SKEW_MS = 5_000;
+const OWNER_ID_PATTERN = /^[A-Za-z0-9._-]{1,64}$/u;
+const ACCEPT_DECISION = "accept_observed_runtime_evidence";
+const REJECT_DECISION = "reject";
+const BINDING_DECISION = "accept_for_pages_binding";
+const BINDING_ROLLBACK = "restore_unobserved_provider_health";
+
+function fail(message) {
+  throw new Error(`Pages Page Builder observed-health owner acceptance failed: ${message}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  const options = {};
+  const accepted = new Set([
+    "--runtime-evidence",
+    "--identity",
+    "--evaluation",
+    "--binding-acceptance",
+    "--owner-id",
+    "--decision",
+    "--output",
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      console.log(
+        "usage: accept-pages-builder-provider-health-runtime.mjs " +
+          "--runtime-evidence FILE --identity FILE --evaluation FILE --binding-acceptance FILE " +
+          "--owner-id ID --decision accept_observed_runtime_evidence|reject [--output FILE]",
+      );
+      process.exit(0);
+    }
+    if (!accepted.has(argument)) fail(`unknown argument ${argument}`);
+    const value = argv[index + 1];
+    if (!value) fail(`${argument} requires a value`);
+    options[
+      argument
+        .slice(2)
+        .replace(/-([a-z])/gu, (_, letter) => letter.toUpperCase())
+    ] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function currentCommit() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) fail("git rev-parse HEAD failed");
+  const commit = result.stdout.trim().toLowerCase();
+  if (!/^[0-9a-f]{40}$/u.test(commit)) fail("checkout HEAD is not a canonical Git commit");
+  return commit;
+}
+
+function resolveInput(candidate, label) {
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
+    fail(`${label} path is invalid`);
+  }
+  return path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
+}
+
+function regularFile(location, label, maximumBytes = MAX_INPUT_BYTES) {
+  if (!existsSync(location)) fail(`${label} is missing`);
+  const metadata = lstatSync(location);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    fail(`${label} must be a regular non-symlink file`);
+  }
+  const size = statSync(location).size;
+  if (size <= 0 || size > maximumBytes) fail(`${label} is outside the bounded size`);
+  const bytes = readFileSync(location);
+  return { bytes, size, sha256: sha256(bytes) };
+}
+
+function jsonInput(candidate, label) {
+  const location = resolveInput(candidate, label);
+  const record = regularFile(location, label);
+  try {
+    const document = JSON.parse(record.bytes.toString("utf8"));
+    if (document === null || typeof document !== "object" || Array.isArray(document)) {
+      fail(`${label} must contain a JSON object`);
+    }
+    return { document, ...record };
+  } catch (error) {
+    fail(`${label} is invalid JSON: ${error.message}`);
+  }
+}
+
+function objectValue(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function canonicalCommit(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
+    fail(`${label} must be a lowercase 40-character Git SHA`);
+  }
+  return value;
+}
+
+function canonicalRepoDigest(value, label) {
+  if (typeof value !== "string" || value.length > 1024 || !/^[^\s@]+@sha256:[0-9a-f]{64}$/u.test(value)) {
+    fail(`${label} must be REPOSITORY@sha256:<64 lowercase hex>`);
+  }
+  return value;
+}
+
+function canonicalIso(value, label) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 128) {
+    fail(`${label} is invalid`);
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
+    fail(`${label} must be canonical ISO-8601 UTC`);
+  }
+  return milliseconds;
+}
+
+function boundedOwnerId(value) {
+  if (typeof value !== "string" || !OWNER_ID_PATTERN.test(value)) {
+    fail("--owner-id must match ^[A-Za-z0-9._-]{1,64}$");
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  const normalize = (input) => {
+    if (Array.isArray(input)) return input.map(normalize);
+    if (input !== null && typeof input === "object") {
+      return Object.fromEntries(
+        Object.entries(input)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([key, nested]) => [key, normalize(nested)]),
+      );
+    }
+    return input;
+  };
+  return JSON.stringify(normalize(value));
+}
+
+function requireSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${label} must be a lowercase SHA-256`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) fail(`${label} must be a positive safe integer`);
+  return value;
+}
+
+function regularSourceHash(relativePath) {
+  if (typeof relativePath !== "string" || relativePath.length === 0 || relativePath.length > 4096) {
+    fail("source path is invalid");
+  }
+  const absolute = path.resolve(repoRoot, relativePath);
+  const relative = path.relative(repoRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail(`source file ${relativePath} escapes repository root`);
+  }
+  return sha256(regularFile(absolute, `source file ${relativePath}`, MAX_SOURCE_BYTES).bytes);
+}
+
+function sourceHashes(contract) {
+  const files = contract.required_source_files;
+  if (!Array.isArray(files) || files.length === 0 || files.length > 64) {
+    fail("observed acceptance source contract has invalid required_source_files");
+  }
+  return Object.fromEntries(files.map((relativePath) => [relativePath, regularSourceHash(relativePath)]));
+}
+
+function verifyRuntimeSourceHashes(runtime, runtimeContract) {
+  const retained = objectValue(runtime.source_sha256, "runtime source_sha256");
+  const expected = runtimeContract.required_source_files;
+  if (!Array.isArray(expected) || expected.length === 0 || expected.length > 64) {
+    fail("runtime execution contract required source-file set is invalid");
+  }
+  const actualNames = Object.keys(retained).sort();
+  const expectedNames = [...expected].sort();
+  if (canonicalJson(actualNames) !== canonicalJson(expectedNames)) {
+    fail("runtime source SHA set differs from runtime execution contract");
+  }
+  for (const relativePath of expectedNames) {
+    const retainedSha = requireSha256(retained[relativePath], `runtime source SHA ${relativePath}`);
+    if (regularSourceHash(relativePath) !== retainedSha) {
+      fail(`runtime source SHA for ${relativePath} does not match checkout`);
+    }
+  }
+}
+
+function requirePacketHash(record, retained, label) {
+  const node = objectValue(retained, label);
+  if (requirePositiveInteger(node.bytes, `${label}.bytes`) !== record.size) {
+    fail(`${label} byte length does not match supplied packet`);
+  }
+  if (requireSha256(node.sha256, `${label}.sha256`) !== record.sha256) {
+    fail(`${label} SHA-256 does not match supplied packet`);
+  }
+}
+
+function requireCapability(value, capability, expected) {
+  const result = objectValue(value, `${capability} preflight observation`);
+  if (result.capability !== capability) fail(`${capability} preflight capability drifted`);
+  if (expected === "allowed") {
+    if (result.allowed !== true || result.error_kind !== null || result.error_code !== null) {
+      fail(`${capability} preflight must be allowed`);
+    }
+    return;
+  }
+  if (
+    result.allowed !== false ||
+    result.error_kind !== "feature-disabled" ||
+    result.error_code !== "FEATURE_DISABLED"
+  ) {
+    fail(`${capability} preflight must be feature-disabled / FEATURE_DISABLED`);
+  }
+}
+
+function expectedForHealth(state) {
+  if (state === "ready") {
+    return { preview: "allowed", properties: "allowed", publish: "allowed" };
+  }
+  if (state === "degraded") {
+    return { preview: "allowed", properties: "allowed", publish: "feature_disabled" };
+  }
+  if (state === "unavailable") {
+    return { preview: "feature_disabled", properties: "feature_disabled", publish: "feature_disabled" };
+  }
+  fail(`unsupported accepted provider health state ${state}`);
+}
+
+function requireWorkspaceState(value, expected, state) {
+  const workspace = objectValue(value, "workspace observation");
+  if (workspace.provider_control_state !== state || workspace.provider_health !== state) {
+    fail("workspace provider state does not match accepted health");
+  }
+  if (workspace.preview_enabled !== (expected.preview === "allowed")) {
+    fail("workspace preview state does not match accepted health");
+  }
+  const allowedState = (actual, allowed, label) => {
+    if (allowed && actual !== "enabled") fail(`${label} must be enabled`);
+    if (!allowed && !["disabled", "hidden"].includes(actual)) fail(`${label} must be disabled or hidden`);
+  };
+  allowedState(workspace.properties, expected.properties === "allowed", "workspace properties");
+  allowedState(workspace.publish, expected.publish === "allowed", "workspace publish");
+}
+
+function requireSsrState(value, state) {
+  const ssr = objectValue(value, "authoritative SSR preview observation");
+  if (state === "unavailable") {
+    if (ssr.request_attempted !== false || ssr.ui_blocked !== true || ssr.mutation_possible !== false) {
+      fail("unavailable health must block SSR Preview before request dispatch");
+    }
+    return;
+  }
+  if (
+    ssr.request_attempted !== true ||
+    ssr.capability_disabled !== false ||
+    ssr.mutation_possible !== false ||
+    ssr.raw_request_or_response_persisted !== false
+  ) {
+    fail("ready/degraded health SSR Preview observation drifted");
+  }
+  requirePositiveInteger(ssr.status, "SSR Preview HTTP status");
+  requirePositiveInteger(ssr.response_body_bytes, "SSR Preview response bytes");
+  requireSha256(ssr.response_body_sha256, "SSR Preview response SHA-256");
+}
+
+function requireBrowserDenial(value, intent, capability) {
+  const denial = objectValue(value, `${intent} browser-intent denial`);
+  if (
+    denial.status !== 403 ||
+    denial.code !== "FLY_CAPABILITY_DENIED" ||
+    denial.intent !== intent ||
+    denial.capability !== capability ||
+    denial.mismatch_page_id_used_as_non_mutating_fallback !== true ||
+    denial.raw_request_or_response_persisted !== false
+  ) {
+    fail(`${intent} browser-intent denial drifted`);
+  }
+  requirePositiveInteger(denial.response_body_bytes, `${intent} denial response bytes`);
+  requireSha256(denial.response_body_sha256, `${intent} denial response SHA-256`);
+}
+
+function requireBrowserState(value, state) {
+  if (!Array.isArray(value)) fail("standalone browser-intent observation must be an array");
+  if (state === "ready") {
+    if (value.length !== 0) fail("ready health must not require a browser-intent denial probe");
+    return;
+  }
+  if (state === "degraded") {
+    if (value.length !== 1) fail("degraded health must retain exactly one browser-intent denial");
+    requireBrowserDenial(value[0], "save", "publish");
+    return;
+  }
+  if (value.length !== 2) fail("unavailable health must retain two browser-intent denials");
+  requireBrowserDenial(value[0], "save", "publish");
+  requireBrowserDenial(value[1], "rename_page", "properties");
+}
+
+function requireRuntimeEvidence(runtimeRecord, identityRecord, evaluationRecord, bindingRecord, contract, runtimeContract, head) {
+  const runtime = runtimeRecord.document;
+  if (runtime.format !== contract.runtime_evidence_input.format || runtime.status !== contract.runtime_evidence_input.required_status) {
+    fail("runtime evidence format/status drifted");
+  }
+  const sourceCommit = canonicalCommit(runtime.source_commit, "runtime source_commit");
+  if (sourceCommit !== head) fail("runtime source commit does not equal checkout HEAD");
+  verifyRuntimeSourceHashes(runtime, runtimeContract);
+
+  const runtimeDeployment = objectValue(runtime.deployment, "runtime deployment");
+  const deploymentId = runtimeDeployment.deployment_id;
+  if (typeof deploymentId !== "string" || deploymentId.length === 0 || deploymentId.length > 256) {
+    fail("runtime deployment id is invalid");
+  }
+  const deploymentDigest = canonicalRepoDigest(runtimeDeployment.deployment_image_digest, "runtime deployment image digest");
+
+  const identity = identityRecord.document;
+  const evaluation = evaluationRecord.document;
+  const binding = bindingRecord.document;
+  const identitySpec = contract.supplied_predecessor_packets.deployment_identity;
+  const evaluationSpec = contract.supplied_predecessor_packets.deployment_evaluation;
+  const bindingSpec = contract.supplied_predecessor_packets.binding_owner_acceptance;
+  if (identity.format !== identitySpec.format || identity.status !== identitySpec.status) fail("identity packet format/status drifted");
+  if (evaluation.format !== evaluationSpec.format || evaluation.status !== evaluationSpec.status) fail("evaluation packet format/status drifted");
+  if (binding.format !== bindingSpec.format || binding.status !== bindingSpec.status) fail("binding owner-acceptance packet format/status drifted");
+
+  for (const [document, label] of [[identity, "identity"], [evaluation, "evaluation"], [binding, "binding acceptance"]]) {
+    const deployment = objectValue(document.deployment, `${label} deployment`);
+    if (deployment.source_commit !== sourceCommit || deployment.deployment_id !== deploymentId || deployment.deployment_image_digest !== deploymentDigest) {
+      fail(`${label} deployment identity differs from runtime evidence`);
+    }
+  }
+
+  const inputPackets = objectValue(runtime.input_packets, "runtime input_packets");
+  if (inputPackets.raw_paths_persisted !== false) fail("runtime evidence retained raw predecessor paths");
+  requirePacketHash(identityRecord, inputPackets.deployment_identity, "runtime identity packet");
+  requirePacketHash(evaluationRecord, inputPackets.deployment_evaluation, "runtime evaluation packet");
+  requirePacketHash(bindingRecord, inputPackets.owner_acceptance, "runtime binding acceptance packet");
+
+  const bindingDecision = objectValue(binding.decision, "binding owner decision");
+  if (
+    bindingDecision.value !== bindingSpec.decision ||
+    bindingDecision.rollback_action !== bindingSpec.rollback_action ||
+    bindingDecision.owner_identity_is_operator_assertion !== true ||
+    bindingDecision.cryptographic_signature_present !== false ||
+    bindingDecision.free_text_reason_retained !== false
+  ) {
+    fail("binding owner decision contract drifted");
+  }
+  const bindingEvaluation = objectValue(binding.evaluation, "binding acceptance evaluation");
+  if (bindingEvaluation.evaluation_sha256 !== evaluationRecord.sha256) {
+    fail("binding owner acceptance is not bound to supplied evaluation packet");
+  }
+  const bindingBoundary = objectValue(binding.binding, "binding acceptance boundary");
+  if (
+    bindingBoundary.server_binding_authorized !== true ||
+    bindingBoundary.server_binding_performed !== false ||
+    bindingBoundary.required_live_source_commit !== sourceCommit ||
+    bindingBoundary.required_deployment_image_digest !== deploymentDigest ||
+    bindingBoundary.failure_action !== BINDING_ROLLBACK
+  ) {
+    fail("binding owner acceptance boundary drifted");
+  }
+
+  const acceptedHealth = objectValue(runtime.accepted_health, "runtime accepted_health");
+  const healthValidUntil = acceptedHealth.health_valid_until;
+  const healthValidUntilMs = canonicalIso(healthValidUntil, "runtime health_valid_until");
+  if (bindingEvaluation.health_valid_until !== healthValidUntil) fail("runtime health_valid_until differs from binding acceptance");
+  if (canonicalJson(acceptedHealth.snapshot) !== canonicalJson(bindingEvaluation.snapshot)) {
+    fail("runtime accepted health snapshot differs from binding acceptance");
+  }
+  if (canonicalJson(acceptedHealth.slo_evaluation) !== canonicalJson(bindingEvaluation.slo_evaluation)) {
+    fail("runtime accepted SLO evaluation differs from binding acceptance");
+  }
+  const generatedAtMs = canonicalIso(runtime.generated_at, "runtime generated_at");
+  if (generatedAtMs > healthValidUntilMs + CLOCK_SKEW_MS) {
+    fail("runtime evidence was generated after its admitted health lease deadline");
+  }
+
+  const state = objectValue(acceptedHealth.snapshot, "accepted health snapshot").state;
+  const expected = expectedForHealth(state);
+  const observations = objectValue(runtime.observations, "runtime observations");
+  const graphql = objectValue(observations.graphql, "runtime GraphQL observation");
+  if (
+    graphql.configured_rollout_all_on !== true ||
+    graphql.provider_health_observed !== true ||
+    graphql.provider_state !== state ||
+    graphql.raw_request_or_response_persisted !== false
+  ) {
+    fail("runtime GraphQL provider-health observation drifted");
+  }
+  requireCapability(graphql.preview, "preview", expected.preview);
+  requireCapability(graphql.properties, "properties", expected.properties);
+  requireCapability(graphql.publish, "publish", expected.publish);
+  requireWorkspaceState(observations.workspace, expected, state);
+  requireSsrState(observations.authoritative_ssr_preview, state);
+  requireBrowserState(observations.standalone_browser_intent, state);
+
+  const graphqlAfter = objectValue(observations.graphql_after_consumers, "post-consumer GraphQL observation");
+  if (graphqlAfter.provider_health_still_observed !== true) fail("provider health was not observed after consumer probes");
+  requirePositiveInteger(graphqlAfter.status, "post-consumer GraphQL status");
+  requirePositiveInteger(graphqlAfter.response_body_bytes, "post-consumer GraphQL response bytes");
+  requireSha256(graphqlAfter.response_body_sha256, "post-consumer GraphQL response SHA-256");
+
+  const boundaries = objectValue(runtime.boundaries, "runtime boundaries");
+  for (const key of [
+    "exact_identity_evaluator_acceptance_chain_verified",
+    "accepted_packet_runtime_observed",
+    "configured_rollout_all_on",
+    "mismatched_page_id_protects_browser_intent_probe_if_health_revoked",
+  ]) {
+    if (boundaries[key] !== true) fail(`runtime boundary ${key} must be true`);
+  }
+  for (const key of [
+    "rollout_settings_mutated",
+    "publish_mutation_executed",
+    "owner_observed_health_acceptance",
+    "pages_reference_consumer_gate_accepted",
+    "forum_wave_accepted",
+    "ffa_promoted",
+    "fba_promoted",
+    "canonical_source_mutated",
+  ]) {
+    if (boundaries[key] !== false) fail(`runtime boundary ${key} must be false`);
+  }
+  const privacy = objectValue(runtime.privacy, "runtime privacy");
+  for (const [key, value] of Object.entries(privacy)) {
+    if (value !== false) fail(`runtime privacy flag ${key} must be false`);
+  }
+
+  return {
+    sourceCommit,
+    deploymentId,
+    deploymentDigest,
+    generatedAt: runtime.generated_at,
+    healthValidUntil,
+    snapshot: acceptedHealth.snapshot,
+    sloEvaluation: acceptedHealth.slo_evaluation,
+  };
+}
+
+function outputPath(contract, requested) {
+  const candidate = requested ?? contract.output.default_path;
+  if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 16_384) {
+    fail("output path is invalid");
+  }
+  const absolute = path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(repoRoot, candidate);
+  const targetRoot = path.resolve(repoRoot, "target");
+  const relative = path.relative(targetRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    fail("observed-health owner acceptance output must remain under repository target/");
+  }
+  return absolute;
+}
+
+function writeAtomic(location, document) {
+  mkdirSync(path.dirname(location), { recursive: true });
+  const temporary = `${location}.tmp-${process.pid}`;
+  rmSync(temporary, { force: true });
+  writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+  renameSync(temporary, location);
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  for (const required of ["runtimeEvidence", "identity", "evaluation", "bindingAcceptance", "ownerId", "decision"]) {
+    if (!options[required]) fail(`--${required.replace(/[A-Z]/gu, (letter) => `-${letter.toLowerCase()}`)} is required`);
+  }
+  if (![ACCEPT_DECISION, REJECT_DECISION].includes(options.decision)) {
+    fail(`--decision must be ${ACCEPT_DECISION} or ${REJECT_DECISION}`);
+  }
+  const ownerId = boundedOwnerId(options.ownerId);
+  const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+  const runtimeContract = JSON.parse(readFileSync(runtimeContractPath, "utf8"));
+  if (contract.status !== "source_ready_maintainer_execution_pending") {
+    fail("observed-health acceptance source contract must remain execution-pending before owner decision");
+  }
+  if (runtimeContract.status !== "source_ready_maintainer_execution_pending") {
+    fail("runtime evidence execution contract drifted");
+  }
+  if (
+    contract.owner_decision?.decisions?.[0] !== ACCEPT_DECISION ||
+    !contract.owner_decision?.decisions?.includes(REJECT_DECISION) ||
+    contract.supplied_predecessor_packets?.binding_owner_acceptance?.decision !== BINDING_DECISION ||
+    contract.supplied_predecessor_packets?.binding_owner_acceptance?.rollback_action !== BINDING_ROLLBACK
+  ) {
+    fail("observed-health owner-decision policy drifted");
+  }
+
+  const runtimeRecord = jsonInput(options.runtimeEvidence, "runtime evidence");
+  const identityRecord = jsonInput(options.identity, "deployment identity evidence");
+  const evaluationRecord = jsonInput(options.evaluation, "deployment evaluation evidence");
+  const bindingRecord = jsonInput(options.bindingAcceptance, "binding owner acceptance evidence");
+  const admitted = requireRuntimeEvidence(
+    runtimeRecord,
+    identityRecord,
+    evaluationRecord,
+    bindingRecord,
+    contract,
+    runtimeContract,
+    currentCommit(),
+  );
+  const decidedAt = new Date();
+  if (decidedAt.getTime() < canonicalIso(admitted.generatedAt, "runtime generated_at")) {
+    fail("owner decision predates runtime evidence generation");
+  }
+
+  const accepted = options.decision === ACCEPT_DECISION;
+  const output = outputPath(contract, options.output);
+  rmSync(output, { force: true });
+  writeAtomic(output, {
+    format: contract.output.format,
+    status: accepted ? contract.output.accepted_status : contract.output.rejected_status,
+    decided_at: decidedAt.toISOString(),
+    decision: {
+      value: options.decision,
+      owner_id: ownerId,
+      owner_identity_is_operator_assertion: true,
+      cryptographic_signature_present: false,
+      free_text_reason_retained: false,
+      acceptance_meaning: contract.owner_decision.acceptance_meaning,
+    },
+    source_commit: admitted.sourceCommit,
+    deployment: {
+      deployment_id: admitted.deploymentId,
+      deployment_image_digest: admitted.deploymentDigest,
+    },
+    runtime_evidence: {
+      format: runtimeRecord.document.format,
+      status: runtimeRecord.document.status,
+      generated_at: admitted.generatedAt,
+      runtime_evidence_sha256: runtimeRecord.sha256,
+      deployment_identity_sha256: identityRecord.sha256,
+      deployment_evaluation_sha256: evaluationRecord.sha256,
+      binding_owner_acceptance_sha256: bindingRecord.sha256,
+      health_valid_until: admitted.healthValidUntil,
+      source_hashes_verified_against_checkout: true,
+      raw_input_paths_persisted: false,
+    },
+    observed_health: {
+      snapshot: admitted.snapshot,
+      slo_evaluation: admitted.sloEvaluation,
+      historical_lease_deadline_only: true,
+      current_provider_health_asserted: false,
+    },
+    binding_lineage: {
+      predecessor_decision: BINDING_DECISION,
+      predecessor_rollback_action: BINDING_ROLLBACK,
+      live_binding_action: "unchanged",
+      server_binding_authorized_by_this_packet: false,
+      health_lease_extended: false,
+    },
+    gate: {
+      eligible_for_pages_gate_review: accepted,
+      pages_reference_consumer_gate_accepted: false,
+      automatic_gate_acceptance: false,
+      reference_gate_owner_signoff_satisfied: false,
+      reference_gate_rollback_decision_satisfied: false,
+    },
+    source_files: sourceHashes(contract),
+    raw_input_paths_persisted: false,
+    pages_reference_consumer_gate_accepted: false,
+    forum_wave_accepted: false,
+    ffa_promoted: false,
+    fba_promoted: false,
+  });
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Continue the Pages / Page Builder provider-health parity cursor after #3424 by preparing the explicit retrospective owner decision over observed-health runtime evidence. This PR does not execute any evidence step or make an owner decision.

### Changes

- add `pages_builder_provider_health_observed_acceptance_source_v1` and a bounded owner-decision runner;
- accept only `pages_builder_provider_health_runtime_evidence_v1 / observed_runtime_evidence_owner_review_pending` bound to checkout `HEAD`;
- require exact supplied identity, deployment-evaluation and binding-owner-acceptance packet byte lengths/SHA-256 values retained by the runtime packet;
- revalidate runtime, identity, evaluator and binding-owner packet source hashes against their source contracts and the checkout;
- require exact source commit, deployment id and immutable RepoDigest across the full evidence lineage;
- preserve the original historical `health_valid_until`: runtime evidence must have been produced inside that lease, but retrospective owner review may occur later and never restarts or extends the lease;
- revalidate retained GraphQL HTTP/body hashes, canonical `FEATURE_DISABLED` narrowing, workspace controls, authoritative SSR Preview and standalone browser-intent observations for Ready/Degraded/Unavailable;
- provide explicit `accept_observed_runtime_evidence` or `reject` decisions;
- accepted output is only `pages_builder_provider_health_observed_acceptance_v1 / owner_accepted_observed_runtime_evidence_gate_review_pending`;
- keep live binding unchanged, current provider health unasserted, Pages reference-consumer gate `accepted=false`, Forum Wave blocked and FFA/FBA unclaimed;
- advance runtime-harness and canonical parity cursors to observed-health owner acceptance source-ready / maintainer-execution-pending.

## Acceptance semantics

`accept_observed_runtime_evidence` accepts the correctness of historical exact-deployment evidence for later gate review. It does **not** assert that the provider is currently Ready; correctly enforced Degraded or Unavailable evidence may also be accepted. It does not extend `health_valid_until`, authorize/modify server binding, accept the Pages gate, or satisfy the reference-gate owner sign-off/rollback decision by itself.

## Validation

Per maintainer instruction, tests and verifiers were intentionally not run. No Node verifier, Cargo command, formatter, build, GraphQL/HTTP request, Playwright/browser run, deployment identity capture, Prometheus/evaluator execution, binding owner acceptance, observed runtime harness, observed-health owner decision, workflow or CI run was performed.

Suggested source checks, intentionally not run:

```bash
node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-observed-acceptance.mjs
node crates/rustok-pages/scripts/verify/verify-pages-builder-provider-health-runtime-harness.mjs
node crates/rustok-page-builder/scripts/verify/verify-pages-page-builder-plan-parity.mjs
```

## Next cursor

`provider-health source architecture including runtime evidence + observed owner acceptance [source-ready] -> exact identity/evaluator/binding acceptance/runtime evidence + explicit observed-evidence decision [maintainer execution pending] -> accepted observed-health packet eligible for separate Pages gate review -> Pages reference-consumer gate acceptance [pending]`.