### PR TITLE
feat(forum): admit attachment relations

### DIFF
--- a/crates/rustok-forum/src/attachment_relation.rs
+++ b/crates/rustok-forum/src/attachment_relation.rs
@@ -1,0 +1,208 @@
+use std::collections::BTreeSet;
+
+use rustok_api::normalize_locale_tag;
+use serde::Serialize;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::mentions::ForumContentTarget;
+
+pub const MAX_FORUM_ATTACHMENTS_PER_REVISION: usize = 32;
+pub const MAX_FORUM_ATTACHMENT_CAPTION_BYTES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForumAttachmentUsage {
+    Inline,
+    Attachment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ForumAttachmentRelationInput {
+    pub media_id: Uuid,
+    pub usage: ForumAttachmentUsage,
+    pub position: u16,
+    pub caption: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ForumAttachmentRelationAdmissionRequest {
+    pub tenant_id: Uuid,
+    pub target: ForumContentTarget,
+    /// Logical Forum owner content revision. Initial content is revision 1;
+    /// captured topic/reply revisions advance this value monotonically.
+    pub source_revision: u64,
+    pub locale: String,
+    pub attachments: Vec<ForumAttachmentRelationInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct ForumAttachmentSourceRevision {
+    tenant_id: Uuid,
+    target: ForumContentTarget,
+    source_revision: u64,
+    locale: String,
+}
+
+impl ForumAttachmentSourceRevision {
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
+
+    pub fn target(&self) -> ForumContentTarget {
+        self.target
+    }
+
+    pub fn source_revision(&self) -> u64 {
+        self.source_revision
+    }
+
+    pub fn locale(&self) -> &str {
+        &self.locale
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ForumPreparedAttachmentRelation {
+    pub media_id: Uuid,
+    pub usage: ForumAttachmentUsage,
+    pub position: u16,
+    pub caption: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ForumPreparedAttachmentRelationBatch {
+    source: ForumAttachmentSourceRevision,
+    attachments: Vec<ForumPreparedAttachmentRelation>,
+}
+
+impl ForumPreparedAttachmentRelationBatch {
+    pub fn source(&self) -> &ForumAttachmentSourceRevision {
+        &self.source
+    }
+
+    pub fn attachments(&self) -> &[ForumPreparedAttachmentRelation] {
+        &self.attachments
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.attachments.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum ForumAttachmentRelationAdmissionError {
+    #[error("Forum attachment relation requires a non-nil tenant ID")]
+    NilTenant,
+    #[error("Forum attachment relation requires a non-nil topic/reply target ID")]
+    NilTarget,
+    #[error("Forum attachment relation requires a positive source revision")]
+    InvalidSourceRevision,
+    #[error("Forum attachment relation requires a valid locale")]
+    InvalidLocale,
+    #[error("Forum attachment relation batch exceeds {max} records: {actual}")]
+    BatchTooLarge { max: usize, actual: usize },
+    #[error("Forum attachment relation contains a nil Media asset ID at position {position}")]
+    NilMediaId { position: u16 },
+    #[error("Forum attachment relation repeats position {position}")]
+    DuplicatePosition { position: u16 },
+    #[error("Forum attachment relation positions must be contiguous from zero")]
+    NonContiguousPositions,
+    #[error("Forum attachment caption exceeds {max} UTF-8 bytes at position {position}")]
+    CaptionTooLong { position: u16, max: usize },
+    #[error("Forum attachment caption contains a control character at position {position}")]
+    CaptionContainsControl { position: u16 },
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForumAttachmentRelationPreparer;
+
+impl ForumAttachmentRelationPreparer {
+    pub fn prepare(
+        &self,
+        request: ForumAttachmentRelationAdmissionRequest,
+    ) -> Result<ForumPreparedAttachmentRelationBatch, ForumAttachmentRelationAdmissionError> {
+        if request.tenant_id.is_nil() {
+            return Err(ForumAttachmentRelationAdmissionError::NilTenant);
+        }
+        if request.target.id().is_nil() {
+            return Err(ForumAttachmentRelationAdmissionError::NilTarget);
+        }
+        if request.source_revision == 0 {
+            return Err(ForumAttachmentRelationAdmissionError::InvalidSourceRevision);
+        }
+        let locale = normalize_locale_tag(&request.locale)
+            .ok_or(ForumAttachmentRelationAdmissionError::InvalidLocale)?;
+        if request.attachments.len() > MAX_FORUM_ATTACHMENTS_PER_REVISION {
+            return Err(ForumAttachmentRelationAdmissionError::BatchTooLarge {
+                max: MAX_FORUM_ATTACHMENTS_PER_REVISION,
+                actual: request.attachments.len(),
+            });
+        }
+
+        let mut positions = BTreeSet::new();
+        let mut attachments = Vec::with_capacity(request.attachments.len());
+        for relation in request.attachments {
+            if relation.media_id.is_nil() {
+                return Err(ForumAttachmentRelationAdmissionError::NilMediaId {
+                    position: relation.position,
+                });
+            }
+            if !positions.insert(relation.position) {
+                return Err(ForumAttachmentRelationAdmissionError::DuplicatePosition {
+                    position: relation.position,
+                });
+            }
+            let caption = normalize_caption(relation.caption, relation.position)?;
+            attachments.push(ForumPreparedAttachmentRelation {
+                media_id: relation.media_id,
+                usage: relation.usage,
+                position: relation.position,
+                caption,
+            });
+        }
+
+        if positions
+            .iter()
+            .copied()
+            .map(usize::from)
+            .ne(0..attachments.len())
+        {
+            return Err(ForumAttachmentRelationAdmissionError::NonContiguousPositions);
+        }
+
+        attachments.sort_by_key(|relation| relation.position);
+        Ok(ForumPreparedAttachmentRelationBatch {
+            source: ForumAttachmentSourceRevision {
+                tenant_id: request.tenant_id,
+                target: request.target,
+                source_revision: request.source_revision,
+                locale,
+            },
+            attachments,
+        })
+    }
+}
+
+fn normalize_caption(
+    caption: Option<String>,
+    position: u16,
+) -> Result<Option<String>, ForumAttachmentRelationAdmissionError> {
+    let Some(caption) = caption else {
+        return Ok(None);
+    };
+    let caption = caption.trim().to_string();
+    if caption.is_empty() {
+        return Ok(None);
+    }
+    if caption.len() > MAX_FORUM_ATTACHMENT_CAPTION_BYTES {
+        return Err(ForumAttachmentRelationAdmissionError::CaptionTooLong {
+            position,
+            max: MAX_FORUM_ATTACHMENT_CAPTION_BYTES,
+        });
+    }
+    if caption.chars().any(char::is_control) {
+        return Err(ForumAttachmentRelationAdmissionError::CaptionContainsControl { position });
+    }
+    Ok(Some(caption))
+}

--- a/crates/rustok-forum/src/lib.rs
+++ b/crates/rustok-forum/src/lib.rs
@@ -8,6 +8,7 @@ use rustok_reactions_api::register_reaction_subject_provider_factory;
 use rustok_seo_targets::register_seo_target_provider;
 use sea_orm_migration::MigrationTrait;
 
+pub mod attachment_relation;
 pub mod audience;
 pub mod category_presentation;
 pub mod category_read_transport;
@@ -50,6 +51,7 @@ mod topic_create_transport;
 pub mod topic_read_transport;
 pub mod visibility;
 
+pub use attachment_relation::*;
 pub use audience::{
     FORUM_AUDIENCE_FACTS_CAPABILITY, FORUM_AUDIENCE_FACTS_CAPABILITY_UNAVAILABLE,
     ForumAudienceConstraints, ForumAudienceDecision, ForumAudienceDecisionReason,

--- a/docs/modules/forum-14-attachment-relation-admission-actualization-2026-08-10.md
+++ b/docs/modules/forum-14-attachment-relation-admission-actualization-2026-08-10.md
@@ -1,0 +1,127 @@
+# FORUM-14A attachment relation admission actualization — 2026-08-10
+
+Status: `source-ready / admission-only / persistence-blocked-on-media-lifecycle / maintainer-execution-open`
+
+## Fresh cursor
+
+This slice was rechecked from `main@2dcffcd7c20c9deee58e6912d7b18ea761e149c5` after FORUM-34Q, Pages #3426 and Commerce #3428.
+
+The FORUM-34 bounded mapping/application chain is source-ready through deleted-reply owner persistence, but a genuinely shared owner-data migration runner still does not exist. `rustok-modules` now has durable artifact-data upgrade/checkpoint primitives, but those contracts are explicitly tied to artifact installation identity (`target_installation_id`, `ModuleInstallationScope`, installation revision CAS) and are not a neutral Forum owner-data migration runner.
+
+FORUM-33 source work is already materially ahead of the stale canonical summary: subscription and mention reconciliation, Search/Notifications shared-owner diagnostics, unread/activity observations and the bounded locale baseline already exist. FORUM-33K correctly stops further blanket locale instrumentation. Its remaining attachment cursor is blocked because FORUM-14 has no persisted Forum-owned attachment authority yet.
+
+The canonical Forum implementation-plan ledger still lists FORUM-14 as `planned` and parts of FORUM-33/FORUM-34 behind the merged source cursor. This dated packet records the truthful slice without replacing the large canonical file wholesale through the contents API.
+
+## Ownership boundary
+
+Media remains authoritative for:
+
+- upload sessions and binary bytes;
+- blob/storage identity and drivers;
+- MIME/dimensions/renditions;
+- quarantine and deletion lifecycle;
+- public delivery/proxy decisions;
+- Media-owned reconciliation.
+
+Forum may own only the relation between one Forum content revision and a Media asset together with Forum usage/order/caption semantics.
+
+FORUM-14A therefore adds no upload command, storage key, URL, blob metadata, Media deletion marker, quarantine copy or Media reconciliation logic.
+
+## Public admission contract
+
+The crate now exposes `attachment_relation` and re-exports its public DTOs.
+
+The source-ready entrypoint is:
+
+```rust
+ForumAttachmentRelationPreparer::prepare(
+    ForumAttachmentRelationAdmissionRequest {
+        tenant_id,
+        target,
+        source_revision,
+        locale,
+        attachments,
+    },
+)
+```
+
+`target` reuses the existing typed `ForumContentTarget`, so only Forum Topic or Reply identities can be supplied.
+
+`source_revision` is the logical Forum content revision used by existing current-revision owner contracts: initial content is revision `1`, and captured topic/reply history advances the logical revision monotonically. It is deliberately not a Media revision and not a relation-row database identity.
+
+A future persistence boundary must independently fence this admitted revision against the current Forum owner revision before committing relations. FORUM-14A performs no database read and makes no claim that a supplied historical revision is currently writable.
+
+## Relation facts
+
+Each admitted relation contains only:
+
+```text
+media_id
+usage = inline | attachment
+position
+caption
+```
+
+The batch is bounded to 32 relations per Forum content revision.
+
+Rules:
+
+- tenant and target UUIDs must be non-nil;
+- source revision must be positive;
+- locale is normalized through the existing Forum/platform locale contract;
+- every Media UUID must be non-nil;
+- positions are unique and contiguous from zero;
+- repeated use of the same Media asset at different positions is allowed;
+- captions are trimmed, empty captions become absent, and retained captions are single-line/control-free UTF-8 up to 512 bytes;
+- input order is not authoritative: the prepared result is sorted by admitted position;
+- an empty relation set is valid and means that content revision carries no admitted attachments.
+
+The preparer creates no UUIDs and performs no external call.
+
+## Why persistence remains blocked
+
+Fresh Media public-port recheck found `MediaAssetReadPort` exposes asset metadata, listing, image descriptors and translations, while `MediaAssetWritePort` owns upload completion/deletion/reconciliation.
+
+The current `MediaItem` read DTO still does not publish the quarantine/deletion lifecycle facts needed for Forum to prove that a relation is safe to persist. The existing Forum category-cover code already documents the same boundary: persistent Media references remain disabled until those owner states are published.
+
+FORUM-14A therefore does **not** call Media merely to check that an asset ID currently resolves. Existence alone is weaker than the lifecycle contract required by the ownership plan and would turn a partial Media DTO into invented attachment admission semantics.
+
+A later FORUM-14 persistence slice must first consume a public Media owner contract that can establish the required lifecycle state, then fence tenant/asset identity and the exact Forum source revision before writing Forum-owned relation rows.
+
+## FORUM-33 impact
+
+This slice establishes the stable in-process relation shape but does not yet unblock attachment reconciliation because there is still no persisted Forum attachment authority to scan.
+
+After actual relation persistence lands, FORUM-33 may add a bounded read-only diagnostic over Forum-owned attachment rows and source revisions. It must not reconcile Media-private asset state by direct table access.
+
+## Deliberately unchanged
+
+FORUM-14A adds no:
+
+- table, entity or migration;
+- owner write service;
+- GraphQL/HTTP/admin/storefront transport;
+- Media dependency or lifecycle copy;
+- upload/session/delete/reconcile command;
+- event/outbox receipt;
+- attachment repair worker;
+- lockfile/dependency change;
+- runtime evidence claim.
+
+Text-only Forum remains independent of Media composition.
+
+## Next cursor
+
+Recheck Media for a public bounded asset-lifecycle admission fact covering at least tenant identity plus deletion/quarantine eligibility. If that fact appears, the next safe slice is FORUM-14B: owner persistence fenced by exact Forum content revision and Media lifecycle admission.
+
+If Media still lacks that fact, do not create attachment persistence from `get_asset` existence alone. Continue another independently authorized Forum plan slice instead.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-attachment-relation-admission-source.mjs
+```

--- a/scripts/verify/verify-forum-attachment-relation-admission-source.mjs
+++ b/scripts/verify/verify-forum-attachment-relation-admission-source.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const contract = read("crates/rustok-forum/src/attachment_relation.rs");
+const lib = read("crates/rustok-forum/src/lib.rs");
+const mediaPorts = read("crates/rustok-media/src/ports.rs");
+const mediaDto = read("crates/rustok-media/src/dto.rs");
+const categoryPresentation = read("crates/rustok-forum/src/category_presentation.rs");
+const packet = read(
+  "docs/modules/forum-14-attachment-relation-admission-actualization-2026-08-10.md",
+);
+
+for (const marker of [
+  "pub mod attachment_relation;",
+  "pub use attachment_relation::*;",
+]) need(lib, marker, "FORUM-14A crate wiring");
+
+for (const marker of [
+  "pub const MAX_FORUM_ATTACHMENTS_PER_REVISION: usize = 32;",
+  "pub const MAX_FORUM_ATTACHMENT_CAPTION_BYTES: usize = 512;",
+  "pub enum ForumAttachmentUsage",
+  "Inline",
+  "Attachment",
+  "pub struct ForumAttachmentRelationAdmissionRequest",
+  "pub tenant_id: Uuid",
+  "pub target: ForumContentTarget",
+  "pub source_revision: u64",
+  "pub locale: String",
+  "pub struct ForumAttachmentSourceRevision",
+  "pub struct ForumPreparedAttachmentRelation",
+  "pub struct ForumPreparedAttachmentRelationBatch",
+  "pub struct ForumAttachmentRelationPreparer",
+  "request.target.id().is_nil()",
+  "request.source_revision == 0",
+  "normalize_locale_tag(&request.locale)",
+  "request.attachments.len() > MAX_FORUM_ATTACHMENTS_PER_REVISION",
+  "relation.media_id.is_nil()",
+  "DuplicatePosition",
+  "NonContiguousPositions",
+  "attachments.sort_by_key(|relation| relation.position)",
+  "caption.trim().to_string()",
+  "caption.chars().any(char::is_control)",
+]) need(contract, marker, "FORUM-14A attachment admission contract");
+
+for (const marker of [
+  "DuplicateMediaId",
+  "MediaAssetReadPort",
+  "MediaAssetWritePort",
+  "DatabaseConnection",
+  "DatabaseTransaction",
+  "sea_orm",
+  "TransactionalEventBus",
+  "Uuid::new_v4",
+  "storage_path",
+  "public_url",
+]) forbid(contract, marker, "FORUM-14A admission-only boundary");
+
+for (const marker of [
+  "async fn get_asset",
+  "async fn list_assets",
+  "async fn get_image_descriptor",
+  "async fn get_translations",
+]) need(mediaPorts, marker, "Media public read baseline");
+for (const marker of [
+  "pub struct MediaItem",
+  "pub tenant_id: Uuid",
+  "pub metadata: serde_json::Value",
+]) need(mediaDto, marker, "Media item baseline");
+
+need(
+  categoryPresentation,
+  "Persistence remains disabled until Media publishes",
+  "Forum category-cover Media lifecycle baseline",
+);
+need(
+  categoryPresentation,
+  "quarantine and deletion lifecycle state",
+  "Forum category-cover Media lifecycle baseline",
+);
+
+for (const marker of [
+  "FORUM-14A",
+  "admission-only",
+  "repeated use of the same Media asset",
+  "does **not** call Media",
+  "does not yet unblock attachment reconciliation",
+  "FORUM-14B",
+  "no Cargo command, test, Node verifier",
+]) need(packet, marker, "FORUM-14A actualization");
+
+console.log("Forum FORUM-14A attachment relation admission source: ok");


### PR DESCRIPTION
## Summary

Start FORUM-14 with a bounded, side-effect-free Forum-owned attachment relation admission contract without taking Media lifecycle ownership.

- add public `attachment_relation` DTOs/preparer for Topic/Reply content targets;
- bind each batch to non-nil tenant, typed Forum target, positive logical Forum content revision and normalized locale;
- admit at most 32 relations per content revision;
- store only Media asset UUID, Forum usage (`inline` / `attachment`), contiguous position and bounded normalized caption;
- allow the same Media asset at multiple positions instead of inventing a per-revision asset uniqueness rule;
- reject nil Media IDs, duplicate/non-contiguous positions, invalid locale/revision and control-bearing/oversized captions;
- normalize output ordering by position and allow an empty batch to represent a content revision with no attachments;
- expose the contract from the crate root;
- add a dated FORUM-14A actualization and a source guard, intentionally not executed.

## Ownership / persistence boundary

This PR performs no DB, Media-port, transaction, event, UUID-generation or persistence work.

Fresh Media owner recheck confirms `MediaAssetReadPort` still exposes asset metadata/list/image-descriptor/translation reads but not the quarantine/deletion lifecycle facts required by the canonical FORUM-13/FORUM-14 ownership boundary. `MediaItem` likewise has no public quarantine/deleted state. Existing Forum category-cover source already states that persistent Media references remain disabled until those owner states are published.

Therefore FORUM-14A deliberately does not treat `get_asset` existence as sufficient persistence admission. A later FORUM-14B must first consume a public Media lifecycle admission fact, then fence tenant/asset identity plus the exact Forum source revision before writing Forum-owned relation rows.

## Cursor recheck

FORUM-34 remains blocked on a genuinely shared owner-data migration runner: current `rustok-modules` checkpoint/apply machinery is artifact-installation-specific (`target_installation_id`, installation scope/revision) rather than neutral owner-data execution.

FORUM-33 is already source-ready beyond the stale canonical summary through subscription/mention reconciliation, Search/Notifications diagnostics and the bounded locale/activity metric baseline. FORUM-33K correctly stops locale expansion; its attachment reconciliation cursor remains blocked until FORUM-14 has persisted Forum-owned relation/source-revision authority.

The branch started from `main@2dcffcd7c20c9deee58e6912d7b18ea761e149c5`; `main` then advanced with one Commerce-only commit to `4db16caa4d704db3cd42394dbd80b914fea8f573`. No Forum/Media overlap was present, so the same reviewed blobs were replayed onto that commit and compared `behind 0` before opening this PR.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, migration, database scenario, GraphQL/HTTP scenario, workflow, CI, lock generation or `git diff --check` was run. `scripts/verify/verify-forum-attachment-relation-admission-source.mjs` was added but intentionally not executed.