### PR TITLE
feat(commerce): route storefront refund reads through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-storefront-order-refund-read-owner-port-cutover-2026-08-10.md
+++ b/crates/rustok-commerce/docs/rest-storefront-order-refund-read-owner-port-cutover-2026-08-10.md
@@ -1,0 +1,76 @@
+# Commerce REST storefront order-refund owner-read cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-10
+
+## Scope
+
+This bounded slice moves mounted `GET /store/orders/{id}/refunds` behind the host-selected
+Payment order-read runtime. Commerce no longer constructs `PaymentService` on this route.
+
+Payment now publishes `PaymentOrderReadPort::list_refunds_by_order` with a typed
+`ListRefundsByOrderRequest` / `PaymentOrderRefundPage` contract. The in-process adapter owns the
+existing `PaymentService::list_refunds` call. The trait method has a default fail-closed
+implementation so existing external adapters remain source-compatible but must explicitly
+implement the new capability before the route can succeed.
+
+## Preserved transport behavior
+
+The mounted route still:
+
+1. requires the Commerce module to be enabled for the request channel;
+2. requires an authenticated customer account;
+3. reads the order through the host-selected Order read port and verifies ownership before
+   any Payment read;
+4. forwards page, per-page, optional status, and the current order id exactly to Payment;
+5. leaves `payment_collection_id` unconstrained inside the owner adapter;
+6. returns the existing `PaginatedResponse<RefundResponse>` with the same pagination metadata.
+
+The owner adapter delegates to the same `PaymentService::list_refunds` implementation, preserving
+its ordering, filtering, count and DTO semantics.
+
+## Context and host composition
+
+Commerce reuses its bounded storefront order read context for the Payment call:
+
+- admitted tenant id;
+- authenticated user as `PortActor::user`;
+- request locale;
+- request channel when present;
+- order-bound correlation identity;
+- two-second deadline.
+
+`CommerceHttpRuntime::payment_order_read_port()` already exposes the host-selected
+`PaymentOrderReadRuntime`; no embedded fallback is introduced in the controller.
+
+## External adapter compatibility
+
+`PaymentOrderReadPort::list_refunds_by_order` has a default implementation that first enforces
+read-port deadline semantics and then returns a stable unavailable `PortError`. Existing external
+implementations therefore continue to compile but fail closed for this newly published capability
+until they opt in explicitly.
+
+## Public error parity and diagnostics
+
+The Payment owner translates concrete errors to bounded port codes. Commerce preserves the
+existing storefront public families, including provider-unavailable, provider-invalid-response,
+reconciliation-required, provider-not-configured, generic validation/not-found/conflict and
+storage-unavailable envelopes.
+
+The mounted Payment boundary logs correlation, identity-presence facts, owner error kind,
+owner-code length, retryability and the selected public envelope. It does not log or return the
+raw owner/backend message or concrete Payment error.
+
+## Topology status
+
+This removes the mounted direct `PaymentService` construction from storefront order refund reads.
+The canonical broad ecommerce topology P0 remains open because other mounted Product/Order/
+Payment/Fulfillment topology and validation work still remains.
+
+## Validation status
+
+Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios,
+workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter
+scenarios were executed. Source guards added or updated by this slice are source-reviewed only
+and were not run.

--- a/crates/rustok-commerce/docs/rest-storefront-order-return-command-owner-port-cutover-2026-08-10.md
+++ b/crates/rustok-commerce/docs/rest-storefront-order-return-command-owner-port-cutover-2026-08-10.md
@@ -56,14 +56,17 @@ The new command boundary maps only bounded `PortError` kind/code-length/retryabi
 request identity-presence facts. It does not log or return raw owner/backend messages from
 the command call.
 
-Existing storefront Order read/customer diagnostics and the Payment refund-list boundary are
-outside this slice and remain unchanged.
+Existing storefront Order read/customer diagnostics are outside this slice and remain unchanged.
 
-## Remaining topology
+## Subsequent topology update
 
-The canonical broad ecommerce topology P0 remains open. In this same mounted controller,
-`GET /store/orders/{id}/refunds` still constructs `PaymentService` directly and is intentionally
-left for a separate Payment owner-read cutover.
+The Payment refund-list gap that was intentionally left after this command slice was subsequently
+moved behind `PaymentOrderReadPort::list_refunds_by_order` in the bounded storefront refund-read
+cutover dated 2026-08-10. This record no longer asserts direct mounted `PaymentService`
+construction for `GET /store/orders/{id}/refunds`.
+
+The canonical broad ecommerce topology P0 remains open for other remaining topology and
+validation work.
 
 ## Validation status
 

--- a/crates/rustok-commerce/src/controllers/store/orders.rs
+++ b/crates/rustok-commerce/src/controllers/store/orders.rs
@@ -12,7 +12,7 @@ use rustok_order::{
     CreateOrderReturnRequest, ListOrderChangeProjectionsRequest, ListOrderReturnProjectionsRequest,
     ReadOrderProjectionRequest,
 };
-use rustok_payment::{PaymentService, error::PaymentError};
+use rustok_payment::ListRefundsByOrderRequest;
 use rustok_web::{HttpError, HttpResult, port_error_to_http_error};
 use uuid::Uuid;
 
@@ -24,8 +24,7 @@ use super::{
     StoreOrderChangesParams, StoreOrderRefundsParams, StoreOrderReturnsParams,
 };
 use crate::dto::{
-    CreateOrderReturnInput, ListRefundsInput, OrderChangeResponse, OrderResponse,
-    OrderReturnResponse, RefundResponse,
+    CreateOrderReturnInput, OrderChangeResponse, OrderResponse, OrderReturnResponse, RefundResponse,
 };
 
 const STOREFRONT_ORDER_CUSTOMER_OWNER: &str = "rustok_customer";
@@ -38,46 +37,6 @@ const STOREFRONT_ORDER_CHANGE_LIST_OPERATION: &str = "list_order_change_projecti
 const STOREFRONT_ORDER_RETURN_COMMAND_OPERATION: &str = "create_return";
 const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";
 const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";
