### PR TITLE
feat(forum): render storefront member cards

### DIFF
--- a/crates/rustok-forum/storefront/locales/en.json
+++ b/crates/rustok-forum/storefront/locales/en.json
@@ -27,5 +27,8 @@
   "forum.thread.repliesTitle": "Replies",
   "forum.thread.repliesTotal": "{count} total",
   "forum.thread.noReplies": "No replies yet.",
+  "forum.member.topics": "topics",
+  "forum.member.replies": "replies",
+  "forum.member.solutions": "solutions",
   "forum.richContent.summary": "Stored in `{format}` format. Raw content length: {count} characters."
 }

--- a/crates/rustok-forum/storefront/locales/ru.json
+++ b/crates/rustok-forum/storefront/locales/ru.json
@@ -27,5 +27,8 @@
   "forum.thread.repliesTitle": "Ответы",
   "forum.thread.repliesTotal": "{count} всего",
   "forum.thread.noReplies": "Ответов пока нет.",
+  "forum.member.topics": "тем",
+  "forum.member.replies": "ответов",
+  "forum.member.solutions": "решений",
   "forum.richContent.summary": "Контент хранится в формате `{format}`. Длина сырого содержимого: {count} символов."
 }

--- a/crates/rustok-forum/storefront/src/ui/leptos.rs
+++ b/crates/rustok-forum/storefront/src/ui/leptos.rs
@@ -3,6 +3,7 @@ use leptos::task::spawn_local;
 use leptos_ui_routing::read_route_query_value;
 use rustok_ui_core::UiRouteContext;
 
