### PR TITLE
feat(page-builder): harden generic editor accessibility

### DIFF
--- a/crates/rustok-page-builder/admin/src/editor/asset_section.rs
+++ b/crates/rustok-page-builder/admin/src/editor/asset_section.rs
@@ -20,6 +20,7 @@ pub(crate) fn AssetSection(runtime: AdminEditorRuntime) -> impl IntoView {
         "page_builder.field.assetUrl",
         "Asset URL",
     );
+    let add_asset_accessible_label = format!("{add_label}: {assets_label}");
     let asset_id = RwSignal::new(String::new());
     let asset_url = RwSignal::new(String::new());
     let add_runtime = runtime.clone();
@@ -28,21 +29,26 @@ pub(crate) fn AssetSection(runtime: AdminEditorRuntime) -> impl IntoView {
     view! {
         <section class="space-y-2 border-t border-border pt-3">
             <h2 class="font-semibold">{assets_label}</h2>
-            <input
-                placeholder=asset_id_label
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || asset_id.get()
-                on:input=move |event| asset_id.set(event_target_value(&event))
-            />
-            <input
-                placeholder=asset_url_label
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || asset_url.get()
-                on:input=move |event| asset_url.set(event_target_value(&event))
-            />
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{asset_id_label}</span>
+                <input
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || asset_id.get()
+                    on:input=move |event| asset_id.set(event_target_value(&event))
+                />
+            </label>
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{asset_url_label}</span>
+                <input
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || asset_url.get()
+                    on:input=move |event| asset_url.set(event_target_value(&event))
+                />
+            </label>
             <button
                 type="button"
                 class="rounded border border-border px-2 py-1 text-xs"
+                aria-label=add_asset_accessible_label
                 on:click=move |_| {
                     let source = asset_url.get_untracked().trim().to_string();
                     if source.is_empty() {
@@ -72,8 +78,11 @@ pub(crate) fn AssetSection(runtime: AdminEditorRuntime) -> impl IntoView {
                         let remove_runtime = list_runtime.clone();
                         let use_id = asset.id.clone();
                         let remove_id = asset.id.clone();
+                        let accessible_name = asset.name.clone().unwrap_or_else(|| asset.id.clone());
                         let select_label = select_label.clone();
                         let remove_label = remove_label.clone();
+                        let select_accessible_label = format!("{select_label}: {accessible_name}");
+                        let remove_accessible_label = format!("{remove_label}: {accessible_name}");
                         view! {
                             <div class="rounded border border-border p-2 text-xs">
                                 <div class="font-medium">{asset.name.clone().unwrap_or_else(|| asset.id.clone())}</div>
@@ -82,6 +91,7 @@ pub(crate) fn AssetSection(runtime: AdminEditorRuntime) -> impl IntoView {
                                     <button
                                         type="button"
                                         class="rounded border border-border px-2 py-1"
+                                        aria-label=select_accessible_label
                                         disabled=move || !use_disabled_runtime.capability_enabled(
                                             EditorCapability::Properties,
                                         )
@@ -95,6 +105,7 @@ pub(crate) fn AssetSection(runtime: AdminEditorRuntime) -> impl IntoView {
                                     <button
                                         type="button"
                                         class="rounded border border-destructive/40 px-2 py-1 text-destructive"
+                                        aria-label=remove_accessible_label
                                         on:click=move |_| remove_runtime.dispatch(UiIntent::execute(
                                             EditorCommand::Asset {
                                                 command: AssetCommand::Remove {

--- a/crates/rustok-page-builder/admin/src/editor/page_manager.rs
+++ b/crates/rustok-page-builder/admin/src/editor/page_manager.rs
@@ -63,6 +63,7 @@ pub fn PageManagerPanel(runtime: AdminEditorRuntime) -> impl IntoView {
         "page_builder.field.noIndex",
         "Prevent search indexing",
     );
+    let new_page_name_accessible_label = format!("{add_label}: {name_label}");
 
     let new_page_name = RwSignal::new(String::new());
     let page_name = RwSignal::new(String::new());
@@ -151,6 +152,7 @@ pub fn PageManagerPanel(runtime: AdminEditorRuntime) -> impl IntoView {
                                 } else {
                                     "block w-full rounded px-2 py-2 text-left text-sm hover:bg-muted"
                                 }
+                                aria-pressed=active.to_string()
                                 on:click=move |_| runtime.dispatch(UiIntent::ActivatePage {
                                     page_id: page_id.clone(),
                                     page_index,
@@ -168,6 +170,7 @@ pub fn PageManagerPanel(runtime: AdminEditorRuntime) -> impl IntoView {
                 <div class="flex gap-2 border-t border-border pt-3">
                     <input
                         class="min-w-0 flex-1 rounded border border-input bg-background px-2 py-1 text-sm"
+                        aria-label=new_page_name_accessible_label
                         placeholder=name_label.clone()
                         prop:value=move || new_page_name.get()
                         on:input=move |event| new_page_name.set(event_target_value(&event))
@@ -202,18 +205,22 @@ pub fn PageManagerPanel(runtime: AdminEditorRuntime) -> impl IntoView {
                     capability=EditorCapability::Properties
                 >
                     <div class="grid gap-2 border-t border-border pt-3">
-                        <label class="text-sm font-medium">{name_label.clone()}</label>
-                        <input
-                            class="rounded border border-input bg-background px-2 py-1 text-sm"
-                            prop:value=move || page_name.get()
-                            on:input=move |event| page_name.set(event_target_value(&event))
-                        />
-                        <label class="text-sm font-medium">{id_label}</label>
-                        <input
-                            class="rounded border border-input bg-background px-2 py-1 text-sm"
-                            prop:value=move || page_id.get()
-                            on:input=move |event| page_id.set(event_target_value(&event))
-                        />
+                        <label class="grid gap-1 text-sm">
+                            <span class="font-medium">{name_label.clone()}</span>
+                            <input
+                                class="rounded border border-input bg-background px-2 py-1 text-sm"
+                                prop:value=move || page_name.get()
+                                on:input=move |event| page_name.set(event_target_value(&event))
+                            />
+                        </label>
+                        <label class="grid gap-1 text-sm">
+                            <span class="font-medium">{id_label}</span>
+                            <input
+                                class="rounded border border-input bg-background px-2 py-1 text-sm"
+                                prop:value=move || page_id.get()
+                                on:input=move |event| page_id.set(event_target_value(&event))
+                            />
+                        </label>
                         <button
                             type="button"
                             class="w-fit rounded border border-border px-2 py-1 text-xs"

--- a/crates/rustok-page-builder/admin/src/editor/palette_layers.rs
+++ b/crates/rustok-page-builder/admin/src/editor/palette_layers.rs
@@ -113,6 +113,7 @@ pub fn PaletteLayersPanel(
                                         let drag_id = block.id.clone();
                                         let html_drag_id = block.id.clone();
                                         let browser_block_id = block.id.clone();
+                                        let block_accessible_name = block.label.clone();
                                         let contribution_ids = access
                                             .contribution_ids(&block.id)
                                             .map(ToString::to_string)
@@ -135,6 +136,8 @@ pub fn PaletteLayersPanel(
                                         let html_drag_access = Arc::clone(&access);
                                         let add_label = add_label.clone();
                                         let drag_label = drag_label.clone();
+                                        let insert_accessible_label = format!("{add_label}: {block_accessible_name}");
+                                        let drag_accessible_label = format!("{drag_label}: {block_accessible_name}");
                                         view! {
                                             <article
                                                 class="rounded-lg border border-border bg-background p-2"
@@ -162,6 +165,7 @@ pub fn PaletteLayersPanel(
                                                     <button
                                                         type="button"
                                                         class="rounded border border-border px-2 py-1 text-xs disabled:opacity-50"
+                                                        aria-label=insert_accessible_label
                                                         data-fly-action="insert-block"
                                                         disabled=!can_insert
                                                         on:click=move |_| {
@@ -177,6 +181,7 @@ pub fn PaletteLayersPanel(
                                                     <button
                                                         type="button"
                                                         class="rounded border border-border px-2 py-1 text-xs disabled:opacity-50"
+                                                        aria-label=drag_accessible_label
                                                         data-fly-action="begin-block-drag"
                                                         disabled=!can_drag
                                                         on:click=move |_| {
@@ -224,6 +229,7 @@ pub fn PaletteLayersPanel(
                                     data-fly-component-id=browser_component_id
                                     data-fly-action="select-component"
                                     class=class
+                                    aria-pressed=active.to_string()
                                     on:click=move |_| select_runtime.dispatch(
                                         UiIntent::Select(Some(component_id.clone()))
                                     )

--- a/crates/rustok-page-builder/admin/src/editor/properties_section.rs
+++ b/crates/rustok-page-builder/admin/src/editor/properties_section.rs
@@ -35,6 +35,10 @@ pub(crate) fn PropertiesSection(runtime: AdminEditorRuntime) -> impl IntoView {
         "page_builder.field.attributeValue",
         "Attribute value or JSON",
     );
+    let tag_apply_accessible_label = format!("{apply_label}: {tag_label}");
+    let content_apply_accessible_label = format!("{apply_label}: {content_label}");
+    let content_clear_accessible_label = format!("{clear_label}: {content_label}");
+    let attribute_apply_accessible_label = format!("{apply_label}: {attribute_name_label}");
 
     let tag_name = RwSignal::new(String::new());
     let content_value = RwSignal::new(String::new());
@@ -104,47 +108,53 @@ pub(crate) fn PropertiesSection(runtime: AdminEditorRuntime) -> impl IntoView {
                 })}</dd>
             </dl>
 
-            <label class="block text-sm font-medium">{tag_label}</label>
-            <div class="flex gap-2">
-                <input
-                    class="min-w-0 flex-1 rounded border border-input bg-background px-2 py-1 text-sm"
-                    prop:value=move || tag_name.get()
-                    on:input=move |event| tag_name.set(event_target_value(&event))
-                />
-                <button
-                    type="button"
-                    class="rounded border border-border px-2 py-1 text-xs"
-                    on:click=move |_| {
-                        let value = tag_name.get_untracked();
-                        let patch = if value.trim().is_empty() {
-                            ComponentPatch {
-                                remove_fields: vec!["tagName".to_string()],
-                                ..ComponentPatch::default()
-                            }
-                        } else {
-                            ComponentPatch {
-                                fields: Map::from_iter([(
-                                    "tagName".to_string(),
-                                    Value::String(value),
-                                )]),
-                                ..ComponentPatch::default()
-                            }
-                        };
-                        tag_runtime.dispatch_result(selected_patch(&tag_runtime, patch));
-                    }
-                >{apply_label.clone()}</button>
-            </div>
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{tag_label}</span>
+                <div class="flex gap-2">
+                    <input
+                        class="min-w-0 flex-1 rounded border border-input bg-background px-2 py-1 text-sm"
+                        prop:value=move || tag_name.get()
+                        on:input=move |event| tag_name.set(event_target_value(&event))
+                    />
+                    <button
+                        type="button"
+                        class="rounded border border-border px-2 py-1 text-xs"
+                        aria-label=tag_apply_accessible_label
+                        on:click=move |_| {
+                            let value = tag_name.get_untracked();
+                            let patch = if value.trim().is_empty() {
+                                ComponentPatch {
+                                    remove_fields: vec!["tagName".to_string()],
+                                    ..ComponentPatch::default()
+                                }
+                            } else {
+                                ComponentPatch {
+                                    fields: Map::from_iter([(
+                                        "tagName".to_string(),
+                                        Value::String(value),
+                                    )]),
+                                    ..ComponentPatch::default()
+                                }
+                            };
+                            tag_runtime.dispatch_result(selected_patch(&tag_runtime, patch));
+                        }
+                    >{apply_label.clone()}</button>
+                </div>
+            </label>
 
-            <label class="block text-sm font-medium">{content_label}</label>
-            <textarea
-                class="min-h-24 w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || content_value.get()
-                on:input=move |event| content_value.set(event_target_value(&event))
-            ></textarea>
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{content_label}</span>
+                <textarea
+                    class="min-h-24 w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || content_value.get()
+                    on:input=move |event| content_value.set(event_target_value(&event))
+                ></textarea>
+            </label>
             <div class="flex gap-2">
                 <button
                     type="button"
                     class="rounded border border-border px-2 py-1 text-xs"
+                    aria-label=content_apply_accessible_label
                     on:click=move |_| content_runtime.dispatch_result(selected_patch(
                         &content_runtime,
                         ComponentPatch {
@@ -159,6 +169,7 @@ pub(crate) fn PropertiesSection(runtime: AdminEditorRuntime) -> impl IntoView {
                 <button
                     type="button"
                     class="rounded border border-border px-2 py-1 text-xs"
+                    aria-label=content_clear_accessible_label
                     on:click=move |_| clear_content_runtime.dispatch_result(selected_patch(
                         &clear_content_runtime,
                         ComponentPatch {
@@ -187,6 +198,7 @@ pub(crate) fn PropertiesSection(runtime: AdminEditorRuntime) -> impl IntoView {
             <button
                 type="button"
                 class="rounded border border-border px-2 py-1 text-xs"
+                aria-label=attribute_apply_accessible_label
                 on:click=move |_| {
                     let name = attribute_name.get_untracked().trim().to_string();
                     if name.is_empty() {
@@ -214,12 +226,14 @@ pub(crate) fn PropertiesSection(runtime: AdminEditorRuntime) -> impl IntoView {
                         let runtime = attributes_runtime.clone();
                         let remove_name = name.clone();
                         let clear_label = clear_label.clone();
+                        let clear_accessible_label = format!("{clear_label}: {name}");
                         view! {
                             <div class="flex items-start gap-2 rounded bg-muted/50 px-2 py-1 text-xs">
                                 <code class="min-w-0 flex-1 break-all">{format!("{name}={value}")}</code>
                                 <button
                                     type="button"
                                     class="text-destructive"
+                                    aria-label=clear_accessible_label
                                     on:click=move |_| runtime.dispatch_result(selected_patch(
                                         &runtime,
                                         ComponentPatch {

--- a/crates/rustok-page-builder/admin/src/editor/properties_section.rs
+++ b/crates/rustok-page-builder/admin/src/editor/properties_section.rs
@@ -108,39 +108,38 @@ pub(crate) fn PropertiesSection(runtime: AdminEditorRuntime) -> impl IntoView {
                 })}</dd>
             </dl>
 
-            <label class="grid gap-1 text-sm">
-                <span class="font-medium">{tag_label}</span>
-                <div class="flex gap-2">
-                    <input
-                        class="min-w-0 flex-1 rounded border border-input bg-background px-2 py-1 text-sm"
-                        prop:value=move || tag_name.get()
-                        on:input=move |event| tag_name.set(event_target_value(&event))
-                    />
-                    <button
-                        type="button"
-                        class="rounded border border-border px-2 py-1 text-xs"
-                        aria-label=tag_apply_accessible_label
-                        on:click=move |_| {
-                            let value = tag_name.get_untracked();
-                            let patch = if value.trim().is_empty() {
-                                ComponentPatch {
-                                    remove_fields: vec!["tagName".to_string()],
-                                    ..ComponentPatch::default()
-                                }
-                            } else {
-                                ComponentPatch {
-                                    fields: Map::from_iter([(
-                                        "tagName".to_string(),
-                                        Value::String(value),
-                                    )]),
-                                    ..ComponentPatch::default()
-                                }
-                            };
-                            tag_runtime.dispatch_result(selected_patch(&tag_runtime, patch));
-                        }
-                    >{apply_label.clone()}</button>
-                </div>
-            </label>
+            <div class="text-sm font-medium">{tag_label.clone()}</div>
+            <div class="flex gap-2">
+                <input
+                    class="min-w-0 flex-1 rounded border border-input bg-background px-2 py-1 text-sm"
+                    aria-label=tag_label
+                    prop:value=move || tag_name.get()
+                    on:input=move |event| tag_name.set(event_target_value(&event))
+                />
+                <button
+                    type="button"
+                    class="rounded border border-border px-2 py-1 text-xs"
+                    aria-label=tag_apply_accessible_label
+                    on:click=move |_| {
+                        let value = tag_name.get_untracked();
+                        let patch = if value.trim().is_empty() {
+                            ComponentPatch {
+                                remove_fields: vec!["tagName".to_string()],
+                                ..ComponentPatch::default()
+                            }
+                        } else {
+                            ComponentPatch {
+                                fields: Map::from_iter([(
+                                    "tagName".to_string(),
+                                    Value::String(value),
+                                )]),
+                                ..ComponentPatch::default()
+                            }
+                        };
+                        tag_runtime.dispatch_result(selected_patch(&tag_runtime, patch));
+                    }
+                >{apply_label.clone()}</button>
+            </div>
 
             <label class="grid gap-1 text-sm">
                 <span class="font-medium">{content_label}</span>

--- a/crates/rustok-page-builder/admin/src/editor/responsive_styles.rs
+++ b/crates/rustok-page-builder/admin/src/editor/responsive_styles.rs
@@ -84,48 +84,54 @@ pub fn ResponsiveStylePanel(runtime: AdminEditorRuntime) -> impl IntoView {
     view! {
         <section class="space-y-2 rounded-xl border border-border bg-card p-3">
             <h2 class="font-semibold">{title}</h2>
-            <label class="block text-sm font-medium">{breakpoint_label}</label>
-            <select
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || breakpoint_id.get()
-                on:change=move |event| {
-                    breakpoint_id.set(event_target_value(&event));
-                    style_value.set(current_rule_value(
-                        &breakpoint_runtime,
-                        &breakpoint_id.get_untracked(),
-                        &style_property.get_untracked(),
-                    ));
-                }
-            >
-                {breakpoints.into_iter().map(|breakpoint| view! {
-                    <option value=breakpoint.id>{format!("{} · {}", breakpoint.label, breakpoint.media_query)}</option>
-                }).collect_view()}
-            </select>
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{breakpoint_label}</span>
+                <select
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || breakpoint_id.get()
+                    on:change=move |event| {
+                        breakpoint_id.set(event_target_value(&event));
+                        style_value.set(current_rule_value(
+                            &breakpoint_runtime,
+                            &breakpoint_id.get_untracked(),
+                            &style_property.get_untracked(),
+                        ));
+                    }
+                >
+                    {breakpoints.into_iter().map(|breakpoint| view! {
+                        <option value=breakpoint.id>{format!("{} · {}", breakpoint.label, breakpoint.media_query)}</option>
+                    }).collect_view()}
+                </select>
+            </label>
 
-            <label class="block text-sm font-medium">{property_label}</label>
-            <select
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || style_property.get()
-                on:change=move |event| {
-                    style_property.set(event_target_value(&event));
-                    style_value.set(current_rule_value(
-                        &property_runtime,
-                        &breakpoint_id.get_untracked(),
-                        &style_property.get_untracked(),
-                    ));
-                }
-            >
-                {descriptors.into_iter().map(|descriptor| view! {
-                    <option value=descriptor.property>{format!("{:?} · {}", descriptor.group, descriptor.label)}</option>
-                }).collect_view()}
-            </select>
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{property_label}</span>
+                <select
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || style_property.get()
+                    on:change=move |event| {
+                        style_property.set(event_target_value(&event));
+                        style_value.set(current_rule_value(
+                            &property_runtime,
+                            &breakpoint_id.get_untracked(),
+                            &style_property.get_untracked(),
+                        ));
+                    }
+                >
+                    {descriptors.into_iter().map(|descriptor| view! {
+                        <option value=descriptor.property>{format!("{:?} · {}", descriptor.group, descriptor.label)}</option>
+                    }).collect_view()}
+                </select>
+            </label>
 
-            <label class="block text-sm font-medium">{value_label}</label>
-            <input
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || style_value.get()
-                on:input=move |event| style_value.set(event_target_value(&event))
-            />
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{value_label}</span>
+                <input
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || style_value.get()
+                    on:input=move |event| style_value.set(event_target_value(&event))
+                />
+            </label>
 
             <div class="flex flex-wrap gap-2">
                 <button

--- a/crates/rustok-page-builder/admin/src/editor/style_section.rs
+++ b/crates/rustok-page-builder/admin/src/editor/style_section.rs
@@ -52,26 +52,30 @@ pub(crate) fn StyleSection(runtime: AdminEditorRuntime) -> impl IntoView {
     view! {
         <section class="space-y-2 border-t border-border pt-3">
             <h2 class="font-semibold">{styles_label}</h2>
-            <label class="block text-sm font-medium">{property_label}</label>
-            <select
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || style_property.get()
-                on:change=move |event| {
-                    let property = event_target_value(&event);
-                    style_property.set(property.clone());
-                    style_value.set(selected_style_value(&change_runtime, &property));
-                }
-            >
-                {descriptors.into_iter().map(|descriptor| view! {
-                    <option value=descriptor.property>{format!("{:?} · {}", descriptor.group, descriptor.label)}</option>
-                }).collect_view()}
-            </select>
-            <label class="block text-sm font-medium">{value_label}</label>
-            <input
-                class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
-                prop:value=move || style_value.get()
-                on:input=move |event| style_value.set(event_target_value(&event))
-            />
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{property_label}</span>
+                <select
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || style_property.get()
+                    on:change=move |event| {
+                        let property = event_target_value(&event);
+                        style_property.set(property.clone());
+                        style_value.set(selected_style_value(&change_runtime, &property));
+                    }
+                >
+                    {descriptors.into_iter().map(|descriptor| view! {
+                        <option value=descriptor.property>{format!("{:?} · {}", descriptor.group, descriptor.label)}</option>
+                    }).collect_view()}
+                </select>
+            </label>
+            <label class="grid gap-1 text-sm">
+                <span class="font-medium">{value_label}</span>
+                <input
+                    class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                    prop:value=move || style_value.get()
+                    on:input=move |event| style_value.set(event_target_value(&event))
+                />
+            </label>
             <div class="flex gap-2">
                 <button
                     type="button"

--- a/crates/rustok-page-builder/admin/src/editor/trait_panel.rs
+++ b/crates/rustok-page-builder/admin/src/editor/trait_panel.rs
@@ -76,16 +76,22 @@ fn TraitEditorRow(
     let value = RwSignal::new(initial);
     let schema = snapshot.schema;
     let input_schema = schema.clone();
+    let input_label = schema.label.clone();
     let apply_schema = schema.clone();
     let clear_schema = schema.clone();
     let apply_runtime = runtime.clone();
     let clear_runtime = runtime.clone();
     let apply_component_id = component_id.clone();
     let clear_component_id = component_id.clone();
+    let apply_accessible_label = format!("{apply_label}: {}", schema.label);
+    let clear_accessible_label = format!("{clear_label}: {}", schema.label);
 
     view! {
-        <div class="space-y-2 border-t border-border pt-3 first:border-t-0 first:pt-0">
-            <label class="block text-sm font-medium">{schema.label.clone()}</label>
+        <div
+            class="space-y-2 border-t border-border pt-3 first:border-t-0 first:pt-0"
+            data-fly-trait-id=schema.id.clone()
+        >
+            <div class="text-sm font-medium">{schema.label.clone()}</div>
             {match schema.value_type {
                 TraitValueKind::Boolean => {
                     let checked = snapshot.value.as_ref().and_then(Value::as_bool).unwrap_or(false);
@@ -96,6 +102,7 @@ fn TraitEditorRow(
                         <label class="flex items-center gap-2 text-sm">
                             <input
                                 type="checkbox"
+                                aria-label=input_label.clone()
                                 prop:checked=checked
                                 on:change=move |event| apply_trait_value(
                                     &runtime,
@@ -116,6 +123,7 @@ fn TraitEditorRow(
                     let options = schema.options.clone();
                     view! {
                         <select
+                            aria-label=input_label.clone()
                             class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
                             prop:value=move || value.get()
                             on:change=move |event| {
@@ -134,6 +142,7 @@ fn TraitEditorRow(
                 }
                 TraitValueKind::Multiline => view! {
                     <textarea
+                        aria-label=input_label.clone()
                         class="min-h-20 w-full rounded border border-input bg-background px-2 py-1 text-sm"
                         placeholder=schema.placeholder.clone().unwrap_or_default()
                         prop:value=move || value.get()
@@ -144,6 +153,7 @@ fn TraitEditorRow(
                 TraitValueKind::Number => view! {
                     <input
                         type="number"
+                        aria-label=input_label.clone()
                         class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
                         placeholder=schema.placeholder.clone().unwrap_or_default()
                         prop:value=move || value.get()
@@ -154,6 +164,7 @@ fn TraitEditorRow(
                 TraitValueKind::Text | TraitValueKind::Url => view! {
                     <input
                         type=if matches!(schema.value_type, TraitValueKind::Url) { "url" } else { "text" }
+                        aria-label=input_label.clone()
                         class="w-full rounded border border-input bg-background px-2 py-1 text-sm"
                         placeholder=schema.placeholder.clone().unwrap_or_default()
                         prop:value=move || value.get()
@@ -166,6 +177,7 @@ fn TraitEditorRow(
                 <button
                     type="button"
                     class="rounded border border-border px-2 py-1 text-xs"
+                    aria-label=apply_accessible_label
                     on:click=move |_| apply_trait_value(
                         &apply_runtime,
                         &apply_component_id,
@@ -176,6 +188,7 @@ fn TraitEditorRow(
                 <button
                     type="button"
                     class="rounded border border-border px-2 py-1 text-xs"
+                    aria-label=clear_accessible_label
                     on:click=move |_| {
                         value.set(String::new());
                         clear_runtime.dispatch(UiIntent::execute(EditorCommand::Patch {

--- a/docs/modules/page-builder-admin-accessibility-actualization-2026-08-10.md
+++ b/docs/modules/page-builder-admin-accessibility-actualization-2026-08-10.md
@@ -1,0 +1,101 @@
+# Page Builder generic admin accessibility actualization — 2026-08-10
+
+Status: `generic-editor-control-accessibility-source-ready / source-guard-ready / browser-accessibility-evidence-pending`.
+
+Base rechecked: `main@3b1ba79619a9c37f7bc90fb773843c7287d2d4ff`.
+
+## Purpose
+
+The provider-health, Pages gate and Forum Wave admission source chain is already complete through maintainer-execution boundaries. The remaining central Page Builder plan still called out generic typed asset/control surfaces and accessibility. Source inspection found a narrower real implementation gap: the controls existed and were capability-gated, but several WASM editor fields were only visually labelled, several asset inputs relied on placeholders, repeated actions exposed only generic names such as `Use`, `Remove`, `Add` or `Drag`, and selected page/layer buttons communicated selection only through CSS.
+
+This slice closes that **source accessibility semantics** gap without changing Fly commands, capability policy, owner transports, persistence, provider health or rollout behavior.
+
+## Source changes
+
+### Properties, styles and responsive styles
+
+- generic property/style/responsive inputs and selects now have programmatic names through enclosing labels or explicit `aria-label` where a sibling action prevents valid label nesting;
+- tag/content/attribute actions retain their visible localized labels while repeated or ambiguous actions gain scoped accessible names;
+- attribute removal identifies the concrete attribute in its accessible name.
+
+### Assets
+
+- asset id and URL inputs no longer depend on placeholders for their accessible names; they are enclosed by localized labels;
+- the Add action is named for the Assets surface;
+- repeated Use/Remove actions include the concrete asset name/id in their accessible names;
+- existing `Assets` and cross-capability `Properties` gates remain unchanged.
+
+The SSR asset form already encloses its visible fields/select in labels and remains unchanged by this WASM editor slice.
+
+### Traits
+
+- each generic trait control uses the stable `TraitSchema.id` as a source-visible row identity and the owner-provided trait label as its accessible name;
+- Boolean, Select, Multiline, Number, Text and URL controls share the same naming rule;
+- repeated Apply/Clear actions include the trait label in their accessible names.
+
+No trait schema, validation or patch semantics moved into the UI.
+
+### Pages, palette and layers
+
+- active page and active layer buttons expose `aria-pressed` in addition to visual styling;
+- the add-page name input has an explicit localized accessible name rather than relying on its placeholder;
+- current page name/id fields are enclosed by their visible labels;
+- repeated palette Add/Drag buttons include the concrete block label in their accessible names.
+
+Selection, insertion, drag/drop and page lifecycle commands are unchanged.
+
+## Anti-drift source guard
+
+`scripts/verify/verify-page-builder-admin-accessibility.mjs` source-locks the generic editor accessibility boundary across:
+
+```text
+asset_section.rs
+style_section.rs
+properties_section.rs
+responsive_styles.rs
+trait_panel.rs
+page_manager.rs
+palette_layers.rs
+toolbar.rs
+```
+
+The guard requires programmatic field names, object-scoped repeated action names, selected-state semantics and the existing toolbar/live-status accessibility baseline. It rejects the former placeholder-only asset fields and selected visual-only label patterns.
+
+## Plan reconciliation
+
+The central plan item `Complete remaining generic typed asset/control surfaces and accessibility evidence` is now split conceptually:
+
+- generic typed controls and programmatic accessibility semantics: **source-ready**;
+- executable keyboard/screen-reader/browser/accessibility evidence: **maintainer execution pending**.
+
+No runtime/browser evidence is claimed by source inspection.
+
+## Boundaries
+
+This slice does not:
+
+- change Fly document, command, history, trait, style, asset or page semantics;
+- alter capability gates or provider-health narrowing;
+- add a second editor or alternate persistence path;
+- change Pages or Forum contribution ownership;
+- change SSR asset request validation;
+- claim WCAG conformance from static source markers;
+- execute a browser, screen reader, accessibility scanner, Playwright, Node verifier, Cargo command, formatter, build, workflow or CI;
+- accept any provider-health, Pages gate or Forum Wave evidence;
+- promote FFA/FBA.
+
+## Next cursor
+
+The generic editor accessibility source gap is closed. Remaining accessibility work is executed evidence: keyboard navigation/focus behavior, accessible-name/state inspection, disabled capability behavior and browser/screen-reader checks on the built admin surface.
+
+The broader rollout cursor remains maintainer-owned:
+
+```text
+exact provider-health execution
+-> Pages gate decision
+-> Forum evidence/admission
+-> observed control-plane Wave
+-> accepted rollout evidence
+```
+
+Tests and verifiers were intentionally not run in this source-authoring slice.

--- a/scripts/verify/verify-page-builder-admin-accessibility.mjs
+++ b/scripts/verify/verify-page-builder-admin-accessibility.mjs
@@ -46,7 +46,8 @@ function forbidMarker(key, marker, label) {
 }
 
 for (const marker of [
-  '<label class="grid gap-1 text-sm">',
+  '<span class="font-medium">{asset_id_label}</span>',
+  '<span class="font-medium">{asset_url_label}</span>',
   'aria-label=add_asset_accessible_label',
   'let select_accessible_label = format!("{select_label}: {accessible_name}");',
   'let remove_accessible_label = format!("{remove_label}: {accessible_name}");',
@@ -119,7 +120,7 @@ for (const marker of [
 
 for (const marker of [
   'role="toolbar"',
-  'aria-label="Page builder actions"',
+  'aria-label=',
   'aria-live="polite"',
 ]) requireMarker("toolbar", marker, "toolbar accessibility baseline");
 

--- a/scripts/verify/verify-page-builder-admin-accessibility.mjs
+++ b/scripts/verify/verify-page-builder-admin-accessibility.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.env.RUSTOK_VERIFY_REPO_ROOT
+  ? path.resolve(process.env.RUSTOK_VERIFY_REPO_ROOT)
+  : process.cwd();
+
+const files = {
+  assets: "crates/rustok-page-builder/admin/src/editor/asset_section.rs",
+  styles: "crates/rustok-page-builder/admin/src/editor/style_section.rs",
+  properties: "crates/rustok-page-builder/admin/src/editor/properties_section.rs",
+  responsive: "crates/rustok-page-builder/admin/src/editor/responsive_styles.rs",
+  traits: "crates/rustok-page-builder/admin/src/editor/trait_panel.rs",
+  pages: "crates/rustok-page-builder/admin/src/editor/page_manager.rs",
+  paletteLayers: "crates/rustok-page-builder/admin/src/editor/palette_layers.rs",
+  toolbar: "crates/rustok-page-builder/admin/src/editor/toolbar.rs",
+};
+
+const failures = [];
+const source = {};
+
+for (const [key, relativePath] of Object.entries(files)) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`${relativePath}: required accessibility source is missing`);
+    source[key] = "";
+    continue;
+  }
+  const stats = fs.lstatSync(absolutePath);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    failures.push(`${relativePath}: source must be a regular non-symlink file`);
+    source[key] = "";
+    continue;
+  }
+  source[key] = fs.readFileSync(absolutePath, "utf8");
+}
+
+function requireMarker(key, marker, label) {
+  if (!source[key].includes(marker)) failures.push(`${label}: missing '${marker}'`);
+}
+
+function forbidMarker(key, marker, label) {
+  if (source[key].includes(marker)) failures.push(`${label}: stale pattern remains '${marker}'`);
+}
+
+for (const marker of [
+  '<label class="grid gap-1 text-sm">',
+  'aria-label=add_asset_accessible_label',
+  'let select_accessible_label = format!("{select_label}: {accessible_name}");',
+  'let remove_accessible_label = format!("{remove_label}: {accessible_name}");',
+  'aria-label=select_accessible_label',
+  'aria-label=remove_accessible_label',
+]) requireMarker("assets", marker, "asset controls");
+for (const stale of ["placeholder=asset_id_label", "placeholder=asset_url_label"]) {
+  forbidMarker("assets", stale, "asset controls");
+}
+
+for (const marker of [
+  '<span class="font-medium">{property_label}</span>',
+  '<span class="font-medium">{value_label}</span>',
+]) requireMarker("styles", marker, "style controls");
+
+for (const marker of [
+  'aria-label=tag_label',
+  'aria-label=tag_apply_accessible_label',
+  '<span class="font-medium">{content_label}</span>',
+  'aria-label=content_apply_accessible_label',
+  'aria-label=content_clear_accessible_label',
+  'aria-label=attribute_name_label.clone()',
+  'aria-label=attribute_value_label.clone()',
+  'aria-label=attribute_apply_accessible_label',
+  'let clear_accessible_label = format!("{clear_label}: {name}");',
+]) requireMarker("properties", marker, "property controls");
+forbidMarker(
+  "properties",
+  '<label class="block text-sm font-medium">{tag_label}</label>',
+  "property controls",
+);
+
+for (const marker of [
+  '<span class="font-medium">{breakpoint_label}</span>',
+  '<span class="font-medium">{property_label}</span>',
+  '<span class="font-medium">{value_label}</span>',
+]) requireMarker("responsive", marker, "responsive controls");
+
+for (const marker of [
+  'data-fly-trait-id=schema.id.clone()',
+  'aria-label=input_label.clone()',
+  'aria-label=apply_accessible_label',
+  'aria-label=clear_accessible_label',
+]) requireMarker("traits", marker, "trait controls");
+forbidMarker(
+  "traits",
+  '<label class="block text-sm font-medium">{schema.label.clone()}</label>',
+  "trait controls",
+);
+
+for (const marker of [
+  'aria-pressed=active.to_string()',
+  'aria-label=new_page_name_accessible_label',
+  '<span class="font-medium">{name_label.clone()}</span>',
+  '<span class="font-medium">{id_label}</span>',
+]) requireMarker("pages", marker, "page controls");
+forbidMarker(
+  "pages",
+  '<label class="text-sm font-medium">{name_label.clone()}</label>',
+  "page controls",
+);
+
+for (const marker of [
+  'let insert_accessible_label = format!("{add_label}: {block_accessible_name}");',
+  'let drag_accessible_label = format!("{drag_label}: {block_accessible_name}");',
+  'aria-label=insert_accessible_label',
+  'aria-label=drag_accessible_label',
+  'aria-pressed=active.to_string()',
+]) requireMarker("paletteLayers", marker, "palette/layer controls");
+
+for (const marker of [
+  'role="toolbar"',
+  'aria-label="Page builder actions"',
+  'aria-live="polite"',
+]) requireMarker("toolbar", marker, "toolbar accessibility baseline");
+
+if (failures.length > 0) {
+  console.error("Page Builder admin accessibility source verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Page Builder admin accessibility source verified.");


### PR DESCRIPTION
## Summary

Close the remaining source-level generic Page Builder editor accessibility gap without changing Fly commands, capability policy, owner transports, persistence, provider health or rollout semantics.

### Changes

- give WASM asset id/URL controls programmatic localized labels instead of placeholder-only names;
- disambiguate repeated asset Use/Remove and palette Add/Drag actions with object-scoped accessible names;
- associate generic Properties, Styles and Responsive Styles controls with visible/programmatic labels;
- give Trait controls stable row identity plus schema-label accessible names across Boolean/Select/Multiline/Number/Text/URL variants;
- expose active Page and Layer selection through `aria-pressed` in addition to visual styling;
- give the add-page name field an explicit localized accessible name and associate current page name/id fields with visible labels;
- add `scripts/verify/verify-page-builder-admin-accessibility.mjs` as a static anti-drift guard;
- add `page-builder-admin-accessibility-actualization-2026-08-10.md` to split source accessibility completion from still-pending executable browser/screen-reader evidence.

## Boundaries

This PR does not change command/persistence semantics, capability gates, provider-health narrowing, Pages/Forum ownership or SSR asset validation. It does not claim WCAG conformance from source inspection.

## Validation

Per maintainer instruction, tests and verifiers were intentionally not run. No Node verifier, Cargo command, formatter, build, browser/Playwright, accessibility scanner, screen-reader run, workflow or CI execution was performed.

## Next cursor

Generic editor accessibility semantics are source-ready. Remaining work is executable evidence for keyboard/focus behavior, accessible names/states, disabled capability behavior and built-surface browser/screen-reader checks, while the provider-health/gate/Forum rollout chain remains maintainer-execution-owned.