-
-type StorefrontOrderPaymentHttpPolicy = (StatusCode, &'static str, &'static str, &'static str);
-
-#[derive(Clone, Copy)]
-struct StorefrontOrderPaymentErrorContext<'a> {
-    tenant_id: Uuid,
-    actor_id: Uuid,
-    customer_id: Uuid,
-    order_id: Uuid,
-    payment_collection_id: Option<Uuid>,
-    refund_id: Option<Uuid>,
-    channel_id: Option<Uuid>,
-    channel_slug: Option<&'a str>,
-    locale: &'a str,
-    operation: &'static str,
-}
-
-impl<'a> StorefrontOrderPaymentErrorContext<'a> {
-    fn new(
-        tenant_id: Uuid,
-        actor_id: Uuid,
-        customer_id: Uuid,
-        order_id: Uuid,
-        request_context: &'a RequestContext,
-        operation: &'static str,
-    ) -> Self {
-        Self {
-            tenant_id,
-            actor_id,
-            customer_id,
-            order_id,
-            payment_collection_id: None,
-            refund_id: None,
-            channel_id: request_context.channel_id,
-            channel_slug: request_context.channel_slug.as_deref(),
-            locale: request_context.locale.as_str(),
-            operation,
-        }
-    }
-}
 
 fn map_storefront_customer_port_error(
     error: PortError,
@@ -322,113 +281,94 @@ fn map_storefront_order_command_port_error(
     HttpError::new(status, code, message)
 }
 
-fn storefront_order_payment_error_policy(
-    context: &mut StorefrontOrderPaymentErrorContext<'_>,
-    error: &PaymentError,
-) -> StorefrontOrderPaymentHttpPolicy {
-    match error {
-        PaymentError::Validation(_) => (
-            StatusCode::BAD_REQUEST,
-            "commerce_store_payment_invalid",
-            "Payment request is invalid",
-            "validation",
-        ),
-        PaymentError::PaymentCollectionNotFound(payment_collection_id) => {
-            context.payment_collection_id = Some(*payment_collection_id);
-            (
-                StatusCode::NOT_FOUND,
-                "commerce_store_payment_not_found",
-                "Payment resource was not found",
-                "payment_collection_not_found",
-            )
-        }
-        PaymentError::PaymentNotFound(payment_collection_id) => {
-            context.payment_collection_id = Some(*payment_collection_id);
-            (
-                StatusCode::NOT_FOUND,
-                "commerce_store_payment_not_found",
-                "Payment resource was not found",
-                "payment_not_found",
-            )
-        }
-        PaymentError::RefundNotFound(refund_id) => {
-            context.refund_id = Some(*refund_id);
-            (
-                StatusCode::NOT_FOUND,
-                "commerce_store_payment_not_found",
-                "Payment resource was not found",
-                "refund_not_found",
-            )
-        }
-        PaymentError::InvalidTransition { .. } => (
-            StatusCode::CONFLICT,
-            "commerce_store_payment_state_conflict",
-            "Payment operation conflicts with the current state",
-            "state_conflict",
-        ),
-        PaymentError::ProviderRejected { .. } => (
-            StatusCode::CONFLICT,
-            "commerce_store_payment_state_conflict",
-            "Payment operation conflicts with the current state",
-            "provider_rejected",
-        ),
-        PaymentError::ProviderUnavailable { .. } => (
+fn map_storefront_payment_port_error(
+    error: PortError,
+    context: &PortContext,
+    actor_id: Uuid,
+    customer_id: Uuid,
+    order_id: Uuid,
+) -> HttpError {
+    let (status, code, message, error_kind) = match error.code.as_str() {
+        "payment.order_refund_provider_unavailable" => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_store_payment_provider_unavailable",
             "Payment provider is temporarily unavailable",
             "provider_unavailable",
         ),
-        PaymentError::ProviderInvalidResponse { .. } => (
+        "payment.order_refund_provider_invalid_response" => (
             StatusCode::BAD_GATEWAY,
             "commerce_store_payment_provider_invalid_response",
             "Payment provider returned an invalid response",
             "provider_invalid_response",
         ),
-        PaymentError::ProviderOutcomeUnknown { .. } => (
+        "payment.order_refund_reconciliation_required" => (
             StatusCode::CONFLICT,
             "commerce_store_payment_reconciliation_required",
             "Payment state requires reconciliation",
             "reconciliation_required",
         ),
-        PaymentError::ProviderConfiguration { .. } => (
+        "payment.order_refund_provider_not_configured" => (
             StatusCode::SERVICE_UNAVAILABLE,
             "commerce_store_payment_provider_not_configured",
             "Payment provider is not configured for this tenant",
             "provider_configuration",
         ),
-        PaymentError::Database(_) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "commerce_store_payment_unavailable",
-            "Payment service is temporarily unavailable",
-            "database",
-        ),
-    }
-}
-
-fn map_storefront_payment_error(
-    mut context: StorefrontOrderPaymentErrorContext<'_>,
-    error: PaymentError,
-) -> HttpError {
-    let (status, code, message, error_kind) =
-        storefront_order_payment_error_policy(&mut context, &error);
+        _ => match &error.kind {
+            PortErrorKind::Validation => (
+                StatusCode::BAD_REQUEST,
+                "commerce_store_payment_invalid",
+                "Payment request is invalid",
+                "validation",
+            ),
+            PortErrorKind::NotFound => (
+                StatusCode::NOT_FOUND,
+                "commerce_store_payment_not_found",
+                "Payment resource was not found",
+                "not_found",
+            ),
+            PortErrorKind::Conflict => (
+                StatusCode::CONFLICT,
+                "commerce_store_payment_state_conflict",
+                "Payment operation conflicts with the current state",
+                "state_conflict",
+            ),
+            PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "commerce_store_payment_unavailable",
+                "Payment service is temporarily unavailable",
+                "unavailable",
+            ),
+            PortErrorKind::InvariantViolation => (
+                StatusCode::BAD_GATEWAY,
+                "commerce_store_payment_provider_invalid_response",
+                "Payment provider returned an invalid response",
+                "provider_invalid_response",
+            ),
+            PortErrorKind::Forbidden => (
+                StatusCode::UNAUTHORIZED,
+                "commerce_store_order_access_denied",
+                "Order does not belong to the current customer",
+                "forbidden",
+            ),
+        },
+    };
     tracing::error!(
-        error = ?error,
         owner = STOREFRONT_ORDER_PAYMENT_OWNER,
-        tenant_id = %context.tenant_id,
-        actor_id = %context.actor_id,
-        customer_id = %context.customer_id,
-        order_id = %context.order_id,
-        payment_collection_id = ?context.payment_collection_id,
-        refund_id = ?context.refund_id,
-        channel_id = ?context.channel_id,
-        channel = ?context.channel_slug,
-        locale = %context.locale,
-        operation = %context.operation,
+        owner_operation = "list_refunds_by_order",
+        consumer_operation = "list_order_refunds",
+        correlation_id = %context.correlation_id,
+        tenant_id_non_empty = !context.tenant_id.is_empty(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        customer_id_non_nil = !customer_id.is_nil(),
+        order_id_non_nil = !order_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
         error_kind,
         public_code = code,
         status = %status,
         boundary = STOREFRONT_ORDER_PAYMENT_BOUNDARY,
-        "storefront payment read failed"
+        "storefront Payment refund read failed with bounded diagnostics"
     );
     HttpError::new(status, code, message)
 }
@@ -788,36 +728,38 @@ pub async fn list_order_refunds(
     )
     .await?;
 
-    let payment_service = PaymentService::new(runtime.db_clone());
-    let (items, total) = payment_service
-        .list_refunds(
-            tenant.id,
-            ListRefundsInput {
+    let payment_context = storefront_order_read_port_context(
+        tenant.id,
+        &auth,
+        &request_context,
+        id,
+        "list_order_refunds",
+    );
+    let page = runtime
+        .payment_order_read_port()
+        .list_refunds_by_order(
+            payment_context.clone(),
+            ListRefundsByOrderRequest {
+                order_id: id,
                 page: params.pagination.page,
                 per_page: params.pagination.per_page,
-                payment_collection_id: None,
-                order_id: Some(id),
                 status: params.status,
             },
         )
         .await
         .map_err(|error| {
-            map_storefront_payment_error(
-                StorefrontOrderPaymentErrorContext::new(
-                    tenant.id,
-                    auth.user_id,
-                    customer_id,
-                    id,
-                    &request_context,
-                    "list_order_refunds",
-                ),
+            map_storefront_payment_port_error(
                 error,
+                &payment_context,
+                auth.user_id,
+                customer_id,
+                id,
             )
         })?;
 
     Ok(Json(PaginatedResponse {
-        data: items,
-        meta: PaginationMeta::new(params.pagination.page, params.pagination.limit(), total),
+        data: page.items,
+        meta: PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total),
     }))
 }
 

--- a/crates/rustok-payment/src/lib.rs
+++ b/crates/rustok-payment/src/lib.rs
@@ -64,8 +64,9 @@ pub use collection_runtime::PaymentCollectionRuntime;
 pub use dto::*;
 pub use entities::*;
 pub use order_read::{
-    InProcessPaymentOrderReadPort, LatestPaymentCollectionByOrderRequest, PaymentOrderReadPort,
-    PaymentOrderReadRuntime, in_process_payment_order_read_port,
+    InProcessPaymentOrderReadPort, LatestPaymentCollectionByOrderRequest, ListRefundsByOrderRequest,
+    PaymentOrderReadPort, PaymentOrderReadRuntime, PaymentOrderRefundPage,
+    in_process_payment_order_read_port,
 };
 pub use ports::*;
 pub use providers::*;

--- a/crates/rustok-payment/src/order_read.rs
+++ b/crates/rustok-payment/src/order_read.rs
@@ -6,7 +6,9 @@ use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{PaymentCollectionResponse, PaymentError, PaymentService};
+use crate::{
+    ListRefundsInput, PaymentCollectionResponse, PaymentError, PaymentService, RefundResponse,
+};
 
 const PAYMENT_ORDER_READ_OWNER: &str = "rustok_payment";
 const PAYMENT_ORDER_READ_BOUNDARY: &str = "payment_order_read_port";
@@ -18,11 +20,37 @@ pub trait PaymentOrderReadPort: Send + Sync {
         context: PortContext,
         request: LatestPaymentCollectionByOrderRequest,
     ) -> Result<Option<PaymentCollectionResponse>, PortError>;
+
+    async fn list_refunds_by_order(
+        &self,
+        context: PortContext,
+        _request: ListRefundsByOrderRequest,
+    ) -> Result<PaymentOrderRefundPage, PortError> {
+        context.require_policy(PortCallPolicy::read())?;
+        Err(PortError::unavailable(
+            "payment.order_refund_read_unavailable",
+            "payment order refund read capability is unavailable",
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LatestPaymentCollectionByOrderRequest {
     pub order_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListRefundsByOrderRequest {
+    pub order_id: Uuid,
+    pub page: u64,
+    pub per_page: u64,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaymentOrderRefundPage {
+    pub items: Vec<RefundResponse>,
+    pub total: u64,
 }
 
 pub struct InProcessPaymentOrderReadPort {
@@ -68,27 +96,58 @@ impl PaymentOrderReadPort for InProcessPaymentOrderReadPort {
         request: LatestPaymentCollectionByOrderRequest,
     ) -> Result<Option<PaymentCollectionResponse>, PortError> {
         let operation = "find_latest_collection_by_order";
-        context.require_policy(PortCallPolicy::read())?;
-        let tenant_id = Uuid::parse_str(&context.tenant_id).map_err(|_| {
-            tracing::warn!(
-                owner = PAYMENT_ORDER_READ_OWNER,
-                operation,
-                correlation_id = %context.correlation_id,
-                tenant_id_length = context.tenant_id.chars().count(),
-                boundary = PAYMENT_ORDER_READ_BOUNDARY,
-                "payment order read context was rejected"
-            );
-            PortError::validation(
-                "payment.order_read_context_invalid",
-                "payment request context is invalid",
-            )
-        })?;
+        let tenant_id = require_order_read_context(&context, operation)?;
 
         self.inner
             .find_latest_collection_by_order(tenant_id, request.order_id)
             .await
             .map_err(|error| map_payment_error(&context, operation, request.order_id, error))
     }
+
+    async fn list_refunds_by_order(
+        &self,
+        context: PortContext,
+        request: ListRefundsByOrderRequest,
+    ) -> Result<PaymentOrderRefundPage, PortError> {
+        let operation = "list_refunds_by_order";
+        let tenant_id = require_order_read_context(&context, operation)?;
+        let (items, total) = self
+            .inner
+            .list_refunds(
+                tenant_id,
+                ListRefundsInput {
+                    page: request.page,
+                    per_page: request.per_page,
+                    payment_collection_id: None,
+                    order_id: Some(request.order_id),
+                    status: request.status,
+                },
+            )
+            .await
+            .map_err(|error| map_refund_read_error(&context, request.order_id, error))?;
+        Ok(PaymentOrderRefundPage { items, total })
+    }
+}
+
+fn require_order_read_context(
+    context: &PortContext,
+    operation: &'static str,
+) -> Result<Uuid, PortError> {
+    context.require_policy(PortCallPolicy::read())?;
+    Uuid::parse_str(&context.tenant_id).map_err(|_| {
+        tracing::warn!(
+            owner = PAYMENT_ORDER_READ_OWNER,
+            operation,
+            correlation_id = %context.correlation_id,
+            tenant_id_length = context.tenant_id.chars().count(),
+            boundary = PAYMENT_ORDER_READ_BOUNDARY,
+            "payment order read context was rejected"
+        );
+        PortError::validation(
+            "payment.order_read_context_invalid",
+            "payment request context is invalid",
+        )
+    })
 }
 
 fn map_payment_error(
@@ -151,6 +210,114 @@ fn map_payment_error(
         ),
     };
 
+    log_payment_read_error(
+        context,
+        operation,
+        order_id,
+        error_variant,
+        code,
+        retryable,
+        technical,
+    );
+    PortError::new(kind, code, message, retryable)
+}
+
+fn map_refund_read_error(
+    context: &PortContext,
+    order_id: Uuid,
+    error: PaymentError,
+) -> PortError {
+    let operation = "list_refunds_by_order";
+    let (kind, code, message, retryable, error_variant, technical) = match &error {
+        PaymentError::Validation(_) => (
+            PortErrorKind::Validation,
+            "payment.order_refund_read_validation",
+            "payment refund request is invalid",
+            false,
+            "validation",
+            false,
+        ),
+        PaymentError::PaymentCollectionNotFound(_)
+        | PaymentError::PaymentNotFound(_)
+        | PaymentError::RefundNotFound(_) => (
+            PortErrorKind::NotFound,
+            "payment.order_refund_read_not_found",
+            "payment refund resource was not found",
+            false,
+            "not_found",
+            false,
+        ),
+        PaymentError::InvalidTransition { .. } | PaymentError::ProviderRejected { .. } => (
+            PortErrorKind::Conflict,
+            "payment.order_refund_read_state_conflict",
+            "payment refund state conflicts with the request",
+            false,
+            "state_conflict",
+            false,
+        ),
+        PaymentError::ProviderUnavailable { .. } => (
+            PortErrorKind::Unavailable,
+            "payment.order_refund_provider_unavailable",
+            "payment provider is temporarily unavailable",
+            true,
+            "provider_unavailable",
+            true,
+        ),
+        PaymentError::ProviderInvalidResponse { .. } => (
+            PortErrorKind::InvariantViolation,
+            "payment.order_refund_provider_invalid_response",
+            "payment provider response could not be read safely",
+            false,
+            "provider_invalid_response",
+            true,
+        ),
+        PaymentError::ProviderOutcomeUnknown { .. } => (
+            PortErrorKind::Conflict,
+            "payment.order_refund_reconciliation_required",
+            "payment state requires reconciliation",
+            false,
+            "provider_outcome_unknown",
+            true,
+        ),
+        PaymentError::ProviderConfiguration { .. } => (
+            PortErrorKind::Unavailable,
+            "payment.order_refund_provider_not_configured",
+            "payment provider is not configured",
+            true,
+            "provider_configuration",
+            true,
+        ),
+        PaymentError::Database(_) => (
+            PortErrorKind::Unavailable,
+            "payment.order_refund_read_unavailable",
+            "payment refund storage is temporarily unavailable",
+            true,
+            "database",
+            true,
+        ),
+    };
+
+    log_payment_read_error(
+        context,
+        operation,
+        order_id,
+        error_variant,
+        code,
+        retryable,
+        technical,
+    );
+    PortError::new(kind, code, message, retryable)
+}
+
+fn log_payment_read_error(
+    context: &PortContext,
+    operation: &'static str,
+    order_id: Uuid,
+    error_variant: &'static str,
+    code: &'static str,
+    retryable: bool,
+    technical: bool,
+) {
     if technical {
         tracing::error!(
             owner = PAYMENT_ORDER_READ_OWNER,
@@ -176,6 +343,4 @@ fn map_payment_error(
             "payment order read was rejected"
         );
     }
-
-    PortError::new(kind, code, message, retryable)
 }

--- a/scripts/verify/verify-commerce-rest-storefront-order-refund-owner-read-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-storefront-order-refund-owner-read-cutover.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
+const httpRuntime = read('crates/rustok-commerce/src/controllers/mod.rs');
+const paymentOwner = read('crates/rustok-payment/src/order_read.rs');
+const paymentLib = read('crates/rustok-payment/src/lib.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-storefront-order-refund-read-owner-port-cutover-2026-08-10.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const refundRoute = between(
+  controller,
+  'pub async fn list_order_refunds(',
+  '/// List order changes for the current customer',
+  'mounted storefront refund route',
+);
+const paymentMapper = between(
+  controller,
+  'fn map_storefront_payment_port_error(',
+  'async fn current_storefront_customer_id(',
+  'storefront Payment port mapper',
+);
+
+requireText(
+  controller,
+  'use rustok_payment::ListRefundsByOrderRequest;',
+  'typed Payment request import',
+);
+for (const [value, label] of [
+  ['let customer_id = ensure_customer_owns_order(', 'ownership admission'],
+  ['"list_order_refunds_access"', 'ownership operation label'],
+  ['let payment_context = storefront_order_read_port_context(', 'bounded read context'],
+  ['.payment_order_read_port()', 'host-selected Payment read port'],
+  ['.list_refunds_by_order(', 'Payment refund owner call'],
+  ['ListRefundsByOrderRequest {', 'typed refund request'],
+  ['order_id: id,', 'order filter'],
+  ['page: params.pagination.page,', 'page forwarding'],
+  ['per_page: params.pagination.per_page,', 'per-page forwarding'],
+  ['status: params.status,', 'status forwarding'],
+  ['data: page.items,', 'page item projection'],
+  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total)', 'pagination metadata'],
+]) requireText(refundRoute, value, label);
+
+for (const value of [
+  'PaymentService::new(',
+  'PaymentError',
+  'ListRefundsInput',
+  '.list_refunds(',
+]) forbidText(refundRoute, value, 'mounted refund route concrete Payment dependency');
+
+for (const [value, label] of [
+  ['fn payment_order_read_port(', 'Commerce runtime accessor'],
+  ['std::sync::Arc<dyn rustok_payment::PaymentOrderReadPort>', 'Commerce trait object'],
+  ['self.payment_order_read_runtime.read_port()', 'host-selected Payment runtime'],
+]) requireText(httpRuntime, value, label);
+
+for (const [value, label] of [
+  ['pub trait PaymentOrderReadPort: Send + Sync', 'Payment order-read trait'],
+  ['async fn list_refunds_by_order(', 'refund-list owner capability'],
+  ['request: ListRefundsByOrderRequest', 'in-process typed request'],
+  ['pub struct ListRefundsByOrderRequest', 'request type'],
+  ['pub struct PaymentOrderRefundPage', 'page type'],
+  ['context.require_policy(PortCallPolicy::read())?', 'read admission'],
+  ['"payment.order_refund_read_unavailable"', 'default fail-closed capability'],
+  ['.list_refunds(', 'owner-local concrete execution'],
+  ['payment_collection_id: None,', 'collection filter parity'],
+  ['order_id: Some(request.order_id),', 'order filter parity'],
+  ['status: request.status,', 'status parity'],
+  ['Ok(PaymentOrderRefundPage { items, total })', 'owner page projection'],
+]) requireText(paymentOwner, value, label);
+
+for (const [value, label] of [
+  ['ListRefundsByOrderRequest', 'request export'],
+  ['PaymentOrderRefundPage', 'page export'],
+]) requireText(paymentLib, value, label);
+
+for (const [value, label] of [
+  ['"payment.order_refund_provider_unavailable"', 'provider unavailable identity'],
+  ['"payment.order_refund_provider_invalid_response"', 'provider invalid-response identity'],
+  ['"payment.order_refund_reconciliation_required"', 'reconciliation identity'],
+  ['"payment.order_refund_provider_not_configured"', 'provider configuration identity'],
+  ['"commerce_store_payment_provider_unavailable"', 'provider unavailable envelope'],
+  ['"commerce_store_payment_provider_invalid_response"', 'provider invalid-response envelope'],
+  ['"commerce_store_payment_reconciliation_required"', 'reconciliation envelope'],
+  ['"commerce_store_payment_provider_not_configured"', 'provider configuration envelope'],
+  ['"commerce_store_payment_unavailable"', 'storage unavailable envelope'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code diagnostic'],
+  ['retryable = error.retryable', 'retryability diagnostic'],
+]) requireText(paymentMapper, value, label);
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'internal_message']) {
+  forbidText(paymentMapper, value, 'raw Payment owner diagnostic');
+}
+
+for (const value of [
+  'use rustok_payment::{PaymentService',
+  'let payment_service = PaymentService::new(runtime.db_clone());',
+  'StorefrontOrderPaymentErrorContext',
+  'fn storefront_order_payment_error_policy(',
+]) forbidText(controller, value, 'stale mounted concrete Payment boundary');
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology P0 remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST storefront order-refund owner-read cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['PaymentOrderReadPort::list_refunds_by_order', 'record owner capability'],
+  ['default fail-closed', 'record external adapter behavior'],
+  ['no tests, Cargo commands, Node verifiers, formatter', 'record validation status'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST storefront order-refund owner-read cutover verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted storefront order refunds use the host-selected Payment owner read port');

--- a/scripts/verify/verify-commerce-rest-storefront-order-return-command-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-storefront-order-return-command-owner-port-cutover.mjs
@@ -69,7 +69,7 @@ if (accessIndex < 0 || commandIndex < 0 || accessIndex > commandIndex) {
 const commandMapper = between(
   controller,
   'fn map_storefront_order_command_port_error(',
-  'fn storefront_order_payment_error_policy(',
+  'fn map_storefront_payment_port_error(',
   'storefront Order command mapper',
 );
 for (const [value, label] of [
@@ -112,11 +112,12 @@ for (const [value, label] of [
   ['.create_return(tenant_id, request.order_id, request.input)', 'owner-local execution'],
 ]) requireText(owner, value, label);
 
-requireText(
-  controller,
+for (const value of [
   'let payment_service = PaymentService::new(runtime.db_clone());',
-  'separate mounted Payment refund-list gap remains explicit',
-);
+  'StorefrontOrderPaymentErrorContext',
+  'fn storefront_order_payment_error_policy(',
+]) forbidText(controller, value, 'stale direct Payment refund boundary');
+
 requireText(
   plan,
   '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
@@ -128,8 +129,9 @@ for (const [value, label] of [
   ['Status: `source_complete_unvalidated`', 'record status'],
   ['OrderPostOrderCommandPort::create_return', 'record owner operation'],
   ['write-admission metadata only', 'record replay limitation'],
-  ['`GET /store/orders/{id}/refunds` still constructs `PaymentService` directly', 'record remaining Payment gap'],
-  ['no tests, Cargo commands, Node verifiers, formatter', 'record no validation execution'],
+  ['subsequently', 'record subsequent Payment cutover'],
+  ['PaymentOrderReadPort::list_refunds_by_order', 'record Payment owner capability'],
+  ['no tests, Cargo commands, Node verifiers, formatter', 'record validation status'],
 ]) requireText(record, value, label);
 
 if (failures.length > 0) {

--- a/scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-http-error-safety.mjs
@@ -11,8 +11,8 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
-const paymentErrors = read('crates/rustok-payment/src/error.rs');
 const orderCommand = read('crates/rustok-order/src/post_order_command.rs');
+const paymentOrderRead = read('crates/rustok-payment/src/order_read.rs');
 const webErrors = read('crates/rustok-web/src/lib.rs');
 const failures = [];
 
@@ -33,14 +33,14 @@ const between = (content, start, end, label) => {
 };
 
 for (const [value, label] of [
-  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext', 'typed Order/customer port context imports'],
+  ['PortActor, PortContext, PortError, PortErrorKind, RequestContext, TenantContext', 'typed Order/Payment context imports'],
   ['CreateOrderReturnRequest', 'typed Order return command request'],
-  ['use rustok_payment::{PaymentService, error::PaymentError};', 'typed Payment error import'],
+  ['use rustok_payment::ListRefundsByOrderRequest;', 'typed Payment refund request'],
   ['port_error_to_http_error', 'safe shared port HTTP mapper'],
   ['fn map_storefront_customer_port_error(', 'customer port mapper'],
   ['fn map_storefront_order_port_error(', 'Order read port mapper'],
   ['fn map_storefront_order_command_port_error(', 'Order command port mapper'],
-  ['fn map_storefront_payment_error(', 'Payment mapper'],
+  ['fn map_storefront_payment_port_error(', 'Payment owner port mapper'],
   ['async fn current_storefront_customer_id(', 'safe customer lookup'],
   ['async fn ensure_customer_owns_order(', 'safe ownership helper'],
   ['boundary = "commerce_storefront_order_http"', 'structured storefront boundary'],
@@ -61,19 +61,17 @@ for (const [value, label] of [
   ['"commerce_store_order_failed"', 'Order fail-closed public code'],
 ]) requireText(controller, value, label);
 
+const paymentMapper = between(
+  controller,
+  'fn map_storefront_payment_port_error(',
+  'async fn current_storefront_customer_id(',
+  'Payment refund port mapper',
+);
 for (const [value, label] of [
-  ['PaymentError::Validation(_)', 'payment validation mapping'],
-  ['PaymentError::PaymentCollectionNotFound(payment_collection_id)', 'collection not-found mapping'],
-  ['PaymentError::PaymentNotFound(payment_collection_id)', 'payment not-found mapping'],
-  ['PaymentError::RefundNotFound(refund_id)', 'refund not-found mapping'],
-  ['PaymentError::InvalidTransition { .. }', 'payment transition mapping'],
-  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable mapping'],
-  ['PaymentError::ProviderRejected { .. }', 'provider rejected mapping'],
-  ['PaymentError::ProviderInvalidResponse { .. }', 'provider invalid response mapping'],
-  ['PaymentError::ProviderOutcomeUnknown { .. }', 'provider unknown outcome mapping'],
-  ['PaymentError::ProviderConfiguration { .. }', 'provider configuration mapping'],
-  ['PaymentError::Database(_)', 'payment database mapping'],
-  ['StatusCode::BAD_GATEWAY', 'bad gateway status'],
+  ['"payment.order_refund_provider_unavailable"', 'provider unavailable owner identity'],
+  ['"payment.order_refund_provider_invalid_response"', 'provider invalid-response owner identity'],
+  ['"payment.order_refund_reconciliation_required"', 'reconciliation owner identity'],
+  ['"payment.order_refund_provider_not_configured"', 'provider configuration owner identity'],
   ['"commerce_store_payment_invalid"', 'payment invalid code'],
   ['"commerce_store_payment_not_found"', 'payment not-found code'],
   ['"commerce_store_payment_state_conflict"', 'payment state code'],
@@ -82,21 +80,20 @@ for (const [value, label] of [
   ['"commerce_store_payment_reconciliation_required"', 'payment reconciliation code'],
   ['"commerce_store_payment_provider_not_configured"', 'payment configuration code'],
   ['"commerce_store_payment_unavailable"', 'payment unavailable code'],
-]) requireText(controller, value, label);
+  ['owner_error_kind = ?error.kind', 'bounded Payment owner kind'],
+  ['owner_code_length = error.code.chars().count()', 'bounded Payment owner code'],
+  ['retryable = error.retryable', 'bounded Payment retryability'],
+]) requireText(paymentMapper, value, label);
+for (const value of ['error = ?error', 'error.message', 'internal_message', 'error.to_string()']) {
+  forbidText(paymentMapper, value, 'Payment owner mapper raw diagnostic');
+}
 
 for (const [ownerSource, value, label] of [
-  [paymentErrors, 'Validation(String)', 'owner payment validation variant'],
-  [paymentErrors, 'PaymentCollectionNotFound(Uuid)', 'owner collection variant'],
-  [paymentErrors, 'PaymentNotFound(Uuid)', 'owner payment variant'],
-  [paymentErrors, 'RefundNotFound(Uuid)', 'owner refund variant'],
-  [paymentErrors, 'ProviderUnavailable {', 'owner provider unavailable variant'],
-  [paymentErrors, 'ProviderRejected {', 'owner provider rejected variant'],
-  [paymentErrors, 'ProviderInvalidResponse {', 'owner invalid response variant'],
-  [paymentErrors, 'ProviderOutcomeUnknown {', 'owner unknown outcome variant'],
-  [paymentErrors, 'ProviderConfiguration { provider_id: String }', 'owner provider configuration variant'],
-  [paymentErrors, 'Database(#[from] DbErr)', 'owner payment database variant'],
   [orderCommand, 'async fn create_return(', 'owner Order return command'],
   [orderCommand, 'context.require_policy(PortCallPolicy::write())', 'owner Order write admission'],
+  [paymentOrderRead, 'async fn list_refunds_by_order(', 'owner Payment refund read'],
+  [paymentOrderRead, 'context.require_policy(PortCallPolicy::read())?', 'owner Payment read admission'],
+  [paymentOrderRead, '"payment.order_refund_read_unavailable"', 'external Payment fail-closed default'],
 ]) requireText(ownerSource, value, label);
 
 for (const [value, label] of [
@@ -109,11 +106,12 @@ for (const [value, label] of [
   ['.read_order_projection(', 'localized Order owner read'],
   ['.order_post_order_command_port()', 'host-selected Order return command'],
   ['CreateOrderReturnRequest {', 'typed return request'],
-  ['let payment_service = PaymentService::new(runtime.db_clone());', 'remaining Payment refund-list service'],
+  ['.payment_order_read_port()', 'host-selected Payment order read'],
+  ['.list_refunds_by_order(', 'typed Payment refund read'],
+  ['ListRefundsByOrderRequest {', 'typed Payment refund request construction'],
   ['page: params.pagination.page', 'page forwarding'],
   ['per_page: params.pagination.per_page', 'per-page forwarding'],
-  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total)', 'Order pagination metadata'],
-  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), total)', 'Payment pagination metadata'],
+  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total)', 'owner pagination metadata'],
 ]) requireText(controller, value, label);
 
 for (const operation of [
@@ -132,27 +130,29 @@ for (const operation of [
 for (const value of [
   'OrderService::new(',
   'error::OrderError',
-  'map_storefront_order_error(',
-  '.create_return(tenant.id, id, input)',
+  'PaymentService::new(',
+  'error::PaymentError',
+  'StorefrontOrderPaymentErrorContext',
+  'fn storefront_order_payment_error_policy(',
   'err.to_string()',
   'error.to_string()',
   'HttpError::bad_request("commerce_operation_failed"',
   'super::current_customer_id_for_db',
   'super::ensure_customer_owns_order_for_db',
-]) forbidText(controller, value, 'stale or unsafe storefront Order path');
+]) forbidText(controller, value, 'stale or unsafe storefront owner path');
 
 const commandMapper = between(
   controller,
   'fn map_storefront_order_command_port_error(',
-  'fn storefront_order_payment_error_policy(',
+  'fn map_storefront_payment_port_error(',
   'Order return command mapper',
 );
 for (const [value, label] of [
-  ['owner_error_kind = ?error.kind', 'bounded owner kind'],
-  ['owner_code_length = error.code.chars().count()', 'bounded owner code'],
-  ['retryable = error.retryable', 'bounded retryability'],
-  ['public_code = code', 'public code'],
-  ['status = %status', 'public status'],
+  ['owner_error_kind = ?error.kind', 'bounded Order owner kind'],
+  ['owner_code_length = error.code.chars().count()', 'bounded Order owner code'],
+  ['retryable = error.retryable', 'bounded Order retryability'],
+  ['public_code = code', 'Order public code'],
+  ['status = %status', 'Order public status'],
 ]) requireText(commandMapper, value, label);
 for (const value of ['error = ?error', 'error.message', 'internal_message', 'error.to_string()']) {
   forbidText(commandMapper, value, 'Order command mapper raw diagnostic');
@@ -173,5 +173,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Commerce storefront Order owner reads/return command and Payment refund HTTP errors use stable public envelopes',
+  '✔ Commerce storefront Order and Payment owner boundaries use stable public envelopes',
 );

--- a/scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
+++ b/scripts/verify/verify-commerce-storefront-order-refund-error-context.mjs
@@ -11,7 +11,7 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const controller = read('crates/rustok-commerce/src/controllers/store/orders.rs');
-const paymentErrors = read('crates/rustok-payment/src/error.rs');
+const paymentOwner = read('crates/rustok-payment/src/order_read.rs');
 const failures = [];
 
 const requireText = (content, value, label) => {
@@ -30,17 +30,11 @@ const between = (content, start, end, label) => {
   return content.slice(startIndex, endIndex);
 };
 
-const policy = between(
-  controller,
-  'fn storefront_order_payment_error_policy(',
-  'fn map_storefront_payment_error(',
-  'storefront order payment policy',
-);
 const mapper = between(
   controller,
-  'fn map_storefront_payment_error(',
+  'fn map_storefront_payment_port_error(',
   'async fn current_storefront_customer_id(',
-  'storefront order payment mapper',
+  'storefront Payment refund mapper',
 );
 const ownership = between(
   controller,
@@ -56,214 +50,96 @@ const refundRoute = between(
 );
 
 for (const [value, label] of [
-  [
-    'const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";',
-    'payment owner constant',
-  ],
-  [
-    'const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";',
-    'payment boundary constant',
-  ],
-  ['type StorefrontOrderPaymentHttpPolicy = (', 'payment policy type'],
-  [
-    'struct StorefrontOrderPaymentErrorContext<\'a> {',
-    'typed payment context',
-  ],
-  ['tenant_id: Uuid,', 'tenant context field'],
-  ['actor_id: Uuid,', 'actor context field'],
-  ['customer_id: Uuid,', 'customer context field'],
-  ['order_id: Uuid,', 'order context field'],
-  ['payment_collection_id: Option<Uuid>,', 'collection context field'],
-  ['refund_id: Option<Uuid>,', 'refund context field'],
-  ['channel_id: Option<Uuid>,', 'channel ID context field'],
-  ['channel_slug: Option<&\'a str>,', 'channel slug context field'],
-  ['locale: &\'a str,', 'locale context field'],
-  ['operation: &\'static str,', 'operation context field'],
-  ['payment_collection_id: None,', 'empty collection identity'],
-  ['refund_id: None,', 'empty refund identity'],
-  ['channel_id: request_context.channel_id,', 'channel ID adoption'],
-  [
-    'channel_slug: request_context.channel_slug.as_deref(),',
-    'channel slug adoption',
-  ],
-  ['locale: request_context.locale.as_str(),', 'locale adoption'],
+  ['const STOREFRONT_ORDER_PAYMENT_OWNER: &str = "rustok_payment.storefront_order_refunds";', 'Payment owner constant'],
+  ['const STOREFRONT_ORDER_PAYMENT_BOUNDARY: &str = "commerce_storefront_order_http";', 'Payment boundary constant'],
+  ['fn map_storefront_payment_port_error(', 'typed Payment port mapper'],
 ]) requireText(controller, value, label);
 
 for (const [value, label] of [
-  ['PaymentError::Validation(_)', 'validation variant'],
+  ['"payment.order_refund_provider_unavailable"', 'provider unavailable owner code'],
+  ['"payment.order_refund_provider_invalid_response"', 'provider invalid response owner code'],
+  ['"payment.order_refund_reconciliation_required"', 'reconciliation owner code'],
+  ['"payment.order_refund_provider_not_configured"', 'provider configuration owner code'],
   ['StatusCode::BAD_REQUEST', 'validation status'],
-  ['"commerce_store_payment_invalid"', 'validation code'],
-  ['"Payment request is invalid"', 'validation message'],
-  ['"validation"', 'validation kind'],
-  [
-    'PaymentError::PaymentCollectionNotFound(payment_collection_id)',
-    'collection not-found variant',
-  ],
-  [
-    'context.payment_collection_id = Some(*payment_collection_id);',
-    'collection identity adoption',
-  ],
-  [
-    'PaymentError::PaymentNotFound(payment_collection_id)',
-    'payment not-found variant',
-  ],
-  ['"payment_not_found"', 'payment not-found kind'],
-  ['PaymentError::RefundNotFound(refund_id)', 'refund not-found variant'],
-  ['context.refund_id = Some(*refund_id);', 'refund identity adoption'],
+  ['"commerce_store_payment_invalid"', 'validation public code'],
   ['StatusCode::NOT_FOUND', 'not-found status'],
-  ['"commerce_store_payment_not_found"', 'not-found code'],
-  ['"Payment resource was not found"', 'not-found message'],
-  ['PaymentError::InvalidTransition { .. }', 'transition variant'],
-  ['"state_conflict"', 'transition kind'],
-  ['PaymentError::ProviderRejected { .. }', 'provider rejected variant'],
-  ['"provider_rejected"', 'provider rejected kind'],
+  ['"commerce_store_payment_not_found"', 'not-found public code'],
   ['StatusCode::CONFLICT', 'conflict status'],
-  ['"commerce_store_payment_state_conflict"', 'state conflict code'],
-  [
-    '"Payment operation conflicts with the current state"',
-    'state conflict message',
-  ],
-  ['PaymentError::ProviderUnavailable { .. }', 'provider unavailable variant'],
+  ['"commerce_store_payment_state_conflict"', 'state-conflict public code'],
   ['StatusCode::SERVICE_UNAVAILABLE', 'unavailable status'],
-  [
-    '"commerce_store_payment_provider_unavailable"',
-    'provider unavailable code',
-  ],
-  [
-    '"Payment provider is temporarily unavailable"',
-    'provider unavailable message',
-  ],
-  [
-    'PaymentError::ProviderInvalidResponse { .. }',
-    'invalid provider response variant',
-  ],
+  ['"commerce_store_payment_provider_unavailable"', 'provider unavailable public code'],
   ['StatusCode::BAD_GATEWAY', 'bad gateway status'],
-  [
-    '"commerce_store_payment_provider_invalid_response"',
-    'invalid provider response code',
-  ],
-  [
-    '"Payment provider returned an invalid response"',
-    'invalid provider response message',
-  ],
-  [
-    'PaymentError::ProviderOutcomeUnknown { .. }',
-    'unknown provider outcome variant',
-  ],
-  [
-    '"commerce_store_payment_reconciliation_required"',
-    'reconciliation code',
-  ],
-  ['"Payment state requires reconciliation"', 'reconciliation message'],
-  [
-    'PaymentError::ProviderConfiguration { .. }',
-    'provider configuration variant',
-  ],
-  [
-    '"commerce_store_payment_provider_not_configured"',
-    'provider configuration code',
-  ],
-  [
-    '"Payment provider is not configured for this tenant"',
-    'provider configuration message',
-  ],
-  ['PaymentError::Database(_)', 'database variant'],
-  ['"commerce_store_payment_unavailable"', 'database code'],
-  ['"Payment service is temporarily unavailable"', 'database message'],
-  ['"database"', 'database kind'],
-]) requireText(policy, value, label);
-
-for (const [value, label] of [
-  ['error = ?error', 'typed payment cause log'],
-  ['owner = STOREFRONT_ORDER_PAYMENT_OWNER', 'owner log'],
-  ['tenant_id = %context.tenant_id', 'tenant log'],
-  ['actor_id = %context.actor_id', 'actor log'],
-  ['customer_id = %context.customer_id', 'customer log'],
-  ['order_id = %context.order_id', 'order log'],
-  [
-    'payment_collection_id = ?context.payment_collection_id',
-    'collection identity log',
-  ],
-  ['refund_id = ?context.refund_id', 'refund identity log'],
-  ['channel_id = ?context.channel_id', 'channel ID log'],
-  ['channel = ?context.channel_slug', 'channel slug log'],
-  ['locale = %context.locale', 'locale log'],
-  ['operation = %context.operation', 'operation log'],
-  ['error_kind,', 'error kind log'],
-  ['public_code = code', 'public code log'],
-  ['status = %status', 'status log'],
-  ['boundary = STOREFRONT_ORDER_PAYMENT_BOUNDARY', 'boundary log'],
+  ['"commerce_store_payment_provider_invalid_response"', 'provider invalid-response public code'],
+  ['"commerce_store_payment_reconciliation_required"', 'reconciliation public code'],
+  ['"commerce_store_payment_provider_not_configured"', 'provider configuration public code'],
+  ['"commerce_store_payment_unavailable"', 'storage unavailable public code'],
+  ['owner = STOREFRONT_ORDER_PAYMENT_OWNER', 'owner diagnostic'],
+  ['owner_operation = "list_refunds_by_order"', 'owner operation diagnostic'],
+  ['consumer_operation = "list_order_refunds"', 'consumer operation diagnostic'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['actor_id_non_nil = !actor_id.is_nil()', 'actor identity diagnostic'],
+  ['customer_id_non_nil = !customer_id.is_nil()', 'customer identity diagnostic'],
+  ['order_id_non_nil = !order_id.is_nil()', 'order identity diagnostic'],
+  ['owner_error_kind = ?error.kind', 'owner kind diagnostic'],
+  ['owner_code_length = error.code.chars().count()', 'bounded code diagnostic'],
+  ['retryable = error.retryable', 'retryability diagnostic'],
   ['HttpError::new(status, code, message)', 'stable public envelope'],
 ]) requireText(mapper, value, label);
+
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'internal_message']) {
+  forbidText(mapper, value, 'raw Payment owner diagnostic');
+}
 
 for (const [value, label] of [
   [') -> HttpResult<Uuid> {', 'ownership helper return type'],
   ['Ok(customer_id)', 'verified customer return'],
-  ['.get_order(tenant_id, order_id)', 'order ownership read'],
+  ['read_storefront_order_projection(', 'owner Order ownership read'],
   ['order.customer_id != Some(customer_id)', 'ownership comparison'],
   ['"commerce_store_customer_required"', 'customer-required envelope'],
   ['"commerce_store_order_access_denied"', 'access-denied envelope'],
 ]) requireText(ownership, value, label);
 
 for (const [value, label] of [
-  [
-    'super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;',
-    'channel guard',
-  ],
-  ['let customer_id =', 'verified customer binding'],
-  [
-    'ensure_customer_owns_order(&runtime, tenant.id, &auth, id, "list_order_refunds_access")',
-    'ownership helper call',
-  ],
-  ['PaymentService::new(runtime.db_clone())', 'payment service construction'],
-  ['.list_refunds(', 'refund list call'],
+  ['super::ensure_storefront_channel_enabled_for_db(runtime.db(), &request_context).await?;', 'channel guard'],
+  ['let customer_id = ensure_customer_owns_order(', 'verified customer binding'],
+  ['"list_order_refunds_access"', 'ownership operation'],
+  ['let payment_context = storefront_order_read_port_context(', 'Payment context construction'],
+  ['tenant.id,', 'tenant forwarding'],
+  ['&auth,', 'actor forwarding'],
+  ['&request_context,', 'request context forwarding'],
+  ['.payment_order_read_port()', 'host-selected Payment port'],
+  ['.list_refunds_by_order(', 'refund owner operation'],
+  ['ListRefundsByOrderRequest {', 'typed refund request'],
+  ['order_id: id,', 'order forwarding'],
   ['page: params.pagination.page,', 'page forwarding'],
   ['per_page: params.pagination.per_page,', 'per-page forwarding'],
-  ['payment_collection_id: None,', 'collection filter contract'],
-  ['order_id: Some(id),', 'order filter contract'],
-  ['status: params.status,', 'status filter forwarding'],
-  ['StorefrontOrderPaymentErrorContext::new(', 'typed mapper context'],
-  ['tenant.id,', 'tenant context forwarding'],
-  ['auth.user_id,', 'actor context forwarding'],
-  ['customer_id,', 'customer context forwarding'],
-  ['id,', 'order context forwarding'],
-  ['&request_context,', 'request context forwarding'],
-  ['"list_order_refunds"', 'route operation'],
-  [
-    'PaginationMeta::new(params.pagination.page, params.pagination.limit(), total)',
-    'pagination response contract',
-  ],
+  ['status: params.status,', 'status forwarding'],
+  ['PaginationMeta::new(params.pagination.page, params.pagination.limit(), page.total)', 'pagination response contract'],
 ]) requireText(refundRoute, value, label);
 
-for (const value of [
-  'Validation(String),',
-  'PaymentCollectionNotFound(Uuid),',
-  'PaymentNotFound(Uuid),',
-  'RefundNotFound(Uuid),',
-  'InvalidTransition { from: String, to: String },',
-  'ProviderUnavailable {',
-  'ProviderRejected {',
-  'ProviderInvalidResponse {',
-  'ProviderOutcomeUnknown {',
-  'ProviderConfiguration { provider_id: String },',
-  'Database(#[from] DbErr),',
-]) requireText(paymentErrors, value, 'payment source enum');
-
-const mapperUses = controller.match(/map_storefront_payment_error\(/g) ?? [];
-if (mapperUses.length !== 2) {
-  failures.push(
-    `expected payment mapper definition plus one route use, found ${mapperUses.length}`,
-  );
-}
+for (const [value, label] of [
+  ['pub trait PaymentOrderReadPort: Send + Sync', 'Payment owner trait'],
+  ['async fn list_refunds_by_order(', 'Payment refund capability'],
+  ['context.require_policy(PortCallPolicy::read())?', 'read admission'],
+  ['pub struct ListRefundsByOrderRequest', 'typed request'],
+  ['pub struct PaymentOrderRefundPage', 'typed page'],
+  ['.list_refunds(', 'owner-local service call'],
+  ['payment_collection_id: None,', 'collection filter contract'],
+  ['order_id: Some(request.order_id),', 'order filter contract'],
+  ['status: request.status,', 'status filter contract'],
+]) requireText(paymentOwner, value, label);
 
 for (const value of [
-  'map_storefront_payment_error(error, "list_order_refunds", tenant.id, id)',
+  'PaymentService::new(runtime.db_clone())',
+  'StorefrontOrderPaymentErrorContext',
+  'fn storefront_order_payment_error_policy(',
+  'PaymentError::',
+  'map_storefront_payment_error(',
   'error.to_string()',
   'err.to_string()',
-  'error.message',
   'HttpError::bad_request(error',
   'HttpError::internal(error',
-]) forbidText(controller, value, 'stale or unsafe refund mapping');
+]) forbidText(controller, value, 'stale or unsafe storefront refund boundary');
 
 if (failures.length > 0) {
   console.error('Commerce storefront order-refund error-context verification failed:');
@@ -272,5 +148,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  '✔ Storefront order refund failures retain typed route context and stable public contracts',
+  '✔ Storefront order refunds preserve ownership context through the host-selected Payment owner port',
 );


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with mounted storefront order-refund reads.

- publish `PaymentOrderReadPort::list_refunds_by_order` with typed `ListRefundsByOrderRequest` / `PaymentOrderRefundPage` while retaining the existing order-read runtime;
- give the new trait capability a default fail-closed implementation that enforces read deadline semantics, so existing external adapters remain source-compatible but must explicitly opt in before the route can succeed;
- keep `PaymentService::list_refunds` inside the in-process Payment owner adapter and preserve page/per-page/status/order filtering, unconstrained payment-collection filter, ordering, total and refund DTO semantics;
- cut mounted `GET /store/orders/{id}/refunds` to the host-selected `PaymentOrderReadPort` after the existing authenticated-customer Order ownership check;
- preserve the existing storefront Payment public error families, including provider unavailable/invalid-response/reconciliation/configuration distinctions, with bounded owner diagnostics and no raw owner/backend messages at the Commerce boundary;
- retire stale source-guard and dated-record assertions that the mounted route still constructs `PaymentService` directly;
- add a dedicated `source_complete_unvalidated` record and source guard;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind `535c6d4a3aca4412c27c69453e08c6942c281ac9` with exactly nine changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST scenarios, workflows, CI reruns, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source guards were added/updated but not run.