### PR TITLE
feat(commerce): route storefront Product list through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-storefront-product-list-owner-read-cutover-2026-08-10.md
+++ b/crates/rustok-commerce/docs/rest-storefront-product-list-owner-read-cutover-2026-08-10.md
@@ -1,0 +1,106 @@
+# Commerce REST storefront Product list owner-read cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-10
+
+## Scope
+
+This bounded slice moves mounted `GET /store/products` behind a Product-owned,
+host-composed read capability. Commerce no longer queries Product entities or constructs
+`CatalogService` on the mounted list route.
+
+The existing Product catalog runtime remains the host composition point. Its embedded
+profile now installs optional `ProductStorefrontHttpReadPort`; external profiles do not
+receive that capability implicitly and therefore fail closed until the host explicitly
+supplies an implementation.
+
+## Why a separate compatibility capability is required
+
+The existing `ProductCatalogReadPort::list_legacy_storefront_products` is the compatibility
+projection for mounted legacy GraphQL and is deliberately left unchanged. Reusing it for
+REST would alter observable legacy REST behavior:
+
+- GraphQL legacy list admits at most 48 rows while REST pagination clamps to 100;
+- GraphQL legacy list uses `"Untitled product"` when no translation can be projected,
+  while REST emits an empty title;
+- GraphQL legacy list prefers the Product shipping-profile column before metadata,
+  while REST derives this list field from metadata only and defaults to `"default"`;
+- REST historically applies public-channel visibility after the active/published/filter
+  query and before pagination/total calculation.
+
+The new optional `ProductStorefrontHttpReadPort::list_legacy_storefront_http_products`
+therefore owns those REST compatibility semantics without mutating the GraphQL contract.
+
+## Preserved REST semantics
+
+The Product-owned projection preserves the mounted list behavior:
+
+1. tenant, active status, and non-null publication filters;
+2. exact optional vendor and product-type filters;
+3. optional raw title `LIKE %search%` across Product translations — the historical helper
+   accepts a locale argument but does not currently restrict the search by locale;
+4. published-at descending, then created-at descending ordering;
+5. in-memory public-channel metadata visibility before total/pagination;
+6. page normalization to at least 1 and page-size clamping to 1..=100 at the HTTP boundary;
+7. translation projection in requested locale, then tenant default locale, then first
+   available translation;
+8. empty title/handle when no translation exists;
+9. existing Product tag hydration with requested/default locale;
+10. metadata-only shipping-profile normalization/defaulting;
+11. unchanged `ProductListItem` JSON projection and pagination metadata.
+
+The storefront channel-enabled guard remains before the Product owner call.
+
+## Context and failure behavior
+
+The mounted handler creates a read `PortContext` with:
+
+- admitted tenant id;
+- stable Commerce storefront Product service actor;
+- effective request/list locale;
+- normalized public channel when present;
+- page-bound correlation id;
+- two-second deadline.
+
+Product owner failures are mapped to the existing public REST families:
+
+- validation -> `400 commerce_store_product_invalid`;
+- not found -> `404 commerce_store_not_found`;
+- unavailable/timeout -> `503 commerce_store_product_unavailable`;
+- conflict/forbidden/invariant -> `500 commerce_store_product_failed`.
+
+If an external `ProductCatalogReadRuntime` has not explicitly installed the optional HTTP
+list capability, Commerce fails closed with `503 commerce_store_product_unavailable` and
+does not construct an embedded fallback.
+
+Diagnostics at the mounted boundary contain bounded owner kind, code length,
+retryability, correlation, tenant-presence and public-envelope facts. Raw owner/backend
+messages are not logged or returned by the new boundary.
+
+## Mounted topology
+
+`controllers/store/mod.rs` now mounts the original `products.rs` as
+`products_legacy` and mounts `products_owner_list.rs` as `products`.
+The new module owns `list_products` and provides thin annotated wrappers that delegate
+Product detail, region, and shipping-option requests to the unchanged legacy handlers.
+This preserves the existing OpenAPI handler markers while changing only the Product list
+implementation. The old direct list implementation remains compiled compatibility source
+but is not mounted.
+
+The existing storefront Product detail remains on
+`ProductCatalogReadPort::read_storefront_product_projection`.
+
+## Topology status
+
+The canonical ecommerce P0 item to move remaining mounted Commerce REST/GraphQL
+Product, Order, Payment, and Fulfillment concrete service construction behind
+host-composed owner ports remains open. This slice only removes the mounted storefront
+Product list violation.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST
+scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios,
+or remote-adapter scenarios were executed. Source guards added/updated by this slice are
+source-reviewed only and were not run.

--- a/crates/rustok-commerce/src/controllers/store/mod.rs
+++ b/crates/rustok-commerce/src/controllers/store/mod.rs
@@ -2,6 +2,9 @@ pub mod carts;
 pub mod checkout;
 pub(crate) mod line_item_resolution;
 pub mod orders;
+#[path = "products.rs"]
+pub mod products_legacy;
+#[path = "products_owner_list.rs"]
 pub mod products;
 
 pub use carts::*;

