### PR TITLE
feat(commerce): route storefront return creation through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-storefront-order-return-command-owner-port-cutover-2026-08-10.md
+++ b/crates/rustok-commerce/docs/rest-storefront-order-return-command-owner-port-cutover-2026-08-10.md
@@ -1,0 +1,73 @@
+# Commerce REST storefront order-return command owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-10
+
+## Scope
+
+This bounded slice moves mounted `POST /store/orders/{id}/returns` behind the existing
+Order-owned `OrderPostOrderCommandPort::create_return` capability.
+
+The route remains mounted in the same controller and keeps the pre-existing storefront
+channel admission and customer-ownership read before any return mutation is attempted.
+The old concrete `OrderService` construction and concrete `OrderError` mapper are removed
+from the mounted storefront order controller.
+
+## Preserved transport behavior
+
+The mounted route still:
+
+1. requires the Commerce module to be enabled for the request channel;
+2. requires an authenticated customer account;
+3. reads the order through the host-selected `OrderReadPort` and rejects orders owned by
+   another customer before mutation;
+4. accepts the unchanged `CreateOrderReturnInput` request body;
+5. returns `201 Created` with the existing `OrderReturnResponse` projection;
+6. preserves the prior public Order error families:
+   - validation -> `400 commerce_store_order_invalid`;
+   - not found -> `404 commerce_store_order_not_found`;
+   - state conflict -> `409 commerce_store_order_state_conflict`;
+   - unavailable/timeout -> `503 commerce_store_order_unavailable`;
+   - invariant failures -> `500 commerce_store_order_failed`.
+
+A defensive `PortErrorKind::Forbidden` mapping remains `401 commerce_store_order_access_denied`,
+consistent with the storefront ownership boundary.
+
+## Owner context
+
+After the ownership check, Commerce creates a write `PortContext` with:
+
+- the admitted tenant id;
+- the authenticated user id as `PortActor::user`;
+- the request locale;
+- the request channel when present;
+- correlation identity `commerce-storefront-order:create-return:{order_id}`;
+- a two-second deadline;
+- a fresh UUID idempotency identity required by the current owner write-admission policy.
+
+The fresh UUID is **write-admission metadata only**. `OrderPostOrderCommandPort` does not retain
+a durable command receipt keyed by that value, so this slice does not claim exactly-once or
+durable replay semantics for storefront return creation.
+
+## Error safety
+
+The new command boundary maps only bounded `PortError` kind/code-length/retryability and
+request identity-presence facts. It does not log or return raw owner/backend messages from
+the command call.
+
+Existing storefront Order read/customer diagnostics and the Payment refund-list boundary are
+outside this slice and remain unchanged.
+
+## Remaining topology
+
+The canonical broad ecommerce topology P0 remains open. In this same mounted controller,
+`GET /store/orders/{id}/refunds` still constructs `PaymentService` directly and is intentionally
+left for a separate Payment owner-read cutover.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios,
+workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter
+scenarios were executed. Source guards added or updated by this slice are source-reviewed only
+and were not run.

--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -9,8 +9,8 @@ use rustok_api::{
 use rustok_customer::dto::CustomerResponse;
 use rustok_customer::{CustomerUserProjectionRequest, in_process_customer_read_port};
 use rustok_order::{
-    ListOrderChangeProjectionsRequest, ListOrderReturnProjectionsRequest, OrderService,
-    ReadOrderProjectionRequest, error::OrderError,
+    CreateOrderReturnRequest, ListOrderChangeProjectionsRequest, ListOrderReturnProjectionsRequest,
+    ReadOrderProjectionRequest,
 };
 use rustok_payment::{PaymentService, error::PaymentError};
 use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
@@ -35,6 +35,7 @@ const STOREFRONT_ORDER_OWNER: &str = "rustok_order.storefront_orders";
 const STOREFRONT_ORDER_DETAIL_OPERATION: &str = "read_order_projection";
 const STOREFRONT_ORDER_RETURN_LIST_OPERATION: &str = "list_order_return_projections";
 const STOREFRONT_ORDER_CHANGE_LIST_OPERATION: &str = "list_order_change_projections";
+const STOREFRONT_ORDER_RETURN_COMMAND_OPERATION: &str = "create_return";
 const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";
 const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";
 
@@ -162,6 +163,26 @@ fn storefront_order_read_port_context(
     }
 }
 
