### PR TITLE
fix(forum): fail closed on profile fallback

### DIFF
--- a/crates/rustok-forum/src/graphql/query_runtime.rs
+++ b/crates/rustok-forum/src/graphql/query_runtime.rs
@@ -9,7 +9,7 @@ use rustok_channel::ChannelService;
 use rustok_core::SecurityContext;
 use rustok_outbox::TransactionalEventBus;
 use rustok_profiles::{
-    ProfileService, ProfileSummaryLoader, ProfileSummaryLoaderKey, ProfilesReader,
+    ProfilePresentationService, ProfileSummaryLoader, ProfileSummaryLoaderKey,
     graphql::GqlProfileSummary,
 };
 use rustok_telemetry::metrics;
@@ -971,7 +971,7 @@ where
             .collect());
     }
 
-    let profiles = ProfileService::new(db.clone())
+    let profiles = ProfilePresentationService::new(db.clone())
         .find_profile_summaries(
             tenant_id,
             &user_ids,

--- a/docs/modules/forum-15-profile-presentation-fallback-actualization-2026-08-10.md
+++ b/docs/modules/forum-15-profile-presentation-fallback-actualization-2026-08-10.md
@@ -1,0 +1,84 @@
+# FORUM-15A profile presentation fallback actualization — 2026-08-10
+
+Status: `source-ready / fallback-fail-closed / stats-enrichment-open / maintainer-execution-open`
+
+## Fresh cursor
+
+This slice started from `main@535c6d4a3aca4412c27c69453e08c6942c281ac9` after FORUM-14A and the later Pages/Commerce main movement.
+
+FORUM-14 attachment persistence remains blocked. Media owns authoritative asset lifecycle state, but the current public Media presentation/read contract still does not publish the lifecycle eligibility required by the Forum ownership plan, and the current Media lifecycle enum has no quarantine state to consume. This slice therefore does not weaken FORUM-14A by treating `get_asset` existence as attachment persistence admission.
+
+The next independently actionable Forum cursor is FORUM-15. The canonical ledger remains `in_progress`: Profiles already owns presentation/privacy behavior, while Forum still needs complete member-card composition, Forum-stat enrichment and retained no-N+1 evidence.
+
+## Existing Profiles owner boundary rechecked
+
+`ProfilePresentationService` is the downstream presentation owner. Its bounded summary path:
+
+1. evaluates the canonical profile privacy/block matrix with `ProfilePrivacyService::evaluate_access_batch`;
+2. keeps only `ProfilePrivacyDecision::Allow` identities;
+3. loads localized summaries only for the allowed identities;
+4. maps privacy-owner failures to `PresentationUnavailable` instead of returning raw profile data.
+
+`ProfileSummaryLoader` is likewise presentation-aware. It groups requests by tenant and locale context and delegates each group to `ProfilePresentationService::for_audience`.
+
+The server request extension binds that loader to the actual request audience:
+
+- anonymous request -> `ProfileAccessAudience::Anonymous`;
+- human request -> `ProfileAccessAudience::Authenticated { actor_id }`;
+- service principal -> `ProfileAccessAudience::TrustedService { actor_id: None }`.
+
+Forum must consume these public presentation contracts and must not reproduce Profiles/Social Graph private-table policy.
+
+## Forum GraphQL gap
+
+Forum topic/reply GraphQL already avoids the ordinary profile N+1 pattern. `load_author_profiles_map` deduplicates author UUIDs and prefers the request-scoped `DataLoader<ProfileSummaryLoader>` for one batched owner presentation read.
+
+The unsafe edge was the fallback used when a host did not install that request-scoped loader. It constructed raw `ProfileService` and called the `ProfilesReader` summary method directly. Raw `ProfileService` is an owner-internal reader and does not carry the request audience presentation policy, so an alternative host/test composition could expose a profile summary that the presentation owner would have hidden.
+
+## Fail-closed fallback
+
+FORUM-15A keeps the request-scoped loader as the preferred path and changes only the missing-loader fallback to:
+
+```rust
+ProfilePresentationService::new(db.clone())
+    .find_profile_summaries(...)
+```
+
+`ProfilePresentationService::new` is intentionally anonymous/fail-closed. If a host fails to compose the request-aware loader, Forum no longer silently upgrades to raw profile visibility. Authenticated-only, follower-only, private or blocked presentation remains unavailable unless the proper audience-aware host composition is present.
+
+This is deliberately least-privilege fallback behavior; it is not a substitute for the authenticated request loader.
+
+## Scope preserved
+
+The existing author lookup shape remains bounded:
+
+- author IDs are deduplicated before owner access;
+- the normal DataLoader path remains unchanged;
+- the fallback still performs one batched presentation call for the deduplicated IDs;
+- Forum does not query Profiles or Social Graph tables;
+- Forum does not copy handle/display-name/avatar/privacy state into Forum persistence;
+- no mutation, migration, event, queue, receipt or new dependency is introduced.
+
+The change applies to the shared helper used by Forum topic lists, selected topics and reply lists, including storefront variants.
+
+## Remaining FORUM-15 work
+
+This slice does not claim complete member cards.
+
+The next bounded source slice should compose Forum-owned statistics without introducing a per-author Forum query. A suitable direction is one deduplicated bounded Forum user-stat read for the same visible author set, then a presentation DTO that combines the Profiles-owned summary with Forum-owned topic/reply/solution counts. The profile presentation decision must remain authoritative: hidden profiles must not become visible merely because Forum statistics exist.
+
+Runtime/browser evidence and explicit no-N+1 execution evidence also remain maintainer work.
+
+## Canonical plan status
+
+The canonical FORUM-15 ledger remains correctly `in_progress`; its broad remaining-work statement is still true after this narrow fallback hardening, so this slice does not rewrite the large canonical plan merely to record a sub-slice.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database fixture, migration, build, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-profile-presentation-fallback-source.mjs
+```

--- a/scripts/verify/verify-forum-profile-presentation-fallback-source.mjs
+++ b/scripts/verify/verify-forum-profile-presentation-fallback-source.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const forumQuery = read("crates/rustok-forum/src/graphql/query_runtime.rs");
+const presentation = read("crates/rustok-profiles/src/presentation.rs");
+const loader = read("crates/rustok-profiles/src/loader.rs");
+const hostPolicy = read("apps/server/src/graphql/profile_summary_policy.rs");
+const packet = read(
+  "docs/modules/forum-15-profile-presentation-fallback-actualization-2026-08-10.md",
+);
+
+for (const marker of [
+  "ProfilePresentationService, ProfileSummaryLoader, ProfileSummaryLoaderKey",
+  "ctx.data_opt::<DataLoader<ProfileSummaryLoader>>()",
+  "loader.load_many(keys).await?",
+  "ProfilePresentationService::new(db.clone())",
+  ".find_profile_summaries(",
+  ".collect::<HashSet<_>>()",
+]) need(forumQuery, marker, "FORUM-15A Forum profile composition");
+
+for (const marker of [
+  "ProfileService::new(db.clone())\n        .find_profile_summaries(",
+  "entities::profile::Entity",
+  "ProfilePrivacyService::new",
+]) forbid(forumQuery, marker, "FORUM-15A Forum must not bypass Profiles presentation owner");
+
+for (const marker of [
+  "pub struct ProfilePresentationService",
+  "ProfilePrivacyService::new(self.db.clone())",
+  ".evaluate_access_batch(tenant_id, user_ids, self.audience)",
+  "ProfilePrivacyDecision::Allow",
+  "ProfileError::PresentationUnavailable",
+  "impl ProfilesReader for ProfilePresentationService",
+]) need(presentation, marker, "Profiles presentation owner baseline");
+
+for (const marker of [
+  "ProfilePresentationService::for_audience(db, audience)",
+  ".find_profile_summaries(",
+  "ProfileSummaryBatchKey",
+]) need(loader, marker, "Profiles request loader baseline");
+
+for (const marker of [
+  "ProfileAccessAudience::Anonymous",
+  "ProfileAccessAudience::Authenticated",
+  "ProfileAccessAudience::TrustedService",
+  "ProfileSummaryLoader::for_audience(db, audience)",
+  "request.data.insert(DataLoader::new(",
+]) need(hostPolicy, marker, "Host profile audience composition baseline");
+
+for (const marker of [
+  "FORUM-15A",
+  "fallback-fail-closed",
+  "anonymous/fail-closed",
+  "request-scoped loader as the preferred path",
+  "does not claim complete member cards",
+  "Forum-owned statistics",
+  "no Cargo command, test, Node verifier",
+]) need(packet, marker, "FORUM-15A actualization");
+
+console.log("Forum FORUM-15A profile presentation fallback source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-15 by hardening Forum author-profile composition when a host does not install the request-scoped Profiles loader.

- keep the existing `DataLoader<ProfileSummaryLoader>` path unchanged as the preferred request-aware path;
- replace the missing-loader raw `ProfileService` fallback with `ProfilePresentationService::new`;
- make missing host audience composition fail closed to anonymous/public profile presentation rather than exposing raw owner summaries;
- preserve deduplication and one batched profile read for topic/reply author IDs;
- add a dated FORUM-15A actualization and a source guard, intentionally not executed.

## Ownership / privacy boundary

`ProfilePresentationService` remains the Profiles-owned presentation boundary. It evaluates the canonical privacy/block matrix in batch before loading localized summaries. The request-scoped host loader still uses `ProfilePresentationService::for_audience`, so authenticated and service-principal audiences retain their existing request-aware behavior.

The fallback is intentionally least-privilege: if a host omits the audience-bound loader, Forum uses the anonymous presentation owner rather than raw `ProfileService`. Forum does not read Profiles or Social Graph private tables and does not duplicate privacy policy.

## Remaining FORUM-15 work

This PR does not claim complete member cards. Forum-stat enrichment and explicit retained no-N+1 execution evidence remain open. The next bounded slice should add one deduplicated Forum user-stat read for the same visible author set and compose those Forum-owned counts with the Profiles-owned presentation result.

FORUM-14B remains blocked: Media has internal deletion lifecycle fields, but the current lifecycle model has no quarantine state and the public Media read contract still does not expose a complete attachment-persistence eligibility fact.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was run. `scripts/verify/verify-forum-profile-presentation-fallback-source.mjs` was added but intentionally not executed.