### PR TITLE
feat(commerce): route admin return decision Order writes through owner port

### DIFF
--- a/crates/rustok-commerce/docs/rest-admin-return-decision-order-owner-port-cutover-2026-08-10.md
+++ b/crates/rustok-commerce/docs/rest-admin-return-decision-order-owner-port-cutover-2026-08-10.md
@@ -1,0 +1,102 @@
+# Commerce REST admin return-decision Order owner-port cutover
+
+Status: `source_complete_unvalidated`
+
+Date: 2026-08-10
+
+## Scope
+
+This slice cuts only the mounted REST
+`POST /admin/orders/{id}/returns/decision` Order-owned writes away from concrete
+`OrderService` construction inside Commerce post-order orchestration.
+
+The route keeps the existing `ORDERS_UPDATE` admission and conditional
+`PAYMENTS_UPDATE` admission. It now supplies the host-selected
+`OrderPostOrderCommandPort` from `CommerceHttpRuntime` to
+`ReturnDecisionOwnerOrchestrationService`.
+
+The following Order-owned effects use the owner command port in the mounted REST
+return-decision path:
+
+- create the return through `create_return`;
+- create an exchange or claim order change through `create_change`;
+- complete the return through the new `complete_return` capability.
+
+## Order owner capability
+
+`OrderPostOrderCommandPort` now publishes `complete_return` with typed
+`CompleteOrderReturnRequest`.
+
+The in-process adapter delegates to the same owner-local
+`OrderService::complete_return` implementation used before this cutover. The trait
+method has a default fail-closed implementation so existing external adapters remain
+source-compatible; an external adapter that does not implement return completion
+returns `order.post_order_complete_return_unavailable` after normal write admission.
+
+The mounted REST route therefore does not silently fall back to an embedded Order
+service when a host-selected adapter lacks the capability.
+
+## Context and replay limitation
+
+The route builds one authenticated root `PortContext` with tenant, user actor,
+request locale/channel, correlation identity, a two-second deadline, and a generated
+UUID idempotency identity.
+
+The return-decision orchestration derives a distinct correlation/idempotency identity
+for each Order owner operation (`create_return`, `create_change`, and
+`complete_return`). The legacy route does not expose a caller idempotency key, so the
+generated identity is **write-admission metadata only**. This slice does not claim
+durable replay or exactly-once semantics for repeated client requests.
+
+## Preserved decision semantics
+
+The pre-cutover validation and action semantics are preserved:
+
+- input validation and action-shape validation happen before return creation;
+- `return_only` creates and completes the return;
+- `refund` creates the return, performs the existing Payment refund flow, then
+  completes the return with the refund id;
+- `exchange` and `claim` create the same return-linked order-change payloads, then
+  complete the return with the order-change id;
+- response action, return, refund, order-change, and metadata projection remain the
+  same.
+
+## Error boundary
+
+Order owner `PortError` values map to the existing admin Order public families:
+validation, not found, state conflict, storage unavailable, and fail-closed internal
+failure. The new mapper records bounded facts only: error kind, owner code length,
+retryability, correlation identity, non-nil request identities, public code/status,
+and boundary. It does not log raw `PortError.message` or stringify the owner error.
+
+Existing Payment and post-order validation errors still use the pre-existing
+post-order mapper in this slice so their public envelopes are unchanged.
+
+## Explicitly deferred topology gaps
+
+This slice is deliberately Order-only and REST-only.
+
+- The refund branch still uses `PaymentService` to find the captured payment
+  collection and the existing Payment orchestration to create the refund. Moving
+  that Payment dependency behind host-composed Payment ports is a separate mounted
+  gap.
+- Mounted GraphQL `createOrderReturnDecision` still uses the legacy
+  `PostOrderOrchestrationService::create_return_decision` path and is a separate
+  transport cutover.
+- Mounted `/admin/returns/{id}/complete` uses the broader
+  `ReturnCompletionOrchestrationService`; its remaining Order/Payment construction is
+  a separate cross-domain slice.
+- Legacy create/list/show/cancel functions in `controllers/admin/returns.rs` still
+  contain concrete Order service source, but the admin router mounts their existing
+  `post_order_commands` / `post_order_reads` replacements instead.
+
+The broad topology P0 therefore remains open:
+
+`Move remaining mounted Commerce REST/GraphQL construction of Product, Order, Payment, and Fulfillment concrete services behind host-composed owner ports.`
+
+## Validation
+
+No tests, Cargo commands, Node verifiers, formatter, REST/GraphQL scenarios,
+workflows/CI, database scenarios, provider calls, restart scenarios, or remote-adapter
+scenarios were executed in this slice. Source guards were added/updated but
+intentionally not run.

--- a/crates/rustok-commerce/src/controllers/admin/returns.rs
+++ b/crates/rustok-commerce/src/controllers/admin/returns.rs
@@ -3,8 +3,10 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use rustok_api::Permission;
-use rustok_api::{AuthContext, TenantContext};
+use rustok_api::{
+    AuthContext, Permission, PortActor, PortContext, PortError, PortErrorKind, RequestContext,
+    TenantContext,
+};
 use rustok_order::OrderService;
 use rustok_order::error::OrderError;
 use rustok_payment::error::PaymentError;
@@ -21,8 +23,9 @@ use super::{
 use crate::{
     CompleteReturnClaimInput, CompleteReturnExchangeInput, CompleteReturnRefundInput,
     CompleteReturnResolutionInput, CreateReturnDecisionInput, PaymentOrchestrationError,
-    PostOrderOrchestrationError, PostOrderOrchestrationService,
-    ReturnCompletionOrchestrationService, ReturnDecisionResponse,
+    PostOrderOrchestrationError, ReturnCompletionOrchestrationService,
+    ReturnDecisionOwnerOrchestrationError, ReturnDecisionOwnerOrchestrationService,
+    ReturnDecisionResponse,
     dto::{
         CancelOrderReturnInput, CreateOrderReturnInput, ListOrderReturnsInput, OrderReturnResponse,
     },
@@ -86,6 +89,29 @@ impl AdminOrderReturnOrchestrationErrorContext {
     }
 }
 
+fn admin_return_decision_order_context(
+    tenant: &TenantContext,
+    auth: &AuthContext,
+    request_context: &RequestContext,
+    order_id: Uuid,
+) -> PortContext {
+    let context = PortContext::new(
+        tenant.id.to_string(),
+        PortActor::user(auth.user_id.to_string()),
+        request_context.locale.as_str(),
+        format!("commerce-admin-return-decision:{order_id}"),
+    )
+    // This legacy route has no caller idempotency header. The generated root is
+    // write-admission metadata only; the orchestration derives a distinct identity
+    // for each Order owner operation without claiming durable request replay.
+    .with_idempotency_key(Uuid::new_v4().to_string())
+    .with_deadline(std::time::Duration::from_secs(2));
+    match request_context.channel_slug.as_deref() {
+        Some(channel) => context.with_channel(channel),
+        None => context,
+    }
+}
+
 fn admin_order_error_policy(error: &OrderError) -> AdminOrderReturnHttpPolicy {
     match error {
         OrderError::Validation(_) => (
@@ -119,6 +145,47 @@ fn admin_order_error_policy(error: &OrderError) -> AdminOrderReturnHttpPolicy {
             "commerce_admin_order_failed",
             "Order operation could not be completed safely",
             "core",
+        ),
+    }
+}
+
+fn admin_order_port_error_policy(error: &PortError) -> AdminOrderReturnHttpPolicy {
+    match &error.kind {
+        PortErrorKind::Validation => (
+            StatusCode::BAD_REQUEST,
+            "commerce_admin_order_invalid",
+            "Order request is invalid",
+            "validation",
+        ),
+        PortErrorKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            "commerce_admin_not_found",
+            "Commerce resource not found",
+            "not_found",
+        ),
+        PortErrorKind::Conflict => (
+            StatusCode::CONFLICT,
+            "commerce_admin_order_state_conflict",
+            "Order operation conflicts with the current state",
+            "state_conflict",
+        ),
+        PortErrorKind::Forbidden => (
+            StatusCode::UNAUTHORIZED,
+            "commerce_permission_denied",
+            "Permission denied",
+            "forbidden",
+        ),
+        PortErrorKind::Unavailable | PortErrorKind::Timeout => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "commerce_admin_order_storage_unavailable",
+            "Order storage is temporarily unavailable",
+            "temporarily_unavailable",
+        ),
+        PortErrorKind::InvariantViolation => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "commerce_admin_order_failed",
+            "Order operation could not be completed safely",
+            "invariant_violation",
         ),
     }
 }