--- a/crates/rustok-commerce/src/controllers/store/products_owner_list.rs
+++ b/crates/rustok-commerce/src/controllers/store/products_owner_list.rs
@@ -1,0 +1,256 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use rustok_api::{
+    OptionalAuthContext, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
+use rustok_product::{LegacyStorefrontHttpProductsRequest, ProductStorefrontHttpReadPort};
+use rustok_web::{HttpError, HttpResult};
+use uuid::Uuid;
+
+use super::{
+    StoreContextQuery, StoreListProductsParams,
+    super::common::{PaginatedResponse, PaginationMeta},
+};
+use crate::controllers::{CommerceHttpRuntime, products::ProductListItem};
+use crate::dto::{ProductResponse, RegionResponse, ShippingOptionResponse};
+use crate::storefront_channel::public_channel_slug_from_request;
+
+const STOREFRONT_PRODUCT_OWNER: &str = "rustok_product";
+const STOREFRONT_PRODUCT_BOUNDARY: &str = "commerce_storefront_product_http";
+const STOREFRONT_PRODUCT_LIST_OPERATION: &str = "list_legacy_storefront_http_products";
+
+impl CommerceHttpRuntime {
+    fn product_storefront_http_read_port(
+        &self,
+    ) -> Option<std::sync::Arc<dyn ProductStorefrontHttpReadPort>> {
+        self.product_catalog_read_runtime.storefront_http_read_port()
+    }
+}
+
+fn storefront_product_list_port_context(
+    tenant_id: Uuid,
+    locale: &str,
+    public_channel_slug: Option<&str>,
+    page: u64,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::service("rustok-commerce.storefront-product"),
+        locale,
+        format!("commerce-storefront-product:list:{page}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    match public_channel_slug {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
+fn storefront_product_list_unavailable() -> HttpError {
+    tracing::error!(
+        owner = STOREFRONT_PRODUCT_OWNER,
+        owner_operation = STOREFRONT_PRODUCT_LIST_OPERATION,
+        error_kind = "capability_unavailable",
+        public_code = "commerce_store_product_unavailable",
+        status = %StatusCode::SERVICE_UNAVAILABLE,
+        boundary = STOREFRONT_PRODUCT_BOUNDARY,
+        "storefront Product HTTP list capability is unavailable"
+    );
+    HttpError::new(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "commerce_store_product_unavailable",
+        "Product service is temporarily unavailable",
+    )
+}
+
+fn map_storefront_product_list_port_error(
+    error: PortError,
+    context: &PortContext,
+    tenant_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_store_product_invalid",
+            "Product request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_store_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_store_product_unavailable",
+            "Product service is temporarily unavailable",
+            "unavailable",
+        ),
+        PortErrorKind::Conflict | PortErrorKind::Forbidden | PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_store_product_failed",
+            "Product operation could not be completed safely",
+            "owner_failure",
+        ),
+    };
+    tracing::error!(
+        owner = STOREFRONT_PRODUCT_OWNER,
+        owner_operation = STOREFRONT_PRODUCT_LIST_OPERATION,
+        correlation_id = %context.correlation_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = STOREFRONT_PRODUCT_BOUNDARY,
+        "storefront Product owner list failed with bounded diagnostics"
+    );
+    HttpError::new(status, code, message)
+}
+
+/// List published storefront products through the Product-owned legacy HTTP projection.
+#[utoipa::path(
+    get,
+    path = "/store/products",
+    tag = "store",
+    params(StoreListProductsParams),
+    responses(
+        (status = 200, description = "Published storefront products", body = PaginatedResponse<ProductListItem>),
+        (status = 400, description = "Invalid request")
+    )
+)]
+pub async fn list_products(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+    Query(params): Query<StoreListProductsParams>,
+) -> HttpResult<Json<PaginatedResponse<ProductListItem>>> {
+    super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
+
+    let pagination = params.pagination.unwrap_or_default();
+    let page = pagination.page.max(1);
+    let per_page = pagination.limit();
+    let locale = params
+        .locale
+        .as_deref()
+        .unwrap_or(request_context.locale.as_str());
+    let public_channel_slug = public_channel_slug_from_request(&request_context);
+    let port_context = storefront_product_list_port_context(
+        tenant.id,
+        locale,
+        public_channel_slug.as_deref(),
+        page,
+    );
+    let port = runtime
+        .product_storefront_http_read_port()
+        .ok_or_else(storefront_product_list_unavailable)?;
+    let list = port
+        .list_legacy_storefront_http_products(
+            port_context.clone(),
+            LegacyStorefrontHttpProductsRequest {
+                locale: Some(locale.to_string()),
+                fallback_locale: Some(tenant.default_locale.clone()),
+                public_channel_slug,
+                vendor: params.vendor,
+                product_type: params.product_type,
+                search: params.search,
+                page,
+                per_page,
+            },
+        )
+        .await
+        .map_err(|error| {
+            map_storefront_product_list_port_error(error, &port_context, tenant.id)
+        })?;
+
+    let items = list
+        .items
+        .into_iter()
+        .map(|item| ProductListItem {
+            id: item.id,
+            status: item.status.to_string(),
+            title: item.title,
+            handle: item.handle,
+            seller_id: item.seller_id,
+            vendor: item.vendor,
+            product_type: item.product_type,
+            shipping_profile_slug: Some(item.shipping_profile_slug),
+            tags: item.tags,
+            created_at: item.created_at.to_rfc3339(),
+            published_at: item.published_at.map(|value| value.to_rfc3339()),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Json(PaginatedResponse {
+        data: items,
+        meta: PaginationMeta::new(list.page, list.per_page, list.total),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/store/products/{id}",
+    tag = "store",
+    params(("id" = Uuid, Path, description = "Product ID")),
+    responses(
+        (status = 200, description = "Product details", body = ProductResponse),
+        (status = 404, description = "Product not found")
+    )
+)]
+pub async fn show_product(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+    Path(id): Path<Uuid>,
+) -> HttpResult<Json<ProductResponse>> {
+    super::products_legacy::show_product(State(runtime), tenant, request_context, Path(id)).await
+}
+
+#[utoipa::path(
+    get,
+    path = "/store/regions",
+    tag = "store",
+    responses(
+        (status = 200, description = "Store regions", body = Vec<RegionResponse>)
+    )
+)]
+pub async fn list_regions(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    request_context: RequestContext,
+) -> HttpResult<Json<Vec<RegionResponse>>> {
+    super::products_legacy::list_regions(State(runtime), tenant, request_context).await
+}
+
+#[utoipa::path(
+    get,
+    path = "/store/shipping-options",
+    tag = "store",
+    params(StoreContextQuery),
+    responses(
+        (status = 200, description = "Shipping options", body = Vec<ShippingOptionResponse>)
+    )
+)]
+pub async fn list_shipping_options(
+    State(runtime): State<CommerceHttpRuntime>,
+    tenant: TenantContext,
+    auth: OptionalAuthContext,
+    request_context: RequestContext,
+    Query(query): Query<StoreContextQuery>,
+) -> HttpResult<Json<Vec<ShippingOptionResponse>>> {
+    super::products_legacy::list_shipping_options(
+        State(runtime),
+        tenant,
+        auth,
+        request_context,
+        Query(query),
+    )
+    .await
+}

--- a/crates/rustok-product/src/lib.rs
+++ b/crates/rustok-product/src/lib.rs
@@ -26,6 +26,7 @@ mod public_error;
 mod runtime;
 mod seo_targets;
 pub mod services;
+mod storefront_http_read_port;
 mod storefront_tag_read_port;
 
 pub use catalog_command_port::ProductCatalogCommandPort;
