### PR TITLE
feat(forum): add bounded member card stats

### DIFF
--- a/crates/rustok-forum/src/graphql/member_card_query.rs
+++ b/crates/rustok-forum/src/graphql/member_card_query.rs
@@ -1,0 +1,196 @@
+use std::collections::{HashMap, HashSet};
+
+use async_graphql::{Context, FieldError, Object, Result, SimpleObject, dataloader::DataLoader};
+use rustok_api::{
+    AuthContext, Permission, TenantContext,
+    graphql::{GraphQLError, require_module_enabled, resolve_graphql_locale},
+    has_any_effective_permission,
+};
+use rustok_profiles::{
+    ProfilePresentationService, ProfileSummaryLoader, ProfileSummaryLoaderKey,
+    graphql::GqlProfileSummary,
+};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use uuid::Uuid;
+
+use crate::entities::forum_user_stat;
+
+const MODULE_SLUG: &str = "forum";
+pub const MAX_FORUM_MEMBER_CARD_USER_IDS: usize = 100;
+
+#[derive(Clone, Debug, SimpleObject)]
+pub struct GqlForumMemberStats {
+    pub topic_count: i32,
+    pub reply_count: i32,
+    pub solution_count: i32,
+}
+
+#[derive(Clone, Debug, SimpleObject)]
+pub struct GqlForumMemberCard {
+    pub user_id: Uuid,
+    pub profile: GqlProfileSummary,
+    pub forum_stats: GqlForumMemberStats,
+}
+
+#[derive(Default)]
+pub struct ForumMemberCardQuery;
+
+#[Object]
+impl ForumMemberCardQuery {
+    async fn forum_member_cards(
+        &self,
+        ctx: &Context<'_>,
+        user_ids: Vec<Uuid>,
+        locale: Option<String>,
+    ) -> Result<Vec<GqlForumMemberCard>> {
+        require_module_enabled(ctx, MODULE_SLUG).await?;
+        require_member_card_permission(ctx)?;
+
+        if user_ids.len() > MAX_FORUM_MEMBER_CARD_USER_IDS {
+            return Err(async_graphql::Error::new(format!(
+                "Forum member-card request exceeds the {MAX_FORUM_MEMBER_CARD_USER_IDS}-user limit"
+            )));
+        }
+
+        let mut seen = HashSet::with_capacity(user_ids.len());
+        let mut requested_user_ids = Vec::with_capacity(user_ids.len());
+        for user_id in user_ids {
+            if user_id.is_nil() {
+                return Err(async_graphql::Error::new(
+                    "Forum member-card request contains a nil user ID",
+                ));
+            }
+            if seen.insert(user_id) {
+                requested_user_ids.push(user_id);
+            }
+        }
+        if requested_user_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let db = ctx.data::<DatabaseConnection>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let requested_locale = resolve_graphql_locale(ctx, locale.as_deref());
+        let mut profiles = load_visible_profiles(
+            ctx,
+            db,
+            tenant.id,
+            &requested_user_ids,
+            requested_locale.as_str(),
+            tenant.default_locale.as_str(),
+        )
+        .await?;
+
+        if profiles.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let visible_user_ids = requested_user_ids
+            .iter()
+            .copied()
+            .filter(|user_id| profiles.contains_key(user_id))
+            .collect::<Vec<_>>();
+        let mut stats = load_forum_stats(db, tenant.id, &visible_user_ids).await?;
+
+        let mut cards = Vec::with_capacity(visible_user_ids.len());
+        for user_id in requested_user_ids {
+            let Some(profile) = profiles.remove(&user_id) else {
+                continue;
+            };
+            let forum_stats = stats.remove(&user_id).unwrap_or(GqlForumMemberStats {
+                topic_count: 0,
+                reply_count: 0,
+                solution_count: 0,
+            });
+            cards.push(GqlForumMemberCard {
+                user_id,
+                profile,
+                forum_stats,
+            });
+        }
+        Ok(cards)
+    }
+}
+
+fn require_member_card_permission(ctx: &Context<'_>) -> Result<()> {
+    let auth = ctx
+        .data::<AuthContext>()
+        .map_err(|_| <FieldError as GraphQLError>::unauthenticated())?;
+    if !has_any_effective_permission(&auth.permissions, &[Permission::FORUM_TOPICS_READ]) {
+        return Err(<FieldError as GraphQLError>::permission_denied(
+            "Permission denied: forum_topics:read required for member cards",
+        ));
+    }
+    Ok(())
+}
+
+async fn load_visible_profiles(
+    ctx: &Context<'_>,
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    user_ids: &[Uuid],
+    requested_locale: &str,
+    tenant_default_locale: &str,
+) -> Result<HashMap<Uuid, GqlProfileSummary>> {
+    if let Some(loader) = ctx.data_opt::<DataLoader<ProfileSummaryLoader>>() {
+        let keys = user_ids
+            .iter()
+            .map(|user_id| ProfileSummaryLoaderKey {
+                tenant_id,
+                user_id: *user_id,
+                requested_locale: Some(requested_locale.to_string()),
+                tenant_default_locale: Some(tenant_default_locale.to_string()),
+            })
+            .collect::<Vec<_>>();
+        let profiles = loader.load_many(keys).await?;
+        return Ok(profiles
+            .into_iter()
+            .map(|(key, summary)| (key.user_id, summary.into()))
+            .collect());
+    }
+
+    let profiles = ProfilePresentationService::new(db.clone())
+        .find_profile_summaries(
+            tenant_id,
+            user_ids,
+            Some(requested_locale),
+            Some(tenant_default_locale),
+        )
+        .await
+        .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+    Ok(profiles
+        .into_iter()
+        .map(|(user_id, summary)| (user_id, summary.into()))
+        .collect())
+}
+
+async fn load_forum_stats(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    visible_user_ids: &[Uuid],
+) -> Result<HashMap<Uuid, GqlForumMemberStats>> {
+    if visible_user_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = forum_user_stat::Entity::find()
+        .filter(forum_user_stat::Column::TenantId.eq(tenant_id))
+        .filter(forum_user_stat::Column::UserId.is_in(visible_user_ids.to_vec()))
+        .all(db)
+        .await
+        .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.user_id,
+                GqlForumMemberStats {
+                    topic_count: row.topic_count,
+                    reply_count: row.reply_count,
+                    solution_count: row.solution_count,
+                },
+            )
+        })
+        .collect())
+}