@@ -214,6 +281,33 @@ fn map_admin_order_return_error(
         status = %status,
         boundary = ADMIN_ORDER_RETURN_BOUNDARY,
         "commerce admin order return owner operation failed"
+    );
+    HttpError::new(status, code, message)
+}
+
+fn map_admin_return_decision_order_port_error(
+    tenant_id: Uuid,
+    actor_id: Uuid,
+    order_id: Uuid,
+    context: &PortContext,
+    error: PortError,
+) -> HttpError {
+    let (status, code, message, error_kind) = admin_order_port_error_policy(&error);
+    tracing::error!(
+        owner = "rustok_order.post_order_command",
+        consumer_operation = "create_return_decision",
+        correlation_id = %context.correlation_id,
+        tenant_id_non_nil = !tenant_id.is_nil(),
+        actor_id_non_nil = !actor_id.is_nil(),
+        order_id_non_nil = !order_id.is_nil(),
+        owner_error_kind = ?error.kind,
+        owner_code_length = error.code.chars().count(),
+        retryable = error.retryable,
+        error_kind,
+        public_code = code,
+        status = %status,
+        boundary = ADMIN_ORDER_RETURN_BOUNDARY,
+        "commerce admin return-decision Order owner command failed with bounded diagnostics"
     );
     HttpError::new(status, code, message)
 }
@@ -334,6 +428,7 @@ pub async fn create_order_return_decision(
     State(runtime): State<CommerceHttpRuntime>,
     tenant: TenantContext,
     auth: AuthContext,
+    request_context: RequestContext,
     Path(id): Path<Uuid>,
     Json(input): Json<CreateReturnDecisionInput>,
 ) -> HttpResult<(StatusCode, Json<ReturnDecisionResponse>)> {
@@ -352,22 +447,38 @@ pub async fn create_order_return_decision(
             "Permission denied: payments:update required",
         )?;
     }
-    let service = PostOrderOrchestrationService::new(runtime.db_clone(), runtime.event_bus())
-        .with_payment_provider_registry(runtime.payment_provider_registry());
+
+    let context = admin_return_decision_order_context(&tenant, &auth, &request_context, id);
+    let service = ReturnDecisionOwnerOrchestrationService::new(
+        runtime.db_clone(),
+        runtime.order_post_order_command_port(),
+    )
+    .with_payment_provider_registry(runtime.payment_provider_registry());
     let decision = service
-        .create_return_decision(tenant.id, auth.user_id, id, input)
+        .create_return_decision(context.clone(), tenant.id, id, input)
         .await