@@ -71,6 +72,9 @@ pub use services::{
     product_attribute_integer_term, product_attribute_localized_presence_term,
     product_attribute_localized_text_expr, product_attribute_localized_text_term,
     product_attribute_option_term, product_attribute_text_term,
+};
+pub use storefront_http_read_port::{
+    LegacyStorefrontHttpProductsRequest, ProductStorefrontHttpReadPort,
 };
 pub use storefront_tag_read_port::{
     ProductStorefrontTagHydration, ProductStorefrontTagHydrationItem,

--- a/crates/rustok-product/src/runtime.rs
+++ b/crates/rustok-product/src/runtime.rs
@@ -5,7 +5,8 @@ use sea_orm::DatabaseConnection;
 
 use crate::{
     CatalogService, ProductCatalogCommandPort, ProductCatalogReadPort, ProductCatalogSchemaReadPort,
-    ProductCatalogSchemaService, ProductCatalogSchemaWritePort, ProductStorefrontTagReadPort,
+    ProductCatalogSchemaService, ProductCatalogSchemaWritePort, ProductStorefrontHttpReadPort,
+    ProductStorefrontTagReadPort,
 };
 
 /// Host-selected execution profile for the Product catalog read boundary.
@@ -33,6 +34,7 @@ impl ProductCatalogReadProfile {
 pub struct ProductCatalogReadRuntime {
     read_port: Arc<dyn ProductCatalogReadPort>,
     schema_read_port: Option<Arc<dyn ProductCatalogSchemaReadPort>>,
+    storefront_http_read_port: Option<Arc<dyn ProductStorefrontHttpReadPort>>,
     storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>,
     profile: ProductCatalogReadProfile,
 }
@@ -45,6 +47,7 @@ impl ProductCatalogReadRuntime {
         Self {
             read_port,
             schema_read_port: None,
+            storefront_http_read_port: None,
             storefront_tag_read_port: None,
             profile,
         }
@@ -54,6 +57,7 @@ impl ProductCatalogReadRuntime {
         let catalog = Arc::new(CatalogService::new(db.clone(), event_bus.clone()));
         Self::new(catalog.clone(), ProductCatalogReadProfile::EmbeddedNative)
             .with_schema_read_port(Arc::new(ProductCatalogSchemaService::new(db, event_bus)))
+            .with_storefront_http_read_port(catalog.clone())
             .with_storefront_tag_read_port(catalog)
     }
 
@@ -66,6 +70,14 @@ impl ProductCatalogReadRuntime {
         schema_read_port: Arc<dyn ProductCatalogSchemaReadPort>,
     ) -> Self {
         self.schema_read_port = Some(schema_read_port);
+        self
+    }
+
+    pub fn with_storefront_http_read_port(
+        mut self,
+        storefront_http_read_port: Arc<dyn ProductStorefrontHttpReadPort>,
+    ) -> Self {
+        self.storefront_http_read_port = Some(storefront_http_read_port);
         self
     }
 
@@ -83,6 +95,10 @@ impl ProductCatalogReadRuntime {
 
     pub fn schema_read_port(&self) -> Option<Arc<dyn ProductCatalogSchemaReadPort>> {
         self.schema_read_port.clone()
+    }
+
+    pub fn storefront_http_read_port(&self) -> Option<Arc<dyn ProductStorefrontHttpReadPort>> {
+        self.storefront_http_read_port.clone()
     }
 
     pub fn storefront_tag_read_port(&self) -> Option<Arc<dyn ProductStorefrontTagReadPort>> {

--- a/crates/rustok-product/src/storefront_http_read_port.rs
+++ b/crates/rustok-product/src/storefront_http_read_port.rs
@@ -1,0 +1,325 @@
+use async_trait::async_trait;
+use rustok_api::{PortCallPolicy, PortContext, PortError, locale_tags_match};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::entities::{product, product_translation};
+use crate::ports::{LegacyStorefrontProductList, LegacyStorefrontProductListItem};
+use crate::{CatalogService, CommerceError};
+
+const MAX_LEGACY_STOREFRONT_HTTP_PRODUCTS_PER_PAGE: u64 = 100;
+const LIST_LEGACY_STOREFRONT_HTTP_PRODUCTS_OPERATION: &str =
+    "list_legacy_storefront_http_products";
+
+/// Optional Product-owned compatibility boundary for the mounted legacy storefront REST list.
+///
+/// This capability is intentionally separate from the legacy GraphQL list projection because the
+/// mounted REST contract allows up to 100 rows, paginates after public-channel visibility, emits an
+/// empty title when no translation exists, and derives the shipping profile from metadata only.
+#[async_trait]
+pub trait ProductStorefrontHttpReadPort: Send + Sync {
+    async fn list_legacy_storefront_http_products(
+        &self,
+        context: PortContext,
+        request: LegacyStorefrontHttpProductsRequest,
+    ) -> Result<LegacyStorefrontProductList, PortError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyStorefrontHttpProductsRequest {
+    pub locale: Option<String>,
+    pub fallback_locale: Option<String>,
+    pub public_channel_slug: Option<String>,
+    pub vendor: Option<String>,
+    pub product_type: Option<String>,
+    pub search: Option<String>,
+    pub page: u64,
+    pub per_page: u64,
+}
+
+#[async_trait]
+impl ProductStorefrontHttpReadPort for CatalogService {
+    async fn list_legacy_storefront_http_products(
+        &self,
+        context: PortContext,
+        request: LegacyStorefrontHttpProductsRequest,
+    ) -> Result<LegacyStorefrontProductList, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        validate_request(&context, &request)?;
+        let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
+            PortError::validation(
+                "product.tenant_id_invalid",
+                "product request context is invalid",
+            )
+        })?;
+        let locale = request.locale.as_deref().unwrap_or(context.locale.as_str());
+
+        list_legacy_storefront_http_products(
+            self,
+            tenant_id,
+            locale,
+            request.fallback_locale.as_deref(),
+            request.public_channel_slug.as_deref(),
+            request.vendor.as_deref(),
+            request.product_type.as_deref(),
+            request.search.as_deref(),
+            request.page,
+            request.per_page,
+        )
+        .await
+        .map_err(|error| map_product_error(&context, error))
+    }
+}
+
+fn validate_request(
+    context: &PortContext,
+    request: &LegacyStorefrontHttpProductsRequest,
+) -> Result<(), PortError> {
+    if request.page == 0 {
+        tracing::warn!(
+            operation = LIST_LEGACY_STOREFRONT_HTTP_PRODUCTS_OPERATION,
+            correlation_id = %context.correlation_id,
+            page = request.page,
+            per_page = request.per_page,
+            code = "product.page_invalid",
+            "legacy storefront HTTP product page validation failed"
+        );
+        return Err(PortError::validation(
+            "product.page_invalid",
+            "published products page is invalid",
+        ));
+    }
+    if !(1..=MAX_LEGACY_STOREFRONT_HTTP_PRODUCTS_PER_PAGE).contains(&request.per_page) {
+        tracing::warn!(
+            operation = LIST_LEGACY_STOREFRONT_HTTP_PRODUCTS_OPERATION,
+            correlation_id = %context.correlation_id,
+            page = request.page,
+            per_page = request.per_page,
+            max_per_page = MAX_LEGACY_STOREFRONT_HTTP_PRODUCTS_PER_PAGE,
+            code = "product.per_page_invalid",
+            "legacy storefront HTTP product page-size validation failed"
+        );
+        return Err(PortError::validation(
+            "product.per_page_invalid",
+            "published products page size is invalid",
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn list_legacy_storefront_http_products(
+    service: &CatalogService,
+    tenant_id: Uuid,
+    locale: &str,
+    fallback_locale: Option<&str>,
+    public_channel_slug: Option<&str>,
+    vendor: Option<&str>,
+    product_type: Option<&str>,
+    search: Option<&str>,
+    page: u64,
+    per_page: u64,
+) -> Result<LegacyStorefrontProductList, CommerceError> {
+    let fallback_locale = fallback_locale.unwrap_or(rustok_api::PLATFORM_FALLBACK_LOCALE);
+    let offset = (page.saturating_sub(1)) * per_page;
+    let db = service.database();
+
+    let mut query = product::Entity::find()
+        .filter(product::Column::TenantId.eq(tenant_id))
+        .filter(product::Column::Status.eq(product::ProductStatus::Active))
+        .filter(product::Column::PublishedAt.is_not_null());
+    if let Some(vendor) = vendor {
+        query = query.filter(product::Column::Vendor.eq(vendor));
+    }
+    if let Some(product_type) = product_type {
+        query = query.filter(product::Column::ProductType.eq(product_type));
+    }
+    if let Some(search) = search {
+        query = query.filter(product_title_search_condition(
+            db.get_database_backend(),
+            search,
+        ));
+    }
+
+    let visible_products = query
+        .order_by_desc(product::Column::PublishedAt)
+        .order_by_desc(product::Column::CreatedAt)
+        .all(db)
+        .await?
+        .into_iter()
+        .filter(|product| {
+            rustok_inventory::is_metadata_visible_for_public_channel(
+                &product.metadata,
+                public_channel_slug,
+            )
+        })
+        .collect::<Vec<_>>();
+    let total = visible_products.len() as u64;
+    let products = visible_products
+        .into_iter()
+        .skip(offset as usize)
+        .take(per_page as usize)
+        .collect::<Vec<_>>();
+
+    let product_ids = products.iter().map(|product| product.id).collect::<Vec<_>>();
+    let translations = if product_ids.is_empty() {
+        Vec::new()
+    } else {
+        product_translation::Entity::find()
+            .filter(product_translation::Column::ProductId.is_in(product_ids))
+            .all(db)
+            .await?
+    };
+    let mut translations_by_product =
+        std::collections::HashMap::<Uuid, Vec<product_translation::Model>>::new();
+    for translation in translations {
+        translations_by_product
+            .entry(translation.product_id)
+            .or_default()
+            .push(translation);
+    }
+    let product_tags = service
+        .load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))
+        .await?;
+
+    let items = products
+        .into_iter()
+        .map(|product| {
+            let translation = translations_by_product.get(&product.id).and_then(|items| {
+                pick_product_translation(items.as_slice(), locale, fallback_locale)
+            });
+            LegacyStorefrontProductListItem {
+                id: product.id,
+                status: product.status,
+                title: translation
+                    .map(|value| value.title.clone())
+                    .unwrap_or_default(),
+                handle: translation
+                    .map(|value| value.handle.clone())
+                    .unwrap_or_default(),
+                seller_id: product.seller_id,
+                vendor: product.vendor,
+                product_type: product.product_type,
+                shipping_profile_slug: shipping_profile_slug_from_metadata(&product.metadata),
+                tags: product_tags.get(&product.id).cloned().unwrap_or_default(),
+                created_at: product.created_at.into(),
+                published_at: product.published_at.map(Into::into),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(LegacyStorefrontProductList {
+        items,
+        total,
+        page,
+        per_page,
+        has_next: page * per_page < total,
+    })
+}
+
+fn pick_product_translation<'a>(
+    translations: &'a [product_translation::Model],
+    locale: &str,
+    fallback_locale: &str,
+) -> Option<&'a product_translation::Model> {
+    translations
+        .iter()
+        .find(|translation| locale_tags_match(&translation.locale, locale))
+        .or_else(|| {
+            (!locale_tags_match(fallback_locale, locale)).then(|| {
+                translations.iter().find(|translation| {
+                    locale_tags_match(&translation.locale, fallback_locale)
+                })
+            })?
+        })
+        .or_else(|| translations.first())
+}
+
+fn shipping_profile_slug_from_metadata(metadata: &serde_json::Value) -> String {
+    metadata
+        .get("shipping_profile")
+        .and_then(|profile| profile.get("slug"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(normalize_shipping_profile_slug)
+        .or_else(|| {
+            metadata
+                .get("shipping_profile_slug")
+                .and_then(serde_json::Value::as_str)
+                .and_then(normalize_shipping_profile_slug)
+        })
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn normalize_shipping_profile_slug(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn product_title_search_condition(
+    backend: sea_orm::DbBackend,
+    search: &str,
+) -> sea_orm::Condition {
+    let pattern = format!("%{search}%");
+    let exists_sql = match backend {
+        sea_orm::DbBackend::Sqlite => {
+            "EXISTS (\n                SELECT 1\n                FROM product_translations pt\n                WHERE pt.product_id = products.id\n                  AND pt.title LIKE ?\n            )"
+        }
+        _ => {
+            "EXISTS (\n                SELECT 1\n                FROM product_translations pt\n                WHERE pt.product_id = products.id\n                  AND pt.title LIKE $1\n            )"
+        }
+    };
+
+    sea_orm::Condition::all().add(sea_orm::sea_query::Expr::cust_with_values(
+        exists_sql,
+        vec![sea_orm::Value::from(pattern)],
+    ))
+}
+
+fn map_product_error(context: &PortContext, error: CommerceError) -> PortError {
+    let (kind, code, message, retryable, variant) = match error {
+        CommerceError::Database(_) => (
+            "unavailable",
+            "product.database_unavailable",
+            "product storage is temporarily unavailable",
+            true,
+            "database",
+        ),
+        CommerceError::ProductNotFound(_) => (
+            "not_found",
+            "product.product_not_found",
+            "product was not found",
+            false,
+            "not_found",
+        ),
+        CommerceError::Validation(_) => (
+            "validation",
+            "product.validation",
+            "product request is invalid",
+            false,
+            "validation",
+        ),
+        _ => (
+            "invariant",
+            "product.invariant_violation",
+            "product operation could not be completed safely",
+            false,
+            "invariant",
+        ),
+    };
+    tracing::error!(
+        owner = "rustok_product",
+        operation = LIST_LEGACY_STOREFRONT_HTTP_PRODUCTS_OPERATION,
+        correlation_id = %context.correlation_id,
+        error_variant = variant,
+        public_code = code,
+        retryable,
+        "legacy storefront HTTP product owner read failed"
+    );
+    match kind {
+        "unavailable" => PortError::unavailable(code, message),
+        "not_found" => PortError::not_found(code, message),
+        "validation" => PortError::validation(code, message),
+        _ => PortError::invariant_violation(code, message),
+    }
+}

--- a/scripts/verify/verify-commerce-rest-storefront-product-list-owner-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-storefront-product-list-owner-read-cutover.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const router = read('crates/rustok-commerce/src/controllers/store/mod.rs');
+const mounted = read('crates/rustok-commerce/src/controllers/store/products_owner_list.rs');
+const legacy = read('crates/rustok-commerce/src/controllers/store/products.rs');
+const owner = read('crates/rustok-product/src/storefront_http_read_port.rs');
+const runtime = read('crates/rustok-product/src/runtime.rs');
+const lib = read('crates/rustok-product/src/lib.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-storefront-product-list-owner-read-cutover-2026-08-10.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+
+for (const [value, label] of [
+  ['#[path = "products.rs"]\npub mod products_legacy;', 'legacy Product compatibility module'],
+  ['#[path = "products_owner_list.rs"]\npub mod products;', 'mounted Product owner-list module'],
+  ['.route("/products", axum::routing::get(products::list_products))', 'mounted list route'],
+  ['.route("/products/{id}", axum::routing::get(products::show_product))', 'preserved detail route'],
+]) requireText(router, value, label);
+
+for (const [value, label] of [
+  ['ProductStorefrontHttpReadPort', 'Product HTTP owner port type'],
+  ['self.product_catalog_read_runtime.storefront_http_read_port()', 'host-selected optional capability'],
+  ['ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;', 'channel guard'],
+  ['let page = pagination.page.max(1);', 'page normalization'],
+  ['let per_page = pagination.limit();', '100-row REST clamp'],
+  ['unwrap_or(request_context.locale.as_str())', 'effective locale'],
+  ['public_channel_slug_from_request(&request_context)', 'public channel'],
+  ['PortActor::service("rustok-commerce.storefront-product")', 'service actor'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'bounded deadline'],
+  ['.product_storefront_http_read_port()', 'runtime capability lookup'],
+  ['.ok_or_else(storefront_product_list_unavailable)?', 'missing capability fail closed'],
+  ['.list_legacy_storefront_http_products(', 'owner list call'],
+  ['LegacyStorefrontHttpProductsRequest {', 'typed owner request'],
+  ['locale: Some(locale.to_string())', 'locale forwarding'],
+  ['fallback_locale: Some(tenant.default_locale.clone())', 'tenant fallback forwarding'],
+  ['vendor: params.vendor', 'vendor forwarding'],
+  ['product_type: params.product_type', 'product-type forwarding'],
+  ['search: params.search', 'search forwarding'],
+  ['page,', 'page forwarding'],
+  ['per_page,', 'page-size forwarding'],
+  ['shipping_profile_slug: Some(item.shipping_profile_slug)', 'shipping-profile projection'],
+  ['PaginationMeta::new(list.page, list.per_page, list.total)', 'pagination metadata'],
+  ['path = "/store/products/{id}"', 'detail OpenAPI wrapper'],
+  ['super::products_legacy::show_product(', 'detail wrapper delegation'],
+  ['path = "/store/regions"', 'regions OpenAPI wrapper'],
+  ['super::products_legacy::list_regions(', 'regions wrapper delegation'],
+  ['path = "/store/shipping-options"', 'shipping-options OpenAPI wrapper'],
+  ['super::products_legacy::list_shipping_options(', 'shipping-options wrapper delegation'],
+]) requireText(mounted, value, label);
+
+for (const value of [
+  'CatalogService::new(',
+  'product::Entity::find()',
+  'product_translation::Entity::find()',
+  'product_translation_title_search_condition(',
+  'load_product_tag_map(',
+  'is_metadata_visible_for_public_channel(',
+  'error = ?error',
+  'error.message',
+  'error.to_string()',
+]) forbidText(mounted, value, 'mounted Product module must not own Product storage/backend details');
+
+for (const [value, label] of [
+  ['StatusCode::BAD_REQUEST', 'validation status'],
+  ['StatusCode::NOT_FOUND', 'not-found status'],
+  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
+  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
+  ['"commerce_store_product_invalid"', 'validation code'],
+  ['"commerce_store_not_found"', 'not-found code'],
+  ['"commerce_store_product_unavailable"', 'unavailable code'],
+  ['"commerce_store_product_failed"', 'fail-closed code'],
+  ['owner_error_kind = ?error.kind', 'bounded error-kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner-code diagnostic'],
+  ['retryable = error.retryable', 'bounded retryable diagnostic'],
+]) requireText(mounted, value, label);
+
+for (const [value, label] of [
+  ['pub trait ProductStorefrontHttpReadPort', 'Product owner HTTP port'],
+  ['async fn list_legacy_storefront_http_products(', 'Product owner HTTP operation'],
+  ['MAX_LEGACY_STOREFRONT_HTTP_PRODUCTS_PER_PAGE: u64 = 100', 'REST page-size contract'],
+  ['context.require_policy(PortCallPolicy::read())?', 'read admission'],
+  ['product::Column::TenantId.eq(tenant_id)', 'tenant filter'],
+  ['product::Column::Status.eq(product::ProductStatus::Active)', 'active filter'],
+  ['product::Column::PublishedAt.is_not_null()', 'published filter'],
+  ['product::Column::Vendor.eq(vendor)', 'vendor filter'],
+  ['product::Column::ProductType.eq(product_type)', 'product-type filter'],
+  ['product_title_search_condition(', 'raw title search'],
+  ['.order_by_desc(product::Column::PublishedAt)', 'published ordering'],
+  ['.order_by_desc(product::Column::CreatedAt)', 'created ordering'],
+  ['.all(db)', 'pre-visibility materialization'],
+  ['rustok_inventory::is_metadata_visible_for_public_channel(', 'owner channel visibility'],
+  ['let total = visible_products.len() as u64;', 'post-visibility total'],
+  ['.skip(offset as usize)', 'post-visibility page offset'],
+  ['.take(per_page as usize)', 'post-visibility page size'],
+  ['pick_product_translation(items.as_slice(), locale, fallback_locale)', 'locale fallback projection'],
+  ['.unwrap_or_default()', 'empty missing translation projection'],
+  ['shipping_profile_slug_from_metadata(&product.metadata)', 'metadata-only shipping profile'],
+  ['.load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))', 'owner tag projection'],
+]) requireText(owner, value, label);
+
+const visibilityIndex = owner.indexOf('rustok_inventory::is_metadata_visible_for_public_channel(');
+const skipIndex = owner.indexOf('.skip(offset as usize)');
+if (visibilityIndex < 0 || skipIndex < 0 || visibilityIndex > skipIndex) {
+  failures.push('owner REST compatibility projection must apply channel visibility before pagination');
+}
+
+for (const [value, label] of [
+  ['storefront_http_read_port: Option<Arc<dyn ProductStorefrontHttpReadPort>>', 'optional runtime capability'],
+  ['storefront_http_read_port: None', 'external-safe default'],
+  ['.with_storefront_http_read_port(catalog.clone())', 'embedded owner capability'],
+  ['pub fn with_storefront_http_read_port(', 'explicit external capability builder'],
+  ['pub fn storefront_http_read_port(&self)', 'runtime capability accessor'],
+  ['pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)', 'external runtime constructor'],
+]) requireText(runtime, value, label);
+requireText(lib, 'mod storefront_http_read_port;', 'Product owner module registration');
+requireText(lib, 'ProductStorefrontHttpReadPort', 'Product HTTP owner port export');
+requireText(lib, 'LegacyStorefrontHttpProductsRequest', 'Product HTTP request export');
+
+const externalStart = runtime.indexOf('pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)');
+const httpBuilderStart = runtime.indexOf('pub fn with_storefront_http_read_port(');
+if (externalStart < 0 || httpBuilderStart < 0 || externalStart > httpBuilderStart) {
+  failures.push('unable to verify external Product runtime fail-closed capability composition');
+} else {
+  forbidText(
+    runtime.slice(externalStart, httpBuilderStart),
+    'with_storefront_http_read_port',
+    'external Product runtime must not silently install embedded HTTP capability',
+  );
+}
+
+for (const [value, label] of [
+  ['CatalogService::new(runtime.db_clone(), runtime.event_bus())', 'legacy concrete list compatibility source'],
+  ['product_translation_title_search_condition(', 'legacy raw search compatibility source'],
+]) requireText(legacy, value, label);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology P0 remains open',
+);
+for (const [value, label] of [
+  ['# Commerce REST storefront Product list owner-read cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['ProductStorefrontHttpReadPort::list_legacy_storefront_http_products', 'record owner operation'],
+  ['does not currently restrict the search by locale', 'record raw search parity'],
+  ['metadata-only shipping-profile', 'record shipping-profile parity'],
+  ['thin annotated wrappers', 'record wrapper topology'],
+  ['The canonical ecommerce P0 item', 'record broad P0 open'],
+  ['no tests, Cargo commands, Node verifiers, formatter', 'record no validation execution'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST storefront Product list owner-read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted REST storefront Product list uses the host-selected Product owner HTTP capability');

--- a/scripts/verify/verify-commerce-storefront-product-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-product-http-error-safety.mjs
@@ -10,12 +10,12 @@ const root = configuredRoot
   : new URL('../../', import.meta.url);
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
-const controller = read('crates/rustok-commerce/src/controllers/store/products.rs');
-const commerceErrors = read('crates/rustok-commerce-foundation/src/error.rs');
-const catalogService = read('crates/rustok-product/src/services/catalog.rs');
-const catalogTags = read('crates/rustok-product/src/services/catalog/tags.rs');
+const router = read('crates/rustok-commerce/src/controllers/store/mod.rs');
+const mountedList = read('crates/rustok-commerce/src/controllers/store/products_owner_list.rs');
+const legacyProducts = read('crates/rustok-commerce/src/controllers/store/products.rs');
+const ownerHttp = read('crates/rustok-product/src/storefront_http_read_port.rs');
 const productPorts = read('crates/rustok-product/src/ports.rs');
-const storefrontChannel = read('crates/rustok-commerce/src/storefront_channel.rs');
+const productQueries = read('crates/rustok-product/src/services/catalog/queries.rs');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -34,225 +34,132 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const productBoundary = between(
-  controller,
-  'fn map_storefront_product_error(',
-  '/// List available storefront regions',
-  'storefront product boundary',
+const listStart = mountedList.indexOf('pub async fn list_products(');
+const listHandler = listStart < 0 ? '' : mountedList.slice(listStart);
+if (listStart < 0) failures.push('mounted storefront Product list: unable to isolate source block');
+const listMapper = between(
+  mountedList,
+  'fn map_storefront_product_list_port_error(',
+  '/// List published storefront products through the Product-owned legacy HTTP projection.',
+  'mounted storefront Product list mapper',
 );
-const mapper = between(
-  controller,
-  'fn map_storefront_product_error(',
-  '/// List published storefront products',
-  'storefront product mapper',
-);
-const listHandler = between(
-  controller,
-  'pub async fn list_products(',
-  '/// Show published storefront product',
-  'storefront product list handler',
-);
-const showHandler = between(
-  controller,
+const detailHandler = between(
+  legacyProducts,
   'pub async fn show_product(',
   '/// List available storefront regions',
-  'storefront product detail handler',
+  'mounted storefront Product detail implementation',
 );
-const ownerMapper = between(
-  controller,
+const detailMapper = between(
+  legacyProducts,
   'fn map_storefront_product_port_error(',
   'fn map_storefront_auxiliary_port_error(',
-  'storefront product owner mapper',
+  'storefront Product detail mapper',
 );
 
 for (const [value, label] of [
-  ['http::StatusCode', 'HTTP status import'],
-  ['CommerceError,', 'typed commerce error import'],
-  ['fn map_storefront_product_error(', 'typed storefront product mapper'],
-  ['fn map_storefront_product_database_error(', 'direct database mapper'],
-  ['fn map_storefront_product_port_error(', 'owner port mapper'],
-  ['CommerceError::Database(error)', 'database owner wrapping'],
-  ['operation,', 'operation logging'],
-  ['boundary = "commerce_storefront_product_http"', 'product boundary logging'],
-  ['HttpError::new(status, code, message)', 'static HTTP envelope construction'],
-]) {
-  requireText(controller, value, label);
-}
+  ['#[path = "products.rs"]\npub mod products_legacy;', 'legacy Product source alias'],
+  ['#[path = "products_owner_list.rs"]\npub mod products;', 'mounted Product module alias'],
+  ['.route("/products", axum::routing::get(products::list_products))', 'mounted list route'],
+  ['.route("/products/{id}", axum::routing::get(products::show_product))', 'mounted detail route'],
+]) requireText(router, value, label);
 
 for (const [value, label] of [
-  ['CommerceError::Database(_)', 'database variant'],
-  ['CommerceError::ProductNotFound(_)', 'product not-found variant'],
-  ['CommerceError::VariantNotFound(_)', 'variant not-found variant'],
-  ['CommerceError::Validation(_)', 'validation variant'],
-  ['CommerceError::DuplicateHandle { .. }', 'duplicate handle variant'],
-  ['CommerceError::DuplicateSku(_)', 'duplicate SKU variant'],
-  ['CommerceError::InvalidPrice(_)', 'invalid price variant'],
-  ['CommerceError::InsufficientInventory { .. }', 'inventory variant'],
-  ['CommerceError::InvalidOptionCombination', 'invalid option variant'],
-  ['CommerceError::ShippingProfileNotFound(_)', 'shipping-profile variant'],
-  ['CommerceError::DuplicateShippingProfileSlug(_)', 'shipping-profile conflict variant'],
-  ['CommerceError::NoVariants', 'no-variants variant'],
-  ['CommerceError::CannotDeletePublished', 'published-delete variant'],
-  ['CommerceError::Rich(_)', 'rich error variant'],
-  ['CommerceError::Core(_)', 'core error variant'],
-]) {
-  requireText(mapper, value, label);
-}
-
-for (const [value, label] of [
-  ['StatusCode::BAD_REQUEST', 'validation status'],
-  ['StatusCode::NOT_FOUND', 'not-found status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'storage status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'fail-closed status'],
-  ['"commerce_store_product_invalid"', 'product invalid code'],
-  ['"commerce_store_not_found"', 'storefront not-found code'],
-  ['"commerce_store_product_unavailable"', 'product unavailable code'],
-  ['"commerce_store_product_failed"', 'product fail-closed code'],
-  ['"unexpected_owner_error"', 'unexpected owner kind'],
-]) {
-  requireText(mapper, value, label);
-}
+  ['ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;', 'list channel guard'],
+  ['.product_storefront_http_read_port()', 'host-selected optional list owner capability'],
+  ['.list_legacy_storefront_http_products(', 'list owner call'],
+  ['LegacyStorefrontHttpProductsRequest {', 'typed list request'],
+  ['let page = pagination.page.max(1);', 'list page normalization'],
+  ['let per_page = pagination.limit();', 'list page-size clamp'],
+  ['fallback_locale: Some(tenant.default_locale.clone())', 'list fallback locale'],
+  ['shipping_profile_slug: Some(item.shipping_profile_slug)', 'list response projection'],
+  ['PaginationMeta::new(list.page, list.per_page, list.total)', 'list pagination response'],
+]) requireText(listHandler, value, label);
 
 for (const value of [
-  'commerce_operation_failed',
-  'err.to_string()',
-  'error.to_string()',
-  'error.message',
-  'HttpError::bad_request(',
-]) {
-  forbidText(productBoundary, value, 'unsafe storefront product public conversion');
+  'CatalogService::new(',
+  'product::Entity::find()',
+  'product_translation::Entity::find()',
+  '.load_product_tag_map(',
+  'product_translation_title_search_condition(',
+]) forbidText(listHandler, value, 'mounted list foreign Product storage/service access');
+
+for (const [mapper, prefix] of [[listMapper, 'list'], [detailMapper, 'detail']]) {
+  for (const [value, label] of [
+    ['PortErrorKind::Validation', `${prefix} validation mapping`],
+    ['PortErrorKind::NotFound', `${prefix} not-found mapping`],
+    ['PortErrorKind::Unavailable | PortErrorKind::Timeout', `${prefix} unavailable mapping`],
+    ['PortErrorKind::Conflict | PortErrorKind::Forbidden | PortErrorKind::InvariantViolation', `${prefix} fail-closed mapping`],
+    ['"commerce_store_product_invalid"', `${prefix} validation code`],
+    ['"commerce_store_not_found"', `${prefix} not-found code`],
+    ['"commerce_store_product_unavailable"', `${prefix} unavailable code`],
+    ['"commerce_store_product_failed"', `${prefix} fail-closed code`],
+    ['owner_error_kind = ?error.kind', `${prefix} bounded owner kind`],
+    ['owner_code_length = error.code.chars().count()', `${prefix} bounded owner code`],
+    ['retryable = error.retryable', `${prefix} retryability diagnostic`],
+  ]) requireText(mapper, value, label);
+  for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'err.to_string()']) {
+    forbidText(mapper, value, `${prefix} raw Product owner diagnostic`);
+  }
 }
 
 for (const [value, label] of [
-  ['ensure_storefront_channel_enabled_for_db(', 'storefront channel guard'],
-  ['let pagination = params.pagination.unwrap_or_default();', 'pagination input'],
-  ['unwrap_or(request_context.locale.as_str())', 'locale fallback'],
-  ['product::Column::TenantId.eq(tenant.id)', 'tenant filter'],
-  ['product::Column::Status.eq(product::ProductStatus::Active)', 'active product filter'],
-  ['product::Column::PublishedAt.is_not_null()', 'published product filter'],
-  ['product::Column::Vendor.eq(vendor)', 'vendor filter'],
-  ['product::Column::ProductType.eq(product_type)', 'product type filter'],
-  ['product_translation_title_search_condition(', 'localized search filter'],
-  ['.order_by_desc(product::Column::PublishedAt)', 'published ordering'],
-  ['.order_by_desc(product::Column::CreatedAt)', 'created ordering'],
-  ['is_metadata_visible_for_public_channel(', 'channel visibility filter'],
-  ['.skip(pagination.offset() as usize)', 'pagination offset'],
-  ['.take(pagination.limit() as usize)', 'pagination limit'],
-  ['.load_product_tag_map(', 'product tag projection'],
-  ['PaginationMeta::new(pagination.page, pagination.limit(), total)', 'pagination metadata'],
-  ['"list_products"', 'list operation label'],
-  ['"list_product_translations"', 'translation operation label'],
-  ['"list_product_tags"', 'tag operation label'],
-]) {
-  requireText(listHandler, value, label);
-}
-
-for (const [value, label] of [
-  ['ensure_storefront_channel_enabled_for_db(', 'detail channel guard'],
-  ['runtime\n        .product_catalog_read_port()', 'host-selected product read port'],
-  ['.read_storefront_product_projection(', 'owner detail read'],
-  ['StorefrontProductProjectionSubject::ProductId { product_id: id }', 'detail product identity'],
+  ['ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;', 'detail channel guard'],
+  ['runtime\n        .product_catalog_read_port()', 'detail host-selected Product read port'],
+  ['.read_storefront_product_projection(', 'detail owner read'],
+  ['StorefrontProductProjectionSubject::ProductId { product_id: id }', 'detail Product identity'],
   ['locale: Some(request_context.locale.clone())', 'detail requested locale'],
-  ['fallback_locale: Some(tenant.default_locale.clone())', 'detail tenant fallback locale'],
-  ['public_channel_slug,', 'detail public channel'],
-  ['"read_storefront_product_projection"', 'owner operation label'],
-  ['"commerce_store_not_found"', 'hidden product not-found code'],
-  ['Ok(Json(product))', 'detail response'],
-]) {
-  requireText(showHandler, value, label);
-}
+  ['fallback_locale: Some(tenant.default_locale.clone())', 'detail fallback locale'],
+  ['"commerce_store_not_found"', 'hidden detail not-found envelope'],
+]) requireText(detailHandler, value, label);
 for (const value of [
   'CatalogService::new(',
   '.get_product_with_locale_fallback(',
   'product.status != product::ProductStatus::Active',
   'apply_public_channel_inventory_to_product(',
-  'show_product_inventory',
-]) {
-  forbidText(showHandler, value, 'stale concrete product detail path');
-}
+]) forbidText(detailHandler, value, 'stale concrete Product detail path');
 
 for (const [value, label] of [
-  ['PortErrorKind::Validation', 'owner validation mapping'],
-  ['PortErrorKind::NotFound', 'owner not-found mapping'],
-  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'owner unavailable mapping'],
-  ['PortErrorKind::Conflict | PortErrorKind::Forbidden | PortErrorKind::InvariantViolation', 'owner fail-closed mapping'],
-  ['owner = "rustok_product"', 'owner diagnostic identity'],
-  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
-  ['owner_error_kind = ?error.kind', 'owner error-kind diagnostic'],
-  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
-  ['retryable = error.retryable', 'owner retryability diagnostic'],
-]) {
-  requireText(ownerMapper, value, label);
-}
-for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'err.to_string()']) {
-  forbidText(ownerMapper, value, 'raw owner detail diagnostic');
-}
-
-const serviceMapperUses = productBoundary.match(/map_storefront_product_error\(/g) ?? [];
-if (serviceMapperUses.length !== 3) {
-  failures.push(
-    `expected service mapper definition, database delegation, and tag callsite, found ${serviceMapperUses.length}`,
-  );
-}
-const databaseMapperUses = productBoundary.match(/map_storefront_product_database_error\(/g) ?? [];
-if (databaseMapperUses.length !== 3) {
-  failures.push(
-    `expected database mapper definition plus product page and translations callsites, found ${databaseMapperUses.length}`,
-  );
-}
-const ownerMapperUses = productBoundary.match(/map_storefront_product_port_error\(/g) ?? [];
-if (ownerMapperUses.length !== 2) {
-  failures.push(`expected owner mapper definition plus detail callsite, found ${ownerMapperUses.length}`);
-}
+  ['pub trait ProductStorefrontHttpReadPort', 'Product HTTP owner capability'],
+  ['MAX_LEGACY_STOREFRONT_HTTP_PRODUCTS_PER_PAGE: u64 = 100', 'REST page-size compatibility'],
+  ['product::Column::Status.eq(product::ProductStatus::Active)', 'owner active filter'],
+  ['product::Column::PublishedAt.is_not_null()', 'owner published filter'],
+  ['rustok_inventory::is_metadata_visible_for_public_channel(', 'owner channel visibility'],
+  ['let total = visible_products.len() as u64;', 'owner visible total'],
+  ['.skip(offset as usize)', 'owner pagination offset'],
+  ['.take(per_page as usize)', 'owner pagination limit'],
+  ['.unwrap_or_default()', 'owner empty missing translation'],
+  ['shipping_profile_slug_from_metadata(&product.metadata)', 'owner metadata-only shipping profile'],
+  ['.load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))', 'owner tag projection'],
+]) requireText(ownerHttp, value, label);
 
 for (const [value, label] of [
-  ['Database(#[from] sea_orm::DbErr)', 'owner database variant'],
-  ['ProductNotFound(Uuid)', 'owner product variant'],
-  ['VariantNotFound(Uuid)', 'owner variant variant'],
-  ['DuplicateHandle { handle: String, locale: String }', 'owner handle variant'],
-  ['DuplicateSku(String)', 'owner SKU variant'],
-  ['InvalidPrice(String)', 'owner price variant'],
-  ['InsufficientInventory { requested: i32, available: i32 }', 'owner inventory variant'],
-  ['InvalidOptionCombination', 'owner option variant'],
-  ['Validation(String)', 'owner validation variant'],
-  ['ShippingProfileNotFound(Uuid)', 'owner shipping-profile variant'],
-  ['DuplicateShippingProfileSlug(String)', 'owner profile-conflict variant'],
-  ['NoVariants', 'owner no-variants variant'],
-  ['CannotDeletePublished', 'owner state variant'],
-  ['Rich(#[source] Box<RichError>)', 'owner rich variant'],
-  ['Core(#[from] CoreError)', 'owner core variant'],
-]) {
-  requireText(commerceErrors, value, label);
-}
-
-for (const [content, value, label] of [
-  [catalogService, 'pub async fn get_product_with_locale_fallback(', 'catalog detail operation'],
-  [catalogService, '-> CommerceResult<ProductResponse>', 'typed catalog detail result'],
-  [catalogService, 'CommerceError::ProductNotFound(product_id)', 'catalog not-found construction'],
-  [catalogTags, 'pub async fn load_product_tag_map(', 'catalog tag operation'],
-  [catalogTags, '-> CommerceResult<HashMap<Uuid, Vec<String>>>', 'typed tag result'],
-  [catalogTags, 'CommerceError::Validation(error.to_string())', 'taxonomy error ownership'],
-  [productPorts, 'async fn read_storefront_product_projection(', 'owner storefront detail capability'],
-  [productPorts, 'StorefrontProductProjectionSubject::ProductId { product_id }', 'owner product-id subject'],
-  [productPorts, 'get_published_product_by_id_with_locale_fallback(', 'owner published detail implementation'],
-  [storefrontChannel, 'pub(crate) async fn apply_public_channel_inventory_to_product(', 'inventory projection operation'],
-  [storefrontChannel, '-> Result<(), sea_orm::DbErr>', 'typed inventory database result'],
-  [storefrontChannel, 'load_inventory_projection_by_variant_for_public_channel(', 'inventory owner call'],
-]) {
-  requireText(content, value, label);
-}
+  ['async fn read_storefront_product_projection(', 'Product detail owner capability'],
+  ['StorefrontProductProjectionSubject::ProductId { product_id }', 'Product detail owner subject'],
+  ['get_published_product_by_id_with_locale_fallback(', 'Product published detail implementation'],
+]) requireText(productPorts, value, label);
+for (const [value, label] of [
+  ['product.status != entities::product::ProductStatus::Active', 'detail active visibility'],
+  ['product.published_at.is_none()', 'detail publication visibility'],
+  ['is_metadata_visible_for_public_channel(&product.metadata, public_channel_slug)', 'detail channel visibility'],
+  ['apply_public_channel_inventory_to_product(', 'detail public inventory'],
+]) requireText(productQueries, value, label);
 
 for (const [value, label] of [
-  ['pub async fn list_regions(', 'region handler retained'],
-  ['pub async fn list_shipping_options(', 'shipping-options handler retained'],
-]) {
-  requireText(controller, value, label);
-}
+  ['super::products_legacy::show_product(', 'detail wrapper delegation'],
+  ['super::products_legacy::list_regions(', 'region wrapper delegation'],
+  ['super::products_legacy::list_shipping_options(', 'shipping-options wrapper delegation'],
+]) requireText(mountedList, value, label);
+requireText(legacyProducts, 'pub async fn list_regions(', 'legacy region handler retained');
+requireText(
+  legacyProducts,
+  'pub async fn list_shipping_options(',
+  'legacy shipping-options handler retained',
+);
 
 if (failures.length > 0) {
-  console.error('Commerce storefront product HTTP error-safety verification failed:');
+  console.error('Commerce storefront Product HTTP error-safety verification failed:');
   for (const failure of failures) console.error(`✗ ${failure}`);
   process.exit(Math.min(failures.length, 255));
 }
 