+use super::member_card::{ForumAuthorBadge, member_card_context};
 use crate::core::{
     ForumStorefrontCategoryRailLabels, forum_storefront_category_card_view_model,
     forum_storefront_count_label, forum_storefront_status_badge_class,
@@ -143,9 +144,10 @@ fn ForumShowcase(
         selected_topic_id,
         selected_topic,
         replies,
-        member_cards: _,
+        member_cards,
         read_state_available,
     } = data;
+    provide_context(member_card_context(member_cards));
 
     view! {
         <div class="grid gap-6 xl:grid-cols-[16rem_minmax(0,1fr)_24rem]">
@@ -317,6 +319,7 @@ fn ForumTopicFeed(
 
             <div class="space-y-3">
                 {items.into_iter().map(|item| {
+                    let author_id = item.author_id.clone();
                     let card = forum_storefront_topic_card_view_model(
                         module_route_base.as_str(),
                         &item,
@@ -362,6 +365,7 @@ fn ForumTopicFeed(
                                         <h4 class="text-lg font-semibold text-foreground">{card.title}</h4>
                                         <p class="mt-1 text-sm text-muted-foreground">{card.slug_label}</p>
                                     </div>
+                                    <ForumAuthorBadge author_id />
                                 </div>
                                 <div class="text-right">
                                     <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
@@ -406,6 +410,7 @@ fn ForumThreadPanel(
     };
 
     let topic_id = topic.id.clone();
+    let author_id = topic.author_id.clone();
     let status_class = topic_status_class(topic.status.as_str());
     let body_html = topic.body.html.clone();
     let pinned_label = t(locale.as_deref(), "forum.topic.pinned", "Pinned");
@@ -456,6 +461,7 @@ fn ForumThreadPanel(
                     <h3 class="text-2xl font-semibold text-card-foreground">{topic.title}</h3>
                     <p class="mt-2 text-sm text-muted-foreground">{crate::core::forum_storefront_slug_label(slug_template.as_str(), topic.slug.as_str())}</p>
                 </div>
+                <ForumAuthorBadge author_id />
                 <div
                     class="richtext text-sm leading-7 text-muted-foreground"
                     inner_html=body_html
@@ -518,6 +524,7 @@ fn ForumThreadPanel(
 
 #[component]
 fn ReplyCard(reply: ForumReplyDetail) -> impl IntoView {
+    let author_id = reply.author_id.clone();
     let status_class = topic_status_class(reply.status.as_str());
     let content_html = reply.content.html.clone();
 
@@ -528,6 +535,9 @@ fn ReplyCard(reply: ForumReplyDetail) -> impl IntoView {
                 <span class="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
                     {reply.effective_locale}
                 </span>
+            </div>
+            <div class="mt-3">
+                <ForumAuthorBadge author_id />
             </div>
             <div
                 class="richtext mt-3 text-sm leading-6 text-muted-foreground"

--- a/crates/rustok-forum/storefront/src/ui/member_card.rs
+++ b/crates/rustok-forum/storefront/src/ui/member_card.rs
@@ -1,0 +1,84 @@
+use std::{collections::HashMap, sync::Arc};
+
+use leptos::prelude::*;
+use rustok_ui_core::UiRouteContext;
+
+use crate::{i18n::t, model::ForumMemberCard};
+
+pub type ForumMemberCardContext = Arc<HashMap<String, ForumMemberCard>>;
+
+pub fn member_card_context(cards: Vec<ForumMemberCard>) -> ForumMemberCardContext {
+    Arc::new(
+        cards
+            .into_iter()
+            .map(|card| (card.user_id.clone(), card))
+            .collect(),
+    )
+}
+
+#[component]
+pub fn ForumAuthorBadge(author_id: Option<String>) -> impl IntoView {
+    let card = use_context::<ForumMemberCardContext>().and_then(|cards| {
+        author_id
+            .as_deref()
+            .and_then(|user_id| cards.get(user_id))
+            .cloned()
+    });
+
+    card.map(|card| view! { <ForumMemberCardBadge card /> })
+}
+
+#[component]
+fn ForumMemberCardBadge(card: ForumMemberCard) -> impl IntoView {
+    let locale = use_context::<UiRouteContext>().unwrap_or_default().locale;
+    let topics_label = t(locale.as_deref(), "forum.member.topics", "topics");
+    let replies_label = t(locale.as_deref(), "forum.member.replies", "replies");
+    let solutions_label = t(locale.as_deref(), "forum.member.solutions", "solutions");
+    let initials = profile_initials(&card);
+    let display_name = card.profile.display_name.clone();
+    let handle = card.profile.handle.clone();
+    let avatar_alt = display_name.clone();
+
+    view! {
+        <div class="forum-member-card inline-flex max-w-full items-center gap-2 rounded-xl border border-border bg-background/70 px-2.5 py-2">
+            <div
+                role="img"
+                aria-label=avatar_alt
+                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-xs font-bold text-primary"
+            >
+                <span aria-hidden="true">{initials}</span>
+            </div>
+            <div class="min-w-0">
+                <div class="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+                    <span class="truncate text-xs font-semibold text-foreground">{display_name}</span>
+                    <span class="truncate text-[11px] text-muted-foreground">{format!("@{handle}")}</span>
+                </div>
+                <div class="mt-0.5 flex flex-wrap gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
+                    <span>{format!("{} {topics_label}", card.forum_stats.topic_count)}</span>
+                    <span>{format!("{} {replies_label}", card.forum_stats.reply_count)}</span>
+                    <span>{format!("{} {solutions_label}", card.forum_stats.solution_count)}</span>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn profile_initials(card: &ForumMemberCard) -> String {
+    let initials = card
+        .profile
+        .display_name
+        .split_whitespace()
+        .filter_map(|part| part.chars().next())
+        .take(2)
+        .collect::<String>();
+    if initials.is_empty() {
+        card.profile
+            .handle
+            .chars()
+            .next()
+            .map(|value| value.to_uppercase().to_string())
+            .unwrap_or_else(|| "?".to_string())
+    } else {
+        initials.to_uppercase()
+    }
+}

--- a/crates/rustok-forum/storefront/src/ui/mod.rs
+++ b/crates/rustok-forum/storefront/src/ui/mod.rs
@@ -1,1 +1,2 @@
 pub mod leptos;
+mod member_card;

--- a/docs/modules/forum-15-storefront-member-card-ui-actualization-2026-08-10.md
+++ b/docs/modules/forum-15-storefront-member-card-ui-actualization-2026-08-10.md
@@ -1,0 +1,104 @@
+# FORUM-15E storefront member-card UI actualization — 2026-08-10
+
+Status: `source-ready / storefront-presentation / privacy-filtered-lookup / no-new-owner-reads / media-avatar-resolution-open / runtime-evidence-open`
+
+## Fresh cursor
+
+This slice started from `main@3b1ba79619a9c37f7bc90fb773843c7287d2d4ff`. The one commit after FORUM-15D changed Commerce-only sources and did not overlap Forum storefront composition.
+
+During the final pre-merge gate, `main` advanced to `d7d6044c9e6bddf42f0ea4fa03ac6ba376873ba9` through Index contract CI work only. That movement did not touch Forum storefront files, and the exact FORUM-15E file set was replayed onto the new base before the final `behind 0` gate.
+
+FORUM-15 remains `in_progress`. FORUM-15D carried bounded, privacy-aware member-card data through both real Forum storefront transports, but the Leptos storefront still explicitly ignored `StorefrontForumData.member_cards`.
+
+FORUM-15E consumes that already-loaded payload in the real storefront presentation. It adds no owner read, GraphQL request, server function or package dependency.
+
+## Presentation boundary
+
+The Forum storefront continues to own only its local presentation DTO. Profiles remains authoritative for handle, display name, tags, preferred locale, avatar Media identity and profile privacy/block admission. Forum remains authoritative only for its topic/reply/solution counters.
+
+The UI does not query Profiles, Media or Forum statistics. It receives only the member cards admitted by the FORUM-15B/15C/15D composition path.
+
+`member_cards` are converted once per `ForumShowcase` into an `Arc<HashMap<String, ForumMemberCard>>` and placed in the Leptos owner context. Topic-feed cards, the selected opening post and reply cards then perform only in-memory author-ID lookups.
+
+This keeps the UI lookup cost bounded and prevents prop-threading or per-row transport reads.
+
+## Privacy and block behavior
+
+The presentation rule is deliberately fail-closed:
+
+- a topic/reply `authorId` is never rendered directly;
+- `ForumAuthorBadge` renders only when the corresponding user ID exists in the privacy-filtered member-card context;
+- missing, blocked, hidden, anonymous-unavailable or permission-unavailable member cards produce no author presentation;
+- Forum counters are shown only as part of an admitted member card, so a statistics row cannot manufacture a visible identity;
+- the UI does not invent a fallback handle/name from the raw Forum author UUID.
+
+Anonymous Forum content therefore remains readable exactly as in FORUM-15D while authenticated viewers with admitted member cards receive the richer presentation.
+
+## Member-card surface
+
+The same compact member-card component is used on all three intended storefront surfaces:
+
+1. topic-feed rows;
+2. the selected topic/opening post;
+3. each visible reply.
+
+An admitted card shows:
+
+- Profiles-owned display name and handle;
+- initials as the current avatar fallback;
+- Forum-owned topic, reply and solution counts.
+
+The statistics labels are localized in the existing English and Russian storefront locale files.
+
+The component carries a stable `forum-member-card` class so retained browser evidence can target the actual presentation later without coupling to Tailwind utility details.
+
+## Avatar / Media boundary
+
+The 15D transport currently carries `avatarMediaId`, not a Media-owned presentation URL/alt payload. FORUM-15E intentionally does **not** turn that ID into a guessed URL, call Media per card, or add a direct Media dependency.
+
+Instead the compact card uses a deterministic initials fallback derived from the already-admitted display name, with handle fallback when needed. Media-backed avatar rendering remains open until the storefront has an appropriate owner-provided presentation asset contract that preserves the same bounded composition.
+
+## No-N+1 presentation shape
+
+FORUM-15D already bounded one storefront snapshot to at most one member-card batch/service call. FORUM-15E adds no network/database work on top of it:
+
+- one member-card vector becomes one `Arc<HashMap>`;
+- each visible topic/reply presentation performs only a map lookup;
+- the shared `Arc` is cloned through Leptos context rather than cloning the whole card map per row;
+- there is no per-author `fetch`, GraphQL call, server function or owner-service call in UI source.
+
+Retained runtime/query-count evidence is still open and is not claimed by this source slice.
+
+## Compatibility and scope
+
+Existing category/topic/reply content rendering, routing, unread state and mark-read behavior are unchanged. The UI integration is additive: when `member_cards` is empty, the existing Forum content remains visible with no author badge.
+
+This slice does not:
+
+- broaden `forumMemberCards` permissions;
+- add a public statistics endpoint;
+- migrate the legacy storefront reply read surface;
+- add Profiles or Media owner dependencies to `rustok-forum-storefront`;
+- claim browser/runtime privacy evidence;
+- claim Media avatar lifecycle/presentation eligibility.
+
+## Remaining FORUM-15 work
+
+FORUM-15 stays `in_progress`. Remaining work is now primarily retained evidence and any owner-safe presentation refinement:
+
+- browser/runtime evidence for admitted, hidden and blocked profile presentation on the real storefront;
+- retained query-count evidence demonstrating the bounded dual-path composition under real host execution;
+- Media-backed avatar presentation once an appropriate owner presentation contract is available;
+- review whether any additional permitted Forum activity/reputation presentation is required without moving ownership into Forum.
+
+The canonical ledger wording remains materially true and is not rewritten for this bounded UI slice.
+
+## Maintainer validation
+
+Per maintainer instruction, no Cargo command, test, Node verifier, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was executed while preparing this slice.
+
+Suggested source guard, intentionally not run here:
+
+```bash
+node scripts/verify/verify-forum-storefront-member-card-ui-source.mjs
+```

--- a/scripts/verify/verify-forum-storefront-member-card-ui-source.mjs
+++ b/scripts/verify/verify-forum-storefront-member-card-ui-source.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function need(text, marker, label) {
+  if (!text.includes(marker)) throw new Error(`${label}: missing ${marker}`);
+}
+
+function forbid(text, marker, label) {
+  if (text.includes(marker)) throw new Error(`${label}: forbidden ${marker}`);
+}
+
+function count(text, marker) {
+  return text.split(marker).length - 1;
+}
+
+const leptos = read("crates/rustok-forum/storefront/src/ui/leptos.rs");
+const memberCard = read("crates/rustok-forum/storefront/src/ui/member_card.rs");
+const uiMod = read("crates/rustok-forum/storefront/src/ui/mod.rs");
+const model = read("crates/rustok-forum/storefront/src/model.rs");
+const graphql = read("crates/rustok-forum/storefront/src/transport/graphql_adapter.rs");
+const native = read("crates/rustok-forum/storefront/src/transport/native_server_adapter.rs");
+const cargo = read("crates/rustok-forum/storefront/Cargo.toml");
+const en = read("crates/rustok-forum/storefront/locales/en.json");
+const ru = read("crates/rustok-forum/storefront/locales/ru.json");
+const packet = read(
+  "docs/modules/forum-15-storefront-member-card-ui-actualization-2026-08-10.md",
+);
+
+for (const marker of [
+  "pub member_cards: Vec<ForumMemberCard>",
+  'rename = "authorId"',
+  "pub struct ForumMemberCard",
+]) need(model, marker, "FORUM-15E transport baseline");
+
+for (const marker of [
+  "member_cards,",
+  "provide_context(member_card_context(member_cards));",
+  "use super::member_card::{ForumAuthorBadge, member_card_context};",
+]) need(leptos, marker, "FORUM-15E storefront composition");
+if (count(leptos, "<ForumAuthorBadge author_id />") !== 3) {
+  throw new Error("FORUM-15E must render the shared author badge on feed, opening post and reply surfaces");
+}
+forbid(leptos, "member_cards: _", "FORUM-15E member-card payload must be consumed");
+
+for (const marker of [
+  "pub type ForumMemberCardContext = Arc<HashMap<String, ForumMemberCard>>",
+  "pub fn member_card_context(",
+  "pub fn ForumAuthorBadge(",
+  "cards.get(user_id)",
+  "card.map(|card|",
+  'class="forum-member-card ',
+  '"forum.member.topics"',
+  '"forum.member.replies"',
+  '"forum.member.solutions"',
+  "fn profile_initials(",
+]) need(memberCard, marker, "FORUM-15E member-card presentation helper");
+
+for (const source of [leptos, memberCard]) {
+  for (const marker of [
+    "forumMemberCards",
+    "ForumMemberCardService",
+    "rustok_profiles",
+    "rustok_media",
+    "avatar_media_id",
+    "author_id.unwrap",
+    "author_id.expect",
+  ]) forbid(source, marker, "FORUM-15E UI must remain owner-read-free and fail closed");
+}
+
+for (const marker of [
+  '"forum.member.topics"',
+  '"forum.member.replies"',
+  '"forum.member.solutions"',
+]) {
+  need(en, marker, "FORUM-15E English locale");
+  need(ru, marker, "FORUM-15E Russian locale");
+}
+
+need(uiMod, "mod member_card;", "FORUM-15E UI module wiring");
+forbid(cargo, "rustok-profiles", "FORUM-15E storefront must not add Profiles dependency");
+forbid(cargo, "rustok-media", "FORUM-15E storefront must not add Media dependency");
+
+for (const marker of [
+  "FORUM-15E",
+  "privacy-filtered-lookup",
+  "no-new-owner-reads",
+  "Media-backed avatar rendering remains open",
+  "browser/runtime evidence",
+  "no Cargo command, test, Node verifier",
+]) need(packet, marker, "FORUM-15E actualization");
+
+for (const marker of [
+  "forumMemberCards(userIds: $userIds, locale: $locale)",
+  "Err(error) if personalization_unavailable(&error) => Ok(Vec::new())",
+]) need(graphql, marker, "FORUM-15E GraphQL transport baseline");
+for (const marker of [
+  "Permission::FORUM_TOPICS_READ",
+  "ForumMemberCardService::new(db.clone())",
+]) need(native, marker, "FORUM-15E native transport baseline");
+
+console.log("Forum FORUM-15E storefront member-card UI source: ok");


### PR DESCRIPTION
## Summary

Continue FORUM-15 by consuming the bounded member-card payload added in FORUM-15D on the real Leptos storefront surfaces.

- consume `StorefrontForumData.member_cards` instead of ignoring it;
- build one view-local `Arc<HashMap<user_id, ForumMemberCard>>` and expose it through Leptos context;
- render one shared compact member-card badge on topic-feed rows, the selected opening post and visible replies;
- render Profiles-owned display name/handle and Forum-owned topic/reply/solution counters only when a privacy-filtered card exists;
- omit author presentation entirely for missing/blocked/hidden/anonymous-unavailable cards; raw Forum author UUIDs are never shown as fallback identity;
- use deterministic initials for avatar presentation because the current transport carries only `avatarMediaId`, not a Media-owned presentation URL;
- add EN/RU labels for Forum member statistics;
- add a dated actualization and source guard, intentionally not executed.

## Privacy / ownership

No new Profiles, Media, Forum-stat, GraphQL or server-function read is introduced by the UI. The member-card vector has already passed Profiles privacy/block admission and Forum stat composition. The UI performs only in-memory lookups and cannot manufacture an identity from a Forum stats row.

The storefront package still has no direct `rustok-profiles` or `rustok-media` dependency. Media-backed avatar rendering remains open until an owner-provided presentation asset contract is available; this PR does not guess URLs from Media IDs.

## No-N+1 shape

FORUM-15D bounded the transport to at most one member-card batch/service call per storefront snapshot. This PR adds only one `Arc<HashMap>` construction plus O(1) lookups on visible surfaces. There are no per-author network/database reads.

## Scope

FORUM-15 remains `in_progress`: browser/runtime privacy evidence, retained query-count evidence and owner-safe Media avatar presentation remain open.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, GraphQL request, database scenario, migration, workflow, CI, lock generation or `git diff --check` was run. `scripts/verify/verify-forum-storefront-member-card-ui-source.mjs` was added but intentionally not executed.