-        .map_err(|error| {
-            map_admin_order_return_orchestration_error(
-                AdminOrderReturnOrchestrationErrorContext::new(
+        .map_err(|error| match error {
+            ReturnDecisionOwnerOrchestrationError::OrderCommand(error) => {
+                map_admin_return_decision_order_port_error(
                     tenant.id,
                     auth.user_id,
-                    Some(id),
-                    None,
-                    "create_return_decision",
-                ),
-                error,
-            )
+                    id,
+                    &context,
+                    error,
+                )
+            }
+            ReturnDecisionOwnerOrchestrationError::PostOrder(error) => {
+                map_admin_order_return_orchestration_error(
+                    AdminOrderReturnOrchestrationErrorContext::new(
+                        tenant.id,
+                        auth.user_id,
+                        Some(id),
+                        None,
+                        "create_return_decision",
+                    ),
+                    error,
+                )
+            }
         })?;
     Ok((StatusCode::CREATED, Json(decision)))
 }

--- a/crates/rustok-commerce/src/lib.rs
+++ b/crates/rustok-commerce/src/lib.rs
@@ -78,10 +78,11 @@ pub use services::{
     ReturnClaimDecisionInput, ReturnCompletionOperationCheckpoint, ReturnCompletionOperationError,
     ReturnCompletionOperationJournal, ReturnCompletionOperationResult,
     ReturnCompletionOperationStage, ReturnCompletionOperationStatus,
-    ReturnCompletionOrchestrationService, ReturnDecisionInput, ReturnDecisionResponse,
-    ReturnExchangeDecisionInput, ReturnRefundDecisionInput, ShippingProfileService,
-    StagedCheckoutError, StagedCheckoutResult, StagedCheckoutService, StoreContextError,
-    StoreContextResult, StoreContextService,
+    ReturnCompletionOrchestrationService, ReturnDecisionInput,
+    ReturnDecisionOwnerOrchestrationError, ReturnDecisionOwnerOrchestrationResult,
+    ReturnDecisionOwnerOrchestrationService, ReturnDecisionResponse, ReturnExchangeDecisionInput,
+    ReturnRefundDecisionInput, ShippingProfileService, StagedCheckoutError, StagedCheckoutResult,
+    StagedCheckoutService, StoreContextError, StoreContextResult, StoreContextService,
 };
 #[cfg(feature = "marketplace-financial")]
 pub use services::{

--- a/crates/rustok-commerce/src/services/mod.rs
+++ b/crates/rustok-commerce/src/services/mod.rs
@@ -68,6 +68,7 @@ mod refund_reconciliation;
 mod return_completion_operation;
 mod return_completion_orchestration;
 mod return_completion_recovery;
+mod return_decision_owner_orchestration;
 mod shipping_profile;
 mod staged_checkout;
 #[path = "../storefront_staged_checkout_runtime.rs"]
@@ -253,6 +254,10 @@ pub use return_completion_orchestration::{
 pub use return_completion_recovery::{
     ListReturnCompletionOperationsInput, ReturnCompletionOperationResponse,
     ReturnCompletionOrchestrationService,
+};
+pub use return_decision_owner_orchestration::{
+    ReturnDecisionOwnerOrchestrationError, ReturnDecisionOwnerOrchestrationResult,
+    ReturnDecisionOwnerOrchestrationService,
 };
 pub use shipping_profile::ShippingProfileService;
 pub use staged_checkout::{StagedCheckoutError, StagedCheckoutResult, StagedCheckoutService};

--- a/crates/rustok-commerce/src/services/return_decision_owner_orchestration.rs
+++ b/crates/rustok-commerce/src/services/return_decision_owner_orchestration.rs
@@ -1,0 +1,465 @@
+use std::sync::Arc;
+
+use rust_decimal::Decimal;
+use rustok_api::{PortContext, PortError};
+use rustok_order::{
+    CompleteOrderReturnInput, CompleteOrderReturnRequest, CreateOrderChangeInput,
+    CreateOrderChangeRequest, CreateOrderReturnRequest, OrderPostOrderCommandPort,
+    OrderReturnResponse,
+};
+use rustok_payment::{
+    PaymentService,
+    dto::{CreateRefundInput, ListPaymentCollectionsInput, RefundResponse},
+    providers::PaymentProviderRegistry,
+};
+use sea_orm::DatabaseConnection;
+use serde_json::Value;
+use thiserror::Error;
+use uuid::Uuid;
+use validator::Validate;
+
+use super::{
+    PaymentOrchestrationService,
+    post_order::{
+        CreateReturnDecisionInput, PostOrderOrchestrationError, PostOrderOrchestrationResult,
+        ReturnDecisionInput, ReturnDecisionResponse, ReturnRefundDecisionInput,
+    },
+};
+
+#[derive(Debug, Error)]
+pub enum ReturnDecisionOwnerOrchestrationError {
+    #[error("order command owner port error: {0}")]
+    OrderCommand(#[from] PortError),
+    #[error(transparent)]
+    PostOrder(#[from] PostOrderOrchestrationError),
+}
+
+pub type ReturnDecisionOwnerOrchestrationResult<T> =
+    Result<T, ReturnDecisionOwnerOrchestrationError>;
+
+/// Mounted return-decision orchestration with Order-owned writes behind a host-selected port.
+///
+/// Payment lookup/refund execution deliberately retains the existing Payment compatibility path in
+/// this bounded slice. That dependency remains a separate topology gap.
+pub struct ReturnDecisionOwnerOrchestrationService {
+    db: DatabaseConnection,
+    order_commands: Arc<dyn OrderPostOrderCommandPort>,
+    payment_provider_registry: PaymentProviderRegistry,
+}
+
+impl ReturnDecisionOwnerOrchestrationService {
+    pub fn new(
+        db: DatabaseConnection,
+        order_commands: Arc<dyn OrderPostOrderCommandPort>,
+    ) -> Self {
+        Self {
+            db,
+            order_commands,
+            payment_provider_registry: PaymentProviderRegistry::with_manual_provider(),
+        }
+    }
+
+    pub fn with_payment_provider_registry(
+        mut self,
+        payment_provider_registry: PaymentProviderRegistry,
+    ) -> Self {
+        self.payment_provider_registry = payment_provider_registry;
+        self
+    }
+
+    pub async fn create_return_decision(
+        &self,
+        base_context: PortContext,
+        tenant_id: Uuid,
+        order_id: Uuid,
+        input: CreateReturnDecisionInput,
+    ) -> ReturnDecisionOwnerOrchestrationResult<ReturnDecisionResponse> {
+        if base_context.tenant_id != tenant_id.to_string() {
+            return Err(ReturnDecisionOwnerOrchestrationError::OrderCommand(
+                PortError::validation(
+                    "commerce.return_decision_owner_context_invalid",
+                    "return decision owner context is invalid",
+                ),
+            ));
+        }
+
+        input
+            .validate()
+            .map_err(|error| PostOrderOrchestrationError::Validation(error.to_string()))?;
+        let action = normalize_decision_action(&input.decision.action)?;
+        validate_decision_shape(&action, &input.decision)?;
+
+        let decision_metadata = input.decision.metadata.clone();
+        let create_context = command_context_for(&base_context, "create_return", order_id)?;
+        let order_return = self
+            .order_commands
+            .create_return(
+                create_context,
+                CreateOrderReturnRequest {
+                    order_id,
+                    input: input.return_request,
+                },
+            )
+            .await
+            .map_err(ReturnDecisionOwnerOrchestrationError::OrderCommand)?;
+
+        let (order_return, refund, order_change) = match action.as_str() {
+            "return_only" => {
+                let order_return = self
+                    .complete_return_decision(
+                        &base_context,
+                        order_return.id,
+                        None,
+                        None,
+                        None,
+                        decision_metadata.clone(),
+                    )
+                    .await?;
+                (order_return, None, None)
+            }
+            "refund" => {
+                let refund_input = input.decision.refund.as_ref().ok_or_else(|| {
+                    PostOrderOrchestrationError::Validation(
+                        "refund decision requires refund details".to_string(),
+                    )
+                })?;
+                let refund = self
+                    .create_refund_for_return(tenant_id, order_id, &order_return, refund_input)
+                    .await?;
+                let order_return = self
+                    .complete_return_decision(
+                        &base_context,
+                        order_return.id,
+                        Some("refund"),
+                        Some(refund.id),
+                        None,
+                        decision_metadata.clone(),
+                    )
+                    .await?;
+                (order_return, Some(refund), None)
+            }
+            "exchange" => {
+                let exchange_input = input.decision.exchange.as_ref().ok_or_else(|| {
+                    PostOrderOrchestrationError::Validation(
+                        "exchange decision requires exchange details".to_string(),
+                    )
+                })?;
+                let change_context = command_context_for(&base_context, "create_change", order_id)?;
+                let order_change = self
+                    .order_commands
+                    .create_change(
+                        change_context,
+                        CreateOrderChangeRequest {
+                            order_id,
+                            input: build_return_order_change_input(
+                                "exchange",
+                                exchange_input.description.clone(),
+                                exchange_input.preview.clone(),
+                                exchange_input.metadata.clone(),
+                                order_return.id,
+                            )?,
+                        },
+                    )
+                    .await
+                    .map_err(ReturnDecisionOwnerOrchestrationError::OrderCommand)?;
+                let order_return = self
+                    .complete_return_decision(
+                        &base_context,
+                        order_return.id,
+                        Some("exchange"),
+                        None,
+                        Some(order_change.id),
+                        decision_metadata.clone(),
+                    )
+                    .await?;
+                (order_return, None, Some(order_change))
+            }
+            "claim" => {
+                let claim_input = input.decision.claim.as_ref().ok_or_else(|| {
+                    PostOrderOrchestrationError::Validation(
+                        "claim decision requires claim details".to_string(),
+                    )
+                })?;
+                let change_context = command_context_for(&base_context, "create_change", order_id)?;
+                let order_change = self
+                    .order_commands
+                    .create_change(
+                        change_context,
+                        CreateOrderChangeRequest {
+                            order_id,
+                            input: build_return_order_change_input(
+                                "claim",
+                                claim_input.description.clone(),
+                                claim_input.preview.clone(),
+                                claim_input.metadata.clone(),
+                                order_return.id,
+                            )?,
+                        },
+                    )
+                    .await
+                    .map_err(ReturnDecisionOwnerOrchestrationError::OrderCommand)?;
+                let order_return = self
+                    .complete_return_decision(
+                        &base_context,
+                        order_return.id,
+                        Some("claim"),
+                        None,
+                        Some(order_change.id),
+                        decision_metadata.clone(),
+                    )
+                    .await?;
+                (order_return, None, Some(order_change))
+            }
+            _ => unreachable!("validated action"),
+        };
+
+        Ok(ReturnDecisionResponse {
+            action,
+            order_return,
+            refund,
+            order_change,
+            metadata: normalize_object_or_empty(decision_metadata, "decision.metadata")?,
+        })
+    }
+
+    async fn complete_return_decision(
+        &self,
+        base_context: &PortContext,
+        return_id: Uuid,
+        resolution_type: Option<&str>,
+        refund_id: Option<Uuid>,
+        order_change_id: Option<Uuid>,
+        metadata: Value,
+    ) -> ReturnDecisionOwnerOrchestrationResult<OrderReturnResponse> {
+        let context = command_context_for(base_context, "complete_return", return_id)?;
+        self.order_commands
+            .complete_return(
+                context,
+                CompleteOrderReturnRequest {
+                    return_id,
+                    input: CompleteOrderReturnInput {
+                        resolution_type: resolution_type.map(str::to_string),
+                        refund_id,
+                        order_change_id,
+                        metadata: normalize_object_or_empty(metadata, "decision.metadata")?,
+                    },
+                },
+            )
+            .await
+            .map_err(ReturnDecisionOwnerOrchestrationError::OrderCommand)
+    }
+
+    async fn create_refund_for_return(
+        &self,
+        tenant_id: Uuid,
+        order_id: Uuid,
+        order_return: &OrderReturnResponse,
+        input: &ReturnRefundDecisionInput,
+    ) -> PostOrderOrchestrationResult<RefundResponse> {
+        let payment_service = PaymentService::new(self.db.clone());
+        let collection_id = match input.payment_collection_id {
+            Some(id) => id,
+            None => {
+                let (collections, _) = payment_service
+                    .list_collections(
+                        tenant_id,
+                        ListPaymentCollectionsInput {
+                            page: 1,
+                            per_page: 1,
+                            status: Some("captured".to_string()),
+                            order_id: Some(order_id),
+                            cart_id: None,
+                            customer_id: None,
+                        },
+                    )
+                    .await?;
+                collections
+                    .into_iter()
+                    .next()
+                    .map(|collection| collection.id)
+                    .ok_or_else(|| {
+                        PostOrderOrchestrationError::Validation(format!(
+                            "order {order_id} has no captured payment collection for return refund"
+                        ))
+                    })?
+            }
+        };
+
+        let amount = match input.amount {
+            Some(amount) => amount,
+            None => return_items_amount(order_return)?,
+        };
+        if amount <= Decimal::ZERO {
+            return Err(PostOrderOrchestrationError::Validation(
+                "refund decision requires a positive amount or priced return items".to_string(),
+            ));
+        }
+
+        PaymentOrchestrationService::new(self.db.clone())
+            .with_provider_registry(self.payment_provider_registry.clone())
+            .create_refund(
+                tenant_id,
+                collection_id,
+                CreateRefundInput {
+                    amount,
+                    reason: input.reason.clone().or_else(|| order_return.reason.clone()),
+                    metadata: attach_return_context(input.metadata.clone(), order_return.id)?,
+                },
+            )
+            .await
+            .map_err(Into::into)
+    }
+}
+
+fn command_context_for(
+    base: &PortContext,
+    operation: &'static str,
+    resource_id: Uuid,
+) -> Result<PortContext, PortError> {
+    let Some(root_idempotency_key) = base
+        .idempotency_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Err(PortError::validation(
+            "commerce.return_decision_owner_context_invalid",
+            "return decision owner context is invalid",
+        ));
+    };
+    let mut context = base.clone();
+    context.correlation_id = format!("{}:{operation}:{resource_id}", base.correlation_id);
+    context.idempotency_key = Some(format!(
+        "{root_idempotency_key}:{operation}:{resource_id}"
+    ));
+    Ok(context)
+}
+
+fn normalize_decision_action(action: &str) -> PostOrderOrchestrationResult<String> {
+    let normalized = action.trim().to_ascii_lowercase().replace('-', "_");
+    match normalized.as_str() {
+        "none" | "return" | "return_only" => Ok("return_only".to_string()),
+        "refund" => Ok("refund".to_string()),
+        "exchange" => Ok("exchange".to_string()),
+        "claim" => Ok("claim".to_string()),
+        _ => Err(PostOrderOrchestrationError::Validation(
+            "return decision action must be one of return_only, refund, exchange, claim"
+                .to_string(),
+        )),
+    }
+}
+
+fn validate_decision_shape(
+    action: &str,
+    decision: &ReturnDecisionInput,
+) -> PostOrderOrchestrationResult<()> {
+    if action != "refund" && decision.refund.is_some() {
+        return Err(PostOrderOrchestrationError::Validation(
+            "refund details are only allowed for refund decisions".to_string(),
+        ));
+    }
+    if action != "exchange" && decision.exchange.is_some() {
+        return Err(PostOrderOrchestrationError::Validation(
+            "exchange details are only allowed for exchange decisions".to_string(),
+        ));
+    }
+    if action != "claim" && decision.claim.is_some() {
+        return Err(PostOrderOrchestrationError::Validation(
+            "claim details are only allowed for claim decisions".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn build_return_order_change_input(
+    change_type: &str,
+    description: Option<String>,
+    preview: Value,
+    metadata: Value,
+    return_id: Uuid,
+) -> PostOrderOrchestrationResult<CreateOrderChangeInput> {
+    Ok(CreateOrderChangeInput {
+        change_type: change_type.to_string(),
+        description,
+        preview: attach_return_order_change_context(preview, return_id, change_type)?,
+        metadata: attach_return_order_change_context(metadata, return_id, change_type)?,
+    })
+}
+
+fn attach_return_order_change_context(
+    value: Value,
+    return_id: Uuid,
+    change_type: &str,
+) -> PostOrderOrchestrationResult<Value> {
+    let mut object = match attach_return_context(value, return_id)? {
+        Value::Object(object) => object,
+        _ => unreachable!("attach_return_context returns object"),
+    };
+    object.insert(
+        "return_decision_action".to_string(),
+        Value::String(change_type.to_string()),
+    );
+    object.insert(
+        "return_decision_source".to_string(),
+        Value::String("rustok-commerce".to_string()),
+    );
+    Ok(Value::Object(object))
+}
+
+fn attach_return_context(value: Value, return_id: Uuid) -> PostOrderOrchestrationResult<Value> {
+    let mut object = match normalize_object_or_empty(value, "metadata")? {
+        Value::Object(object) => object,
+        _ => unreachable!("normalize returns object"),
+    };
+    object.insert(
+        "order_return_id".to_string(),
+        Value::String(return_id.to_string()),
+    );
+    Ok(Value::Object(object))
+}
+
+fn normalize_object_or_empty(value: Value, field: &str) -> PostOrderOrchestrationResult<Value> {
+    match value {
+        Value::Null => Ok(serde_json::json!({})),
+        Value::Object(_) => Ok(value),
+        _ => Err(PostOrderOrchestrationError::Validation(format!(
+            "{field} must be a JSON object"
+        ))),
+    }
+}
+
+fn return_items_amount(order_return: &OrderReturnResponse) -> PostOrderOrchestrationResult<Decimal> {
+    order_return
+        .items
+        .iter()
+        .filter_map(|item| item.metadata.get("refund_amount"))
+        .try_fold(Decimal::ZERO, |total, value| {
+            let amount = decimal_from_json_value(value, "refund_amount")?;
+            if amount < Decimal::ZERO {
+                return Err(PostOrderOrchestrationError::Validation(
+                    "refund_amount must not be negative".to_string(),
+                ));
+            }
+            total.checked_add(amount).ok_or_else(|| {
+                PostOrderOrchestrationError::Validation(
+                    "return item refund amount total overflowed Decimal".to_string(),
+                )
+            })
+        })
+}
+
+fn decimal_from_json_value(value: &Value, field: &str) -> PostOrderOrchestrationResult<Decimal> {
+    let text = match value {
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        _ => {
+            return Err(PostOrderOrchestrationError::Validation(format!(
+                "{field} must be a decimal string or JSON number"
+            )));
+        }
+    };
+    text.parse::<Decimal>().map_err(|error| {
+        PostOrderOrchestrationError::Validation(format!(
+            "{field} contains an invalid decimal value: {error}"
+        ))
+    })
+}

--- a/crates/rustok-order/src/lib.rs
+++ b/crates/rustok-order/src/lib.rs
@@ -72,8 +72,8 @@ pub use order_read::{
 };
 pub use post_order_command::{
     ApplyOrderChangeRequest, CancelOrderChangeRequest, CancelOrderReturnRequest,
-    CreateOrderChangeRequest, CreateOrderReturnRequest, InProcessOrderPostOrderCommandPort,
-    OrderPostOrderCommandPort, OrderPostOrderCommandRuntime,
+    CompleteOrderReturnRequest, CreateOrderChangeRequest, CreateOrderReturnRequest,
+    InProcessOrderPostOrderCommandPort, OrderPostOrderCommandPort, OrderPostOrderCommandRuntime,
     in_process_order_post_order_command_port,
 };
 pub use ports::*;

--- a/crates/rustok-order/src/post_order_command.rs
+++ b/crates/rustok-order/src/post_order_command.rs
@@ -8,8 +8,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    ApplyOrderChangeInput, CancelOrderChangeInput, CancelOrderReturnInput, CreateOrderChangeInput,
-    CreateOrderReturnInput, OrderChangeResponse, OrderError, OrderReturnResponse, OrderService,
+    ApplyOrderChangeInput, CancelOrderChangeInput, CancelOrderReturnInput, CompleteOrderReturnInput,
+    CreateOrderChangeInput, CreateOrderReturnInput, OrderChangeResponse, OrderError,
+    OrderReturnResponse, OrderService,
 };
 
 const ORDER_POST_ORDER_COMMAND_OWNER: &str = "rustok_order";
@@ -47,6 +48,18 @@ pub trait OrderPostOrderCommandPort: Send + Sync {
         request: CreateOrderReturnRequest,
     ) -> Result<OrderReturnResponse, PortError>;
 
+    async fn complete_return(
+        &self,
+        context: PortContext,
+        _request: CompleteOrderReturnRequest,
+    ) -> Result<OrderReturnResponse, PortError> {
+        context.require_policy(PortCallPolicy::write())?;
+        Err(PortError::unavailable(
+            "order.post_order_complete_return_unavailable",
+            "order return completion capability is unavailable",
+        ))
+    }
+
     async fn cancel_return(
         &self,
         context: PortContext,
@@ -76,6 +89,12 @@ pub struct CancelOrderChangeRequest {
 pub struct CreateOrderReturnRequest {
     pub order_id: Uuid,
     pub input: CreateOrderReturnInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompleteOrderReturnRequest {
+    pub return_id: Uuid,
+    pub input: CompleteOrderReturnInput,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -174,6 +193,19 @@ impl OrderPostOrderCommandPort for InProcessOrderPostOrderCommandPort {
             .create_return(tenant_id, request.order_id, request.input)
             .await
             .map_err(|error| map_order_error(&context, OPERATION, request.order_id, error))
+    }
+
+    async fn complete_return(
+        &self,
+        context: PortContext,
+        request: CompleteOrderReturnRequest,
+    ) -> Result<OrderReturnResponse, PortError> {
+        const OPERATION: &str = "complete_return";
+        let (tenant_id, _) = require_post_order_command_context(&context, OPERATION)?;
+        self.inner
+            .complete_return(tenant_id, request.return_id, request.input)
+            .await
+            .map_err(|error| map_order_error(&context, OPERATION, request.return_id, error))
     }
 
     async fn cancel_return(

--- a/scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs
+++ b/scripts/verify/verify-commerce-admin-order-return-orchestration-error-context.mjs
@@ -11,6 +11,9 @@ const root = configuredRoot
 const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
 
 const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const ownerDecision = read(
+  'crates/rustok-commerce/src/services/return_decision_owner_orchestration.rs',
+);
 const orderErrors = read('crates/rustok-order/src/error.rs');
 const paymentErrors = read('crates/rustok-payment/src/error.rs');
 const paymentOrchestration = read(
@@ -38,8 +41,14 @@ const between = (content, start, end, label) => {
 const orderPolicy = between(
   returns,
   'fn admin_order_error_policy(',
-  'fn admin_payment_error_policy(',
+  'fn admin_order_port_error_policy(',
   'admin order policy',
+);
+const orderPortPolicy = between(
+  returns,
+  'fn admin_order_port_error_policy(',
+  'fn admin_payment_error_policy(',
+  'admin Order port policy',
 );
 const paymentPolicy = between(
   returns,
@@ -52,6 +61,12 @@ const reservedRefundPolicy = between(
   'fn admin_reserved_refund_error_policy(',
   'fn map_admin_order_return_error(',
   'reserved refund policy',
+);
+const ownerPortMapper = between(
+  returns,
+  'fn map_admin_return_decision_order_port_error(',
+  'fn map_admin_order_return_orchestration_error(',
+  'return-decision Order owner-port mapper',
 );
 const orchestrationMapper = between(
   returns,
@@ -76,6 +91,7 @@ for (const [value, label] of [
   ['use rustok_payment::error::PaymentError;', 'typed payment error import'],
   ['PaymentOrchestrationError,', 'typed payment orchestration import'],
   ['PostOrderOrchestrationError,', 'typed post-order import'],
+  ['ReturnDecisionOwnerOrchestrationError,', 'typed return-decision owner error import'],
   [
     'const ADMIN_ORDER_RETURN_ORCHESTRATION_OWNER: &str =',
     'orchestration owner constant',
@@ -111,6 +127,19 @@ for (const [value, label] of [
   ['"commerce_admin_order_storage_unavailable"', 'order storage code'],
   ['"commerce_admin_order_failed"', 'order fail-closed code'],
 ]) requireText(orderPolicy, value, label);
+
+for (const [value, label] of [
+  ['PortErrorKind::Validation', 'port validation kind'],
+  ['PortErrorKind::NotFound', 'port not-found kind'],
+  ['PortErrorKind::Conflict', 'port conflict kind'],
+  ['PortErrorKind::Forbidden', 'port forbidden kind'],
+  ['PortErrorKind::Unavailable | PortErrorKind::Timeout', 'port unavailable kind'],
+  ['PortErrorKind::InvariantViolation', 'port invariant kind'],
+  ['"commerce_admin_order_invalid"', 'port validation code'],
+  ['"commerce_admin_order_state_conflict"', 'port conflict code'],
+  ['"commerce_admin_order_storage_unavailable"', 'port storage code'],
+  ['"commerce_admin_order_failed"', 'port fail-closed code'],
+]) requireText(orderPortPolicy, value, label);
 
 for (const [value, label] of [
   ['PaymentError::PaymentCollectionNotFound(_)', 'collection not-found variant'],
@@ -182,35 +211,65 @@ for (const [value, label] of [
   ['HttpError::new(status, code, message)', 'single static envelope constructor'],
 ]) requireText(orchestrationMapper, value, label);
 
-for (const [block, operation, identity, label] of [
-  [
-    decisionRoute,
-    '"create_return_decision"',
-    'auth.user_id,\n                    Some(id),\n                    None,',
-    'decision context',
-  ],
-  [
-    completeRoute,
-    '"complete_return"',
-    'auth.user_id,\n                    None,\n                    Some(id),',
-    'completion context',
-  ],
-]) {
-  requireText(block, '.map_err(|error| {', `${label} typed mapping closure`);
-  requireText(block, 'map_admin_order_return_orchestration_error(', `${label} mapper handoff`);
-  requireText(block, 'AdminOrderReturnOrchestrationErrorContext::new(', `${label} context construction`);
-  requireText(block, operation, `${label} operation`);
-  requireText(block, identity, `${label} truthful route identity`);
+for (const [value, label] of [
+  ['owner = "rustok_order.post_order_command"', 'Order owner label'],
+  ['consumer_operation = "create_return_decision"', 'consumer operation'],
+  ['correlation_id = %context.correlation_id', 'correlation identity'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code'],
+  ['retryable = error.retryable', 'owner retryability'],
+  ['public_code = code', 'public code'],
+  ['status = %status', 'public status'],
+]) requireText(ownerPortMapper, value, label);
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'internal_message']) {
+  forbidText(ownerPortMapper, value, 'return-decision Order owner raw diagnostics');
 }
 
 for (const [value, label] of [
-  ['.create_return_decision(tenant.id, auth.user_id, id, input)', 'decision service contract'],
-  ['.complete_return(tenant.id, auth.user_id, id, command)', 'completion service contract'],
+  ['request_context: RequestContext,', 'request context extractor'],
+  ['admin_return_decision_order_context(&tenant, &auth, &request_context, id)', 'owner base context'],
+  ['ReturnDecisionOwnerOrchestrationService::new(', 'owner-backed orchestration'],
+  ['runtime.order_post_order_command_port()', 'host-selected Order command port'],
+  ['.create_return_decision(context.clone(), tenant.id, id, input)', 'owner-backed decision contract'],
+  ['.map_err(|error| match error {', 'typed decision error dispatch'],
+  ['ReturnDecisionOwnerOrchestrationError::OrderCommand(error)', 'Order owner error branch'],
+  ['map_admin_return_decision_order_port_error(', 'Order owner mapper handoff'],
+  ['ReturnDecisionOwnerOrchestrationError::PostOrder(error)', 'Payment/validation orchestration branch'],
+  ['map_admin_order_return_orchestration_error(', 'post-order mapper handoff'],
+  ['"create_return_decision"', 'decision operation'],
   ['[Permission::ORDERS_UPDATE]', 'order update permission'],
   ['[Permission::PAYMENTS_UPDATE]', 'payment update permission'],
   ['super::decision_requires_payments_update(', 'decision payment permission gate'],
+]) requireText(decisionRoute, value, label);
+for (const value of [
+  'PostOrderOrchestrationService::new(',
+  'OrderService::new(',
+  '.create_return(tenant.id, id,',
+]) forbidText(decisionRoute, value, 'mounted decision route concrete Order dependency');
+
+for (const [value, label] of [
+  ['.map_err(|error| {', 'completion typed mapping closure'],
+  ['map_admin_order_return_orchestration_error(', 'completion mapper handoff'],
+  ['AdminOrderReturnOrchestrationErrorContext::new(', 'completion context construction'],
+  ['"complete_return"', 'completion operation'],
+  ['auth.user_id,\n                    None,\n                    Some(id),', 'completion truthful route identity'],
+  ['.complete_return(tenant.id, auth.user_id, id, command)', 'completion service contract'],
   ['if input.refund.is_some() {', 'completion payment permission gate'],
-]) requireText(returns, value, label);
+]) requireText(completeRoute, value, label);
+
+for (const [value, label] of [
+  ['OrderPostOrderCommandPort', 'owner command port dependency'],
+  ['.create_return(', 'owner return creation'],
+  ['CreateOrderReturnRequest {', 'typed return request'],
+  ['.create_change(', 'owner change creation'],
+  ['CreateOrderChangeRequest {', 'typed change request'],
+  ['.complete_return(', 'owner return completion'],
+  ['CompleteOrderReturnRequest {', 'typed completion request'],
+  ['PaymentService::new(self.db.clone())', 'deferred Payment compatibility path'],
+]) requireText(ownerDecision, value, label);
+for (const value of ['OrderService::new(', '.create_order_change(', '.complete_return(tenant_id,']) {
+  forbidText(ownerDecision, value, 'owner-backed decision orchestration concrete Order dependency');
+}
 
 const orchestrationMapperUses =
   returns.match(

--- a/scripts/verify/verify-commerce-rest-admin-return-decision-order-owner-port-cutover.mjs
+++ b/scripts/verify/verify-commerce-rest-admin-return-decision-order-owner-port-cutover.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const configuredRoot = process.env.RUSTOK_VERIFY_REPO_ROOT?.trim();
+const root = configuredRoot
+  ? pathToFileURL(`${path.resolve(configuredRoot)}${path.sep}`)
+  : new URL('../../', import.meta.url);
+const read = (relativePath) => readFileSync(new URL(relativePath, root), 'utf8');
+
+const adminRouter = read('crates/rustok-commerce/src/controllers/admin/mod.rs');
+const returns = read('crates/rustok-commerce/src/controllers/admin/returns.rs');
+const ownerDecision = read(
+  'crates/rustok-commerce/src/services/return_decision_owner_orchestration.rs',
+);
+const servicesMod = read('crates/rustok-commerce/src/services/mod.rs');
+const commerceLib = read('crates/rustok-commerce/src/lib.rs');
+const ownerCommand = read('crates/rustok-order/src/post_order_command.rs');
+const ownerLib = read('crates/rustok-order/src/lib.rs');
+const graphql = read('crates/rustok-commerce/src/graphql/mutations/fulfillment.rs');
+const plan = read('crates/rustok-commerce/docs/implementation-plan.md');
+const record = read(
+  'crates/rustok-commerce/docs/rest-admin-return-decision-order-owner-port-cutover-2026-08-10.md',
+);
+const failures = [];
+
+const requireText = (content, value, label) => {
+  if (!content.includes(value)) failures.push(`${label}: missing ${value}`);
+};
+const forbidText = (content, value, label) => {
+  if (content.includes(value)) failures.push(`${label}: forbidden ${value}`);
+};
+const between = (content, start, end, label) => {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    failures.push(`${label}: unable to isolate source block`);
+    return '';
+  }
+  return content.slice(startIndex, endIndex);
+};
+
+const decisionRoute = between(
+  returns,
+  'pub async fn create_order_return_decision(',
+  '#[utoipa::path(\n    get,\n    path = "/admin/returns"',
+  'mounted REST return-decision route',
+);
+const ownerPortMapper = between(
+  returns,
+  'fn map_admin_return_decision_order_port_error(',
+  'fn map_admin_order_return_orchestration_error(',
+  'REST return-decision Order owner mapper',
+);
+const ownerDecisionMethod = between(
+  ownerDecision,
+  'pub async fn create_return_decision(',
+  '    async fn complete_return_decision(',
+  'owner-backed return-decision method',
+);
+
+for (const [value, label] of [
+  ['pub mod returns;', 'admin returns module mount'],
+  ['"/orders/{id}/returns/decision"', 'admin decision route'],
+  ['axum::routing::post(returns::create_order_return_decision)', 'mounted decision handler'],
+  ['axum::routing::post(post_order_commands::create_order_return)', 'mounted create replacement'],
+  ['axum::routing::get(post_order_reads::list_order_returns)', 'mounted list replacement'],
+  ['axum::routing::get(post_order_reads::show_order_return)', 'mounted show replacement'],
+  ['axum::routing::post(post_order_commands::cancel_order_return)', 'mounted cancel replacement'],
+]) requireText(adminRouter, value, label);
+
+for (const [value, label] of [
+  ['request_context: RequestContext,', 'request context extractor'],
+  ['[Permission::ORDERS_UPDATE]', 'orders:update admission'],
+  ['super::decision_requires_payments_update(', 'conditional payment admission'],
+  ['[Permission::PAYMENTS_UPDATE]', 'payments:update admission'],
+  ['admin_return_decision_order_context(&tenant, &auth, &request_context, id)', 'owner base context'],
+  ['PortActor::user(auth.user_id.to_string())', 'authenticated Order actor'],
+  ['format!("commerce-admin-return-decision:{order_id}")', 'root correlation identity'],
+  ['.with_idempotency_key(Uuid::new_v4().to_string())', 'root write admission identity'],
+  ['.with_deadline(std::time::Duration::from_secs(2))', 'bounded deadline'],
+  ['request_context.channel_slug.as_deref()', 'request channel forwarding'],
+  ['ReturnDecisionOwnerOrchestrationService::new(', 'owner-backed orchestration'],
+  ['runtime.order_post_order_command_port()', 'host-selected Order command port'],
+  ['.create_return_decision(context.clone(), tenant.id, id, input)', 'owner-backed decision call'],
+  ['ReturnDecisionOwnerOrchestrationError::OrderCommand(error)', 'Order owner error branch'],
+  ['map_admin_return_decision_order_port_error(', 'bounded owner mapper'],
+  ['ReturnDecisionOwnerOrchestrationError::PostOrder(error)', 'preserved Payment/validation branch'],
+  ['map_admin_order_return_orchestration_error(', 'preserved post-order mapper'],
+]) requireText(decisionRoute, value, label);
+for (const value of [
+  'PostOrderOrchestrationService::new(',
+  'OrderService::new(',
+  '.create_return(tenant.id, id,',
+  '.create_order_change(',
+  '.complete_return(tenant.id,',
+]) forbidText(decisionRoute, value, 'mounted REST decision concrete Order dependency');
+
+for (const [value, label] of [
+  ['owner = "rustok_order.post_order_command"', 'owner diagnostic label'],
+  ['consumer_operation = "create_return_decision"', 'consumer operation'],
+  ['correlation_id = %context.correlation_id', 'correlation diagnostic'],
+  ['tenant_id_non_nil = !tenant_id.is_nil()', 'tenant diagnostic'],
+  ['actor_id_non_nil = !actor_id.is_nil()', 'actor diagnostic'],
+  ['order_id_non_nil = !order_id.is_nil()', 'order diagnostic'],
+  ['owner_error_kind = ?error.kind', 'bounded owner kind'],
+  ['owner_code_length = error.code.chars().count()', 'bounded owner code'],
+  ['retryable = error.retryable', 'owner retryability'],
+  ['public_code = code', 'public code'],
+  ['status = %status', 'public status'],
+]) requireText(ownerPortMapper, value, label);
+for (const value of ['error = ?error', 'error.message', 'error.to_string()', 'internal_message']) {
+  forbidText(ownerPortMapper, value, 'REST Order owner raw diagnostics');
+}
+
+for (const [value, label] of [
+  ['Arc<dyn OrderPostOrderCommandPort>', 'Order owner dependency'],
+  ['base_context.tenant_id != tenant_id.to_string()', 'tenant context admission'],
+  ['input.validate()', 'legacy input validation'],
+  ['normalize_decision_action(&input.decision.action)', 'legacy action normalization'],
+  ['validate_decision_shape(&action, &input.decision)', 'legacy action shape validation'],
+  ['.create_return(', 'typed Order return creation'],
+  ['CreateOrderReturnRequest {', 'typed create-return request'],
+  ['.create_change(', 'typed Order change creation'],
+  ['CreateOrderChangeRequest {', 'typed create-change request'],
+  ['.complete_return_decision(', 'typed completion helper'],
+  ['"return_only"', 'return-only branch'],
+  ['"refund"', 'refund branch'],
+  ['"exchange"', 'exchange branch'],
+  ['"claim"', 'claim branch'],
+]) requireText(ownerDecisionMethod, value, label);
+for (const value of ['OrderService::new(', '.create_order_change(', '.complete_return(tenant_id,']) {
+  forbidText(ownerDecisionMethod, value, 'owner-backed return-decision concrete Order dependency');
+}
+
+for (const [value, label] of [
+  ['async fn complete_return(', 'Order complete-return capability'],
+  ['_request: CompleteOrderReturnRequest', 'default external-adapter request'],
+  ['context.require_policy(PortCallPolicy::write())?', 'default write admission'],
+  ['"order.post_order_complete_return_unavailable"', 'default fail-closed capability'],
+  ['request: CompleteOrderReturnRequest', 'in-process completion request'],
+  ['.complete_return(tenant_id, request.return_id, request.input)', 'owner-local completion execution'],
+]) requireText(ownerCommand, value, label);
+requireText(ownerLib, 'CompleteOrderReturnRequest', 'Order completion request export');
+
+for (const [value, label] of [
+  ['mod return_decision_owner_orchestration;', 'Commerce service module'],
+  ['ReturnDecisionOwnerOrchestrationService', 'Commerce service export'],
+]) requireText(servicesMod, value, label);
+for (const value of [
+  'ReturnDecisionOwnerOrchestrationError',
+  'ReturnDecisionOwnerOrchestrationResult',
+  'ReturnDecisionOwnerOrchestrationService',
+]) requireText(commerceLib, value, 'Commerce root export');
+
+// These gaps are deliberately outside this REST Order-only slice.
+requireText(
+  graphql,
+  '.create_return_decision(',
+  'mounted GraphQL return-decision compatibility call remains',
+);
+requireText(
+  ownerDecision,
+  'PaymentService::new(self.db.clone())',
+  'mounted Payment collection lookup remains explicit',
+);
+
+requireText(
+  plan,
+  '- [ ] Move remaining mounted Commerce REST/GraphQL construction of Product, Order,\n  Payment, and Fulfillment concrete services behind host-composed owner ports.',
+  'broad ecommerce topology P0 remains open',
+);
+
+for (const [value, label] of [
+  ['# Commerce REST admin return-decision Order owner-port cutover', 'record title'],
+  ['Status: `source_complete_unvalidated`', 'record status'],
+  ['OrderPostOrderCommandPort', 'record owner port'],
+  ['CompleteOrderReturnRequest', 'record completion capability'],
+  ['write-admission metadata only', 'record replay limitation'],
+  ['PaymentService', 'record deferred Payment gap'],
+  ['GraphQL `createOrderReturnDecision`', 'record deferred GraphQL gap'],
+  ['broad topology P0', 'record broad invariant'],
+  ['No tests, Cargo commands, Node verifiers, formatter', 'record validation state'],
+]) requireText(record, value, label);
+
+if (failures.length > 0) {
+  console.error('Commerce REST admin return-decision Order owner-port verification failed:');
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(Math.min(failures.length, 255));
+}
+
+console.log('✔ mounted REST admin return decision uses the host-selected Order command owner port');

--- a/scripts/verify/verify-order-post-order-command-port.mjs
+++ b/scripts/verify/verify-order-post-order-command-port.mjs
@@ -18,14 +18,20 @@ const requireText = (text, marker, message) => {
 for (const marker of [
   'pub trait OrderPostOrderCommandPort',
   'async fn create_change(',
+  'async fn apply_change(',
   'async fn cancel_change(',
   'async fn create_return(',
+  'async fn complete_return(',
   'async fn cancel_return(',
+  'pub struct CompleteOrderReturnRequest',
   'pub struct OrderPostOrderCommandRuntime',
   'context.require_policy(PortCallPolicy::write())',
+  '"order.post_order_complete_return_unavailable"',
   '.create_order_change(tenant_id, actor_id, request.order_id, request.input)',
+  '.apply_order_change(tenant_id, request.change_id, request.input)',
   '.cancel_order_change(tenant_id, request.change_id, request.input)',
   '.create_return(tenant_id, request.order_id, request.input)',
+  '.complete_return(tenant_id, request.return_id, request.input)',
   '.cancel_return(tenant_id, request.return_id, request.input)',
   'PortErrorKind::Unavailable',
   'PortErrorKind::InvariantViolation',
@@ -35,6 +41,7 @@ for (const marker of [
 
 for (const marker of [
   'mod post_order_command;',
+  'CompleteOrderReturnRequest',
   'OrderPostOrderCommandPort',
   'OrderPostOrderCommandRuntime',
   'in_process_order_post_order_command_port',


### PR DESCRIPTION
## Summary

Continue the canonical ecommerce topology P0 with the mounted admin REST return-decision Order boundary.

- publish `OrderPostOrderCommandPort::complete_return` with typed `CompleteOrderReturnRequest`; existing external adapters remain source-compatible through a default fail-closed implementation that enforces normal write admission;
- route mounted `POST /admin/orders/{id}/returns/decision` Order-owned return creation, exchange/claim change creation, and return completion through the host-selected `OrderPostOrderCommandPort` from `CommerceHttpRuntime`;
- preserve the existing `ORDERS_UPDATE` and conditional `PAYMENTS_UPDATE` admission, action validation, return/refund/exchange/claim sequencing, metadata, response projection, and Payment provider registry behavior;
- derive bounded per-operation Order command contexts from an authenticated REST root context; the generated UUID is write-admission metadata only and does not claim durable replay/exactly-once semantics;
- preserve existing Payment/post-order public envelopes while mapping new Order `PortError` values with bounded diagnostics and no raw owner error message logging;
- deliberately retain the direct `PaymentService` captured-collection lookup in the refund branch as a separate mounted Payment gap;
- deliberately retain mounted GraphQL `createOrderReturnDecision` and the broader `/admin/returns/{id}/complete` orchestration as separate slices;
- leave legacy direct create/list/show/cancel source compiled but unmounted because the admin router already uses `post_order_commands` / `post_order_reads` replacements;
- add/update source-only guards and a `source_complete_unvalidated` dated record;
- keep the broad ecommerce topology P0 open.

The branch is one clean commit ahead and zero behind `d0dc8988825de8486271c6b6bd28a9189b3b2837` with exactly 10 changed files.

## Validation

Per maintainer instruction, no tests, Cargo commands, Node verifiers, formatter, REST/GraphQL scenarios, workflows/CI, database scenarios, provider calls, restart scenarios, or remote-adapter scenarios were executed. Source guards were added/updated but not run.