### PR TITLE
refactor(forum): share member card owner service

### DIFF
--- a/crates/rustok-forum/src/graphql/member_card_query.rs
+++ b/crates/rustok-forum/src/graphql/member_card_query.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use async_graphql::{Context, FieldError, Object, Result, SimpleObject, dataloader::DataLoader};
 use rustok_api::{
@@ -6,17 +6,17 @@ use rustok_api::{
     graphql::{GraphQLError, require_module_enabled, resolve_graphql_locale},
     has_any_effective_permission,
 };
-use rustok_profiles::{
-    ProfilePresentationService, ProfileSummaryLoader, ProfileSummaryLoaderKey,
-    graphql::GqlProfileSummary,
-};
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use rustok_profiles::{ProfileSummaryLoader, ProfileSummaryLoaderKey, graphql::GqlProfileSummary};
+use sea_orm::DatabaseConnection;
 use uuid::Uuid;
 
-use crate::entities::forum_user_stat;
+use crate::services::user_stats::{
+    ForumMemberCard, ForumMemberCardAudience, ForumMemberCardService, ForumMemberStats,
+};
+
+pub use crate::services::user_stats::MAX_FORUM_MEMBER_CARD_USER_IDS;
 
 const MODULE_SLUG: &str = "forum";
-pub const MAX_FORUM_MEMBER_CARD_USER_IDS: usize = 100;
 
 #[derive(Clone, Debug, SimpleObject)]
 pub struct GqlForumMemberStats {
@@ -46,69 +46,50 @@ impl ForumMemberCardQuery {
         require_module_enabled(ctx, MODULE_SLUG).await?;
         require_member_card_permission(ctx)?;
 
-        if user_ids.len() > MAX_FORUM_MEMBER_CARD_USER_IDS {
-            return Err(async_graphql::Error::new(format!(
-                "Forum member-card request exceeds the {MAX_FORUM_MEMBER_CARD_USER_IDS}-user limit"
-            )));
-        }
-
-        let mut seen = HashSet::with_capacity(user_ids.len());
-        let mut requested_user_ids = Vec::with_capacity(user_ids.len());
-        for user_id in user_ids {
-            if user_id.is_nil() {
-                return Err(async_graphql::Error::new(
-                    "Forum member-card request contains a nil user ID",
-                ));
-            }
-            if seen.insert(user_id) {
-                requested_user_ids.push(user_id);
-            }
-        }
+        let db = ctx.data::<DatabaseConnection>()?;
+        let tenant = ctx.data::<TenantContext>()?;
+        let requested_locale = resolve_graphql_locale(ctx, locale.as_deref());
+        let service = ForumMemberCardService::new(db.clone());
+        let requested_user_ids = ForumMemberCardService::normalize_user_ids(&user_ids)
+            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
         if requested_user_ids.is_empty() {
             return Ok(Vec::new());
         }
 
-        let db = ctx.data::<DatabaseConnection>()?;
-        let tenant = ctx.data::<TenantContext>()?;
-        let requested_locale = resolve_graphql_locale(ctx, locale.as_deref());
-        let mut profiles = load_visible_profiles(
-            ctx,
-            db,
-            tenant.id,
-            &requested_user_ids,
-            requested_locale.as_str(),
-            tenant.default_locale.as_str(),
-        )
-        .await?;
+        let cards = if let Some(loader) = ctx.data_opt::<DataLoader<ProfileSummaryLoader>>() {
+            let keys = requested_user_ids
+                .iter()
+                .map(|user_id| ProfileSummaryLoaderKey {
+                    tenant_id: tenant.id,
+                    user_id: *user_id,
+                    requested_locale: Some(requested_locale.clone()),
+                    tenant_default_locale: Some(tenant.default_locale.clone()),
+                })
+                .collect::<Vec<_>>();
+            let profiles = loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .map(|(key, summary)| (key.user_id, summary))
+                .collect::<HashMap<_, _>>();
+            service
+                .compose_admitted_profiles(tenant.id, &requested_user_ids, profiles)
+                .await
+                .map_err(|error| async_graphql::Error::new(error.to_string()))?
+        } else {
+            service
+                .read_for_audience(
+                    tenant.id,
+                    ForumMemberCardAudience::Anonymous,
+                    &requested_user_ids,
+                    Some(requested_locale.as_str()),
+                    Some(tenant.default_locale.as_str()),
+                )
+                .await
+                .map_err(|error| async_graphql::Error::new(error.to_string()))?
+        };
 
-        if profiles.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let visible_user_ids = requested_user_ids
-            .iter()
-            .copied()
-            .filter(|user_id| profiles.contains_key(user_id))
-            .collect::<Vec<_>>();
-        let mut stats = load_forum_stats(db, tenant.id, &visible_user_ids).await?;
-
-        let mut cards = Vec::with_capacity(visible_user_ids.len());
-        for user_id in requested_user_ids {
-            let Some(profile) = profiles.remove(&user_id) else {
-                continue;
-            };
-            let forum_stats = stats.remove(&user_id).unwrap_or(GqlForumMemberStats {
-                topic_count: 0,
-                reply_count: 0,
-                solution_count: 0,
-            });
-            cards.push(GqlForumMemberCard {
-                user_id,
-                profile,
-                forum_stats,
-            });
-        }
-        Ok(cards)
+        Ok(cards.into_iter().map(map_member_card).collect())
     }
 }
 
@@ -124,73 +105,18 @@ fn require_member_card_permission(ctx: &Context<'_>) -> Result<()> {
     Ok(())
 }
 
-async fn load_visible_profiles(
-    ctx: &Context<'_>,
-    db: &DatabaseConnection,
-    tenant_id: Uuid,
-    user_ids: &[Uuid],
-    requested_locale: &str,
-    tenant_default_locale: &str,
-) -> Result<HashMap<Uuid, GqlProfileSummary>> {
-    if let Some(loader) = ctx.data_opt::<DataLoader<ProfileSummaryLoader>>() {
-        let keys = user_ids
-            .iter()
-            .map(|user_id| ProfileSummaryLoaderKey {
-                tenant_id,
-                user_id: *user_id,
-                requested_locale: Some(requested_locale.to_string()),
-                tenant_default_locale: Some(tenant_default_locale.to_string()),
-            })
-            .collect::<Vec<_>>();
-        let profiles = loader.load_many(keys).await?;
-        return Ok(profiles
-            .into_iter()
-            .map(|(key, summary)| (key.user_id, summary.into()))
-            .collect());
+fn map_member_card(card: ForumMemberCard) -> GqlForumMemberCard {
+    GqlForumMemberCard {
+        user_id: card.user_id,
+        profile: card.profile.into(),
+        forum_stats: map_member_stats(card.forum_stats),
     }
-
-    let profiles = ProfilePresentationService::new(db.clone())
-        .find_profile_summaries(
-            tenant_id,
-            user_ids,
-            Some(requested_locale),
-            Some(tenant_default_locale),
-        )
-        .await
-        .map_err(|error| async_graphql::Error::new(error.to_string()))?;
-    Ok(profiles
-        .into_iter()
-        .map(|(user_id, summary)| (user_id, summary.into()))
-        .collect())
 }
 
-async fn load_forum_stats(
-    db: &DatabaseConnection,
-    tenant_id: Uuid,
-    visible_user_ids: &[Uuid],
-) -> Result<HashMap<Uuid, GqlForumMemberStats>> {
-    if visible_user_ids.is_empty() {
-        return Ok(HashMap::new());
+fn map_member_stats(stats: ForumMemberStats) -> GqlForumMemberStats {
+    GqlForumMemberStats {
+        topic_count: stats.topic_count,
+        reply_count: stats.reply_count,
+        solution_count: stats.solution_count,
     }
-
-    let rows = forum_user_stat::Entity::find()
-        .filter(forum_user_stat::Column::TenantId.eq(tenant_id))
-        .filter(forum_user_stat::Column::UserId.is_in(visible_user_ids.to_vec()))
-        .all(db)
-        .await
-        .map_err(|error| async_graphql::Error::new(error.to_string()))?;
-
-    Ok(rows
-        .into_iter()
-        .map(|row| {
-            (
-                row.user_id,
-                GqlForumMemberStats {
-                    topic_count: row.topic_count,
-                    reply_count: row.reply_count,
-                    solution_count: row.solution_count,
-                },
-            )
-        })
-        .collect())
 }

--- a/crates/rustok-forum/src/services/member_card.rs
+++ b/crates/rustok-forum/src/services/member_card.rs
@@ -1,0 +1,218 @@
+mod member_card {
+    use std::collections::{HashMap, HashSet};
+
+    use rustok_profiles::{
+        ProfileAccessAudience, ProfilePresentationService, ProfileSummary, ProfilesReader,
+    };
+    use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+    use serde::{Deserialize, Serialize};
+    use uuid::Uuid;
+
+    use crate::entities::forum_user_stat;
+    use crate::{ForumError, ForumResult};
+
+    pub const MAX_FORUM_MEMBER_CARD_USER_IDS: usize = 100;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ForumMemberCardAudience {
+        Anonymous,
+        Authenticated { actor_id: Uuid },
+        TrustedService { actor_id: Option<Uuid> },
+    }
+
+    impl ForumMemberCardAudience {
+        fn into_profile_audience(self) -> ForumResult<ProfileAccessAudience> {
+            match self {
+                Self::Anonymous => Ok(ProfileAccessAudience::Anonymous),
+                Self::Authenticated { actor_id } => {
+                    if actor_id.is_nil() {
+                        return Err(ForumError::Validation(
+                            "Forum member-card authenticated audience actor must not be nil"
+                                .to_string(),
+                        ));
+                    }
+                    Ok(ProfileAccessAudience::Authenticated { actor_id })
+                }
+                Self::TrustedService { actor_id } => {
+                    if actor_id.is_some_and(|actor_id| actor_id.is_nil()) {
+                        return Err(ForumError::Validation(
+                            "Forum member-card trusted-service audience actor must not be nil"
+                                .to_string(),
+                        ));
+                    }
+                    Ok(ProfileAccessAudience::TrustedService { actor_id })
+                }
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ForumMemberStats {
+        pub topic_count: i32,
+        pub reply_count: i32,
+        pub solution_count: i32,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ForumMemberCard {
+        pub user_id: Uuid,
+        pub profile: ProfileSummary,
+        pub forum_stats: ForumMemberStats,
+    }
+
+    pub struct ForumMemberCardService {
+        db: DatabaseConnection,
+    }
+
+    impl ForumMemberCardService {
+        pub fn new(db: DatabaseConnection) -> Self {
+            Self { db }
+        }
+
+        pub fn normalize_user_ids(user_ids: &[Uuid]) -> ForumResult<Vec<Uuid>> {
+            if user_ids.len() > MAX_FORUM_MEMBER_CARD_USER_IDS {
+                return Err(ForumError::Validation(format!(
+                    "Forum member-card request exceeds the {MAX_FORUM_MEMBER_CARD_USER_IDS}-user limit"
+                )));
+            }
+
+            let mut seen = HashSet::with_capacity(user_ids.len());
+            let mut normalized = Vec::with_capacity(user_ids.len());
+            for user_id in user_ids.iter().copied() {
+                if user_id.is_nil() {
+                    return Err(ForumError::Validation(
+                        "Forum member-card request contains a nil user ID".to_string(),
+                    ));
+                }
+                if seen.insert(user_id) {
+                    normalized.push(user_id);
+                }
+            }
+            Ok(normalized)
+        }
+
+        /// Compose privacy-admitted profile presentation with Forum-owned statistics.
+        ///
+        /// Transport authorization remains the caller's responsibility. This method
+        /// always applies the Profiles-owned presentation/privacy decision for the
+        /// supplied audience before any Forum statistics are queried.
+        pub async fn read_for_audience(
+            &self,
+            tenant_id: Uuid,
+            audience: ForumMemberCardAudience,
+            user_ids: &[Uuid],
+            requested_locale: Option<&str>,
+            tenant_default_locale: Option<&str>,
+        ) -> ForumResult<Vec<ForumMemberCard>> {
+            if tenant_id.is_nil() {
+                return Err(ForumError::Validation(
+                    "Forum member-card tenant must not be nil".to_string(),
+                ));
+            }
+            let requested_user_ids = Self::normalize_user_ids(user_ids)?;
+            if requested_user_ids.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let presentation = ProfilePresentationService::for_audience(
+                self.db.clone(),
+                audience.into_profile_audience()?,
+            );
+            let profiles = presentation
+                .find_profile_summaries(
+                    tenant_id,
+                    &requested_user_ids,
+                    requested_locale,
+                    tenant_default_locale,
+                )
+                .await
+                .map_err(profile_presentation_error)?;
+
+            self.compose_admitted_profiles(tenant_id, &requested_user_ids, profiles)
+                .await
+        }
+
+        pub(crate) async fn compose_admitted_profiles(
+            &self,
+            tenant_id: Uuid,
+            requested_user_ids: &[Uuid],
+            mut profiles: HashMap<Uuid, ProfileSummary>,
+        ) -> ForumResult<Vec<ForumMemberCard>> {
+            if tenant_id.is_nil() {
+                return Err(ForumError::Validation(
+                    "Forum member-card tenant must not be nil".to_string(),
+                ));
+            }
+            let requested_user_ids = Self::normalize_user_ids(requested_user_ids)?;
+            if requested_user_ids.is_empty() || profiles.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            // Only identities admitted by the Profiles presentation owner may
+            // reach the Forum statistics read. Extra profile map entries are ignored.
+            let visible_user_ids = requested_user_ids
+                .iter()
+                .copied()
+                .filter(|user_id| profiles.contains_key(user_id))
+                .collect::<Vec<_>>();
+            if visible_user_ids.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let rows = forum_user_stat::Entity::find()
+                .filter(forum_user_stat::Column::TenantId.eq(tenant_id))
+                .filter(forum_user_stat::Column::UserId.is_in(visible_user_ids.clone()))
+                .all(&self.db)
+                .await?;
+            let mut stats = rows
+                .into_iter()
+                .map(|row| {
+                    (
+                        row.user_id,
+                        ForumMemberStats {
+                            topic_count: row.topic_count,
+                            reply_count: row.reply_count,
+                            solution_count: row.solution_count,
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+
+            let mut cards = Vec::with_capacity(visible_user_ids.len());
+            for user_id in requested_user_ids {
+                let Some(profile) = profiles.remove(&user_id) else {
+                    continue;
+                };
+                cards.push(ForumMemberCard {
+                    user_id,
+                    profile,
+                    forum_stats: stats.remove(&user_id).unwrap_or_default(),
+                });
+            }
+            Ok(cards)
+        }
+    }
+
+    fn profile_presentation_error(error: rustok_profiles::ProfileError) -> ForumError {
+        let source_code = error.code();
+        let retryable = error.is_retryable();
+        tracing::warn!(
+            error = %error,
+            source_code,
+            retryable,
+            "Forum member-card profile presentation failed"
+        );
+        ForumError::capability_failure(
+            "profiles",
+            source_code,
+            "Profile presentation is unavailable",
+            retryable,
+        )
+    }
+}
+
+pub use member_card::{
+    ForumMemberCard, ForumMemberCardAudience, ForumMemberCardService, ForumMemberStats,
+    MAX_FORUM_MEMBER_CARD_USER_IDS,
+};

--- a/crates/rustok-forum/src/services/user_stats.rs
+++ b/crates/rustok-forum/src/services/user_stats.rs
@@ -234,3 +234,5 @@ impl UserStatsService {
         Ok(())
     }
 }
+
+include!("member_card.rs");

--- a/docs/modules/forum-15-member-card-owner-service-actualization-2026-08-10.md
+++ b/docs/modules/forum-15-member-card-owner-service-actualization-2026-08-10.md
@@ -1,0 +1,107 @@
+# FORUM-15C member-card owner service actualization — 2026-08-10
+
+Status: `source-ready / shared-owner-service / graphql-adapter-thin / storefront-integration-open / maintainer-execution-open`
+
+## Fresh cursor
+
+This slice began from `main@1d557e8ce1108287befd80c340a534752d3fe0d2`, the FORUM-15B merge. During preparation `main` first advanced by three commits to `1de7925b1055917e5bc37a379c000e0fe611bb7f`, then advanced once more to `676861d89227b18ddbe51074de6ff3d38f2be8f2` before the final merge gate.
+
+The first intervening compare touched server composition/tests, Commerce, Distribution, Product, Page Builder sources/docs and one `crates/rustok-forum/admin/build.rs` line. The later single commit was Commerce/order-only. Neither movement touched the FORUM-15C GraphQL/member-card/user-stats files.
+
+An attempted whole-tree rebase onto the first fresh main was rejected during static review because it would have reverted concurrent changes. The feature was reset and replayed only through its intended files. For the final main movement, the feature tree is rebuilt from the current main base tree with only the intended FORUM-15C blobs overlaid. The final branch must have no unrelated files and `behind 0` before merge.
+
+FORUM-15 remains `in_progress`. FORUM-15B introduced the bounded authenticated GraphQL member-card read, but its Profiles presentation and Forum statistics composition still lived inside the GraphQL transport. The real Forum storefront uses a dual-path transport: GraphQL for headless/CSR and a native server adapter for SSR/hydrate. The storefront package intentionally does not depend directly on `rustok-profiles`.
+
+Therefore directly wiring the 15B GraphQL helper into native storefront UI would either create an HTTP self-call or add a new Profiles dependency to the storefront package. This slice removes that architectural dead end before UI integration.
+
+## Shared Forum owner contract
+
+`rustok_forum::services::user_stats` now exposes:
+
+- `MAX_FORUM_MEMBER_CARD_USER_IDS = 100`;
+- `ForumMemberCardAudience` with anonymous, authenticated and trusted-service audiences;
+- `ForumMemberStats`;
+- `ForumMemberCard`;
+- `ForumMemberCardService`.
+
+The service is included through the already-public `services::user_stats` module, so no large crate-root export rewrite is required.
+
+### Bounded request admission
+
+`ForumMemberCardService::normalize_user_ids`:
+
+- rejects more than 100 requested IDs before owner reads;
+- rejects nil user IDs;
+- deduplicates while preserving first-request order;
+- permits an empty request and returns an empty result.
+
+`read_for_audience` additionally rejects a nil tenant and rejects nil authenticated/trusted actor identities.
+
+## Privacy/ownership order
+
+The public `read_for_audience` method owns the safe cross-owner composition order:
+
+1. convert the Forum audience descriptor to the Profiles-owned `ProfileAccessAudience`;
+2. call `ProfilePresentationService::for_audience(...).find_profile_summaries(...)` once for the bounded deduplicated IDs;
+3. keep only IDs actually returned by Profiles presentation;
+4. query `forum_user_stats` once for those visible IDs only;
+5. zero-fill missing Forum statistic rows;
+6. return cards in first-request order.
+
+A Forum statistics row cannot manufacture or reveal a profile that Profiles presentation did not admit.
+
+Forum does not copy handle/display-name/avatar/privacy state into Forum persistence and does not read Profiles or Social Graph private tables.
+
+Profiles presentation errors retain the Profiles owner `code()` and `is_retryable()` classification when mapped to the Forum capability error. The public Forum message stays generic while server diagnostics retain the owner error context.
+
+## Deliberate API hardening
+
+`compose_admitted_profiles` exists only as `pub(crate)` so the GraphQL adapter can reuse request-scoped `ProfileSummaryLoader` output. External crates cannot pass an arbitrary `ProfileSummary` map into Forum and bypass Profiles presentation.
+
+The only external cross-owner composition entry point is `read_for_audience`, which always executes Profiles presentation before any Forum statistics are queried.
+
+Transport authorization remains outside this owner composition method. Existing GraphQL admission remains authenticated `forum_topics:read`; future storefront integration must apply its existing public/authenticated storefront admission before calling the owner service.
+
+## GraphQL 15B compatibility
+
+`forumMemberCards(userIds, locale)` keeps the exact 15B GraphQL response shape and permission surface.
+
+The request-scoped `DataLoader<ProfileSummaryLoader>` remains the preferred GraphQL path. When present, the loader performs audience-aware Profiles presentation and the GraphQL adapter passes only that admitted map to the crate-local composition helper.
+
+When the host loader is absent, the fallback remains anonymous/fail-closed through `ForumMemberCardService::read_for_audience(..., ForumMemberCardAudience::Anonymous, ...)`, preserving FORUM-15A behavior.
+
+The GraphQL transport no longer contains direct `forum_user_stats` SeaORM reads.
+
+## Storefront cursor
+
+The real storefront inventory was rechecked before this slice:
+
+- `rustok-forum/storefront` models currently omit author identity/profile fields;
+- the Leptos topic/reply UI currently renders no author/member card;
+- GraphQL storefront transport has separate topic/reply requests;
+- SSR/hydrate uses a native server adapter and the storefront package has no direct `rustok-profiles` dependency.
+
+The next bounded FORUM-15 slice may now use `rustok_forum::services::user_stats::ForumMemberCardService` from the native adapter while adding a matching GraphQL storefront member-card transport, without moving Profiles ownership into the storefront package.
+
+That future slice must preserve anonymous storefront availability and must not reuse the authenticated-only `forumMemberCards` transport as a public endpoint without an explicit storefront admission contract.
+
+## Remaining FORUM-15 work
+
+FORUM-15 is not complete. Remaining work includes:
+
+- dual-path storefront member-card transport/composition;
+- adding author identity/member-card presentation to the intended Forum storefront/admin surfaces;
+- retained query-count/runtime evidence for bounded no-N+1 behavior;
+- retained privacy/block/locale runtime or browser evidence.
+
+The canonical FORUM-15 ledger remains materially correct and stays `in_progress`.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-member-card-owner-service-source.mjs
+```

--- a/scripts/verify/verify-forum-member-card-owner-service-source.mjs
+++ b/scripts/verify/verify-forum-member-card-owner-service-source.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+const owner = read("crates/rustok-forum/src/services/member_card.rs");
+const userStats = read("crates/rustok-forum/src/services/user_stats.rs");
+const graphql = read("crates/rustok-forum/src/graphql/member_card_query.rs");
+const storefrontCargo = read("crates/rustok-forum/storefront/Cargo.toml");
+const storefrontModel = read("crates/rustok-forum/storefront/src/model.rs");
+const storefrontUi = read("crates/rustok-forum/storefront/src/ui/leptos.rs");
+const packet = read(
+  "docs/modules/forum-15-member-card-owner-service-actualization-2026-08-10.md",
+);
+
+for (const marker of [
+  "pub const MAX_FORUM_MEMBER_CARD_USER_IDS: usize = 100",
+  "pub enum ForumMemberCardAudience",
+  "Anonymous",
+  "Authenticated { actor_id: Uuid }",
+  "TrustedService { actor_id: Option<Uuid> }",
+  "pub struct ForumMemberStats",
+  "pub struct ForumMemberCard",
+  "pub struct ForumMemberCardService",
+  "pub fn normalize_user_ids(user_ids: &[Uuid])",
+  "pub async fn read_for_audience(",
+  "pub(crate) async fn compose_admitted_profiles(",
+  "ProfilePresentationService::for_audience(",
+  ".find_profile_summaries(",
+  "profiles.contains_key(user_id)",
+  "forum_user_stat::Entity::find()",
+  "forum_user_stat::Column::TenantId.eq(tenant_id)",
+  "forum_user_stat::Column::UserId.is_in(visible_user_ids.clone())",
+  "stats.remove(&user_id).unwrap_or_default()",
+  "error.code()",
+  "error.is_retryable()",
+]) need(owner, marker, "FORUM-15C owner service");
+
+const presentationIndex = owner.indexOf(".find_profile_summaries(");
+const visibleIndex = owner.indexOf("profiles.contains_key(user_id)");
+const statsIndex = owner.indexOf("forum_user_stat::Entity::find()");
+if (!(presentationIndex >= 0 && visibleIndex > presentationIndex && statsIndex > visibleIndex)) {
+  throw new Error("FORUM-15C Profiles admission must precede Forum statistics access");
+}
+
+for (const marker of [
+  "pub async fn compose_admitted_profiles(",
+  "ProfileService::new(",
+  "rustok_profiles::entities",
+  "SocialGraphService::new",
+  "PROFILES_PRESENTATION_FAILED",
+]) forbid(owner, marker, "FORUM-15C owner boundary");
+
+need(userStats, 'include!("member_card.rs");', "FORUM-15C user-stats wiring");
+
+for (const marker of [
+  "ForumMemberCardService::new(db.clone())",
+  "ForumMemberCardService::normalize_user_ids(&user_ids)",
+  "ctx.data_opt::<DataLoader<ProfileSummaryLoader>>()",
+  ".compose_admitted_profiles(tenant.id, &requested_user_ids, profiles)",
+  "ForumMemberCardAudience::Anonymous",
+  ".read_for_audience(",
+]) need(graphql, marker, "FORUM-15C GraphQL adapter");
+
+for (const marker of [
+  "forum_user_stat::Entity::find()",
+  "ProfilePresentationService::new(",
+  "ProfilePresentationService::for_audience(",
+]) forbid(graphql, marker, "FORUM-15C GraphQL must stay thin");
+
+forbid(
+  storefrontCargo,
+  "rustok-profiles",
+  "FORUM-15C storefront must not gain a direct Profiles dependency",
+);
+for (const marker of [
+  "pub struct ForumTopicListItem",
+  "pub struct ForumTopicDetail",
+  "pub struct ForumReplyDetail",
+]) need(storefrontModel, marker, "FORUM-15C storefront baseline");
+forbid(storefrontUi, "ForumMemberCard", "FORUM-15C storefront UI integration remains open");
+
+for (const marker of [
+  "FORUM-15C",
+  "shared-owner-service",
+  "pub(crate)",
+  "before any Forum statistics are queried",
+  "storefront package has no direct `rustok-profiles` dependency",
+  "no Cargo command, test, Node verifier",
+]) need(packet, marker, "FORUM-15C actualization");
+
+console.log("Forum FORUM-15C member-card owner service source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-15 by moving member-card cross-owner composition out of the GraphQL transport into a reusable Forum owner service.

- add `ForumMemberCardService` under the already-public `services::user_stats` surface;
- preserve the 100-ID bound, nil rejection, first-request-order deduplication and zero-filled missing Forum stats;
- make the public owner path accept an explicit anonymous/authenticated/trusted-service audience and always run Profiles presentation before any Forum stats query;
- keep `compose_admitted_profiles` crate-local so external consumers cannot inject arbitrary profile summaries and bypass Profiles privacy;
- preserve Profiles owner `code()` / `is_retryable()` when presentation failures cross the Forum capability boundary;
- refactor the existing authenticated `forumMemberCards` GraphQL query into a thin adapter: request-scoped Profiles DataLoader remains preferred, anonymous/fail-closed fallback remains intact;
- leave storefront UI integration for the next slice; the storefront package still has no direct `rustok-profiles` dependency;
- add a dated FORUM-15C actualization and source guard, intentionally not executed.

## Storefront boundary

The current Forum storefront has separate GraphQL and native SSR/hydrate transports and its topic/reply models do not yet carry member cards. Reusing the authenticated-only GraphQL endpoint for anonymous storefront would be incorrect, while adding a direct Profiles dependency to the storefront package would move composition across the wrong boundary.

This owner service creates the neutral path needed for a later dual-path storefront integration: the native adapter can consume `rustok_forum::services::user_stats::ForumMemberCardService`, while a matching public/authenticated GraphQL storefront contract can preserve existing storefront admission semantics.

## Privacy / ownership

`read_for_audience` maps the Forum audience to Profiles-owned `ProfileAccessAudience`, performs one bounded Profiles presentation read, keeps only admitted identities, then performs one tenant-scoped `forum_user_stats` query for those IDs. Forum statistics cannot manufacture profile visibility.

Transport authorization remains the caller's responsibility. The existing GraphQL member-card admission stays authenticated `forum_topics:read`.

## Fresh-main race handling

The slice began at the FORUM-15B merge. During preparation `main` advanced first by three unrelated commits and then by one Commerce/order-only commit. A full-tree rebase attempt was caught by static compare before merge because it would have reverted concurrent work. The final feature commit is instead built from `main@676861d89227b18ddbe51074de6ff3d38f2be8f2` using that commit's base tree with only the five intended FORUM-15C blobs overlaid. Final compare is 1 commit, `behind 0`, with only those five files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was run. `scripts/verify/verify-forum-member-card-owner-service-source.mjs` was added but intentionally not executed.