### PR TITLE
feat(commerce): route GraphQL order change apply through owner ports

### DIFF
--- a/apps/server/tests/commerce_order_change_transport_guard.rs
+++ b/apps/server/tests/commerce_order_change_transport_guard.rs
@@ -30,8 +30,19 @@ fn order_change_application_uses_commerce_orchestration() {
         "GraphQL order-change application must use the composed orchestration boundary"
     );
     assert!(
-        graphql.contains(".apply_order_change(tenant_id, id, difference_refund, metadata)"),
-        "GraphQL compatibility path must remain explicit until its owner-port cutover"
+        graphql.contains("order_change_read_context(ctx, tenant_id, id)")
+            && graphql.contains(
+                "order_post_order_command_context(ctx, tenant_id, id, \"apply_order_change\")"
+            ),
+        "GraphQL order-change application must build typed owner read/write contexts"
+    );
+    assert!(
+        graphql.contains(".apply_order_change_with_owner_ports("),
+        "GraphQL order-change application must use the owner-port orchestration entrypoint"
+    );
+    assert!(
+        !graphql.contains(".apply_order_change(tenant_id, id, difference_refund, metadata)"),
+        "mounted GraphQL order-change application must not use the concrete compatibility entrypoint"
     );
     assert!(
         !graphql.contains("match order_change.change_type.as_str()"),
@@ -47,21 +58,29 @@ fn order_change_application_uses_commerce_orchestration() {
     );
     assert!(
         graphql_runtime.contains("pub(crate) fn order_change_orchestration_from_context("),
-        "GraphQL runtime must keep the separate order-change orchestration composition point"
+        "GraphQL runtime must keep the order-change orchestration composition point"
+    );
+    assert!(
+        graphql_runtime.contains("OrderChangeOrchestrationService::from_order_ports(")
+            && graphql_runtime.contains("runtime.order_read_runtime().order_read_port()")
+            && graphql_runtime.contains(
+                "runtime.order_post_order_command_runtime().command_port()"
+            ),
+        "mounted GraphQL runtime must inject host-selected Order owner ports"
     );
 
     assert!(
         orchestration.contains("pub async fn apply_order_change_with_owner_ports("),
-        "commerce orchestration must publish the mounted REST owner-port entrypoint"
+        "commerce orchestration must publish the mounted transport owner-port entrypoint"
     );
     assert!(
         orchestration.contains(".read_order_change_projection(")
             && orchestration.contains(".apply_change("),
-        "REST owner-port entrypoint must read and default-apply through Order ports"
+        "owner-port entrypoint must read and default-apply through Order ports"
     );
     assert!(
         orchestration.contains("pub async fn apply_order_change("),
-        "GraphQL compatibility entrypoint must remain explicit for a separate cutover"
+        "directly embedded compatibility entrypoint remains explicit for later cleanup"
     );
     for operation in [".apply_exchange_order_change(", ".apply_claim_order_change("] {
         assert!(

--- a/crates/rustok-commerce/docs/graphql-order-change-apply-owner-port-cutover-2026-08-10.md
+++ b/crates/rustok-commerce/docs/graphql-order-change-apply-owner-port-cutover-2026-08-10.md
@@ -1,0 +1,89 @@
+# Commerce GraphQL order-change apply owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-10
+
+## Scope
+
+This slice cuts the mounted GraphQL `applyOrderChange` mutation away from the
+`OrderChangeOrchestrationService::apply_order_change` compatibility entrypoint that
+constructs `OrderService` internally.
+
+The mounted mutation now uses the existing host-composed Order capabilities already
+present in `CommerceGraphqlRuntimeData`:
+
+- `CommerceOrderReadRuntime` / `OrderReadPort` for the order-change projection read;
+- `OrderPostOrderCommandRuntime` / `OrderPostOrderCommandPort::apply_change` for the
+  ordinary/default apply transition.
+
+No new owner capability was required. The Order read and apply capabilities were
+already published and the in-process adapters preserve the canonical owner-local
+`OrderService::get_order_change` and `OrderService::apply_order_change` semantics.
+
+## Mounted GraphQL composition
+
+`order_change_orchestration_from_context` now selects `from_order_ports` whenever
+`CommerceGraphqlRuntimeData` is present and injects:
+
+- `runtime.order_read_runtime().order_read_port()`;
+- `runtime.order_post_order_command_runtime().command_port()`;
+- the existing host-selected Payment provider registry used by exchange/refund
+  orchestration.
+
+The mutation builds an authenticated read `PortContext` with tenant, user actor,
+request locale/channel, correlation identity, and a two-second deadline. The write
+context reuses the existing GraphQL post-order command context builder.
+
+The generated write idempotency UUID is admission metadata only. The legacy GraphQL
+mutation does not expose a caller idempotency key, so this slice does not claim
+replay/exactly-once semantics for repeated client requests.
+
+## Dispatch and cross-domain behavior
+
+Commerce still owns order-change type dispatch inside
+`OrderChangeOrchestrationService`. The mounted GraphQL transport does not inspect
+`change_type`.
+
+- the ordinary/default path reads through `OrderReadPort` and applies through
+  `OrderPostOrderCommandPort::apply_change`;
+- `exchange` still delegates to the existing exchange post-order orchestration;
+- `claim` still delegates to the existing claim post-order orchestration.
+
+This slice intentionally does not decompose the remaining exchange/claim internals.
+
+## Error boundary
+
+Owner read/command `PortError` values are mapped through the existing stable Order
+GraphQL public envelope policy. Diagnostics retain only bounded facts such as owner
+error kind, owner code length, correlation identity, operation names, public code,
+and retryability. The new owner-port mapper does not log raw `PortError.message` or
+stringify the owner error.
+
+`OrderChangeOrchestrationError::PostOrder` continues through the existing post-order
+GraphQL error mapper so exchange/claim Payment behavior and public envelopes remain
+unchanged by this slice.
+
+## Compatibility
+
+`OrderChangeOrchestrationService::new` and the legacy `apply_order_change` method
+remain for directly embedded schemas and other compatibility consumers that do not
+install `CommerceGraphqlRuntimeData`. Mounted application GraphQL composition already
+requires the Order read and post-order command runtimes, so the production resolver
+uses host-selected adapters.
+
+This is compatibility source, not a claim that all private legacy orchestration can
+be removed yet.
+
+## Plan status
+
+The broad topology P0 remains open. This slice closes only mounted GraphQL
+`applyOrderChange` order-owned read/default-apply construction; other mounted
+Product, Order, Payment, or Fulfillment construction and deeper Commerce orchestration
+must still be audited independently.
+
+## Validation
+
+No tests, Cargo commands, Node verifiers, formatter, GraphQL scenarios, CI/workflows,
+database scenarios, provider calls, restart scenarios, or remote-adapter scenarios
+were executed in this slice. The source guard was added but intentionally not run.

--- a/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
+++ b/crates/rustok-commerce/src/graphql/mutations/fulfillment.rs
@@ -22,7 +22,9 @@ use crate::graphql_runtime::{
     order_post_order_command_runtime_from_context, post_order_orchestration_from_context,
     return_completion_orchestration_from_context,
 };
-use crate::{PaymentOrchestrationError, PostOrderOrchestrationError};
+use crate::{
+    OrderChangeOrchestrationError, PaymentOrchestrationError, PostOrderOrchestrationError,
+};
 
 use super::super::{MODULE_SLUG, current_tenant_scope, require_commerce_permission, types::*};
 use super::helpers::*;
@@ -211,6 +213,33 @@ fn post_order_owner_graphql_error(
     public_fulfillment_graphql_error(message, code, retryable)
 }
 
+fn order_change_owner_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    consumer_operation: &'static str,
+    owner_operation: &'static str,
+    context: &PortContext,
+    error: PortError,
+) -> async_graphql::Error {
+    let (message, code, retryable, error_kind) = order_port_error_envelope(&error);
+    tracing::error!(
+        owner = "rustok_order.order_change",
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        resource_id_non_nil = !resource_id.is_nil(),
+        consumer_operation,
+        owner_operation,
+        correlation_id = %context.correlation_id,
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        error_kind,
+        public_code = code,
+        retryable,
+        boundary = "commerce_graphql_order_change_owner",
+        "commerce GraphQL order-change owner port failed with bounded diagnostics"
+    );
+    public_fulfillment_graphql_error(message, code, retryable)
+}
+
 fn post_order_graphql_error(
     tenant_id: Uuid,
     resource_id: Uuid,
@@ -238,6 +267,60 @@ fn post_order_graphql_error(
         ),
     };
     public_fulfillment_graphql_error(message, code, retryable)
+}
+
+fn order_change_graphql_error(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    read_context: &PortContext,
+    command_context: &PortContext,
+    error: OrderChangeOrchestrationError,
+) -> async_graphql::Error {
+    match error {
+        OrderChangeOrchestrationError::OrderRead(source) => order_change_owner_graphql_error(
+            tenant_id,
+            resource_id,
+            "apply_order_change",
+            "read_order_change_projection",
+            read_context,
+            source,
+        ),
+        OrderChangeOrchestrationError::OrderCommand(source) => order_change_owner_graphql_error(
+            tenant_id,
+            resource_id,
+            "apply_order_change",
+            "apply_change",
+            command_context,
+            source,
+        ),
+        OrderChangeOrchestrationError::PostOrder(source) => {
+            post_order_graphql_error(tenant_id, resource_id, "apply_order_change", source)
+        }
+    }
+}
+
+fn order_change_read_context(
+    ctx: &Context<'_>,
+    tenant_id: Uuid,
+    change_id: Uuid,
+) -> Result<PortContext> {
+    let auth = ctx.data::<AuthContext>()?;
+    let request = ctx.data_opt::<RequestContext>();
+    let locale = request
+        .map(|request| request.locale.as_str())
+        .filter(|locale| !locale.trim().is_empty())
+        .unwrap_or("und");
+    let context = PortContext::new(
+        tenant_id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        locale,
+        format!("commerce-graphql-order-change-read:{change_id}"),
+    )
+    .with_deadline(std::time::Duration::from_secs(2));
+    Ok(match request.and_then(|request| request.channel_slug.as_deref()) {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    })
 }
 
 fn order_command_context(
@@ -579,11 +662,27 @@ impl CommerceFulfillmentMutation {
 
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
         let event_bus = ctx.data::<rustok_outbox::TransactionalEventBus>()?;
+        let read_context = order_change_read_context(ctx, tenant_id, id)?;
+        let command_context =
+            order_post_order_command_context(ctx, tenant_id, id, "apply_order_change")?;
         let result = order_change_orchestration_from_context(ctx, db.clone(), event_bus.clone())
-            .apply_order_change(tenant_id, id, difference_refund, metadata)
+            .apply_order_change_with_owner_ports(
+                tenant_id,
+                id,
+                read_context.clone(),
+                command_context.clone(),
+                difference_refund,
+                metadata,
+            )
             .await
             .map_err(|error| {
-                post_order_graphql_error(tenant_id, id, "apply_order_change", error)
+                order_change_graphql_error(
+                    tenant_id,
+                    id,
+                    &read_context,
+                    &command_context,
+                    error,
+                )
             })?;
 
         Ok(result.order_change.into())

--- a/crates/rustok-commerce/src/graphql_runtime.rs
+++ b/crates/rustok-commerce/src/graphql_runtime.rs
@@ -623,8 +623,16 @@ pub(crate) fn order_change_orchestration_from_context(
     db: DatabaseConnection,
     event_bus: rustok_outbox::TransactionalEventBus,
 ) -> crate::OrderChangeOrchestrationService {
-    crate::OrderChangeOrchestrationService::new(db, event_bus)
-        .with_payment_provider_registry(payment_provider_registry_from_context(ctx))
+    let service = match ctx.data_opt::<CommerceGraphqlRuntimeData>() {
+        Some(runtime) => crate::OrderChangeOrchestrationService::from_order_ports(
+            db,
+            event_bus,
+            runtime.order_read_runtime().order_read_port(),
+            runtime.order_post_order_command_runtime().command_port(),
+        ),
+        None => crate::OrderChangeOrchestrationService::new(db, event_bus),
+    };
+    service.with_payment_provider_registry(payment_provider_registry_from_context(ctx))
 }
 
 pub(crate) fn return_completion_orchestration_from_context(

--- a/crates/rustok-commerce/src/services/order_change_orchestration.rs
+++ b/crates/rustok-commerce/src/services/order_change_orchestration.rs
@@ -33,9 +33,9 @@ pub type OrderChangeOrchestrationResult<T> = Result<T, OrderChangeOrchestrationE
 /// Routes order-change application through the correct post-order workflow.
 ///
 /// Transport layers must not inspect `change_type` and duplicate exchange/claim
-/// branching. Mounted REST can inject host-selected owner ports through
-/// `from_order_ports`; directly embedded and GraphQL compatibility callers retain
-/// the legacy method until their runtime-composition cutover is handled separately.
+/// branching. Mounted REST and GraphQL inject host-selected owner ports through
+/// `from_order_ports`; directly embedded compatibility callers retain the legacy
+/// entrypoint until their separate compatibility cleanup is complete.
 pub struct OrderChangeOrchestrationService {
     db: DatabaseConnection,
     event_bus: TransactionalEventBus,
@@ -75,7 +75,7 @@ impl OrderChangeOrchestrationService {
         self
     }
 
-    /// Legacy compatibility entry point retained for GraphQL/runtime callers in this slice.
+    /// Legacy compatibility entry point retained for directly embedded callers.
     pub async fn apply_order_change(
         &self,
         tenant_id: Uuid,
@@ -119,7 +119,7 @@ impl OrderChangeOrchestrationService {
         }
     }
 
-    /// Host-composed REST entry point for order-owned read/default-apply operations.
+    /// Host-composed mounted transport entry point for order-owned read/default-apply operations.
     pub async fn apply_order_change_with_owner_ports(
         &self,
         tenant_id: Uuid,

--- a/scripts/verify/verify-commerce-admin-boundary.mjs
+++ b/scripts/verify/verify-commerce-admin-boundary.mjs
@@ -205,8 +205,23 @@ assertContains(
 );
 assertContains(
   graphqlFulfillment,
+  "order_change_read_context(ctx, tenant_id, id)",
+  `${files.graphqlFulfillment}: GraphQL order-change apply must build an owner read context`,
+);
+assertContains(
+  graphqlFulfillment,
+  "order_post_order_command_context(ctx, tenant_id, id, \"apply_order_change\")",
+  `${files.graphqlFulfillment}: GraphQL order-change apply must build an owner command context`,
+);
+assertContains(
+  graphqlFulfillment,
+  ".apply_order_change_with_owner_ports(",
+  `${files.graphqlFulfillment}: GraphQL order-change apply must use the owner-port orchestration entrypoint`,
+);
+assertNotContains(
+  graphqlFulfillment,
   ".apply_order_change(tenant_id, id, difference_refund, metadata)",
-  `${files.graphqlFulfillment}: GraphQL compatibility path must stay explicit for its separate cutover`,
+  `${files.graphqlFulfillment}: mounted GraphQL order-change apply must not use the compatibility entrypoint`,
 );
 for (const marker of [
   "match order_change.change_type.as_str()",
@@ -222,28 +237,43 @@ for (const marker of [
 assertContains(
   graphqlRuntime,
   "pub(crate) fn order_change_orchestration_from_context(",
-  `${files.graphqlRuntime}: GraphQL runtime must retain its separate order-change composition point`,
+  `${files.graphqlRuntime}: GraphQL runtime must retain its order-change composition point`,
+);
+assertContains(
+  graphqlRuntime,
+  "OrderChangeOrchestrationService::from_order_ports(",
+  `${files.graphqlRuntime}: mounted GraphQL runtime must compose Order owner ports`,
+);
+assertContains(
+  graphqlRuntime,
+  "runtime.order_read_runtime().order_read_port()",
+  `${files.graphqlRuntime}: mounted GraphQL runtime must use host-selected Order reads`,
+);
+assertContains(
+  graphqlRuntime,
+  "runtime.order_post_order_command_runtime().command_port()",
+  `${files.graphqlRuntime}: mounted GraphQL runtime must use host-selected post-order commands`,
 );
 
 assertContains(
   orderChangeOrchestration,
   "pub async fn apply_order_change_with_owner_ports(",
-  `${files.orderChangeOrchestration}: REST owner-port orchestration entrypoint is missing`,
+  `${files.orderChangeOrchestration}: mounted transport owner-port orchestration entrypoint is missing`,
 );
 assertContains(
   orderChangeOrchestration,
   ".read_order_change_projection(",
-  `${files.orderChangeOrchestration}: REST orchestration must read the change through OrderReadPort`,
+  `${files.orderChangeOrchestration}: mounted orchestration must read the change through OrderReadPort`,
 );
 assertContains(
   orderChangeOrchestration,
   ".apply_change(",
-  `${files.orderChangeOrchestration}: default REST apply must use OrderPostOrderCommandPort`,
+  `${files.orderChangeOrchestration}: default mounted apply must use OrderPostOrderCommandPort`,
 );
 assertContains(
   orderChangeOrchestration,
   "pub async fn apply_order_change(",
-  `${files.orderChangeOrchestration}: GraphQL compatibility entrypoint must remain explicit`,
+  `${files.orderChangeOrchestration}: directly embedded compatibility entrypoint must remain explicit`,
 );
 for (const operation of [
   ".apply_exchange_order_change(",

--- a/scripts/verify/verify-commerce-admin-boundary.test.mjs
+++ b/scripts/verify/verify-commerce-admin-boundary.test.mjs
@@ -35,13 +35,19 @@ function fixture(options = {}) {
     orchestration.cancel_fulfillment();
   `);
   put(root, "crates/rustok-commerce/src/graphql/mutations/fulfillment.rs", `
+    let read_context = order_change_read_context(ctx, tenant_id, id);
+    let command_context = order_post_order_command_context(ctx, tenant_id, id, "apply_order_change");
     let service = order_change_orchestration_from_context();
-    service.apply_order_change(tenant_id, id, difference_refund, metadata);
+    service.apply_order_change_with_owner_ports();
     let service = return_completion_orchestration_from_context();
     service.complete_return(tenant_id, auth.user_id, id, command);
   `);
   put(root, "crates/rustok-commerce/src/graphql_runtime.rs", `
-    pub(crate) fn order_change_orchestration_from_context() {}
+    pub(crate) fn order_change_orchestration_from_context() {
+      OrderChangeOrchestrationService::from_order_ports();
+      runtime.order_read_runtime().order_read_port();
+      runtime.order_post_order_command_runtime().command_port();
+    }
     pub(crate) fn return_completion_orchestration_from_context() {}
   `);
   put(root, "crates/rustok-commerce/src/services/fulfillment_orchestration_facade.rs", `

--- a/scripts/verify/verify-commerce-graphql-order-change-apply-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-graphql-order-change-apply-owner-port-cutover.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const mutationsMod = read('crates/rustok-commerce/src/graphql/mutations/mod.rs');
+const graphql = read('crates/rustok-commerce/src/graphql/mutations/fulfillment.rs');
+const graphqlRuntime = read('crates/rustok-commerce/src/graphql_runtime.rs');
+const orchestration = read('crates/rustok-commerce/src/services/order_change_orchestration.rs');
+const ownerRead = read('crates/rustok-order/src/order_read.rs');
+const ownerCommand = read('crates/rustok-order/src/post_order_command.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/graphql-order-change-apply-owner-port-cutover-2026-08-10.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const applyMutation = between(
+  graphql,
+  'async fn apply_order_change(',
+  'async fn cancel_order_change(',
+  'GraphQL applyOrderChange mutation',
+);
+const readContext = between(
+  graphql,
+  'fn order_change_read_context(',
+  'fn order_command_context(',
+  'GraphQL order-change read context',
+);
+const ownerErrorMapper = between(
+  graphql,
+  'fn order_change_owner_graphql_error(',
+  'fn post_order_graphql_error(',
+  'GraphQL owner-port error mapper',
+);
+const applyErrorMapper = between(
+  graphql,
+  'fn order_change_graphql_error(',
+  'fn order_change_read_context(',
+  'GraphQL order-change error dispatcher',
+);
+const runtimeFactory = between(
+  graphqlRuntime,
+  'pub(crate) fn order_change_orchestration_from_context(',
+  'pub(crate) fn return_completion_orchestration_from_context(',
+  'GraphQL order-change runtime factory',
+);
+const ownerMethod = between(
+  orchestration,
+  'pub async fn apply_order_change_with_owner_ports(',
+  '\n    }\n}',
+  'mounted order-change owner-port orchestration',
+);
+
+requireText(mutationsMod, 'pub mod fulfillment;', 'mounted fulfillment mutation module');
+
+for (const [value, label] of [
+  ['[Permission::ORDERS_UPDATE]', 'orders:update admission'],
+  ['current_tenant_scope(ctx, Some(tenant_id), "Apply order change")', 'tenant scope admission'],
+  ['order_change_read_context(ctx, tenant_id, id)?', 'owner read context'],
+  ['order_post_order_command_context(ctx, tenant_id, id, "apply_order_change")?', 'owner command context'],
+  ['order_change_orchestration_from_context(ctx, db.clone(), event_bus.clone())', 'runtime orchestration factory'],
+  ['.apply_order_change_with_owner_ports(', 'owner-port orchestration entrypoint'],
+  ['read_context.clone()', 'read context forwarding'],
+  ['command_context.clone()', 'command context forwarding'],
+  ['order_change_graphql_error(', 'typed GraphQL error dispatch'],
+]) requireText(applyMutation, value, label);
+
+for (const value of [
+  '.apply_order_change(tenant_id, id, difference_refund, metadata)',
+  'OrderService::new(',
+  '.get_order_change(',
+  'match order_change.change_type.as_str()',
+  '.apply_exchange_order_change(',
+  '.apply_claim_order_change(',
+]) forbidText(applyMutation, value, 'mounted GraphQL apply must not own concrete Order/dispatch');
+
+for (const [value, label] of [
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated owner actor'],
+  ['format!("commerce-graphql-order-change-read:{change_id}")', 'read correlation identity'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'bounded read deadline'],
+  ['request.channel_slug.as_deref()', 'request channel forwarding'],
+]) requireText(readContext, value, label);
+
+for (const [value, label] of [
+  ['owner = "rustok_order.order_change"', 'owner diagnostic label'],
+  ['consumer_operation,', 'consumer operation diagnostic'],
+  ['owner_operation,', 'owner operation diagnostic'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code'],
+  ['public_code = code', 'stable public code'],
+  ['retryable,', 'retryability'],
+  ['boundary = "commerce_graphql_order_change_owner"', 'boundary diagnostic'],
+]) requireText(ownerErrorMapper, value, label);
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'internal_message']) {
+  forbidText(ownerErrorMapper, value, 'GraphQL owner-port raw diagnostics');
+}
+
+for (const [value, label] of [
+  ['OrderChangeOrchestrationError::OrderRead(source)', 'typed read error branch'],
+  ['"read_order_change_projection"', 'read owner operation'],
+  ['OrderChangeOrchestrationError::OrderCommand(source)', 'typed command error branch'],
+  ['"apply_change"', 'command owner operation'],
+  ['OrderChangeOrchestrationError::PostOrder(source)', 'cross-domain orchestration branch'],
+  ['post_order_graphql_error(tenant_id, resource_id, "apply_order_change", source)', 'existing post-order envelope handoff'],
+]) requireText(applyErrorMapper, value, label);
+
+for (const [value, label] of [
+  ['ctx.data_opt::<CommerceGraphqlRuntimeData>()', 'host runtime data lookup'],
+  ['Some(runtime) => crate::OrderChangeOrchestrationService::from_order_ports(', 'host-composed service'],
+  ['runtime.order_read_runtime().order_read_port()', 'host-selected Order read'],
+  ['runtime.order_post_order_command_runtime().command_port()', 'host-selected Order command'],
+  ['None => crate::OrderChangeOrchestrationService::new(db, event_bus)', 'embedded compatibility fallback'],
+  ['with_payment_provider_registry(payment_provider_registry_from_context(ctx))', 'host payment registry preservation'],
+]) requireText(runtimeFactory, value, label);
+
+for (const [value, label] of [
+  ['.read_order_change_projection(', 'owner read call'],
+  ['ReadOrderChangeProjectionRequest { change_id }', 'typed owner read request'],
+  ['.apply_change(', 'owner default apply call'],
+  ['ApplyOrderChangeRequest {', 'typed owner apply request'],
+  ['OrderChangeOrchestrationError::OrderRead', 'read error preservation'],
+  ['OrderChangeOrchestrationError::OrderCommand', 'command error preservation'],
+  ['.apply_exchange_order_change(', 'exchange orchestration retained'],
+  ['.apply_claim_order_change(', 'claim orchestration retained'],
+]) requireText(ownerMethod, value, label);
+for (const value of ['OrderService::new(', '.get_order_change(']) {
+  forbidText(ownerMethod, value, 'mounted owner-port orchestration concrete Order dependency');
+}
+
+for (const [source, value, label] of [
+  [ownerRead, 'async fn read_order_change_projection(', 'Order read capability'],
+  [ownerRead, '.get_order_change(tenant_id, request.change_id)', 'owner-local read implementation'],
+  [ownerCommand, 'async fn apply_change(', 'Order apply capability'],
+  [ownerCommand, '.apply_order_change(tenant_id, request.change_id, request.input)', 'owner-local apply implementation'],
+]) requireText(source, value, label);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology P0 remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce GraphQL order-change apply owner-port cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['mounted GraphQL `applyOrderChange`', 'record scope'],
+  ['CommerceOrderReadRuntime', 'record read runtime'],
+  ['OrderPostOrderCommandRuntime', 'record command runtime'],
+  ['admission metadata only', 'record replay limitation'],
+  ['directly embedded schemas', 'record compatibility fallback'],
+  ['broad topology P0 remains open', 'record open broad invariant'],
+  ['No tests, Cargo commands, Node verifiers, formatter', 'record validation status'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce GraphQL order-change apply owner-port verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted GraphQL applyOrderChange uses host-selected Order owner ports');

--- a/scripts/verify/verify-commerce-rest-admin-order-change-apply-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-admin-order-change-apply-owner-port-cutover.mjs
@@ -56,7 +56,7 @@ const ownerMethod = between(
   orchestration,
   'pub async fn apply_order_change_with_owner_ports(',
   '\n    }\n}',
-  'REST owner-port orchestration method',
+  'mounted owner-port orchestration method',
 );
 
 for (const [value, label] of [
@@ -111,7 +111,7 @@ for (const [value, label] of [
   ['.apply_claim_order_change(', 'claim orchestration retained'],
 ]) requireText(ownerMethod, value, label);
 for (const value of ['OrderService::new(', '.get_order_change(']) {
-  forbidText(ownerMethod, value, 'REST owner-port orchestration concrete Order dependency');
+  forbidText(ownerMethod, value, 'mounted owner-port orchestration concrete Order dependency');
 }
 
 for (const [value, label] of [
@@ -135,16 +135,23 @@ for (const value of ['error = ?error', 'error.message', 'internal_message', 'err
   forbidText(portMapper, value, 'REST owner-port raw diagnostics');
 }
 
-// GraphQL is deliberately not claimed by this REST slice.
+// The later GraphQL slice may supersede the historical deferred scope, but must
+// reuse the same owner-port orchestration entrypoint rather than reintroduce a
+// concrete Order dependency.
 requireText(
   graphql,
-  '.apply_order_change(tenant_id, id, difference_refund, metadata)',
-  'separate GraphQL compatibility call remains',
+  '.apply_order_change_with_owner_ports(',
+  'GraphQL reuses the mounted owner-port orchestration entrypoint',
 );
 requireText(
   graphqlRuntime,
-  'OrderChangeOrchestrationService::new(db, event_bus)',
-  'separate GraphQL in-process composition remains explicit',
+  'OrderChangeOrchestrationService::from_order_ports(',
+  'GraphQL runtime composes the same host-selected Order owner ports',
+);
+forbidText(
+  graphql,
+  '.apply_order_change(tenant_id, id, difference_refund, metadata)',
+  'GraphQL must not regress to the concrete compatibility entrypoint',
 );
 
 requireText(
@@ -158,7 +165,7 @@ for (const [value, label] of [
   ['Status: `source_complete_unvalidated`', 'record status'],
   ['OrderPostOrderCommandPort::apply_change', 'record owner command'],
   ['write-admission metadata only', 'record replay limitation'],
-  ['mounted GraphQL `applyOrderChange`', 'record deferred GraphQL scope'],
+  ['mounted GraphQL `applyOrderChange`', 'historical deferred GraphQL scope'],
   ['no tests, Cargo commands, Node verifiers, formatter', 'record validation status'],
 ]) requireText(record, value, label);
 


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with the mounted GraphQL `applyOrderChange` path.

- compose `OrderChangeOrchestrationService` from the host-selected `CommerceOrderReadRuntime` and `OrderPostOrderCommandRuntime` whenever mounted `CommerceGraphqlRuntimeData` is present;
- route the mounted `applyOrderChange` mutation through the existing `apply_order_change_with_owner_ports` entrypoint instead of the compatibility method that constructs `OrderService` internally;
- build authenticated Order read/write `PortContext` values with tenant, actor, request locale/channel, correlation identity, bounded deadlines, and the existing post-order write admission identity;
- preserve the existing exchange/claim Commerce orchestration and Payment provider registry behavior;
- preserve stable GraphQL public Order/PostOrder envelopes while mapping owner read/command `PortError` values with bounded diagnostics and no raw owner error message logging;
- retain the in-process `OrderChangeOrchestrationService::new` / legacy apply entrypoint only as an explicit directly embedded compatibility fallback;
- update stale REST/admin source guards and add a dedicated GraphQL source-only guard plus a `source_complete_unvalidated` dated record;
- keep the broad ecommerce topology P0 open because this slice does not claim all remaining Product/Order/Payment/Fulfillment construction is gone.

The branch is one clean commit ahead and zero behind `363e3da6b4ee1b2a61abc504cde6bad15e09cbb2` with exactly 9 changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, GraphQL scenarios, workflows/CI, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source guards were added/updated but not run.