--- a/crates/rustok-forum/src/graphql/mod.rs
+++ b/crates/rustok-forum/src/graphql/mod.rs
@@ -6,6 +6,7 @@ mod category_tree_query;
 mod connection;
 mod content_commands;
 mod error_extension;
+mod member_card_query;
 mod mention_reconciliation_query;
 mod mutation;
 #[path = "query_runtime.rs"]
@@ -48,6 +49,9 @@ pub use content_commands::{
     UpdateForumReplyWithQuotesInput, UpdateForumTopicWithQuotesInput,
 };
 pub use error_extension::ForumGraphqlErrorExtension;
+pub use member_card_query::{
+    GqlForumMemberCard, GqlForumMemberStats, MAX_FORUM_MEMBER_CARD_USER_IDS,
+};
 pub use mention_reconciliation_query::{
     GqlForumMentionDrift, GqlForumMentionReconciliationReport,
 };
@@ -96,6 +100,7 @@ pub struct ForumQuery(
     reconciliation_query::ForumReconciliationQuery,
     subscription_reconciliation_query::ForumSubscriptionReconciliationQuery,
     mention_reconciliation_query::ForumMentionReconciliationQuery,
+    member_card_query::ForumMemberCardQuery,
     reply_audience_query::ForumReplyAudienceQuery,
     storefront_read_state::ForumStorefrontReadStateQuery,
     storefront_audience_topic::ForumStorefrontAudienceTopicQuery,

--- a/docs/modules/forum-15-member-card-stats-actualization-2026-08-10.md
+++ b/docs/modules/forum-15-member-card-stats-actualization-2026-08-10.md
@@ -1,0 +1,96 @@
+# FORUM-15B member-card statistics actualization — 2026-08-10
+
+Status: `source-ready / bounded-member-card-read / profile-privacy-authoritative / runtime-evidence-open`
+
+## Fresh cursor
+
+This slice started from `main@d3781ddbabc3a4122324b991ddb2a31eca0a80cb` after FORUM-15A. The intervening main movement changed Forum/Page Builder rollout evidence and related verification sources, not Forum GraphQL profile composition or Forum user-stat ownership.
+
+The canonical FORUM-15 ledger remains `in_progress`: this slice adds a bounded source contract for member-card composition, while retained runtime/no-N+1 evidence and product integration into the complete Forum member-card experience remain open.
+
+## Owner boundaries
+
+Profiles remains authoritative for public identity and presentation privacy. Forum does not copy handle, display name, avatar or privacy/block state and does not read Profiles/Social Graph private tables.
+
+Forum remains authoritative only for Forum-local statistics. The member-card read composes:
+
+- Profiles-owned `GqlProfileSummary` admitted through `ProfileSummaryLoader` / `ProfilePresentationService`;
+- Forum-owned topic/reply/solution counters from `forum_user_stats`.
+
+The composition order is security-significant: Profiles presentation admission happens first, and Forum statistics are loaded only for the identities returned by that owner. A Forum statistics row can never make a hidden or blocked profile visible.
+
+## New bounded GraphQL contract
+
+`forumMemberCards(userIds, locale)` is mounted on `ForumQuery` through `ForumMemberCardQuery`.
+
+The contract:
+
+1. requires the Forum module and authenticated `forum_topics:read`, matching the existing single-user Forum stats admission surface;
+2. accepts at most `MAX_FORUM_MEMBER_CARD_USER_IDS = 100` requested IDs;
+3. rejects nil IDs and deduplicates repeated IDs while preserving first-request order;
+4. resolves locale from the request/tenant context;
+5. loads Profiles presentation in one bounded batch;
+6. loads Forum statistics in one `forum_user_stats` query for visible profile IDs only;
+7. zero-fills missing Forum statistics rows without manufacturing a profile;
+8. returns cards in first-request order for visible identities only.
+
+The response shape is:
+
+```text
+GqlForumMemberCard {
+  user_id
+  profile: GqlProfileSummary
+  forum_stats: GqlForumMemberStats {
+    topic_count
+    reply_count
+    solution_count
+  }
+}
+```
+
+## Profiles presentation behavior
+
+The preferred host path is the request-scoped `DataLoader<ProfileSummaryLoader>`. The host binds that loader to the request audience, so authenticated/block/privacy behavior stays owned by Profiles.
+
+As established in FORUM-15A, if the loader is absent the query falls back to `ProfilePresentationService::new`, which is anonymous/fail-closed rather than raw `ProfileService`.
+
+The new query does not invoke `ProfilePrivacyService` directly and does not reproduce its matrix.
+
+## No-N+1 source shape
+
+For a request of up to 100 IDs:
+
+- input IDs are deduplicated before any owner read;
+- one loader `load_many` call or one fallback `find_profile_summaries` call handles Profiles presentation;
+- one SeaORM query loads all matching Forum user-stat rows;
+- there is no per-user `UserStatsService::get` loop;
+- there is no per-user Profiles read loop.
+
+This establishes a bounded no-N+1 source shape. Retained database/query-count/runtime evidence is still maintainer work and is not claimed here.
+
+## Compatibility
+
+Existing `authorProfile` fields on Forum topic/reply GraphQL types are unchanged. This slice adds a separate batch member-card read instead of changing established topic/reply response shapes.
+
+That keeps existing consumers compatible and gives authenticated Forum member-card consumers an explicit bounded enrichment contract.
+
+## Remaining FORUM-15 work
+
+FORUM-15 remains `in_progress`. Remaining work includes:
+
+- integrating the batch member-card contract into the intended Forum member-card UI surfaces;
+- retained runtime/query-count evidence proving the bounded source shape under real host composition;
+- browser/runtime evidence for privacy/block behavior and locale presentation;
+- any additional permitted Forum activity/reputation composition required by later tasks without moving ownership into Forum.
+
+Because those broader deliverables remain open, the canonical ledger wording is still materially true and is not rewritten merely to mark this source slice.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-member-card-stats-source.mjs
+```

--- a/scripts/verify/verify-forum-member-card-stats-source.mjs
+++ b/scripts/verify/verify-forum-member-card-stats-source.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const query = read("crates/rustok-forum/src/graphql/member_card_query.rs");
+const gqlMod = read("crates/rustok-forum/src/graphql/mod.rs");
+const profilePresentation = read("crates/rustok-profiles/src/presentation.rs");
+const profileLoader = read("crates/rustok-profiles/src/loader.rs");
+const packet = read("docs/modules/forum-15-member-card-stats-actualization-2026-08-10.md");
+
+for (const marker of [
+  "pub const MAX_FORUM_MEMBER_CARD_USER_IDS: usize = 100",
+  "async fn forum_member_cards(",
+  "Permission::FORUM_TOPICS_READ",
+  "if user_ids.len() > MAX_FORUM_MEMBER_CARD_USER_IDS",
+  "if user_id.is_nil()",
+  "seen.insert(user_id)",
+  "load_visible_profiles(",
+  "profiles.contains_key(user_id)",
+  "load_forum_stats(db, tenant.id, &visible_user_ids)",
+  "ProfilePresentationService::new(db.clone())",
+  "ctx.data_opt::<DataLoader<ProfileSummaryLoader>>()",
+  "loader.load_many(keys).await?",
+  "forum_user_stat::Entity::find()",
+  "forum_user_stat::Column::TenantId.eq(tenant_id)",
+  "forum_user_stat::Column::UserId.is_in(visible_user_ids.to_vec())",
+]) need(query, marker, "FORUM-15B member-card query");
+
+const profileIndex = query.indexOf("load_visible_profiles(");
+const visibleFilterIndex = query.indexOf("profiles.contains_key(user_id)");
+const statsIndex = query.indexOf("load_forum_stats(db, tenant.id, &visible_user_ids)");
+if (!(profileIndex >= 0 && visibleFilterIndex > profileIndex && statsIndex > visibleFilterIndex)) {
+  throw new Error("FORUM-15B privacy admission must precede Forum stats loading");
+}
+
+for (const marker of [
+  "Permission::FORUM_TOPICS_LIST",
+  "Permission::FORUM_REPLIES_LIST",
+  "ProfileService::new(",
+  "ProfilePrivacyService",
+  "rustok_profiles::entities",
+  "UserStatsService::new",
+  ".get(tenant_id",
+]) forbid(query, marker, "FORUM-15B must not broaden or bypass batch owner composition");
+
+for (const marker of [
+  "mod member_card_query;",
+  "GqlForumMemberCard, GqlForumMemberStats, MAX_FORUM_MEMBER_CARD_USER_IDS",
+  "member_card_query::ForumMemberCardQuery",
+]) need(gqlMod, marker, "FORUM-15B GraphQL wiring");
+
+for (const marker of [
+  "ProfilePrivacyService::new(self.db.clone())",
+  ".evaluate_access_batch(tenant_id, user_ids, self.audience)",
+  "ProfilePrivacyDecision::Allow",
+  "ProfileError::PresentationUnavailable",
+]) need(profilePresentation, marker, "Profiles presentation owner baseline");
+
+for (const marker of [
+  "ProfilePresentationService::for_audience(db, audience)",
+  "ProfileSummaryBatchKey",
+  ".find_profile_summaries(",
+]) need(profileLoader, marker, "Profiles batch loader baseline");
+
+for (const marker of [
+  "FORUM-15B",
+  "profile-privacy-authoritative",
+  "MAX_FORUM_MEMBER_CARD_USER_IDS = 100",
+  "one `forum_user_stats` query",
+  "is not claimed here",
+  "no Cargo command, test, Node verifier",
+]) need(packet, marker, "FORUM-15B actualization");
+
+console.log("Forum FORUM-15B member-card statistics source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-15 with an explicit bounded member-card composition read.

- add `forumMemberCards(userIds, locale)` with a 100-ID request ceiling, nil rejection and first-request-order deduplication;
- keep Profiles presentation/privacy authoritative through the request-scoped `ProfileSummaryLoader`, with the FORUM-15A anonymous/fail-closed `ProfilePresentationService` fallback;
- query `forum_user_stats` once, only for profile IDs admitted by Profiles presentation;
- zero-fill missing Forum stats rows without manufacturing profile visibility;
- keep existing topic/reply `authorProfile` fields unchanged for compatibility;
- add dated FORUM-15B actualization and a source guard, intentionally not executed.

## Privacy and ownership

The order is deliberate: Profiles presentation admission runs first, then Forum stats are loaded only for those visible IDs. A Forum stats row cannot reveal a hidden/blocked profile. Forum does not read Profiles or Social Graph private tables and does not duplicate profile privacy logic.

Forum-owned data in this contract is limited to topic/reply/solution counters from `forum_user_stats`.

## Admission / boundedness

The query requires the Forum module plus authenticated `forum_topics:read`, matching the existing single-user `forum_user_stats` admission surface. It accepts at most 100 requested IDs. IDs are deduplicated before owner reads. Profiles uses one batch loader call (or one fail-closed fallback batch), and Forum stats use one SeaORM query.

## Remaining FORUM-15 work

This PR does not claim the full task complete. UI integration and retained runtime/query-count/browser evidence remain open, so the canonical FORUM-15 ledger remains `in_progress`.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was run. `scripts/verify/verify-forum-member-card-stats-source.mjs` was added but intentionally not executed.