-console.log('✔ Storefront product list and detail use stable typed public envelopes');
+console.log('✔ mounted storefront Product list/detail use bounded owner reads and stable public envelopes');

--- a/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
+++ b/scripts/verify/verify-product-catalog-read-runtime-composition.mjs
@@ -31,12 +31,14 @@ function forbid(source, marker, description) {
 
 const runtimePath = "crates/rustok-product/src/runtime.rs";
 const libPath = "crates/rustok-product/src/lib.rs";
+const httpPortPath = "crates/rustok-product/src/storefront_http_read_port.rs";
 const tagPortPath = "crates/rustok-product/src/storefront_tag_read_port.rs";
 const hostPath = "apps/server/src/services/commerce_provider_runtime.rs";
 const registryPath = "crates/rustok-product/contracts/product-fba-registry.json";
 const planPath = "crates/rustok-product/docs/implementation-plan.md";
 const runtime = read(runtimePath);
 const lib = read(libPath);
+const httpPort = read(httpPortPath);
 const tagPort = read(tagPortPath);
 const host = read(hostPath);
 const registry = read(registryPath);
@@ -47,22 +49,37 @@ requireAll(runtime, [
   "EmbeddedNative",
   "External",
   "pub struct ProductCatalogReadRuntime",
+  "storefront_http_read_port: Option<Arc<dyn ProductStorefrontHttpReadPort>>",
   "storefront_tag_read_port: Option<Arc<dyn ProductStorefrontTagReadPort>>",
   "pub fn in_process",
+  ".with_storefront_http_read_port(catalog.clone())",
   ".with_storefront_tag_read_port(catalog)",
   "pub fn external",
   "pub fn read_port",
+  "pub fn with_storefront_http_read_port",
+  "pub fn storefront_http_read_port",
   "pub fn storefront_tag_read_port",
   "pub const fn profile",
 ], "Product owner runtime");
 requireAll(lib, [
   "mod runtime;",
+  "mod storefront_http_read_port;",
   "mod storefront_tag_read_port;",
   "ProductCatalogReadProfile",
   "ProductCatalogReadRuntime",
+  "ProductStorefrontHttpReadPort",
+  "LegacyStorefrontHttpProductsRequest",
   "ProductStorefrontTagReadPort",
   "ProductStorefrontTagHydrationRequest",
 ], "Product public exports");
+requireAll(httpPort, [
+  "pub trait ProductStorefrontHttpReadPort",
+  "impl ProductStorefrontHttpReadPort for CatalogService",
+  "MAX_LEGACY_STOREFRONT_HTTP_PRODUCTS_PER_PAGE: u64 = 100",
+  "context.require_policy(PortCallPolicy::read())?",
+  "rustok_inventory::is_metadata_visible_for_public_channel(",
+  ".load_product_tag_map(tenant_id, &products, locale, Some(fallback_locale))",
+], "Product optional Storefront HTTP capability");
 requireAll(tagPort, [
   "pub trait ProductStorefrontTagReadPort",
   "impl ProductStorefrontTagReadPort for CatalogService",
@@ -110,7 +127,13 @@ requireAll(plan, [
 ], "Product implementation plan");
 
 const externalStart = runtime.indexOf("pub fn external(read_port: Arc<dyn ProductCatalogReadPort>)");
+const withHttpStart = runtime.indexOf("pub fn with_storefront_http_read_port(");
 const withTagStart = runtime.indexOf("pub fn with_storefront_tag_read_port(");
+if (externalStart < 0 || withHttpStart <= externalStart) {
+  failures.push("Product owner runtime: external/HTTP capability boundaries are missing");
+} else if (runtime.slice(externalStart, withHttpStart).includes("with_storefront_http_read_port")) {
+  failures.push("Product owner runtime: external profile must not silently install embedded HTTP list capability");
+}
 if (externalStart < 0 || withTagStart <= externalStart) {
   failures.push("Product owner runtime: external/tag capability boundaries are missing");
 } else if (runtime.slice(externalStart, withTagStart).includes("with_storefront_tag_read_port")) {


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with the mounted storefront Product REST list.

- publish optional Product-owned `ProductStorefrontHttpReadPort::list_legacy_storefront_http_products` without changing the existing GraphQL legacy list contract;
- carry the optional capability through `ProductCatalogReadRuntime`: embedded Product composition installs it, external profiles must opt in explicitly and otherwise fail closed;
- move mounted `GET /store/products` to a dedicated owner-list module while retaining the old direct list as unmounted compatibility source;
- preserve exact legacy REST candidate filters, raw any-translation title search, published/created ordering, in-memory public-channel visibility before total/pagination, 1..=100 page-size behavior, requested/default/first translation fallback, empty missing title/handle, Product tag hydration, metadata-only shipping-profile projection, DTOs and pagination metadata;
- preserve the channel-enabled guard and build a bounded read `PortContext` with tenant, stable service actor, effective locale, normalized channel, page-bound correlation and two-second deadline;
- fail closed with the existing `commerce_store_product_unavailable` family when an external Product runtime has not supplied the optional HTTP capability;
- keep raw Product/backend messages out of the mounted boundary;
- retain detail/regions/shipping behavior through thin annotated wrappers so existing OpenAPI handler markers remain stable;
- add/update source guards and a dated `source_complete_unvalidated` record;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind `e66bd6012a7bc0380a10d3659723973760c2d85c` with exactly nine changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source verifiers were added/updated but not run.