+fn storefront_order_return_command_context(
+    tenant_id: Uuid,
+    auth: &rustok_api::AuthContext,
+    request_context: &RequestContext,
+    order_id: Uuid,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-storefront-order:create-return:{order_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2))
+    .with_idempotency_key(Uuid::new_v4().to_string());
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
 fn map_storefront_order_port_error(
     error: PortError,
     context: &PortContext,
@@ -235,56 +256,68 @@ fn map_storefront_order_port_error(
     HttpError::new(status, code, message)
 }
 
-fn map_storefront_order_error(
-    error: OrderError,
-    operation: &'static str,
-    tenant_id: Uuid,
+fn map_storefront_order_command_port_error(
+    error: PortError,
+    context: &PortContext,
+    actor_id: Uuid,
+    customer_id: Uuid,
     order_id: Uuid,
 ) -> HttpError {
-    let (status, code, message, error_kind) = match &error {
-        OrderError::Validation(_) => (
+    let (status, code, message, error_kind) = match &error.kind {
+        PortErrorKind::Validation => (
             StatusCode::BAD_REQUEST,
             "commerce_store_order_invalid",
             "Order request is invalid",
             "validation",
         ),
-        OrderError::OrderNotFound(_)
-        | OrderError::OrderReturnNotFound(_)
-        | OrderError::OrderChangeNotFound(_) => (
+        PortErrorKind::NotFound => (
             StatusCode::NOT_FOUND,
             "commerce_store_order_not_found",
             "Order resource was not found",
             "not_found",
         ),
-        OrderError::InvalidTransition { .. } => (
+        PortErrorKind::Conflict => (
             StatusCode::CONFLICT,
             "commerce_store_order_state_conflict",
             "Order operation conflicts with the current state",
             "state_conflict",
         ),
-        OrderError::Database(_) => (
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_store_order_access_denied",
+            "Order does not belong to the current customer",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_store_order_unavailable",
             "Order service is temporarily unavailable",
-            "database",
+            "unavailable",
         ),
-        OrderError::Core(_) => (
+        PortErrorKind::InvariantViolation => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "commerce_store_order_failed",
             "Order operation could not be completed safely",
-            "core",
+            "invariant_violation",
         ),
     };
     tracing::error!(
-        error = ?error,
-        operation,
-        tenant_id = %tenant_id,
-        order_id = %order_id,
+        owner = "rustok_order",
+        owner_operation = STOREFRONT_ORDER_RETURN_COMMAND_OPERATION,
+        consumer_operation = "create_order_return",
+        correlation_id = %context.correlation_id,
+        tenant_id_non_nil = !context.tenant_id.is_empty(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        customer_id_non_nil = !customer_id.is_nil(),
+        order_id_non_nil = !order_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
         error_kind,
         public_code = code,
         status = %status,
-        boundary = "commerce_storefront_order_http",
-        "storefront order operation failed"
+        boundary = STOREFRONT_ORDER_CUSTOMER_BOUNDARY,
+        "storefront Order return command failed with bounded diagnostics"
     );
     HttpError::new(status, code, message)
 }
@@ -608,7 +641,7 @@ pub async fn create_order_return(
 ) -> HttpResult<(StatusCode, Json<OrderReturnResponse>)> {
     super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;
 
-    ensure_customer_owns_order(
+    let customer_id = ensure_customer_owns_order(
         &runtime,
         tenant.id,
         tenant.default_locale.as_str(),
@@ -619,10 +652,27 @@ pub async fn create_order_return(
     )
     .await?;
 
-    let created = OrderService::new(runtime.db_clone(), runtime.event_bus())
-        .create_return(tenant.id, id, input)
+    let command_context =
+        storefront_order_return_command_context(tenant.id, &auth, &request_context, id);
+    let created = runtime
+        .order_post_order_command_port()
+        .create_return(
+            command_context.clone(),
+            CreateOrderReturnRequest {
+                order_id: id,
+                input,
+            },
+        )
         .await
-        .map_err(|error| map_storefront_order_error(error, "create_order_return", tenant.id, id))?;
+        .map_err(|error| {
+            map_storefront_order_command_port_error(
+                error,
+                &command_context,
+                auth.user_id,
+                customer_id,
+                id,
+            )
+        })?;
 
     Ok((StatusCode::CREATED, Json(created)))
 }

--- a/scripts/verify/verify-commerce-rest-storefront-order-return-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-storefront-order-return-command-owner-port-cutover.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const owner = read('crates/rustok-order/src/post_order_command.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-storefront-order-return-command-owner-port-cutover-2026-08-10.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+for (const [value, label] of [
+  ['CreateOrderReturnRequest', 'owner create-return request import'],
+  ['fn storefront_order_return_command_context(', 'storefront write context builder'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated actor'],
+  ['format!("commerce-storefront-order:create-return:{order_id}")', 'operation correlation'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'bounded deadline'],
+  ['.with_idempotency_key(Uuid::new_v4().to_string())', 'write-admission identity'],
+  ['let customer_id = ensure_customer_owns_order(', 'ownership admission retained'],
+  ['"create_order_return_access"', 'ownership operation label'],
+  ['.order_post_order_command_port()', 'host-selected Order command port'],
+  ['.create_return(', 'owner create-return call'],
+  ['CreateOrderReturnRequest {', 'typed owner request construction'],
+  ['order_id: id', 'order id forwarding'],
+  ['input,', 'input forwarding'],
+  ['StatusCode::CREATED', 'created response status'],
+  ['fn map_storefront_order_command_port_error(', 'bounded command mapper'],
+]) requireText(controller, value, label);
+
+for (const value of [
+  'OrderService::new(',
+  'error::OrderError',
+  'map_storefront_order_error(',
+  '.create_return(tenant.id, id, input)',
+]) forbidText(controller, value, 'mounted storefront Order return command must not construct concrete Order service');
+
+const accessIndex = controller.indexOf('let customer_id = ensure_customer_owns_order(');
+const commandIndex = controller.indexOf('.order_post_order_command_port()');
+if (accessIndex < 0 || commandIndex < 0 || accessIndex > commandIndex) {
+  failures.push('storefront return ownership admission must happen before the owner command call');
+}
+
+const commandMapper = between(
+  controller,
+  'fn map_storefront_order_command_port_error(',
+  'fn storefront_order_payment_error_policy(',
+  'storefront Order command mapper',
+);
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'validation mapping'],
+  ['PortErrorKind::NotFound', 'not-found mapping'],
+  ['PortErrorKind::Conflict', 'conflict mapping'],
+  ['PortErrorKind::Forbidden', 'forbidden mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'unavailable mapping'],
+  ['PortErrorKind::InvariantViolation', 'invariant mapping'],
+  ['"commerce_store_order_invalid"', 'validation public code'],
+  ['"commerce_store_order_not_found"', 'not-found public code'],
+  ['"commerce_store_order_state_conflict"', 'conflict public code'],
+  ['"commerce_store_order_access_denied"', 'forbidden public code'],
+  ['"commerce_store_order_unavailable"', 'unavailable public code'],
+  ['"commerce_store_order_failed"', 'fail-closed public code'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
+  ['retryable = error.retryable', 'retryability diagnostic'],
+]) requireText(commandMapper, value, label);
+for (const value of [
+  'error = ?error',
+  'error.message',
+  'error.to_string()',
+  'internal_message',
+]) forbidText(commandMapper, value, 'storefront Order command diagnostics must stay bounded');
+
+for (const [value, label] of [
+  ['fn order_post_order_command_port(', 'HTTP runtime accessor'],
+  ['std::sync::Arc<dyn rustok_order::OrderPostOrderCommandPort>', 'HTTP command trait object'],
+  ['self.order_post_order_command_runtime.command_port()', 'HTTP selected owner runtime'],
+  ['shared_get::<rustok_order::OrderPostOrderCommandRuntime>()', 'HTTP host runtime requirement'],
+]) requireText(httpRuntime, value, label);
+
+for (const [value, label] of [
+  ['pub trait OrderPostOrderCommandPort: Send + Sync', 'Order owner command trait'],
+  ['async fn create_return(', 'Order owner return capability'],
+  ['request: CreateOrderReturnRequest', 'Order owner request type'],
+  ['context.require_policy(PortCallPolicy::write())', 'owner write policy'],
+  ['inner: OrderService', 'concrete Order service retained inside owner'],
+  ['.create_return(tenant_id, request.order_id, request.input)', 'owner-local execution'],
+]) requireText(owner, value, label);
+
+requireText(
+  controller,
+  'let payment_service = PaymentService::new(runtime.db_clone());',
+  'separate mounted Payment refund-list gap remains explicit',
+);
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology P0 remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST storefront order-return command owner-port cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['OrderPostOrderCommandPort::create_return', 'record owner operation'],
+  ['write-admission metadata only', 'record replay limitation'],
+  ['`GET /store/orders/{id}/refunds` still constructs `PaymentService` directly', 'record remaining Payment gap'],
+  ['no tests, Cargo commands, Node verifiers, formatter', 'record no validation execution'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST storefront order-return owner command cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted storefront order-return creation uses the host-selected Order owner command port');

--- a/scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
@@ -11,8 +11,8 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
-const orderErrors = read('crates/rustok-order/src/error.rs');
 const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const orderCommand = read('crates/rustok-order/src/post_order_command.rs');
 const webErrors = read('crates/rustok-web/src/lib.rs');
 const failures = [];
 
@@ -22,54 +22,50 @@ const requireText = (content, value, label) => {
 const forbidText = (content, value, label) => {
   if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
 };
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
 
 for (const [value, label] of [
-  ['use rustok_api::{PortError, RequestContext, TenantContext};', 'typed customer port error import'],
-  ['use rustok_order::{OrderService, error::OrderError};', 'typed order error import'],
-  ['use rustok_payment::{PaymentService, error::PaymentError};', 'typed payment error import'],
-  ['port_error_to_http_error', 'safe port HTTP mapper'],
+  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext', 'typed Order/customer port context imports'],
+  ['CreateOrderReturnRequest', 'typed Order return command request'],
+  ['use rustok_payment::{PaymentService, error::PaymentError};', 'typed Payment error import'],
+  ['port_error_to_http_error', 'safe shared port HTTP mapper'],
   ['fn map_storefront_customer_port_error(', 'customer port mapper'],
-  ['fn map_storefront_order_error(', 'order mapper'],
-  ['fn map_storefront_payment_error(', 'payment mapper'],
+  ['fn map_storefront_order_port_error(', 'Order read port mapper'],
+  ['fn map_storefront_order_command_port_error(', 'Order command port mapper'],
+  ['fn map_storefront_payment_error(', 'Payment mapper'],
   ['async fn current_storefront_customer_id(', 'safe customer lookup'],
   ['async fn ensure_customer_owns_order(', 'safe ownership helper'],
-  ['boundary = "commerce_storefront_order_http"', 'structured boundary name'],
-  ['operation,', 'operation logging'],
-  ['tenant_id = %tenant_id', 'tenant logging'],
-  ['order_id = %order_id', 'order logging'],
-  ['public_code = code', 'public code logging'],
-  ['status = %status', 'HTTP status logging'],
-]) {
-  requireText(controller, value, label);
-}
+  ['boundary = "commerce_storefront_order_http"', 'structured storefront boundary'],
+]) requireText(controller, value, label);
 
 for (const [value, label] of [
-  ['OrderError::Validation(_)', 'order validation mapping'],
-  ['OrderError::OrderNotFound(_)', 'order not-found mapping'],
-  ['OrderError::OrderReturnNotFound(_)', 'return not-found mapping'],
-  ['OrderError::OrderChangeNotFound(_)', 'change not-found mapping'],
-  ['OrderError::InvalidTransition { .. }', 'order transition mapping'],
-  ['OrderError::Database(_)', 'order database mapping'],
-  ['OrderError::Core(_)', 'order core mapping'],
-  ['StatusCode::BAD_REQUEST', 'bad request status'],
-  ['StatusCode::NOT_FOUND', 'not found status'],
-  ['StatusCode::CONFLICT', 'conflict status'],
-  ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
-  ['StatusCode::INTERNAL_SERVER_ERROR', 'internal status'],
-  ['"commerce_store_order_invalid"', 'order invalid code'],
-  ['"commerce_store_order_not_found"', 'order not-found code'],
-  ['"commerce_store_order_state_conflict"', 'order state code'],
-  ['"commerce_store_order_unavailable"', 'order unavailable code'],
-  ['"commerce_store_order_failed"', 'order fail-closed code'],
-]) {
-  requireText(controller, value, label);
-}
+  ['PortErrorKind::Validation', 'Order validation mapping'],
+  ['PortErrorKind::NotFound', 'Order not-found mapping'],
+  ['PortErrorKind::Conflict', 'Order conflict mapping'],
+  ['PortErrorKind::Forbidden', 'Order forbidden mapping'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'Order unavailable mapping'],
+  ['PortErrorKind::InvariantViolation', 'Order invariant mapping'],
+  ['"commerce_store_order_invalid"', 'Order invalid public code'],
+  ['"commerce_store_order_not_found"', 'Order not-found public code'],
+  ['"commerce_store_order_state_conflict"', 'Order state public code'],
+  ['"commerce_store_order_access_denied"', 'Order access public code'],
+  ['"commerce_store_order_unavailable"', 'Order unavailable public code'],
+  ['"commerce_store_order_failed"', 'Order fail-closed public code'],
+]) requireText(controller, value, label);
 
 for (const [value, label] of [
   ['PaymentError::Validation(_)', 'payment validation mapping'],
-  ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found mapping'],
-  ['PaymentError::PaymentNotFound(_)', 'payment not-found mapping'],
-  ['PaymentError::RefundNotFound(_)', 'refund not-found mapping'],
+  ['PaymentError::PaymentCollectionNotFound(payment_collection_id)', 'collection not-found mapping'],
+  ['PaymentError::PaymentNotFound(payment_collection_id)', 'payment not-found mapping'],
+  ['PaymentError::RefundNotFound(refund_id)', 'refund not-found mapping'],
   ['PaymentError::InvalidTransition { .. }', 'payment transition mapping'],
   ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable mapping'],
   ['PaymentError::ProviderRejected { .. }', 'provider rejected mapping'],
@@ -86,18 +82,9 @@ for (const [value, label] of [
   ['"commerce_store_payment_reconciliation_required"', 'payment reconciliation code'],
   ['"commerce_store_payment_provider_not_configured"', 'payment configuration code'],
   ['"commerce_store_payment_unavailable"', 'payment unavailable code'],
-]) {
-  requireText(controller, value, label);
-}
+]) requireText(controller, value, label);
 
 for (const [ownerSource, value, label] of [
-  [orderErrors, 'Validation(String)', 'owner order validation variant'],
-  [orderErrors, 'OrderNotFound(Uuid)', 'owner order-not-found variant'],
-  [orderErrors, 'OrderReturnNotFound(Uuid)', 'owner return-not-found variant'],
-  [orderErrors, 'OrderChangeNotFound(Uuid)', 'owner change-not-found variant'],
-  [orderErrors, 'InvalidTransition { from: String, to: String }', 'owner order transition variant'],
-  [orderErrors, 'Database(#[from] DbErr)', 'owner order database variant'],
-  [orderErrors, 'Core(#[from] rustok_core::Error)', 'owner order core variant'],
   [paymentErrors, 'Validation(String)', 'owner payment validation variant'],
   [paymentErrors, 'PaymentCollectionNotFound(Uuid)', 'owner collection variant'],
   [paymentErrors, 'PaymentNotFound(Uuid)', 'owner payment variant'],
@@ -108,9 +95,9 @@ for (const [ownerSource, value, label] of [
   [paymentErrors, 'ProviderOutcomeUnknown {', 'owner unknown outcome variant'],
   [paymentErrors, 'ProviderConfiguration { provider_id: String }', 'owner provider configuration variant'],
   [paymentErrors, 'Database(#[from] DbErr)', 'owner payment database variant'],
-]) {
-  requireText(ownerSource, value, label);
-}
+  [orderCommand, 'async fn create_return(', 'owner Order return command'],
+  [orderCommand, 'context.require_policy(PortCallPolicy::write())', 'owner Order write admission'],
+]) requireText(ownerSource, value, label);
 
 for (const [value, label] of [
   ['pub async fn get_me(', 'customer resolver'],
@@ -119,17 +106,15 @@ for (const [value, label] of [
   ['pub async fn list_order_returns(', 'list returns resolver'],
   ['pub async fn list_order_refunds(', 'list refunds resolver'],
   ['pub async fn list_order_changes(', 'list changes resolver'],
-  ['get_order_with_locale_fallback(', 'localized order read'],
-  ['create_return(tenant.id, id, input)', 'return creation call'],
-  ['ListOrderReturnsInput {', 'return pagination input'],
-  ['ListRefundsInput {', 'refund pagination input'],
-  ['ListOrderChangesInput {', 'change pagination input'],
+  ['.read_order_projection(', 'localized Order owner read'],
+  ['.order_post_order_command_port()', 'host-selected Order return command'],
+  ['CreateOrderReturnRequest {', 'typed return request'],
+  ['let payment_service = PaymentService::new(runtime.db_clone());', 'remaining Payment refund-list service'],
   ['page: params.pagination.page', 'page forwarding'],
   ['per_page: params.pagination.per_page', 'per-page forwarding'],
-  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), total)', 'pagination metadata'],
-]) {
-  requireText(controller, value, label);
-}
+  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total)', 'Order pagination metadata'],
+  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), total)', 'Payment pagination metadata'],
+]) requireText(controller, value, label);
 
 for (const operation of [
   '"get_me"',
@@ -142,32 +127,35 @@ for (const operation of [
   '"list_order_refunds"',
   '"list_order_changes_access"',
   '"list_order_changes"',
-]) {
-  requireText(controller, operation, 'diagnostic operation label');
-}
+]) requireText(controller, operation, 'diagnostic operation label');
 
 for (const value of [
+  'OrderService::new(',
+  'error::OrderError',
+  'map_storefront_order_error(',
+  '.create_return(tenant.id, id, input)',
   'err.to_string()',
   'error.to_string()',
-  'error.message',
   'HttpError::bad_request("commerce_operation_failed"',
   'super::current_customer_id_for_db',
   'super::ensure_customer_owns_order_for_db',
-]) {
-  forbidText(controller, value, 'unsafe storefront order public conversion');
-}
+]) forbidText(controller, value, 'stale or unsafe storefront Order path');
 
