### PR TITLE
fix(ci): restore reactions module parity

### DIFF
--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -74,6 +74,7 @@ It is important to distinguish:
 | `product` | `rustok-product` | `taxonomy` |
 | `profiles` | `rustok-profiles` | `media`, `social_graph`, `taxonomy` |
 | `social_graph` | `rustok-social-graph` | `outbox` |
+| `reactions` | `rustok-reactions` | `outbox` |
 | `groups` | `rustok-groups` | — |
 | `region` | `rustok-region` | — |
 | `pricing` | `rustok-pricing` | `product` |

--- a/modules.toml.example
+++ b/modules.toml.example
@@ -45,6 +45,7 @@ customer = { crate = "rustok-customer", source = "path", path = "crates/rustok-c
 product = { crate = "rustok-product", source = "path", path = "crates/rustok-product", depends_on = ["taxonomy"] }
 profiles = { crate = "rustok-profiles", source = "path", path = "crates/rustok-profiles", depends_on = ["media", "social_graph", "taxonomy"] }
 social_graph = { crate = "rustok-social-graph", source = "path", path = "crates/rustok-social-graph", depends_on = ["outbox"] }
+reactions = { crate = "rustok-reactions", source = "path", path = "crates/rustok-reactions", depends_on = ["outbox"] }
 groups = { crate = "rustok-groups", source = "path", path = "crates/rustok-groups" }
 region = { crate = "rustok-region", source = "path", path = "crates/rustok-region" }
 pricing = { crate = "rustok-pricing", source = "path", path = "crates/rustok-pricing", depends_on = ["product"] }


### PR DESCRIPTION
## Summary
- sync `modules.toml.example` with the registered optional `reactions` module
- document `reactions` in the platform module overview
- remove the confirmed module-manifest/documentation parity drift from CI

## Scope
Only `modules.toml.example` and `docs/modules/overview.md` are changed. Other currently failing CI groups are intentionally handled in fresh follow-up branches from updated `main`.