### PR TITLE
feat(forum): persist admitted deleted replies

### DIFF
--- a/crates/rustok-forum/src/services/import_tombstone_write.rs
+++ b/crates/rustok-forum/src/services/import_tombstone_write.rs
@@ -1,0 +1,273 @@
+impl ForumImportWriteService {
+    /// Applies one already-admitted 34P tombstone batch in exactly one
+    /// Forum-owned transaction.
+    ///
+    /// The legacy `apply_prepared_batch` entrypoint remains unchanged and
+    /// therefore keeps deleted replies fail-closed. Shared migration execution
+    /// should use this entrypoint only after 34P tombstone admission.
+    pub async fn apply_prepared_tombstone_batch(
+        &self,
+        security: &SecurityContext,
+        batch: &crate::import_tombstone_preparation::ForumPreparedImportTombstoneBatch,
+    ) -> ForumResult<ForumImportWriteResult> {
+        let batch = revalidate_prepared_tombstone_batch(batch)?;
+        let relations = &batch.relations;
+        validate_tombstone_apply_shape(security, relations)?;
+        validate_relation_alignment(relations)?;
+        let category_order = ordered_category_indices(&relations.writes.categories)?;
+        let reply_order = ordered_reply_indices(&relations.writes.replies)?;
+        let tombstones = batch
+            .deleted_replies
+            .iter()
+            .map(|tombstone| (tombstone.reply_id, tombstone))
+            .collect::<BTreeMap<_, _>>();
+
+        let topic_service =
+            super::topic::TopicService::new(self.db.clone(), self.event_bus.clone());
+        let reply_service =
+            super::reply_owner::ReplyService::new(self.db.clone(), self.event_bus.clone());
+        let relation_service = super::mention_relation::MentionRelationService::new(self.db.clone());
+
+        let mut prepared_topics = Vec::with_capacity(relations.writes.topics.len());
+        for record in &relations.writes.topics {
+            prepared_topics.push(
+                topic_service
+                    .prepare_import_topic(relations.writes.tenant_id, record)
+                    .await?,
+            );
+        }
+        let mut prepared_replies = Vec::with_capacity(relations.writes.replies.len());
+        for record in &relations.writes.replies {
+            prepared_replies.push(reply_service.prepare_import_reply_with_tombstone(
+                relations.writes.tenant_id,
+                record,
+                tombstones.get(&record.id).copied(),
+            )?);
+        }
+
+        let txn = self.db.begin().await?;
+        ensure_target_ids_absent_in_tx(&txn, relations).await?;
+
+        for index in category_order {
+            super::category::CategoryService::insert_import_category_in_tx(
+                &txn,
+                relations.writes.tenant_id,
+                &relations.writes.categories[index],
+            )
+            .await?;
+        }
+
+        for (index, prepared) in prepared_topics.iter().enumerate() {
+            topic_service
+                .insert_import_topic_in_tx(
+                    &txn,
+                    relations.writes.tenant_id,
+                    prepared,
+                    &relations.topics[index],
+                    &relation_service,
+                    relations.relation_event_mode,
+                    relations.writes.event_mode,
+                )
+                .await?;
+        }
+
+        for index in reply_order {
+            reply_service
+                .insert_import_reply_with_tombstone_in_tx(
+                    &txn,
+                    relations.writes.tenant_id,
+                    &prepared_replies[index],
+                    &relations.replies[index],
+                    tombstones.get(&prepared_replies[index].id()).copied(),
+                    relations.relation_event_mode,
+                    relations.writes.event_mode,
+                )
+                .await?;
+        }
+
+        let reply_aggregates = approved_reply_aggregates(&prepared_replies)?;
+        for prepared in &prepared_topics {
+            let (count, last_reply_at) = reply_aggregates
+                .get(&prepared.id())
+                .cloned()
+                .unwrap_or((0, None));
+            super::topic::TopicService::finalize_import_topic_in_tx(
+                &txn,
+                relations.writes.tenant_id,
+                prepared,
+                count,
+                last_reply_at,
+            )
+            .await?;
+        }
+
+        // This consistency projection is required even when all historical
+        // interactive events, including deleted-content mention events, are
+        // suppressed.
+        super::projection_invalidation::publish_forum_projection_scope_direct_in_tx(
+            &txn,
+            relations.writes.tenant_id,
+            security.user_id,
+        )
+        .await?;
+
+        txn.commit().await?;
+
+        Ok(ForumImportWriteResult {
+            tenant_id: relations.writes.tenant_id,
+            category_ids: relations
+                .writes
+                .categories
+                .iter()
+                .map(|record| record.id)
+                .collect(),
+            topic_ids: relations
+                .writes
+                .topics
+                .iter()
+                .map(|record| record.id)
+                .collect(),
+            reply_ids: relations
+                .writes
+                .replies
+                .iter()
+                .map(|record| record.id)
+                .collect(),
+        })
+    }
+}
+
+fn revalidate_prepared_tombstone_batch(
+    batch: &crate::import_tombstone_preparation::ForumPreparedImportTombstoneBatch,
+) -> ForumResult<crate::import_tombstone_preparation::ForumPreparedImportTombstoneBatch> {
+    let checked = crate::import_tombstone_preparation::ForumImportTombstonePreparer
+        .prepare(
+            crate::import_tombstone_preparation::ForumImportTombstonePreparationRequest {
+                relations: batch.relations.clone(),
+                deleted_replies: batch
+                    .deleted_replies
+                    .iter()
+                    .map(|tombstone| {
+                        crate::import_tombstone_preparation::ForumImportReplyTombstoneFact {
+                            source: tombstone.source.clone(),
+                            deleted_at_ms: tombstone.deleted_at_ms,
+                        }
+                    })
+                    .collect(),
+            },
+        )
+        .map_err(|error| {
+            ForumError::Validation(format!(
+                "Forum import tombstone batch revalidation failed: {error}"
+            ))
+        })?;
+
+    if checked.deleted_replies != batch.deleted_replies {
+        return Err(ForumError::Validation(
+            "Forum import tombstone batch identity differs after revalidation".to_string(),
+        ));
+    }
+    Ok(checked)
+}
+
+fn validate_tombstone_apply_shape(
+    security: &SecurityContext,
+    batch: &ForumPreparedImportRelationBatch,
+) -> ForumResult<()> {
+    if batch.writes.tenant_id.is_nil() {
+        return Err(ForumError::Validation(
+            "Forum import application requires a non-nil tenant ID".to_string(),
+        ));
+    }
+    let total = batch
+        .writes
+        .categories
+        .len()
+        .saturating_add(batch.writes.topics.len())
+        .saturating_add(batch.writes.replies.len());
+    if total == 0 || total > MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH {
+        return Err(ForumError::Validation(format!(
+            "Forum import application requires 1..={MAX_FORUM_IMPORT_APPLY_RECORDS_PER_BATCH} owner records"
+        )));
+    }
+
+    let locale = normalize_locale_code(&batch.writes.locale).ok_or_else(|| {
+        ForumError::Validation("Forum import application requires a valid locale".to_string())
+    })?;
+    if locale != batch.writes.locale {
+        return Err(ForumError::Validation(
+            "Forum import application locale must already be normalized".to_string(),
+        ));
+    }
+
+    if !batch.writes.categories.is_empty() {
+        require_all_manage(security, Resource::ForumCategories)?;
+    }
+    if !batch.writes.topics.is_empty() {
+        require_all_manage(security, Resource::ForumTopics)?;
+    }
+    if !batch.writes.replies.is_empty() {
+        require_all_manage(security, Resource::ForumReplies)?;
+    }
+
+    let expected_relation_event_mode = match batch.writes.event_mode {
+        ForumImportWriteEventMode::SuppressInteractiveEvents => {
+            ForumImportRelationEventMode::SuppressAddedTargetEvents
+        }
+        ForumImportWriteEventMode::EmitDomainEvents => {
+            ForumImportRelationEventMode::EmitAddedTargetEvents
+        }
+    };
+    if batch.relation_event_mode != expected_relation_event_mode {
+        return Err(ForumError::Validation(
+            "Forum import relation event mode differs from prepared write event mode".to_string(),
+        ));
+    }
+
+    let category_ids = unique_ids(
+        "category",
+        batch.writes.categories.iter().map(|record| record.id),
+    )?;
+    let topic_ids = unique_ids("topic", batch.writes.topics.iter().map(|record| record.id))?;
+    let reply_ids = unique_ids("reply", batch.writes.replies.iter().map(|record| record.id))?;
+
+    for category in &batch.writes.categories {
+        validate_source_ref(&category.source, ForumImportEntityKind::Category)?;
+        validate_record_locale(&batch.writes.locale, &category.source, &category.locale)?;
+        validate_timestamp("category", &category.source, category.created_at_ms)?;
+    }
+
+    for topic in &batch.writes.topics {
+        validate_source_ref(&topic.source, ForumImportEntityKind::Topic)?;
+        validate_source_ref(&topic.body_source, ForumImportEntityKind::Post)?;
+        validate_record_locale(&batch.writes.locale, &topic.source, &topic.locale)?;
+        validate_author(topic.author.as_ref())?;
+        validate_timestamp("topic", &topic.source, topic.created_at_ms)?;
+        if !category_ids.contains(&topic.category_id) {
+            return Err(ForumError::Validation(
+                "Forum import topic category must be inside the bounded batch".to_string(),
+            ));
+        }
+    }
+
+    for reply in &batch.writes.replies {
+        validate_source_ref(&reply.source, ForumImportEntityKind::Post)?;
+        validate_record_locale(&batch.writes.locale, &reply.source, &reply.locale)?;
+        validate_author(reply.author.as_ref())?;
+        validate_timestamp("reply", &reply.source, reply.created_at_ms)?;
+        if !topic_ids.contains(&reply.topic_id) {
+            return Err(ForumError::Validation(
+                "Forum import reply topic must be inside the bounded batch".to_string(),
+            ));
+        }
+        if let Some(parent_reply_id) = reply.parent_reply_id {
+            if !reply_ids.contains(&parent_reply_id) {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent must be inside the bounded batch".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rustok-forum/src/services/mod.rs
+++ b/crates/rustok-forum/src/services/mod.rs
@@ -49,7 +49,10 @@ mod category_visibility;
 mod counter_reconciliation;
 mod solution_reconciliation;
 pub mod event;
-mod import_write;
+mod import_write {
+    include!("import_tombstone_write.rs");
+    include!("import_write.rs");
+}
 #[allow(clippy::collapsible_if, clippy::too_many_arguments)]
 mod mention_relation {
     include!("mention_relation_import.rs");
@@ -95,6 +98,7 @@ mod reply_audience_read;
 mod reply_create_audience_authorization;
 mod reply_facade;
 mod reply_owner {
+    include!("reply_owner_tombstone_import.rs");
     include!("reply_owner_import.rs");
     include!("reply_owner.rs");
     include!("reply_owner_inline.rs");

--- a/crates/rustok-forum/src/services/reply_owner_tombstone_import.rs
+++ b/crates/rustok-forum/src/services/reply_owner_tombstone_import.rs
@@ -1,0 +1,322 @@
+impl ReplyService {
+    pub(crate) fn prepare_import_reply_with_tombstone(
+        &self,
+        tenant_id: Uuid,
+        record: &crate::import_write_preparation::ForumPreparedImportReply,
+        tombstone: Option<&crate::import_tombstone_preparation::ForumPreparedDeletedReplyTombstone>,
+    ) -> ForumResult<PreparedImportReplyInsert> {
+        if record.status != ReplyStatus::Deleted {
+            if tombstone.is_some() {
+                return Err(ForumError::Validation(
+                    "Forum import live reply cannot carry a deleted tombstone".to_string(),
+                ));
+            }
+            return self.prepare_import_reply(tenant_id, record);
+        }
+
+        let tombstone = tombstone.ok_or_else(|| {
+            ForumError::Validation(
+                "Forum import deleted reply requires an admitted tombstone timestamp".to_string(),
+            )
+        })?;
+        validate_import_reply_tombstone(record, tombstone)?;
+
+        if tenant_id.is_nil() || record.id.is_nil() || record.topic_id.is_nil() {
+            return Err(ForumError::Validation(
+                "Forum import reply preparation requires non-nil tenant, reply and topic IDs"
+                    .to_string(),
+            ));
+        }
+        let locale = normalize_locale(&record.locale)?;
+        if locale != record.locale {
+            return Err(ForumError::Validation(
+                "Forum import reply locale must already be normalized".to_string(),
+            ));
+        }
+        let document = crate::richtext::normalize_discussion(record.content.clone())?;
+        let stored_body = crate::richtext::serialize_discussion(document.clone())?;
+        let created_at = chrono::DateTime::<Utc>::from_timestamp_millis(record.created_at_ms)
+            .ok_or_else(|| {
+                ForumError::Validation(
+                    "Forum import reply creation timestamp is outside owner range".to_string(),
+                )
+            })?;
+        let deleted_at = chrono::DateTime::<Utc>::from_timestamp_millis(tombstone.deleted_at_ms)
+            .ok_or_else(|| {
+                ForumError::Validation(
+                    "Forum import reply tombstone timestamp is outside owner range".to_string(),
+                )
+            })?;
+        if deleted_at < created_at {
+            return Err(ForumError::Validation(
+                "Forum import reply tombstone cannot predate reply creation".to_string(),
+            ));
+        }
+
+        Ok(PreparedImportReplyInsert {
+            record: record.clone(),
+            document,
+            stored_body,
+            created_at,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn insert_import_reply_with_tombstone_in_tx(
+        &self,
+        txn: &DatabaseTransaction,
+        tenant_id: Uuid,
+        prepared: &PreparedImportReplyInsert,
+        relation: &crate::import_relation_preparation::ForumPreparedImportContentRelations,
+        tombstone: Option<&crate::import_tombstone_preparation::ForumPreparedDeletedReplyTombstone>,
+        relation_event_mode: crate::import_relation_preparation::ForumImportRelationEventMode,
+        write_event_mode: crate::import_write_preparation::ForumImportWriteEventMode,
+    ) -> ForumResult<()> {
+        if prepared.record.status != ReplyStatus::Deleted {
+            if tombstone.is_some() {
+                return Err(ForumError::Validation(
+                    "Forum import live reply cannot carry a deleted tombstone".to_string(),
+                ));
+            }
+            return self
+                .insert_import_reply_in_tx(
+                    txn,
+                    tenant_id,
+                    prepared,
+                    relation,
+                    relation_event_mode,
+                    write_event_mode,
+                )
+                .await;
+        }
+
+        let tombstone = tombstone.ok_or_else(|| {
+            ForumError::Validation(
+                "Forum import deleted reply requires an admitted tombstone timestamp".to_string(),
+            )
+        })?;
+        validate_import_reply_tombstone(&prepared.record, tombstone)?;
+
+        if relation.source != prepared.record.source
+            || relation.target != ForumContentTarget::reply(prepared.record.id)
+            || relation.locale != prepared.record.locale
+        {
+            return Err(ForumError::Validation(
+                "Forum import reply relation admission does not match prepared reply".to_string(),
+            ));
+        }
+
+        let topic = TopicService::find_topic_in_tx(txn, tenant_id, prepared.record.topic_id).await?;
+        if topic.status != TopicStatus::Open || topic.is_locked {
+            return Err(ForumError::Validation(
+                "Forum import reply insertion requires the private provisional topic state"
+                    .to_string(),
+            ));
+        }
+
+        if let Some(parent_reply_id) = prepared.record.parent_reply_id {
+            let parent = reply::ReplyService::find_reply_in_tx(txn, tenant_id, parent_reply_id).await?;
+            if parent.topic_id != prepared.record.topic_id {
+                return Err(ForumError::Validation(
+                    "Forum import reply parent belongs to another topic".to_string(),
+                ));
+            }
+            // Historical reconstruction differs from interactive create: a child
+            // may legitimately survive after its parent was later soft-deleted.
+            // The enclosing 34P tombstone batch proves every final Deleted row.
+        }
+
+        let position = allocate_reply_position_in_tx(txn, tenant_id, prepared.record.topic_id).await?;
+        let author_id = prepared.record.author.as_ref().map(|author| author.user_id);
+
+        forum_reply::ActiveModel {
+            id: Set(prepared.record.id),
+            tenant_id: Set(tenant_id),
+            topic_id: Set(prepared.record.topic_id),
+            author_id: Set(author_id),
+            parent_reply_id: Set(prepared.record.parent_reply_id),
+            status: Set(ReplyStatus::Deleted),
+            position: Set(position),
+            created_at: Set(prepared.created_at.clone().into()),
+            updated_at: Set(prepared.created_at.clone().into()),
+        }
+        .insert(txn)
+        .await?;
+
+        forum_reply_body::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            reply_id: Set(prepared.record.id),
+            tenant_id: Set(tenant_id),
+            locale: Set(prepared.record.locale.clone()),
+            body: Set(prepared.stored_body.clone()),
+            created_at: Set(prepared.created_at.clone().into()),
+            updated_at: Set(prepared.created_at.clone().into()),
+        }
+        .insert(txn)
+        .await?;
+
+        // Final-deleted historical content keeps its relation projection for
+        // owner consistency but never emits interactive mention-added events.
+        self.relations
+            .persist_import_admitted_in_tx(
+                txn,
+                tenant_id,
+                relation,
+                &prepared.document,
+                author_id,
+                crate::import_relation_preparation::ForumImportRelationEventMode::SuppressAddedTargetEvents,
+            )
+            .await?;
+
+        persist_import_reply_tombstone_in_tx(txn, tenant_id, prepared, tombstone).await?;
+        Ok(())
+    }
+}
+
+fn validate_import_reply_tombstone(
+    record: &crate::import_write_preparation::ForumPreparedImportReply,
+    tombstone: &crate::import_tombstone_preparation::ForumPreparedDeletedReplyTombstone,
+) -> ForumResult<()> {
+    if tombstone.source != record.source || tombstone.reply_id != record.id {
+        return Err(ForumError::Validation(
+            "Forum import reply tombstone does not match prepared reply identity".to_string(),
+        ));
+    }
+    if tombstone.deleted_at_ms < record.created_at_ms {
+        return Err(ForumError::Validation(
+            "Forum import reply tombstone cannot predate reply creation".to_string(),
+        ));
+    }
+    if chrono::DateTime::<Utc>::from_timestamp_millis(tombstone.deleted_at_ms).is_none() {
+        return Err(ForumError::Validation(
+            "Forum import reply tombstone timestamp is outside owner range".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn persist_import_reply_tombstone_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    prepared: &PreparedImportReplyInsert,
+    tombstone: &crate::import_tombstone_preparation::ForumPreparedDeletedReplyTombstone,
+) -> ForumResult<()> {
+    let deleted_at = chrono::DateTime::<Utc>::from_timestamp_millis(tombstone.deleted_at_ms)
+        .ok_or_else(|| {
+            ForumError::Validation(
+                "Forum import reply tombstone timestamp is outside owner range".to_string(),
+            )
+        })?;
+
+    let before = count_import_delete_revisions_in_tx(txn, tenant_id, prepared.record.id).await?;
+    if before != 0 {
+        return Err(ForumError::Validation(
+            "Forum import deleted reply must not have a pre-existing delete revision".to_string(),
+        ));
+    }
+
+    let statement = match txn.get_database_backend() {
+        DatabaseBackend::Postgres => Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "UPDATE forum_replies \
+             SET deleted_at = $1, updated_at = $1 \
+             WHERE tenant_id = $2 AND id = $3 AND status = 'deleted' AND deleted_at IS NULL",
+            vec![
+                deleted_at.clone().into(),
+                tenant_id.into(),
+                prepared.record.id.into(),
+            ],
+        ),
+        DatabaseBackend::Sqlite => Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "UPDATE forum_replies \
+             SET deleted_at = ?, updated_at = ? \
+             WHERE tenant_id = ? AND id = ? AND status = 'deleted' AND deleted_at IS NULL",
+            vec![
+                deleted_at.clone().into(),
+                deleted_at.clone().into(),
+                tenant_id.into(),
+                prepared.record.id.into(),
+            ],
+        ),
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum import reply tombstones do not support database backend {backend:?}"
+            )));
+        }
+    };
+    if txn.execute(statement).await?.rows_affected() != 1 {
+        return Err(ForumError::Validation(
+            "Forum import reply tombstone update did not claim exactly one reply".to_string(),
+        ));
+    }
+
+    let after = count_import_delete_revisions_in_tx(txn, tenant_id, prepared.record.id).await?;
+    if after != 1 {
+        return Err(ForumError::Validation(
+            "Forum import reply tombstone must create exactly one delete revision".to_string(),
+        ));
+    }
+
+    let statement = match txn.get_database_backend() {
+        DatabaseBackend::Postgres => Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "UPDATE forum_reply_revisions \
+             SET created_at = $1 \
+             WHERE tenant_id = $2 AND reply_id = $3 AND revision_reason = 'delete'",
+            vec![deleted_at.into(), tenant_id.into(), prepared.record.id.into()],
+        ),
+        DatabaseBackend::Sqlite => Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "UPDATE forum_reply_revisions \
+             SET created_at = ? \
+             WHERE tenant_id = ? AND reply_id = ? AND revision_reason = 'delete'",
+            vec![deleted_at.into(), tenant_id.into(), prepared.record.id.into()],
+        ),
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum import reply tombstones do not support database backend {backend:?}"
+            )));
+        }
+    };
+    if txn.execute(statement).await?.rows_affected() != 1 {
+        return Err(ForumError::Validation(
+            "Forum import reply delete revision retimestamp did not affect exactly one row"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+async fn count_import_delete_revisions_in_tx(
+    txn: &DatabaseTransaction,
+    tenant_id: Uuid,
+    reply_id: Uuid,
+) -> ForumResult<i64> {
+    let statement = match txn.get_database_backend() {
+        DatabaseBackend::Postgres => Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "SELECT COUNT(*) AS revision_count \
+             FROM forum_reply_revisions \
+             WHERE tenant_id = $1 AND reply_id = $2 AND revision_reason = 'delete'",
+            vec![tenant_id.into(), reply_id.into()],
+        ),
+        DatabaseBackend::Sqlite => Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "SELECT COUNT(*) AS revision_count \
+             FROM forum_reply_revisions \
+             WHERE tenant_id = ? AND reply_id = ? AND revision_reason = 'delete'",
+            vec![tenant_id.into(), reply_id.into()],
+        ),
+        backend => {
+            return Err(ForumError::Validation(format!(
+                "Forum import reply tombstones do not support database backend {backend:?}"
+            )));
+        }
+    };
+    let row = txn.query_one(statement).await?.ok_or_else(|| {
+        ForumError::Validation("Forum import reply revision count returned no row".to_string())
+    })?;
+    Ok(row.try_get("", "revision_count")?)
+}

--- a/docs/modules/forum-34-deleted-reply-persistence-actualization-2026-08-10.md
+++ b/docs/modules/forum-34-deleted-reply-persistence-actualization-2026-08-10.md
@@ -1,0 +1,145 @@
+# FORUM-34Q deleted-reply owner persistence actualization — 2026-08-10
+
+Status: `source-ready / maintainer-execution-open / deleted-reply-owner-persistence-ready / standard-nodebb-tombstone-enrichment-conditional / shared-runner-blocked`
+
+## Fresh cursor
+
+FORUM-34A through FORUM-34P are merged before this slice. FORUM-34P merged as `ea3bbd6495f6826f0177f5064f583c9051bd8dea` and added the bounded, side-effect-free tombstone enrichment boundary without pretending that canonical NodeBB post state always contains a deletion timestamp.
+
+34Q was rechecked from fresh `main` `eb946d4056db3517b464fa9cca978c9d792a8437`. The mainline commits after 34P at that cursor are Pages and Commerce changes; they do not modify Forum source. Immediate premerge freshness remains a separate `behind 0` gate so unrelated later mainline movement does not rewrite this source history.
+
+The canonical Forum implementation-plan ledger still carries the stale FORUM-34 `planned` row. This dated packet records the truthful execution cursor without replacing the large roadmap wholesale.
+
+## Public owner entrypoint
+
+34Q extends the existing `ForumImportWriteService` with:
+
+```rust
+pub async fn apply_prepared_tombstone_batch(
+    &self,
+    security: &SecurityContext,
+    batch: &ForumPreparedImportTombstoneBatch,
+) -> ForumResult<ForumImportWriteResult>
+```
+
+The FORUM-34O `apply_prepared_batch(&ForumPreparedImportRelationBatch)` entrypoint is intentionally unchanged. It still rejects every `ReplyStatus::Deleted` reply, so callers cannot bypass 34P tombstone admission through the older API.
+
+The new entrypoint re-runs `ForumImportTombstonePreparer` over the supplied wrapper and compares the re-derived prepared tombstones with the supplied identities before opening a transaction. A forged or stale wrapper therefore fails before owner writes.
+
+It also rechecks the 34O owner boundary: bounded record count, normalized locale, tenant-wide `Manage/All` authorization for every owner kind present, relation-event mode, non-nil/unique target IDs, NodeBB source kinds, author IDs, timestamps and in-batch category/topic/reply dependencies.
+
+## One atomic owner transaction
+
+After side-effect-free owner content preparation, 34Q opens the same single Forum-owned transaction used by 34O.
+
+Inside it, the service:
+
+1. rejects already-existing admitted Category/Topic/Reply target IDs;
+2. inserts categories in parent-safe order through the existing category import owner primitive;
+3. inserts topics through the existing topic import owner primitive and relation bridge;
+4. inserts replies in parent-safe order;
+5. applies exact tombstones for final-deleted replies;
+6. finalizes topic status/reply-count/last-reply facts from Approved replies only;
+7. publishes the existing direct Forum projection-scope invalidation regardless of interactive event mode;
+8. commits once.
+
+Any error in tombstone capture, revision creation or revision retimestamp aborts the same transaction. No partial deleted-reply state is intentionally committed.
+
+## Deleted reply owner primitive
+
+The new import-only reply extension keeps the existing live-reply primitive untouched.
+
+For a non-deleted prepared reply it delegates to the 34O `prepare_import_reply` / `insert_import_reply_in_tx` path and rejects any unexpected tombstone.
+
+For `ReplyStatus::Deleted`, it requires the exact 34P tombstone to match both external source and admitted Reply UUID and rechecks that `deleted_at_ms >= created_at_ms` and both timestamps fit the owner time range.
+
+It then reconstructs the final historical row by:
+
+- preserving the admitted Reply UUID, topic, author, parent, body, locale and creation time;
+- allocating the owner reply position through the existing PostgreSQL/SQLite owner allocator;
+- inserting the reply in final `Deleted` status while `deleted_at` is still NULL;
+- inserting the admitted body;
+- materializing admitted mention/audience relations through the established 34N relation persistence path;
+- forcing `SuppressAddedTargetEvents` for final-deleted content even when the batch requests domain-event emission;
+- applying the exact admitted tombstone only after body/relation persistence succeeds.
+
+The temporary NULL tombstone exists only inside the uncommitted owner transaction. It is required because the persisted Forum entity model does not expose `deleted_at` and because the established DB delete-revision triggers capture the body on the NULL -> non-NULL tombstone transition.
+
+## Exact tombstone and delete revision time
+
+The interactive reply delete command cannot be reused for historical import because it writes `CURRENT_TIMESTAMP`.
+
+34Q instead performs an owner-local backend-specific update inside the existing transaction:
+
+```text
+forum_replies.deleted_at = admitted deleted_at
+forum_replies.updated_at = admitted deleted_at
+```
+
+with predicates requiring the admitted tenant/reply, final `status = 'deleted'` and `deleted_at IS NULL`.
+
+The existing PostgreSQL and SQLite soft-delete revision triggers then capture the persisted body into `forum_reply_revisions` with `revision_reason = 'delete'`.
+
+To prevent an execution-time revision timestamp from masquerading as historical truth, the owner helper enforces:
+
+1. zero delete revisions for that new reply before tombstoning;
+2. exactly one affected reply row on the tombstone update;
+3. exactly one delete revision after the trigger runs;
+4. exactly one row affected when that delete revision's `created_at` is rewritten to the same admitted historical deletion timestamp.
+
+The update is migration-specific but remains Forum-owner-local and transaction-scoped. It does not modify the schema or replace the established body-capture trigger.
+
+## Counters, events and parent history
+
+A final-deleted imported reply never enters Approved public counters. It does not increment topic/category/UserStats reply counts and does not contribute to the imported topic's `reply_count` or `last_reply_at` aggregate.
+
+34Q does not fabricate interactive lifecycle events for deleted history:
+
+- no `ForumTopicReplied` event for a final-deleted reply;
+- no `ForumReplyStatusChanged` event because NodeBB tombstone enrichment does not establish the RusTok old status/moderator transition envelope;
+- no mention-added events for final-deleted content.
+
+The relation projection itself may still be materialized so owner relation state remains consistent with the stored body.
+
+Historical child -> deleted-parent relationships are allowed in this import-only path. Interactive create correctly refuses choosing an already-deleted parent, but a historical child may have been created while the parent was live and survive after that parent was later deleted. The bounded reply graph and 34P tombstone wrapper are both revalidated before persistence.
+
+## Deliberately unchanged
+
+34Q does not:
+
+- add a `deletedTimestamp` field to canonical `NodebbPostRecord`;
+- infer deletion time from creation time;
+- use migration execution time as historical deletion truth;
+- change the normal interactive reply delete command;
+- change the 34O non-deleted import entrypoint;
+- modify PostgreSQL or SQLite migration definitions;
+- create a second mention/quote persistence implementation;
+- invent historical timestamps for relation revisions/mention rows, for which no source-owned historical fact is admitted;
+- add a durable import receipt, checkpoint or replay journal;
+- create a Forum-local substitute for the still-missing shared owner-data migration runner.
+
+Standard current NodeBB deleted posts without an independently captured historical deletion timestamp remain blocked from exact deleted-reply persistence.
+
+## Current FORUM-34 chain
+
+The bounded in-process chain is now:
+
+`34A mapping -> 34B/34C inspection -> 34K application resolution -> 34L owner-write preparation -> 34M relation admission -> 34N relation persistence bridge -> 34O atomic non-deleted application -> 34P exact optional tombstone admission -> 34Q atomic deleted-reply owner persistence`.
+
+With explicit tombstone enrichment, the bounded owner transaction can now persist categories, topics, live replies and final-deleted replies while preserving admitted identities, creation times and exact deletion time.
+
+## Next cursor
+
+The remaining FORUM-34 execution gap is no longer the deleted-reply owner mutation itself. Durable cross-batch checkpoint/replay and operator execution must still use a genuinely shared owner-data migration runner contract rather than a Forum-local journal.
+
+The next safe Forum slice should therefore recheck the repository for a shared migration-runner capability. If that capability still does not exist, continue only with another independently bounded source/owner contract that does not fabricate durable execution semantics.
+
+## Maintainer validation
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-deleted-reply-persistence-source.mjs
+```

--- a/scripts/verify/verify-forum-deleted-reply-persistence-source.mjs
+++ b/scripts/verify/verify-forum-deleted-reply-persistence-source.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const files = {
+  services: "crates/rustok-forum/src/services/mod.rs",
+  tombstoneAdmission: "crates/rustok-forum/src/import_tombstone_preparation.rs",
+  writer: "crates/rustok-forum/src/services/import_tombstone_write.rs",
+  legacyWriter: "crates/rustok-forum/src/services/import_write.rs",
+  replyImport: "crates/rustok-forum/src/services/reply_owner_tombstone_import.rs",
+  legacyReplyImport: "crates/rustok-forum/src/services/reply_owner_import.rs",
+  replyOwner: "crates/rustok-forum/src/services/reply_owner.rs",
+  relationImport: "crates/rustok-forum/src/services/mention_relation_import.rs",
+  relationOwner: "crates/rustok-forum/src/services/mention_relation.rs",
+  postgres: "crates/rustok-forum/src/migrations/m20260713_000009_add_forum_soft_delete_revisions/postgres_up.rs",
+  sqlite: "crates/rustok-forum/src/migrations/m20260713_000009_add_forum_soft_delete_revisions/sqlite_revisions.rs",
+  packet: "docs/modules/forum-34-deleted-reply-persistence-actualization-2026-08-10.md",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, path]) => [key, read(path)]),
+);
+
+for (const marker of [
+  'include!("import_tombstone_write.rs");',
+  'include!("import_write.rs");',
+  'include!("reply_owner_tombstone_import.rs");',
+  'include!("reply_owner_import.rs");',
+]) need(source.services, marker, "FORUM-34Q include wiring");
+
+for (const marker of [
+  "pub async fn apply_prepared_tombstone_batch",
+  "ForumPreparedImportTombstoneBatch",
+  "revalidate_prepared_tombstone_batch",
+  "ForumImportTombstonePreparer",
+  "validate_tombstone_apply_shape",
+  "prepare_import_reply_with_tombstone",
+  "insert_import_reply_with_tombstone_in_tx",
+  "approved_reply_aggregates",
+  "publish_forum_projection_scope_direct_in_tx",
+  "txn.commit().await?",
+]) need(source.writer, marker, "FORUM-34Q atomic tombstone writer");
+
+for (const marker of [
+  "pub async fn apply_prepared_batch",
+  "Forum import deleted replies remain blocked until a tombstone timestamp is admitted",
+]) need(source.legacyWriter, marker, "FORUM-34O legacy fail-closed entrypoint");
+
+for (const marker of [
+  "pub struct ForumPreparedImportTombstoneBatch",
+  "pub struct ForumPreparedDeletedReplyTombstone",
+  "MissingDeletedReplyTombstone",
+  "LiveReplyHasTombstone",
+  "TombstonePredatesCreation",
+]) need(source.tombstoneAdmission, marker, "FORUM-34P tombstone admission baseline");
+
+for (const marker of [
+  "prepare_import_reply_with_tombstone",
+  "insert_import_reply_with_tombstone_in_tx",
+  "ReplyStatus::Deleted",
+  "SuppressAddedTargetEvents",
+  "persist_import_reply_tombstone_in_tx",
+  "count_import_delete_revisions_in_tx",
+  "SET deleted_at = $1, updated_at = $1",
+  "SET deleted_at = ?, updated_at = ?",
+  "status = 'deleted' AND deleted_at IS NULL",
+  "revision_reason = 'delete'",
+  "SET created_at = $1",
+  "SET created_at = ?",
+  "Forum import reply tombstone must create exactly one delete revision",
+  "Historical reconstruction differs from interactive create",
+]) need(source.replyImport, marker, "FORUM-34Q deleted reply owner primitive");
+
+for (const marker of [
+  "pub(crate) fn prepare_import_reply",
+  "pub(crate) async fn insert_import_reply_in_tx",
+  "record.status == ReplyStatus::Deleted",
+  "requires an admitted tombstone timestamp",
+]) need(source.legacyReplyImport, marker, "FORUM-34O live reply primitive baseline");
+
+for (const marker of [
+  "persist_import_admitted_in_tx",
+  "SuppressAddedTargetEvents",
+]) need(source.relationImport, marker, "FORUM-34N relation bridge baseline");
+
+for (const marker of [
+  "lock_source_in_tx",
+  "ensure_prepared_matches_source_in_tx",
+]) need(source.relationOwner, marker, "Forum relation owner persistence baseline");
+
+for (const marker of [
+  "forum_guard_deleted_reply_update",
+  "forum_reply_revisions",
+  "revision_reason",
+  "'delete'",
+]) need(source.postgres, marker, "Postgres delete revision trigger baseline");
+for (const marker of [
+  "forum_reply_delete_revision_update",
+  "OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL",
+  "forum_reply_revisions",
+  "'delete'",
+]) need(source.sqlite, marker, "SQLite delete revision trigger baseline");
+
+for (const marker of [
+  "FORUM-34Q",
+  "apply_prepared_tombstone_batch",
+  "exactly one delete revision",
+  "no `ForumTopicReplied` event",
+  "no `ForumReplyStatusChanged` event",
+  "Historical child -> deleted-parent relationships are allowed",
+  "relation revisions/mention rows",
+  "shared owner-data migration runner",
+  "no tests, Cargo commands",
+]) need(source.packet, marker, "FORUM-34Q actualization");
+
+for (const marker of [
+  "CURRENT_TIMESTAMP",
+  "Utc::now()",
+  "ForumTopicReplied",
+  "ForumReplyStatusChanged",
+  "adjust_reply_count_in_tx",
+  "adjust_counters_in_tx",
+  "UserStatsService::adjust_reply_count_in_tx",
+  ".begin(",
+  ".commit(",
+]) forbid(source.replyImport, marker, "deleted reply historical owner primitive");
+
+forbid(
+  source.replyImport,
+  "parent.status == ReplyStatus::Deleted",
+  "historical deleted-parent reconstruction",
+);
+
+for (const marker of [
+  "deletedTimestamp",
+  "deleted_at_ms",
+]) forbid(
+  read("crates/rustok-forum/src/import_mapping.rs"),
+  marker,
+  "canonical NodeBB mapping must remain tombstone-sidecar free",
+);
+
+console.log("Forum FORUM-34Q deleted reply persistence source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-34 with exact owner persistence for deleted replies after the explicit FORUM-34P tombstone admission boundary.

- add `ForumImportWriteService::apply_prepared_tombstone_batch` over `ForumPreparedImportTombstoneBatch`;
- keep the existing FORUM-34O `apply_prepared_batch` entrypoint unchanged and fail-closed for deleted replies;
- re-run 34P tombstone admission before opening the owner transaction and recheck the existing 34O bounded authorization/identity/dependency boundary;
- preserve the existing single atomic Category/Topic/Reply transaction, owner target-ID checks, topological ordering, relation persistence, topic finalization and direct projection invalidation;
- preserve admitted Reply UUID, author, parent, body, locale and creation time;
- insert final-deleted replies without public counters or `ForumTopicReplied` events;
- materialize admitted relations for final-deleted content through the established owner relation bridge while forcing added-target event suppression;
- apply exact admitted `deleted_at` through an owner-local in-transaction update;
- reuse the existing PostgreSQL/SQLite delete-revision triggers to snapshot the persisted body, require exactly one new delete revision, then retimestamp that revision to the same admitted historical deletion time;
- emit no fabricated `ForumReplyStatusChanged` lifecycle event because the source does not establish the RusTok old-status/moderator envelope;
- allow historical child -> final-deleted-parent relations in the import-only path;
- leave canonical `NodebbPostRecord`, interactive delete commands, schemas and migration definitions unchanged.

## Fresh-main recheck

The slice started from `main@eb946d4056db3517b464fa9cca978c9d792a8437`. During preparation, main advanced to `3653c475bc2c097405943fb0b7b9d2498196fbe8`; the only Forum overlap in those commits is `crates/rustok-forum/admin/build.rs`, with no owner/import source overlap. The final branch was replayed onto `3653c475bc2c097405943fb0b7b9d2498196fbe8` and compared `behind 0` before opening this PR.

## Historical truth boundary

Standard current NodeBB deleted posts still require an independently captured historical deletion timestamp through the 34P exporter/audit sidecar. 34Q does not infer deletion time from creation time or use migration execution time as historical truth.

Only the admitted tombstone and delete-revision timestamp are historicalized. Relation revisions and mention rows remain normal owner persistence facts because no source-owned historical relation-revision timestamp has been admitted.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, workflow, CI command, lock generation or `git diff --check` was run. `scripts/verify/verify-forum-deleted-reply-persistence-source.mjs` was added but intentionally not executed.