-const orderMapperUses = controller.match(/map_storefront_order_error\(/g) ?? [];
-if (orderMapperUses.length !== 6) {
-  failures.push(`expected order mapper definition plus five uses, found ${orderMapperUses.length}`);
-}
-const paymentMapperUses = controller.match(/map_storefront_payment_error\(/g) ?? [];
-if (paymentMapperUses.length !== 2) {
-  failures.push(`expected payment mapper definition plus one use, found ${paymentMapperUses.length}`);
-}
-const customerMapperUses = controller.match(/map_storefront_customer_port_error\(/g) ?? [];
-if (customerMapperUses.length !== 3) {
-  failures.push(`expected customer mapper definition plus two uses, found ${customerMapperUses.length}`);
+const commandMapper = between(
+  controller,
+  'fn map_storefront_order_command_port_error(',
+  'fn storefront_order_payment_error_policy(',
+  'Order return command mapper',
+);
+for (const [value, label] of [
+  ['owner_error_kind = ?error.kind', 'bounded owner kind'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code'],
+  ['retryable = error.retryable', 'bounded retryability'],
+  ['public_code = code', 'public code'],
+  ['status = %status', 'public status'],
+]) requireText(commandMapper, value, label);
+for (const value of ['error = ?error', 'error.message', 'internal_message', 'error.to_string()']) {
+  forbidText(commandMapper, value, 'Order command mapper raw diagnostic');
 }
 
 for (const value of [
@@ -176,9 +164,7 @@ for (const value of [
   'PortErrorKind::InvariantViolation => StatusCode::INTERNAL_SERVER_ERROR',
   '"The requested service is temporarily unavailable"',
   '"The requested operation could not be completed"',
-]) {
-  requireText(webErrors, value, 'shared port HTTP safety contract');
-}
+]) requireText(webErrors, value, 'shared port HTTP safety contract');
 
 if (failures.length > 0) {
   console.error('Commerce storefront order HTTP error-safety verification failed:');
@@ -187,5 +173,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce storefront order and refund HTTP errors use stable typed public envelopes',
+  '✔ Commerce storefront Order owner reads/return command and Payment refund HTTP errors use stable public envelopes',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with mounted storefront order-return creation.

- cut `POST /store/orders/{id}/returns` from direct `OrderService` construction to the host-selected `OrderPostOrderCommandPort::create_return` capability;
- preserve the existing storefront channel gate, authenticated-customer requirement, host-selected Order read ownership check, request DTO, `201 Created` response, and legacy public Order error families;
- construct a write `PortContext` from admitted tenant, authenticated user actor, request locale/channel, an order-bound correlation id, a two-second deadline, and a fresh UUID admission idempotency identity;
- keep that UUID explicitly as write-admission metadata only; no durable owner receipt/exactly-once claim is introduced;
- remove concrete `OrderService` / `OrderError` usage from the mounted storefront order controller;
- keep the mounted `PaymentService` refund-list construction unchanged and explicitly recorded as the next separate Payment topology gap;
- add a dedicated source guard and align the existing storefront Order HTTP error-safety guard with the current owner-read/owner-command topology;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind `2dcffcd7c20c9deee58e6912d7b18ea761e149c5` with exactly four changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source guards were added/updated but not run.